### PR TITLE
Enforce spec-valid OTA block sizes in Matter.framework.

### DIFF
--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
@@ -19,6 +19,7 @@
 #import "MTRDeviceControllerFactory_Internal.h"
 #import "MTRDeviceController_Internal.h"
 #import "MTRError_Internal.h"
+#import "MTRLogging_Internal.h"
 #import "MTRMetricKeys.h"
 #import "MTRMetricsCollector.h"
 #import "MTROTAUnsolicitedBDXMessageHandler.h"
@@ -368,6 +369,20 @@ CHIP_ERROR MTROTAImageTransferHandler::OnBlockQuery(const TransferSession::Outpu
                 }
 
                 if (data == nil) {
+                    MTR_LOG_ERROR("Nil OTA data block when updating " ChipLogFormatScopedNodeId,
+                        ChipLogValueScopedNodeId(strongWrapper.otaImageTransferHandler->mPeer));
+                    NotifyEventHandled(eventType, CHIP_ERROR_INCORRECT_STATE);
+                    return;
+                }
+
+                if (data.length != blockSize.unsignedLongLongValue && !isEOF) {
+                    // "Transfer of OTA Software Update images" in the spec says:
+                    //
+                    // Actual Block Size used over all transports SHALL be the negotiated Maximum
+                    // Block Size for every block except the last one, which may be of any size less
+                    // or equal to the Maximum Block Size (including zero).
+                    MTR_LOG_ERROR("Invalid OTA block size %llu for non-final block when updating " ChipLogFormatScopedNodeId ".  Expected block of size %@",
+                        static_cast<unsigned long long>(data.length), ChipLogValueScopedNodeId(strongWrapper.otaImageTransferHandler->mPeer), blockSize);
                     NotifyEventHandled(eventType, CHIP_ERROR_INCORRECT_STATE);
                     return;
                 }

--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
@@ -381,8 +381,8 @@ CHIP_ERROR MTROTAImageTransferHandler::OnBlockQuery(const TransferSession::Outpu
                     // Actual Block Size used over all transports SHALL be the negotiated Maximum
                     // Block Size for every block except the last one, which may be of any size less
                     // or equal to the Maximum Block Size (including zero).
-                    MTR_LOG_ERROR("Invalid OTA block size %llu for non-final block when updating " ChipLogFormatScopedNodeId ".  Expected block of size %@",
-                        static_cast<unsigned long long>(data.length), ChipLogValueScopedNodeId(strongWrapper.otaImageTransferHandler->mPeer), blockSize);
+                    MTR_LOG_ERROR("Invalid OTA block size %lu for non-final block when updating " ChipLogFormatScopedNodeId ".  Expected block of size %@",
+                        static_cast<unsigned long>(data.length), ChipLogValueScopedNodeId(strongWrapper.otaImageTransferHandler->mPeer), blockSize);
                     NotifyEventHandled(eventType, CHIP_ERROR_INCORRECT_STATE);
                     return;
                 }

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
@@ -155,6 +155,10 @@ NS_ASSUME_NONNULL_BEGIN
  * Notify the delegate when a BDX Query message has been received for some node.
  * The controller identifies the fabric the node is on, and the nodeID
  * identifies the node within that fabric.
+ *
+ * The data passed to the completion must be of size blockSize, unless it's the
+ * last block of data.  In that case, it may be smaller than blockSize, and
+ * isEOF must be set to YES.
  */
 - (void)handleBDXQueryForNodeID:(NSNumber *)nodeID
                      controller:(MTRDeviceController *)controller


### PR DESCRIPTION
#### Summary

The spec requires all blocks except the last one to be the max block size.

#### Testing

New code protects against bad behavior no one is exhibiting right now yet.  Normal OTA should be unaffected and is tested.