### PR TITLE
Notify errors if StopPairing is called before PASE is set up.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1082,6 +1082,7 @@ CHIP_ERROR DeviceCommissioner::StopPairing(NodeId remoteDeviceId)
     if (mSetUpCodePairer.StopPairing(remoteDeviceId))
     {
         mRunCommissioningAfterConnection = false;
+        OnSessionEstablishmentError(CHIP_ERROR_CANCELLED);
         return CHIP_NO_ERROR;
     }
 


### PR DESCRIPTION
If StopPairing happens after PASE is set up and we are doing our state machine, we send out a notification that the relevant commissioning step failed.

But a StopPairing during PASE setup would just silently stop things and not deliver any notifications.

This fix makes sure that in that situation we deliver a "pairing failed" notification (which is all we can do at that level).

#### Testing

Manual testing for now.  https://github.com/project-chip/connectedhomeip/pull/40309 will add automated tests.