### PR TITLE
Fix various issues with TCP connections

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -103,6 +103,7 @@ shared_library("ChipDeviceCtrl") {
         "matter/webrtc/WebRTCTransportCluster.cpp",
       ]
     }
+    defines += [ "CHIP_CONFIG_MAX_ACTIVE_TCP_CONNECTIONS=20" ]
     defines += [ "CHIP_CONFIG_MAX_GROUPS_PER_FABRIC=50" ]
     defines += [ "CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC=50" ]
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -960,7 +960,11 @@ PyChipError pychip_CloseTCPConnectionWithPeer(chip::OperationalDeviceProxy * dev
     VerifyOrReturnError(deviceProxy->GetSecureSession().Value()->AsSecureSession()->AllowsLargePayload(),
                         ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
 
-    deviceProxy->GetSecureSession().Value()->AsSecureSession()->ReleaseTCPConnection();
+    auto tcpConnection = deviceProxy->GetSecureSession().Value()->AsSecureSession()->GetTCPConnection();
+    if (!tcpConnection.IsNull())
+    {
+        tcpConnection->ForceDisconnect();
+    }
 
     return ToPyChipError(CHIP_NO_ERROR);
 #else

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -960,7 +960,7 @@ PyChipError pychip_CloseTCPConnectionWithPeer(chip::OperationalDeviceProxy * dev
     VerifyOrReturnError(deviceProxy->GetSecureSession().Value()->AsSecureSession()->AllowsLargePayload(),
                         ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
 
-    deviceProxy->GetSecureSession().Value()->AsSecureSession()->GetTCPConnection().Release();
+    deviceProxy->GetSecureSession().Value()->AsSecureSession()->ReleaseTCPConnection();
 
     return ToPyChipError(CHIP_NO_ERROR);
 #else

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -932,7 +932,7 @@ PyChipError pychip_IsSessionOverTCPConnection(chip::OperationalDeviceProxy * dev
     VerifyOrReturnError(isSessionOverTCP != nullptr, ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    *isSessionOverTCP = deviceProxy->GetSecureSession().Value()->AsSecureSession()->GetTCPConnection() != nullptr;
+    *isSessionOverTCP = !deviceProxy->GetSecureSession().Value()->AsSecureSession()->GetTCPConnection().IsNull();
 #else
     *isSessionOverTCP = false;
 #endif
@@ -960,8 +960,7 @@ PyChipError pychip_CloseTCPConnectionWithPeer(chip::OperationalDeviceProxy * dev
     VerifyOrReturnError(deviceProxy->GetSecureSession().Value()->AsSecureSession()->AllowsLargePayload(),
                         ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
 
-    deviceProxy->GetExchangeManager()->GetSessionManager()->TCPDisconnect(
-        deviceProxy->GetSecureSession().Value()->AsSecureSession()->GetTCPConnection(), /* shouldAbort = */ false);
+    deviceProxy->GetSecureSession().Value()->AsSecureSession()->GetTCPConnection().Release();
 
     return ToPyChipError(CHIP_NO_ERROR);
 #else

--- a/src/lib/support/AutoRelease.h
+++ b/src/lib/support/AutoRelease.h
@@ -46,8 +46,6 @@ public:
     inline const Releasable * operator->() const { return mReleasable; }
     inline const Releasable & operator*() const { return *mReleasable; }
     inline Releasable & operator*() { return *mReleasable; }
-    inline operator const Releasable *() const { return mReleasable; }
-    inline operator Releasable *() { return mReleasable; }
 
     inline bool IsNull() const { return mReleasable == nullptr; }
 
@@ -58,7 +56,13 @@ public:
         mReleasable = nullptr;
     }
 
-private:
+    void Set(Releasable * releasable)
+    {
+        Release();
+        mReleasable = releasable;
+    }
+
+protected:
     Releasable * mReleasable = nullptr;
 };
 

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -210,6 +210,58 @@
     } while (false)
 
 /**
+ *  @def LogAndReturnOnFailure(expr)
+ *
+ *  @brief
+ *    If expr returns something than CHIP_NO_ERROR, log a chip message for the specified module
+ *    in the 'Error' category and return.
+ *
+ *  Example usage:
+ *
+ *  @code
+ *    LogAndReturnOnFailure(channel->SendMsg(msg), Module, "Failure message: %s", param);
+ *  @endcode
+ *
+ *  @param[in]  expr        A scalar expression to be evaluated against CHIP_NO_ERROR.
+ */
+#define LogAndReturnOnFailure(expr, MOD, MSG, ...)                                                                                 \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        CHIP_ERROR __err = (expr);                                                                                                 \
+        if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
+        {                                                                                                                          \
+            ChipLogError(MOD, MSG ": %" CHIP_ERROR_FORMAT, ##__VA_ARGS__, __err.Format());                                         \
+            return;                                                                                                                \
+        }                                                                                                                          \
+    } while (false)
+
+/**
+ *  @def LogAndReturnErrorOnFailure(expr)
+ *
+ *  @brief
+ *    If expr returns something than CHIP_NO_ERROR, lg a chip message for the specified module
+ *    in the 'Error' category and return the error.
+ *
+ *  Example usage:
+ *
+ *  @code
+ *    LogAndReturnErrorOnFailure(channel->SendMsg(msg), Module, "Failure message: %s", param);
+ *  @endcode
+ *
+ *  @param[in]  expr        A scalar expression to be evaluated against CHIP_NO_ERROR.
+ */
+#define LogAndReturnErrorOnFailure(expr, MOD, MSG, ...)                                                                            \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        CHIP_ERROR __err = (expr);                                                                                                 \
+        if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
+        {                                                                                                                          \
+            ChipLogError(MOD, MSG ": %" CHIP_ERROR_FORMAT, ##__VA_ARGS__, __err.Format());                                         \
+            return _err;                                                                                                           \
+        }                                                                                                                          \
+    } while (false)
+
+/**
  *  @def ReturnOnFailure(expr)
  *
  *  @brief

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -671,9 +671,20 @@ void ExchangeContext::ExchangeSessionHolder::GrabExpiredSession(const SessionHan
 }
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-void ExchangeContext::OnSessionConnectionClosed(CHIP_ERROR conErr)
+void ExchangeContext::OnSessionConnectionClosed(const Transport::ActiveTCPConnectionState & conn, CHIP_ERROR connErr)
 {
-    // TODO: Handle connection closure at the ExchangeContext level.
+    if (mDelegate != nullptr)
+    {
+        return mDelegate->HandleConnectionClosed(conn, connErr);
+    }
+}
+
+void ExchangeContext::OnConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR connErr)
+{
+    if (mDelegate != nullptr)
+    {
+        return mDelegate->HandleConnectionAttemptComplete(conn, connErr);
+    }
 }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -87,7 +87,8 @@ public:
     void OnSessionReleased() override;
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    void OnSessionConnectionClosed(CHIP_ERROR conErr) override;
+    void OnSessionConnectionClosed(const Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr) override;
+    void OnConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr) override;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
     /**
      *  Send a CHIP message on this exchange.

--- a/src/messaging/ExchangeDelegate.h
+++ b/src/messaging/ExchangeDelegate.h
@@ -135,6 +135,11 @@ public:
     virtual void OnExchangeClosing(ExchangeContext * ec) {}
 
     virtual ExchangeMessageDispatch & GetMessageDispatch() { return ApplicationExchangeDispatch::Instance(); }
+
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    virtual void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr){};
+    virtual void HandleConnectionClosed(const Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr){};
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 };
 
 /**

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -453,15 +453,31 @@ void ExchangeManager::CloseAllContextsForDelegate(const ExchangeDelegate * deleg
 }
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-void ExchangeManager::OnTCPConnectionClosed(const SessionHandle & session, CHIP_ERROR conErr)
+void ExchangeManager::OnTCPConnectionClosed(const Transport::ActiveTCPConnectionState & conn, const SessionHandle & session,
+                                            CHIP_ERROR conErr)
 {
     mContextPool.ForEachActiveObject([&](auto * ec) {
         if (ec->HasSessionHandle() && ec->GetSessionHandle() == session)
         {
-            ec->OnSessionConnectionClosed(conErr);
+            ec->OnSessionConnectionClosed(conn, conErr);
         }
         return Loop::Continue;
     });
+}
+
+bool ExchangeManager::OnTCPConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr)
+{
+    bool foundHandler = false;
+    mContextPool.ForEachActiveObject([&](auto * ec) {
+        if (ec->HasSessionHandle())
+        {
+            ec->OnConnectionAttemptComplete(conn, conErr);
+            foundHandler = true;
+        }
+        return Loop::Continue;
+    });
+
+    return foundHandler;
 }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -251,7 +251,9 @@ private:
     void SendStandaloneAckIfNeeded(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
                                    const SessionHandle & session, MessageFlags msgFlags, System::PacketBufferHandle && msgBuf);
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    void OnTCPConnectionClosed(const SessionHandle & session, CHIP_ERROR conErr) override;
+    void OnTCPConnectionClosed(const Transport::ActiveTCPConnectionState & conn, const SessionHandle & session,
+                               CHIP_ERROR conErr) override;
+    bool OnTCPConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr) override;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 };
 

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -67,10 +67,10 @@ constexpr size_t kMaxTCPConnectAttempts = 3;
 chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
 
 chip::Transport::AppTCPConnectionCallbackCtxt gAppTCPConnCbCtxt;
-chip::Transport::ActiveTCPConnectionState * gActiveTCPConnState = nullptr;
+chip::Transport::ActiveTCPConnectionHolder gActiveTCPConnState;
 
-static void HandleConnectionAttemptComplete(chip::Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
-static void HandleConnectionClosed(chip::Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
+static void HandleConnectionAttemptComplete(chip::Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr);
+static void HandleConnectionClosed(chip::Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr);
 
 // True, if client is still connecting to the server, false otherwise.
 static bool gClientConInProgress = false;
@@ -202,7 +202,7 @@ CHIP_ERROR EstablishSecureSession()
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
         if (gUseTCP)
         {
-            printf("Associating secure session with connection %p\n", gActiveTCPConnState);
+            printf("Associating secure session with connection %p\n", static_cast<const void *>(gActiveTCPConnState));
             gSession.Get().Value()->AsSecureSession()->SetTCPConnection(gActiveTCPConnState);
         }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
@@ -219,7 +219,7 @@ void CloseConnection()
     char peerAddrBuf[chip::Transport::PeerAddress::kMaxToStringSize];
     chip::Transport::PeerAddress peerAddr = chip::Transport::PeerAddress::TCP(gDestAddr, CHIP_PORT);
 
-    gSessionManager.TCPDisconnect(peerAddr);
+    gActiveTCPConnState.Release();
 
     peerAddr.ToString(peerAddrBuf);
     printf("Connection closed to peer at %s\n", peerAddrBuf);
@@ -228,7 +228,7 @@ void CloseConnection()
     gClientConInProgress  = false;
 }
 
-void HandleConnectionAttemptComplete(chip::Transport::ActiveTCPConnectionState * conn, CHIP_ERROR err)
+void HandleConnectionAttemptComplete(chip::Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR err)
 {
     chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
 
@@ -256,7 +256,7 @@ void HandleConnectionAttemptComplete(chip::Transport::ActiveTCPConnectionState *
     gClientConInProgress  = false;
 }
 
-void HandleConnectionClosed(chip::Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr)
+void HandleConnectionClosed(chip::Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr)
 {
     CloseConnection();
 }
@@ -275,7 +275,7 @@ void EstablishTCPConnection()
     chip::Transport::PeerAddress peerAddr = chip::Transport::PeerAddress::TCP(gDestAddr, CHIP_PORT);
 
     // Connect to the peer
-    err = gSessionManager.TCPConnect(peerAddr, &gAppTCPConnCbCtxt, &gActiveTCPConnState);
+    err = gSessionManager.TCPConnect(peerAddr, &gAppTCPConnCbCtxt, gActiveTCPConnState);
     if (err != CHIP_NO_ERROR)
     {
         printf("Connection FAILED with err: %s\n", chip::ErrorStr(err));
@@ -417,10 +417,7 @@ int main(int argc, char * argv[])
     gUDPManager.Close();
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    if (gUseTCP)
-    {
-        gTCPManager.TCPDisconnect(chip::Transport::PeerAddress::TCP(gDestAddr));
-    }
+    gActiveTCPConnState.Release();
     gTCPManager.Close();
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -542,8 +542,8 @@ private:
     void InvalidateIfPendingEstablishmentOnFabric(FabricIndex fabricIndex);
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    static void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
-    static void HandleConnectionClosed(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
+    static void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr);
+    static void HandleConnectionClosed(Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr);
 
     // Context to pass down when connecting to peer
     Transport::AppTCPConnectionCallbackCtxt mTCPConnCbCtxt;
@@ -554,7 +554,7 @@ private:
     // invocation of the callbacks when the connection is established/closed.
     //
     // This pointer must be nulled out when the connection is closed.
-    Transport::ActiveTCPConnectionState * mPeerConnState = nullptr;
+    Transport::ActiveTCPConnectionHolder mPeerConnState;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -545,7 +545,7 @@ private:
     void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr) override;
     void HandleConnectionClosed(const Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr) override;
 
-    // Pointer to the underlying TCP connection state. Returned by the
+    // Reference holder to the underlying TCP connection state. Returned by the
     // TCPConnect() method (on the connection Initiator side) when an
     // ActiveTCPConnectionState object is allocated. This connection
     // context is used on the CASE Initiator side to facilitate the

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -542,11 +542,9 @@ private:
     void InvalidateIfPendingEstablishmentOnFabric(FabricIndex fabricIndex);
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    static void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr);
-    static void HandleConnectionClosed(Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr);
+    void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr) override;
+    void HandleConnectionClosed(const Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr) override;
 
-    // Context to pass down when connecting to peer
-    Transport::AppTCPConnectionCallbackCtxt mTCPConnCbCtxt;
     // Pointer to the underlying TCP connection state. Returned by the
     // TCPConnect() method (on the connection Initiator side) when an
     // ActiveTCPConnectionState object is allocated. This connection

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -67,8 +67,7 @@ void PairingSession::Finish()
     {
         // Fetch the connection for the unauthenticated session used to set up
         // the secure session.
-        Transport::ActiveTCPConnectionState * conn =
-            mExchangeCtxt.Value()->GetSessionHandle()->AsUnauthenticatedSession()->GetTCPConnection();
+        auto conn = mExchangeCtxt.Value()->GetSessionHandle()->AsUnauthenticatedSession()->GetTCPConnection();
 
         // Associate the connection with the secure session being activated.
         mSecureSessionHolder->AsSecureSession()->SetTCPConnection(conn);

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -300,10 +300,10 @@ public:
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     // This API is used to associate the connection with the session when the
     // latter is about to be marked active. It is also used to reset the
-    // connection to a nullptr when the connection is lost and the session
-    // is marked as Defunct.
-    ActiveTCPConnectionHolder GetTCPConnection() const { return const_cast<Session *>(this)->mTCPConnection; }
-    void SetTCPConnection(ActiveTCPConnectionHolder & conn) { mTCPConnection = conn; }
+    // connection when the connection is lost and the session is marked as Defunct.
+    inline const ActiveTCPConnectionHolder & GetTCPConnection() const { return const_cast<Session *>(this)->mTCPConnection; }
+    inline void SetTCPConnection(ActiveTCPConnectionHolder & conn) { mTCPConnection = conn; }
+    inline void ReleaseTCPConnection() { mTCPConnection.Release(); }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     void NotifySessionHang()

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -302,8 +302,8 @@ public:
     // latter is about to be marked active. It is also used to reset the
     // connection to a nullptr when the connection is lost and the session
     // is marked as Defunct.
-    ActiveTCPConnectionState * GetTCPConnection() const { return mTCPConnection; }
-    void SetTCPConnection(ActiveTCPConnectionState * conn) { mTCPConnection = conn; }
+    ActiveTCPConnectionHolder GetTCPConnection() const { return const_cast<Session *>(this)->mTCPConnection; }
+    void SetTCPConnection(ActiveTCPConnectionHolder & conn) { mTCPConnection = conn; }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     void NotifySessionHang()
@@ -352,7 +352,7 @@ private:
     // as that of the underlying connection with the peer.
     // It would remain as a nullptr for all sessions that are not set up over
     // a TCP connection.
-    ActiveTCPConnectionState * mTCPConnection = nullptr;
+    ActiveTCPConnectionHolder mTCPConnection;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 };
 

--- a/src/transport/SessionConnectionDelegate.h
+++ b/src/transport/SessionConnectionDelegate.h
@@ -21,6 +21,11 @@
 
 namespace chip {
 
+namespace Transport {
+class ActiveTCPConnectionHolder;
+struct ActiveTCPConnectionState;
+} // namespace Transport
+
 /**
  * @brief
  *   This class defines a delegate that will be called by the SessionManager on
@@ -35,12 +40,23 @@ public:
 
     /**
      * @brief
-     *   Called when the underlying connection for the session is closed.
+     *   Called when the underlying TCP connection for the session is closed.
      *
+     * @param conn          The TCP connection state
      * @param session       The handle to the secure session
      * @param conErr        The connection error code
      */
-    virtual void OnTCPConnectionClosed(const SessionHandle & session, CHIP_ERROR conErr) = 0;
+    virtual void OnTCPConnectionClosed(const Transport::ActiveTCPConnectionState & conn, const SessionHandle & session,
+                                       CHIP_ERROR conErr) = 0;
+
+    /**
+     * @brief
+     *   Called when the underlying TCP connection attempt for the session is complete. Returns true if handled.
+     *
+     * @param conn          The TCP connection state
+     * @param conErr        The connection error code if the connection was unsuccessful
+     */
+    virtual bool OnTCPConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr) = 0;
 };
 
 } // namespace chip

--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -23,6 +23,11 @@
 
 namespace chip {
 
+namespace Transport {
+class ActiveTCPConnectionHolder;
+struct ActiveTCPConnectionState;
+} // namespace Transport
+
 class DLL_EXPORT SessionDelegate
 {
 public:
@@ -67,7 +72,8 @@ public:
     virtual void OnSessionHang() {}
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    virtual void OnSessionConnectionClosed(CHIP_ERROR conErr) {}
+    virtual void OnSessionConnectionClosed(const Transport::ActiveTCPConnectionState & conn, CHIP_ERROR connErr) {}
+    virtual void OnConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR connErr) {}
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 };
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -819,7 +819,7 @@ void SessionManager::UnauthenticatedMessageDispatch(const PacketHeader & partial
         {
             if (sessionConn != ctxt->conn)
             {
-                ChipLogError(Inet, "Data received over %p for wrong connection %p. Dropping it!",
+                ChipLogError(Inet, "Unauthenticated data received over %p for wrong connection %p. Dropping it!",
                              static_cast<const void *>(sessionConn), static_cast<const void *>(ctxt->conn));
                 return;
             }
@@ -908,7 +908,7 @@ void SessionManager::SecureUnicastMessageDispatch(const PacketHeader & partialPa
         {
             if (sessionConn != ctxt->conn)
             {
-                ChipLogError(Inet, "Data received over %p for wrong connection %p. Dropping it!",
+                ChipLogError(Inet, "Unicast data received over %p for wrong connection %p. Dropping it!",
                              static_cast<const void *>(sessionConn), static_cast<const void *>(ctxt->conn));
                 return;
             }

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -475,24 +475,20 @@ public:
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     CHIP_ERROR TCPConnect(const Transport::PeerAddress & peerAddress, Transport::AppTCPConnectionCallbackCtxt * appState,
-                          Transport::ActiveTCPConnectionState ** peerConnState);
+                          Transport::ActiveTCPConnectionHolder & peerConnState);
 
-    CHIP_ERROR TCPDisconnect(const Transport::PeerAddress & peerAddress);
+    void HandleConnectionReceived(Transport::ActiveTCPConnectionState & conn) override;
 
-    void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0);
+    void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr) override;
 
-    void HandleConnectionReceived(Transport::ActiveTCPConnectionState * conn) override;
-
-    void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr) override;
-
-    void HandleConnectionClosed(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr) override;
+    void HandleConnectionClosed(Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr) override;
 
     // Functors for callbacks into higher layers
-    using OnTCPConnectionReceivedCallback = void (*)(Transport::ActiveTCPConnectionState * conn);
+    using OnTCPConnectionReceivedCallback = void (*)(Transport::ActiveTCPConnectionHolder & conn);
 
-    using OnTCPConnectionCompleteCallback = void (*)(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
+    using OnTCPConnectionCompleteCallback = void (*)(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr);
 
-    using OnTCPConnectionClosedCallback = void (*)(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
+    using OnTCPConnectionClosedCallback = void (*)(Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr);
 
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
@@ -617,7 +613,7 @@ private:
     void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source);
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    void MarkSecureSessionOverTCPForEviction(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
+    void MarkSecureSessionOverTCPForEviction(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr);
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     static bool IsControlMessage(PayloadHeader & payloadHeader)

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -613,7 +613,7 @@ private:
     void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source);
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    void MarkSecureSessionOverTCPForEviction(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr);
+    void MarkSecureSessionOverTCPForEviction(Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr);
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     static bool IsControlMessage(PayloadHeader & payloadHeader)

--- a/src/transport/TransportMgr.h
+++ b/src/transport/TransportMgr.h
@@ -66,11 +66,11 @@ public:
      * @param conn      the connection object
      * @param conErr    the connection error on the attempt, or CHIP_NO_ERROR.
      */
-    virtual void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr){};
+    virtual void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr){};
 
-    virtual void HandleConnectionClosed(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr){};
+    virtual void HandleConnectionClosed(Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr){};
 
-    virtual void HandleConnectionReceived(Transport::ActiveTCPConnectionState * conn){};
+    virtual void HandleConnectionReceived(Transport::ActiveTCPConnectionState & conn){};
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 };
 

--- a/src/transport/TransportMgrBase.h
+++ b/src/transport/TransportMgrBase.h
@@ -44,17 +44,13 @@ public:
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     CHIP_ERROR TCPConnect(const Transport::PeerAddress & address, Transport::AppTCPConnectionCallbackCtxt * appState,
-                          Transport::ActiveTCPConnectionState ** peerConnState);
+                          Transport::ActiveTCPConnectionHolder & peerConnState);
 
-    void TCPDisconnect(const Transport::PeerAddress & address);
+    void HandleConnectionReceived(Transport::ActiveTCPConnectionState & conn) override;
 
-    void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0);
+    void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr) override;
 
