### PR TITLE
[CI] Fix for Mergify deadlock

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,8 @@ pull_request_rules:
       label:
         toggle:
           - conflict
+  # WARNING: If the rule name below is changed, you must also update the
+  # condition `check-failure~=Automatic merge on PullApprove` to match the new name.
   - name: Automatic merge on PullApprove
     conditions:
       - or:
@@ -26,6 +28,8 @@ pull_request_rules:
           - '#check-failure=0'
           - and:
               - '#check-failure=1'
+              # WARNING: This must match the rule name defined above.
+              # If the rule name changes, update this condition accordingly.
               - check-failure~=Automatic merge on PullApprove
       - '#check-pending=0'
       - check-success~=Build

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,7 +17,16 @@ pull_request_rules:
       - '#review-threads-unresolved=0'
       - '-draft'
       - label!=docker
-      - '#check-failure=0'
+      # Workaround for Mergify deadlock due to using "#check-failure=0":
+      # Mergify’s own action check can appear as failed/cancelled if conditions stop matching;
+      # and GitHub keeps those historic failures forever. Since `#check-failure=0` counts ALL
+      # failures (including historic ones), this would cause a deadlock and block merges indefinitely.
+      # We whitelist only this self-check so merges aren’t deadlocked, while all other failures still block.
+      - or:
+          - '#check-failure=0'
+          - and:
+              - '#check-failure=1'
+              - check-failure~=Automatic merge on PullApprove
       - '#check-pending=0'
       - check-success~=Build
       - or:


### PR DESCRIPTION
#### Summary

- Mergify sometimes doesn't automatically merge although ALL checks are ok.

- This can happen when the actual "Mergify Rule" fails (or is cancelled) in the beginning (due to failed CI or any other valid reason) and then due to the fact that it ALREADY failed, the mergify check `'#check-failure=0'` will NEVER be true and we will stay stuck in a deadlock.

- FIX: whitelist a failure of the mergify self-check by allowing '#check-failure=1' AND `check-failure~=Automatic merge on PullApprove`.

This is how this deadlock looked like in GitHub UI:

<img width="1479" height="1092" alt="image" src="https://github.com/user-attachments/assets/a9e1bee3-6030-4d9d-b19d-3312f08bd439" />


#### Testing

- Tested by putting the new Workflow in "Mergify Config Editor" and made sure Config passed for a PR that was stuck in this deadlock: https://github.com/project-chip/connectedhomeip/pull/40709/checks?check_run_id=48927120884
- We can see below that the "Deadlock conditions" were triggered.
<img width="1799" height="818" alt="image" src="https://github.com/user-attachments/assets/c4cc7296-3d4f-4576-8374-340a14176419" />

