### PR TITLE
Add AVSM test script 2.17 for SoftLivestreamPrivacy and WebRTC stream handling.

### DIFF
--- a/examples/camera-app/camera-common/BUILD.gn
+++ b/examples/camera-app/camera-common/BUILD.gn
@@ -41,12 +41,14 @@ source_set("camera-lib") {
     "include/camera-device-interface.h",
     "include/media-controller/media-controller.h",
     "include/transport/transport.h",
+    "include/webrtc-provider-controller/webrtc-provider-controller.h",
     "src/camera-app.cpp",
   ]
 
   include_dirs = [
     "include",
     "include/camera-avstream-controller",
+    "include/webrtc-provider-controller",
     "include/media-controller",
     "include/transport",
     "${chip_root}/examples/all-clusters-app/all-clusters-common/include",

--- a/examples/camera-app/camera-common/include/camera-device-interface.h
+++ b/examples/camera-app/camera-common/include/camera-device-interface.h
@@ -19,6 +19,7 @@
 #pragma once
 #include "camera-avstream-controller.h"
 #include "media-controller.h"
+#include "webrtc-provider-controller.h"
 #include <app/clusters/camera-av-settings-user-level-management-server/camera-av-settings-user-level-management-server.h>
 #include <app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h>
 #include <app/clusters/chime-server/chime-server.h>
@@ -122,6 +123,9 @@ public:
 
     // Getter for WebRTCProvider Delegate
     virtual chip::app::Clusters::WebRTCTransportProvider::Delegate & GetWebRTCProviderDelegate() = 0;
+
+    // Getter for WebRTCProvider Controller
+    virtual chip::app::Clusters::WebRTCTransportProvider::WebRTCTransportProviderController & GetWebRTCProviderController() = 0;
 
     // Getter for CameraAVStreamManagement Delegate
     virtual chip::app::Clusters::CameraAvStreamManagement::CameraAVStreamMgmtDelegate & GetCameraAVStreamMgmtDelegate() = 0;

--- a/examples/camera-app/camera-common/include/webrtc-provider-controller/webrtc-provider-controller.h
+++ b/examples/camera-app/camera-common/include/webrtc-provider-controller/webrtc-provider-controller.h
@@ -1,0 +1,42 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace WebRTCTransportProvider {
+
+/**
+ * The application interface to define the options & implement commands.
+ */
+class WebRTCTransportProviderController
+{
+public:
+    virtual ~WebRTCTransportProviderController() = default;
+
+    virtual void SetWebRTCTransportProvider(std::unique_ptr<WebRTCTransportProviderServer> webRTCTransportProvider) = 0;
+};
+
+} // namespace WebRTCTransportProvider
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -264,6 +264,7 @@ void CameraApp::InitCameraDeviceClusters()
 {
     // Initialize Cluster Servers
     mWebRTCTransportProviderPtr->Init();
+    mCameraDevice->GetWebRTCProviderController().SetWebRTCTransportProvider(std::move(mWebRTCTransportProviderPtr));
 
     mChimeServerPtr->Init();
 

--- a/examples/camera-app/linux/BUILD.gn
+++ b/examples/camera-app/linux/BUILD.gn
@@ -47,6 +47,7 @@ config("config") {
     "${chip_root}/examples/camera-app/camera-common/include",
     "${chip_root}/examples/camera-app/camera-common/include/media-controller",
     "${chip_root}/examples/camera-app/camera-common/include/camera-avstream-controller",
+    "${chip_root}/examples/camera-app/camera-common/include/webrtc-provider-controller",
     "${chip_root}/examples/camera-app/camera-common/include/transport",
     "${chip_root}/third_party/libdatachannel/repo/include",
   ]

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -84,6 +84,7 @@ class CameraDevice : public CameraDeviceInterface, public CameraDeviceInterface:
 public:
     chip::app::Clusters::ChimeDelegate & GetChimeDelegate() override;
     chip::app::Clusters::WebRTCTransportProvider::Delegate & GetWebRTCProviderDelegate() override;
+    chip::app::Clusters::WebRTCTransportProvider::WebRTCTransportProviderController & GetWebRTCProviderController() override;
     chip::app::Clusters::CameraAvStreamManagement::CameraAVStreamMgmtDelegate & GetCameraAVStreamMgmtDelegate() override;
     chip::app::Clusters::CameraAvStreamManagement::CameraAVStreamController & GetCameraAVStreamMgmtController() override;
     chip::app::Clusters::CameraAvSettingsUserLevelManagement::Delegate & GetCameraAVSettingsUserLevelMgmtDelegate() override;

--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -39,7 +39,7 @@ using ICECandidateStruct       = chip::app::Clusters::Globals::Structs::ICECandi
 using StreamUsageEnum          = chip::app::Clusters::Globals::StreamUsageEnum;
 using WebRTCEndReasonEnum      = chip::app::Clusters::Globals::WebRTCEndReasonEnum;
 
-class WebRTCProviderManager : public Delegate
+class WebRTCProviderManager : public Delegate, public WebRTCTransportProviderController
 {
 public:
     WebRTCProviderManager() :
@@ -53,6 +53,8 @@ public:
     void CloseConnection();
 
     void SetMediaController(MediaController * mediaController);
+
+    void SetWebRTCTransportProvider(std::unique_ptr<WebRTCTransportProviderServer> webRTCTransportProvider) override;
 
     CHIP_ERROR HandleSolicitOffer(const OfferRequestArgs & args, WebRTCSessionStruct & outSession,
                                   bool & outDeferredOffer) override;
@@ -84,12 +86,16 @@ public:
 
     bool HasAllocatedAudioStreams() override;
 
+    void LiveStreamPrivacyModeChanged(bool privacyModeEnabled);
+
 private:
     void ScheduleOfferSend(uint16_t sessionId);
 
     void ScheduleICECandidatesSend(uint16_t sessionId);
 
     void ScheduleAnswerSend(uint16_t sessionId);
+
+    void ScheduleEndSend(uint16_t sessionId);
 
     void RegisterWebrtcTransport(uint16_t sessionId);
 
@@ -101,6 +107,9 @@ private:
 
     CHIP_ERROR SendICECandidatesCommand(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle,
                                         uint16_t sessionId);
+
+    CHIP_ERROR SendEndCommand(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle,
+                              uint16_t sessionId, WebRTCEndReasonEnum endReason);
 
     CHIP_ERROR AcquireAudioVideoStreams(uint16_t sessionId);
 
@@ -126,9 +135,13 @@ private:
 
     MediaController * mMediaController = nullptr;
 
+    std::unique_ptr<WebRTCTransportProviderServer> mWebRTCTransportProvider = nullptr;
+
     // Handle to the Camera Device interface. For accessing other
     // clusters, if required.
     CameraDeviceInterface * mCameraDevice = nullptr;
+
+    bool mSoftLiveStreamPrivacyEnabled = false;
 };
 
 } // namespace WebRTCTransportProvider

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -36,6 +36,7 @@ public:
         kOffer         = 1,
         kAnswer        = 2,
         kICECandidates = 3,
+        kEnd           = 4,
     };
 
     enum class State : uint8_t