-    void HandleConnectionReceived(Transport::ActiveTCPConnectionState * conn) override;
-
-    void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr) override;
-
-    void HandleConnectionClosed(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr) override;
+    void HandleConnectionClosed(Transport::ActiveTCPConnectionState & conn, CHIP_ERROR conErr) override;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     void SetSessionManager(TransportMgrDelegate * sessionManager) { mSessionManager = sessionManager; }

--- a/src/transport/raw/ActiveTCPConnectionState.h
+++ b/src/transport/raw/ActiveTCPConnectionState.h
@@ -23,10 +23,13 @@
 
 #pragma once
 
+#include <functional>
 #include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <inet/TCPEndPoint.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/core/ReferenceCounted.h>
+#include <lib/support/AutoRelease.h>
 #include <transport/raw/PeerAddress.h>
 #include <transport/raw/TCPConfig.h>
 
@@ -36,7 +39,7 @@ namespace Transport {
 /**
  *  The State of the TCP connection
  */
-enum class TCPState
+enum class TCPState : uint8_t
 {
     kNotReady    = 0, /**< State before initialization. */
     kInitialized = 1, /**< State after class is listening and ready. */
@@ -46,31 +49,23 @@ enum class TCPState
 };
 
 struct AppTCPConnectionCallbackCtxt;
+
+// Templatized to force inlining
+template <typename State>
+class ActiveTCPConnectionStateDeleter
+{
+public:
+    inline static void Release(State * entry) { entry->mReleaseConnection(*entry); }
+};
+
 /**
  *  State for each active TCP connection
  */
+class ActiveTCPConnectionHolder;
 struct ActiveTCPConnectionState
+    : public ReferenceCounted<ActiveTCPConnectionState, ActiveTCPConnectionStateDeleter<ActiveTCPConnectionState>, 0, uint16_t>
 {
-
-    void Init(Inet::TCPEndPoint * endPoint, const PeerAddress & peerAddr)
-    {
-        mEndPoint = endPoint;
-        mPeerAddr = peerAddr;
-        mReceived = nullptr;
-        mAppState = nullptr;
-    }
-
-    void Free()
-    {
-        if (mEndPoint)
-        {
-            mEndPoint->Free();
-        }
-        mPeerAddr = PeerAddress::Uninitialized();
-        mEndPoint = nullptr;
-        mReceived = nullptr;
-        mAppState = nullptr;
-    }
+    using ReleaseFnType = std::function<void(ActiveTCPConnectionState & connection)>;
 
     bool InUse() const { return mEndPoint != nullptr; }
 
@@ -78,6 +73,8 @@ struct ActiveTCPConnectionState
 
     bool IsConnecting() const { return (mEndPoint != nullptr && mConnectionState == TCPState::kConnecting); }
 
+    inline bool operator==(const ActiveTCPConnectionHolder & other) const;
+    inline bool operator!=(const ActiveTCPConnectionHolder & other) const;
     // Associated endpoint.
     Inet::TCPEndPoint * mEndPoint;
 
@@ -103,14 +100,90 @@ struct ActiveTCPConnectionState
     // KeepAlive interval in seconds
     uint16_t mTCPKeepAliveIntervalSecs = CHIP_CONFIG_TCP_KEEPALIVE_INTERVAL_SECS;
     uint16_t mTCPMaxNumKeepAliveProbes = CHIP_CONFIG_MAX_TCP_KEEPALIVE_PROBES;
+
+private:
+    friend class TCPBase;
+    template <size_t kActiveConnectionsSize, size_t kPendingPacketSize>
+    friend class TCP;
+    friend class ActiveTCPConnectionStateDeleter<ActiveTCPConnectionState>;
+    ReleaseFnType mReleaseConnection;
+
+    void Init(Inet::TCPEndPoint * endPoint, const PeerAddress & peerAddr, ReleaseFnType releaseConnection)
+    {
+        mEndPoint          = endPoint;
+        mPeerAddr          = peerAddr;
+        mReceived          = nullptr;
+        mAppState          = nullptr;
+        mReleaseConnection = releaseConnection;
+    }
+
+    void Free()
+    {
+        if (mEndPoint)
+        {
+            mEndPoint->Free();
+        }
+        mPeerAddr          = PeerAddress::Uninitialized();
+        mEndPoint          = nullptr;
+        mReceived          = nullptr;
+        mAppState          = nullptr;
+        mReleaseConnection = [](auto &) {};
+    }
 };
 
+/**
+ * A holder for ActiveTCPConnectionState which properly ref-counts on ctor/copy/dtor.
+ */
+class ActiveTCPConnectionHolder : private AutoRelease<ActiveTCPConnectionState>
+{
+    friend class TCPBase;
+    friend struct ActiveTCPConnectionState;
+
+public:
+    using AutoRelease<ActiveTCPConnectionState>::operator->;
+    using AutoRelease<ActiveTCPConnectionState>::IsNull;
+    using AutoRelease<ActiveTCPConnectionState>::Release;
+
+    ActiveTCPConnectionHolder() : AutoRelease<ActiveTCPConnectionState>(nullptr) {}
+    ActiveTCPConnectionHolder(ActiveTCPConnectionState * releasable) :
+        AutoRelease<ActiveTCPConnectionState>(releasable ? releasable->Retain() : nullptr)
+    {}
+
+    ActiveTCPConnectionHolder(const ActiveTCPConnectionHolder & src) : ActiveTCPConnectionHolder(src.mReleasable) {}
+
+    inline AutoRelease & operator=(const ActiveTCPConnectionHolder & src)
+    {
+        if (mReleasable != src.mReleasable)
+        {
+            Set(src.IsNull() ? nullptr : src.mReleasable->Retain());
+        }
+        return *this;
+    }
+
+    inline bool operator==(const ActiveTCPConnectionHolder & other) const { return mReleasable == other.mReleasable; }
+    inline bool operator!=(const ActiveTCPConnectionHolder & other) const { return mReleasable != other.mReleasable; }
+    inline bool operator==(const ActiveTCPConnectionState & other) const { return mReleasable == &other; }
+    inline bool operator!=(const ActiveTCPConnectionState & other) const { return mReleasable != &other; }
+
+    // For printing
+    inline operator const void *() const { return mReleasable; }
+};
+
+inline bool ActiveTCPConnectionState::operator==(const ActiveTCPConnectionHolder & other) const
+{
+    return this == other.mReleasable;
+}
+inline bool ActiveTCPConnectionState::operator!=(const ActiveTCPConnectionHolder & other) const
+{
+    return this != other.mReleasable;
+}
+
 // Functors for callbacks into higher layers
-using OnTCPConnectionReceivedCallback = void (*)(ActiveTCPConnectionState * conn);
+using OnTCPConnectionReceivedCallback = void (*)(ActiveTCPConnectionState & conn);
 
-using OnTCPConnectionCompleteCallback = void (*)(ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
+using OnTCPConnectionCompleteCallback = void (*)(ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr);
 
-using OnTCPConnectionClosedCallback = void (*)(ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
+using OnTCPConnectionClosedCallback = void (*)(ActiveTCPConnectionState & conn, CHIP_ERROR conErr);
 
 /*
  *  Application callback state that is passed down at connection establishment

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -40,7 +40,7 @@ namespace Transport {
 struct MessageTransportContext
 {
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    ActiveTCPConnectionState * conn = nullptr;
+    ActiveTCPConnectionHolder conn;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 };
 
@@ -52,9 +52,9 @@ public:
                                        MessageTransportContext * ctxt = nullptr) = 0;
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    virtual void HandleConnectionReceived(ActiveTCPConnectionState * conn){};
-    virtual void HandleConnectionAttemptComplete(ActiveTCPConnectionState * conn, CHIP_ERROR conErr){};
-    virtual void HandleConnectionClosed(ActiveTCPConnectionState * conn, CHIP_ERROR conErr){};
+    virtual void HandleConnectionReceived(ActiveTCPConnectionState & conn){};
+    virtual void HandleConnectionAttemptComplete(ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr){};
+    virtual void HandleConnectionClosed(ActiveTCPConnectionState & conn, CHIP_ERROR conErr){};
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 };
 
@@ -100,20 +100,10 @@ public:
      * Connect to the specified peer.
      */
     virtual CHIP_ERROR TCPConnect(const PeerAddress & address, Transport::AppTCPConnectionCallbackCtxt * appState,
-                                  Transport::ActiveTCPConnectionState ** peerConnState)
+                                  ActiveTCPConnectionHolder & peerConnState)
     {
         return CHIP_NO_ERROR;
     }
-
-    /**
-     * Handle disconnection from the specified peer if currently connected to it.
-     */
-    virtual void TCPDisconnect(const PeerAddress & address) {}
-
-    /**
-     * Disconnect on the active connection that is passed in.
-     */
-    virtual void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0) {}
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     /**
@@ -139,17 +129,17 @@ protected:
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     // Handle an incoming connection request from a peer.
-    void HandleConnectionReceived(ActiveTCPConnectionState * conn) { mDelegate->HandleConnectionReceived(conn); }
+    void HandleConnectionReceived(ActiveTCPConnectionState & conn) { mDelegate->HandleConnectionReceived(conn); }
 
     // Callback during connection establishment to notify of success or any
     // error.
-    void HandleConnectionAttemptComplete(ActiveTCPConnectionState * conn, CHIP_ERROR conErr)
+    void HandleConnectionAttemptComplete(ActiveTCPConnectionHolder & conn, CHIP_ERROR conErr)
     {
         mDelegate->HandleConnectionAttemptComplete(conn, conErr);
     }
 
     // Callback to notify the higher layer of an unexpected connection closure.
-    void HandleConnectionClosed(ActiveTCPConnectionState * conn, CHIP_ERROR conErr)
+    void HandleConnectionClosed(ActiveTCPConnectionState & conn, CHIP_ERROR conErr)
     {
         mDelegate->HandleConnectionClosed(conn, conErr);
     }

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -147,6 +147,9 @@ void TCPBase::Close()
 
 ActiveTCPConnectionState * TCPBase::AllocateConnection(Inet::TCPEndPoint * endpoint, const PeerAddress & address)
 {
+    // If a peer initiates a connection through HandleIncomingConnection but the connection is never claimed
+    // in ProcessSingleMessage, we'll be left with a dangling ActiveTCPConnectionState which can be
+    // reclaimed.  Don't try to reclaim these connections unless we're out of space
     for (int reclaim = 0; reclaim < 1; reclaim++)
     {
         for (size_t i = 0; i < mActiveConnectionsSize; i++)
@@ -161,7 +164,7 @@ ActiveTCPConnectionState * TCPBase::AllocateConnection(Inet::TCPEndPoint * endpo
             }
         }
 
-        // Verify that previously-unclaimed connections are released
+        // Out of space; reclaim connections that were never claimed by ProcessSingleMessage
         for (size_t i = 0; i < mActiveConnectionsSize; i++)
         {
             ActiveTCPConnectionHolder releaseUnclaimed(&mActiveConnections[i]);

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -708,16 +708,19 @@ CHIP_ERROR TCPBase::TCPConnect(const PeerAddress & address, Transport::AppTCPCon
 
 void TCPBase::TCPDisconnect(ActiveTCPConnectionState & conn, bool shouldAbort)
 {
+    // If there are still active references, we need to notify them of connection closure
+    SuppressCallback suppressCallback = (conn.GetReferenceCount() > 0) ? SuppressCallback::No : SuppressCallback::Yes;
+
     // This call should be able to disconnect the connection either when it is
     // already established, or when it is being set up.
     if ((conn.IsConnected() && shouldAbort) || conn.IsConnecting())
     {
-        CloseConnectionInternal(conn, CHIP_ERROR_CONNECTION_ABORTED, SuppressCallback::Yes);
+        CloseConnectionInternal(conn, CHIP_ERROR_CONNECTION_ABORTED, suppressCallback);
     }
 
     if (conn.IsConnected() && !shouldAbort)
     {
-        CloseConnectionInternal(conn, CHIP_NO_ERROR, SuppressCallback::Yes);
+        CloseConnectionInternal(conn, CHIP_NO_ERROR, suppressCallback);
     }
 }
 

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -211,7 +211,7 @@ private:
     friend class TCPBaseTestAccess;
 
     /**
-     * Allocate an initialize a connection from the pool.
+     * Allocate and initialize a connection from the pool.
      */
     ActiveTCPConnectionState * AllocateConnection(Inet::TCPEndPoint * endpoint, const PeerAddress & address);
     /**

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -211,8 +211,7 @@ private:
     friend class TCPBaseTestAccess;
 
     /**
-     * Allocate an unused connection from the pool
-     *
+     * Allocate an initialize a connection from the pool.
      */
     ActiveTCPConnectionState * AllocateConnection(Inet::TCPEndPoint * endpoint, const PeerAddress & address);
     /**

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -159,6 +159,7 @@ public:
     void Close() override;
 
     CHIP_ERROR SendMessage(const PeerAddress & address, System::PacketBufferHandle && msgBuf) override;
+    CHIP_ERROR SendMessage(const ActiveTCPConnectionHolder & connection, System::PacketBufferHandle && msgBuf);
 
     /*
      * Connect to the given peerAddress over TCP.
@@ -229,14 +230,13 @@ private:
     /**
      * Sends the specified message once a connection has been established.
      *
-     * @param existing - an already-existing connection, otherwise an empty holder
-     * @param addr - what peer to connect to
+     * @param existing - an already-existing connection; must not be empty
      * @param msg - what buffer to send once a connection has been established.
      *
      * Ownership of msg is taken over and will be freed at some unspecified time
      * in the future (once connection succeeds/fails).
      */
-    CHIP_ERROR SendAfterConnect(ActiveTCPConnectionHolder & existing, const PeerAddress & addr, System::PacketBufferHandle && msg);
+    CHIP_ERROR SendAfterConnect(const ActiveTCPConnectionHolder & existing, System::PacketBufferHandle && msg);
 
     /**
      * Process a single received buffer from the specified peer address.
@@ -307,6 +307,7 @@ private:
 
     void InitEndpoint(Inet::TCPEndPoint * endpoint);
     CHIP_ERROR TryResetConnection(ActiveTCPConnectionState & connection);
+    CHIP_ERROR PrepareBuffer(System::PacketBufferHandle & msgBuf);
 
     Inet::TCPEndPoint * mListenSocket = nullptr;                       ///< TCP socket used by the transport
     Inet::IPAddressType mEndpointType = Inet::IPAddressType::kUnknown; ///< Socket listening type

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -178,14 +178,7 @@ public:
      *
      */
     CHIP_ERROR TCPConnect(const PeerAddress & address, Transport::AppTCPConnectionCallbackCtxt * appState,
-                          Transport::ActiveTCPConnectionState ** outPeerConnState) override;
-
-    void TCPDisconnect(const PeerAddress & address) override;
-
-    // Close an active connection (corresponding to the passed
-    // ActiveTCPConnectionState object)
-    // and release from the pool.
-    void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = false) override;
+                          Transport::ActiveTCPConnectionHolder & outPeerConnState) override;
 
     bool CanSendToPeer(const PeerAddress & address) override
     {
@@ -195,9 +188,9 @@ public:
 
     const Optional<PeerAddress> GetConnectionPeerAddress(const Inet::TCPEndPoint * con)
     {
-        ActiveTCPConnectionState * activeConState = FindActiveConnection(con);
+        ActiveTCPConnectionHolder activeConState = FindActiveConnection(con);
 
-        return activeConState != nullptr ? MakeOptional<PeerAddress>(activeConState->mPeerAddr) : Optional<PeerAddress>::Missing();
+        return !activeConState.IsNull() ? MakeOptional<PeerAddress>(activeConState->mPeerAddr) : Optional<PeerAddress>::Missing();
     }
 
     /**
@@ -221,29 +214,30 @@ private:
      * Allocate an unused connection from the pool
      *
      */
-    ActiveTCPConnectionState * AllocateConnection();
+    ActiveTCPConnectionState * AllocateConnection(Inet::TCPEndPoint * endpoint, const PeerAddress & address);
     /**
      * Find an active connection to the given peer or return nullptr if
      * no active connection exists.
      */
-    ActiveTCPConnectionState * FindActiveConnection(const PeerAddress & addr);
+    ActiveTCPConnectionHolder FindInUseConnection(const PeerAddress & addr);
     ActiveTCPConnectionState * FindActiveConnection(const Inet::TCPEndPoint * endPoint);
 
     /**
      * Find an allocated connection that matches the corresponding TCPEndPoint.
      */
-    ActiveTCPConnectionState * FindInUseConnection(const Inet::TCPEndPoint * endPoint);
+    ActiveTCPConnectionHolder FindInUseConnection(const Inet::TCPEndPoint * endPoint);
 
     /**
      * Sends the specified message once a connection has been established.
      *
+     * @param existing - an already-existing connection, otherwise an empty holder
      * @param addr - what peer to connect to
      * @param msg - what buffer to send once a connection has been established.
      *
      * Ownership of msg is taken over and will be freed at some unspecified time
      * in the future (once connection succeeds/fails).
      */
-    CHIP_ERROR SendAfterConnect(const PeerAddress & addr, System::PacketBufferHandle && msg);
+    CHIP_ERROR SendAfterConnect(ActiveTCPConnectionHolder & existing, const PeerAddress & addr, System::PacketBufferHandle && msg);
 
     /**
      * Process a single received buffer from the specified peer address.
@@ -267,7 +261,7 @@ private:
      *                              is no other data).
      * @param[in]     messageSize   Size of the single message.
      */
-    CHIP_ERROR ProcessSingleMessage(const PeerAddress & peerAddress, ActiveTCPConnectionState * state, size_t messageSize);
+    CHIP_ERROR ProcessSingleMessage(const PeerAddress & peerAddress, ActiveTCPConnectionState & state, size_t messageSize);
 
     /**
      * Initiate a connection to the given peer. On connection completion,
@@ -275,13 +269,18 @@ private:
      *
      */
     CHIP_ERROR StartConnect(const PeerAddress & addr, AppTCPConnectionCallbackCtxt * appState,
-                            Transport::ActiveTCPConnectionState ** outPeerConnState);
+                            ActiveTCPConnectionHolder & outPeerConnState);
+
+    // Close an active connection (corresponding to the passed
+    // ActiveTCPConnectionState object)
+    // and release from the pool.
+    void TCPDisconnect(ActiveTCPConnectionState & conn, bool shouldAbort = false);
 
     /**
      * Gracefully Close or Abort a given connection.
      *
      */
