### PR TITLE
Closure App command timeout optimisation

### DIFF
--- a/examples/closure-app/linux/ClosureManager.cpp
+++ b/examples/closure-app/linux/ClosureManager.cpp
@@ -753,9 +753,9 @@ void ClosureManager::HandlePanelStepAction(EndpointId endpointId)
         {
             // Underflow protection: if currentPosition <= stepValue, set to 0.
             chip::Percent100ths decreasedCurrentPosition = (currentPosition > stepValue)
-                                                        ? static_cast<chip::Percent100ths>(currentPosition - stepValue)
-                                                        : static_cast<chip::Percent100ths>(0);
-            nextCurrentPosition = std::max(decreasedCurrentPosition, targetPosition);
+                ? static_cast<chip::Percent100ths>(currentPosition - stepValue)
+                : static_cast<chip::Percent100ths>(0);
+            nextCurrentPosition                          = std::max(decreasedCurrentPosition, targetPosition);
         }
 
         panelCurrentState.Value().position.SetValue(DataModel::MakeNullable(nextCurrentPosition));
@@ -943,7 +943,8 @@ bool ClosureManager::GetPanelNextPosition(const GenericDimensionStateStruct & cu
     else if (currentPosition > targetPosition)
     {
         // Handling overflow for CurrentPosition
-        chip::Percent100ths newCurrentPosition = (currentPosition > kMotionPositionStep) ? currentPosition - kMotionPositionStep : 0;
+        chip::Percent100ths newCurrentPosition =
+            (currentPosition > kMotionPositionStep) ? currentPosition - kMotionPositionStep : 0;
         // Moving down: Decreasing the current position by a step of 2000 units,
         // ensuring it does not go below the target position.
         nextPosition.SetNonNull(std::max(newCurrentPosition, targetPosition));

--- a/examples/closure-app/linux/ClosureManager.cpp
+++ b/examples/closure-app/linux/ClosureManager.cpp
@@ -34,8 +34,9 @@ using namespace chip::app::Clusters::ClosureDimension;
 namespace {
 // Define a constant for the countdown time
 constexpr uint32_t kCountdownTimeSeconds          = 10;
+constexpr uint32_t kCalibrateCountdownTimeMs      = 3000; // 3 seconds for calibrate motion
 constexpr uint32_t kMotionCountdownTimeMs         = 1000; // 1 second for each motion.
-constexpr chip::Percent100ths kMotionPositionStep = 1000; // 10% of the total range per motion interval.
+constexpr chip::Percent100ths kMotionPositionStep = 2000; // 20% of the total range per motion interval.
 
 // Define the Namespace and Tag for the endpoint
 // Derived from https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/namespaces/Namespace-Closure.adoc
@@ -169,7 +170,7 @@ CHIP_ERROR ClosureManager::SetClosurePanelInitialState(ClosureDimensionEndpoint 
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetTargetState(targetState));
 
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetResolution(Percent100ths(100)));
-    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetStepValue(1000));
+    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetStepValue(2000));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetUnit(ClosureUnitEnum::kMillimeter));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetUnitRange(
         ClosureDimension::Structs::UnitRangeStruct::Type{ .min = static_cast<int16_t>(0), .max = static_cast<int16_t>(10000) }));
@@ -198,7 +199,7 @@ chip::Protocols::InteractionModel::Status ClosureManager::OnCalibrateCommand()
 
     // For sample application, we are using a timer to simulate the hardware calibration action.
     // In a real application, this would be replaced with actual calibration logic and call HandleClosureActionComplete.
-    VerifyOrReturnValue(DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(kCountdownTimeSeconds),
+    VerifyOrReturnValue(DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kCalibrateCountdownTimeMs),
                                                               HandleEp1ClosureActionTimer, nullptr) == CHIP_NO_ERROR,
                         Status::Failure, ChipLogError(AppServer, "Failed to start closure action timer"));
 
