### PR TITLE
Enable PushAV server cluster TCs for CI build.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/push-av-stream-transport-delegate-impl.h
+++ b/examples/all-clusters-app/all-clusters-common/include/push-av-stream-transport-delegate-impl.h
@@ -74,6 +74,10 @@ public:
 
     Protocols::InteractionModel::Status ValidateAudioStream(uint16_t audioStreamId) override;
 
+    Protocols::InteractionModel::Status ValidateZoneId(uint16_t zoneId) override;
+
+    bool ValidateMotionZoneSize(uint16_t zoneSize) override;
+
     PushAvStreamTransportStatusEnum GetTransportBusyStatus(const uint16_t connectionID) override;
 
     void OnAttributeChanged(AttributeId attributeId) override;

--- a/examples/all-clusters-app/all-clusters-common/src/push-av-stream-transport-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/push-av-stream-transport-delegate-impl.cpp
@@ -155,6 +155,20 @@ Protocols::InteractionModel::Status PushAvStreamTransportManager::ValidateAudioS
     return Status::Success;
 }
 
+Protocols::InteractionModel::Status PushAvStreamTransportManager::ValidateZoneId(uint16_t zoneId)
+{
+    // TODO: Validate zoneId from the allocated zones
+    // Returning Status::Success to pass through checks in the Server Implementation.
+    return Status::Success;
+}
+
+bool PushAvStreamTransportManager::ValidateMotionZoneSize(uint16_t zoneSize)
+{
+    // TODO: Validate motion zone size
+    // Returning true to pass through checks in the Server Implementation.
+    return true;
+}
+
 PushAvStreamTransportStatusEnum PushAvStreamTransportManager::GetTransportBusyStatus(const uint16_t connectionID)
 {
     for (PushAvStream & stream : pushavStreams)

--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -79,6 +79,10 @@ public:
     ValidateBandwidthLimit(StreamUsageEnum streamUsage, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
                            const Optional<DataModel::Nullable<uint16_t>> & audioStreamId) override;
 
+    Protocols::InteractionModel::Status ValidateZoneId(uint16_t zoneId) override;
+
+    bool ValidateMotionZoneSize(uint16_t zoneSize) override;
+
     Protocols::InteractionModel::Status SelectVideoStream(StreamUsageEnum streamUsage, uint16_t & videoStreamId) override;
 
     Protocols::InteractionModel::Status SelectAudioStream(StreamUsageEnum streamUsage, uint16_t & audioStreamId) override;

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -323,6 +323,40 @@ Protocols::InteractionModel::Status PushAvStreamTransportManager::SelectAudioStr
     return Status::Failure;
 }
 
+Protocols::InteractionModel::Status PushAvStreamTransportManager::ValidateZoneId(uint16_t zoneId)
+{
+    if (mCameraDevice == nullptr)
+    {
+        ChipLogError(Camera, "CameraDeviceInterface not initialized");
+        return Status::Failure;
+    }
+    auto & zones = mCameraDevice->GetZoneManagementDelegate().GetZoneMgmtServer()->GetZones();
+
+    for (const auto & zone : zones)
+    {
+        if (zone.zoneID == zoneId)
+        {
+            return Status::Success;
+        }
+    }
+    return Status::Failure;
+}
+
+bool PushAvStreamTransportManager::ValidateMotionZoneSize(uint16_t zoneSize)
+{
+    if (mCameraDevice == nullptr)
+    {
+        ChipLogError(Camera, "CameraDeviceInterface not initialized");
+        return false;
+    }
+    auto maxZones = mCameraDevice->GetZoneManagementDelegate().GetZoneMgmtServer()->GetMaxZones();
+    if (zoneSize >= maxZones)
+    {
+        return false;
+    }
+    return true;
+}
+
 Protocols::InteractionModel::Status PushAvStreamTransportManager::ValidateVideoStream(uint16_t videoStreamId)
 {
     if (mCameraDevice == nullptr)

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -205,6 +205,23 @@ public:
     virtual Protocols::InteractionModel::Status ValidateAudioStream(uint16_t audioStreamId) = 0;
 
     /**
+     * @brief Validates that the zone corresponding to zoneId exists.
+     *
+     * @param zoneId Identifier for the requested zone
+     * @return Status::Success if zone exists;
+     *         Status::InvalidZone if no zone with zoneId exists
+     */
+    virtual Protocols::InteractionModel::Status ValidateZoneId(uint16_t zoneId) = 0;
+
+    /**
+     * @brief Validates size of motion zone List.
+     *
+     * @param zoneSize Size for the requested zone list
+     * @return true if URL is valid, false otherwise
+     */
+    virtual bool ValidateMotionZoneSize(uint16_t zoneSize) = 0;
+
+    /**
      * @brief Gets the status of the transport.
      *
      * @param connectionID The connectionID of the stream transport to check status

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
@@ -612,14 +612,16 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
 
         auto & motionZonesList = transportOptions.triggerOptions.motionZones;
         auto iter              = motionZonesList.Value().Value().begin();
-        uint16_t zonesize=0;
+        uint16_t zonesize      = 0;
         auto itsz              = motionZonesList.Value().Value().begin();
         while (itsz.Next())
         {
-            zonesize+=1;
+            zonesize += 1;
         }
         bool isValidZoneSize = mDelegate->ValidateMotionZoneSize(zonesize);
-        VerifyOrReturnValue(isValidZoneSize, Status::ConstraintError,ChipLogError(Zcl, "Transport Options verification from command data[ep=%d]: Invalid Motion Zone Size ", mEndpointId));
+        VerifyOrReturnValue(
+            isValidZoneSize, Status::ConstraintError,
+            ChipLogError(Zcl, "Transport Options verification from command data[ep=%d]: Invalid Motion Zone Size ", mEndpointId));
 
         while (iter.Next())
         {

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
@@ -301,12 +301,10 @@ Status PushAvStreamTransportServerLogic::ValidateIncomingTransportOptions(
         {
             auto & motionZonesList = triggerOptions.motionZones;
             auto iter              = motionZonesList.Value().Value().begin();
-            int zoneSize           = 0;
 
             while (iter.Next())
             {
                 auto & transportZoneOption = iter.GetValue();
-                zoneSize += 1;
 
                 if (mFeatures.Has(Feature::kPerZoneSensitivity))
                 {
@@ -331,12 +329,6 @@ Status PushAvStreamTransportServerLogic::ValidateIncomingTransportOptions(
                                                      mEndpointId));
                 }
             }
-
-            bool isValidZoneSize = mDelegate->ValidateMotionZoneSize(zoneSize);
-            VerifyOrReturnValue(isValidZoneSize, Status::ConstraintError,
-                                ChipLogError(Zcl,
-                                             "Transport Options verification from command data[ep=%d]: Invalid Motion Zone Size ",
-                                             mEndpointId));
 
             if (iter.GetStatus() != CHIP_NO_ERROR)
             {
@@ -620,6 +612,15 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
 
         auto & motionZonesList = transportOptions.triggerOptions.motionZones;
         auto iter              = motionZonesList.Value().Value().begin();
+        uint16_t zonesize=0;
+        auto itsz              = motionZonesList.Value().Value().begin();
+        while (itsz.Next())
+        {
+            zonesize+=1;
+        }
+        bool isValidZoneSize = mDelegate->ValidateMotionZoneSize(zonesize);
+        VerifyOrReturnValue(isValidZoneSize, Status::ConstraintError,ChipLogError(Zcl, "Transport Options verification from command data[ep=%d]: Invalid Motion Zone Size ", mEndpointId));
+
         while (iter.Next())
         {
             auto & transportZoneOption = iter.GetValue();

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
@@ -673,7 +673,6 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
                 auto cluster_status = to_underlying(StatusCodeEnum::kInvalidStream);
                 ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Invalid Video Stream ", mEndpointId);
                 handler.AddClusterSpecificFailure(commandPath, cluster_status);
-                handler.AddStatus(commandPath, delegateStatus);
                 return std::nullopt;
             }
         }
@@ -706,7 +705,6 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
                 auto cluster_status = to_underlying(StatusCodeEnum::kInvalidStream);
                 ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Invalid Audio Stream ", mEndpointId);
                 handler.AddClusterSpecificFailure(commandPath, cluster_status);
-                handler.AddStatus(commandPath, delegateStatus);
                 return std::nullopt;
             }
         }

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -326,6 +326,20 @@ public:
         return Status::Success;
     }
 
+    Protocols::InteractionModel::Status ValidateZoneId(uint16_t zoneId) override
+    {
+        // TODO: Validate zoneId from the allocated zones
+        // Returning Status::Success to pass through checks in the Server Implementation.
+        return Status::Success;
+    }
+
+    bool ValidateMotionZoneSize(uint16_t zoneSize) override
+    {
+        // TODO: Validate motion zone size
+        // Returning true to pass through checks in the Server Implementation.
+        return true;
+    }
+
     PushAvStreamTransportStatusEnum GetTransportBusyStatus(const uint16_t connectionID) override
     {
         for (PushAvStream & stream : pushavStreams)

--- a/src/app/clusters/zone-management-server/zone-management-server.h
+++ b/src/app/clusters/zone-management-server/zone-management-server.h
@@ -232,7 +232,7 @@ private:
      * @param aZoneMgmtServer  A pointer to the ZoneMgmtServer object related to this delegate object.
      */
     void SetZoneMgmtServer(ZoneMgmtServer * aZoneMgmtServer) { mZoneMgmtServer = aZoneMgmtServer; }
-    
+
 };
 
 class ZoneMgmtServer : public CommandHandlerInterface, public AttributeAccessInterface

