### PR TITLE
Expose Network Commissioning FeatureMap values on MTRCommissioneeInfo.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
@@ -19,6 +19,7 @@
 
 @class MTRProductIdentity;
 @class MTREndpointInfo;
+@class MTRNetworkInterfaceInfo;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -49,13 +50,6 @@ MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
 @property (nonatomic, copy, readonly, nullable) MTREndpointInfo * rootEndpoint;
 
 /**
- * A dictionary mapping endpoint IDs to FeatureMap values for the Network
- * Commissioning cluster, for endpoints that implement that cluster.  May
- * contain no entries if there are no such endpoints.
- */
-@property (nonatomic, copy, readonly) NSDictionary<NSNumber *, NSNumber *> * networkCommissioningFeatureMaps MTR_AVAILABLE(ios(26.1), macos(26.1), watchos(26.1), tvos(26.1));
-
-/**
  * Attributes that were read from the commissionee.  This will contain the
  * following, if they are available:
  *
@@ -63,6 +57,14 @@ MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
  * 2) The FeatureMap attributes of all Network Commissioning clusters on the commissionee.
  */
 @property (nonatomic, copy, readonly, nullable) NSDictionary<MTRAttributePath *, NSDictionary<NSString *, id> *> * attributes MTR_PROVISIONALLY_AVAILABLE;
+
+/**
+ * Network interfaces the commissionee has.  If there are no interfaces of a
+ * given type, the corresponding array will be empty.
+ */
+@property (nonatomic, copy, readonly) NSArray<MTRNetworkInterfaceInfo *> * wifiInterfaces MTR_PROVISIONALLY_AVAILABLE;
+@property (nonatomic, copy, readonly) NSArray<MTRNetworkInterfaceInfo *> * threadInterfaces MTR_PROVISIONALLY_AVAILABLE;
+@property (nonatomic, copy, readonly) NSArray<MTRNetworkInterfaceInfo *> * ethernetInterfaces MTR_PROVISIONALLY_AVAILABLE;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
@@ -59,12 +59,10 @@ MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
 @property (nonatomic, copy, readonly, nullable) NSDictionary<MTRAttributePath *, NSDictionary<NSString *, id> *> * attributes MTR_PROVISIONALLY_AVAILABLE;
 
 /**
- * Network interfaces the commissionee has.  If there are no interfaces of a
- * given type, the corresponding array will be empty.
+ * Network interfaces the commissionee has.  The array will be empty if there
+ * are no network interfaces exposed on the commissionee.
  */
-@property (nonatomic, copy, readonly) NSArray<MTRNetworkInterfaceInfo *> * wifiInterfaces MTR_PROVISIONALLY_AVAILABLE;
-@property (nonatomic, copy, readonly) NSArray<MTRNetworkInterfaceInfo *> * threadInterfaces MTR_PROVISIONALLY_AVAILABLE;
-@property (nonatomic, copy, readonly) NSArray<MTRNetworkInterfaceInfo *> * ethernetInterfaces MTR_PROVISIONALLY_AVAILABLE;
+@property (nonatomic, copy, readonly) NSArray<MTRNetworkInterfaceInfo *> * networkInterfaces MTR_UNSTABLE_API;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
@@ -49,6 +49,13 @@ MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
 @property (nonatomic, copy, readonly, nullable) MTREndpointInfo * rootEndpoint;
 
 /**
+ * A dictionary mapping endpoint IDs to FeatureMap values for the Network
+ * Commissioning cluster, for endpoints that implement that cluster.  May
+ * contain no entries if there are no such endpoints.
+ */
+@property (nonatomic, copy, readonly) NSDictionary<NSNumber *, NSNumber *> * networkCommissioningFeatureMaps MTR_AVAILABLE(ios(26.1), macos(26.1), watchos(26.1), tvos(26.1));
+
+/**
  * Attributes that were read from the commissionee.  This will contain the
  * following, if they are available:
  *

--- a/src/darwin/Framework/CHIP/MTRNetworkInterfaceInfo.h
+++ b/src/darwin/Framework/CHIP/MTRNetworkInterfaceInfo.h
@@ -1,0 +1,48 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/MTRDefines.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Information about a network interface on a Matter node.
+ */
+
+NS_SWIFT_SENDABLE
+MTR_PROVISIONALLY_AVAILABLE
+@interface MTRNetworkInterfaceInfo : NSObject <NSCopying, NSSecureCoding>
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+/**
+ * The endpoint this network interface is exposed on (i.e. the endpoint its
+ * corresponding Network Commissioning server cluster instance is on).
+ */
+@property (nonatomic, copy, readonly) NSNumber * endpointID;
+
+/**
+ * The value of the FeatureMap attribute of the corresponding Network
+ * Commissioning cluster instance (which indicates what network technology is
+ * being used; see MTRNetworkCommissioningFeature).
+ */
+@property (nonatomic, copy, readonly) NSNumber * featureMap;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRNetworkInterfaceInfo.h
+++ b/src/darwin/Framework/CHIP/MTRNetworkInterfaceInfo.h
@@ -15,6 +15,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Matter/MTRBaseClusters.h>
 #import <Matter/MTRDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -24,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 
 NS_SWIFT_SENDABLE