@@ -44,6 +45,7 @@ public:
         SendingOffer,         ///< Sending Offer command from camera
         SendingAnswer,        ///< Sending Answer command from camera
         SendingICECandidates, ///< Sending ICECandidates command from camera
+        SendingEnd,           ///< Sending End command from camera
     };
 
     struct RequestArgs

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -1054,6 +1054,9 @@ CameraError CameraDevice::SetSoftLivestreamPrivacyModeEnabled(bool softLivestrea
 {
     mSoftLivestreamPrivacyModeEnabled = softLivestreamPrivacyMode;
 
+    // Notify WebRTCProviderManager about change
+    mWebRTCProviderManager.LiveStreamPrivacyModeChanged(softLivestreamPrivacyMode);
+
     return CameraError::SUCCESS;
 }
 
@@ -1307,6 +1310,11 @@ ChimeDelegate & CameraDevice::GetChimeDelegate()
 }
 
 WebRTCTransportProvider::Delegate & CameraDevice::GetWebRTCProviderDelegate()
+{
+    return mWebRTCProviderManager;
+}
+
+WebRTCTransportProvider::WebRTCTransportProviderController & CameraDevice::GetWebRTCProviderController()
 {
     return mWebRTCProviderManager;
 }

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -54,6 +54,11 @@ void WebRTCProviderManager::SetMediaController(MediaController * mediaController
     mMediaController = mediaController;
 }
 
+void WebRTCProviderManager::SetWebRTCTransportProvider(std::unique_ptr<WebRTCTransportProviderServer> aWebRTCTransportProvider)
+{
+    mWebRTCTransportProvider = std::move(aWebRTCTransportProvider);
+}
+
 CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & args, WebRTCSessionStruct & outSession,
                                                      bool & outDeferredOffer)
 {
@@ -491,6 +496,33 @@ void WebRTCProviderManager::ScheduleAnswerSend(uint16_t sessionId)
     });
 }
 