--- a/src/app/clusters/zone-management-server/zone-management-server.h
+++ b/src/app/clusters/zone-management-server/zone-management-server.h
@@ -232,7 +232,6 @@ private:
      * @param aZoneMgmtServer  A pointer to the ZoneMgmtServer object related to this delegate object.
      */
     void SetZoneMgmtServer(ZoneMgmtServer * aZoneMgmtServer) { mZoneMgmtServer = aZoneMgmtServer; }
-
 };
 
 class ZoneMgmtServer : public CommandHandlerInterface, public AttributeAccessInterface

--- a/src/app/clusters/zone-management-server/zone-management-server.h
+++ b/src/app/clusters/zone-management-server/zone-management-server.h
@@ -217,6 +217,8 @@ public:
 
     virtual CHIP_ERROR LoadTriggers(std::vector<ZoneTriggerControlStruct> & aTriggers) = 0;
 
+    ZoneMgmtServer * GetZoneMgmtServer() const { return mZoneMgmtServer; }
+
 private:
     friend class ZoneMgmtServer;
 
@@ -230,9 +232,7 @@ private:
      * @param aZoneMgmtServer  A pointer to the ZoneMgmtServer object related to this delegate object.
      */
     void SetZoneMgmtServer(ZoneMgmtServer * aZoneMgmtServer) { mZoneMgmtServer = aZoneMgmtServer; }
-
-protected:
-    ZoneMgmtServer * GetZoneMgmtServer() const { return mZoneMgmtServer; }
+    
 };
 
 class ZoneMgmtServer : public CommandHandlerInterface, public AttributeAccessInterface

--- a/src/python_testing/TC_PAVSTI_Utils.py
+++ b/src/python_testing/TC_PAVSTI_Utils.py
@@ -47,7 +47,7 @@ class PushAvServerProcess(Subprocess):
 
     # By default this points to the push_av_server in Test Harness
     # TCs utilizing this should expect th_server_app_path otherwise
-    DEFAULT_SERVER_PATH = "/root/apps/push_av_server/server.py"
+    DEFAULT_SERVER_PATH = "src/tools/push_av_server/server.py"
 
     def __init__(
         self,

--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -21,8 +21,8 @@ import random
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.clusters.Types import Nullable
 from matter import ChipDeviceCtrl
+from matter.clusters.Types import Nullable
 from matter.interaction_model import InteractionModelError, Status
 
 logger = logging.getLogger(__name__)

--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -188,7 +188,7 @@ class PAVSTTestBase:
     async def allocate_one_pushav_transport(self, endpoint, triggerType=Clusters.PushAvStreamTransport.Enums.TransportTriggerTypeEnum.kContinuous,
                                             trigger_Options=None, ingestMethod=Clusters.PushAvStreamTransport.Enums.IngestMethodsEnum.kCMAFIngest,
                                             url="https://localhost:1234/streams/1", stream_Usage=None, container_Options=None,
-                                            videoStream_ID=None, audioStream_ID=None, expected_cluster_status=None):
+                                            videoStream_ID=None, audioStream_ID=None, expected_cluster_status=None, tlsEndPoint=1, expiryTime=10):
         endpoint = self.get_endpoint(default=1)
         cluster = Clusters.PushAvStreamTransport
 
@@ -250,12 +250,12 @@ class PAVSTTestBase:
                         "streamUsage": streamUsage,
                         "videoStreamID": videoStreamID,
                         "audioStreamID": audioStreamID,
-                        "endpointID": endpoint,
+                        "endpointID": tlsEndPoint,
                         "url": url,
                         "triggerOptions": triggerOptions,
                         "ingestMethod": ingestMethod,
                         "containerOptions": containerOptions,
-                        "expiryTime": 5,
+                        "expiryTime": expiryTime,
                     }
                 ),
                 endpoint=endpoint,

--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -234,7 +234,7 @@ class PAVSTTestBase:
             "containerType": cluster.Enums.ContainerFormatEnum.kCmaf,
             "CMAFContainerOptions": {"CMAFInterface": cluster.Enums.CMAFInterfaceEnum.kInterface1, "chunkDuration": 4, "segmentDuration": 3,
                                      "sessionGroup": 3, "trackName": ""},
-            }
+        }
 
         if (container_Options is not None):
             containerOptions = container_Options

--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -232,8 +232,8 @@ class PAVSTTestBase:
 
         containerOptions = {
             "containerType": cluster.Enums.ContainerFormatEnum.kCmaf,
-            "CMAFContainerOptions": {"CMAFInterface": cluster.Enums.CMAFInterfaceEnum.kInterface1, "chunkDuration": 4, "segmentDuration": 3,
-                                     "sessionGroup": 3, "trackName": ""},
+            "CMAFContainerOptions": {"CMAFInterface": cluster.Enums.CMAFInterfaceEnum.kInterface1, "chunkDuration": 4, "segmentDuration": 500,
+                                     "sessionGroup": 3, "trackName": " "},
         }
 
         if (container_Options is not None):

--- a/src/python_testing/TC_PAVST_2_1.py
+++ b/src/python_testing/TC_PAVST_2_1.py
@@ -40,7 +40,7 @@ import logging
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class TC_PAVST_2_1(MatterBaseTest):
                      "Verify that the DUT response contains a list of TransportConfigurationStruct entries. For each entry in the list, verify that the TransportStatus is a defined TransportStatusEnum value."),
         ]
 
-    @async_test_body
+    @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport))
     async def test_TC_PAVST_2_1(self):
         endpoint = self.get_endpoint(default=1)
         cluster = Clusters.PushAvStreamTransport
@@ -71,27 +71,24 @@ class TC_PAVST_2_1(MatterBaseTest):
         # Commission DUT - already done
 
         self.step(2)
-        if self.pics_guard(self.check_pics("PAVST.S.A0000")):
-            supported_formats = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster, attribute=attr.SupportedFormats
-            )
-            asserts.assert_greater_equal(len(supported_formats, 1), "SupportedFormats must not be empty!")
-            for format in supported_formats:
-                validContainerformat = format.ContainerFormat == cluster.ContainerFormatEnum.kCmaf
-                isValidIngestMethod = format.IngestMethod == cluster.IngestMethodEnum.kCMAFIngest
-                asserts.assert_true((validContainerformat & isValidIngestMethod),
-                                    "(ContainerFormat & IngestMethod) must be defined values!")
+        supported_formats = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.SupportedFormats
+        )
+        asserts.assert_greater_equal(len(supported_formats), 1, "SupportedFormats must not be empty!")
+        for format in supported_formats:
+            validContainerformat = format.containerFormat == cluster.Enums.ContainerFormatEnum.kCmaf
+            isValidIngestMethod = format.ingestMethod == cluster.Enums.IngestMethodsEnum.kCMAFIngest
+            asserts.assert_true((validContainerformat & isValidIngestMethod),
+                                "(ContainerFormat & IngestMethod) must be defined values!")
 
         self.step(3)
-        if self.pics_guard(self.check_pics("PAVST.S.A0001")):
-            transport_configs = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster, attribute=attr.CurrentConnections
-            )
-            asserts.assert_greater_equal(len(transport_configs, 1), "TransportConfigurations must not be empty!")
-            for config in transport_configs:
-                isValidTransportStatus = (config.TransportStatus == cluster.TransportStatusEnum.kActive |
-                                          config.TransportStatus == cluster.TransportStatusEnum.kInactive)
-                asserts.assert_true(isValidTransportStatus, "TransportStatus must be a defined value!")
+        transport_configs = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.CurrentConnections
+        )
+        for config in transport_configs:
+            isValidTransportStatus = (config.TransportStatus == cluster.TransportStatusEnum.kActive |
+                                        config.TransportStatus == cluster.TransportStatusEnum.kInactive)
+            asserts.assert_true(isValidTransportStatus, "TransportStatus must be a defined value!")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_PAVST_2_1.py
+++ b/src/python_testing/TC_PAVST_2_1.py
@@ -87,7 +87,7 @@ class TC_PAVST_2_1(MatterBaseTest):
         )
         for config in transport_configs:
             isValidTransportStatus = (config.TransportStatus == cluster.TransportStatusEnum.kActive |
-                                        config.TransportStatus == cluster.TransportStatusEnum.kInactive)
+                                      config.TransportStatus == cluster.TransportStatusEnum.kInactive)
             asserts.assert_true(isValidTransportStatus, "TransportStatus must be a defined value!")
 
 

--- a/src/python_testing/TC_PAVST_2_2.py
+++ b/src/python_testing/TC_PAVST_2_2.py
@@ -39,23 +39,43 @@ import logging
 
 from mobly import asserts
 from TC_PAVSTTestBase import PAVSTTestBase
+from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
 
 logger = logging.getLogger(__name__)
 
 
