### PR TITLE
Expose more information on MTRDeviceAttestationDeviceInfo.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
@@ -31,12 +31,14 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- * The vendor ID from the Device Attestation Certificate. May be nil only if attestation was unsuccessful.
+ * The vendor ID from the Device Attestation Certificate. May be nil only if
+ * attestation verification failed.
  */
 @property (nonatomic, readonly, nullable) NSNumber * vendorID MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 
 /**
- * The product ID from the Device Attestation Certificate. May be nil only if attestation was unsuccessful.
+ * The product ID from the Device Attestation Certificate. May be nil only if
+ * attestation verification failed.
  */
 @property (nonatomic, readonly, nullable) NSNumber * productID MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 
@@ -56,7 +58,37 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 
 @property (nonatomic, readonly) MTRCertificateDERBytes dacCertificate;
 @property (nonatomic, readonly) MTRCertificateDERBytes dacPAICertificate;
-@property (nonatomic, readonly, nullable) NSData * certificateDeclaration;
+@property (nonatomic, readonly, nullable) NSData * certificateDeclaration MTR_DEPRECATED_WITH_REPLACEMENT("certificationDeclaration", ios(16.1, 26.1), macos(13.0, 26.1), watchos(9.1, 26.1), tvos(16.1, 26.1));
+
+/**
+ * The attestation challenge from the secure session.
+ */
+@property (nonatomic, copy, readonly) NSData * attestationChallenge MTR_AVAILABLE(ios(26.1), macos(26.1), watchos(26.1), tvos(26.1));
+
+/**
+ * The attestation nonce from the AttestationRequest command.
+ */
+@property (nonatomic, copy, readonly) NSData * attestationNonce MTR_AVAILABLE(ios(26.1), macos(26.1), watchos(26.1), tvos(26.1));
+
+/**
+ * The TLV-encoded attestation_elements_message that was used to find the
+ * certificationDeclaration (possibly unsuccessfully).
+ */
+@property (nonatomic, copy, readonly) MTRTLVBytes elementsTLV MTR_AVAILABLE(ios(26.1), macos(26.1), watchos(26.1), tvos(26.1));
+
+/**
+ * The certification declaration of the device, if available.  This is a DER-encoded string
+ * representing a CMS-formatted certification declaration.  May be nil only if
+ * attestation verification failed.
+ */
+@property (nonatomic, copy, readonly, nullable) NSData * certificationDeclaration MTR_AVAILABLE(ios(26.1), macos(26.1), watchos(26.1), tvos(26.1));
+
+/**
+ * A signature, using the device attestation private key of the device that sent
+ * the attestation information, over the concatenation of elementsTLV and
+ * attestationChallenge.
+ */
+@property (nonatomic, copy, readonly) NSData * elementsSignature MTR_AVAILABLE(ios(26.1), macos(26.1), watchos(26.1), tvos(26.1));
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.mm
@@ -25,16 +25,24 @@ using namespace chip::Crypto;
 
 @implementation MTRDeviceAttestationDeviceInfo
 
-- (instancetype)initWithDACCertificate:(MTRCertificateDERBytes)dacCertificate
-                     dacPAICertificate:(MTRCertificateDERBytes)dacPAICertificate
-                certificateDeclaration:(NSData *)certificateDeclaration
-              basicInformationVendorID:(NSNumber *)basicInformationVendorID
-             basicInformationProductID:(NSNumber *)basicInformationProductID
+- (instancetype)initWithAttestationChallenge:(NSData *)attestationChallenge
+                            attestationNonce:(NSData *)attestationNonce
+                                 elementsTLV:(MTRTLVBytes)elementsTLV
+                           elementsSignature:(NSData *)elementsSignature
+                              dacCertificate:(MTRCertificateDERBytes)dacCertificate
+                           dacPAICertificate:(MTRCertificateDERBytes)dacPAICertificate
+                    certificationDeclaration:(nullable NSData *)certificationDeclaration
+                    basicInformationVendorID:(NSNumber *)basicInformationVendorID
+                   basicInformationProductID:(NSNumber *)basicInformationProductID
 {
     if (self = [super init]) {
+        _attestationChallenge = [attestationChallenge copy];
+        _attestationNonce = [attestationNonce copy];
+        _elementsTLV = [elementsTLV copy];
+        _elementsSignature = [elementsSignature copy];
         _dacCertificate = [dacCertificate copy];
         _dacPAICertificate = [dacPAICertificate copy];
-        _certificateDeclaration = [certificateDeclaration copy];
+        _certificationDeclaration = [certificationDeclaration copy];
         _basicInformationVendorID = [basicInformationVendorID copy];
         _basicInformationProductID = [basicInformationProductID copy];
 
@@ -45,6 +53,11 @@ using namespace chip::Crypto;
         }
     }
     return self;
