### PR TITLE
Add NFC-based commissioning test (in python)

### DIFF
--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -455,8 +455,22 @@ PyChipError pychip_DeviceController_ConnectIP(chip::Controller::DeviceCommission
 }
 
 PyChipError pychip_DeviceController_ConnectWithCode(chip::Controller::DeviceCommissioner * devCtrl, const char * onboardingPayload,
-                                                    chip::NodeId nodeid, uint8_t discoveryType)
+                                                    chip::NodeId nodeid, uint8_t discoveryType, bool useNFC)
 {
+#if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
+    if (useNFC) {
+        // Trick to force NTL usage: other discovery bits (RendezvousInformationFlag) are cleared.
+        SetupPayload payload;
+        PyReturnErrorOnFailure(ToPyChipError(QRCodeSetupPayloadParser(onboardingPayload).populatePayload(payload)));
+        VerifyOrReturnError(payload.isValidQRCodePayload(), ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+        payload.rendezvousInformation.ClearAll();
+        payload.rendezvousInformation.Set(kNFC);
+        std::string maskedOnboardingPayload;
+        CHIP_ERROR err = QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(maskedOnboardingPayload);
+        VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
+        onboardingPayload = maskedOnboardingPayload.c_str();
+    }
+#endif
     return ToPyChipError(devCtrl->PairDevice(nodeid, onboardingPayload, sCommissioningParameters,
                                              static_cast<chip::Controller::DiscoveryType>(discoveryType)));
 }

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -2979,10 +2979,11 @@ class ChipDeviceController(ChipDeviceControllerBase):
             return None
         return rcac_bytes
 
-    async def CommissionWithCode(self, setupPayload: str, nodeid: int, discoveryType: DiscoveryType = DiscoveryType.DISCOVERY_ALL) -> int:
+    async def CommissionWithCode(self, setupPayload: str, nodeid: int, discoveryType: DiscoveryType = DiscoveryType.DISCOVERY_ALL, useNFC: bool = False) -> int:
         '''
         Commission with the given nodeid from the setupPayload.
         setupPayload may be a QR or manual code.
+        If useNFC is True, the commissioning should use NTL as temporary channel
 
         Args:
             setupPayload (str): The setup payload (QR or manual code).
@@ -3001,7 +3002,7 @@ class ChipDeviceController(ChipDeviceControllerBase):
             self._enablePairingCompleteCallback(True)
             await self._ChipStack.CallAsync(
                 lambda: self._dmLib.pychip_DeviceController_ConnectWithCode(
-                    self.devCtrl, setupPayload.encode("utf-8"), nodeid, discoveryType.value)
+                    self.devCtrl, setupPayload.encode("utf-8"), nodeid, discoveryType.value, useNFC)
             )
 
             return await asyncio.futures.wrap_future(ctx.future)

--- a/src/python_testing/TC_DD_3_23.py
+++ b/src/python_testing/TC_DD_3_23.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2025 Project CHIP Authors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import chip.clusters as Clusters
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+
+class TC_DD_3_23(MatterBaseTest):
+    def steps_TC_DD_3_23(self):
+        return [
+            TestStep(0, "Display Hello World", "Hello World is displayed")
+        ]
+
+    def pics_TC_DD_3_23(self):
+        return ["HELLO_WORLD.S"]
+
+    @async_test_body
+    async def test_TC_DD_3_23(self):
+        self.step(0)
+        print("Hello World")
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_DD_3_23.py
+++ b/src/python_testing/TC_DD_3_23.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import chip.clusters as Clusters
+import chip  # Pour chip.NodeId
+from chip import ChipDeviceCtrl  # Pour DiscoveryType
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 class TC_DD_3_23(MatterBaseTest):
@@ -28,7 +30,26 @@ class TC_DD_3_23(MatterBaseTest):
     @async_test_body
     async def test_TC_DD_3_23(self):
         self.step(0)
-        print("Hello World")
+        print("Perform commissioning")
+        # Work on-going!
+        # For the moment it is configured for BLE commissioning
+        setup_payload: str = "MT:4CT9142C00KA0648G00"
+        node_id: chip.NodeId = 1
+        useNFC: bool = False
+
+        print(f"Setup payload: {setup_payload}")
+        print(f"NodeId: {node_id}")
+        print(f"useNFC: {useNFC}")
+
+        try:
+            await self.default_controller.CommissionWithCode(
+                setupPayload=setup_payload,
+                nodeid=node_id,
+                discoveryType=ChipDeviceCtrl.DiscoveryType.DISCOVERY_ALL,
+                useNFC=useNFC
+            )
+        except Exception as e:
+            print(f"Failure! {e}")
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_DD_3_23.py
+++ b/src/python_testing/TC_DD_3_23.py
@@ -35,21 +35,20 @@ class TC_DD_3_23(MatterBaseTest):
         # For the moment it is configured for BLE commissioning
         setup_payload: str = "MT:4CT9142C00KA0648G00"
         node_id: chip.NodeId = 1
-        useNFC: bool = False
+        #useNFC: bool = False
 
         print(f"Setup payload: {setup_payload}")
         print(f"NodeId: {node_id}")
-        print(f"useNFC: {useNFC}")
+        #print(f"useNFC: {useNFC}")
 
         try:
+        # Argument to add later:                useNFC=useNFC
             await self.default_controller.CommissionWithCode(
                 setupPayload=setup_payload,
                 nodeid=node_id,
-                discoveryType=ChipDeviceCtrl.DiscoveryType.DISCOVERY_ALL,
-                useNFC=useNFC
-            )
+                discoveryType=ChipDeviceCtrl.DiscoveryType.DISCOVERY_ALL)
         except Exception as e:
-            print(f"Failure! {e}")
+            self.fail(f"Commissioning failed with exception: {e}")
 
 if __name__ == "__main__":
     default_matter_test_main()


### PR DESCRIPTION
Work on going on NFC commissioning test in python.

Added a new "useNFC" parameter to ConnectWithCode binding function. Added a new "useNFC" parameter to CommissionWithCode python function.
