### PR TITLE
Update lint workflow to exclude new usages of `SafeAttributePersistenceProvider`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -342,6 +342,7 @@ jobs:
               run: |
                   scripts/find_attribute_persistence_provider_usage.sh \
                   --skip-subtree .github/ \
+                  --skip-subtree scripts/ \
                   --skip-from-file scripts/attribute_persistence_provider_exclusions.txt
 
             # git grep exits with 0 if it finds a match, but we want

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -253,7 +253,10 @@ jobs:
             # to avoid our grep regexp matching itself.
             #
             # Known client-side clusters are allowed to use this only.
-            - name: emberAfClusterInit/Shutdown callbacks are for client side use, not server side. Use ClusterServerInit/Shutdown for server clusters
+            - name:
+                  emberAfClusterInit/Shutdown callbacks are for client side use,
+                  not server side. Use ClusterServerInit/Shutdown for server
+                  clusters
               if: always()
               run: |
                   git grep -I -n "void emberAf.*Cluster\(Init\|Shutdown\)Callback("  -- \
@@ -329,6 +332,17 @@ jobs:
                   --skip-subtree src/app/tests \
                   --skip-subtree src/controller/tests \
                   --skip-from-file scripts/ember_exclusions.txt
+
+            # This check ensures that `SafeAttributePersistenceProvider` nor `AttributePersistenceProvider`
+            # are being used. Exclusions should be removed as soon as a refactor of the file affected is done.
+            - name:
+                  Check for use of 'SafeAttributePersistenceProvider' and
+                  'AttributePersistenceProvider' symbols
+              if: always()
+              run: |
+                  scripts/find_attribute_persistence_provider_usage.sh \
+                  --skip-subtree .github/ \
+                  --skip-from-file scripts/attribute_persistence_provider_exclusions.txt
 
             # git grep exits with 0 if it finds a match, but we want
             # to fail (exit nonzero) on match.  And we want to exclude this file,

--- a/scripts/attribute_persistence_provider_exclusions.txt
+++ b/scripts/attribute_persistence_provider_exclusions.txt
@@ -1,0 +1,61 @@
+# Exclusion list for AttributePersistenceProvider and SafeAttributePersistenceProvider usage checker
+# This file contains paths to files that currently use these classes and are allowed to continue using them
+# Files listed here will be skipped when checking for new usage of these persistence providers
+
+# Documentation files
+docs/cluster_and_device_type_dev/cluster_and_device_type_dev.md
+docs/upgrading.md
+
+# Example applications
+examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
+examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseManager.cpp
+
+# Build files
+src/app/BUILD.gn
+src/app/chip_data_model.cmake
+src/app/persistence/BUILD.gn
+
+# Core persistence provider implementation files
+src/app/SafeAttributePersistenceProvider.h
+src/app/SafeAttributePersistenceProvider.cpp
+src/app/DefaultSafeAttributePersistenceProvider.h
+src/app/persistence/AttributePersistence.cpp
+src/app/persistence/AttributePersistence.h
+src/app/persistence/AttributePersistenceProvider.h
+src/app/persistence/AttributePersistenceProviderInstance.cpp
+src/app/persistence/AttributePersistenceProviderInstance.h
+src/app/persistence/DefaultAttributePersistenceProvider.h
+src/app/persistence/DeferredAttributePersistenceProvider.cpp
+src/app/persistence/DeferredAttributePersistenceProvider.h
+src/app/persistence/String.h
+
+# Server and data model implementations
+src/app/server/Server.cpp
+src/app/server-cluster/ServerClusterContext.h
+src/app/server-cluster/testing/TestServerClusterContext.h
+src/app/util/attribute-storage.cpp
+
+# Data model providers
+src/data-model-providers/codedriven/CodeDrivenDataModelProvider.cpp
+src/data-model-providers/codedriven/CodeDrivenDataModelProvider.h
+src/data-model-providers/codedriven/tests/TestCodeDrivenDataModelProvider.cpp
+src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+src/data-model-providers/codegen/model.cmake
+
+# Cluster server implementations that currently use SafeAttributePersistenceProvider
+src/app/clusters/basic-information/BasicInformationCluster.cpp
+src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-server.cpp
+src/app/clusters/camera-av-settings-user-level-management-server/camera-av-settings-user-level-management-server.h
+src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+src/app/clusters/chime-server/chime-server.cpp
+src/app/clusters/mode-base-server/mode-base-server.cpp
+src/app/clusters/mode-base-server/mode-base-server.h
+src/app/clusters/resource-monitoring-server/resource-monitoring-server.cpp
+src/app/clusters/thread-network-directory-server/thread-network-directory-server.cpp
+src/app/clusters/tls-certificate-management-server/tls-certificate-management-server.cpp
+src/app/clusters/tls-client-management-server/tls-client-management-server.cpp
+src/app/clusters/unit-localization-server/unit-localization-server.cpp
+src/app/clusters/zone-management-server/zone-management-server.h
+
+# Platform-specific project files
+src/darwin/Framework/Matter.xcodeproj/project.pbxproj