+}
+
+- (nullable NSData *)certificateDeclaration
+{
+    return _certificationDeclaration;
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.mm
@@ -21,13 +21,57 @@
 #import "MTRLogging_Internal.h"
 #import "NSDataSpanConversion.h"
 
+#include <app/DeviceProxy.h>
+#include <controller/CHIPDeviceController.h>
+#include <controller/CommissioningDelegate.h>
 #include <lib/support/TypeTraits.h>
+#include <platform/LockTracker.h>
 
 void MTRDeviceAttestationDelegateBridge::OnDeviceAttestationCompleted(chip::Controller::DeviceCommissioner * deviceCommissioner,
     chip::DeviceProxy * device, const chip::Credentials::DeviceAttestationVerifier::AttestationDeviceInfo & info,
     chip::Credentials::AttestationVerificationResult attestationResult)
 {
+    assertChipStackLockedByCurrentThread();
+
+    // Capture any values passed by reference, so we are not relying on them
+    // sticking around after we go async.
+    NSData * dacData = AsData(info.dacDerBuffer());
+    NSData * paiData = AsData(info.paiDerBuffer());
+    NSData * cdData = info.cdBuffer().HasValue() ? AsData(info.cdBuffer().Value()) : nil;
+
+    NSData * attestationChallenge;
+    auto session = device->GetSecureSession();
+    if (session.HasValue()) {
+        attestationChallenge = AsData(session.Value()->AsSecureSession()->GetCryptoContext().GetAttestationChallenge());
+    } else {
+        // Really should not happen.
+        MTR_LOG_ERROR("OnDeviceAttestationCompleted for a device with no PASE session, making up fake attestation challenge");
+        attestationChallenge = [NSData data];
+    }
+
+    // CommissioningParameters is always available; the DeviceCommissioner API is broken when it
+    // pretends it might not be.  And at this point in commissioning, the various attestation
+    // information received from the device is stored in those commissioning parameters; otherwise
+    // we would not have been called at all.
+    chip::Controller::CommissioningParameters commissioningParameters
+        = deviceCommissioner->GetCommissioningParameters().Value();
+    NSData * attestationNonce = AsData(commissioningParameters.GetAttestationNonce().Value());
+    NSData * elementsTLV = AsData(commissioningParameters.GetAttestationElements().Value());
+    NSData * elementsSignature = AsData(commissioningParameters.GetAttestationSignature().Value());
+
+    NSNumber * basicInformationVendorID = @(info.BasicInformationVendorId());
+    NSNumber * basicInformationProductID = @(info.BasicInformationProductId());
+
+    void * deviceHandle = device;
+
+    // TODO: Consider exposing the actual attestation verification result in MTRDeviceAttestationDeviceInfo; need to
+    // figure out how best to do that.
+
     dispatch_async(mQueue, ^{
+        // Hide things that are not passed to us by value, so we don't use them by accident.
+        mtr_hide(deviceCommissioner);
+        mtr_hide(device);
+        mtr_hide(info);
         MTR_LOG("MTRDeviceAttestationDelegateBridge::OnDeviceAttestationCompleted with result: %hu (%s)",
             chip::to_underlying(attestationResult), chip::Credentials::GetAttestationResultDescription(attestationResult));
 
@@ -38,26 +82,27 @@ void MTRDeviceAttestationDelegateBridge::OnDeviceAttestationCompleted(chip::Cont
             || [strongDelegate respondsToSelector:@selector(deviceAttestation:completedForDevice:attestationDeviceInfo:error:)]) {
             MTRDeviceController * strongController = mDeviceController;
             if (strongController) {
-                NSData * dacData = AsData(info.dacDerBuffer());
-                NSData * paiData = AsData(info.paiDerBuffer());
-                NSData * cdData = info.cdBuffer().HasValue() ? AsData(info.cdBuffer().Value()) : nil;
                 MTRDeviceAttestationDeviceInfo * deviceInfo =
-                    [[MTRDeviceAttestationDeviceInfo alloc] initWithDACCertificate:dacData
-                                                                 dacPAICertificate:paiData
-                                                            certificateDeclaration:cdData
-                                                          basicInformationVendorID:@(info.BasicInformationVendorId())
-                                                         basicInformationProductID:@(info.BasicInformationProductId())];
+                    [[MTRDeviceAttestationDeviceInfo alloc] initWithAttestationChallenge:attestationChallenge
+                                                                        attestationNonce:attestationNonce
+                                                                             elementsTLV:elementsTLV
+                                                                       elementsSignature:elementsSignature
+                                                                          dacCertificate:dacData
+                                                                       dacPAICertificate:paiData
+                                                                certificationDeclaration:cdData
+                                                                basicInformationVendorID:basicInformationVendorID
+                                                               basicInformationProductID:basicInformationProductID];
                 NSError * error = (attestationResult == chip::Credentials::AttestationVerificationResult::kSuccess)
                     ? nil
                     : [MTRError errorForCHIPErrorCode:CHIP_ERROR_INTEGRITY_CHECK_FAILED];
                 if ([strongDelegate respondsToSelector:@selector(deviceAttestationCompletedForController:opaqueDeviceHandle:attestationDeviceInfo:error:)]) {
                     [strongDelegate deviceAttestationCompletedForController:mDeviceController
-                                                         opaqueDeviceHandle:device
+                                                         opaqueDeviceHandle:deviceHandle
                                                       attestationDeviceInfo:deviceInfo
                                                                       error:error];
                 } else {
                     [strongDelegate deviceAttestation:mDeviceController
-                                   completedForDevice:device
+                                   completedForDevice:deviceHandle
                                 attestationDeviceInfo:deviceInfo
                                                 error:error];
                 }
@@ -70,9 +115,9 @@ void MTRDeviceAttestationDelegateBridge::OnDeviceAttestationCompleted(chip::Cont
             if (strongController) {
                 NSError * error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INTEGRITY_CHECK_FAILED];
                 if ([strongDelegate respondsToSelector:@selector(deviceAttestationFailedForController:opaqueDeviceHandle:error:)]) {
-                    [strongDelegate deviceAttestationFailedForController:mDeviceController opaqueDeviceHandle:device error:error];
+                    [strongDelegate deviceAttestationFailedForController:mDeviceController opaqueDeviceHandle:deviceHandle error:error];
                 } else {
-                    [strongDelegate deviceAttestation:mDeviceController failedForDevice:device error:error];
+                    [strongDelegate deviceAttestation:mDeviceController failedForDevice:deviceHandle error:error];
                 }
             }
         }

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate_Internal.h
@@ -21,11 +21,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDeviceAttestationDeviceInfo ()
 
-- (instancetype)initWithDACCertificate:(MTRCertificateDERBytes)dacCertificate
-                     dacPAICertificate:(MTRCertificateDERBytes)dacPAICertificate
-                certificateDeclaration:(NSData *)certificateDeclaration
-              basicInformationVendorID:(NSNumber *)basicInformationVendorID
-             basicInformationProductID:(NSNumber *)basicInformationProductID;
+- (instancetype)initWithAttestationChallenge:(NSData *)attestationChallenge
+                            attestationNonce:(NSData *)attestationNonce
+                                 elementsTLV:(MTRTLVBytes)elementsTLV
+                           elementsSignature:(NSData *)elementsSignature
+                              dacCertificate:(MTRCertificateDERBytes)dacCertificate
+                           dacPAICertificate:(MTRCertificateDERBytes)dacPAICertificate
+                    certificationDeclaration:(nullable NSData *)certificationDeclaration
+                    basicInformationVendorID:(NSNumber *)basicInformationVendorID
+                   basicInformationProductID:(NSNumber *)basicInformationProductID;
 
 @end
 

--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -91,6 +91,9 @@ static MTRTestKeys * sTestKeys = nil;
     XCTAssertEqualObjects(attestationDeviceInfo.productID, @(0x8001));
     XCTAssertEqualObjects(attestationDeviceInfo.basicInformationVendorID, @(0xFFF1));
     XCTAssertEqualObjects(attestationDeviceInfo.basicInformationProductID, @(0x8000));
+    XCTAssertEqualObjects(attestationDeviceInfo.certificateDeclaration,
+        attestationDeviceInfo.certificationDeclaration);
+    XCTAssertNotNil(attestationDeviceInfo.certificationDeclaration);
 
     if (_callback) {
         _callback();


### PR DESCRIPTION
This should expose enough information that an API client could re-run attestation themselves as desired.

#### Testing

Some really basic tests added, but hard to test things about the opaque data without reimplementing device attestation from scratch.

Fixes https://github.com/project-chip/connectedhomeip/issues/26695