### PR TITLE
[Silabs] Add verbose mode

### DIFF
--- a/examples/air-quality-sensor-app/silabs/README.md
+++ b/examples/air-quality-sensor-app/silabs/README.md
@@ -223,7 +223,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -231,7 +236,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/examples/dishwasher-app/silabs/README.md
+++ b/examples/dishwasher-app/silabs/README.md
@@ -176,7 +176,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -184,7 +189,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/examples/energy-management-app/silabs/README.md
+++ b/examples/energy-management-app/silabs/README.md
@@ -217,7 +217,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -225,7 +230,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/examples/light-switch-app/silabs/README.md
+++ b/examples/light-switch-app/silabs/README.md
@@ -221,7 +221,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -229,7 +234,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/examples/lighting-app/silabs/README.md
+++ b/examples/lighting-app/silabs/README.md
@@ -211,7 +211,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -219,7 +224,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/examples/lit-icd-app/silabs/README.md
+++ b/examples/lit-icd-app/silabs/README.md
@@ -206,7 +206,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -214,7 +219,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/examples/lock-app/silabs/README.md
+++ b/examples/lock-app/silabs/README.md
@@ -234,7 +234,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -242,7 +247,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -34,6 +34,8 @@ declare_args() {
   ota_periodic_query_timeout_sec = 86400
 }
 
+chip_detail_logging = verbose_mode
+
 # Sanity check
 assert(chip_enable_wifi)
 silabs_plat_dir = "${chip_root}/src/platform/silabs"

--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -34,7 +34,7 @@ declare_args() {
   ota_periodic_query_timeout_sec = 86400
 }
 
-chip_detail_logging = verbose_mode
+chip_detail_logging = sl_verbose_mode
 
 # Sanity check
 assert(chip_enable_wifi)

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -32,6 +32,8 @@ declare_args() {
   ota_periodic_query_timeout_sec = 86400
 }
 
+chip_detail_logging = verbose_mode
+
 import("${silabs_common_plat_dir}/args.gni")
 
 # Sanity check

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -32,7 +32,7 @@ declare_args() {
   ota_periodic_query_timeout_sec = 86400
 }
 
-chip_detail_logging = verbose_mode
+chip_detail_logging = sl_verbose_mode
 
 import("${silabs_common_plat_dir}/args.gni")
 

--- a/examples/pump-app/silabs/README.md
+++ b/examples/pump-app/silabs/README.md
@@ -201,7 +201,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -209,7 +214,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/examples/refrigerator-app/silabs/README.md
+++ b/examples/refrigerator-app/silabs/README.md
@@ -210,7 +210,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -218,7 +223,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/examples/smoke-co-alarm-app/silabs/README.md
+++ b/examples/smoke-co-alarm-app/silabs/README.md
@@ -224,7 +224,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -232,7 +237,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/examples/thermostat/silabs/README.md
+++ b/examples/thermostat/silabs/README.md
@@ -217,7 +217,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -225,7 +230,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/examples/window-app/silabs/README.md
+++ b/examples/window-app/silabs/README.md
@@ -206,7 +206,12 @@ combination with JLinkRTTClient as follows:
 
 If the binary was built with this option or if you're using the Siwx917 WiFi
 SoC, the logs and the CLI (if enabled) will be available on the serial console.
-This console required a baudrate of **921600** with CTS/RTS.
+
+This console required a baudrate of **115200** with CTS/RTS. This is the default
+configuration of Silicon Labs dev kits.
+
+**HOWEVER** the console will required a baudrate of **921600** with CTS/RTS if
+the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
@@ -214,7 +219,7 @@ This console required a baudrate of **921600** with CTS/RTS.
     Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
 -   Using commander-cli
     ```
-    commander vcom config --baudrate 921600 --handshake none
+    commander vcom config --baudrate 921600 --handshake rtscts
     ```
 
 ### Using the console

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -276,7 +276,7 @@ else
                 shift
                 ;;
             --verbose)
-                optArgs+="verbose_mode=true "
+                optArgs+="sl_verbose_mode=true "
                 VERBOSE_MODE=true
                 shift
                 ;;
@@ -361,7 +361,7 @@ else
         echo "================= Warning!!!!! ================"
         echo "Verbose mode is enabled. BAUDRATE FOR UART LOGS IS SET TO 921600"
         echo "Use Simplicity Studio or commander with the following command to set the baudrate:"
