### PR TITLE
Reduce the codesize of enum encoding in attribute values.

### DIFF
--- a/src/app/AttributeValueEncoder.h
+++ b/src/app/AttributeValueEncoder.h
@@ -107,7 +107,8 @@ public:
             return mAttributeValueEncoder.EncodeListItem(mCheckpoint, aArg, mAttributeValueEncoder.AccessingFabricIndex());
         }
 
-        template <typename T, std::enable_if_t<IsBaseType<T> && !DataModel::IsFabricScoped<T>::value && !IsMatterEnum<T>, bool> = true>
+        template <typename T,
+                  std::enable_if_t<IsBaseType<T> && !DataModel::IsFabricScoped<T>::value && !IsMatterEnum<T>, bool> = true>
         CHIP_ERROR Encode(const T & aArg) const
         {
             return mAttributeValueEncoder.EncodeListItem(mCheckpoint, aArg);
@@ -119,8 +120,8 @@ public:
         CHIP_ERROR Encode(const T & aArg) const
         {
             static_assert(!DataModel::IsFabricScoped<T>::value, "How do we have a fabric-scoped enum?");
-            static_assert(!std::is_same_v<std::remove_cv_t<std::remove_reference_t<decltype(to_underlying(aArg))>>, T>,
-                          "Encode will call itself recursively");
+            using UnderlyingType = std::remove_cv_t<std::remove_reference_t<decltype(to_underlying(aArg))>>;
+            static_assert(!std::is_same_v<UnderlyingType, T>, "Encode will call itself recursively");
 
             CHIP_DM_ENCODING_MAYBE_FAIL_UNKNOWN_ENUM_VALUE(aArg);
 
@@ -165,8 +166,8 @@ public:
     template <typename T, std::enable_if_t<IsBaseType<T> && IsMatterEnum<T>, bool> = true>
     CHIP_ERROR Encode(const T & aArg)
     {
-        static_assert(!std::is_same_v<std::remove_cv_t<std::remove_reference_t<decltype(to_underlying(aArg))>>, T>,
-                      "Encode will call itself recursively");
+        using UnderlyingType = std::remove_cv_t<std::remove_reference_t<decltype(to_underlying(aArg))>>;
+        static_assert(!std::is_same_v<UnderlyingType, T>, "Encode will call itself recursively");
 
         CHIP_DM_ENCODING_MAYBE_FAIL_UNKNOWN_ENUM_VALUE(aArg);
 

--- a/src/app/AttributeValueEncoder.h
+++ b/src/app/AttributeValueEncoder.h
@@ -25,6 +25,7 @@
 #include <app/data-model/List.h>
 #include <lib/support/BitFlags.h>
 #include <lib/support/BitMask.h>
+#include <lib/support/TypeTraits.h>
 
 #include <type_traits>
 
@@ -84,6 +85,9 @@ private:
     template <typename T>
     static constexpr bool IsBaseType = std::is_same_v<const T &, decltype(BaseEncodableValue(std::declval<const T &>()))>;
 
+    template <typename T>
+    static constexpr bool IsMatterEnum = std::is_enum_v<T> && DataModel::detail::HasUnknownValue<T>;
+
 public:
     class ListEncodeHelper
     {
@@ -103,10 +107,24 @@ public:
             return mAttributeValueEncoder.EncodeListItem(mCheckpoint, aArg, mAttributeValueEncoder.AccessingFabricIndex());
         }
 
-        template <typename T, std::enable_if_t<IsBaseType<T> && !DataModel::IsFabricScoped<T>::value, bool> = true>
+        template <typename T, std::enable_if_t<IsBaseType<T> && !DataModel::IsFabricScoped<T>::value && !IsMatterEnum<T>, bool> = true>
         CHIP_ERROR Encode(const T & aArg) const
         {
             return mAttributeValueEncoder.EncodeListItem(mCheckpoint, aArg);
+        }
+
+        // Specialization for enums to share as much code as possible in attribute encoding while
+        // still doing the "unknown value" checks that might be needed..
+        template <typename T, std::enable_if_t<IsBaseType<T> && IsMatterEnum<T>, bool> = true>
+        CHIP_ERROR Encode(const T & aArg) const
+        {
+            static_assert(!DataModel::IsFabricScoped<T>::value, "How do we have a fabric-scoped enum?");
+            static_assert(!std::is_same_v<std::remove_cv_t<std::remove_reference_t<decltype(to_underlying(aArg))>>, T>,
+                          "Encode will call itself recursively");
+
+            CHIP_DM_ENCODING_MAYBE_FAIL_UNKNOWN_ENUM_VALUE(aArg);
+
+            return Encode(to_underlying(aArg));
         }
 
         template <typename T, std::enable_if_t<!IsBaseType<T>, bool> = true>
@@ -137,11 +155,22 @@ public:
      * entirely encoded or fail to be encoded.  Consumers are allowed to make
      * either one call to Encode or one call to EncodeList to handle a read.
      */
-    template <typename T, std::enable_if_t<IsBaseType<T>, bool> = true>
+    template <typename T, std::enable_if_t<IsBaseType<T> && !IsMatterEnum<T>, bool> = true>
     CHIP_ERROR Encode(const T & aArg)
     {
         mTriedEncode = true;
         return EncodeAttributeReportIB(aArg);
+    }
+
+    template <typename T, std::enable_if_t<IsBaseType<T> && IsMatterEnum<T>, bool> = true>
+    CHIP_ERROR Encode(const T & aArg)
+    {
+        static_assert(!std::is_same_v<std::remove_cv_t<std::remove_reference_t<decltype(to_underlying(aArg))>>, T>,
+                      "Encode will call itself recursively");
+
+        CHIP_DM_ENCODING_MAYBE_FAIL_UNKNOWN_ENUM_VALUE(aArg);
+
+        return Encode(to_underlying(aArg));
     }
 
     template <typename T, std::enable_if_t<!IsBaseType<T>, bool> = true>

--- a/src/app/data-model/Encode.h
+++ b/src/app/data-model/Encode.h
@@ -70,17 +70,19 @@ CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, X x)
 // Reusable macro for dealing with unknown enum values that we can use in
 // attribute value encoding.
 #if CHIP_CONFIG_IM_ENABLE_ENCODING_SENTINEL_ENUM_VALUES
-#define CHIP_DM_ENCODING_MAYBE_FAIL_UNKNOWN_ENUM_VALUE(value) \
-    do {                                                      \
-        /* Nothing to do */                                   \
+#define CHIP_DM_ENCODING_MAYBE_FAIL_UNKNOWN_ENUM_VALUE(value)                                                                      \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        /* Nothing to do */                                                                                                        \
     } while (0)
 #else
-#define CHIP_DM_ENCODING_MAYBE_FAIL_UNKNOWN_ENUM_VALUE(value) \
-    do {                                                      \
-        if (value == std::remove_reference_t<decltype(value)>::kUnknownEnumValue) \
-        {                                                     \
-            return CHIP_IM_GLOBAL_STATUS(ConstraintError);    \
-        }                                                     \
+#define CHIP_DM_ENCODING_MAYBE_FAIL_UNKNOWN_ENUM_VALUE(value)                                                                      \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (value == std::remove_reference_t<decltype(value)>::kUnknownEnumValue)                                                  \
+        {                                                                                                                          \
+            return CHIP_IM_GLOBAL_STATUS(ConstraintError);                                                                         \
+        }                                                                                                                          \
     } while (0)
 #endif // CHIP_CONFIG_IM_ENABLE_ENCODING_SENTINEL_ENUM_VALUES
 

--- a/src/app/data-model/Encode.h
+++ b/src/app/data-model/Encode.h
@@ -20,6 +20,7 @@
 
 #include <app/data-model/FabricScoped.h>
 #include <app/data-model/Nullable.h>
+#include <lib/core/CHIPConfig.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
@@ -66,15 +67,27 @@ CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, X x)
     return writer.Put(tag, x);
 }
 
