### PR TITLE
Add a way to update the commissioning parameters on CHIPDeviceController.

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -823,6 +823,11 @@ public:
         return mDefaultCommissioner == nullptr ? NullOptional : MakeOptional(mDefaultCommissioner->GetCommissioningParameters());
     }
 
+    CHIP_ERROR UpdateCommissioningParameters(const CommissioningParameters & newParameters)
+    {
+        return mDefaultCommissioner->SetCommissioningParameters(newParameters);
+    }
+
     // Reset the arm failsafe timer during commissioning.  If this returns
     // false, that means that the timer was already set for a longer time period
     // than the new time we are trying to set.  In this case, neither


### PR DESCRIPTION
This is needed when doing a network scan and then needing to provide credentials.  Right now cumbersome workarounds involving a separate out-of-band AutoCommissioner have to be used to handle this.

#### Testing

No great way to test this in CI (nothing to scan), but manual testing will be done when this is used in https://github.com/project-chip/connectedhomeip/pull/40309