--- a/scripts/attribute_persistence_provider_exclusions.txt
+++ b/scripts/attribute_persistence_provider_exclusions.txt
@@ -1,10 +1,9 @@
-# Exclusion list for AttributePersistenceProvider and SafeAttributePersistenceProvider usage checker
-# This file contains paths to files that currently use these classes and are allowed to continue using them
-# Files listed here will be skipped when checking for new usage of these persistence providers
+# Exclusion list for SafeAttributePersistenceProvider usage checker
+# This file contains paths to files that currently use SafeAttributePersistenceProvider and are allowed to continue using it
+# Files listed here will be skipped when checking for new usage of SafeAttributePersistenceProvider
 
 # Documentation files
 docs/cluster_and_device_type_dev/cluster_and_device_type_dev.md
-docs/upgrading.md
 
 # Example applications
 examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
@@ -13,49 +12,25 @@ examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEv
 # Build files
 src/app/BUILD.gn
 src/app/chip_data_model.cmake
-src/app/persistence/BUILD.gn
 
-# Core persistence provider implementation files
+# Core SafeAttributePersistenceProvider implementation files
 src/app/SafeAttributePersistenceProvider.h
 src/app/SafeAttributePersistenceProvider.cpp
 src/app/DefaultSafeAttributePersistenceProvider.h
-src/app/persistence/AttributePersistence.cpp
-src/app/persistence/AttributePersistence.h
 src/app/persistence/AttributePersistenceProvider.h
-src/app/persistence/AttributePersistenceProviderInstance.cpp
-src/app/persistence/AttributePersistenceProviderInstance.h
-src/app/persistence/DefaultAttributePersistenceProvider.h
-src/app/persistence/DeferredAttributePersistenceProvider.cpp
-src/app/persistence/DeferredAttributePersistenceProvider.h
-src/app/persistence/String.h
 
-# Server and data model implementations
+# Server implementation
 src/app/server/Server.cpp
-src/app/server-cluster/ServerClusterContext.h
-src/app/server-cluster/testing/TestServerClusterContext.h
-src/app/util/attribute-storage.cpp
-
-# Data model providers
-src/data-model-providers/codedriven/CodeDrivenDataModelProvider.cpp
-src/data-model-providers/codedriven/CodeDrivenDataModelProvider.h
-src/data-model-providers/codedriven/tests/TestCodeDrivenDataModelProvider.cpp
-src/data-model-providers/codegen/CodegenDataModelProvider.cpp
-src/data-model-providers/codegen/model.cmake
 
 # Cluster server implementations that currently use SafeAttributePersistenceProvider
-src/app/clusters/basic-information/BasicInformationCluster.cpp
 src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-server.cpp
 src/app/clusters/camera-av-settings-user-level-management-server/camera-av-settings-user-level-management-server.h
 src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
 src/app/clusters/chime-server/chime-server.cpp
 src/app/clusters/mode-base-server/mode-base-server.cpp
-src/app/clusters/mode-base-server/mode-base-server.h
 src/app/clusters/resource-monitoring-server/resource-monitoring-server.cpp
 src/app/clusters/thread-network-directory-server/thread-network-directory-server.cpp
 src/app/clusters/tls-certificate-management-server/tls-certificate-management-server.cpp
 src/app/clusters/tls-client-management-server/tls-client-management-server.cpp
 src/app/clusters/unit-localization-server/unit-localization-server.cpp
 src/app/clusters/zone-management-server/zone-management-server.h
-
-# Platform-specific project files
-src/darwin/Framework/Matter.xcodeproj/project.pbxproj

--- a/scripts/find_attribute_persistence_provider_usage.sh
+++ b/scripts/find_attribute_persistence_provider_usage.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# This script checks for the use of 'SafeAttributePersistenceProvider' and 'AttributePersistenceProvider' 
+# This script checks for the use of 'SafeAttributePersistenceProvider' 
 # symbols in the codebase. It takes exclusion folders as arguments and can also read exclusions from a file.
 