+void WebRTCProviderManager::ScheduleEndSend(uint16_t sessionId)
+{
+    ChipLogProgress(Camera, "ScheduleEndSend called.");
+
+    DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() {
+        WebrtcTransport * transport = GetTransport(sessionId);
+        if (transport == nullptr)
+        {
+            return;
+        }
+
+        WebrtcTransport::RequestArgs requestArgs = transport->GetRequestArgs();
+        chip::ScopedNodeId peerId                = requestArgs.peerId;
+        ChipLogProgress(Camera, "Sending End command to node " ChipLogFormatX64, ChipLogValueX64(peerId.GetNodeId()));
+
+        transport->SetCommandType(WebrtcTransport::CommandType::kEnd);
+
+        // Attempt to find or establish a CASE session to the target PeerId.
+        CASESessionManager * caseSessionMgr = Server::GetInstance().GetCASESessionManager();
+        VerifyOrDie(caseSessionMgr != nullptr);
+
+        // WebRTC Answer requires a large payload session establishment.
+        caseSessionMgr->FindOrEstablishSession(peerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
+                                               TransportPayloadCapability::kLargePayload);
+    });
+}
+
 void WebRTCProviderManager::ScheduleICECandidatesSend(uint16_t sessionId)
 {
     ChipLogProgress(Camera, "ScheduleICECandidatesSend called.");
@@ -527,13 +559,14 @@ void WebRTCProviderManager::OnDeviceConnected(void * context, Messaging::Exchang
     WebrtcTransport * transport = nullptr;
     uint16_t sessionId          = 0;
 
-    for (auto & mapEntry : self->mWebrtcTransportMap)
+    for (auto it = self->mWebrtcTransportMap.begin(); it != self->mWebrtcTransportMap.end();)
     {
-        sessionId = mapEntry.first;
-        transport = (WebrtcTransport *) mapEntry.second.get();
+        sessionId = it->first;
+        transport = (WebrtcTransport *) it->second.get();
 
         if (transport == nullptr)
         {
+            ++it;
             continue;
         }
 
@@ -557,7 +590,28 @@ void WebRTCProviderManager::OnDeviceConnected(void * context, Messaging::Exchang
             err = self->SendICECandidatesCommand(exchangeMgr, sessionHandle, sessionId);
             transport->MoveToState(WebrtcTransport::State::Idle);
             break;
+        case WebrtcTransport::CommandType::kEnd:
+            if (self->mSoftLiveStreamPrivacyEnabled)
+            {
+                err = self->SendEndCommand(exchangeMgr, sessionHandle, sessionId, WebRTCEndReasonEnum::kPrivacyMode);
+                // Release the Video and Audio Streams from the CameraAVStreamManagement
+                // cluster and update the reference counts.
+                self->ReleaseAudioVideoStreams(sessionId);
+                WebrtcTransport * transport = self->GetTransport(sessionId);
+                if (transport != nullptr)
+                {
+                    self->mMediaController->UnregisterTransport(transport);
+                    WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
+                    self->mSessionIdMap.erase(args.peerNodeId);
+                    // remove from current sessions list
+                    self->mWebRTCTransportProvider->RemoveSession(sessionId);
+                }
 
+                it = self->mWebrtcTransportMap.erase(it);
+                continue;
+            }
+            transport->MoveToState(WebrtcTransport::State::Idle);
+            break;
         default:
             err = CHIP_ERROR_INVALID_ARGUMENT;
             break;
@@ -567,6 +621,7 @@ void WebRTCProviderManager::OnDeviceConnected(void * context, Messaging::Exchang
         {
             ChipLogError(Camera, "OnDeviceConnected::SendCommand failed: %" CHIP_ERROR_FORMAT, err.Format());
         }
+        ++it;
     }
 }
 
@@ -586,6 +641,36 @@ WebrtcTransport * WebRTCProviderManager::GetTransport(uint16_t sessionId)
     }
 
     return transport;
+}
+
+void WebRTCProviderManager::LiveStreamPrivacyModeChanged(bool privacyModeEnabled)
+{
+    mSoftLiveStreamPrivacyEnabled = privacyModeEnabled;
+
+    if (privacyModeEnabled)
+    {
+        WebrtcTransport * transport = nullptr;
+        uint16_t sessionId          = 0;
+        for (auto & mapEntry : mWebrtcTransportMap)
+        {
+            sessionId = mapEntry.first;
+
+            transport = (WebrtcTransport *) mapEntry.second.get();
+
+            if (transport == nullptr)
+            {
+                continue;
+            }
+
+            transport->MoveToState(WebrtcTransport::State::SendingEnd);
+
+            ScheduleEndSend(sessionId);
+        }
+    }
+    else
+    {
+        ChipLogProgress(Camera, "Privacy mode is disabled");
+    }
 }
 
 CHIP_ERROR WebRTCProviderManager::SendOfferCommand(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle,
@@ -729,6 +814,36 @@ CHIP_ERROR WebRTCProviderManager::SendICECandidatesCommand(Messaging::ExchangeMa
 
     command.webRTCSessionID = sessionId;
     command.ICECandidates = DataModel::List<const ICECandidateStruct>(iceCandidateStructList.data(), iceCandidateStructList.size());
+
+    WebrtcTransport::RequestArgs requestArgs = transport->GetRequestArgs();
+    // Now invoke the command using the found session handle
+    return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, requestArgs.originatingEndpointId, command, onSuccess,
+                                            onFailure,
+                                            /* timedInvokeTimeoutMs = */ NullOptional, /* responseTimeout = */ NullOptional,
+                                            /* outCancelFn = */ nullptr, /*allowLargePayload = */ true);
+}
+
+CHIP_ERROR WebRTCProviderManager::SendEndCommand(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle,
+                                                 uint16_t sessionId, WebRTCEndReasonEnum endReason)
+{
+    auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
+        ChipLogProgress(Camera, "End command succeeds");
+    };
+
+    auto onFailure = [](CHIP_ERROR error) { ChipLogError(Camera, "End command failed: %" CHIP_ERROR_FORMAT, error.Format()); };
+
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
+    {
+        ChipLogError(Camera, "WebTransport not found for the sessionId: %u", sessionId);
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    // Build the command
+    WebRTCTransportRequestor::Commands::End::Type command;
+
+    command.webRTCSessionID = sessionId;
+    command.reason          = endReason;
 
     WebrtcTransport::RequestArgs requestArgs = transport->GetRequestArgs();
     // Now invoke the command using the found session handle

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -117,6 +117,9 @@ const char * WebrtcTransport::GetStateStr() const
 
     case State::SendingICECandidates:
         return "SendingICECandidates";
+
+    case State::SendingEnd:
+        return "SendingEnd";
     }
     return "N/A";
 }

--- a/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.h
+++ b/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.h
@@ -320,6 +320,12 @@ public:
      */
     const std::vector<WebRTCSessionStruct> & GetCurrentSessions() const { return mCurrentSessions; }
 