-class TC_PAVST_2_2(MatterBaseTest, PAVSTTestBase):
+class TC_PAVST_2_2(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
     def desc_TC_PAVST_2_2(self) -> str:
         return " [TC-PAVST-2.2] Verify reading CurrentConnections attribute over transports MRP and TCP with Server as DUT"
 
     def pics_TC_PAVST_2_2(self):
         return ["PAVST.S"]
 
+    @async_test_body
+    async def setup_class(self):
+        th_server_app = self.user_params.get("th_server_app_path", None)
+        if th_server_app:
+            self.server = PushAvServerProcess(server_path=th_server_app)
+        else:
+            self.server = PushAvServerProcess()
+        self.server.start(
+            expected_output="Running on https://0.0.0.0:1234",
+            timeout=30,
+        )
+        super().setup_class()
+
+    def teardown_class(self):
+        if self.server is not None:
+            self.server.terminate()
+        super().teardown_class()
+
     def steps_TC_PAVST_2_2(self) -> list[TestStep]:
         return [
+            TestStep("precondition", "Commissioning, already done", is_commissioning=True),
             TestStep(1, "TH Reads CurrentConnections attribute from PushAV Stream Transport Cluster on DUT",
                      "Verify the number of PushAV Connections in the list is 0. If not 0, issue DeAllocatePushAVTransport with `ConnectionID to remove any connections."),
             TestStep(2, "TH Reads SupportedFormats attribute from PushAV Stream Transport Cluster on DUT",
@@ -75,8 +95,14 @@ class TC_PAVST_2_2(MatterBaseTest, PAVSTTestBase):
     @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport))
     async def test_TC_PAVST_2_2(self):
         endpoint = self.get_endpoint(default=1)
+        self.endpoint = endpoint
+        self.node_id = self.dut_node_id
         pvcluster = Clusters.PushAvStreamTransport
         pvattr = Clusters.PushAvStreamTransport.Attributes
+
+        self.step("precondition")
+        tlsEndpointId = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server)
+        uploadStreamId = self.server.create_stream()
 
         self.step(1)
         status = await self.check_and_delete_all_push_av_transports(endpoint, pvattr)
@@ -112,7 +138,7 @@ class TC_PAVST_2_2(MatterBaseTest, PAVSTTestBase):
         )
 
         self.step(5)
-        status = await self.allocate_one_pushav_transport(endpoint)
+        status = await self.allocate_one_pushav_transport(endpoint, tlsEndPoint=tlsEndpointId, url=f"https://localhost:1234/streams/{uploadStreamId}")
         asserts.assert_equal(
             status, Status.Success, "Push AV Transport should be allocated successfully"
         )

--- a/src/python_testing/TC_PAVST_2_2.py
+++ b/src/python_testing/TC_PAVST_2_2.py
@@ -45,6 +45,7 @@ from TC_PAVSTTestBase import PAVSTTestBase
 
 logger = logging.getLogger(__name__)
 
+
 class TC_PAVST_2_2(MatterBaseTest, PAVSTTestBase):
     def desc_TC_PAVST_2_2(self) -> str:
         return "[TC-PAVST-2.2] Attributes with Server as DUT"

--- a/src/python_testing/TC_PAVST_2_2.py
+++ b/src/python_testing/TC_PAVST_2_2.py
@@ -38,12 +38,13 @@
 import logging
 
 from mobly import asserts
-from TC_PAVSTTestBase import PAVSTTestBase
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
+from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
+                                           run_if_endpoint_matches)
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_2.py
+++ b/src/python_testing/TC_PAVST_2_2.py
@@ -37,11 +37,12 @@
 
 import logging
 
+from mobly import asserts
+from TC_PAVSTTestBase import PAVSTTestBase
+
 import matter.clusters as Clusters
 from matter.interaction_model import Status
 from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
-from mobly import asserts
-from TC_PAVSTTestBase import PAVSTTestBase
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_2.py
+++ b/src/python_testing/TC_PAVST_2_2.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 
 class TC_PAVST_2_2(MatterBaseTest, PAVSTTestBase):
     def desc_TC_PAVST_2_2(self) -> str:
-        return "[TC-PAVST-2.2] Attributes with Server as DUT"
+        return " [TC-PAVST-2.2] Verify reading CurrentConnections attribute over transports MRP and TCP with Server as DUT"
 
     def pics_TC_PAVST_2_2(self):
         return ["PAVST.S"]

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -43,7 +43,7 @@ from TC_PAVSTTestBase import PAVSTTestBase
 import matter.clusters as Clusters
 from matter.clusters.Types import Nullable
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main)
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -37,16 +37,17 @@
 
 import logging
 
-from mobly import asserts
-
 import matter.clusters as Clusters
+from matter.clusters.Types import Nullable
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from mobly import asserts
+from TC_PAVSTTestBase import PAVSTTestBase
 
 logger = logging.getLogger(__name__)
 
 
-class TC_PAVST_2_3(MatterBaseTest):
+class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase):
     def desc_TC_PAVST_2_3(self) -> str:
         return "[TC-PAVST-2.3] Attributes with Server as DUT"
 
@@ -118,98 +119,57 @@ class TC_PAVST_2_3(MatterBaseTest):
         endpoint = self.get_endpoint(default=1)
         pvcluster = Clusters.PushAvStreamTransport
         avcluster = Clusters.CameraAvStreamManagement
-        zmcluster = Clusters.ZonesManagement
-        tlscluster = Clusters.TLSClientManagement
+        zmcluster = Clusters.ZoneManagement
+        tlscluster = Clusters.TlsClientManagement
         pvattr = Clusters.PushAvStreamTransport.Attributes
         avattr = Clusters.CameraAvStreamManagement.Attributes
-        aSupportedFormats = []
-        aAllocatedVideoStreams = []
-        aAllocatedAudioStreams = []
         aZones = []
         aMaxZones = []
         aProvisionedEndpoints = []
-
+        aConnectionID = ""
+        
         self.step(1)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            transport_configs = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=pvcluster, attribute=pvattr.CurrentConnections
-            )
-            for config in transport_configs:
-                if config.ConnectionID != 0:
-                    try:
-                        await self.send_single_cmd(cmd=pvcluster.Commands.DeallocatePushTransport(ConnectionID=config.ConnectionID),
-                                                   endpoint=endpoint)
-                    except InteractionModelError as e:
-                        asserts.assert_true(e.status == Status.Success, "Unexpected error returned")
+        status = await self.check_and_delete_all_push_av_transports(endpoint, pvattr)
+        asserts.assert_equal(
+            status, Status.Success, "Status must be SUCCESS!"
+        )
 
         self.step(2)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            aSupportedFormats = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=pvcluster, attribute=pvattr.SupportedFormats
-            )
-            asserts.assert_greater_equal(len(aSupportedFormats, 1), "SupportedFormats must not be empty!")
+        supported_formats = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=pvcluster, attribute=pvattr.SupportedFormats
+        )
+        asserts.assert_greater_equal(len(supported_formats), 1, "SupportedFormats must not be empty!")
 
         self.step(3)
-        if self.pics_guard(self.check_pics("AVSM.S")):
-            await self.send_single_cmd(cmd=Clusters.CameraAvStreamManagement.Commands.VideoStreamAllocate(
-                streamUsage=0,
-                videoCodec=0,
-                minFrameRate=30,
-                maxFrameRate=120,
-                minResolution=Clusters.CameraAvStreamManagement.Structs.VideoResolutionStruct(width=400, height=300),
-                maxResolution=Clusters.CameraAvStreamManagement.Structs.VideoResolutionStruct(width=1920, height=1080),
-                minBitRate=20000,
-                maxBitRate=150000,
-                minFragmentLen=2000,
-                maxFragmentLen=8000
-            ),
-                endpoint=endpoint)
-
-            aAllocatedVideoStreams = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=avcluster, attribute=avattr.AllocatedVideoStreams
-            )
-            asserts.assert_greater_equal(len(aAllocatedVideoStreams), 1, "AllocatedVideoStreams must not be empty")
+        aAllocatedVideoStreams = await self.allocate_one_video_stream()
+        asserts.assert_greater_equal(
+            len(aAllocatedVideoStreams),
+            1,
+            "AllocatedVideoStreams must not be empty",
+        )
 
         self.step(4)
-        if self.pics_guard(self.check_pics("AVSM.S")):
-            await self.send_single_cmd(cmd=Clusters.CameraAvStreamManagement.Commands.AudioStreamAllocate(
-                streamUsage=0,
-                audioCodec=0,
-                channelCount=2,
-                sampleRate=48000,
-                bitRate=96000,
-                bitDepth=16
-            ),
-                endpoint=endpoint)
-
-            aAllocatedAudioStreams = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=avcluster, attribute=avattr.AllocatedAudioStreams
-            )
-            asserts.assert_greater_equal(len(aAllocatedAudioStreams), 1, "AllocatedAudioStreams must not be empty")
+        aAllocatedAudioStreams = await self.allocate_one_audio_stream()
+        asserts.assert_greater_equal(
+            len(aAllocatedAudioStreams),
+            1,
+            "AllocatedAudioStreams must not be empty",
+        )
 
         self.step(5)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 2},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
+        status = await self.allocate_one_pushav_transport(endpoint)
+        asserts.assert_equal(
+            status, Status.Success, "Push AV Transport should be allocated successfully"
+        )
 
         self.step(6)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            current_connections = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=pvcluster, attribute=pvcluster.Attributes.CurrentConnections
-            )
-            asserts.assert_equal(len(current_connections), 1, "TransportConfigurations must be 1")
-            asserts.assert_equal(current_connections[0].TransportStatus,
-                                 pvcluster.TransportStatusEnum.kInactive, "TransportStatus must be Inactive")
+        current_connections = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=pvcluster, attribute=pvcluster.Attributes.CurrentConnections
+        )
+        asserts.assert_equal(len(current_connections), 1, "TransportConfigurations must be 1")
+        aConnectionID = current_connections[0].connectionID
+        asserts.assert_equal(current_connections[0].transportStatus, 
+                             pvcluster.Enums.TransportStatusEnum.kInactive, "TransportStatus must be Inactive")
 
         self.step(7)
         aZones = await self.read_single_attribute_check_success(
@@ -224,10 +184,11 @@ class TC_PAVST_2_3(MatterBaseTest):
         logger.info(f"aMaxZones: {aMaxZones}")
 
         self.step(9)
-        aProvisionedEndpoints = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=tlscluster, attribute=tlscluster.Attributes.ProvisionedEndpoints
-        )
-        logger.info(f"aProvisionedEndpoints: {aProvisionedEndpoints}")
+        if self.pics_guard(self.check_pics("PAVST.S")):
+            aProvisionedEndpoints = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=tlscluster, attribute=tlscluster.Attributes.ProvisionedEndpoints
+            )
+            logger.info(f"aProvisionedEndpoints: {aProvisionedEndpoints}")
 
         self.step(10)
         if self.pics_guard(self.check_pics("PAVST.S")):