-MTR_PROVISIONALLY_AVAILABLE
+MTR_UNSTABLE_API
 @interface MTRNetworkInterfaceInfo : NSObject <NSCopying, NSSecureCoding>
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -38,10 +39,15 @@ MTR_PROVISIONALLY_AVAILABLE
 
 /**
  * The value of the FeatureMap attribute of the corresponding Network
- * Commissioning cluster instance (which indicates what network technology is
- * being used; see MTRNetworkCommissioningFeature).
+ * Commissioning cluster instance.
  */
 @property (nonatomic, copy, readonly) NSNumber * featureMap;
+
+/**
+ * The network technology used by the interface.  This will be one of the
+ * MTRNetworkCommissioningFeature*NetworkInterface values (exactly one bit).
+ */
+@property (nonatomic, assign, readonly) MTRNetworkCommissioningFeature type;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRNetworkInterfaceInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRNetworkInterfaceInfo.mm
@@ -1,0 +1,103 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRNetworkInterfaceInfo_Internal.h"
+
+#import "MTRDefines_Internal.h"
+#import "MTRUtilities.h"
+
+#include <lib/support/CodeUtils.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+MTR_DIRECT_MEMBERS
+@implementation MTRNetworkInterfaceInfo
+
+- (instancetype)initWithEndpointID:(NSNumber *)endpointID featureMap:(NSNumber *)featureMap
+{
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    _endpointID = [endpointID copy];
+    _featureMap = [featureMap copy];
+
+    return self;
+}
+
+#pragma mark - NSCopying implementation
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    return self; // immutable
+}
+
+#pragma mark - NSSecureCoding implementation
+
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
+
+static NSString * const sEndpointIDCodingKey = @"endpointID";
+static NSString * const sFeatureMapCodingKey = @"featureMap";
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    [coder encodeObject:self.endpointID forKey:sEndpointIDCodingKey];
+    [coder encodeObject:self.featureMap forKey:sFeatureMapCodingKey];
+}
+
+- (nullable instancetype)initWithCoder:(NSCoder *)coder
+{
+    NSNumber * endpointID = [coder decodeObjectOfClass:NSNumber.class forKey:sEndpointIDCodingKey];
+    NSNumber * featureMap = [coder decodeObjectOfClass:NSNumber.class forKey:sFeatureMapCodingKey];
+
+    if (endpointID == nil || featureMap == nil) {
+        return nil;
+    }
+
+    return [self initWithEndpointID:endpointID featureMap:featureMap];
+}
+
+#pragma mark - NSObject implementation
+
+- (NSUInteger)hash
+{
+    return self.endpointID.hash ^ self.featureMap.hash;
+}
+
+- (BOOL)isEqual:(id)object
+{
+    VerifyOrReturnValue([object class] == [self class], NO);
+
+    MTRNetworkInterfaceInfo * other = object;
+
+    VerifyOrReturnValue(MTREqualObjects(_endpointID, other->_endpointID), NO);
+    VerifyOrReturnValue(MTREqualObjects(_featureMap, other->_featureMap), NO);
+
+    return YES;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MTRNetworkInterfaceInfo: endpointID=%@, featureMap=0x%llx>",
+                     self.endpointID, self.featureMap.unsignedLongLongValue];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRNetworkInterfaceInfo_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRNetworkInterfaceInfo_Internal.h
@@ -23,7 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 MTR_DIRECT_MEMBERS
 @interface MTRNetworkInterfaceInfo ()
 