+    /**
+     * @brief Removes a WebRTC session given a session ID.
+     *
+     */
+    void RemoveSession(uint16_t sessionId);
+
 private:
     enum class UpsertResultEnum : uint8_t
     {
@@ -334,7 +340,6 @@ private:
     WebRTCSessionStruct * FindSession(uint16_t sessionId);
     WebRTCSessionStruct * CheckForMatchingSession(HandlerContext & ctx, uint16_t sessionId);
     UpsertResultEnum UpsertSession(const WebRTCSessionStruct & session);
-    void RemoveSession(uint16_t sessionId);
     CHIP_ERROR GenerateSessionId(uint16_t & outSessionId);
 
     // Command Handlers

--- a/src/controller/python/matter/webrtc/types.py
+++ b/src/controller/python/matter/webrtc/types.py
@@ -39,6 +39,7 @@ class Events(Enum):
     ANSWER = auto()
     ICE_CANDIDATE = auto()
     PEER_CONNECTION_STATE = auto()
+    END = auto()
 
 
 class IceCandidateStruct(Structure):

--- a/src/controller/python/matter/webrtc/webrtc_manager.py
+++ b/src/controller/python/matter/webrtc/webrtc_manager.py
@@ -215,6 +215,7 @@ class WebRTCManager(WebRTCRequestorNativeBindings):
             return -1
         # Deleting PeerConnection will take care of cleanup
         asyncio.run_coroutine_threadsafe(WebRTCManager.remove_peer(sessionId), peer.event_loop).result(timeout=10)
+        peer.on_remote_end(sessionId, reason)
         return 0
 
     def handle_ws_message(self, message):

--- a/src/python_testing/TC_AVSM_2_17.py
+++ b/src/python_testing/TC_AVSM_2_17.py
@@ -39,7 +39,6 @@ import logging
 
 from mobly import asserts
 from TC_AVSMTestBase import AVSMTestBase
-from TC_WEBRTC_Utils import WebRTCTestHelper
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl

--- a/src/python_testing/TC_AVSM_2_17.py
+++ b/src/python_testing/TC_AVSM_2_17.py
@@ -1,0 +1,328 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import logging
+
+from mobly import asserts
+from TC_AVSMTestBase import AVSMTestBase
+
+import matter.clusters as Clusters
+from matter import ChipDeviceCtrl
+from matter.interaction_model import InteractionModelError, Status
+from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
+
+logger = logging.getLogger(__name__)
+
+
+class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
+    def desc_TC_AVSM_2_17(self) -> str:
+        return "[TC-AVSM-2.17] Validate stream Soft Privacy and Livestream handling with Server as DUT"
+
+    def pics_TC_AVSM_2_17(self):
+        return ["AVSM.S"]
+
+    def steps_TC_AVSM_2_17(self) -> list[TestStep]:
+        return [
+            TestStep("precondition", "DUT commissioned and allocated audio and video streams", is_commissioning=True),
+            TestStep(
+                1,
+                "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify VDO, ADO and PRIV are supported.",
+            ),
+            TestStep(
+                2,
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify the number of allocated video streams in the list is 1.",
+                "Store StreamID as aVideoStreamID.Store ReferenceCount as aVideoRefCount",
+            ),
+            TestStep(
+                3,
+                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify the number of allocated audio streams in the list is 1.",
+                "Store StreamID as aAudioStreamID.Store ReferenceCount as aAudioRefCount",
+            ),
+            TestStep(
+                4,
+                "TH writes attribute `SoftLivestreamPrivacyModeEnabled` to false in the CameraAVStreamManagement Cluster on DUT.",
+                "DUT responds with Success",
+            ),
+            TestStep(
+                5,
+                "TH reads `CurrentSessions` attribute from WebRTCTransportProvider Cluster on DUT.",
+                "Verify that the count is equal to 0.",
+            ),
+            TestStep(
+                6,
+                "TH sends the ProvideOffer command on the WebRTCTransportProvider Cluster with a null WebRTCSessionID, aVideoStreamID and aAudioStreamID.",
+                "DUT responds with ProvideOfferResponse containing allocated WebRTCSessionID.",
+            ),
+            TestStep(
+                7,
+                "TH reads `CurrentSessions` attribute from WebRTCTransportProvider Cluster on DUT.",
+                "Verify that the count is equal to 1 and the session ID matches the one in the ProvideOfferResponse in step 6.",
+                "Save session as aWebRTCSessionID",
+            ),
+            TestStep(
+                8,
+                "H reads `AllocatedVideoStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Verify that the reference count of the VideoStream for `aVideoStreamID` is equal to `aVideoRefCount` + 1.",
+            ),
+            TestStep(
+                9,
+                "H reads `AllocatedAudioStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Verify that the reference count of the AudioStream for `aAudioStreamID` is equal to `aAudioRefCount` + 1.",
+            ),
+            TestStep(
+                10,
+                "TH writes attribute `SoftLivestreamPrivacyModeEnabled` to true in the CameraAVStreamManagement Cluster on DUT.",
+                "DUT responds with Success",
+            ),
+            TestStep(
+                11,
+                "TH reads `CurrentSessions` attribute from WebRTCTransportProvider Cluster on DUT.",
+                "Verify that the count is equal to 0.",
+            ),
+            TestStep(
+                12,
+                "TH reads `AllocatedVideoStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Verify that the reference count of the VideoStream for `aVideoStreamID` is equal to `aVideoRefCount.",
+            ),
+            TestStep(
+                13,
+                "TH reads `AllocatedAudioStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Verify that the reference count of the AudioStream for `aAudioStreamID` is equal to `aAudioRefCount.",
+            ),
+            TestStep(
+                14,
+                "TH sends the VideoStreamDeallocate command with VideoStreamID set to aVideoStreamID.",
+                "DUT responds with Success",
+            ),
+            TestStep(
+                15,
+                "TH sends the AudioStreamDeallocate command with AudioStreamID set to aAudioStreamID.",
+                "DUT responds with Success.",
+            ),
+            TestStep(
+                16,
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "Verify the number of allocated video streams in the list is 0.",
+            ),
+            TestStep(
+                17,
+                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "Verify the number of allocated audio streams in the list is 0.",
+            ),
+        ]
+
+    @run_if_endpoint_matches(
+        has_feature(Clusters.CameraAvStreamManagement, Clusters.CameraAvStreamManagement.Bitmaps.Feature.kVideo)
+        and has_feature(Clusters.CameraAvStreamManagement, Clusters.CameraAvStreamManagement.Bitmaps.Feature.kAudio)
+        and has_feature(Clusters.CameraAvStreamManagement, Clusters.CameraAvStreamManagement.Bitmaps.Feature.kPrivacy)
+    )
+    async def test_TC_AVSM_2_17(self):
+        endpoint = self.get_endpoint(default=1)
+        cluster = Clusters.CameraAvStreamManagement
+        attr = Clusters.CameraAvStreamManagement.Attributes
+        commands = Clusters.CameraAvStreamManagement.Commands
+
+        self.step("precondition")
+        # Commission DUT - already done
+        await self.precondition_one_allocated_video_stream()
+        await self.precondition_one_allocated_audio_stream()
+
+        self.step(1)
+        aFeatureMap = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.FeatureMap)
+        logger.info(f"Rx'd FeatureMap: {aFeatureMap}")
+        vdoSupport = aFeatureMap & cluster.Bitmaps.Feature.kVideo
+        adoSupport = aFeatureMap & cluster.Bitmaps.Feature.kAudio
+        privacySupport = aFeatureMap & cluster.Bitmaps.Feature.kPrivacy
+        asserts.assert_equal(vdoSupport, cluster.Bitmaps.Feature.kVideo, "Video Feature is not supported.")
+        asserts.assert_equal(adoSupport, cluster.Bitmaps.Feature.kVideo, "Audio Feature is not supported.")
+        asserts.assert_equal(privacySupport, cluster.Bitmaps.Feature.kPrivacy, "Privacy Feature is not supported.")
+
+        self.step(2)
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+        logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
+        asserts.assert_equal(len(aAllocatedVideoStreams), 1, "The number of allocated video streams in the list is not 1")
+        aVideoStreamID = aAllocatedVideoStreams[0].videoStreamID
+        aVideoRefCount = aAllocatedVideoStreams[0].referenceCount
+
+        self.step(3)
+        aAllocatedAudioStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedAudioStreams
+        )
+        logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
+        asserts.assert_equal(len(aAllocatedVideoStreams), 1, "The number of allocated audio streams in the list is not 1")
+        aAudioStreamID = aAllocatedAudioStreams[0].audioStreamID
+        aAudioRefCount = aAllocatedAudioStreams[0].referenceCount
+
+        self.step(4)
+        result = await self.write_single_attribute(attr.SoftLivestreamPrivacyModeEnabled(False), endpoint_id=endpoint)
+        asserts.assert_equal(result, Status.Success, "Error when trying to write SoftLivestreamPrivacyModeEnabled")
+        logger.info(f"Tx'd : SoftLivestreamPrivacyModeEnabled{False}")
+
+        self.step(5)
+        current_sessions = await self.read_single_attribute_check_success(
+            endpoint=endpoint,
+            cluster=Clusters.WebRTCTransportProvider,
+            attribute=cluster.Attributes.CurrentSessions
+        )
+        asserts.assert_equal(len(current_sessions), 0, "CurrentSessions must be empty!")
+
+        self.step(6)
+        # Sample SDP for testing
+        test_sdp = (
+            "v=0\n"
+            "o=rtc 2281582238 0 IN IP4 127.0.0.1\n"
+            "s=-\n"
+            "t=0 0\n"
+            "a=group:BUNDLE 0\n"
+            "a=msid-semantic:WMS *\n"
+            "a=ice-options:ice2,trickle\n"
+            "a=fingerprint:sha-256 8F:BF:9A:B9:FA:59:EC:F6:08:EA:47:D3:F4:AC:FA:AC:E9:27:FA:28:D3:00:1D:9B:EF:62:3F:B8:C6:09:FB:B9\n"
+            "m=application 9 UDP/DTLS/SCTP webrtc-datachannel\n"
+            "c=IN IP4 0.0.0.0\n"
+            "a=mid:0\n"
+            "a=sendrecv\n"
+            "a=sctp-port:5000\n"
+            "a=max-message-size:262144\n"
+            "a=setup:actpass\n"
+            "a=ice-ufrag:ytRw\n"
+            "a=ice-pwd:blrzPJtaV9Y1BNgbC1bXpi"
+        )
+
+        # Send valid ProvideOffer command with allocated VideoStreamID and
+        # AudioStreamID and Null webRTCSessionID
+        cmd = Clusters.WebRTCTransportProvider.Commands.ProvideOffer(
+            webRTCSessionID=NullValue,
+            sdp=test_sdp,
+            streamUsage=3,
+            originatingEndpointID=endpoint,
+            videoStreamID=aVideoStreamID,
+            audioStreamID=aAudioStreamID
+        )
+        resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
+        asserts.assert_equal(type(resp), Clusters.WebRTCTransportProvider.Commands.ProvideOfferResponse,
+                             "Incorrect response type")
+        aSessionID = resp.webRTCSessionID
+
+        self.step(7)
+        # Verify CurrentSessions contains the new session
+        current_sessions = await self.read_single_attribute_check_success(
+            endpoint=endpoint,
+            cluster=Clusters.WebRTCTransportProvider,
+            attribute=Clusters.WebRTCTransportProvider.Attributes.CurrentSessions
+        )
+        asserts.assert_equal(len(current_sessions), 1, "Expected CurrentSessions to be 1")
+        asserts.assert_equal(current_sessions[0].ID, aSessionID, "Created session does not match ID in CurrentSessions")
+
+        self.step(8)
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+        logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
+        asserts.assert_equal(aAllocatedVideoStreams[0].referenceCount, aVideoRefCount+1,
+                             "The reference count for allocated video streams is not as expected")
+
+        self.step(9)
+        aAllocatedAudioStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedAudioStreams
+        )
+        logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
+        asserts.assert_equal(aAllocatedAudioStreams[0].referenceCount, aAudioRefCount+1,
+                             "The reference count for allocated video streams is not as expected")
+
+        self.step(10)
+        result = await self.write_single_attribute(attr.SoftLivestreamPrivacyModeEnabled(true), endpoint_id=endpoint)
+        asserts.assert_equal(result, Status.Success, "Error when trying to write SoftLivestreamPrivacyModeEnabled")
+        logger.info(f"Tx'd : SoftLivestreamPrivacyModeEnabled{False}")
+
+        self.step(11)
+        current_sessions = await self.read_single_attribute_check_success(
+            endpoint=endpoint,
+            cluster=Clusters.WebRTCTransportProvider,
+            attribute=Clusters.WebRTCTransportProvider.Attributes.CurrentSessions
+        )
+        asserts.assert_equal(len(current_sessions), 0, "CurrentSessions must be empty!")
+
+        self.step(12)
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+        logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
+        asserts.assert_equal(aAllocatedVideoStreams[0].referenceCount, aVideoRefCount, "The reference count should be unchanged")
+
+        self.step(13)
+        aAllocatedAudioStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedAudioStreams
+        )
+        logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
+        asserts.assert_equal(aAllocatedAudioStreams[0].referenceCount, aAudioRefCount, "The reference count should be unchanged")
+
+        self.step(14)
+        try:
+            await self.send_single_cmd(endpoint=endpoint, cmd=commands.VideoStreamDeallocate(videoStreamID=(aVideoStreamID)))
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
+
+        self.step(15)
+        try:
+            await self.send_single_cmd(endpoint=endpoint, cmd=commands.AudioStreamDeallocate(videoStreamID=(aAudioStreamID)))
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
+
+        self.step(16)
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+        logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
+        asserts.assert_equal(len(aAllocatedVideoStreams), 0, "The number of allocated video streams in the list is not 0")
+
+        self.step(17)
+        aAllocatedAudioStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedAudioStreams
+        )
+        logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedVideoStreams}")
+        asserts.assert_equal(len(aAllocatedAudioStreams), 0, "The number of allocated audio streams in the list is not 0")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_AVSM_2_17.py
+++ b/src/python_testing/TC_AVSM_2_17.py
@@ -39,11 +39,14 @@ import logging
 
 from mobly import asserts
 from TC_AVSMTestBase import AVSMTestBase