@@ -243,348 +204,194 @@ class TC_PAVST_2_3(MatterBaseTest):
                  "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
                  "expiryTime": 5
                  }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.InvalidTLSEndpoint,
+            asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidTLSEndpoint,
                                  "DUT must responds with Status Code InvalidTLSEndpoint.")
 
         self.step(11)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 2},
-                 "ingestMethod": 10,
-                 "containerFormat": 10,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.InvalidCombination,
-                                 "DUT must  responds with Status Code InvalidCombination.")
+        status = await self.allocate_one_pushav_transport(endpoint, ingestMethod=pvcluster.Enums.IngestMethodsEnum.kUnknownEnumValue,
+                                                          expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidCombination)
+        asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidCombination,
+                             "DUT must  responds with Status Code InvalidCombination.")
 
         self.step(12)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https:/localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 2},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.InvalidURL,
-                                 "DUT must  responds with Status Code InvalidURL.")
+        status = await self.allocate_one_pushav_transport(endpoint, url="https:/localhost:1234/streams/1",
+                                                          expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidURL)
+        asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidURL,
+                             "DUT must  responds with Status Code InvalidURL.")
 
         self.step(13)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 10},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.InvalidTriggerType,
-                                 "DUT must  responds with Status Code InvalidTriggerType.")
+        status = await self.allocate_one_pushav_transport(endpoint, triggerType=pvcluster.Enums.TransportTriggerTypeEnum.kUnknownEnumValue,
+                                                          expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidTriggerType)
+        asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidTriggerType,
+                             "DUT must  responds with Status Code InvalidTriggerType.")
 
         self.step(14)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 2, "motionZones": {"zoneID": 11}},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.InvalidZone,
-                                 "DUT must  responds with Status Code InvalidZone.")
+        try:
+            zoneList = [{"zone": 14, "sensitivity": 4}]
+            triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                        "maxPreRollLen": 4000,
+                        "motionZones": zoneList,
+                        "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1,"maxDuration": 1, "blindDuration": 1}}
+            status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions, expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidZone)
+            asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidZone,
+                                "DUT must responds with Status Code InvalidZone.")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.clusterStatus, pvcluster.Enums.StatusCodeEnum.kInvalidZone,
+                                "DUT must responds with Status Code InvalidZone.")
+            
 
         self.step(15)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 11,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 2},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.InvalidStream,
-                                 "DUT must  responds with Status Code InvalidStream.")
+        status = await self.allocate_one_pushav_transport(endpoint, videoStream_ID=-1,
+                                                          expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidStream)
+        asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidStream,
+                             "DUT must  responds with Status Code InvalidStream.")
 
         self.step(16)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 11,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 2},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.InvalidStream,
-                                 "DUT must  responds with Status Code InvalidStream.")
+        status = await self.allocate_one_pushav_transport(endpoint, audioStream_ID=-1,
+                                                          expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidStream)
+        asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidStream,
+                             "DUT must  responds with Status Code InvalidStream.")
 
         self.step(17)
-        if self.pics_guard(self.check_pics("PAVST.S")):
+        try:
+            aStreamUsagePriorities = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=avcluster, attribute=avattr.StreamUsagePriorities
+            )
+            asserts.assert_greater(len(aStreamUsagePriorities), 0, "StreamUsagePriorities is empty")
+        
+            streamUsage = aStreamUsagePriorities[0]
+            containerOptions = {
+            "containerType": pvcluster.Enums.ContainerFormatEnum.kCmaf,
+            "CMAFContainerOptions": {"CMAFInterface": pvcluster.Enums.CMAFInterfaceEnum.kInterface1, "chunkDuration": 4, "segmentDuration": 3,
+                                     "sessionGroup": 3, "trackName": ""},
+            }
             status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 2},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.ConstraintError,
-                                 "DUT must  responds with Status Code ConstraintError.")
+                {"streamUsage": streamUsage,
+                "endpointID": endpoint,
+                "url": "https://localhost:1234/streams/1",
+                "triggerOptions": {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kContinuous},
+                "ingestMethod": pvcluster.Enums.IngestMethodsEnum.kCMAFIngest,
+                "containerOptions": containerOptions,
+                "expiryTime": 5
+                }), endpoint=endpoint)
+            asserts.assert_equal(status, Status.InvalidCommand,
+                                "DUT must  responds with Status Code InvalidCommand.")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.InvalidCommand,
+                                "DUT must  responds with Status Code InvalidCommand.")
 
         self.step(18)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": None,
-                 "audioStreamID": None,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 2},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.Success,
-                                 "DUT must responds with Status code Success")
+        status = await self.allocate_one_pushav_transport(endpoint, videoStream_ID=Nullable(), audioStream_ID=Nullable())
+        asserts.assert_equal(status, Status.Success,
+                             "DUT must  responds with Status Code Success.")
 
         self.step(19)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            zonesList = {{"zoneID": 1}, {"zoneID": 2}, {"zoneID": 3}, {"zoneID": 4}, {"zoneID": 5}, {"zoneID": 6}, {"zoneID": 7}, {"zoneID": 8}, {
-                "zoneID": 9}, {"zoneID": 10}, {"zoneID": 11}, {"zoneID": 12}, {"zoneID": 13}, {"zoneID": 14}, {"zoneID": 15}, {"zoneID": 16}}
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 1, "motionZones": zonesList},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.ConstraintError,
-                                 "DUT must  responds with Status code ConstraintError")
+        zoneList = [{"zone": 1, "sensitivity": 4},{"zone": 2, "sensitivity": 4},{"zone": 3, "sensitivity": 4},{"zone": 4, "sensitivity": 4},{"zone": 5, "sensitivity": 4},{"zone": 6, "sensitivity": 4},
+                    {"zone": 7, "sensitivity": 4},{"zone": 8, "sensitivity": 4},{"zone": 9, "sensitivity": 4},{"zone": 10, "sensitivity": 4},{"zone": 11, "sensitivity": 4},{"zone": 12, "sensitivity": 4}]
+        triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                        "maxPreRollLen": 4000,
+                        "motionZones": zoneList,
+                        "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1,"maxDuration": 1, "blindDuration": 1}}
+        status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions)
+        asserts.assert_equal(status, Status.ConstraintError,
+                                "DUT must  responds with Status code ConstraintError")
 
         self.step(20)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 1, "MotionSensitivity ": 3},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.InvalidCommand,
-                                 "DUT must  responds with Status code InvalidCommand")
+        zoneList = []
+        triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                          "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1},
+                          "motionSensitivity": 3,
+                          "motionZones": zoneList}
+        status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions)
+        asserts.assert_equal(status, Status.InvalidCommand,
+                             "DUT must  responds with Status Code InvalidCommand.")
 
         self.step(21)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 1, "MotionSensitivity ": 11},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.ConstraintError,
-                                 "DUT must  responds with Status code ConstraintError")
+        zoneList = []
+        triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                          "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1},
+                          "motionSensitivity": 11,
+                          "motionZones": zoneList}
+        status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions)
+        asserts.assert_equal(status, Status.InvalidCommand,
+                             "DUT must  responds with Status Code InvalidCommand.")
 
         self.step(22)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 1},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.InvalidCommand,
-                                 "DUT must  responds with Status code InvalidCommand")
+        zoneList = []
+        triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                          "motionZones": zoneList,
+                          "motionSensitivity": 3}
+        status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions)
+        asserts.assert_equal(status, Status.InvalidCommand,
+                             "DUT must  responds with Status Code InvalidCommand.")
 
         self.step(23)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 1, "motionTimeControl": {"initialDuration": 0}},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.ConstraintError,
-                                 "DUT must  responds with Status code ConstraintError")
-
-        self.step(23)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 1, "motionTimeControl": {"initialDuration": 0}},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.ConstraintError,
-                                 "DUT must  responds with Status code ConstraintError")
-
-        self.step(23)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 1, "motionTimeControl": {"initialDuration": 0}},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.ConstraintError,
-                                 "DUT must  responds with Status code ConstraintError")
+        zoneList = []
+        triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                          "motionZones": zoneList,
+                          "motionSensitivity": 3,
+                          "motionTimeControl": {"initialDuration": 0, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1}}
+        status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions)
+        asserts.assert_equal(status, Status.ConstraintError,
+                             "DUT must  responds with Status code ConstraintError")
 
         self.step(24)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 1, "motionTimeControl": {"maxDuration": 0}},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.ConstraintError,
-                                 "DUT must  responds with Status code ConstraintError")
+        zoneList = []
+        triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                          "motionZones": zoneList,
+                          "motionSensitivity": 3,
+                          "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 0, "blindDuration": 1}}
+        status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions)
+        asserts.assert_equal(status, Status.ConstraintError,
+                             "DUT must  responds with Status code ConstraintError")
 
         self.step(25)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 1, "motionZones": None, "motionSensitivity": None},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.Success,
