### PR TITLE
Add passcode display length field to UDC messages

### DIFF
--- a/examples/platform/linux/CommissioneeShellCommands.cpp
+++ b/examples/platform/linux/CommissioneeShellCommands.cpp
@@ -66,8 +66,8 @@ static CHIP_ERROR PrintAllCommands()
                     "  udccommissionerpasscode <address> <port> [CommissionerPasscodeReady] [PairingHint] [PairingInst] Send UDC "
                     "commissioner passcode message to address. Usage: udccommissionerpasscode ::1 5543 t 5 HelloWorld\r\n");
     streamer_printf(sout,
-                    "  testudc <address> <port> [NoPasscode] [CdUponPasscodeDialog] [vid] [PairingHint] [PairingInst] Send UDC "
-                    "message to address. Usage: cast testudc ::1 5543 t t 5 HelloWorld\r\n");
+                    "  testudc <address> <port> [NoPasscode] [CdUponPasscodeDialog] [vid] [PairingHint] [PairingInst] [PinLength] "
+                    "Send UDC message to address. Usage: cast testudc ::1 5543 t t 5 HelloWorld 8\r\n");
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // TODO: Figure out whether setdiscoverytimeout is a reasonable thing to do
     // at all, and if so what semantics it should have.  Presumably it should
@@ -157,7 +157,7 @@ static CHIP_ERROR CommissioneeHandler(int argc, char ** argv)
         chip::Inet::IPAddress::FromString(argv[1], commissioner);
         uint16_t port = (uint16_t) strtol(argv[2], &eptr, 10);
 
-        // sendudc <address> <port> [NoPasscode] [CdUponPasscodeDialog] [vid] [PairingHint] [PairingInst]
+        // testudc <address> <port> [NoPasscode] [CdUponPasscodeDialog] [vid] [PairingHint] [PairingInst] [PinLength]
         // ex. sendudc <address> <port> t t 111 5 'hello world'
 
         Protocols::UserDirectedCommissioning::IdentificationDeclaration id;
@@ -185,6 +185,11 @@ static CHIP_ERROR CommissioneeHandler(int argc, char ** argv)
         if (argc > 7)
         {
             id.SetPairingInst(argv[7]);
+        }
+        if (argc > 8)
+        {
+            uint8_t pinLength = (uint8_t) strtol(argv[8], &eptr, 10);
+            id.SetPasscodeLength(pinLength);
         }
         return Server::GetInstance().SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress::UDP(commissioner, port),
                                                                           id);

--- a/examples/platform/linux/CommissioneeShellCommands.cpp
+++ b/examples/platform/linux/CommissioneeShellCommands.cpp
@@ -161,6 +161,7 @@ static CHIP_ERROR CommissioneeHandler(int argc, char ** argv)
         // ex. sendudc <address> <port> t t 111 5 'hello world'
 
         Protocols::UserDirectedCommissioning::IdentificationDeclaration id;