+from TC_WEBRTC_Utils import WebRTCTestHelper
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
+from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
+from matter.webrtc import LibdatachannelPeerConnection, WebRTCManager
 
 logger = logging.getLogger(__name__)
 
@@ -92,59 +95,74 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 7,
+                "TH waits for the `Answer` command for the sent `Offer`. DUT sends the `Answer`.",
+                "Verify that the `sessionID` matches that in the `ProvideOfferResponse in step 6.",
+            ),
+            TestStep(
+                8,
                 "TH reads `CurrentSessions` attribute from WebRTCTransportProvider Cluster on DUT.",
                 "Verify that the count is equal to 1 and the session ID matches the one in the ProvideOfferResponse in step 6.",
                 "Save session as aWebRTCSessionID",
             ),
             TestStep(
-                8,
-                "H reads `AllocatedVideoStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
+                9,
+                "TH reads `AllocatedVideoStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Verify that the reference count of the VideoStream for `aVideoStreamID` is equal to `aVideoRefCount` + 1.",
             ),
             TestStep(
-                9,
-                "H reads `AllocatedAudioStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
+                10,
+                "TH reads `AllocatedAudioStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Verify that the reference count of the AudioStream for `aAudioStreamID` is equal to `aAudioRefCount` + 1.",
             ),
             TestStep(
-                10,
+                11,
                 "TH writes attribute `SoftLivestreamPrivacyModeEnabled` to true in the CameraAVStreamManagement Cluster on DUT.",
                 "DUT responds with Success",
             ),
             TestStep(
-                11,
+                12,
+                "TH waits for the `End` command for the WebRTC session. DUT sends the `End` command.",
+                "Verify that the `sessionID` matches `aWebRTCSessionID` and reason code is `Privacy`.",
+            ),
+            TestStep(
+                13,
                 "TH reads `CurrentSessions` attribute from WebRTCTransportProvider Cluster on DUT.",
                 "Verify that the count is equal to 0.",
             ),
             TestStep(
-                12,
-                "TH reads `AllocatedVideoStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
-                "Verify that the reference count of the VideoStream for `aVideoStreamID` is equal to `aVideoRefCount.",
-            ),
-            TestStep(
-                13,
-                "TH reads `AllocatedAudioStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
-                "Verify that the reference count of the AudioStream for `aAudioStreamID` is equal to `aAudioRefCount.",
-            ),
-            TestStep(
                 14,
+                "TH reads `AllocatedVideoStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Verify that the reference count of the VideoStream for `aVideoStreamID` is equal to `aVideoRefCount`.",
+            ),
+            TestStep(
+                15,
+                "TH reads `AllocatedAudioStreams` attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Verify that the reference count of the AudioStream for `aAudioStreamID` is equal to `aAudioRefCount`.",
+            ),
+            TestStep(
+                16,
                 "TH sends the VideoStreamDeallocate command with VideoStreamID set to aVideoStreamID.",
                 "DUT responds with Success",
             ),
             TestStep(
-                15,
+                17,
                 "TH sends the AudioStreamDeallocate command with AudioStreamID set to aAudioStreamID.",
                 "DUT responds with Success.",
             ),
             TestStep(
-                16,
+                18,
                 "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
                 "Verify the number of allocated video streams in the list is 0.",
             ),
             TestStep(
-                17,
+                19,
                 "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
                 "Verify the number of allocated audio streams in the list is 0.",
+            ),
+            TestStep(
+                20,
+                "TH writes attribute `SoftLivestreamPrivacyModeEnabled` to false in the CameraAVStreamManagement Cluster on DUT.",
+                "DUT responds with Success",
             ),
         ]
 