-        echo "commander vcom config --baudrate 921600 --handshake none"
+        echo "commander vcom config --baudrate 921600 --handshake rtscts"
         echo "==============================================="
     fi
 

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -160,7 +160,7 @@ if [ "$#" == "0" ]; then
         --slc_reuse_files
             Use generated files without running slc again.
         --verbose
-            Add additionnal logs.
+            Add additional logs.
         --bootloader
             Add bootloader to the generated image.
 
@@ -279,7 +279,7 @@ else
                 optArgs+="verbose_mode=true "
                 VERBOSE_MODE=true
                 shift
-                ;;    
+                ;;
             --gn_path)
                 if [ -z "$2" ]; then
                     echo "--gn_path requires a path to GN"

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -36,7 +36,6 @@ else
     PW_PATH="$PW_ENVIRONMENT_ROOT/cipd/packages/pigweed"
 fi
 
-set -x
 env
 USE_WIFI=false
 USE_DOCKER=false
@@ -44,6 +43,7 @@ USE_GIT_SHA_FOR_VERSION=true
 GN_PATH="$PW_PATH/gn"
 USE_BOOTLOADER=false
 DOTFILE=".gn"
+VERBOSE_MODE=false
 
 SILABS_THREAD_TARGET=\""../silabs:ot-efr32-cert"\"
 USAGE="./scripts/examples/gn_silabs_example.sh <AppRootFolder> <outputFolder> <silabs_board_name> [<Build options>]"
@@ -159,6 +159,8 @@ if [ "$#" == "0" ]; then
             Generate files with SLC for current board and options Requires an SLC-CLI installation or running in Docker.
         --slc_reuse_files
             Use generated files without running slc again.
+        --verbose
+            Add additionnal logs.
         --bootloader
             Add bootloader to the generated image.
 
@@ -273,6 +275,11 @@ else
                 optArgs+="slc_reuse_files=true "
                 shift
                 ;;
+            --verbose)
+                optArgs+="verbose_mode=true "
+                VERBOSE_MODE=true
+                shift
+                ;;    
             --gn_path)
                 if [ -z "$2" ]; then
                     echo "--gn_path requires a path to GN"
@@ -346,8 +353,17 @@ else
     "$GN_PATH" gen --check --script-executable="$PYTHON_PATH" --fail-on-unused-args --add-export-compile-commands=* --root="$ROOT" --dotfile="$DOTFILE" --args="silabs_board=\"$SILABS_BOARD\" $optArgs" "$BUILD_DIR"
 
     ninja -C "$BUILD_DIR"/
+
     #print stats
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
+
+    if [ "$VERBOSE_MODE" == true ]; then
+        echo "================= Warning!!!!! ================"
+        echo "Verbose mode is enabled. BAUDRATE FOR UART LOGS IS SET TO 921600"
+        echo "Use Simplicity Studio or commander with the following command to set the baudrate:"
+        echo "commander vcom config --baudrate 921600 --handshake none"
+        echo "==============================================="
+    fi
 
     # add bootloader to generated image
     if [ "$USE_BOOTLOADER" == true ]; then

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -96,7 +96,7 @@ declare_args() {
   # Enable TestEventTrigger in GeneralDiagnostics cluster
   sl_enable_test_event_trigger = false
 
-  verbose_mode = false
+  sl_verbose_mode = false
 }
 
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
@@ -681,7 +681,7 @@ template("efr32_sdk") {
       ]
     }
 
-    if (verbose_mode) {
+    if (sl_verbose_mode) {
       defines += [ "VERBOSE_MODE=1" ]
     }
 

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -95,6 +95,8 @@ declare_args() {
 
   # Enable TestEventTrigger in GeneralDiagnostics cluster
   sl_enable_test_event_trigger = false
+
+  verbose_mode = false
 }
 
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
@@ -677,6 +679,10 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform/emdrv/uartdrv/config",
         "${efr32_sdk_root}/hardware/driver/memlcd/inc/memlcd_usart",
       ]
+    }
+
+    if (verbose_mode) {
+      defines += [ "VERBOSE_MODE=1" ]
     }
 
     if (sl_use_subscription_syncing) {


### PR DESCRIPTION
#### Summary

Inline with PR #40521 this PR introduces a verbose mode for Silicon Labs examples. By default the "Debug" or "Detail" Log category won't be compiled, thus reducing the code size and RAM usage and reducing the UART baudrate to the old default of 115200. 

When enable the verbose mode will change the baudrate to 921600 and enables the Debug logs during compilation

#### Related issues
N/A
#### Testing

Tested using BRD4187C locally. 