### PR TITLE
Remove sync scheduling of events for startup in basicinfo.

### DIFF
--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -448,7 +448,6 @@ void BasicInformationCluster::OnStartUp(uint32_t softwareVersion)
 
     DataModel::EventsGenerator & eventsGenerator = mContext->interactionContext.eventsGenerator;
     eventsGenerator.GenerateEvent(event, kRootEndpointId);
-    eventsGenerator.ScheduleUrgentEventDeliverySync();
 }
 
 void BasicInformationCluster::OnShutDown()


### PR DESCRIPTION
#### Summary

The code driven cluster conversion added this however there is no need to flush startup as connections are not about to be dropped (as opposed to shutdown...).

This addresses post-merge comment in
https://github.com/project-chip/connectedhomeip/pull/40422#discussion_r2291165130

#### Testing

Trivial change - N/A (CI integration will test as event is still generated - TC_BINFO_2_2.yaml still applies)