@@ -164,6 +182,11 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
         await self.precondition_one_allocated_video_stream()
         await self.precondition_one_allocated_audio_stream()
 
+        webrtc_manager = WebRTCManager(event_loop=self.event_loop)
+        webrtc_peer: LibdatachannelPeerConnection = webrtc_manager.create_peer(
+            node_id=self.dut_node_id, fabric_index=self.default_controller.GetFabricIndexInternal(), endpoint=endpoint
+        )
+
         self.step(1)
         aFeatureMap = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.FeatureMap)
         logger.info(f"Rx'd FeatureMap: {aFeatureMap}")
@@ -171,7 +194,7 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
         adoSupport = aFeatureMap & cluster.Bitmaps.Feature.kAudio
         privacySupport = aFeatureMap & cluster.Bitmaps.Feature.kPrivacy
         asserts.assert_equal(vdoSupport, cluster.Bitmaps.Feature.kVideo, "Video Feature is not supported.")
-        asserts.assert_equal(adoSupport, cluster.Bitmaps.Feature.kVideo, "Audio Feature is not supported.")
+        asserts.assert_equal(adoSupport, cluster.Bitmaps.Feature.kAudio, "Audio Feature is not supported.")
         asserts.assert_equal(privacySupport, cluster.Bitmaps.Feature.kPrivacy, "Privacy Feature is not supported.")
 
         self.step(2)
