### PR TITLE
[Linux] Fix SIGSEGV when returning error from call handler

### DIFF
--- a/build/chip/linux/BUILD.gn
+++ b/build/chip/linux/BUILD.gn
@@ -18,7 +18,7 @@ import("${build_root}/config/linux/pkg_config.gni")
 
 pkg_config("glib") {
   packages = [
-    "glib-2.0",
+    "glib-2.0 >= 2.68",
     "gio-unix-2.0",
   ]
   optional = true  # Only certain conditionally-compiled modules depend on glib

--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include <gio/gio.h>
+#include <gio/gunixfdlist.h>
 #include <glib.h>
 
 namespace chip {
@@ -148,6 +149,12 @@ template <>
 struct GAutoPtrDeleter<GSource>
 {
     using deleter = GSourceDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<GUnixFDList>
+{
+    using deleter = GObjectDeleter;
 };
 
 template <>

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -96,7 +96,7 @@ gboolean BluezAdvertisement::BluezLEAdvertisement1Release(BluezLEAdvertisement1 
     mIsAdvertising = false;
     bluez_leadvertisement1_complete_release(aAdv, aInvocation);
     BLEManagerImpl::NotifyBLEPeripheralAdvReleased();
-    return TRUE;
+    return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 CHIP_ERROR BluezAdvertisement::InitImpl()

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -91,7 +91,7 @@ gboolean BluezEndpoint::BluezCharacteristicReadValue(BluezGattCharacteristic1 * 
     ChipLogDetail(DeviceLayer, "Received %s", __func__);
     GVariant * val = bluez_gatt_characteristic1_get_value(aChar);
     bluez_gatt_characteristic1_complete_read_value(aChar, aInvocation, val);
-    return TRUE;
+    return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 gboolean BluezEndpoint::BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
@@ -100,38 +100,35 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireWrite(BluezGattCharacteristic1
     int fds[2]             = { -1, -1 };
     BluezConnection * conn = nullptr;
     const char * deviceObjectPath;
+    GAutoPtr<GUnixFDList> fdList;
     uint16_t mtu;
 
-    VerifyOrReturnValue(
-        g_variant_lookup(aOptions, "device", "&o", &deviceObjectPath), FALSE,
+    VerifyOrExit(
+        g_variant_lookup(aOptions, "device", "&o", &deviceObjectPath),
         ChipLogError(DeviceLayer, "FAIL: No device in options in %s", __func__);
         g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No device object path"));
-    VerifyOrReturnValue(
-        g_variant_lookup(aOptions, "mtu", "q", &mtu), FALSE, ChipLogError(DeviceLayer, "FAIL: No MTU in options in %s", __func__);
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No MTU value"));
+    VerifyOrExit(g_variant_lookup(aOptions, "mtu", "q", &mtu), ChipLogError(DeviceLayer, "FAIL: No MTU in options in %s", __func__);
+                 g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No MTU value"));
 
     conn = GetBluezConnection(deviceObjectPath);
-    VerifyOrReturnValue(
-        conn != nullptr, FALSE,
+    VerifyOrExit(
+        conn != nullptr,
         g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No CHIPoBLE connection for the device"));
 
     conn->SetMTU(mtu);
 
-    if (socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, fds) < 0)
-    {
-        ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(strerror(errno)), __func__);
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed");
-        return FALSE;
-    }
+    VerifyOrExit(socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, fds) == 0,
+                 ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(strerror(errno)), __func__);
+                 g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed"));
 
     conn->SetupWriteHandler(fds[0]);
     bluez_gatt_characteristic1_set_write_acquired(aChar, TRUE);
 
-    GUnixFDList * fdList = g_unix_fd_list_new_from_array(&fds[1], 1);
-    bluez_gatt_characteristic1_complete_acquire_write(aChar, aInvocation, fdList, g_variant_new_handle(0), conn->GetMTU());
-    g_object_unref(fdList);
+    fdList.reset(g_unix_fd_list_new_from_array(&fds[1], 1));
+    bluez_gatt_characteristic1_complete_acquire_write(aChar, aInvocation, fdList.get(), g_variant_new_handle(0), conn->GetMTU());
 
-    return TRUE;
+exit:
+    return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 static gboolean BluezCharacteristicAcquireWriteError(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
@@ -140,7 +137,7 @@ static gboolean BluezCharacteristicAcquireWriteError(BluezGattCharacteristic1 * 
     ChipLogDetail(DeviceLayer, "Received %s", __func__);
     g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.NotSupported",
                                                "AcquireWrite for characteristic is unsupported");
-    return TRUE;
+    return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 gboolean BluezEndpoint::BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
@@ -150,48 +147,44 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireNotify(BluezGattCharacteristic
     BluezConnection * conn       = nullptr;
     bool isAdditionalAdvertising = false;
     const char * deviceObjectPath;
+    GAutoPtr<GUnixFDList> fdList;
     uint16_t mtu;
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
     isAdditionalAdvertising = (aChar == mC3.get());
 #endif
 
-    VerifyOrReturnValue(
-        !bluez_gatt_characteristic1_get_notifying(aChar), FALSE,
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.NotPermitted", "Already notifying"));
-    VerifyOrReturnValue(
-        g_variant_lookup(aOptions, "device", "&o", &deviceObjectPath), FALSE,
+    VerifyOrExit(!bluez_gatt_characteristic1_get_notifying(aChar),
+                 g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.NotPermitted", "Already notifying"));
+    VerifyOrExit(
+        g_variant_lookup(aOptions, "device", "&o", &deviceObjectPath),
         ChipLogError(DeviceLayer, "FAIL: No device in options in %s", __func__);
         g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No device object path"));
-    VerifyOrReturnValue(
-        g_variant_lookup(aOptions, "mtu", "q", &mtu), FALSE, ChipLogError(DeviceLayer, "FAIL: No MTU in options in %s", __func__);
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No MTU value"));
+    VerifyOrExit(g_variant_lookup(aOptions, "mtu", "q", &mtu), ChipLogError(DeviceLayer, "FAIL: No MTU in options in %s", __func__);
+                 g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No MTU value"));
 
     conn = GetBluezConnection(deviceObjectPath);
-    VerifyOrReturnValue(
-        conn != nullptr, FALSE,
+    VerifyOrExit(
+        conn != nullptr,
         g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No CHIPoBLE connection for the device"));
 
     conn->SetMTU(mtu);
 
-    if (socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, fds) < 0)
-    {
-        ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(strerror(errno)), __func__);
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed");
-        return FALSE;
-    }
+    VerifyOrExit(socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, fds) == 0,
+                 ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(strerror(errno)), __func__);
+                 g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed"));
 
     conn->SetupNotifyHandler(fds[0], isAdditionalAdvertising);
     bluez_gatt_characteristic1_set_notify_acquired(aChar, TRUE);
     conn->SetNotifyAcquired(true);
 
-    GUnixFDList * fdList = g_unix_fd_list_new_from_array(&fds[1], 1);
-    bluez_gatt_characteristic1_complete_acquire_notify(aChar, aInvocation, fdList, g_variant_new_handle(0), conn->GetMTU());
-    g_object_unref(fdList);
+    fdList.reset(g_unix_fd_list_new_from_array(&fds[1], 1));
+    bluez_gatt_characteristic1_complete_acquire_notify(aChar, aInvocation, fdList.get(), g_variant_new_handle(0), conn->GetMTU());
 
     BLEManagerImpl::HandleTXCharCCCDWrite(conn);
 
-    return TRUE;
+exit:
+    return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 static gboolean BluezCharacteristicAcquireNotifyError(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
@@ -200,7 +193,7 @@ static gboolean BluezCharacteristicAcquireNotifyError(BluezGattCharacteristic1 *
     ChipLogDetail(DeviceLayer, "Received %s", __func__);
     g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.NotSupported",
                                                "AcquireNotify for characteristic is unsupported");
-    return TRUE;
+    return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 // NOTE: When using with BlueZ >= 5.80, this method can be removed. Also, the GetBluezConnectionViaDevice
@@ -212,13 +205,13 @@ gboolean BluezEndpoint::BluezCharacteristicConfirm(BluezGattCharacteristic1 * aC
     ChipLogDetail(DeviceLayer, "Indication confirmation: conn=%p", conn);
     bluez_gatt_characteristic1_complete_confirm(aChar, aInvocation);
     BLEManagerImpl::HandleTXComplete(conn);
-    return TRUE;
+    return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 static gboolean BluezCharacteristicConfirmError(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation)
 {
     g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "Confirm from characteristic is unsupported");
-    return TRUE;
+    return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
 BluezGattCharacteristic1 * BluezEndpoint::CreateGattCharacteristic(BluezGattService1 * aService, const char * aCharName,

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -103,23 +103,27 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireWrite(BluezGattCharacteristic1
     GAutoPtr<GUnixFDList> fdList;
     uint16_t mtu;
 
-    VerifyOrExit(
-        g_variant_lookup(aOptions, "device", "&o", &deviceObjectPath),
-        ChipLogError(DeviceLayer, "FAIL: No device in options in %s", __func__);
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No device object path"));
-    VerifyOrExit(g_variant_lookup(aOptions, "mtu", "q", &mtu), ChipLogError(DeviceLayer, "FAIL: No MTU in options in %s", __func__);
-                 g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No MTU value"));
+    VerifyOrExit(g_variant_lookup(aOptions, "device", "&o", &deviceObjectPath), {
+        ChipLogError(DeviceLayer, "FAIL: %s: No device in options", __func__);
+        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No device object path");
+    });
+    VerifyOrExit(g_variant_lookup(aOptions, "mtu", "q", &mtu), {
+        ChipLogError(DeviceLayer, "FAIL: %s: No MTU in options", __func__);
+        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No MTU value");
+    });
 
     conn = GetBluezConnection(deviceObjectPath);
-    VerifyOrExit(
-        conn != nullptr,
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No CHIPoBLE connection for the device"));
+    VerifyOrExit(conn != nullptr, {
+        ChipLogError(DeviceLayer, "FAIL: %s: No CHIPoBLE connection for device %s", __func__, deviceObjectPath);
+        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No CHIPoBLE connection for the device");
+    });
 
     conn->SetMTU(mtu);
 
-    VerifyOrExit(socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, fds) == 0,
-                 ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(strerror(errno)), __func__);
-                 g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed"));
+    VerifyOrExit(socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, fds) == 0, {
+        ChipLogError(DeviceLayer, "FAIL: %s: socketpair: %s", __func__, StringOrNullMarker(strerror(errno)));
+        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed");
+    });
 
     conn->SetupWriteHandler(fds[0]);
     bluez_gatt_characteristic1_set_write_acquired(aChar, TRUE);
@@ -156,23 +160,27 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireNotify(BluezGattCharacteristic
 
     VerifyOrExit(!bluez_gatt_characteristic1_get_notifying(aChar),
                  g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.NotPermitted", "Already notifying"));
-    VerifyOrExit(
-        g_variant_lookup(aOptions, "device", "&o", &deviceObjectPath),
-        ChipLogError(DeviceLayer, "FAIL: No device in options in %s", __func__);
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No device object path"));
-    VerifyOrExit(g_variant_lookup(aOptions, "mtu", "q", &mtu), ChipLogError(DeviceLayer, "FAIL: No MTU in options in %s", __func__);
-                 g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No MTU value"));
+    VerifyOrExit(g_variant_lookup(aOptions, "device", "&o", &deviceObjectPath), {
+        ChipLogError(DeviceLayer, "FAIL: %s: No device in options", __func__);
+        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No device object path");
+    });
+    VerifyOrExit(g_variant_lookup(aOptions, "mtu", "q", &mtu), {
+        ChipLogError(DeviceLayer, "FAIL: %s: No MTU in options", __func__);
+        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.InvalidArguments", "No MTU value");
+    });
 
     conn = GetBluezConnection(deviceObjectPath);
-    VerifyOrExit(
-        conn != nullptr,
-        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No CHIPoBLE connection for the device"));
+    VerifyOrExit(conn != nullptr, {
+        ChipLogError(DeviceLayer, "FAIL: %s: No CHIPoBLE connection for device %s", __func__, deviceObjectPath);
+        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "No CHIPoBLE connection for the device");
+    });
 
     conn->SetMTU(mtu);
 
-    VerifyOrExit(socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, fds) == 0,
-                 ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(strerror(errno)), __func__);
-                 g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed"));
+    VerifyOrExit(socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, fds) == 0, {
+        ChipLogError(DeviceLayer, "FAIL: %s: socketpair: %s", __func__, StringOrNullMarker(strerror(errno)));
+        g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed");
+    });
 
     conn->SetupNotifyHandler(fds[0], isAdditionalAdvertising);
     bluez_gatt_characteristic1_set_notify_acquired(aChar, TRUE);
@@ -365,7 +373,7 @@ BluezGattService1 * BluezEndpoint::CreateGattService(const char * aUUID)
     BluezGattService1 * service;
 
     mServicePath.reset(g_strdup_printf("%s/service", mRootPath.get()));
-    ChipLogDetail(DeviceLayer, "CREATE service object at %s", mServicePath.get());
+    ChipLogDetail(DeviceLayer, "Creating GATT service object at %s", mServicePath.get());
     object = bluez_object_skeleton_new(mServicePath.get());
 
     service = bluez_gatt_service1_skeleton_new();


### PR DESCRIPTION
#### Summary

The call handler needs to return TRUE (G_DBUS_METHOD_INVOCATION_HANDLED) if the call was handed. Returning FALSE means that the call will be handled internally by glib. In our scenario returning FALSE results in handling call twice which leads to double-free.

```
[1756721207.779] [68516:68519] [DL] New BLE connection: conn=0x7ffff001dc20 device=00:00:00:22:22:22 path=/org/bluez/hci0/dev_00_00_00_22_22_22

Thread 2 "gmain-matter" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff6f976c0 (LWP 68519)]
g_type_check_instance_is_fundamentally_a (type_instance=type_instance@entry=0x7fffe000e260, fundamental_type=fundamental_type@entry=80) at ../gobject/gtype.c:4153
4153      node = lookup_type_node_I (type_instance->g_class->g_type);
(gdb) bt
#0  g_type_check_instance_is_fundamentally_a (type_instance=type_instance@entry=0x7fffe000e260, fundamental_type=fundamental_type@entry=80) at ../gobject/gtype.c:4153
#1  0x00007ffff7f5a8cf in g_object_unref (_object=0x7fffe000e260) at ../gobject/gobject.c:4287
#2  0x00007ffff771fa4d in g_source_callback_unref (cb_data=0x7fffe0003ae0) at ../glib/gmain.c:1622
#3  g_source_callback_unref (cb_data=0x7fffe0003ae0) at ../glib/gmain.c:1615
#4  0x00007ffff772037f in g_source_destroy_internal (source=source@entry=0x7fffe0009bd0, context=context@entry=0x555555c3f5b0, have_lock=have_lock@entry=1) at ../glib/gmain.c:1287
#5  0x00007ffff772058c in g_main_dispatch (context=context@entry=0x555555c3f5b0) at ../glib/gmain.c:3374
#6  0x00007ffff7723787 in g_main_context_dispatch_unlocked (context=0x555555c3f5b0) at ../glib/gmain.c:4152
#7  g_main_context_iterate_unlocked (context=0x555555c3f5b0, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../glib/gmain.c:4217
#8  0x00007ffff772408f in g_main_loop_run (loop=0x555555c3f7a0) at ../glib/gmain.c:4419
#9  0x000055555598cd8d in chip::DeviceLayer::(anonymous namespace)::GLibMainLoopThread (userData=0x555555c3f7a0)
```

#### Testing

Locally verified, that in case of issue while handling D-Bus call, the app will not send duplicated D-Bus call response, and will not crash.