### PR TITLE
Remove specialization from bool encode assuming it can be auto-deduced

### DIFF
--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -341,9 +341,7 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
     case ConfigurationVersion::Id:
         return ReadConfigurationVersion(configManager, encoder);
     case Reachable::Id:
-        // On some platforms `true` is defined as a unsigned int and that gets
-        // a ambigous TLVWriter::Put error. Hence the specialization.
-        return encoder.Encode<bool>(true);
+        return encoder.Encode(true);
     default:
         return Protocols::InteractionModel::Status::UnsupportedAttribute;
     }


### PR DESCRIPTION
#### Summary

This is to test the underlying error as it is assumed that compile will actually fail for some platforms.

#### Testing

Trivial change.