### PR TITLE
Make FindCommissioneeDevice more reliable.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -596,7 +596,7 @@ CommissioneeDeviceProxy * DeviceCommissioner::FindCommissioneeDevice(NodeId id)
     MATTER_TRACE_SCOPE("FindCommissioneeDevice", "DeviceCommissioner");
     CommissioneeDeviceProxy * foundDevice = nullptr;
     mCommissioneeDevicePool.ForEachActiveObject([&](auto * deviceProxy) {
-        if (deviceProxy->GetDeviceId() == id || deviceProxy->GetOriginalDeviceId() == id)
+        if (deviceProxy->GetDeviceId() == id || deviceProxy->GetTemporaryCommissioningId() == id)
         {
             foundDevice = deviceProxy;
             return Loop::Break;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -596,7 +596,7 @@ CommissioneeDeviceProxy * DeviceCommissioner::FindCommissioneeDevice(NodeId id)
     MATTER_TRACE_SCOPE("FindCommissioneeDevice", "DeviceCommissioner");
     CommissioneeDeviceProxy * foundDevice = nullptr;
     mCommissioneeDevicePool.ForEachActiveObject([&](auto * deviceProxy) {
-        if (deviceProxy->GetDeviceId() == id)
+        if (deviceProxy->GetDeviceId() == id || deviceProxy->GetOriginalDeviceId() == id)
         {
             foundDevice = deviceProxy;
             return Loop::Break;

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -84,11 +84,11 @@ public:
      */
     void Init(ControllerDeviceInitParams params, NodeId deviceId, const Transport::PeerAddress & peerAddress)
     {
-        mSessionManager   = params.sessionManager;
-        mExchangeMgr      = params.exchangeMgr;
-        mPeerId           = PeerId().SetNodeId(deviceId);
-        mOriginalDeviceId = deviceId;
-        mState            = ConnectionState::Connecting;
+        mSessionManager           = params.sessionManager;
+        mExchangeMgr              = params.exchangeMgr;
+        mPeerId                   = PeerId().SetNodeId(deviceId);
+        mTemporaryCommissioningId = deviceId;
+        mState                    = ConnectionState::Connecting;
 
         mDeviceAddress = peerAddress;
     }
@@ -151,7 +151,7 @@ public:
 
     Transport::Type GetDeviceTransportType() const { return mDeviceAddress.GetTransportType(); }
 
-    NodeId GetOriginalDeviceId() const { return mOriginalDeviceId; }
+    NodeId GetTemporaryCommissioningId() const { return mTemporaryCommissioningId; }
 
 private:
     enum class ConnectionState
@@ -166,10 +166,10 @@ private:
 
     /*
      * mPeerId can change when we get a NOC, but for purposes of stopping
-     * commissioning it's useful to allow clients to use the original ID they
-     * used as a commissioning process identifier.
+     * commissioning it's useful to allow clients to use the (possibly
+     * temporary) ID they used as a commissioning process identifier.
      */
-    NodeId mOriginalDeviceId;
+    NodeId mTemporaryCommissioningId;
 
     /** Address used to communicate with the device.
      */

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -84,10 +84,11 @@ public:
      */
     void Init(ControllerDeviceInitParams params, NodeId deviceId, const Transport::PeerAddress & peerAddress)
     {
-        mSessionManager = params.sessionManager;
-        mExchangeMgr    = params.exchangeMgr;
-        mPeerId         = PeerId().SetNodeId(deviceId);
-        mState          = ConnectionState::Connecting;
+        mSessionManager   = params.sessionManager;
+        mExchangeMgr      = params.exchangeMgr;
+        mPeerId           = PeerId().SetNodeId(deviceId);
+        mOriginalDeviceId = deviceId;
+        mState            = ConnectionState::Connecting;
 
         mDeviceAddress = peerAddress;
     }
@@ -150,6 +151,8 @@ public:
 
     Transport::Type GetDeviceTransportType() const { return mDeviceAddress.GetTransportType(); }
 
+    NodeId GetOriginalDeviceId() const { return mOriginalDeviceId; }
+
 private:
     enum class ConnectionState
     {
@@ -160,6 +163,13 @@ private:
 
     /* Compressed fabric ID and node ID assigned to the device. */
     PeerId mPeerId;
+
+    /*
+     * mPeerId can change when we get a NOC, but for purposes of stopping
+     * commissioning it's useful to allow clients to use the original ID they
+     * used as a commissioning process identifier.
+     */
+    NodeId mOriginalDeviceId;
 
     /** Address used to communicate with the device.
      */


### PR DESCRIPTION
Right now, whether FindCommissioneeDevice works or not depends on whether the initial "commmissioning ID" matches the final node ID assigned to the node and on whether the call to FindCommissioneeDevice happens before or after AddNOC.

This means, in particular, that StopPairing is not very reliable, because it can race the AddNOC bits and then you don't know what ID to pass to StopPairing.

This change allows either the original or the updated ID to be used to identify the commissionee device.

#### Testing

Existing behavior should not change, CI will check that.