### PR TITLE
[Camera] Fix no local SDP to send error

### DIFF
--- a/examples/camera-controller/device-manager/DeviceManager.cpp
+++ b/examples/camera-controller/device-manager/DeviceManager.cpp
@@ -24,6 +24,7 @@
 #include <lib/support/StringBuilder.h>
 #include <webrtc-manager/WebRTCManager.h>
 
+#include <chrono>
 #include <cstring>
 #include <errno.h>
 #include <map>
@@ -31,6 +32,7 @@
 #include <string>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <thread>
 #include <unistd.h>
 
 using namespace chip;
@@ -194,6 +196,9 @@ void DeviceManager::InitiateWebRTCSession(uint16_t videoStreamId)
         ChipLogError(Camera, "Failed to connect WebRTC manager. Error: %" CHIP_ERROR_FORMAT, err.Format());
         return;
     }
+
+    // Add a 1-second delay after successful connection to allow local SDP gets populated
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 
     auto videoStreamIdNullable = app::DataModel::MakeNullable(videoStreamId);
     auto videoStreamIdOptional = MakeOptional(videoStreamIdNullable);


### PR DESCRIPTION
#### Summary

REPL fail on WebRTCR_2_4
https://github.com/project-chip/connectedhomeip/actions/runs/17249155572/job/48946692872?pr=40742

```
[2025-08-26 20:49:36.391483][APP ][STDOUT][1756241376.383] [45882:45890] [CAM] DeviceManager: Initiating WebRTC session for node=0x0000000000000001
[2025-08-26 20:49:36.391639][TEST][STDOUT][SERVER][1756241376.380] [45897:45897] [ZCL] CameraAVStreamMgmt[ep=1]: Allocating Video Stream
[2025-08-26 20:49:36.391732][APP ][STDOUT][1756241376.383] [45882:45890] [CAM] Attempting to establish WebRTC connection to node 0x0000000000000001 on endpoint 0x1
[2025-08-26 20:49:36.391862][APP ][STDOUT][1756241376.383] [45882:45890] [CAM] Disconnecting WebRTC session
[2025-08-26 20:49:36.391886][TEST][STDOUT][SERVER][1756241376.380] [45897:45897] [CAM] Setting per stream viewport for stream 1.
[2025-08-26 20:49:36.392020][APP ][STDOUT][1756241376.383] [45882:45890] [CAM] Commissioner is on Fabric ID 0x0000000000000001
[2025-08-26 20:49:36.392055][TEST][STDOUT][SERVER][1756241376.380] [45897:45897] [CAM] New viewport. x1=0, x2=1920, y1=0, y2=1080.
[2025-08-26 20:49:36.392216][TEST][STDOUT][SERVER][1756241376.380] [45897:45897] [DMG] Endpoint 1, Cluster 0x0000_0552 update version to c89fabcf
[2025-08-26 20:49:36.392242][APP ][STDOUT][1756241376.383] [45882:45890] [CAM] WebRTCProviderClient: Initialized with PeerId=0x0000000000000001, endpoint=1
[2025-08-26 20:49:36.392353][APP ][STDOUT][1756241376.388] [45882:45890] [CAM] Generate and set the SDP
[2025-08-26 20:49:36.392416][TEST][STDOUT][SERVER][1756241376.380] [45897:45897] [CAM] Attribute changed for AttributeId = 0x0000_000C
[2025-08-26 20:49:36.392510][APP ][STDOUT][1756241376.389] [45882:45890] [CAM] Using ProvideOffer for WebRTC session establishment
[2025-08-26 20:49:36.392571][TEST][STDOUT][SERVER][1756241376.380] [45897:45897] [CAM] Unknown Attribute with AttributeId = 0x0000_000C
[2025-08-26 20:49:36.392663][APP ][STDOUT][1756241376.389] [45882:45890] [CAM] Sending ProvideOffer command to the peer device
[2025-08-26 20:49:36.392765][TEST][STDOUT][SERVER][1756241376.380] [45897:45897] [DMG] Endpoint 1, Cluster 0x0000_0551 update version to 62639dc7
[2025-08-26 20:49:36.392802][APP ][STDOUT][1756241376.389] [45882:45890] [CAM] No local SDP to send
[2025-08-26 20:49:36.392938][TEST][STDOUT][SERVER][1756241376.380] [45897:45897] [CAM] Attribute changed for AttributeId = 0x0000_000F
[2025-08-26 20:49:36.393081][TEST][STDOUT][SERVER][1756241376.380] [45897:45897] [CAM] Unknown Attribute with AttributeId = 0x0000_000F
[2025-08-26 20:49:36.393109][APP ][STDOUT][1756241376.389] [45882:45890] [CAM] Failed to initiate WebRTC offer. Error: ../../examples/camera-controller/webrtc-manager/WebRTCManager.cpp:351: CHIP Error 0x0000002F: Invalid argument
[2025-08-26 20:49:36.393218][APP ][STDOUT][1756241376.389] [45882:45890] [DMG] ICR moving to [AwaitingDe]

```
I can see the timing issue clearly from the logs. The issue is that ProvideOffer is being called immediately after mPeerConnection->setLocalDescription(), but the local SDP generation is asynchronous and the onLocalDescription callback hasn't been triggered yet.

This PR simply add 1s delay, which might not be a perfect solution, but can greatly make the CI more solid

#### Related issues

N/A

#### Testing

Validated by CI