-- (instancetype)initWithEndpointID:(NSNumber *)endpointID featureMap:(NSNumber *)featureMap;
+// Will fail init if the featureMap claims multiple interface types.
+- (nullable instancetype)initWithEndpointID:(NSNumber *)endpointID featureMap:(NSNumber *)featureMap;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRNetworkInterfaceInfo_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRNetworkInterfaceInfo_Internal.h
@@ -1,0 +1,30 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Matter/MTRNetworkInterfaceInfo.h>
+
+#import "MTRDefines_Internal.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+MTR_DIRECT_MEMBERS
+@interface MTRNetworkInterfaceInfo ()
+
+- (instancetype)initWithEndpointID:(NSNumber *)endpointID featureMap:(NSNumber *)featureMap;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/Matter.h
+++ b/src/darwin/Framework/CHIP/Matter.h
@@ -63,6 +63,7 @@
 #import <Matter/MTRLogging.h>
 #import <Matter/MTRManualSetupPayloadParser.h>
 #import <Matter/MTRMetrics.h>
+#import <Matter/MTRNetworkInterfaceInfo.h>
 #import <Matter/MTROTAHeader.h>
 #import <Matter/MTROTAProviderDelegate.h>
 #import <Matter/MTROnboardingPayloadParser.h>

--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -301,9 +301,7 @@ typedef BOOL (^CommissioningSessionHandler)(NSError * _Nullable error);
         XCTAssertEqualObjects(decoded.endpointsById, info.endpointsById);
         XCTAssertEqualObjects(decoded.rootEndpoint.children, info.rootEndpoint.children);
         XCTAssertEqualObjects(decoded.attributes, info.attributes);
-        XCTAssertEqualObjects(decoded.wifiInterfaces, info.wifiInterfaces);
-        XCTAssertEqualObjects(decoded.threadInterfaces, info.threadInterfaces);
-        XCTAssertEqualObjects(decoded.ethernetInterfaces, info.ethernetInterfaces);
+        XCTAssertEqualObjects(decoded.networkInterfaces, info.networkInterfaces);
     } else {
         XCTAssertNil(info.endpointsById);
         XCTAssertNil(info.rootEndpoint);
@@ -315,10 +313,9 @@ typedef BOOL (^CommissioningSessionHandler)(NSError * _Nullable error);
         return [path.cluster isEqual:@(MTRClusterIDTypeNetworkCommissioningID)] &&
             [path.attribute isEqual:@(MTRAttributeIDTypeGlobalAttributeFeatureMapID)];
     };