-    void CloseConnectionInternal(ActiveTCPConnectionState * connection, CHIP_ERROR err, SuppressCallback suppressCallback);
+    void CloseConnectionInternal(ActiveTCPConnectionState & connection, CHIP_ERROR err, SuppressCallback suppressCallback);
 
     // Close the listening socket endpoint
     void CloseListeningSocket();
@@ -306,6 +305,9 @@ private:
     // Callback handler for handling accept error
     // @see TCPEndpoint::OnAcceptErrorFunct
     static void HandleAcceptError(Inet::TCPEndPoint * endPoint, CHIP_ERROR err);
+
+    void InitEndpoint(Inet::TCPEndPoint * endpoint);
+    CHIP_ERROR TryResetConnection(ActiveTCPConnectionState & connection);
 
     Inet::TCPEndPoint * mListenSocket = nullptr;                       ///< TCP socket used by the transport
     Inet::IPAddressType mEndpointType = Inet::IPAddressType::kUnknown; ///< Socket listening type
@@ -334,7 +336,7 @@ public:
     {
         for (size_t i = 0; i < kActiveConnectionsSize; ++i)
         {
-            mConnectionsBuffer[i].Init(nullptr, PeerAddress::Uninitialized());
+            mConnectionsBuffer[i].Init(nullptr, PeerAddress::Uninitialized(), [](auto &) {});
         }
     }
 

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -41,10 +41,6 @@
 namespace chip {
 namespace Transport {
 
-// Forward declaration of friend class for test access.
-template <size_t kActiveConnectionsSize, size_t kPendingPacketSize>
-class TCPBaseTestAccess;
-
 /** Defines listening parameters for setting up a TCP transport */
 class TcpListenParameters
 {

--- a/src/transport/raw/Tuple.h
+++ b/src/transport/raw/Tuple.h
@@ -86,7 +86,7 @@ public:
         return SendMessageImpl<0>(address, std::move(msgBuf));
     }
 
-    CHIP_ERROR MulticastGroupJoinLeave(const Transport::PeerAddress & address, bool join) override
+    CHIP_ERROR MulticastGroupJoinLeave(const PeerAddress & address, bool join) override
     {
         return MulticastGroupJoinLeaveImpl<0>(address, join);
     }
@@ -94,17 +94,10 @@ public:
     bool CanSendToPeer(const PeerAddress & address) override { return CanSendToPeerImpl<0>(address); }
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    CHIP_ERROR TCPConnect(const PeerAddress & address, Transport::AppTCPConnectionCallbackCtxt * appState,
-                          Transport::ActiveTCPConnectionState ** peerConnState) override
+    CHIP_ERROR TCPConnect(const PeerAddress & address, AppTCPConnectionCallbackCtxt * appState,
+                          ActiveTCPConnectionHolder & peerConnState) override
     {
         return TCPConnectImpl<0>(address, appState, peerConnState);
-    }
-
-    void TCPDisconnect(const PeerAddress & address) override { return TCPDisconnectImpl<0>(address); }
-
-    void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0) override
-    {
-        return TCPDisconnectImpl<0>(conn, shouldAbort);
     }
 
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
@@ -161,8 +154,8 @@ private:
      * @param address what address to connect to.
      */
     template <size_t N, typename std::enable_if<(N < sizeof...(TransportTypes))>::type * = nullptr>
-    CHIP_ERROR TCPConnectImpl(const PeerAddress & address, Transport::AppTCPConnectionCallbackCtxt * appState,
-                              Transport::ActiveTCPConnectionState ** peerConnState)
+    CHIP_ERROR TCPConnectImpl(const PeerAddress & address, AppTCPConnectionCallbackCtxt * appState,
+                              ActiveTCPConnectionHolder & peerConnState)
     {
         Base * base = &std::get<N>(mTransports);
         if (base->CanSendToPeer(address))
@@ -176,8 +169,8 @@ private:
      * TCPConnectImpl template for out of range N.
      */
     template <size_t N, typename std::enable_if<(N >= sizeof...(TransportTypes))>::type * = nullptr>
-    CHIP_ERROR TCPConnectImpl(const PeerAddress & address, Transport::AppTCPConnectionCallbackCtxt * appState,
-                              Transport::ActiveTCPConnectionState ** peerConnState)
+    CHIP_ERROR TCPConnectImpl(const PeerAddress & address, AppTCPConnectionCallbackCtxt * appState,
+                              ActiveTCPConnectionHolder & peerConnState)
     {
         return CHIP_ERROR_NO_MESSAGE_HANDLER;
     }
@@ -211,7 +204,7 @@ private:
      * @param conn pointer to the connection to the peer.
      */
     template <size_t N, typename std::enable_if<(N < sizeof...(TransportTypes))>::type * = nullptr>
-    void TCPDisconnectImpl(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0)
+    void TCPDisconnectImpl(ActiveTCPConnectionHolder & conn, bool shouldAbort = 0)
     {
         std::get<N>(mTransports).TCPDisconnect(conn, shouldAbort);
         TCPDisconnectImpl<N + 1>(conn, shouldAbort);
@@ -221,7 +214,7 @@ private:
      * TCPDisconnectImpl template for out of range N.
      */
     template <size_t N, typename std::enable_if<(N >= sizeof...(TransportTypes))>::type * = nullptr>
-    void TCPDisconnectImpl(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0)
+    void TCPDisconnectImpl(ActiveTCPConnectionHolder & conn, bool shouldAbort = 0)
     {}
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
@@ -285,7 +278,7 @@ private:
      * @param join a boolean indicating if the transport should join or leave the group
      */
     template <size_t N, typename std::enable_if<(N < sizeof...(TransportTypes))>::type * = nullptr>
-    CHIP_ERROR MulticastGroupJoinLeaveImpl(const Transport::PeerAddress & address, bool join)
+    CHIP_ERROR MulticastGroupJoinLeaveImpl(const PeerAddress & address, bool join)
     {
         Base * base = &std::get<N>(mTransports);
         if (base->CanListenMulticast())
@@ -299,7 +292,7 @@ private:
      * GroupJoinLeave when N is out of range. Always returns an error code.
      */
     template <size_t N, typename std::enable_if<(N >= sizeof...(TransportTypes))>::type * = nullptr>
-    CHIP_ERROR MulticastGroupJoinLeaveImpl(const Transport::PeerAddress & address, bool join)
+    CHIP_ERROR MulticastGroupJoinLeaveImpl(const PeerAddress & address, bool join)
     {
         return CHIP_ERROR_NO_MESSAGE_HANDLER;
     }

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -53,7 +53,6 @@ namespace {
 constexpr size_t kMaxTcpActiveConnectionCount = 4;
 constexpr size_t kMaxTcpPendingPackets        = 4;
 constexpr size_t kPacketSizeBytes             = sizeof(uint32_t);
-chip::Transport::AppTCPConnectionCallbackCtxt gAppTCPConnCbCtxt;
 
 using TCPImpl    = Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>;
 using TestAccess = Transport::TCPBaseTestAccess<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>;
@@ -181,11 +180,6 @@ public:
         mReceiveHandlerCallCount        = 0;
         mHandleConnectionCompleteCalled = false;
         mHandleConnectionCloseCalled    = false;
-
-        gAppTCPConnCbCtxt.appContext     = nullptr;
-        gAppTCPConnCbCtxt.connReceivedCb = nullptr;
-        gAppTCPConnCbCtxt.connCompleteCb = nullptr;
-        gAppTCPConnCbCtxt.connClosedCb   = nullptr;
     }
 
     void SingleMessageTest(TCPImpl & tcp, const IPAddress & addr, uint16_t port)
@@ -202,7 +196,7 @@ public:
         CHIP_ERROR err = header.EncodeBeforeData(buffer);
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
-        err = tcp.TCPConnect(Transport::PeerAddress::TCP(addr, port), &gAppTCPConnCbCtxt, refHolder);
+        err = tcp.TCPConnect(Transport::PeerAddress::TCP(addr, port), nullptr, refHolder);
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         // Should be able to send a message to itself by just calling send.
@@ -218,7 +212,7 @@ public:
     void ConnectTest(TCPImpl & tcp, const IPAddress & addr, uint16_t port)
     {
         // Connect and wait for seeing active connection
-        CHIP_ERROR err = tcp.TCPConnect(Transport::PeerAddress::TCP(addr, port), &gAppTCPConnCbCtxt, activeTCPConnState);
+        CHIP_ERROR err = tcp.TCPConnect(Transport::PeerAddress::TCP(addr, port), nullptr, activeTCPConnState);
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(5), [&tcp]() { return tcp.HasActiveConnections(); });
@@ -229,7 +223,7 @@ public:
     {
         // Connect and wait for seeing active connection and connection complete
         // handler being called.
-        CHIP_ERROR err = tcp.TCPConnect(Transport::PeerAddress::TCP(addr, port), &gAppTCPConnCbCtxt, activeTCPConnState);
+        CHIP_ERROR err = tcp.TCPConnect(Transport::PeerAddress::TCP(addr, port), nullptr, activeTCPConnState);
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(5), [this]() { return mHandleConnectionCompleteCalled; });
@@ -240,7 +234,7 @@ public:
     {
         // Connect and wait for seeing active connection and connection complete
         // handler being called.
-        CHIP_ERROR err = tcp.TCPConnect(Transport::PeerAddress::TCP(addr, port), &gAppTCPConnCbCtxt, activeTCPConnState);
+        CHIP_ERROR err = tcp.TCPConnect(Transport::PeerAddress::TCP(addr, port), nullptr, activeTCPConnState);
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(5), [this]() { return mHandleConnectionCompleteCalled; });


### PR DESCRIPTION
#### Summary

Previously, `TCPBase::TCPConnect` & `TCPBase::HandleIncomingConnection` would pre-allocate a TCP connection, which `Session::mTCPConnection` would hold onto.

Because said TCP connection ends up being shared between the insecure connection & secure connection & `CASESesssion`, the only safe way to properly release this TCP connection when a session is closed is via reference-counting.

`TCPBase::SendMessage` would also allocate a TCP connection if there was no previous call to `TCPBase::TCPConnect`, and [said connection would be leaked, with no straightforward way to clean-up](https://github.com/project-chip/connectedhomeip/blob/f3fbd606da8194ecc7e9d8451b4cc21d11356f36/src/transport/raw/TCP.cpp#L298).

This PR makes it so that all connections must be explicitly initiated & owned via `ActiveTCPConnectionHolder`, which will decrement the reference on dtor.

Lastly, this PR fixes multiple connections to same peer (e.g. 2 controllers for 2 fabrics), which previously would fail CASE due to 2 TCP connections being created but messages being sent through the first connection found with `FindActiveConnection`.

#### Related issues

Fixes https://github.com/project-chip/connectedhomeip/issues/39690, which was caused by TCP connections being allocated & never freed

#### Testing

Existing tests run in CI now properly check for ownership