### PR TITLE
ESP32: fix header path to fix the external platform builds

### DIFF
--- a/src/platform/ESP32/ESP32SecureCertDataProvider.h
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
+#include "ESP32FactoryDataProvider.h"
 #include <lib/core/CHIPError.h>
 #include <lib/support/Span.h>
-#include "ESP32FactoryDataProvider.h"
 
 #include <esp_secure_cert_tlv_config.h>
 

--- a/src/platform/ESP32/ESP32SecureCertDataProvider.h
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.h
@@ -27,7 +27,7 @@
 
 #include <lib/core/CHIPError.h>
 #include <lib/support/Span.h>
-#include <platform/ESP32/ESP32FactoryDataProvider.h>
+#include "ESP32FactoryDataProvider.h"
 
 #include <esp_secure_cert_tlv_config.h>
 


### PR DESCRIPTION
#### Summary

failure

```
In file included from /Users/shubhampatil/esp/esp-matter/connectedhomeip/connectedhomeip/config/esp32/../../../../../platform/ESP32_custom/../../platform/ESP32_custom/ESP32SecureCertDataProvider.h:30,
                 from /Users/shubhampatil/esp/esp-matter/components/esp_matter/esp_matter_providers.cpp:40:
/Users/shubhampatil/esp/esp-matter/connectedhomeip/connectedhomeip/src/platform/ESP32/ESP32FactoryDataProvider.h:31:7: error: redefinition of 'class chip::DeviceLayer::ESP32FactoryDataProvider'
   31 | class ESP32FactoryDataProvider : public CommissionableDataProvider,
      |       ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /Users/shubhampatil/esp/esp-matter/components/esp_matter/esp_matter_providers.cpp:38:
/Users/shubhampatil/esp/esp-matter/connectedhomeip/connectedhomeip/config/esp32/../../../../../platform/ESP32_custom/../../platform/ESP32_custom/ESP32FactoryDataProvider.h:31:7: note: previous definition of 'class chip::DeviceLayer::ESP32FactoryDataProvider'
   31 | class ESP32FactoryDataProvider : public CommissionableDataProvider,
      |       ^~~~~~~~~~~~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```

#### Testing
- re-built after the change and build works fine `idf.py build`