### PR TITLE
[CHIME] Update CHIME 2.4 to align with the test plan changes for issue 5439

### DIFF
--- a/src/python_testing/TC_CHIME_2_4.py
+++ b/src/python_testing/TC_CHIME_2_4.py
@@ -54,6 +54,13 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
             TestStep(3, "Invoke the PlayChimeSound command. Verify a success response, and no chime is played."),
             TestStep(4, "Write the value of True to the Enabled attribute."),
             TestStep(5, "Invoke the PlayChimeSound command. Verify a success response, and a chime is played."),
+            TestStep(6, "Ensure that the SelectedChime is the longest chime available on the DUT"),
+            TestStep(7, "Invoke PlayChimeSound three (3) times in rapid succession. Enure success responses. Ensure no more than two were audible"),
+            TestStep(8, "If there is more than one chime sound supported, proceed to step 9, otherwise end the test case"),
+            TestStep(9, "Invoke PlayChimeSound on the DUT. Verify success"),
+            TestStep(10, "Write a new supported chime sound to SelectedChime"),
+            TestStep(11, "Obtain manual verification that the chime sound from step 9 is complete"),
+            TestStep(12, "Invoke PlayChimeSound on the DUT. Verify that a different sound from the one played in step 9 is heard"),
         ]
         return steps
 
@@ -93,6 +100,62 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
                                                      prompt_msg_placeholder="y",
                                                      default_value="y")
             asserts.assert_equal(user_response.lower(), "y")
+
+        self.step(6)
+
+        self.step(7)
+        if not self.is_ci:
+            self.wait_for_user_input(prompt_msg="About to play multiple chimes on the DUT. Hit ENTER once ready.")
+        
+        await self.send_play_chime_sound_command(endpoint)
+        await self.send_play_chime_sound_command(endpoint)
+        await self.send_play_chime_sound_command(endpoint)
+
+        if not self.is_ci:
+            user_response = self.wait_for_user_input(prompt_msg="No more than two chime sounds should have been played, is this correct? Enter 'y' or 'n'",
+                                                     prompt_msg_placeholder="y",
+                                                     default_value="y")
+            asserts.assert_equal(user_response.lower(), "y")
+        
+        self.step(8)
+        myChimeSounds = await self.read_chime_attribute_expect_success(endpoint, attributes.InstalledChimeSounds)
+        if len(myChimeSounds) > 1: 
+
+            if not self.is_ci:
+                self.wait_for_user_input(prompt_msg="About to play a single chime on the DUT. Hit ENTER once ready.")
+
+            self.step(9)
+            await self.send_play_chime_sound_command(endpoint)
+
+            self.step(10)
+            myChimeSounds = await self.read_chime_attribute_expect_success(endpoint, attributes.InstalledChimeSounds)
+            mySelectedChime = await self.read_chime_attribute_expect_success(endpoint, attributes.SelectedChime)
+
+            newSelectedChime = mySelectedChime
+            for chime in myChimeSounds:
+                if chime.chimeID != mySelectedChime:
+                    newSelectedChime = chime.chimeID
+                    break
+
+            await self.write_chime_attribute_expect_success(endpoint, attributes.SelectedChime, newSelectedChime)            
+
+            self.step(11)
+            if not self.is_ci:
+                self.wait_for_user_input(prompt_msg="Hit ENTER once the chime has completed playing.")
+
+            self.step(12)
+            await self.send_play_chime_sound_command(endpoint)
+            if not self.is_ci:
+                user_response = self.wait_for_user_input(prompt_msg="A different chime sound should have just been played, is this correct? Enter 'y' or 'n'",
+                                                         prompt_msg_placeholder="y",
+                                                         default_value="y")
+                asserts.assert_equal(user_response.lower(), "y")
+
+        else:
+            self.skip_step(9)
+            self.skip_step(10)
+            self.skip_step(11)
+            self.skip_step(12)
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_CHIME_2_4.py
+++ b/src/python_testing/TC_CHIME_2_4.py
@@ -106,7 +106,7 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
         self.step(7)
         if not self.is_ci:
             self.wait_for_user_input(prompt_msg="About to play multiple chimes on the DUT. Hit ENTER once ready.")
-        
+
         await self.send_play_chime_sound_command(endpoint)
         await self.send_play_chime_sound_command(endpoint)
         await self.send_play_chime_sound_command(endpoint)
@@ -116,10 +116,10 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
                                                      prompt_msg_placeholder="y",
                                                      default_value="y")
             asserts.assert_equal(user_response.lower(), "y")
-        
+
         self.step(8)
         myChimeSounds = await self.read_chime_attribute_expect_success(endpoint, attributes.InstalledChimeSounds)
-        if len(myChimeSounds) > 1: 
+        if len(myChimeSounds) > 1:
 
             if not self.is_ci:
                 self.wait_for_user_input(prompt_msg="About to play a single chime on the DUT. Hit ENTER once ready.")
@@ -137,7 +137,7 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
                     newSelectedChime = chime.chimeID
                     break
 
-            await self.write_chime_attribute_expect_success(endpoint, attributes.SelectedChime, newSelectedChime)            
+            await self.write_chime_attribute_expect_success(endpoint, attributes.SelectedChime, newSelectedChime)
 
             self.step(11)
             if not self.is_ci:

--- a/src/python_testing/TC_CHIME_2_4.py
+++ b/src/python_testing/TC_CHIME_2_4.py
@@ -104,7 +104,7 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
         self.step(6)
         # Use the current selected chime when in CI
         longestChimeDurationChime = await self.read_chime_attribute_expect_success(endpoint, attributes.SelectedChime)
-        
+
         if not self.is_ci:
             user_response = self.wait_for_user_input(prompt_msg="Plesse enter the ChimeID of the longest duration chime",
                                                      prompt_msg_placeholder=str(longestChimeDurationChime),
@@ -120,9 +120,9 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
 
             if not found_id:
                 asserts.assert_fail("Unknown ChimeID selected")
-            
+
             longestChimeDurationChime = chosenChimeID
-            
+
         await self.write_chime_attribute_expect_success(endpoint, attributes.SelectedChime, longestChimeDurationChime)
 
         self.step(7)


### PR DESCRIPTION
#### Summary

Adds test steps to CHIME 2.4 to handle spec requirements that weren't being covered.  By necessity this is quite manual as confirmation that chimes were heard needs to be provided. 

#### Related issues



#### Testing

Using the Python Runner exercise CHIME 2.4, providing a PICS file that sets PICS_SDK_CI_ONLY to 1. 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