@@ -275,16 +276,16 @@ ClosureManager::OnMoveToCommand(const Optional<TargetPositionEnum> & position, c
             ep3Position = static_cast<chip::Percent100ths>(0);
             break;
         case TargetPositionEnum::kMoveToPedestrianPosition:
-            ep2Position = static_cast<chip::Percent100ths>(3000);
-            ep3Position = static_cast<chip::Percent100ths>(3000);
+            ep2Position = static_cast<chip::Percent100ths>(6000);
+            ep3Position = static_cast<chip::Percent100ths>(6000);
             break;
         case TargetPositionEnum::kMoveToSignaturePosition:
-            ep2Position = static_cast<chip::Percent100ths>(2000);
-            ep3Position = static_cast<chip::Percent100ths>(2000);
+            ep2Position = static_cast<chip::Percent100ths>(4000);
+            ep3Position = static_cast<chip::Percent100ths>(4000);
             break;
         case TargetPositionEnum::kMoveToVentilationPosition:
-            ep2Position = static_cast<chip::Percent100ths>(1000);
-            ep3Position = static_cast<chip::Percent100ths>(1000);
+            ep2Position = static_cast<chip::Percent100ths>(2000);
+            ep3Position = static_cast<chip::Percent100ths>(2000);
             break;
         default:
             ChipLogError(AppServer, "Invalid target position received in OnMoveToCommand");
@@ -750,7 +751,11 @@ void ClosureManager::HandlePanelStepAction(EndpointId endpointId)
         }
         else
         {
-            nextCurrentPosition = std::max(static_cast<chip::Percent100ths>(currentPosition - stepValue), targetPosition);
+            // Underflow protection: if currentPosition <= stepValue, set to 0.
+            chip::Percent100ths decreasedCurrentPosition = (currentPosition > stepValue)
+                                                        ? static_cast<chip::Percent100ths>(currentPosition - stepValue)
+                                                        : static_cast<chip::Percent100ths>(0);
+            nextCurrentPosition = std::max(decreasedCurrentPosition, targetPosition);
         }
 
         panelCurrentState.Value().position.SetValue(DataModel::MakeNullable(nextCurrentPosition));
@@ -931,14 +936,17 @@ bool ClosureManager::GetPanelNextPosition(const GenericDimensionStateStruct & cu
 
     if (currentPosition < targetPosition)
     {
-        // Increment position by 1000 units, capped at target.
+        // Increment position by 2000 units, capped at target.
+        // No overflow handling needed due to currentposition max value is 10000
         nextPosition.SetNonNull(std::min(static_cast<chip::Percent100ths>(currentPosition + kMotionPositionStep), targetPosition));
     }
     else if (currentPosition > targetPosition)
     {
-        // Moving down: Decreasing the current position by a step of 1000 units,
+        // Handling overflow for CurrentPosition
+        chip::Percent100ths newCurrentPosition = (currentPosition > kMotionPositionStep) ? currentPosition - kMotionPositionStep : 0;
+        // Moving down: Decreasing the current position by a step of 2000 units,
         // ensuring it does not go below the target position.
-        nextPosition.SetNonNull(std::max(static_cast<chip::Percent100ths>(currentPosition - kMotionPositionStep), targetPosition));
+        nextPosition.SetNonNull(std::max(newCurrentPosition, targetPosition));
     }
     else
     {

--- a/examples/closure-app/silabs/src/ClosureManager.cpp
+++ b/examples/closure-app/silabs/src/ClosureManager.cpp
@@ -37,10 +37,10 @@ using namespace chip::app::Clusters::ClosureControl;
 using namespace chip::app::Clusters::ClosureDimension;
 
 namespace {
-constexpr uint32_t kDefaultCountdownTimeSeconds   = 10;    // 10 seconds
+constexpr uint32_t kDefaultCountdownTimeSeconds   = 10;   // 10 seconds
 constexpr uint32_t kCalibrateCountdownTimeMs      = 3000; // 3 seconds
-constexpr uint32_t kMotionCountdownTimeMs         = 1000;  // 1 second for each motion.
-constexpr chip::Percent100ths kMotionPositionStep = 2000;  // 20% of the total range per motion interval.
+constexpr uint32_t kMotionCountdownTimeMs         = 1000; // 1 second for each motion.
+constexpr chip::Percent100ths kMotionPositionStep = 2000; // 20% of the total range per motion interval.
 
 // Define the Namespace and Tag for the endpoint
 // Derived from https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/namespaces/Namespace-Closure.adoc
@@ -1102,11 +1102,11 @@ void ClosureManager::HandlePanelStepAction(EndpointId endpointId)
         }
         else
         {
-                        // Underflow protection: if currentPosition <= stepValue, set to 0.
+            // Underflow protection: if currentPosition <= stepValue, set to 0.
             chip::Percent100ths decreasedCurrentPosition = (currentPosition > stepValue)
-                                                        ? static_cast<chip::Percent100ths>(currentPosition - stepValue)
-                                                        : static_cast<chip::Percent100ths>(0);
-            nextCurrentPosition = std::max(decreasedCurrentPosition, targetPosition);
+                ? static_cast<chip::Percent100ths>(currentPosition - stepValue)
+                : static_cast<chip::Percent100ths>(0);
+            nextCurrentPosition                          = std::max(decreasedCurrentPosition, targetPosition);
         }
 
         panelCurrentState.Value().position.SetValue(DataModel::MakeNullable(nextCurrentPosition));
@@ -1168,7 +1168,8 @@ bool ClosureManager::GetPanelNextPosition(const GenericDimensionStateStruct & cu
     else if (currentPosition > targetPosition)
     {
         // Handling overflow for CurrentPosition
-        chip::Percent100ths newCurrentPosition = (currentPosition > kMotionPositionStep) ? currentPosition - kMotionPositionStep : 0;
+        chip::Percent100ths newCurrentPosition =
+            (currentPosition > kMotionPositionStep) ? currentPosition - kMotionPositionStep : 0;
         // Moving down: Decreasing the current position by a step of 2000 units,
         // ensuring it does not go below the target position.
         nextPosition.SetNonNull(std::max(newCurrentPosition, targetPosition));

--- a/examples/closure-app/silabs/src/ClosureManager.cpp
+++ b/examples/closure-app/silabs/src/ClosureManager.cpp
@@ -38,9 +38,9 @@ using namespace chip::app::Clusters::ClosureDimension;
 
 namespace {
 constexpr uint32_t kDefaultCountdownTimeSeconds   = 10;    // 10 seconds
-constexpr uint32_t kCalibrateTimerMs              = 10000; // 10 seconds
+constexpr uint32_t kCalibrateCountdownTimeMs      = 3000; // 3 seconds
 constexpr uint32_t kMotionCountdownTimeMs         = 1000;  // 1 second for each motion.
-constexpr chip::Percent100ths kMotionPositionStep = 1000;  // 10% of the total range per motion interval.
+constexpr chip::Percent100ths kMotionPositionStep = 2000;  // 20% of the total range per motion interval.
 
 // Define the Namespace and Tag for the endpoint
 // Derived from https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/namespaces/Namespace-Closure.adoc
@@ -168,7 +168,7 @@ CHIP_ERROR ClosureManager::SetClosurePanelInitialState(ClosureDimensionEndpoint 
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetTargetState(targetState));
 
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetResolution(Percent100ths(100)));
-    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetStepValue(1000));
+    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetStepValue(2000));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetUnit(ClosureUnitEnum::kMillimeter));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetUnitRange(
         ClosureDimension::Structs::UnitRangeStruct::Type{ .min = static_cast<int16_t>(0), .max = static_cast<int16_t>(10000) }));