-# Function to check for SafeAttributePersistenceProvider and AttributePersistenceProvider symbols
+# Function to check for SafeAttributePersistenceProvider symbols
 check_symbols() {
     local exclusions=()
     while [[ $# -gt 0 ]]; do
@@ -40,24 +40,14 @@ check_symbols() {
     # Search for SafeAttributePersistenceProvider usage (class usage, not just includes)
     safe_provider_matches=$(git grep -I -n '\<SafeAttributePersistenceProvider\>' -- './*' "${exclusions[@]}" | grep -v '#include')
 
-    # Search for AttributePersistenceProvider usage (class usage, not just includes)
-    provider_matches=$(git grep -I -n '\<AttributePersistenceProvider\>' -- './*' "${exclusions[@]}" | grep -v '#include')
-
-    if [[ -n "$safe_provider_matches" || -n "$provider_matches" ]]; then
-        echo "Error: Found 'SafeAttributePersistenceProvider' or 'AttributePersistenceProvider' usage in the following files and lines:"
-        if [[ -n "$safe_provider_matches" ]]; then
-            echo ""
-            echo "SafeAttributePersistenceProvider usage:"
-            echo "$safe_provider_matches"
-        fi
-        if [[ -n "$provider_matches" ]]; then
-            echo ""
-            echo "AttributePersistenceProvider usage:"
-            echo "$provider_matches"
-        fi
+    if [[ -n "$safe_provider_matches" ]]; then
+        echo "Error: Found 'SafeAttributePersistenceProvider' usage in the following files and lines:"
+        echo ""
+        echo "SafeAttributePersistenceProvider usage:"
+        echo "$safe_provider_matches"
         exit 1
     else
-        echo "SUCCESS: No unauthorized usage of AttributePersistenceProvider or SafeAttributePersistenceProvider found."
+        echo "SUCCESS: No unauthorized usage of SafeAttributePersistenceProvider found."
     fi
 }
 

--- a/scripts/find_attribute_persistence_provider_usage.sh
+++ b/scripts/find_attribute_persistence_provider_usage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script checks for the use of 'SafeAttributePersistenceProvider' 
+# This script checks for the use of 'SafeAttributePersistenceProvider'
 # symbols in the codebase. It takes exclusion folders as arguments and can also read exclusions from a file.
 
 # Function to check for SafeAttributePersistenceProvider symbols

--- a/scripts/find_attribute_persistence_provider_usage.sh
+++ b/scripts/find_attribute_persistence_provider_usage.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# This script checks for the use of 'SafeAttributePersistenceProvider' and 'AttributePersistenceProvider' 
+# symbols in the codebase. It takes exclusion folders as arguments and can also read exclusions from a file.
+
+# Function to check for SafeAttributePersistenceProvider and AttributePersistenceProvider symbols
+check_symbols() {
+    local exclusions=()
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --skip-subtree)
+                exclusions+=(":(exclude)$2")
+                shift 2
+                ;;
+            --skip-from-file)
+                if [[ -f "$2" ]]; then
+                    while IFS= read -r line || [[ -n "$line" ]]; do
+                        [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+                        exclusions+=(":(exclude)$line")
+                    done <"$2"
+                else
+                    echo "Warning: File '$2' not found, continuing without these exclusions"
+                fi
+                shift 2
+                ;;
+            --help)
+                echo "Usage: $0 [--skip-subtree <dir>] [--skip-from-file <file>]"
+                echo "  --skip-subtree <dir>     Skip the specified subtree or file from the search (can be used multiple times)"
+                echo "  --skip-from-file <file>  Read paths to exclude from the specified file (one path per line)"
+                echo "  --help                   Display this help message"
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    # Search for SafeAttributePersistenceProvider usage (class usage, not just includes)
+    safe_provider_matches=$(git grep -I -n '\<SafeAttributePersistenceProvider\>' -- './*' "${exclusions[@]}" | grep -v '#include')
+
+    # Search for AttributePersistenceProvider usage (class usage, not just includes)
+    provider_matches=$(git grep -I -n '\<AttributePersistenceProvider\>' -- './*' "${exclusions[@]}" | grep -v '#include')
+
+    if [[ -n "$safe_provider_matches" || -n "$provider_matches" ]]; then
+        echo "Error: Found 'SafeAttributePersistenceProvider' or 'AttributePersistenceProvider' usage in the following files and lines:"
+        if [[ -n "$safe_provider_matches" ]]; then
+            echo ""
+            echo "SafeAttributePersistenceProvider usage:"
+            echo "$safe_provider_matches"
+        fi
+        if [[ -n "$provider_matches" ]]; then
+            echo ""
+            echo "AttributePersistenceProvider usage:"
+            echo "$provider_matches"
+        fi
+        exit 1
+    else
+        echo "SUCCESS: No unauthorized usage of AttributePersistenceProvider or SafeAttributePersistenceProvider found."
+    fi
+}
+
+# Main script execution here
+check_symbols "$@"


### PR DESCRIPTION
#### Summary

Fixes #40635 

Update the `lint.yml` workflow so that it checks for **new** usages of `SafeAttributePersistenceProvider`, which will become obsolete and should not be used after #40699 passes and is active.

It works very similarly to the ember exclusion script from #38006 , with similar usage too.

#### Testing

Tested with the latest changes to `master` from 27/08/2025, by running the script to find all usages and matching its output vs a regular grep to get all usages. Then, adding those places to a file for exclusions, as well as excluding the scripts and .github directories by default.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