-                                 "DUT must responds with Status code Success")
+        cmd = pvcluster.Commands.DeallocatePushTransport(
+            connectionID=aConnectionID
+        )
+        status = await self.psvt_deallocate_push_transport(cmd)
+        asserts.assert_true(status == Status.Success,
+        "DUT responds with SUCCESS status code.")
+        zoneList = []
+        triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                           "maxPreRollLen": 4000,
+                           "motionZones": zoneList,
+                           "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1,"maxDuration": 1, "blindDuration": 1}}
+
+        status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions)
+        asserts.assert_equal(status, Status.Success,
+                             "DUT must  responds with Status Code Success.")
+        current_connections = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=pvcluster, attribute=pvcluster.Attributes.CurrentConnections
+        )
+        aConnectionID = current_connections[len(current_connections)-1].connectionID
 
         self.step(26)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 1, "motionZones": ""},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.Success,
-                                 "DUT must  responds with Status code Success")
+        cmd = pvcluster.Commands.DeallocatePushTransport(
+            connectionID=aConnectionID
+        )
+        status = await self.psvt_deallocate_push_transport(cmd)
+        asserts.assert_true(status == Status.Success,
+                            "DUT responds with SUCCESS status code.")
+        zoneList = []
+        triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                          "maxPreRollLen": 4000,
+                          "motionZones": zoneList,
+                          "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1}}
+        status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions)
+        asserts.assert_equal(status, Status.Success,
+                             "DUT must  responds with Status Code Success.")
 
         self.step(27)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 1},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.InvalidCommand,
-                                 "DUT must  responds with Status code InvalidCommand")
+        status = await self.allocate_one_pushav_transport(endpoint, stream_Usage=Clusters.Globals.Enums.StreamUsageEnum.kUnknownEnumValue)
+        asserts.assert_equal(status, Status.ConstraintError,
+                             "DUT must  responds with Status code ConstraintError")
 
         self.step(28)
-        if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 10,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 1,
-                 "url": "https://localhost:1234/streams/1",
-                 "triggerOptions": {"triggerType": 2},
-                 "ingestMethod": 0,
-                 "containerFormat": 0,
-                 "containerOptions": {"containerType": 0},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.PushAvStreamTransport.StatusCodeEnum.InvalidCommand,
-                                 "DUT must  responds with Status code InvalidCommand")
+        containerOptions = {"containerType": pvcluster.Enums.ContainerFormatEnum.kCmaf}
+        status = await self.allocate_one_pushav_transport(endpoint, container_Options=containerOptions)
+        asserts.assert_equal(status, Status.InvalidCommand,
+                             "DUT must  responds with Status code InvalidCommand")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -37,12 +37,14 @@
 
 import logging
 
+from mobly import asserts
+from TC_PAVSTTestBase import PAVSTTestBase
+
 import matter.clusters as Clusters
 from matter.clusters.Types import Nullable
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
-from mobly import asserts
-from TC_PAVSTTestBase import PAVSTTestBase
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
+                                           run_if_endpoint_matches)
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase):
     def desc_TC_PAVST_2_3(self) -> str:
-        return "[TC-PAVST-2.3] Attributes with Server as DUT"
+        return "[TC-PAVST-2.3] Allocate PushAV Transport with Server as DUT"
 
     def pics_TC_PAVST_2_3(self):
         return ["PAVST.S"]
@@ -80,7 +80,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase):
             TestStep(11, "TH sends the AllocatePushTransport command with a combination of IngestMethod and ContainerFormat not in aSupportedFormats.",
                      "DUT responds with Status Code InvalidCombination."),
             TestStep(12, "DUT responds with Status Code InvalidURL.",
-                     "Store value as aMaxZones."),
+                     "DUT responds with Status Code InvalidURL."),
             TestStep(13, "TH sends the AllocatePushTransport command with an invalid TriggerType in the TransportTriggerOptions struct field.",
                      "DUT responds with Status Code InvalidTriggerType."),
             TestStep(14, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with an invalid ZoneID that is not present in aZones.",
@@ -201,7 +201,6 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase):
                  "url": "https://localhost:1234/streams/1",
                  "triggerOptions": {"triggerType": 2},
                  "ingestMethod": 0,
-                 "containerFormat": 0,
                  "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
                  "expiryTime": 5
                  }), endpoint=endpoint)

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -127,7 +127,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase):
         aMaxZones = []
         aProvisionedEndpoints = []
         aConnectionID = ""
-        
+
         self.step(1)
         status = await self.check_and_delete_all_push_av_transports(endpoint, pvattr)
         asserts.assert_equal(
@@ -168,7 +168,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase):
         )
         asserts.assert_equal(len(current_connections), 1, "TransportConfigurations must be 1")
         aConnectionID = current_connections[0].connectionID
-        asserts.assert_equal(current_connections[0].transportStatus, 
+        asserts.assert_equal(current_connections[0].transportStatus,
                              pvcluster.Enums.TransportStatusEnum.kInactive, "TransportStatus must be Inactive")
 
         self.step(7)
@@ -229,16 +229,15 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase):
         try:
             zoneList = [{"zone": 14, "sensitivity": 4}]
             triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
-                        "maxPreRollLen": 4000,
-                        "motionZones": zoneList,
-                        "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1,"maxDuration": 1, "blindDuration": 1}}
+                              "maxPreRollLen": 4000,
+                              "motionZones": zoneList,
+                              "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1}}
             status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions, expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidZone)
             asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidZone,
-                                "DUT must responds with Status Code InvalidZone.")
+                                 "DUT must responds with Status Code InvalidZone.")
         except InteractionModelError as e:
             asserts.assert_equal(e.clusterStatus, pvcluster.Enums.StatusCodeEnum.kInvalidZone,
-                                "DUT must responds with Status Code InvalidZone.")
-            
+                                 "DUT must responds with Status Code InvalidZone.")
 
         self.step(15)
         status = await self.allocate_one_pushav_transport(endpoint, videoStream_ID=-1,
@@ -258,27 +257,27 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase):
                 endpoint=endpoint, cluster=avcluster, attribute=avattr.StreamUsagePriorities
             )
             asserts.assert_greater(len(aStreamUsagePriorities), 0, "StreamUsagePriorities is empty")
-        
+
             streamUsage = aStreamUsagePriorities[0]
             containerOptions = {
-            "containerType": pvcluster.Enums.ContainerFormatEnum.kCmaf,
-            "CMAFContainerOptions": {"CMAFInterface": pvcluster.Enums.CMAFInterfaceEnum.kInterface1, "chunkDuration": 4, "segmentDuration": 3,
-                                     "sessionGroup": 3, "trackName": ""},
+                "containerType": pvcluster.Enums.ContainerFormatEnum.kCmaf,
+                "CMAFContainerOptions": {"CMAFInterface": pvcluster.Enums.CMAFInterfaceEnum.kInterface1, "chunkDuration": 4, "segmentDuration": 3,
+                                         "sessionGroup": 3, "trackName": ""},
             }
             status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
                 {"streamUsage": streamUsage,
-                "endpointID": endpoint,
-                "url": "https://localhost:1234/streams/1",
-                "triggerOptions": {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kContinuous},
-                "ingestMethod": pvcluster.Enums.IngestMethodsEnum.kCMAFIngest,
-                "containerOptions": containerOptions,
-                "expiryTime": 5
-                }), endpoint=endpoint)
+                 "endpointID": endpoint,
+                 "url": "https://localhost:1234/streams/1",
+                 "triggerOptions": {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kContinuous},
+                 "ingestMethod": pvcluster.Enums.IngestMethodsEnum.kCMAFIngest,
+                 "containerOptions": containerOptions,
+                 "expiryTime": 5
+                 }), endpoint=endpoint)
             asserts.assert_equal(status, Status.InvalidCommand,
-                                "DUT must  responds with Status Code InvalidCommand.")
+                                 "DUT must  responds with Status Code InvalidCommand.")
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.InvalidCommand,
-                                "DUT must  responds with Status Code InvalidCommand.")
+                                 "DUT must  responds with Status Code InvalidCommand.")
 
         self.step(18)
         status = await self.allocate_one_pushav_transport(endpoint, videoStream_ID=Nullable(), audioStream_ID=Nullable())
@@ -286,15 +285,15 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase):
                              "DUT must  responds with Status Code Success.")
 
         self.step(19)
-        zoneList = [{"zone": 1, "sensitivity": 4},{"zone": 2, "sensitivity": 4},{"zone": 3, "sensitivity": 4},{"zone": 4, "sensitivity": 4},{"zone": 5, "sensitivity": 4},{"zone": 6, "sensitivity": 4},
-                    {"zone": 7, "sensitivity": 4},{"zone": 8, "sensitivity": 4},{"zone": 9, "sensitivity": 4},{"zone": 10, "sensitivity": 4},{"zone": 11, "sensitivity": 4},{"zone": 12, "sensitivity": 4}]
+        zoneList = [{"zone": 1, "sensitivity": 4}, {"zone": 2, "sensitivity": 4}, {"zone": 3, "sensitivity": 4}, {"zone": 4, "sensitivity": 4}, {"zone": 5, "sensitivity": 4}, {"zone": 6, "sensitivity": 4},
+                    {"zone": 7, "sensitivity": 4}, {"zone": 8, "sensitivity": 4}, {"zone": 9, "sensitivity": 4}, {"zone": 10, "sensitivity": 4}, {"zone": 11, "sensitivity": 4}, {"zone": 12, "sensitivity": 4}]
         triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