@@ -227,7 +227,7 @@ void ClosureManager::InitiateAction(AppEvent * event)
         ChipLogDetail(AppServer, "Initiating calibration action");
         // Timer used in sample application to simulate the calibration process.
         // In a real application, this would be replaced with actual calibration logic.
-        instance.StartTimer(kCalibrateTimerMs);
+        instance.StartTimer(kCalibrateCountdownTimeMs);
         break;
     case Action_t::MOVE_TO_ACTION:
         ChipLogDetail(AppServer, "Initiating move to action");
@@ -535,16 +535,16 @@ chip::Protocols::InteractionModel::Status ClosureManager::OnMoveToCommand(const 
             mClosurePanelEndpoint3Position = static_cast<Percent100ths>(0);
             break;
         case TargetPositionEnum::kMoveToPedestrianPosition:
-            mClosurePanelEndpoint2Position = static_cast<Percent100ths>(3000);
-            mClosurePanelEndpoint3Position = static_cast<Percent100ths>(3000);
+            mClosurePanelEndpoint2Position = static_cast<Percent100ths>(6000);
+            mClosurePanelEndpoint3Position = static_cast<Percent100ths>(6000);
             break;
         case TargetPositionEnum::kMoveToSignaturePosition:
-            mClosurePanelEndpoint2Position = static_cast<Percent100ths>(2000);
-            mClosurePanelEndpoint3Position = static_cast<Percent100ths>(2000);
+            mClosurePanelEndpoint2Position = static_cast<Percent100ths>(4000);
+            mClosurePanelEndpoint3Position = static_cast<Percent100ths>(4000);
             break;
         case TargetPositionEnum::kMoveToVentilationPosition:
-            mClosurePanelEndpoint2Position = static_cast<Percent100ths>(1000);
-            mClosurePanelEndpoint3Position = static_cast<Percent100ths>(1000);
+            mClosurePanelEndpoint2Position = static_cast<Percent100ths>(2000);
+            mClosurePanelEndpoint3Position = static_cast<Percent100ths>(2000);
             break;
         default:
             ChipLogError(AppServer, "Invalid target position received in OnMoveToCommand");
@@ -1102,7 +1102,11 @@ void ClosureManager::HandlePanelStepAction(EndpointId endpointId)
         }
         else
         {
-            nextCurrentPosition = std::max(static_cast<chip::Percent100ths>(currentPosition - stepValue), targetPosition);
+                        // Underflow protection: if currentPosition <= stepValue, set to 0.
+            chip::Percent100ths decreasedCurrentPosition = (currentPosition > stepValue)
+                                                        ? static_cast<chip::Percent100ths>(currentPosition - stepValue)
+                                                        : static_cast<chip::Percent100ths>(0);
+            nextCurrentPosition = std::max(decreasedCurrentPosition, targetPosition);
         }
 
         panelCurrentState.Value().position.SetValue(DataModel::MakeNullable(nextCurrentPosition));