+// Reusable macro for dealing with unknown enum values that we can use in
+// attribute value encoding.
+#if CHIP_CONFIG_IM_ENABLE_ENCODING_SENTINEL_ENUM_VALUES
+#define CHIP_DM_ENCODING_MAYBE_FAIL_UNKNOWN_ENUM_VALUE(value) \
+    do {                                                      \
+        /* Nothing to do */                                   \
+    } while (0)
+#else
+#define CHIP_DM_ENCODING_MAYBE_FAIL_UNKNOWN_ENUM_VALUE(value) \
+    do {                                                      \
+        if (value == std::remove_reference_t<decltype(value)>::kUnknownEnumValue) \
+        {                                                     \
+            return CHIP_IM_GLOBAL_STATUS(ConstraintError);    \
+        }                                                     \
+    } while (0)
+#endif // CHIP_CONFIG_IM_ENABLE_ENCODING_SENTINEL_ENUM_VALUES
+
 template <typename X, typename std::enable_if_t<std::is_enum<X>::value && detail::HasUnknownValue<X>, int> = 0>
 CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, X x)
 {
-#if !CHIP_CONFIG_IM_ENABLE_ENCODING_SENTINEL_ENUM_VALUES
-    if (x == X::kUnknownEnumValue)
-    {
-        return CHIP_IM_GLOBAL_STATUS(ConstraintError);
-    }
-#endif // !CHIP_CONFIG_IM_ENABLE_ENCODING_SENTINEL_ENUM_VALUES
+    CHIP_DM_ENCODING_MAYBE_FAIL_UNKNOWN_ENUM_VALUE(x);
 
     return writer.Put(tag, x);
 }


### PR DESCRIPTION
If we hoist up the "is this a valid enum value?" check, we can share a bunch of the "encode an attribute data IB" code with the generic unsigned integer case.

#### Testing

This should compile and change CI; no expected behavior changes except smaller codesize.