-                        "maxPreRollLen": 4000,
-                        "motionZones": zoneList,
-                        "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1,"maxDuration": 1, "blindDuration": 1}}
+                          "maxPreRollLen": 4000,
+                          "motionZones": zoneList,
+                          "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1}}
         status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions)
         asserts.assert_equal(status, Status.ConstraintError,
-                                "DUT must  responds with Status code ConstraintError")
+                             "DUT must  responds with Status code ConstraintError")
 
         self.step(20)
         zoneList = []
@@ -351,12 +350,12 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase):
         )
         status = await self.psvt_deallocate_push_transport(cmd)
         asserts.assert_true(status == Status.Success,
-        "DUT responds with SUCCESS status code.")
+                            "DUT responds with SUCCESS status code.")
         zoneList = []
         triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
-                           "maxPreRollLen": 4000,
-                           "motionZones": zoneList,
-                           "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1,"maxDuration": 1, "blindDuration": 1}}
+                          "maxPreRollLen": 4000,
+                          "motionZones": zoneList,
+                          "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1}}
 
         status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions)
         asserts.assert_equal(status, Status.Success,

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -43,8 +43,7 @@ from TC_PAVSTTestBase import PAVSTTestBase
 import matter.clusters as Clusters
 from matter.clusters.Types import Nullable
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
-                                           run_if_endpoint_matches)
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main)
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -38,8 +38,8 @@
 import logging
 
 from mobly import asserts
-from TC_PAVSTTestBase import PAVSTTestBase
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
+from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
 from matter.clusters.Types import Nullable

--- a/src/python_testing/TC_PAVST_2_4.py
+++ b/src/python_testing/TC_PAVST_2_4.py
@@ -38,12 +38,13 @@
 import logging
 
 from mobly import asserts
-from TC_PAVSTTestBase import PAVSTTestBase
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
+from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
+                                           run_if_endpoint_matches)
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_4.py
+++ b/src/python_testing/TC_PAVST_2_4.py
@@ -39,23 +39,43 @@ import logging
 
 from mobly import asserts
 from TC_PAVSTTestBase import PAVSTTestBase
+from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
 
 logger = logging.getLogger(__name__)
 
 
-class TC_PAVST_2_4(MatterBaseTest, PAVSTTestBase):
+class TC_PAVST_2_4(MatterBaseTest, PAVSTTestBase,PAVSTIUtils):
     def desc_TC_PAVST_2_4(self) -> str:
         return "[TC-PAVST-2.4] Modify PushAV Transport with Server as DUT"
 
     def pics_TC_PAVST_2_4(self):
         return ["PAVST.S"]
 
+    @async_test_body
+    async def setup_class(self):
+        th_server_app = self.user_params.get("th_server_app_path", None)
+        if th_server_app:
+            self.server = PushAvServerProcess(server_path=th_server_app)
+        else:
+            self.server = PushAvServerProcess()
+        self.server.start(
+            expected_output="Running on https://0.0.0.0:1234",
+            timeout=30,
+        )
+        super().setup_class()
+
+    def teardown_class(self):
+        if self.server is not None:
+            self.server.terminate()
+        super().teardown_class()
+
     def steps_TC_PAVST_2_4(self) -> list[TestStep]:
         return [
+            TestStep("precondition", "Commissioning, already done", is_commissioning=True),
             TestStep(
                 1,
                 "TH1 executes step 1-5 of TC-PAVST-2.3 to allocate a PushAV transport.",
@@ -91,6 +111,8 @@ class TC_PAVST_2_4(MatterBaseTest, PAVSTTestBase):
     @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport))
     async def test_TC_PAVST_2_4(self):
         endpoint = self.get_endpoint(default=1)
+        self.endpoint = endpoint
+        self.node_id = self.dut_node_id
         pvcluster = Clusters.PushAvStreamTransport
         pvattr = Clusters.PushAvStreamTransport.Attributes
         aAllocatedVideoStreams = []
@@ -98,6 +120,10 @@ class TC_PAVST_2_4(MatterBaseTest, PAVSTTestBase):
 
         aTransportOptions = ""
         aConnectionID = ""
+
+        self.step("precondition")
+        tlsEndpointId = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server)
+        uploadStreamId = self.server.create_stream()
 
         self.step(1)
         # Commission DUT - already done
@@ -120,7 +146,7 @@ class TC_PAVST_2_4(MatterBaseTest, PAVSTTestBase):
             "AllocatedAudioStreams must not be empty",
         )
 
-        status = await self.allocate_one_pushav_transport(endpoint)
+        status = await self.allocate_one_pushav_transport(endpoint, tlsEndPoint=tlsEndpointId, url=f"https://localhost:1234/streams/{uploadStreamId}")
         asserts.assert_equal(
             status, Status.Success, "Push AV Transport should be allocated successfully"
         )

--- a/src/python_testing/TC_PAVST_2_4.py
+++ b/src/python_testing/TC_PAVST_2_4.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 
 class TC_PAVST_2_4(MatterBaseTest, PAVSTTestBase):
     def desc_TC_PAVST_2_4(self) -> str:
-        return "[TC-PAVST-2.4] Attributes with Server as DUT"
+        return "[TC-PAVST-2.4] Modify PushAV Transport with Server as DUT"
 
     def pics_TC_PAVST_2_4(self):
         return ["PAVST.S"]
@@ -78,13 +78,13 @@ class TC_PAVST_2_4(MatterBaseTest, PAVSTTestBase):
             ),
             TestStep(
                 5,
-                "TH1 sends the ModifyPushTransport command with ConnectionID != aConnectionID.",
-                "DUT responds with NOT_FOUND status code.",
+                "TH1 sends the ModifyPushTransport command with ConnectionID = aConnectionID and aTransportOptions, with ExpiryTime incremented by 120 in aTransportOptions",
+                "DUT responds with SUCCESS  status code.",
             ),
             TestStep(
                 6,
                 "TH1 Reads CurrentConnections attribute from PushAV Stream Transport Cluster on DUT over a large-payload session.",
-                "Verify the number of PushAV Connections in the list is 1. Store the TransportOptions and ConnectionID in the corresponding TransportConfiguration as aTransportOptions and aConnectionID.",
+                "Verify that ConnectionID == aConnectionID and ExpiryTime in TransportConfiguration.TransportOptions is incremented by 120.",
             )
         ]
 

--- a/src/python_testing/TC_PAVST_2_4.py
+++ b/src/python_testing/TC_PAVST_2_4.py
@@ -48,7 +48,7 @@ from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_b
 logger = logging.getLogger(__name__)
 
 
-class TC_PAVST_2_4(MatterBaseTest, PAVSTTestBase,PAVSTIUtils):
+class TC_PAVST_2_4(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
     def desc_TC_PAVST_2_4(self) -> str:
         return "[TC-PAVST-2.4] Modify PushAV Transport with Server as DUT"
 

--- a/src/python_testing/TC_PAVST_2_5.py
+++ b/src/python_testing/TC_PAVST_2_5.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 
 class TC_PAVST_2_5(MatterBaseTest, PAVSTTestBase):
     def desc_TC_PAVST_2_5(self) -> str:
-        return "[TC-PAVST-2.5] Attributes with Server as DUT"
+        return "[TC-PAVST-2.5] Deallocate PushAV Transport with Server as DUT"
 
     def pics_TC_PAVST_2_5(self):
         return ["PAVST.S"]

--- a/src/python_testing/TC_PAVST_2_5.py
+++ b/src/python_testing/TC_PAVST_2_5.py
@@ -38,12 +38,13 @@
 import logging
 
 from mobly import asserts
-from TC_PAVSTTestBase import PAVSTTestBase
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
+from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
+                                           run_if_endpoint_matches)
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_6.py
+++ b/src/python_testing/TC_PAVST_2_6.py
@@ -38,12 +38,13 @@
 import logging
 
 from mobly import asserts
-from TC_PAVSTTestBase import PAVSTTestBase
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
+from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
+                                           run_if_endpoint_matches)
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_6.py
+++ b/src/python_testing/TC_PAVST_2_6.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 
 class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase):
     def desc_TC_PAVST_2_6(self) -> str:
-        return "[TC-PAVST-2.5] Attributes with Server as DUT"
+        return "[TC-PAVST-2.6] Validate SetTransportStatus command with Server as DUT"
 
     def pics_TC_PAVST_2_6(self):
         return ["PAVST.S"]
@@ -68,23 +68,23 @@ class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase):
             ),
             TestStep(
                 3,
-                "TH1 sends the DeallocatePushTransport command with ConnectionID != aConnectionID.",
+                "TH1 sends the SetTransportStatus  command with ConnectionID != aConnectionID.",
                 "DUT responds with NOT_FOUND status code.",
             ),
             TestStep(
                 4,
-                "TH2 sends the DeallocatePushTransport command with ConnectionID = aConnectionID.",
+                "TH2 sends the SetTransportStatus  command with ConnectionID = aConnectionID.",
                 "DUT responds with NOT_FOUND status code.",
             ),
             TestStep(
                 5,
-                "TH1 sends the DeallocatePushTransport command with ConnectionID = aConnectionID.",
+                "TH1 sends the SetTransportStatus  command with ConnectionID = aConnectionID.",
                 "DUT responds with SUCCESS status code.",
             ),
             TestStep(
                 6,
                 "TH1 Reads CurrentConnections attribute from PushAV Stream Transport Cluster on DUT.",
-                "Verify the number of PushAV Connections is 0.",
+                "Verify that the TransportStatus is set to !aTransportStatus in the TransportConfiguration corresponding to aConnectionID.",
             )
         ]
 

