### PR TITLE
Remove unused setupPayload variable in MTRBaseDevice.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -2021,7 +2021,6 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
                 });
             };
 
-            SetupPayload setupPayload;
             auto errorCode = OpenCommissioningWindowHelper::OpenCommissioningWindow(commissioner, self.nodeID,
                 chip::System::Clock::Seconds16(static_cast<uint16_t>(durationVal)), static_cast<uint16_t>(discriminatorVal),
                 passcode, resultCallback);


### PR DESCRIPTION
This variable is not used for anything.

#### Testing

No behavior changes.