-    __auto_type endpointInList = ^(NSNumber * endpoint, NSArray<MTRNetworkInterfaceInfo *> * list, MTRNetworkCommissioningFeature expectedFeature) {
+    __auto_type endpointInList = ^(NSNumber * endpoint, NSArray<MTRNetworkInterfaceInfo *> * list) {
         for (MTRNetworkInterfaceInfo * info in list) {
             if ([info.endpointID isEqual:endpoint]) {
-                XCTAssertTrue(info.featureMap.unsignedLongLongValue & expectedFeature);
                 return YES;
             }
         }
@@ -329,13 +326,12 @@ typedef BOOL (^CommissioningSessionHandler)(NSError * _Nullable error);
     for (MTRAttributePath * path in info.attributes) {
         if (isNetworkCommissioningFeatureMap(path)) {
             ++networkCommissioningFeatureMapCount;
-            XCTAssertTrue(endpointInList(path.endpoint, info.wifiInterfaces, MTRNetworkCommissioningFeatureWiFiNetworkInterface) || endpointInList(path.endpoint, info.threadInterfaces, MTRNetworkCommissioningFeatureThreadNetworkInterface) || endpointInList(path.endpoint, info.ethernetInterfaces, MTRNetworkCommissioningFeatureEthernetNetworkInterface));
+            XCTAssertTrue(endpointInList(path.endpoint, info.networkInterfaces));
         }
     }
     XCTAssertGreaterThan(networkCommissioningFeatureMapCount, 0);
 
-    XCTAssertEqual(networkCommissioningFeatureMapCount,
-        info.wifiInterfaces.count + info.threadInterfaces.count + info.ethernetInterfaces.count);
+    XCTAssertEqual(networkCommissioningFeatureMapCount, info.networkInterfaces.count);
 
     if (self.extraAttributesToRead) {
         // The attributes we tried to read should really have worked.

--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -315,9 +315,12 @@ typedef BOOL (^CommissioningSessionHandler)(NSError * _Nullable error);
     for (MTRAttributePath * path in info.attributes) {
         if (isNetworkCommissioningFeatureMap(path)) {
             ++networkCommissioningFeatureMapCount;
+            XCTAssertNotNil(info.networkCommissioningFeatureMaps[path.endpoint]);
         }
     }
     XCTAssertGreaterThan(networkCommissioningFeatureMapCount, 0);
+
+    XCTAssertEqual(networkCommissioningFeatureMapCount, info.networkCommissioningFeatureMaps.count);
 
     if (self.extraAttributesToRead) {
         // The attributes we tried to read should really have worked.

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -257,6 +257,9 @@
 		51D0B1412B61B3A4006E3511 /* MTRServerCluster.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51D0B13F2B61B3A3006E3511 /* MTRServerCluster.mm */; };
 		51D10D2E2808E2CA00E8CA3D /* MTRTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 51D10D2D2808E2CA00E8CA3D /* MTRTestStorage.m */; };
 		51D9CB0B2BA37DCE0049D6DB /* MTRDSTOffsetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51D9CB0A2BA37DCE0049D6DB /* MTRDSTOffsetTests.m */; };
+		51DA8F422E7B4236008B7A65 /* MTRNetworkInterfaceInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51DA8F402E7B4236008B7A65 /* MTRNetworkInterfaceInfo.mm */; };
+		51DA8F432E7B4236008B7A65 /* MTRNetworkInterfaceInfo_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51DA8F412E7B4236008B7A65 /* MTRNetworkInterfaceInfo_Internal.h */; };
+		51DA8F442E7B4236008B7A65 /* MTRNetworkInterfaceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 51DA8F3F2E7B4236008B7A65 /* MTRNetworkInterfaceInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51E0FC102ACBBF230001E197 /* MTRSwiftDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E0FC0F2ACBBF230001E197 /* MTRSwiftDeviceTests.swift */; };
 		51E24E73274E0DAC007CCF6E /* MTRErrorTestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E24E72274E0DAC007CCF6E /* MTRErrorTestUtils.mm */; };
 		51E51FBF282AD37A00FC978D /* MTRDeviceControllerStartupParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E51FBC282AD37A00FC978D /* MTRDeviceControllerStartupParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -882,6 +885,9 @@
 		51D0B13F2B61B3A3006E3511 /* MTRServerCluster.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRServerCluster.mm; sourceTree = "<group>"; };
 		51D10D2D2808E2CA00E8CA3D /* MTRTestStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRTestStorage.m; sourceTree = "<group>"; };
 		51D9CB0A2BA37DCE0049D6DB /* MTRDSTOffsetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRDSTOffsetTests.m; sourceTree = "<group>"; };
+		51DA8F3F2E7B4236008B7A65 /* MTRNetworkInterfaceInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRNetworkInterfaceInfo.h; sourceTree = "<group>"; };
+		51DA8F402E7B4236008B7A65 /* MTRNetworkInterfaceInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRNetworkInterfaceInfo.mm; sourceTree = "<group>"; };
+		51DA8F412E7B4236008B7A65 /* MTRNetworkInterfaceInfo_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRNetworkInterfaceInfo_Internal.h; sourceTree = "<group>"; };
 		51E0FC0F2ACBBF230001E197 /* MTRSwiftDeviceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MTRSwiftDeviceTests.swift; sourceTree = "<group>"; };
 		51E24E72274E0DAC007CCF6E /* MTRErrorTestUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRErrorTestUtils.mm; sourceTree = "<group>"; };
 		51E51FBC282AD37A00FC978D /* MTRDeviceControllerStartupParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceControllerStartupParams.h; sourceTree = "<group>"; };
@@ -1878,6 +1884,9 @@
 				3DECCB712934AFE200585AEC /* MTRLogging.mm */,
 				B2E0D7A9245B0B5C003C5B48 /* MTRManualSetupPayloadParser.h */,
 				B2E0D7AD245B0B5C003C5B48 /* MTRManualSetupPayloadParser.mm */,