--- a/src/python_testing/TC_PAVST_2_6.py
+++ b/src/python_testing/TC_PAVST_2_6.py
@@ -39,23 +39,43 @@ import logging
 
 from mobly import asserts
 from TC_PAVSTTestBase import PAVSTTestBase
+from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
 
 logger = logging.getLogger(__name__)
 
 
-class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase):
+class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
     def desc_TC_PAVST_2_6(self) -> str:
         return "[TC-PAVST-2.6] Validate SetTransportStatus command with Server as DUT"
 
     def pics_TC_PAVST_2_6(self):
         return ["PAVST.S"]
 
+    @async_test_body
+    async def setup_class(self):
+        th_server_app = self.user_params.get("th_server_app_path", None)
+        if th_server_app:
+            self.server = PushAvServerProcess(server_path=th_server_app)
+        else:
+            self.server = PushAvServerProcess()
+        self.server.start(
+            expected_output="Running on https://0.0.0.0:1234",
+            timeout=30,
+        )
+        super().setup_class()
+
+    def teardown_class(self):
+        if self.server is not None:
+            self.server.terminate()
+        super().teardown_class()
+
     def steps_TC_PAVST_2_6(self) -> list[TestStep]:
         return [
+            TestStep("precondition", "Commissioning, already done", is_commissioning=True),
             TestStep(
                 1,
                 "TH1 executes step 1-5 of TC-PAVST-2.3 to allocate a PushAV transport.",
@@ -91,6 +111,8 @@ class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase):
     @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport))
     async def test_TC_PAVST_2_6(self):
         endpoint = self.get_endpoint(default=1)
+        self.endpoint = endpoint
+        self.node_id = self.dut_node_id
         pvcluster = Clusters.PushAvStreamTransport
         pvattr = Clusters.PushAvStreamTransport.Attributes
         aAllocatedVideoStreams = []
@@ -98,6 +120,10 @@ class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase):
 
         aConnectionID = ""
         aTransportStatus = ""
+
+        self.step("precondition")
+        tlsEndpointId = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server)
+        uploadStreamId = self.server.create_stream()
 
         self.step(1)
         # Commission DUT - already done
@@ -120,7 +146,7 @@ class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase):
             "AllocatedAudioStreams must not be empty",
         )
 
-        status = await self.allocate_one_pushav_transport(endpoint)
+        status = await self.allocate_one_pushav_transport(endpoint, tlsEndPoint=tlsEndpointId, url=f"https://localhost:1234/streams/{uploadStreamId}")
         asserts.assert_equal(
             status, Status.Success, "Push AV Transport should be allocated successfully"
         )

--- a/src/python_testing/TC_PAVST_2_7.py
+++ b/src/python_testing/TC_PAVST_2_7.py
@@ -38,12 +38,13 @@
 import logging
 
 from mobly import asserts
-from TC_PAVSTTestBase import PAVSTTestBase
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
+from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
+                                           run_if_endpoint_matches)
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_7.py
+++ b/src/python_testing/TC_PAVST_2_7.py
@@ -54,7 +54,7 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
 
     def pics_TC_PAVST_2_7(self):
         return ["PAVST.S"]
-    
+
     @async_test_body
     async def setup_class(self):
         th_server_app = self.user_params.get("th_server_app_path", None)

--- a/src/python_testing/TC_PAVST_2_7.py
+++ b/src/python_testing/TC_PAVST_2_7.py
@@ -39,23 +39,43 @@ import logging
 
 from mobly import asserts
 from TC_PAVSTTestBase import PAVSTTestBase
+from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
 
 logger = logging.getLogger(__name__)
 
 
-class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase):
+class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
     def TC_PAVST_2_7(self) -> str:
         return "[TC-PAVST-2.7] Manually Trigger PushAV Transport Flow with Server as DUT"
 
     def pics_TC_PAVST_2_7(self):
         return ["PAVST.S"]
+    
+    @async_test_body
+    async def setup_class(self):
+        th_server_app = self.user_params.get("th_server_app_path", None)
+        if th_server_app:
+            self.server = PushAvServerProcess(server_path=th_server_app)
+        else:
+            self.server = PushAvServerProcess()
+        self.server.start(
+            expected_output="Running on https://0.0.0.0:1234",
+            timeout=30,
+        )
+        super().setup_class()
+
+    def teardown_class(self):
+        if self.server is not None:
+            self.server.terminate()
+        super().teardown_class()
 
     def steps_TC_PAVST_2_7(self) -> list[TestStep]:
         return [
+            TestStep("precondition", "Commissioning, already done", is_commissioning=True),
             TestStep(
                 1,
                 "TH1 executes step 1-5 of TC-PAVST-2.3 to allocate a PushAV transport with TriggerType = Continuous.",
@@ -121,12 +141,18 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase):
     @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport))
     async def test_TC_PAVST_2_7(self):
         endpoint = self.get_endpoint(default=1)
+        self.endpoint = endpoint
+        self.node_id = self.dut_node_id
         pvcluster = Clusters.PushAvStreamTransport
         pvattr = Clusters.PushAvStreamTransport.Attributes
         aAllocatedVideoStreams = []
         aAllocatedAudioStreams = []
 
         aConnectionID = ""
+
+        self.step("precondition")
+        tlsEndpointId = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server)
+        uploadStreamId = self.server.create_stream()
 
         self.step(1)
         # Commission DUT - already done
@@ -149,7 +175,8 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase):
             "AllocatedAudioStreams must not be empty",
         )
 
-        status = await self.allocate_one_pushav_transport(endpoint, triggerType=pvcluster.Enums.TransportTriggerTypeEnum.kContinuous)
+        status = await self.allocate_one_pushav_transport(endpoint, triggerType=pvcluster.Enums.TransportTriggerTypeEnum.kContinuous,
+                                                          tlsEndPoint=tlsEndpointId, url=f"https://localhost:1234/streams/{uploadStreamId}")
         asserts.assert_equal(
             status, Status.Success, "Push AV Transport should be allocated successfully"
         )
@@ -263,7 +290,8 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase):
         triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kCommand,
                           "maxPreRollLen": 4000, }
 
-        status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions)
+        status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions, tlsEndPoint=tlsEndpointId,
+                                                          url=f"https://localhost:1234/streams/{uploadStreamId}")
         asserts.assert_equal(
             status, Status.Success, "Push AV Transport should be allocated successfully"
         )

--- a/src/python_testing/TC_PAVST_2_7.py
+++ b/src/python_testing/TC_PAVST_2_7.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 
 class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase):
     def TC_PAVST_2_7(self) -> str:
-        return "[TC-PAVST-2.5] Attributes with Server as DUT"
+        return "[TC-PAVST-2.7] Manually Trigger PushAV Transport Flow with Server as DUT"
 
     def pics_TC_PAVST_2_7(self):
         return ["PAVST.S"]
@@ -206,9 +206,11 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase):
             "DUT responds with SUCCESS status code.")
 
         self.step(6)
+        timeControl = {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1}
         cmd = pvcluster.Commands.ManuallyTriggerTransport(
             connectionID=aConnectionID,
-            activationReason=pvcluster.Enums.TriggerActivationReasonEnum.kEmergency
+            activationReason=pvcluster.Enums.TriggerActivationReasonEnum.kEmergency,
+            timeControl=timeControl
         )
         status = await self.psvt_manually_trigger_transport(cmd, expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidTransportStatus)
         asserts.assert_true(
@@ -227,9 +229,11 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase):
             "DUT responds with SUCCESS status code.")
 
         self.step(8)
+        timeControl = {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1}
         cmd = pvcluster.Commands.ManuallyTriggerTransport(
             connectionID=aConnectionID,
-            activationReason=pvcluster.Enums.TriggerActivationReasonEnum.kEmergency
+            activationReason=pvcluster.Enums.TriggerActivationReasonEnum.kEmergency,
+            timeControl=timeControl
         )
         status = await self.psvt_manually_trigger_transport(cmd, expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidTriggerType)
         asserts.assert_true(

--- a/src/python_testing/TC_PAVST_2_8.py
+++ b/src/python_testing/TC_PAVST_2_8.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 class TC_PAVST_2_8(MatterBaseTest, PAVSTTestBase):
     def desc_TC_PAVST_2_8(self) -> str:
-        return "[TC-PAVST-2.8] Attributes with Server as DUT"
+        return "[TC-PAVST-2.8] Validate FindTransport command with Server as DUT"
 
     def pics_TC_PAVST_2_8(self):
         return ["PAVST.S"]

--- a/src/python_testing/TC_PAVST_2_8.py
+++ b/src/python_testing/TC_PAVST_2_8.py
@@ -38,13 +38,14 @@
 import logging
 
 from mobly import asserts
-from TC_PAVSTTestBase import PAVSTTestBase
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
+from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
 from matter.clusters.Types import Nullable
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
+                                           run_if_endpoint_matches)
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_8.py
+++ b/src/python_testing/TC_PAVST_2_8.py
@@ -39,24 +39,44 @@ import logging
 
 from mobly import asserts
 from TC_PAVSTTestBase import PAVSTTestBase
+from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
 
 import matter.clusters as Clusters
 from matter.clusters.Types import Nullable
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
 
 logger = logging.getLogger(__name__)
 
 