@@ -188,7 +211,7 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedAudioStreams
         )
         logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
-        asserts.assert_equal(len(aAllocatedVideoStreams), 1, "The number of allocated audio streams in the list is not 1")
+        asserts.assert_equal(len(aAllocatedAudioStreams), 1, "The number of allocated audio streams in the list is not 1")
         aAudioStreamID = aAllocatedAudioStreams[0].audioStreamID
         aAudioRefCount = aAllocatedAudioStreams[0].referenceCount
 
@@ -201,48 +224,42 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
         current_sessions = await self.read_single_attribute_check_success(
             endpoint=endpoint,
             cluster=Clusters.WebRTCTransportProvider,
-            attribute=cluster.Attributes.CurrentSessions
+            attribute=Clusters.WebRTCTransportProvider.Attributes.CurrentSessions
         )
         asserts.assert_equal(len(current_sessions), 0, "CurrentSessions must be empty!")
 
         self.step(6)
-        # Sample SDP for testing
-        test_sdp = (
-            "v=0\n"
-            "o=rtc 2281582238 0 IN IP4 127.0.0.1\n"
-            "s=-\n"
-            "t=0 0\n"
-            "a=group:BUNDLE 0\n"
-            "a=msid-semantic:WMS *\n"
-            "a=ice-options:ice2,trickle\n"
-            "a=fingerprint:sha-256 8F:BF:9A:B9:FA:59:EC:F6:08:EA:47:D3:F4:AC:FA:AC:E9:27:FA:28:D3:00:1D:9B:EF:62:3F:B8:C6:09:FB:B9\n"
-            "m=application 9 UDP/DTLS/SCTP webrtc-datachannel\n"
-            "c=IN IP4 0.0.0.0\n"
-            "a=mid:0\n"
-            "a=sendrecv\n"
-            "a=sctp-port:5000\n"
-            "a=max-message-size:262144\n"
-            "a=setup:actpass\n"
-            "a=ice-ufrag:ytRw\n"
-            "a=ice-pwd:blrzPJtaV9Y1BNgbC1bXpi"
-        )
+        webrtc_peer.create_offer()
+        offer = await webrtc_peer.get_local_offer()
 
         # Send valid ProvideOffer command with allocated VideoStreamID and
         # AudioStreamID and Null webRTCSessionID
-        cmd = Clusters.WebRTCTransportProvider.Commands.ProvideOffer(
-            webRTCSessionID=NullValue,
-            sdp=test_sdp,
-            streamUsage=3,
-            originatingEndpointID=endpoint,
-            videoStreamID=aVideoStreamID,
-            audioStreamID=aAudioStreamID
+        provide_offer_response: Clusters.WebRTCTransportProvider.Commands.ProvideOfferResponse = await webrtc_peer.send_command(
+            cmd=Clusters.WebRTCTransportProvider.Commands.ProvideOffer(
+                webRTCSessionID=NullValue,
+                sdp=offer,
+                streamUsage=Clusters.Objects.Globals.Enums.StreamUsageEnum.kLiveView,
+                videoStreamID=aVideoStreamID,
+                audioStreamID=aAudioStreamID,
+                originatingEndpointID=1,
+            ),
+            endpoint=endpoint,
+            payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD,
         )
-        resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
-        asserts.assert_equal(type(resp), Clusters.WebRTCTransportProvider.Commands.ProvideOfferResponse,
-                             "Incorrect response type")
-        aSessionID = resp.webRTCSessionID
+        aSessionID = provide_offer_response.webRTCSessionID
+        asserts.assert_true(aSessionID >= 0, "Invalid response")
+
+        webrtc_manager.session_id_created(aSessionID, self.dut_node_id)
 
         self.step(7)
+        answer_sessionId, answer = await webrtc_peer.get_remote_answer()
+
+        asserts.assert_equal(aSessionID, answer_sessionId, "Answer command invoked with wrong session id")
+        asserts.assert_true(len(answer) > 0, "Invalid answer SDP received")
+
+        webrtc_peer.set_remote_answer(answer)
+
+        self.step(8)
         # Verify CurrentSessions contains the new session
         current_sessions = await self.read_single_attribute_check_success(
             endpoint=endpoint,
@@ -250,9 +267,9 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
             attribute=Clusters.WebRTCTransportProvider.Attributes.CurrentSessions
         )
         asserts.assert_equal(len(current_sessions), 1, "Expected CurrentSessions to be 1")
-        asserts.assert_equal(current_sessions[0].ID, aSessionID, "Created session does not match ID in CurrentSessions")
+        asserts.assert_equal(current_sessions[0].id, aSessionID, "Created session does not match ID in CurrentSessions")
 
-        self.step(8)
+        self.step(9)
         aAllocatedVideoStreams = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
         )