+        id.SetPasscodeLength(8);
         if (argc > 3)
         {
             id.SetNoPasscode(strcmp(argv[3], "t") == 0);

--- a/examples/platform/linux/CommissioneeShellCommands.cpp
+++ b/examples/platform/linux/CommissioneeShellCommands.cpp
@@ -161,7 +161,6 @@ static CHIP_ERROR CommissioneeHandler(int argc, char ** argv)
         // ex. sendudc <address> <port> t t 111 5 'hello world'
 
         Protocols::UserDirectedCommissioning::IdentificationDeclaration id;
-        id.SetPasscodeLength(8);
         if (argc > 3)
         {
             id.SetNoPasscode(strcmp(argv[3], "t") == 0);

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/MatterCommissioningPrompter.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/MatterCommissioningPrompter.java
@@ -71,13 +71,19 @@ public class MatterCommissioningPrompter extends UserPrompterResolver implements
   }
 
   @Override
-  public void promptForCommissionPinCode(int vendorId, int productId, String commissioneeName) {
+  public void promptForCommissionPinCode(int vendorId, int productId, int passcodeLength, String commissioneeName, int pairingHint, String pairingInstruction) {
     Log.d(
         TAG,
         "Received prompt for PIN code vendor id:"
             + vendorId
             + " productId:"
             + productId
+            + " passcode length:"
+            + passcodeLength
+            + " pairing hint:"
+            + pairingHint
+            + " pairing instruction:"
+            + pairingInstruction
             + ". Commissionee: "
             + commissioneeName);
     android.os.Message obtained = android.os.Message.obtain();
@@ -106,6 +112,7 @@ public class MatterCommissioningPrompter extends UserPrompterResolver implements
       int productId,
       String commissioneeName,
       long passcode,
+      int passcodeLength,
       int pairingHint,
       String pairingInstruction) {
     Log.d(
@@ -116,12 +123,18 @@ public class MatterCommissioningPrompter extends UserPrompterResolver implements
             + vendorId
             + " productId:"
             + productId
+            + " passcode length:"
+            + passcodeLength
+            + " pairing hint:"
+            + pairingHint
+            + " pairing instruction:"
+            + pairingInstruction
             + ". Commissionee: "
             + commissioneeName);
     Bundle bundle = new Bundle();
     PromptCommissionerPasscode promptCommissionerPasscode =
         new PromptCommissionerPasscode(
-            vendorId, productId, commissioneeName, passcode, pairingHint, pairingInstruction);
+            vendorId, productId, commissioneeName, passcode, passcodeLength, pairingHint, pairingInstruction);
     bundle.putParcelable(MsgHandler.KEY_PROMPT_COMMISSIONER_PASSCODE, promptCommissionerPasscode);
     android.os.Message obtained = android.os.Message.obtain();
     obtained.what = MsgHandler.MSG_CommissionerPasscode;

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/MatterCommissioningPrompter.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/MatterCommissioningPrompter.java
@@ -71,7 +71,13 @@ public class MatterCommissioningPrompter extends UserPrompterResolver implements
   }
 
   @Override
-  public void promptForCommissionPinCode(int vendorId, int productId, int passcodeLength, String commissioneeName, int pairingHint, String pairingInstruction) {
+  public void promptForCommissionPinCode(
+      int vendorId,
+      int productId,
+      int passcodeLength,
+      String commissioneeName,
+      int pairingHint,
+      String pairingInstruction) {
     Log.d(
         TAG,
         "Received prompt for PIN code vendor id:"
@@ -134,7 +140,13 @@ public class MatterCommissioningPrompter extends UserPrompterResolver implements
     Bundle bundle = new Bundle();
     PromptCommissionerPasscode promptCommissionerPasscode =
         new PromptCommissionerPasscode(
-            vendorId, productId, commissioneeName, passcode, passcodeLength, pairingHint, pairingInstruction);
+            vendorId,
+            productId,
+            commissioneeName,
+            passcode,
+            passcodeLength,
+            pairingHint,
+            pairingInstruction);
     bundle.putParcelable(MsgHandler.KEY_PROMPT_COMMISSIONER_PASSCODE, promptCommissionerPasscode);
     android.os.Message obtained = android.os.Message.obtain();
     obtained.what = MsgHandler.MSG_CommissionerPasscode;

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/model/PromptCommissionerPasscode.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/model/PromptCommissionerPasscode.java
@@ -8,6 +8,7 @@ public class PromptCommissionerPasscode implements Parcelable {
   private int productId;
   private String commissioneeName;
   private long passcode;
+  private int passcodeLength;
   private int pairingHint;
   private String pairingInstruction;
 
@@ -16,12 +17,14 @@ public class PromptCommissionerPasscode implements Parcelable {
       int productId,
       String commissioneeName,
       long passcode,
+      int passcodeLength,
       int pairingHint,
       String pairingInstruction) {
     this.vendorId = vendorId;
     this.productId = productId;
     this.commissioneeName = commissioneeName;
     this.passcode = passcode;
+    this.passcodeLength = passcodeLength;
     this.pairingHint = pairingHint;
     this.pairingInstruction = pairingInstruction;
   }
@@ -31,6 +34,7 @@ public class PromptCommissionerPasscode implements Parcelable {
     productId = in.readInt();
     commissioneeName = in.readString();
     passcode = in.readLong();
+    passcodeLength = in.readInt();
     pairingHint = in.readInt();
     pairingInstruction = in.readString();
   }
@@ -80,6 +84,14 @@ public class PromptCommissionerPasscode implements Parcelable {
     this.passcode = passcode;
   }
 
+  public int getPasscodeLength() {
+    return passcodeLength;
+  }
+
+  public void setPasscodeLength(int passcodeLength) {
+    this.passcodeLength = passcodeLength;
+  }
+
   public int getPairingHint() {
     return pairingHint;
   }
@@ -108,6 +120,8 @@ public class PromptCommissionerPasscode implements Parcelable {
         + '\''
         + ", passcode="
         + passcode
+        + ", passcodeLength="
+        + passcodeLength
         + ", pairingHint="
         + pairingHint
         + ", pairingInstruction='"
@@ -127,6 +141,7 @@ public class PromptCommissionerPasscode implements Parcelable {
     parcel.writeInt(productId);
     parcel.writeString(commissioneeName);
     parcel.writeLong(passcode);
+    parcel.writeInt(passcodeLength);
     parcel.writeInt(pairingHint);
     parcel.writeString(pairingInstruction);
   }

--- a/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
+++ b/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
@@ -44,7 +44,7 @@ JNIMyUserPrompter::JNIMyUserPrompter(jobject provider)
     }
 
     mPromptForCommissionPincodeMethod =
-        env->GetMethodID(JNIMyUserPrompterClass, "promptForCommissionPinCode", "(IILjava/lang/String;)V");
+        env->GetMethodID(JNIMyUserPrompterClass, "promptForCommissionPinCode", "(IIILjava/lang/String;ILjava/lang/String;)V");
     if (mPromptForCommissionPincodeMethod == nullptr)
     {
         ChipLogError(Zcl, "Failed to access JNIMyUserPrompter 'promptForCommissionPinCode' method");
@@ -59,7 +59,7 @@ JNIMyUserPrompter::JNIMyUserPrompter(jobject provider)
     }
 
     mPromptWithCommissionerPasscodeMethod =
-        env->GetMethodID(JNIMyUserPrompterClass, "promptWithCommissionerPasscode", "(IILjava/lang/String;JILjava/lang/String;)V");
+        env->GetMethodID(JNIMyUserPrompterClass, "promptWithCommissionerPasscode", "(IILjava/lang/String;JIILjava/lang/String;)V");
     if (mPromptWithCommissionerPasscodeMethod == nullptr)
     {
         ChipLogError(Zcl, "Failed to access JNIMyUserPrompter 'promptWithCommissionerPasscode' method");
@@ -142,7 +142,7 @@ exit:
  *
  */
 void JNIMyUserPrompter::PromptForCommissionPasscode(uint16_t vendorId, uint16_t productId, const char * commissioneeName,
-                                                    uint16_t pairingHint, const char * pairingInstruction)
+                                                    uint16_t pairingHint, const char * pairingInstruction, uint8_t passcodeLength)
 {
     DeviceLayer::StackUnlock unlock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -156,9 +156,12 @@ void JNIMyUserPrompter::PromptForCommissionPasscode(uint16_t vendorId, uint16_t 
         jstring jcommissioneeName = env->NewStringUTF(commissioneeName);
         VerifyOrExit(jcommissioneeName != nullptr, ChipLogError(Zcl, "Could not create jstring"); err = CHIP_ERROR_INTERNAL);
 
+        ChipLogError(Zcl, "JNIMyUserPrompter::PromptForCommissionPasscode length=%d", static_cast<uint16_t>(passcodeLength));
+
         env->ExceptionClear();
         env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptForCommissionPincodeMethod, static_cast<jint>(vendorId),
-                            static_cast<jint>(productId), jcommissioneeName);
+                            static_cast<jint>(productId), static_cast<jint>(passcodeLength), jcommissioneeName, 
+                            static_cast<jint>(pairingHint), pairingInstruction);
         if (env->ExceptionCheck())
         {
             ChipLogError(Zcl, "Java exception in PromptForCommissionPincode");
@@ -234,7 +237,8 @@ bool JNIMyUserPrompter::DisplaysPasscodeAndQRCode()
  * For example "Casting Passcode: [passcode]. For more instructions, click here."
  */
 void JNIMyUserPrompter::PromptWithCommissionerPasscode(uint16_t vendorId, uint16_t productId, const char * commissioneeName,
-                                                       uint32_t passcode, uint16_t pairingHint, const char * pairingInstruction)
+                                                       uint32_t passcode, uint8_t passcodeLength, uint16_t pairingHint,
+                                                       const char * pairingInstruction)
 {
     ChipLogError(Zcl, "JNIMyUserPrompter::PromptWithCommissionerPasscode");
 
@@ -256,7 +260,8 @@ void JNIMyUserPrompter::PromptWithCommissionerPasscode(uint16_t vendorId, uint16
         env->ExceptionClear();
         env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptWithCommissionerPasscodeMethod,
                             static_cast<jint>(vendorId), static_cast<jint>(productId), jcommissioneeName,
-                            static_cast<jlong>(passcode), static_cast<jint>(pairingHint), jpairingInstruction);
+                            static_cast<jlong>(passcode), static_cast<jint>(passcodeLength), static_cast<jint>(pairingHint),
+                            jpairingInstruction);
         if (env->ExceptionCheck())
         {
             ChipLogError(DeviceLayer, "Java exception in PromptWithCommissionerPasscode");

--- a/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
+++ b/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
@@ -160,7 +160,7 @@ void JNIMyUserPrompter::PromptForCommissionPasscode(uint16_t vendorId, uint16_t 
 
         env->ExceptionClear();
         env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptForCommissionPincodeMethod, static_cast<jint>(vendorId),
-                            static_cast<jint>(productId), static_cast<jint>(passcodeLength), jcommissioneeName, 
+                            static_cast<jint>(productId), static_cast<jint>(passcodeLength), jcommissioneeName,
                             static_cast<jint>(pairingHint), pairingInstruction);
         if (env->ExceptionCheck())
         {

--- a/examples/tv-app/android/java/MyUserPrompter-JNI.h
+++ b/examples/tv-app/android/java/MyUserPrompter-JNI.h
@@ -28,11 +28,11 @@ public:
     JNIMyUserPrompter(jobject prompter);
     void PromptForCommissionOKPermission(uint16_t vendorId, uint16_t productId, const char * commissioneeName) override;
     void PromptForCommissionPasscode(uint16_t vendorId, uint16_t productId, const char * commissioneeName, uint16_t pairingHint,
-                                     const char * pairingInstruction) override;
+                                     const char * pairingInstruction, uint8_t passcodeLength) override;
     void HidePromptsOnCancel(uint16_t vendorId, uint16_t productId, const char * commissioneeName) override;
     bool DisplaysPasscodeAndQRCode() override;
     void PromptWithCommissionerPasscode(uint16_t vendorId, uint16_t productId, const char * commissioneeName, uint32_t passcode,
-                                        uint16_t pairingHint, const char * pairingInstruction) override;
+                                        uint8_t passcodeLength, uint16_t pairingHint, const char * pairingInstruction) override;
     void PromptCommissioningStarted(uint16_t vendorId, uint16_t productId, const char * commissioneeName) override;
     void PromptCommissioningSucceeded(uint16_t vendorId, uint16_t productId, const char * commissioneeName) override;
     void PromptCommissioningFailed(const char * commissioneeName, CHIP_ERROR error) override;

--- a/examples/tv-app/android/java/TVApp-JNI.cpp
+++ b/examples/tv-app/android/java/TVApp-JNI.cpp
@@ -228,10 +228,10 @@ class MyPincodeService : public PasscodeService
         }
     }
 
-    uint32_t GetCommissionerPasscode(uint16_t vendorId, uint16_t productId, chip::CharSpan rotatingId) override
+    PasscodeInfo GetCommissionerPasscode(uint16_t vendorId, uint16_t productId, chip::CharSpan rotatingId) override
     {
         // TODO: randomly generate this value
-        return 12345678;
+        return { 12345678, 8 };
     }
 
     void FetchCommissionPasscodeFromContentApp(uint16_t vendorId, uint16_t productId, CharSpan rotatingId) override

--- a/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/UserPrompter.java
+++ b/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/UserPrompter.java
@@ -37,7 +37,13 @@ public interface UserPrompter {
    * If user responds with Cancel then implementor calls UserPrompterResolver.OnPinCodeDeclined();
    *
    */
-  void promptForCommissionPinCode(int vendorId, int productId, int passcodeLength, String commissioneeName, int pairingHint, String pairingInstruction);
+  void promptForCommissionPinCode(
+      int vendorId,
+      int productId,
+      int passcodeLength,
+      String commissioneeName,
+      int pairingHint,
+      String pairingInstruction);
 
   /**
    * Called to when CancelCommissioning is received via UDC. Indicates that commissioner can stop

--- a/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/UserPrompter.java
+++ b/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/UserPrompter.java
@@ -37,7 +37,7 @@ public interface UserPrompter {
    * If user responds with Cancel then implementor calls UserPrompterResolver.OnPinCodeDeclined();
    *
    */
-  void promptForCommissionPinCode(int vendorId, int productId, String commissioneeName);
+  void promptForCommissionPinCode(int vendorId, int productId, int passcodeLength, String commissioneeName, int pairingHint, String pairingInstruction);
 
   /**
    * Called to when CancelCommissioning is received via UDC. Indicates that commissioner can stop
@@ -57,6 +57,7 @@ public interface UserPrompter {
       int productId,
       String commissioneeName,
       long passcode,
+      int passcodeLength,
       int pairingHint,
       String pairingInstruction);
 

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -131,10 +131,10 @@ class MyPasscodeService : public PasscodeService
         }
     }
 
-    uint32_t GetCommissionerPasscode(uint16_t vendorId, uint16_t productId, chip::CharSpan rotatingId) override
+    PasscodeInfo GetCommissionerPasscode(uint16_t vendorId, uint16_t productId, chip::CharSpan rotatingId) override
     {
         // TODO: randomly generate this value
-        return 12345678;
+        return { 12345678, 8 };
     }
 
     void FetchCommissionPasscodeFromContentApp(uint16_t vendorId, uint16_t productId, CharSpan rotatingId) override

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -66,7 +66,7 @@ class MyUserPrompter : public UserPrompter
 
     // tv should override this with a dialog prompt
     inline void PromptForCommissionPasscode(uint16_t vendorId, uint16_t productId, const char * commissioneeName,
-                                            uint16_t pairingHint, const char * pairingInstruction) override
+                                            uint16_t pairingHint, const char * pairingInstruction, uint8_t passcodeLength) override
     {
         return;
     }
@@ -79,7 +79,8 @@ class MyUserPrompter : public UserPrompter
 
     // tv should override this with a dialog prompt
     inline void PromptWithCommissionerPasscode(uint16_t vendorId, uint16_t productId, const char * commissioneeName,
-                                               uint32_t passcode, uint16_t pairingHint, const char * pairingInstruction) override
+                                               uint32_t passcode, uint8_t passcodeLength, uint16_t pairingHint,
+                                               const char * pairingInstruction) override
     {
         return;
     }
@@ -134,6 +135,7 @@ class MyPasscodeService : public PasscodeService
     PasscodeInfo GetCommissionerPasscode(uint16_t vendorId, uint16_t productId, chip::CharSpan rotatingId) override
     {
         // TODO: randomly generate this value
+        ChipLogDetail(AppServer, "GetCommissionerPasscode: returning a passcode");
         return { 12345678, 8 };
     }
 

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -219,7 +219,9 @@ public class ConnectionExampleFragment extends Fragment {
                                 displayPasscodeInputDialog(activity);
 
                                 connectionFragmentStatusTextView.setText(
-                                    "CommissionerDeclaration message received from Casting Player: A passcode (length "+cd.getPasscodeLength()+") is now displayed for the user by the Casting Player. \n\n");
+                                    "CommissionerDeclaration message received from Casting Player: A passcode (length "
+                                        + cd.getPasscodeLength()
+                                        + ") is now displayed for the user by the Casting Player. \n\n");
                               }
                               if (cd.getCancelPasscode()) {
                                 if (useCommissionerGeneratedPasscode) {

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -136,7 +136,8 @@ public class ConnectionExampleFragment extends Fragment {
               if (useCommissionerGeneratedPasscode) {
                 // Set commissionerPasscode to true for CastingPlayer/Commissioner-Generated
                 // passcode commissioning.
-                idOptions = new IdentificationDeclarationOptions(false, false, true, false, false, 0);
+                idOptions =
+                    new IdentificationDeclarationOptions(false, false, true, false, false, 0);
                 Log.d(
                     TAG,
                     "onViewCreated() calling CastingPlayer.verifyOrEstablishConnection() Target Content Application Vendor ID: "
@@ -150,7 +151,7 @@ public class ConnectionExampleFragment extends Fragment {
                                 InitializationExample.commissionableDataProvider
                                     .get()
                                     .getSetupPasscode()))
-                         .length();
+                        .length();
                 idOptions =
                     new IdentificationDeclarationOptions(
                         false, false, false, false, false, passcodeLength);

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -30,7 +30,7 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
-import com.R;
+import com.chip.casting.R;
 import com.matter.casting.core.CastingPlayer;
 import com.matter.casting.support.CommissionerDeclaration;
 import com.matter.casting.support.ConnectionCallbacks;

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -144,8 +144,16 @@ public class ConnectionExampleFragment extends Fragment {
                         + ", useCommissionerGeneratedPasscode: "
                         + useCommissionerGeneratedPasscode);
               } else {
-                int passcodeLength = String.valueOf(Math.abs(InitializationExample.commissionableDataProvider.get().getSetupPasscode())).length();
-                idOptions = new IdentificationDeclarationOptions(false, false, false, false, false, passcodeLength);
+                int passcodeLength =
+                    String.valueOf(
+                            Math.abs(
+                                InitializationExample.commissionableDataProvider
+                                    .get()
+                                    .getSetupPasscode()))
+                         .length();
+                idOptions =
+                    new IdentificationDeclarationOptions(
+                        false, false, false, false, false, passcodeLength);
                 Log.d(
                     TAG,
                     "onViewCreated() calling CastingPlayer.verifyOrEstablishConnection() Target Content Application Vendor ID: "

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -30,7 +30,7 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
-import com.chip.casting.R;
+import com.R;
 import com.matter.casting.core.CastingPlayer;
 import com.matter.casting.support.CommissionerDeclaration;
 import com.matter.casting.support.ConnectionCallbacks;
@@ -219,7 +219,7 @@ public class ConnectionExampleFragment extends Fragment {
                                 displayPasscodeInputDialog(activity);
 
                                 connectionFragmentStatusTextView.setText(
-                                    "CommissionerDeclaration message received from Casting Player: A passcode is now displayed for the user by the Casting Player. \n\n");
+                                    "CommissionerDeclaration message received from Casting Player: A passcode (length "+cd.getPasscodeLength()+") is now displayed for the user by the Casting Player. \n\n");
                               }
                               if (cd.getCancelPasscode()) {
                                 if (useCommissionerGeneratedPasscode) {

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -136,7 +136,7 @@ public class ConnectionExampleFragment extends Fragment {
               if (useCommissionerGeneratedPasscode) {
                 // Set commissionerPasscode to true for CastingPlayer/Commissioner-Generated
                 // passcode commissioning.
-                idOptions = new IdentificationDeclarationOptions(false, false, true, false, false);
+                idOptions = new IdentificationDeclarationOptions(false, false, true, false, false, 0);
                 Log.d(
                     TAG,
                     "onViewCreated() calling CastingPlayer.verifyOrEstablishConnection() Target Content Application Vendor ID: "
@@ -144,7 +144,8 @@ public class ConnectionExampleFragment extends Fragment {
                         + ", useCommissionerGeneratedPasscode: "
                         + useCommissionerGeneratedPasscode);
               } else {
-                idOptions = new IdentificationDeclarationOptions();
+                int passcodeLength = String.valueOf(Math.abs(InitializationExample.commissionableDataProvider.get().getSetupPasscode())).length();
+                idOptions = new IdentificationDeclarationOptions(false, false, false, false, false, passcodeLength);
                 Log.d(
                     TAG,
                     "onViewCreated() calling CastingPlayer.verifyOrEstablishConnection() Target Content Application Vendor ID: "

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/CommissionerDeclaration.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/CommissionerDeclaration.java
@@ -110,6 +110,11 @@ public class CommissionerDeclaration {
    */
   private boolean cancelPasscode = false;
 
+  /**
+   * Feature: Commissioner-Generated Passcode - Length of passcode
+   */
+  private int passcodeLength = 0;
+
   public CommissionerDeclaration(
       int errorCode,
       boolean needsPasscode,
@@ -117,7 +122,8 @@ public class CommissionerDeclaration {
       boolean passcodeDialogDisplayed,
       boolean commissionerPasscode,
       boolean qRCodeDisplayed,
-      boolean cancelPasscode) {
+      boolean cancelPasscode,
+      int passcodeLength) {
     this.errorCode = CdError.values()[errorCode];
     this.needsPasscode = needsPasscode;
     this.noAppsFound = noAppsFound;
@@ -125,6 +131,7 @@ public class CommissionerDeclaration {
     this.commissionerPasscode = commissionerPasscode;
     this.qRCodeDisplayed = qRCodeDisplayed;
     this.cancelPasscode = cancelPasscode;
+    this.passcodeLength = passcodeLength;
   }
 
   public void setErrorCode(CdError errorCode) {
@@ -179,6 +186,10 @@ public class CommissionerDeclaration {
     return this.cancelPasscode;
   }
 
+  public int getPasscodeLength() {
+    return this.passcodeLength;
+  }
+
   @Override
   public String toString() {
     return "CommissionerDeclaration::errorCode:               "
@@ -195,6 +206,9 @@ public class CommissionerDeclaration {
         + "\n"
         + "CommissionerDeclaration:commissionerPasscode:     "
         + commissionerPasscode
+        + "\n"
+        + "CommissionerDeclaration:passcodeLength:     "
+        + passcodeLength
         + "\n"
         + "CommissionerDeclaration::qRCodeDisplayed:         "
         + qRCodeDisplayed

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/CommissionerDeclaration.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/CommissionerDeclaration.java
@@ -110,9 +110,7 @@ public class CommissionerDeclaration {
    */
   private boolean cancelPasscode = false;
 
-  /**
-   * Feature: Commissioner-Generated Passcode - Length of passcode
-   */
+  /** Feature: Commissioner-Generated Passcode - Length of passcode */
   private int passcodeLength = 0;
 
   public CommissionerDeclaration(

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
@@ -90,9 +90,7 @@ public class IdentificationDeclarationOptions {
    * to exit the commissioning process.
    */
   private boolean cancelPasscode = false;
-  /**
-   * Feature: Coordinate Passcode Dialogs Flag - to indicate the passcode length.
-   */
+  /** Feature: Coordinate Passcode Dialogs Flag - to indicate the passcode length. */
   private int passcodeLength = 0;
   /**
    * Feature: Target Content Application - The set of content app Vendor IDs (and optionally,

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
@@ -38,18 +38,21 @@ public class IdentificationDeclarationOptions {
    * @param commissionerPasscode the commissioner passcode flag.
    * @param commissionerPasscodeReady the commissioner passcode ready flag.
    * @param cancelPasscode the cancel passcode flag.
+   * @param passcodeLength the passcode length.
    */
   public IdentificationDeclarationOptions(
       boolean noPasscode,
       boolean cdUponPasscodeDialog,
       boolean commissionerPasscode,
       boolean commissionerPasscodeReady,
-      boolean cancelPasscode) {
+      boolean cancelPasscode,
+      int passcodeLength) {
     this.noPasscode = noPasscode;
     this.cdUponPasscodeDialog = cdUponPasscodeDialog;
     this.commissionerPasscode = commissionerPasscode;
     this.commissionerPasscodeReady = commissionerPasscodeReady;
     this.cancelPasscode = cancelPasscode;
+    this.passcodeLength = passcodeLength;
   }
 
   /**
@@ -87,6 +90,10 @@ public class IdentificationDeclarationOptions {
    * to exit the commissioning process.
    */
   private boolean cancelPasscode = false;
+  /**
+   * Feature: Coordinate Passcode Dialogs Flag - to indicate the passcode length.
+   */
+  private int passcodeLength = 0;
   /**
    * Feature: Target Content Application - The set of content app Vendor IDs (and optionally,
    * Product IDs) that can be used for authentication. Also, if TargetAppInfo is passed in,
@@ -132,6 +139,10 @@ public class IdentificationDeclarationOptions {
     return cancelPasscode;
   }
 
+  public int getPasscodeLength() {
+    return passcodeLength;
+  }
+
   public List<TargetAppInfo> getTargetAppInfoList() {
     return targetAppInfos;
   }
@@ -153,6 +164,9 @@ public class IdentificationDeclarationOptions {
         .append("\n");
     sb.append("IdentificationDeclarationOptions::cancelPasscode:            ")
         .append(cancelPasscode)
+        .append("\n");
+    sb.append("IdentificationDeclarationOptions::passcodeLength:            ")
+        .append(passcodeLength)
         .append("\n");
     sb.append("IdentificationDeclarationOptions::targetAppInfos list: \n");
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -480,7 +480,7 @@ matter::casting::core::IdentificationDeclarationOptions * convertIdentificationD
     cppIdOptions->mCommissionerPasscode      = env->GetBooleanField(jIdOptions, commissionerPasscodeField);
     cppIdOptions->mCommissionerPasscodeReady = env->GetBooleanField(jIdOptions, commissionerPasscodeReadyField);
     cppIdOptions->mCancelPasscode            = env->GetBooleanField(jIdOptions, cancelPasscodeField);
-    cppIdOptions->mPasscodeLength            = env->GetIntField(jIdOptions, passcodeLengthField);
+    cppIdOptions->mPasscodeLength            = static_cast<uint8_t>(env->GetIntField(jIdOptions, passcodeLengthField));
 
     jobject targetAppInfosList = env->GetObjectField(jIdOptions, targetAppInfosField);
     VerifyOrReturnValue(

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -448,6 +448,7 @@ matter::casting::core::IdentificationDeclarationOptions * convertIdentificationD
     jfieldID commissionerPasscodeReadyField = env->GetFieldID(idOptionsClass, "commissionerPasscodeReady", "Z");
     jfieldID cancelPasscodeField            = env->GetFieldID(idOptionsClass, "cancelPasscode", "Z");
     jfieldID targetAppInfosField            = env->GetFieldID(idOptionsClass, "targetAppInfos", "Ljava/util/List;");
+    jfieldID passcodeLengthField            = env->GetFieldID(idOptionsClass, "passcodeLength", "I");
     VerifyOrReturnValue(
         noPasscodeField != nullptr, nullptr,
         ChipLogError(AppServer, "convertIdentificationDeclarationOptionsFromJavaToCpp() noPasscodeField not found!"));
@@ -467,6 +468,9 @@ matter::casting::core::IdentificationDeclarationOptions * convertIdentificationD
     VerifyOrReturnValue(
         targetAppInfosField != nullptr, nullptr,
         ChipLogError(AppServer, "convertIdentificationDeclarationOptionsFromJavaToCpp() targetAppInfosField not found!"));
+    VerifyOrReturnValue(
+        passcodeLengthField != nullptr, nullptr,
+        ChipLogError(AppServer, "convertIdentificationDeclarationOptionsFromJavaToCpp() passcodeLengthField not found!"));
 
     matter::casting::core::IdentificationDeclarationOptions * cppIdOptions =
         new matter::casting::core::IdentificationDeclarationOptions();
@@ -476,6 +480,7 @@ matter::casting::core::IdentificationDeclarationOptions * convertIdentificationD
     cppIdOptions->mCommissionerPasscode      = env->GetBooleanField(jIdOptions, commissionerPasscodeField);
     cppIdOptions->mCommissionerPasscodeReady = env->GetBooleanField(jIdOptions, commissionerPasscodeReadyField);
     cppIdOptions->mCancelPasscode            = env->GetBooleanField(jIdOptions, cancelPasscodeField);
+    cppIdOptions->mPasscodeLength            = env->GetIntField(jIdOptions, passcodeLengthField);
 
     jobject targetAppInfosList = env->GetObjectField(jIdOptions, targetAppInfosField);
     VerifyOrReturnValue(

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -541,7 +541,7 @@ convertCommissionerDeclarationFromCppToJava(const chip::Protocols::UserDirectedC
     return env->NewObject(jCommissionerDeclarationClass, jCommissionerDeclarationConstructor,
                           static_cast<jint>(cppCd.GetErrorCode()), cppCd.GetNeedsPasscode(), cppCd.GetNoAppsFound(),
                           cppCd.GetPasscodeDialogDisplayed(), cppCd.GetCommissionerPasscode(), cppCd.GetQRCodeDisplayed(),
-                          cppCd.GetCancelPasscode());
+                          cppCd.GetCancelPasscode(), cppCd.GetPasscodeLength());
 }
 
 }; // namespace support

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCommissionerDeclaration.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCommissionerDeclaration.h
@@ -83,6 +83,8 @@ typedef NS_ENUM(NSInteger, CdError) {
  * user has decided to exit the commissioning process.
  */
 @property (nonatomic, readonly) BOOL cancelPasscode;
+/** Feature: Commissioner-Generated Passcode - length of passcode displayed. */
+@property (nonatomic, readonly) NSInteger passcodeLength;
 
 - (instancetype)initWithOptions:(NSInteger)errorCode
                   needsPasscode:(BOOL)needsPasscode
@@ -90,7 +92,8 @@ typedef NS_ENUM(NSInteger, CdError) {
         passcodeDialogDisplayed:(BOOL)passcodeDialogDisplayed
            commissionerPasscode:(BOOL)commissionerPasscode
                 qRCodeDisplayed:(BOOL)qRCodeDisplayed
-                 cancelPasscode:(BOOL)cancelPasscode;
+                 cancelPasscode:(BOOL)cancelPasscode
+                 passcodeLength:(NSInteger)passcodeLength;
 
 /**
  * Function to return the error code as a string.

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCommissionerDeclaration.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCommissionerDeclaration.mm
@@ -37,6 +37,7 @@
         _commissionerPasscode = cppCommissionerDeclaration->GetCommissionerPasscode();
         _qRCodeDisplayed = cppCommissionerDeclaration->GetQRCodeDisplayed();
         _cancelPasscode = cppCommissionerDeclaration->GetCancelPasscode();
+        _passcodeLength = cppCommissionerDeclaration->GetPasscodeLength();
     }
     return self;
 }
@@ -48,6 +49,7 @@
            commissionerPasscode:(BOOL)commissionerPasscode
                 qRCodeDisplayed:(BOOL)qRCodeDisplayed
                  cancelPasscode:(BOOL)cancelPasscode
+                 passcodeLength:(NSInteger)passcodeLength
 {
     self = [super init];
     if (self) {
@@ -58,20 +60,22 @@
         _commissionerPasscode = commissionerPasscode;
         _qRCodeDisplayed = qRCodeDisplayed;
         _cancelPasscode = cancelPasscode;
+        _passcodeLength = passcodeLength;
     }
     return self;
 }
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"MCCommissionerDeclaration::errorCode:               %@\nMCCommissionerDeclaration::needsPasscode:           %d\nMCCommissionerDeclaration::noAppsFound:             %d\nMCCommissionerDeclaration::passcodeDialogDisplayed: %d\nMCCommissionerDeclaration::commissionerPasscode:    %d\nMCCommissionerDeclaration::qRCodeDisplayed:         %d\nMCCommissionerDeclaration::cancelPasscode:          %d",
+    return [NSString stringWithFormat:@"MCCommissionerDeclaration::errorCode:               %@\nMCCommissionerDeclaration::needsPasscode:           %d\nMCCommissionerDeclaration::noAppsFound:             %d\nMCCommissionerDeclaration::passcodeDialogDisplayed: %d\nMCCommissionerDeclaration::commissionerPasscode:    %d\nMCCommissionerDeclaration::qRCodeDisplayed:         %d\nMCCommissionerDeclaration::cancelPasscode:          %d\nMCCommissionerDeclaration::passcodeLength: %d",
                      [self stringForErrorCode:self.errorCode],
                      self.needsPasscode,
                      self.noAppsFound,
                      self.passcodeDialogDisplayed,
                      self.commissionerPasscode,
                      self.qRCodeDisplayed,
-                     self.cancelPasscode];
+                     self.cancelPasscode,
+                     self.passcodeLength];
 }
 
 - (NSString *)getErrorCodeString

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCIdentificationDeclarationOptions.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCIdentificationDeclarationOptions.h
@@ -54,10 +54,14 @@
  * to exit the commissioning process.
  */
 @property (nonatomic, readonly) BOOL cancelPasscode;
+/** Feature: Commissioner-Generated Passcode - length of passcode displayed. */
+@property (nonatomic, readonly) NSInteger passcodeLength;
 
 - (instancetype)init;
 
 - (instancetype)initWithCommissionerPasscodeOnly:(BOOL)commissionerPasscode;
+
+- (instancetype)initWithPasscodeLengthOnly:(NSInteger)passcodeLength;
 
 /**
  * @brief Adds a TargetAppInfo to the IdentificationDeclarationOptions.java TargetAppInfos list,

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCIdentificationDeclarationOptions.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCIdentificationDeclarationOptions.mm
@@ -43,6 +43,7 @@
         _commissionerPasscodeReady = NO;
         _cancelPasscode = NO;
         _targetAppInfos = [[NSMutableArray alloc] init];
+        _passcodeLength = 0;
     }
     return self;
 }
@@ -57,6 +58,22 @@
         _commissionerPasscodeReady = NO;
         _cancelPasscode = NO;
         _targetAppInfos = [[NSMutableArray alloc] init];
+        _passcodeLength = 0;
+    }
+    return self;
+}
+
+- (instancetype)initWithPasscodeLengthOnly:(NSInteger)passcodeLength
+{
+    self = [super init];
+    if (self) {
+        _noPasscode = NO;
+        _cdUponPasscodeDialog = NO;
+        _commissionerPasscode = NO;
+        _commissionerPasscodeReady = NO;
+        _cancelPasscode = NO;
+        _targetAppInfos = [[NSMutableArray alloc] init];
+        _passcodeLength = passcodeLength;
     }
     return self;
 }
@@ -87,6 +104,11 @@
     return _cancelPasscode;
 }
 
+- (NSInteger)getPasscodeLength
+{
+    return _passcodeLength;
+}
+
 - (BOOL)addTargetAppInfo:(MCTargetAppInfo *)targetAppInfo
 {
     if (self.targetAppInfos.count >= CHIP_DEVICE_CONFIG_UDC_MAX_TARGET_APPS) {
@@ -109,6 +131,7 @@
     [sb appendFormat:@"MCIdentificationDeclarationOptions::commissionerPasscode:      %d\n", self.commissionerPasscode];
     [sb appendFormat:@"MCIdentificationDeclarationOptions::commissionerPasscodeReady: %d\n", self.commissionerPasscodeReady];
     [sb appendFormat:@"MCIdentificationDeclarationOptions::cancelPasscode:            %d\n", self.cancelPasscode];
+    [sb appendFormat:@"MCIdentificationDeclarationOptions::passcodeLength:            %d\n", self.passcodeLength];
     [sb appendString:@"MCIdentificationDeclarationOptions::targetAppInfos list:\n"];
 
     for (MCTargetAppInfo * targetAppInfo in self.targetAppInfos) {
@@ -126,6 +149,7 @@
     cppIdOptions.mCommissionerPasscode = [self getCommissionerPasscode];
     cppIdOptions.mCommissionerPasscodeReady = [self getCommissionerPasscodeReady];
     cppIdOptions.mCancelPasscode = [self getCancelPasscode];
+    cppIdOptions.mPasscodeLength = [self getPasscodeLength];
 
     NSArray<MCTargetAppInfo *> * targetAppInfos = [self getTargetAppInfoList];
     for (MCTargetAppInfo * appInfo in targetAppInfos) {

--- a/examples/tv-casting-app/linux/CastingShellCommands.cpp
+++ b/examples/tv-casting-app/linux/CastingShellCommands.cpp
@@ -236,6 +236,7 @@ static CHIP_ERROR CastingHandler(int argc, char ** argv)
         DeviceLayer::SetCommissionableDataProvider(&gCommissionableDataProvider);
 
         CastingServer::GetInstance()->SetCommissionerPasscodeReady();
+        return CHIP_NO_ERROR;
     }
     if (strcmp(argv[0], "testudc") == 0)
     {
@@ -248,6 +249,7 @@ static CHIP_ERROR CastingHandler(int argc, char ** argv)
         // ex. sendudc <address> <port> t t 111 5 'hello world'
 
         Protocols::UserDirectedCommissioning::IdentificationDeclaration id;
+        id.SetPasscodeLength(8);
         if (argc > 3)
         {
             id.SetNoPasscode(strcmp(argv[3], "t") == 0);

--- a/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
+++ b/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
@@ -61,6 +61,11 @@ public:
      * Flag to indicate when the Commissionee user has decided to exit the commissioning process.
      */
     bool mCancelPasscode = false;
+    /**
+     * Feature: Coordinate Passcode Dialogs
+     * Field to indicate the length of the passcode displayed by the client.
+     */
+    uint8_t mPasscodeLength = 0;
 
     /**
      * Commissionee's (random) DNS-SD instance name. This field is mandatory and will be auto generated if not provided by the
@@ -92,6 +97,7 @@ public:
         mCommissionerPasscode      = false;
         mCommissionerPasscodeReady = false;
         mCancelPasscode            = false;
+        mPasscodeLength            = 0;
         mTargetAppInfos.clear();
     }
 
@@ -113,6 +119,11 @@ public:
         id.SetCdUponPasscodeDialog(mCdUponPasscodeDialog);
         id.SetCancelPasscode(mCancelPasscode);
         id.SetCommissionerPasscode(mCommissionerPasscode);
+        if (!mCommissionerPasscode)
+        {
+            // only makes sense to have a length when the client is displaying the passcode
+            id.SetPasscodeLength(mPasscodeLength);
+        }
         if (mCommissionerPasscodeReady)
         {
             id.SetCommissionerPasscodeReady(true);
@@ -157,6 +168,8 @@ public:
         ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mCancelPasscode:            %s",
                       mCancelPasscode ? "true" : "false");
         ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mCommissioneeInstanceName:  %s", mCommissioneeInstanceName);
+        ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mPasscodeLength:            %d", 
+                      static_cast<uint16_t>(mPasscodeLength));
 
         ChipLogDetail(AppServer, "IdentificationDeclarationOptions::TargetAppInfos list:");
         for (size_t i = 0; i < mTargetAppInfos.size(); i++)

--- a/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
+++ b/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
@@ -168,7 +168,7 @@ public:
         ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mCancelPasscode:            %s",
                       mCancelPasscode ? "true" : "false");
         ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mCommissioneeInstanceName:  %s", mCommissioneeInstanceName);
-        ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mPasscodeLength:            %d", 
+        ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mPasscodeLength:            %d",
                       static_cast<uint16_t>(mPasscodeLength));
 
         ChipLogDetail(AppServer, "IdentificationDeclarationOptions::TargetAppInfos list:");

--- a/src/controller/CommissionerDiscoveryController.cpp
+++ b/src/controller/CommissionerDiscoveryController.cpp
@@ -436,11 +436,13 @@ void CommissionerDiscoveryController::InternalHandleContentAppPasscodeResponse()
 
     if (mPasscodeService != nullptr)
     {
+        ChipLogDetail(AppServer, "UX Ok: have a passcodeService");
         // if CommissionerPasscode
         //    - if CommissionerPasscodeReady, then start commissioning
         //    - if CommissionerPasscode, then call new UX method to show passcode, send CDC
         if (passcode == 0 && client->GetCommissionerPasscode() && client->GetCdPort() != 0)
         {
+            ChipLogDetail(AppServer, "UX Ok: commissioner passcode and passcode from apps is 0");
             char rotatingIdBuffer[Dnssd::kMaxRotatingIdLen * 2];
             size_t rotatingIdLength = client->GetRotatingIdLength();
             CHIP_ERROR err = Encoding::BytesToUppercaseHexBuffer(client->GetRotatingId(), rotatingIdLength, rotatingIdBuffer,
@@ -491,11 +493,13 @@ void CommissionerDiscoveryController::InternalHandleContentAppPasscodeResponse()
                           client->GetPairingInst(), ChipLogValueMEI(client->GetVendorId()), ChipLogValueMEI(client->GetProductId()),
                           client->GetInstanceName());
             mUserPrompter->PromptWithCommissionerPasscode(client->GetVendorId(), client->GetProductId(), client->GetDeviceName(),
-                                                          passcode, client->GetPairingHint(), client->GetPairingInst());
+                                                          passcode, client->GetPasscodeLength(), client->GetPairingHint(), 
+                                                          client->GetPairingInst());
             return;
         }
         if (passcode != 0)
         {
+            ChipLogDetail(AppServer, "UX Ok: passcode is not 0, commissioning");
             CommissionWithPasscode(passcode);
             return;
         }
@@ -525,7 +529,7 @@ void CommissionerDiscoveryController::InternalHandleContentAppPasscodeResponse()
     if (mUserPrompter != nullptr)
     {
         mUserPrompter->PromptForCommissionPasscode(client->GetVendorId(), client->GetProductId(), client->GetDeviceName(),
-                                                   client->GetPairingHint(), client->GetPairingInst());
+                                                   client->GetPairingHint(), client->GetPairingInst(), client->GetPasscodeLength());
     }
     ChipLogDetail(Controller, "------Via Shell Enter: controller ux ok [passcode]");
 }

--- a/src/controller/CommissionerDiscoveryController.cpp
+++ b/src/controller/CommissionerDiscoveryController.cpp
@@ -493,7 +493,7 @@ void CommissionerDiscoveryController::InternalHandleContentAppPasscodeResponse()
                           client->GetPairingInst(), ChipLogValueMEI(client->GetVendorId()), ChipLogValueMEI(client->GetProductId()),
                           client->GetInstanceName());
             mUserPrompter->PromptWithCommissionerPasscode(client->GetVendorId(), client->GetProductId(), client->GetDeviceName(),
-                                                          passcode, client->GetPasscodeLength(), client->GetPairingHint(), 
+                                                          passcode, client->GetPasscodeLength(), client->GetPairingHint(),
                                                           client->GetPairingInst());
             return;
         }

--- a/src/controller/CommissionerDiscoveryController.cpp
+++ b/src/controller/CommissionerDiscoveryController.cpp
@@ -455,7 +455,9 @@ void CommissionerDiscoveryController::InternalHandleContentAppPasscodeResponse()
             // first step of commissioner passcode
             ChipLogError(AppServer, "UX Ok: commissioner passcode, sending CDC");
             // generate a passcode
-            passcode = mPasscodeService->GetCommissionerPasscode(client->GetVendorId(), client->GetProductId(), rotatingIdSpan);
+            PasscodeInfo passcodeInfo = mPasscodeService->GetCommissionerPasscode(client->GetVendorId(), client->GetProductId(),
+                                                                                  rotatingIdSpan);
+            passcode = passcodeInfo.passcode;
             if (passcode == 0)
             {
                 // passcode feature disabled
@@ -473,6 +475,7 @@ void CommissionerDiscoveryController::InternalHandleContentAppPasscodeResponse()
 
             CommissionerDeclaration cd;
             cd.SetCommissionerPasscode(true);
+            cd.SetPasscodeLength(passcodeInfo.displayLength);
             if (mUserPrompter->DisplaysPasscodeAndQRCode())
             {
                 cd.SetQRCodeDisplayed(true);

--- a/src/controller/CommissionerDiscoveryController.cpp
+++ b/src/controller/CommissionerDiscoveryController.cpp
@@ -455,8 +455,8 @@ void CommissionerDiscoveryController::InternalHandleContentAppPasscodeResponse()
             // first step of commissioner passcode
             ChipLogError(AppServer, "UX Ok: commissioner passcode, sending CDC");
             // generate a passcode
-            PasscodeInfo passcodeInfo = mPasscodeService->GetCommissionerPasscode(client->GetVendorId(), client->GetProductId(),
-                                                                                  rotatingIdSpan);
+            PasscodeInfo passcodeInfo =
+                mPasscodeService->GetCommissionerPasscode(client->GetVendorId(), client->GetProductId(), rotatingIdSpan);
             passcode = passcodeInfo.passcode;
             if (passcode == 0)
             {

--- a/src/controller/CommissionerDiscoveryController.h
+++ b/src/controller/CommissionerDiscoveryController.h
@@ -119,7 +119,7 @@ public:
      *
      */
     virtual void PromptWithCommissionerPasscode(uint16_t vendorId, uint16_t productId, const char * commissioneeName,
-                                                uint32_t passcode, uint8_t passcodeLength, uint16_t pairingHint, 
+                                                uint32_t passcode, uint8_t passcodeLength, uint16_t pairingHint,
                                                 const char * pairingInstruction) = 0;
 
     /**

--- a/src/controller/CommissionerDiscoveryController.h
+++ b/src/controller/CommissionerDiscoveryController.h
@@ -153,6 +153,12 @@ public:
     virtual ~UserPrompter() = default;
 };
 
+struct PasscodeInfo
+{
+    uint32_t passcode;
+    uint32_t displayLength;
+};
+
 class DLL_EXPORT PasscodeService
 {
 public:
@@ -177,14 +183,14 @@ public:
     /**
      * @brief
      *   Called to get the commissioner-generated setup passcode.
-     * Returns 0 if feature is disabled.
+     * Returns {0, 0} if feature is disabled.
      *
      *  @param[in]    vendorId           The vendorId in the DNS-SD advertisement of the requesting commissionee.
      *  @param[in]    productId          The productId in the DNS-SD advertisement of the requesting commissionee.
      *  @param[in]    rotatingId         The rotatingId in the DNS-SD advertisement of the requesting commissionee.
      *
      */
-    virtual uint32_t GetCommissionerPasscode(uint16_t vendorId, uint16_t productId, chip::CharSpan rotatingId) = 0;
+    virtual PasscodeInfo GetCommissionerPasscode(uint16_t vendorId, uint16_t productId, chip::CharSpan rotatingId) = 0;
 
     /**
      * @brief

--- a/src/controller/CommissionerDiscoveryController.h
+++ b/src/controller/CommissionerDiscoveryController.h
@@ -156,7 +156,7 @@ public:
 struct PasscodeInfo
 {
     uint32_t passcode;
-    uint32_t displayLength;
+    uint8_t displayLength;
 };
 
 class DLL_EXPORT PasscodeService

--- a/src/controller/CommissionerDiscoveryController.h
+++ b/src/controller/CommissionerDiscoveryController.h
@@ -76,10 +76,11 @@ public:
      *  @param[in]    commissioneeName   The commissioneeName in the DNS-SD advertisement of the requesting commissionee.
      *  @param[in]    pairingHint        The pairingHint in the DNS-SD advertisement of the requesting commissionee.
      *  @param[in]    pairingInstruction The pairingInstruction in the DNS-SD advertisement of the requesting commissionee.
+     *  @param[in]    passcodeLength     The length of the passcode as specificed by the commissionee. 0 means not specified.
      *
      */
     virtual void PromptForCommissionPasscode(uint16_t vendorId, uint16_t productId, const char * commissioneeName,
-                                             uint16_t pairingHint, const char * pairingInstruction) = 0;
+                                             uint16_t pairingHint, const char * pairingInstruction, uint8_t passcodeLength) = 0;
 
     /**
      * @brief
@@ -112,12 +113,14 @@ public:
      *  @param[in]    productId          The productId in the DNS-SD advertisement of the requesting commissionee.
      *  @param[in]    commissioneeName   The commissioneeName in the DNS-SD advertisement of the requesting commissionee.
      *  @param[in]    passcode           The passcode to display.
+     *  @param[in]    passcodeLength     The length of the passcode as specificed by the commissionee. 0 means not specified.
      *  @param[in]    pairingHint        The pairingHint in the DNS-SD advertisement of the requesting commissionee.
      *  @param[in]    pairingInstruction The pairingInstruction in the DNS-SD advertisement of the requesting commissionee.
      *
      */
     virtual void PromptWithCommissionerPasscode(uint16_t vendorId, uint16_t productId, const char * commissioneeName,
-                                                uint32_t passcode, uint16_t pairingHint, const char * pairingInstruction) = 0;
+                                                uint32_t passcode, uint8_t passcodeLength, uint16_t pairingHint, 
+                                                const char * pairingInstruction) = 0;
 
     /**
      * @brief

--- a/src/protocols/user_directed_commissioning/UDCClientState.h
+++ b/src/protocols/user_directed_commissioning/UDCClientState.h
@@ -185,6 +185,9 @@ public:
     void SetCancelPasscode(bool newValue) { mCancelPasscode = newValue; };
     bool GetCancelPasscode() const { return mCancelPasscode; };
 
+    void SetPasscodeLength(uint8_t newValue) { mPasscodeLength = newValue; };
+    uint8_t GetPasscodeLength() const { return mPasscodeLength; };
+
     void SetCachedCommissionerPasscode(uint32_t newValue) { mCachedCommissionerPasscode = newValue; };
     uint32_t GetCachedCommissionerPasscode() const { return mCachedCommissionerPasscode; };
 
@@ -211,6 +214,7 @@ public:
         mUDCClientProcessingState   = UDCClientProcessingState::kNotInitialized;
         mCachedCommissionerPasscode = 0;
         mNumTargetAppInfos          = 0;
+        mPasscodeLength             = 0;
     }
 
 private:
@@ -235,6 +239,7 @@ private:
     bool mCommissionerPasscode      = false;
     bool mCommissionerPasscodeReady = false;
     bool mCancelPasscode            = false;
+    uint8_t mPasscodeLength = 0;
 
     UDCClientProcessingState mUDCClientProcessingState;
     System::Clock::Timestamp mExpirationTime = System::Clock::kZero;

--- a/src/protocols/user_directed_commissioning/UDCClientState.h
+++ b/src/protocols/user_directed_commissioning/UDCClientState.h
@@ -239,7 +239,7 @@ private:
     bool mCommissionerPasscode      = false;
     bool mCommissionerPasscodeReady = false;
     bool mCancelPasscode            = false;
-    uint8_t mPasscodeLength = 0;
+    uint8_t mPasscodeLength         = 0;
 
     UDCClientProcessingState mUDCClientProcessingState;
     System::Clock::Timestamp mExpirationTime = System::Clock::kZero;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -147,6 +147,9 @@ public:
     void SetCancelPasscode(bool newValue) { mCancelPasscode = newValue; };
     bool GetCancelPasscode() const { return mCancelPasscode; };
 
+    void SetPasscodeLength(uint8_t newValue) { mPasscodeLength = newValue; };
+    uint8_t GetPasscodeLength() const { return mPasscodeLength; };
+
     /**
      *  Writes the IdentificationDeclaration message to the given buffer.
      *
@@ -185,6 +188,7 @@ public:
         client->SetCommissionerPasscode(GetCommissionerPasscode());
         client->SetCommissionerPasscodeReady(GetCommissionerPasscodeReady());
         client->SetCancelPasscode(GetCancelPasscode());
+        client->SetPasscodeLength(GetPasscodeLength());
     }
 
     void DebugLog()
@@ -247,6 +251,10 @@ public:
         {
             ChipLogDetail(AppServer, "\tcancel passcode: true");
         }
+        if (mPasscodeLength != 0)
+        {
+            ChipLogDetail(AppServer, "\tpasscode length: %d", static_cast<uint16_t>(mPasscodeLength));
+        }
         ChipLogDetail(AppServer, "---- Identification Declaration End ----");
     }
 
@@ -271,6 +279,7 @@ private:
         kCommissionerPasscodeTag,
         kCommissionerPasscodeReadyTag,
         kCancelPasscodeTag,
+        kPasscodeLengthTag,
 
         kMaxNum = UINT8_MAX
     };
@@ -296,6 +305,7 @@ private:
     bool mCommissionerPasscode      = false;
     bool mCommissionerPasscodeReady = false;
     bool mCancelPasscode            = false;
+    uint8_t mPasscodeLength       = 0;
 };
 
 /**

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -305,7 +305,7 @@ private:
     bool mCommissionerPasscode      = false;
     bool mCommissionerPasscodeReady = false;
     bool mCancelPasscode            = false;
-    uint8_t mPasscodeLength       = 0;
+    uint8_t mPasscodeLength         = 0;
 };
 
 /**

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -96,7 +96,7 @@ public:
     size_t GetRotatingIdLength() const { return mRotatingIdLen; }
     void SetRotatingId(const uint8_t * rotatingId, size_t rotatingIdLen)
     {
-        size_t maxSize = MATTER_ARRAY_SIZE(mRotatingId);
+        size_t maxSize = ArraySize(mRotatingId);
         mRotatingIdLen = (maxSize < rotatingIdLen) ? maxSize : rotatingIdLen;
         memcpy(mRotatingId, rotatingId, mRotatingIdLen);
     }
@@ -351,6 +351,9 @@ public:
     void SetCancelPasscode(bool newValue) { mCancelPasscode = newValue; };
     bool GetCancelPasscode() const { return mCancelPasscode; };
 
+    void SetPasscodeLength(uint4_t newValue) { mPasscodeLength = newValue; };
+    uint4_t GetPasscodeLength() const { return mPasscodeLength; };
+
     /**
      *  Writes the CommissionerDeclaration message to the given buffer.
      *
@@ -396,6 +399,10 @@ public:
         {
             ChipLogDetail(AppServer, "\tPasscode cancelled: true");
         }
+        if (mPasscodeLength != 0)
+        {
+            ChipLogDetail(AppServer, "\ttPasscode length: %d", static_cast<uint16_t>(mPasscodeLength));
+        }
         ChipLogDetail(AppServer, "---- Commissioner Declaration End ----");
     }
 
@@ -410,6 +417,7 @@ private:
         kCommissionerPasscodeTag,
         kQRCodeDisplayedTag,
         kCancelPasscodeTag,
+        kPasscodeLengthTag,
 
         kMaxNum = UINT8_MAX
     };
@@ -421,6 +429,7 @@ private:
     bool mCommissionerPasscode    = false;
     bool mQRCodeDisplayed         = false;
     bool mCancelPasscode          = false;
+    uint4_t mPasscodeLength       = 0;
 };
 
 class DLL_EXPORT InstanceNameResolver

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -351,7 +351,7 @@ public:
     void SetCancelPasscode(bool newValue) { mCancelPasscode = newValue; };
     bool GetCancelPasscode() const { return mCancelPasscode; };
 
-    void SetPasscodeLength(uint4_t newValue) { mPasscodeLength = newValue; };
+    void SetPasscodeLength(uint8_t newValue) { mPasscodeLength = newValue; };
     uint4_t GetPasscodeLength() const { return mPasscodeLength; };
 
     /**
@@ -401,7 +401,7 @@ public:
         }
         if (mPasscodeLength != 0)
         {
-            ChipLogDetail(AppServer, "\ttPasscode length: %d", static_cast<uint16_t>(mPasscodeLength));
+            ChipLogDetail(AppServer, "\tpasscode length: %d", static_cast<uint16_t>(mPasscodeLength));
         }
         ChipLogDetail(AppServer, "---- Commissioner Declaration End ----");
     }
@@ -429,7 +429,7 @@ private:
     bool mCommissionerPasscode    = false;
     bool mQRCodeDisplayed         = false;
     bool mCancelPasscode          = false;
-    uint4_t mPasscodeLength       = 0;
+    uint8_t mPasscodeLength       = 0;
 };
 
 class DLL_EXPORT InstanceNameResolver

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -96,7 +96,7 @@ public:
     size_t GetRotatingIdLength() const { return mRotatingIdLen; }
     void SetRotatingId(const uint8_t * rotatingId, size_t rotatingIdLen)
     {
-        size_t maxSize = ArraySize(mRotatingId);
+        size_t maxSize = MATTER_ARRAY_SIZE(mRotatingId);
         mRotatingIdLen = (maxSize < rotatingIdLen) ? maxSize : rotatingIdLen;
         memcpy(mRotatingId, rotatingId, mRotatingIdLen);
     }
@@ -352,7 +352,7 @@ public:
     bool GetCancelPasscode() const { return mCancelPasscode; };
 
     void SetPasscodeLength(uint8_t newValue) { mPasscodeLength = newValue; };
-    uint4_t GetPasscodeLength() const { return mPasscodeLength; };
+    uint8_t GetPasscodeLength() const { return mPasscodeLength; };
 
     /**
      *  Writes the CommissionerDeclaration message to the given buffer.

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
@@ -169,6 +169,8 @@ uint32_t IdentificationDeclaration::WritePayload(uint8_t * payloadBuffer, size_t
                  LogErrorOnFailure(err));
     VerifyOrExit(CHIP_NO_ERROR == (err = writer.PutBoolean(chip::TLV::ContextTag(kCancelPasscodeTag), mCancelPasscode)),
                  LogErrorOnFailure(err));
+    VerifyOrExit(CHIP_NO_ERROR == (err = writer.Put(chip::TLV::ContextTag(kPasscodeLengthTag), GetPasscodeLength())),
+                 LogErrorOnFailure(err));
 
     VerifyOrExit(CHIP_NO_ERROR == (err = writer.EndContainer(outerContainerType)), LogErrorOnFailure(err));
     VerifyOrExit(CHIP_NO_ERROR == (err = writer.Finalize()), LogErrorOnFailure(err));

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
@@ -226,6 +226,9 @@ CHIP_ERROR CommissionerDeclaration::ReadPayload(uint8_t * udcPayload, size_t pay
         case kCancelPasscodeTag:
             err = reader.Get(mCancelPasscode);
             break;
+        case kPasscodeLengthTag:
+            err = reader.Get(mPasscodeLength);
+            break;
         }
     }
 

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -437,6 +437,7 @@ uint32_t CommissionerDeclaration::WritePayload(uint8_t * payloadBuffer, size_t p
                  LogErrorOnFailure(err));
     VerifyOrExit(CHIP_NO_ERROR == (err = writer.PutBoolean(chip::TLV::ContextTag(kCancelPasscodeTag), mCancelPasscode)),
                  LogErrorOnFailure(err));
+    VerifyOrExit(CHIP_NO_ERROR == (err = writer.Put(chip::TLV::ContextTag(kPasscodeLengthTag), GetPasscodeLength())), LogErrorOnFailure(err));
 
     VerifyOrExit(CHIP_NO_ERROR == (err = writer.EndContainer(outerContainerType)), LogErrorOnFailure(err));
     VerifyOrExit(CHIP_NO_ERROR == (err = writer.Finalize()), LogErrorOnFailure(err));

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -437,7 +437,7 @@ uint32_t CommissionerDeclaration::WritePayload(uint8_t * payloadBuffer, size_t p
                  LogErrorOnFailure(err));
     VerifyOrExit(CHIP_NO_ERROR == (err = writer.PutBoolean(chip::TLV::ContextTag(kCancelPasscodeTag), mCancelPasscode)),
                  LogErrorOnFailure(err));
-    VerifyOrExit(CHIP_NO_ERROR == (err = writer.Put(chip::TLV::ContextTag(kPasscodeLengthTag), GetPasscodeLength())), 
+    VerifyOrExit(CHIP_NO_ERROR == (err = writer.Put(chip::TLV::ContextTag(kPasscodeLengthTag), GetPasscodeLength())),
                  LogErrorOnFailure(err));
 
     VerifyOrExit(CHIP_NO_ERROR == (err = writer.EndContainer(outerContainerType)), LogErrorOnFailure(err));

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -386,6 +386,9 @@ CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t p
         case kCancelPasscodeTag:
             err = reader.Get(mCancelPasscode);
             break;
+        case kPasscodeLengthTag:
+            err = reader.Get(mPasscodeLength);
+            break;
         }
         if (err != CHIP_NO_ERROR)
         {

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -437,7 +437,8 @@ uint32_t CommissionerDeclaration::WritePayload(uint8_t * payloadBuffer, size_t p
                  LogErrorOnFailure(err));
     VerifyOrExit(CHIP_NO_ERROR == (err = writer.PutBoolean(chip::TLV::ContextTag(kCancelPasscodeTag), mCancelPasscode)),
                  LogErrorOnFailure(err));
-    VerifyOrExit(CHIP_NO_ERROR == (err = writer.Put(chip::TLV::ContextTag(kPasscodeLengthTag), GetPasscodeLength())), LogErrorOnFailure(err));
+    VerifyOrExit(CHIP_NO_ERROR == (err = writer.Put(chip::TLV::ContextTag(kPasscodeLengthTag), GetPasscodeLength())), 
+                 LogErrorOnFailure(err));
 
     VerifyOrExit(CHIP_NO_ERROR == (err = writer.EndContainer(outerContainerType)), LogErrorOnFailure(err));
     VerifyOrExit(CHIP_NO_ERROR == (err = writer.Finalize()), LogErrorOnFailure(err));

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -390,6 +390,7 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclaration)
     const char * deviceName   = "device1";
     uint16_t pairingHint      = 33;
     const char * pairingInst  = "Read 6 digit code from screen";
+    uint8_t passcodeLength    = 6;
 
     TargetAppInfo appInfo;
 
@@ -426,6 +427,7 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclaration)
     id.SetCdUponPasscodeDialog(true);
     id.SetCommissionerPasscode(true);
     id.SetCommissionerPasscodeReady(true);
+    id.SetPasscodeLength(passcodeLength);
 
     EXPECT_TRUE(id.HasDiscoveryInfo());
     EXPECT_STREQ(id.GetInstanceName(), instanceName);
@@ -446,6 +448,7 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclaration)
     EXPECT_EQ(id.GetCdUponPasscodeDialog(), true);
     EXPECT_EQ(id.GetCommissionerPasscode(), true);
     EXPECT_EQ(id.GetCommissionerPasscodeReady(), true);
+    EXPECT_EQ(id.GetPasscodeLength(), passcodeLength);
 
     // TODO: add an ip
 
@@ -475,6 +478,7 @@ TEST_F(TestUdcMessages, TestUDCIdentificationDeclaration)
     EXPECT_EQ(id.GetCdUponPasscodeDialog(), idOut.GetCdUponPasscodeDialog());
     EXPECT_EQ(id.GetCommissionerPasscode(), idOut.GetCommissionerPasscode());
     EXPECT_EQ(id.GetCommissionerPasscodeReady(), idOut.GetCommissionerPasscodeReady());
+    EXPECT_EQ(id.GetPasscodeLength(), idOut.GetPasscodeLength());
 
     // TODO: remove following "force-fail" debug line
     // NL_TEST_ASSERT(inSuite, rotatingIdLen != id.GetRotatingIdLength());

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -493,6 +493,7 @@ TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)
     id.SetPasscodeDialogDisplayed(true);
     id.SetCommissionerPasscode(true);
     id.SetQRCodeDisplayed(true);
+    id.SetPasscodeLength(8);
 
     EXPECT_EQ(errorCode, id.GetErrorCode());
     EXPECT_EQ(id.GetNeedsPasscode(), true);
@@ -500,6 +501,7 @@ TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)
     EXPECT_EQ(id.GetPasscodeDialogDisplayed(), true);
     EXPECT_EQ(id.GetCommissionerPasscode(), true);
     EXPECT_EQ(id.GetQRCodeDisplayed(), true);
+    EXPECT_EQ(id.GetPasscodeLength(), 8);
 
     uint8_t idBuffer[500];
     id.WritePayload(idBuffer, sizeof(idBuffer));
@@ -513,4 +515,5 @@ TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)
     EXPECT_EQ(id.GetPasscodeDialogDisplayed(), idOut.GetPasscodeDialogDisplayed());
     EXPECT_EQ(id.GetCommissionerPasscode(), idOut.GetCommissionerPasscode());
     EXPECT_EQ(id.GetQRCodeDisplayed(), idOut.GetQRCodeDisplayed());
+    EXPECT_EQ(id.GetPasscodeLength(), idOut.GetPasscodeLength());
 }


### PR DESCRIPTION
Add new passcodeLength field in CDC field
Update PasscodeService to return both a passcode and a display length

Addresses https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/12129

### Testing
> run linux tv-app
> run linux tv-casting-app
> verify length