-class TC_PAVST_2_8(MatterBaseTest, PAVSTTestBase):
+class TC_PAVST_2_8(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
     def desc_TC_PAVST_2_8(self) -> str:
         return "[TC-PAVST-2.8] Validate FindTransport command with Server as DUT"
 
     def pics_TC_PAVST_2_8(self):
         return ["PAVST.S"]
 
+    @async_test_body
+    async def setup_class(self):
+        th_server_app = self.user_params.get("th_server_app_path", None)
+        if th_server_app:
+            self.server = PushAvServerProcess(server_path=th_server_app)
+        else:
+            self.server = PushAvServerProcess()
+        self.server.start(
+            expected_output="Running on https://0.0.0.0:1234",
+            timeout=30,
+        )
+        super().setup_class()
+
+    def teardown_class(self):
+        if self.server is not None:
+            self.server.terminate()
+        super().teardown_class()
+
     def steps_TC_PAVST_2_8(self) -> list[TestStep]:
         return [
+            TestStep("precondition", "Commissioning, already done", is_commissioning=True),
             TestStep(
                 1,
                 "TH1 executes step 1-5 of TC-PAVST-2.3 to allocate a PushAV transport.",
@@ -92,12 +112,18 @@ class TC_PAVST_2_8(MatterBaseTest, PAVSTTestBase):
     @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport))
     async def test_TC_PAVST_2_8(self):
         endpoint = self.get_endpoint(default=1)
+        self.endpoint = endpoint
+        self.node_id = self.dut_node_id
         pvcluster = Clusters.PushAvStreamTransport
         pvattr = Clusters.PushAvStreamTransport.Attributes
         aAllocatedVideoStreams = []
         aAllocatedAudioStreams = []
 
         aConnectionID = ""
+
+        self.step("precondition")
+        tlsEndpointId = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server)
+        uploadStreamId = self.server.create_stream()
 
         self.step(1)
         # Commission DUT - already done
@@ -120,7 +146,7 @@ class TC_PAVST_2_8(MatterBaseTest, PAVSTTestBase):
             "AllocatedAudioStreams must not be empty",
         )
 
-        status = await self.allocate_one_pushav_transport(endpoint)
+        status = await self.allocate_one_pushav_transport(endpoint, tlsEndPoint=tlsEndpointId, url=f"https://localhost:1234/streams/{uploadStreamId}")
         asserts.assert_equal(
             status, Status.Success, "Push AV Transport should be allocated successfully"
         )

--- a/src/python_testing/TC_PAVST_2_9.py
+++ b/src/python_testing/TC_PAVST_2_9.py
@@ -107,7 +107,7 @@ class TC_PAVST_2_9(MatterBaseTest, PAVSTTestBase):
             endpoint=endpoint, cluster=pvcluster, attribute=pvattr.SupportedFormats
         )
         aSupportedContainerFormats = list({fmt.containerFormat for fmt in aSupportedFormat})
-        logger.info(f"SupportedContainerFormats: {aSupportedFormats}")
+        logger.info(f"SupportedContainerFormats: {aSupportedContainerFormats}")
 
         self.step(4)
         aAllocatedVideoStreams = await self.allocate_one_video_stream()

--- a/src/python_testing/TC_PAVST_2_9.py
+++ b/src/python_testing/TC_PAVST_2_9.py
@@ -74,7 +74,6 @@ class TC_PAVST_2_9(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             self.server.terminate()
         super().teardown_class()
 
-
     def steps_TC_PAVST_2_9(self) -> list[TestStep]:
         return [
             TestStep("precondition", "Commissioning, already done", is_commissioning=True),

--- a/src/python_testing/TC_PAVST_2_9.py
+++ b/src/python_testing/TC_PAVST_2_9.py
@@ -40,23 +40,44 @@ import time
 
 from mobly import asserts
 from TC_PAVSTTestBase import PAVSTTestBase
+from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
 
 logger = logging.getLogger(__name__)
 
 
-class TC_PAVST_2_9(MatterBaseTest, PAVSTTestBase):
+class TC_PAVST_2_9(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
     def desc_TC_PAVST_2_9(self) -> str:
         return "[TC-PAVST-2.9] Validate Transport allocation with an ExpiryTime with Server as DUT"
 
     def pics_TC_PAVST_2_9(self):
         return ["PAVST.S"]
 
+    @async_test_body
+    async def setup_class(self):
+        th_server_app = self.user_params.get("th_server_app_path", None)
+        if th_server_app:
+            self.server = PushAvServerProcess(server_path=th_server_app)
+        else:
+            self.server = PushAvServerProcess()
+        self.server.start(
+            expected_output="Running on https://0.0.0.0:1234",
+            timeout=30,
+        )
+        super().setup_class()
+
+    def teardown_class(self):
+        if self.server is not None:
+            self.server.terminate()
+        super().teardown_class()
+
+
     def steps_TC_PAVST_2_9(self) -> list[TestStep]:
         return [
+            TestStep("precondition", "Commissioning, already done", is_commissioning=True),
             TestStep(1, "TH Reads CurrentConnections attribute from PushAV Stream Transport Cluster on DUT",
                      "Verify the number of PushAV Connections in the list is 0. If not 0, issue DeAllocatePushAVTransport with `ConnectionID to remove any connections."),
             TestStep(2, "TH Reads SupportedIngestMethods attribute from PushAV Stream Transport Cluster on DUT",
@@ -78,10 +99,16 @@ class TC_PAVST_2_9(MatterBaseTest, PAVSTTestBase):
     @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport))
     async def test_TC_PAVST_2_9(self):
         endpoint = self.get_endpoint(default=1)
+        self.endpoint = endpoint
+        self.node_id = self.dut_node_id
         pvcluster = Clusters.PushAvStreamTransport
         pvattr = Clusters.PushAvStreamTransport.Attributes
 
         # Commission DUT - already done
+
+        self.step("precondition")
+        tlsEndpointId = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server)
+        uploadStreamId = self.server.create_stream()
 
         self.step(1)
         transport_configs = await self.read_single_attribute_check_success(
@@ -126,7 +153,7 @@ class TC_PAVST_2_9(MatterBaseTest, PAVSTTestBase):
         )
 
         self.step(6)
-        status = await self.allocate_one_pushav_transport(endpoint)
+        status = await self.allocate_one_pushav_transport(endpoint, tlsEndPoint=tlsEndpointId, url=f"https://localhost:1234/streams/{uploadStreamId}", expiryTime=5)
         asserts.assert_equal(
             status, Status.Success, "Push AV Transport should be allocated successfully"
         )

--- a/src/python_testing/TC_PAVST_2_9.py
+++ b/src/python_testing/TC_PAVST_2_9.py
@@ -39,12 +39,13 @@ import logging
 import time
 
 from mobly import asserts
-from TC_PAVSTTestBase import PAVSTTestBase
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
+from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
+                                           run_if_endpoint_matches)
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_9.py
+++ b/src/python_testing/TC_PAVST_2_9.py
@@ -106,7 +106,7 @@ class TC_PAVST_2_9(MatterBaseTest, PAVSTTestBase):
         aSupportedFormats = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=pvcluster, attribute=pvattr.SupportedFormats
         )
-        aSupportedContainerFormats = list({fmt.containerFormat for fmt in aSupportedFormat})
+        aSupportedContainerFormats = list({fmt.containerFormat for fmt in aSupportedFormats})
         logger.info(f"SupportedContainerFormats: {aSupportedContainerFormats}")
 
         self.step(4)

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -127,10 +127,6 @@ not_automated:
       reason:
           Shared code for Push AV Cluster tests (TC_PAVST_*), not a standalone
           test.
-    - name: TC_PAVST_2_3.py
-      reason:
-          Depends on PushAV cluster. Will be enabled once local tests are fully
-          verified.
     - name: TC_PAVSTI_1_1.py
       reason:
           Depends on TLS Certification Management cluster. Will be enabled once

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -127,39 +127,7 @@ not_automated:
       reason:
           Shared code for Push AV Cluster tests (TC_PAVST_*), not a standalone
           test.
-    - name: TC_PAVST_2_1.py
-      reason:
-          Depends on PushAV cluster. Will be enabled once local tests are fully
-          verified.
-    - name: TC_PAVST_2_2.py
-      reason:
-          Depends on PushAV cluster. Will be enabled once local tests are fully
-          verified.
     - name: TC_PAVST_2_3.py
-      reason:
-          Depends on PushAV cluster. Will be enabled once local tests are fully
-          verified.
-    - name: TC_PAVST_2_4.py
-      reason:
-          Depends on PushAV cluster. Will be enabled once local tests are fully
-          verified.
-    - name: TC_PAVST_2_5.py
-      reason:
-          Depends on PushAV cluster. Will be enabled once local tests are fully
-          verified.
-    - name: TC_PAVST_2_6.py
-      reason:
-          Depends on PushAV cluster. Will be enabled once local tests are fully
-          verified.
-    - name: TC_PAVST_2_7.py
-      reason:
-          Depends on PushAV cluster. Will be enabled once local tests are fully
-          verified.
-    - name: TC_PAVST_2_8.py
-      reason:
-          Depends on PushAV cluster. Will be enabled once local tests are fully
-          verified.
-    - name: TC_PAVST_2_9.py
       reason:
           Depends on PushAV cluster. Will be enabled once local tests are fully
           verified.


### PR DESCRIPTION
#### Summary

This PR is to enable PAVST_2_1 -> 2_9 TCs for CI build. Also, fixed issues those are causing TC failures in the latest code.
Added missing changes for zone validation & TLS command validation

#### Testing
```
# Build and run camera application
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debu/chip-camera-app

# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run Push AV Cluster TCs 

example:
python3 src/python_testing/TC_PAVST_2_4.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint
```
#### Fixes for 
Fixes #40664 
Fixes #40665 
Fixes #40666 
Fixes #40806 
Fixes #40808 
Fixes #40809 

#### Depends on
PR:  https://github.com/project-chip/connectedhomeip/pull/40815 - PushAV server logic shutdown crash in CI