@@ -260,20 +277,27 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
         asserts.assert_equal(aAllocatedVideoStreams[0].referenceCount, aVideoRefCount+1,
                              "The reference count for allocated video streams is not as expected")
 
-        self.step(9)
+        self.step(10)
         aAllocatedAudioStreams = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedAudioStreams
         )
         logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
         asserts.assert_equal(aAllocatedAudioStreams[0].referenceCount, aAudioRefCount+1,
-                             "The reference count for allocated video streams is not as expected")
-
-        self.step(10)
-        result = await self.write_single_attribute(attr.SoftLivestreamPrivacyModeEnabled(true), endpoint_id=endpoint)
-        asserts.assert_equal(result, Status.Success, "Error when trying to write SoftLivestreamPrivacyModeEnabled")
-        logger.info(f"Tx'd : SoftLivestreamPrivacyModeEnabled{False}")
+                             "The reference count for allocated audio streams is not as expected")
 
         self.step(11)
+        result = await self.write_single_attribute(attr.SoftLivestreamPrivacyModeEnabled(True), endpoint_id=endpoint)
+        asserts.assert_equal(result, Status.Success, "Error when trying to write SoftLivestreamPrivacyModeEnabled")
+        logger.info(f"Tx'd : SoftLivestreamPrivacyModeEnabled{True}")
+
+        self.step(12)
+        kPrivacyReasonCode = 11
+        # wait for the DUT to send the End session command
+        end_sessionId, reason = await webrtc_peer.get_remote_end()
+        asserts.assert_equal(aSessionID, end_sessionId, "End Session invoked with wrong session id")
+        asserts.assert_equal(reason, kPrivacyReasonCode, "Invalid End reason")
+
+        self.step(13)
         current_sessions = await self.read_single_attribute_check_success(
             endpoint=endpoint,
             cluster=Clusters.WebRTCTransportProvider,
@@ -281,47 +305,54 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
         )
         asserts.assert_equal(len(current_sessions), 0, "CurrentSessions must be empty!")
 
-        self.step(12)
+        self.step(14)
         aAllocatedVideoStreams = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
         )
         logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
         asserts.assert_equal(aAllocatedVideoStreams[0].referenceCount, aVideoRefCount, "The reference count should be unchanged")
 
-        self.step(13)
+        self.step(15)
         aAllocatedAudioStreams = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedAudioStreams
         )
         logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
         asserts.assert_equal(aAllocatedAudioStreams[0].referenceCount, aAudioRefCount, "The reference count should be unchanged")
 
-        self.step(14)
+        self.step(16)
         try:
             await self.send_single_cmd(endpoint=endpoint, cmd=commands.VideoStreamDeallocate(videoStreamID=(aVideoStreamID)))
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
-        self.step(15)
+        self.step(17)
         try:
-            await self.send_single_cmd(endpoint=endpoint, cmd=commands.AudioStreamDeallocate(videoStreamID=(aAudioStreamID)))
+            await self.send_single_cmd(endpoint=endpoint, cmd=commands.AudioStreamDeallocate(audioStreamID=(aAudioStreamID)))
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
-        self.step(16)
+        self.step(18)
         aAllocatedVideoStreams = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
         )
         logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
         asserts.assert_equal(len(aAllocatedVideoStreams), 0, "The number of allocated video streams in the list is not 0")
 
-        self.step(17)
+        self.step(19)
         aAllocatedAudioStreams = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedAudioStreams
         )
-        logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedVideoStreams}")
+        logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
         asserts.assert_equal(len(aAllocatedAudioStreams), 0, "The number of allocated audio streams in the list is not 0")
+
+        self.step(20)
+        result = await self.write_single_attribute(attr.SoftLivestreamPrivacyModeEnabled(False), endpoint_id=endpoint)
+        asserts.assert_equal(result, Status.Success, "Error when trying to write SoftLivestreamPrivacyModeEnabled")
+        logger.info(f"Tx'd : SoftLivestreamPrivacyModeEnabled{False}")
+
+        await webrtc_manager.close_all()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Summary
Test script for corresponding test plan test case in https://github.com/CHIP-Specifications/chip-test-plans/pull/5476

- Add ability for CameraApp to send WebRTCEndSession
- Hookup SoftLivestreamPrivacy mode changes between CameraAVSM and
  WebRTCProviderManager.
- Update test script to wait for Answer command for session setup.
- Update test script to wait for End command for session termination
  on softLivestreamPrivacy setting on DUT.
 
#### Testing
Run TC_AVSM_2_17.py against chip-camera-app

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