@@ -1157,14 +1161,17 @@ bool ClosureManager::GetPanelNextPosition(const GenericDimensionStateStruct & cu
 
     if (currentPosition < targetPosition)
     {
-        // Increment position by 1000 units, capped at target.
+        // Increment position by 2000 units, capped at target.
+        // No overflow handling needed due to currentposition max value is 10000
         nextPosition.SetNonNull(std::min(static_cast<chip::Percent100ths>(currentPosition + kMotionPositionStep), targetPosition));
     }
     else if (currentPosition > targetPosition)
     {
-        // Moving down: Decreasing the current position by a step of 1000 units,
+        // Handling overflow for CurrentPosition
+        chip::Percent100ths newCurrentPosition = (currentPosition > kMotionPositionStep) ? currentPosition - kMotionPositionStep : 0;
+        // Moving down: Decreasing the current position by a step of 2000 units,
         // ensuring it does not go below the target position.
-        nextPosition.SetNonNull(std::max(static_cast<chip::Percent100ths>(currentPosition - kMotionPositionStep), targetPosition));
+        nextPosition.SetNonNull(std::max(newCurrentPosition, targetPosition));
     }
     else
     {

--- a/src/python_testing/TC_CLCTRL_3_1.py
+++ b/src/python_testing/TC_CLCTRL_3_1.py
@@ -69,11 +69,6 @@ def current_latch_matcher(current_latch: bool) -> AttributeMatcher:
 
 
 class TC_CLCTRL_3_1(MatterBaseTest):
-    @property
-    def default_timeout(self) -> int:
-        # Default timeout for this test case is 120 seconds, multiple calibrates can take a while
-        return 120
-
     async def read_clctrl_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.ClosureControl
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)

--- a/src/python_testing/TC_CLCTRL_3_1.py
+++ b/src/python_testing/TC_CLCTRL_3_1.py
@@ -25,7 +25,7 @@
 #       --commissioning-method on-network
 #       --discriminator 1234
 #       --passcode 20202021
-#       --timeout 120
+#       --timeout 30
 #       --endpoint 1
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto

--- a/src/python_testing/TC_CLCTRL_6_1.py
+++ b/src/python_testing/TC_CLCTRL_6_1.py
@@ -25,7 +25,7 @@
 #       --commissioning-method on-network
 #       --discriminator 1234
 #       --passcode 20202021
-#       --timeout 60
+#       --timeout 30
 #       --endpoint 1
 #       --hex-arg enableKey:000102030405060708090a0b0c0d0e0f
 #       --trace-to json:${TRACE_TEST_JSON}.json
@@ -68,11 +68,6 @@ def current_latch_matcher(current_latch: bool) -> AttributeMatcher:
 
 
 class TC_CLCTRL_6_1(MatterBaseTest):
-    @property
-    def default_timeout(self) -> int:
-        # This test has potentially 45s waits, so set the timeout to 60
-        return 60
-
     async def read_clctrl_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.ClosureControl
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -177,5 +177,3 @@ slow_tests:
     - { name: TC_TIMESYNC_2_12.py, duration: 20 seconds }
     - { name: TC_TIMESYNC_2_7.py, duration: 20 seconds }
     - { name: TC_TIMESYNC_2_8.py, duration: 1.5 minutes }
-    - { name: TC_CLCTRL_3_1.py, duration: 45 seconds }
-    - { name: TC_CLCTRL_6_1.py, duration: 45 seconds }


### PR DESCRIPTION
#### Summary
   
   At present , the timeout for closure sample app move commands are 10 sec ()with rate of 1000/sec), which leads to timeout      in testscripts . so Optimising the timeout for commands in closure sample app
   
   calibrate commands timeout - 10 sec -> 3sec
   Move commands timeout -> 10 sec -> 5 sec
   Each step increases from 1000 -> 2000

#### Related issues

        Fixes: #40154 



#### Testing

Build app and bring up closure app locally.
validated against all test scripts in local and CI.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
