### PR TITLE
ThreadBRManagement: Fix GetDataset return of GenericThreadBorderRouterDelegate

### DIFF
--- a/src/app/clusters/thread-border-router-management-server/thread-br-delegate.h
+++ b/src/app/clusters/thread-border-router-management-server/thread-br-delegate.h
@@ -73,8 +73,8 @@ public:
 
     // Get the BorderAgentId of the Thread BR.
     // @return
-    //   -IncorrectState When Thread stack is not initialized.
-    //   -InvalidArgument When the size of borderAgentId is not 16 bytes.
+    //   -CHIP_ERROR_INCORRECT_STATE When Thread stack is not initialized.
+    //   -CHIP_ERROR_INVALID_ARGUMENT When the size of borderAgentId is not 16 bytes.
     //   -ThreadErrors When failing to get BorderAgentId.
     virtual CHIP_ERROR GetBorderAgentId(MutableByteSpan & borderAgentId) = 0;
 
@@ -86,8 +86,8 @@ public:
 
     // Get the active dataset or the pending dataset.
     // @return
-    //   -IncorrectState When Thread stack is not initialized.
-    //   -NotFound when failing to get the dataset.
+    //   -CHIP_ERROR_INCORRECT_STATE When Thread stack is not initialized.
+    //   -CHIP_ERROR_NOT_FOUND when failing to get the dataset.
     virtual CHIP_ERROR GetDataset(Thread::OperationalDataset & dataset, DatasetType type) = 0;
 
     // There should be no active dataset configured when calling this API, otherwise we should use SetPendingDataset.

--- a/src/platform/OpenThread/GenericThreadBorderRouterDelegate.cpp
+++ b/src/platform/OpenThread/GenericThreadBorderRouterDelegate.cpp
@@ -120,7 +120,8 @@ CHIP_ERROR GenericOpenThreadBorderRouterDelegate::GetDataset(Thread::Operational
     {
         return dataset.Init(ByteSpan(datasetTlvs.mTlvs, datasetTlvs.mLength));
     }
-    return DeviceLayer::Internal::MapOpenThreadError(otErr);
+    // Otherwise the dataset is not configured, return CHIP_ERROR_NOT_FOUND.
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 void GenericOpenThreadBorderRouterDelegate::SetActiveDataset(const Thread::OperationalDataset & activeDataset, uint32_t sequenceNum,

--- a/src/platform/OpenThread/GenericThreadBorderRouterDelegate.cpp
+++ b/src/platform/OpenThread/GenericThreadBorderRouterDelegate.cpp
@@ -120,8 +120,8 @@ CHIP_ERROR GenericOpenThreadBorderRouterDelegate::GetDataset(Thread::Operational
     {
         return dataset.Init(ByteSpan(datasetTlvs.mTlvs, datasetTlvs.mLength));
     }
-    // Otherwise the dataset is not configured, return CHIP_ERROR_NOT_FOUND.
-    return CHIP_ERROR_NOT_FOUND;
+    // If the dataset is not configured, return CHIP_ERROR_NOT_FOUND. Otherwise, map the error.
+    return (otErr == OT_ERROR_NOT_FOUND) ? CHIP_ERROR_NOT_FOUND : DeviceLayer::Internal::MapOpenThreadError(otErr);
 }
 
 void GenericOpenThreadBorderRouterDelegate::SetActiveDataset(const Thread::OperationalDataset & activeDataset, uint32_t sequenceNum,


### PR DESCRIPTION
#### Summary

- Fix GetDataset return of GenericThreadBorderRouterDelegate
- Update the document of ThreadBorderRouterDelegate class

#### Related issues

Fixes #40747

#### Testing
Tested on ESP32-S3, the device replies an empty dataset instead of Failure error when the dataset is not configured.

