### PR TITLE
[SILABS] : Replace INCLUDE_vTaskDelayUntil with INCLUDE_xTaskDelayUntil 

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -268,7 +268,7 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 #define INCLUDE_vTaskDelete (1)
 #define INCLUDE_vTaskSuspend (1)
 #define INCLUDE_xResumeFromISR (1)
-#define INCLUDE_vTaskDelayUntil (1)
+#define INCLUDE_xTaskDelayUntil (1)
 #define INCLUDE_vTaskDelay (1)
 #define INCLUDE_xTaskGetSchedulerState (1)
 #define INCLUDE_xTaskGetCurrentTaskHandle (1)


### PR DESCRIPTION
#### Summary
Removing INCLUDE_vTaskDelayUntil as it causes a build issue when using with the latest sisdk and replacing with INCLUDE_xTaskDelayUntil

#### Related issues

#### Testing
Tested commissioning for lighting app

Replace this HTML comment with the actual information about how the testing was done.


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