+				51DA8F3F2E7B4236008B7A65 /* MTRNetworkInterfaceInfo.h */,
+				51DA8F402E7B4236008B7A65 /* MTRNetworkInterfaceInfo.mm */,
+				51DA8F412E7B4236008B7A65 /* MTRNetworkInterfaceInfo_Internal.h */,
 				B289D41F2639C0D300D4E314 /* MTROnboardingPayloadParser.h */,
 				B289D4202639C0D300D4E314 /* MTROnboardingPayloadParser.mm */,
 				3CF134AE289D90FF0017A19E /* MTROperationalCertificateIssuer.h */,
@@ -2314,6 +2323,8 @@
 				7592BD0C2CC6BCC300EB74A0 /* EmberAttributeDataBuffer.h in Headers */,
 				9B231B042C62EF650030EB37 /* (null) in Headers */,
 				515BE4ED2B72C0C5000BC1FD /* MTRUnfairLock.h in Headers */,
+				51DA8F432E7B4236008B7A65 /* MTRNetworkInterfaceInfo_Internal.h in Headers */,
+				51DA8F442E7B4236008B7A65 /* MTRNetworkInterfaceInfo.h in Headers */,
 				998F286F26D55EC5001846C6 /* MTRP256KeypairBridge.h in Headers */,
 				3D9F2FC72D10EA11003CA2BB /* MTREndpointInfo.h in Headers */,
 				CF3B63CF2CA31E71003C1C87 /* MTROTAImageTransferHandler.h in Headers */,
@@ -2735,6 +2746,7 @@
 				B289D4222639C0D300D4E314 /* MTROnboardingPayloadParser.mm in Sources */,
 				3CF134AD289D8E570017A19E /* MTRDeviceAttestationInfo.mm in Sources */,
 				2C1B027A2641DB4E00780EF1 /* MTROperationalCredentialsDelegate.mm in Sources */,
+				51DA8F422E7B4236008B7A65 /* MTRNetworkInterfaceInfo.mm in Sources */,
 				754784652BFE65CB0089C372 /* MTRDeviceStorageBehaviorConfiguration.mm in Sources */,
 				7534D1782CF8CDDF00F64654 /* AttributePersistenceProviderInstance.cpp in Sources */,
 				7560FD1C27FBBD3F005E85B3 /* MTREventTLVValueDecoder.mm in Sources */,


### PR DESCRIPTION
This is easier for API consumers than dealing with the "attributes" data structures.

#### Testing

Unit tests added.