### PR TITLE
Fix: Bridge Action cluster NodeLabel attribute shows Success

### DIFF
--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -585,7 +585,7 @@ Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Devic
         return Protocols::InteractionModel::Status::ConstraintError;
     }
 
-    chip::CharSpan nameSpan = chip::CharSpan::fromZclString(buffer);
+    CharSpan nameSpan = CharSpan::fromZclString(buffer);
     std::string name(nameSpan.data(), nameSpan.size());    
     dev->SetName(name.c_str());
 

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -26,18 +26,15 @@
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/EventLogging.h>
-#include <app/persistence/String.h>
 #include <app/reporting/reporting.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
-#include <app/util/ember-strings.h>
 #include <app/util/endpoint-config-api.h>
 #include <app/util/util.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>
-#include <lib/support/Span.h>
 #include <lib/support/ZclString.h>
 #include <platform/CommissionableDataProvider.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
@@ -64,7 +61,6 @@ using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 using namespace chip::app::Clusters;
-using namespace chip::app::Storage;
 
 // These variables need to be in global scope for bridged-actions-stub.cpp to access them
 std::vector<Room *> gRooms;
@@ -578,14 +574,13 @@ Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Devic
         return Protocols::InteractionModel::Status::UnsupportedWrite;
     }
 
-    const uint8_t len = emberAfStringLength(buffer);
+    CharSpan nameSpan = CharSpan::fromZclString(buffer);
 
-    if (len > kNodeLabelSize)
+    if (nameSpan.size() > kNodeLabelSize)
     {
         return Protocols::InteractionModel::Status::ConstraintError;
     }
 
-    CharSpan nameSpan = CharSpan::fromZclString(buffer);
     std::string name(nameSpan.data(), nameSpan.size());
     dev->SetName(name.c_str());
 

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -136,7 +136,7 @@ DECLARE_DYNAMIC_ATTRIBUTE(Descriptor::Attributes::DeviceTypeList::Id, ARRAY, kDe
 
 // Declare Bridged Device Basic Information cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(bridgedDeviceBasicAttrs)
-DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::NodeLabel::Id, CHAR_STRING, kNodeLabelSize,
+DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::NodeLabel::Id, CHAR_STRING, kNodeLabelSize + 1,
                           ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE)),         /* NodeLabel */
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::Reachable::Id, BOOLEAN, 1, 0), /* Reachable */
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::UniqueID::Id, CHAR_STRING, kUniqueIdSize, 0),
@@ -582,7 +582,7 @@ Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Devic
         return Protocols::InteractionModel::Status::InvalidValue;
     }
 
-    dev->SetName(std::string{reinterpret_cast<const char *>(buffer + 1),  len}.c_str());
+    dev->SetName(std::string{reinterpret_cast<const char *>(buffer + 1), len}.c_str());
 
     HandleDeviceStatusChanged(dev, Device::kChanged_Name);
 

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -573,13 +573,13 @@ Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Devic
 
     if (attributeId != chip::app::Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id)
     {
-        return Protocols::InteractionModel::Status::Failure;
+        return Protocols::InteractionModel::Status::UnsupportedWrite;
     }
 
     const uint8_t len = emberAfStringLength(buffer);
     if (len > kNodeLabelSize)
     {
-        return Protocols::InteractionModel::Status::InvalidValue;
+        return Protocols::InteractionModel::Status::ConstraintError;
     }
 
     dev->SetName(std::string{ reinterpret_cast<const char *>(buffer + 1), len }.c_str());

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -571,24 +571,22 @@ Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Devic
 {
     ChipLogProgress(DeviceLayer, "HandleWriteBridgedDeviceBasicAttribute: attrId=%d", attributeId);
 
-    if ((attributeId == chip::app::Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id) && (dev->IsReachable()))
-    {
-        const uint8_t len = emberAfStringLength(buffer);
-        if (len > static_cast<uint8_t>(kNodeLabelSize))
-        {
-            return Protocols::InteractionModel::Status::InvalidValue;
-        }
-
-        std::string label(reinterpret_cast<const char *>(buffer + 1), reinterpret_cast<const char *>(buffer + 1) + len);
-
-        dev->SetName(label.c_str());
-
-        HandleDeviceStatusChanged(dev, Device::kChanged_Name);
-    }
-    else
+    if (attributeId != chip::app::Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id)
     {
         return Protocols::InteractionModel::Status::Failure;
     }
+
+    const uint8_t len = emberAfStringLength(buffer);
+    if (len > kNodeLabelSize)
+    {
+        return Protocols::InteractionModel::Status::InvalidValue;
+    }
+
+    std::string label(reinterpret_cast<const char *>(buffer + 1), len);
+
+    dev->SetName(label.c_str());
+
+    HandleDeviceStatusChanged(dev, Device::kChanged_Name);
 
     return Protocols::InteractionModel::Status::Success;
 }

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -137,7 +137,7 @@ DECLARE_DYNAMIC_ATTRIBUTE(Descriptor::Attributes::DeviceTypeList::Id, ARRAY, kDe
 // Declare Bridged Device Basic Information cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(bridgedDeviceBasicAttrs)
 DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::NodeLabel::Id, CHAR_STRING, kNodeLabelSize,
-                          ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE)), /* NodeLabel */
+                          ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE)),         /* NodeLabel */
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::Reachable::Id, BOOLEAN, 1, 0), /* Reachable */
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::UniqueID::Id, CHAR_STRING, kUniqueIdSize, 0),
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::ConfigurationVersion::Id, INT32U, 4,

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -136,8 +136,8 @@ DECLARE_DYNAMIC_ATTRIBUTE(Descriptor::Attributes::DeviceTypeList::Id, ARRAY, kDe
 
 // Declare Bridged Device Basic Information cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(bridgedDeviceBasicAttrs)
-    DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::NodeLabel::Id, CHAR_STRING, kNodeLabelSize,
-                              ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE)), /* NodeLabel */
+DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::NodeLabel::Id, CHAR_STRING, kNodeLabelSize,
+                          ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE)), /* NodeLabel */
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::Reachable::Id, BOOLEAN, 1, 0), /* Reachable */
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::UniqueID::Id, CHAR_STRING, kUniqueIdSize, 0),
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::ConfigurationVersion::Id, INT32U, 4,

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -582,9 +582,7 @@ Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Devic
         return Protocols::InteractionModel::Status::InvalidValue;
     }
 
-    std::string label(reinterpret_cast<const char *>(buffer + 1), len);
-
-    dev->SetName(label.c_str());
+    dev->SetName(std::string{reinterpret_cast<const char *>(buffer + 1),  len}.c_str());
 
     HandleDeviceStatusChanged(dev, Device::kChanged_Name);
 
@@ -740,7 +738,7 @@ Protocols::InteractionModel::Status emberAfExternalAttributeWriteCallback(Endpoi
         }
         else if ((dev->IsReachable()) && (clusterId == BridgedDeviceBasicInformation::Id))
         {
-            ret = HandleWriteBridgedDeviceBasicAttribute(static_cast<Device *>(dev), attributeMetadata->attributeId, buffer);
+            ret = HandleWriteBridgedDeviceBasicAttribute(dev, attributeMetadata->attributeId, buffer);
         }
     }
 

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -585,11 +585,9 @@ Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Devic
         return Protocols::InteractionModel::Status::ConstraintError;
     }
 
-    chip::Span<char> full(reinterpret_cast<char *>(buffer), static_cast<size_t>(len) + 1);
-    ShortPascalString pascal(full);
-    auto content = pascal.Content();
-
-    dev->SetName(content.data());
+    chip::CharSpan nameSpan = chip::CharSpan::fromZclString(buffer);
+    std::string name(nameSpan.data(), nameSpan.size());    
+    dev->SetName(name.c_str());
 
     HandleDeviceStatusChanged(dev, Device::kChanged_Name);
 

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -569,10 +569,9 @@ Protocols::InteractionModel::Status HandleWriteOnOffAttribute(DeviceOnOff * dev,
     return Protocols::InteractionModel::Status::Success;
 }
 
-Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Device * dev, AttributeId attributeId,
-                                                                           uint8_t * buffer)
+Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Device * dev, AttributeId attributeId, uint8_t * buffer)
 {
-    ChipLogProgress(DeviceLayer, "HandleWriteBridgedDeviceBasicAttribute: attrId=%d", attributeId);
+    ChipLogProgress(DeviceLayer, "HandleWriteBridgedDeviceBasicAttribute: attrId=" ChipLogFormatMEI, ChipLogValueMEI(attributeId));
 
     if (attributeId != BridgedDeviceBasicInformation::Attributes::NodeLabel::Id)
     {

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -136,7 +136,7 @@ DECLARE_DYNAMIC_ATTRIBUTE(Descriptor::Attributes::DeviceTypeList::Id, ARRAY, kDe
 
 // Declare Bridged Device Basic Information cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(bridgedDeviceBasicAttrs)
-DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::NodeLabel::Id, CHAR_STRING, kNodeLabelSize + 1,
+DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::NodeLabel::Id, CHAR_STRING, kNodeLabelSize,
                           ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE)),         /* NodeLabel */
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::Reachable::Id, BOOLEAN, 1, 0), /* Reachable */
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::UniqueID::Id, CHAR_STRING, kUniqueIdSize, 0),

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -574,7 +574,7 @@ Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Devic
 {
     ChipLogProgress(DeviceLayer, "HandleWriteBridgedDeviceBasicAttribute: attrId=%d", attributeId);
 
-    if (attributeId != chip::app::Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id)
+    if (attributeId != BridgedDeviceBasicInformation::Attributes::NodeLabel::Id)
     {
         return Protocols::InteractionModel::Status::UnsupportedWrite;
     }

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -569,7 +569,7 @@ Protocols::InteractionModel::Status HandleWriteOnOffAttribute(DeviceOnOff * dev,
     return Protocols::InteractionModel::Status::Success;
 }
 
-Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Device * dev, chip::AttributeId attributeId,
+Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Device * dev, AttributeId attributeId,
                                                                            uint8_t * buffer)
 {
     ChipLogProgress(DeviceLayer, "HandleWriteBridgedDeviceBasicAttribute: attrId=%d", attributeId);

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -582,7 +582,7 @@ Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Devic
         return Protocols::InteractionModel::Status::InvalidValue;
     }
 
-    dev->SetName(std::string{reinterpret_cast<const char *>(buffer + 1), len}.c_str());
+    dev->SetName(std::string{ reinterpret_cast<const char *>(buffer + 1), len }.c_str());
 
     HandleDeviceStatusChanged(dev, Device::kChanged_Name);
 

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -586,7 +586,7 @@ Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Devic
     }
 
     CharSpan nameSpan = CharSpan::fromZclString(buffer);
-    std::string name(nameSpan.data(), nameSpan.size());    
+    std::string name(nameSpan.data(), nameSpan.size());
     dev->SetName(name.c_str());
 
     HandleDeviceStatusChanged(dev, Device::kChanged_Name);

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -136,8 +136,9 @@ DECLARE_DYNAMIC_ATTRIBUTE(Descriptor::Attributes::DeviceTypeList::Id, ARRAY, kDe
 
 // Declare Bridged Device Basic Information cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(bridgedDeviceBasicAttrs)
-DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::NodeLabel::Id, CHAR_STRING, kNodeLabelSize, ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE)), /* NodeLabel */
-    DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::Reachable::Id, BOOLEAN, 1, 0),              /* Reachable */
+    DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::NodeLabel::Id, CHAR_STRING, kNodeLabelSize,
+                              ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE)), /* NodeLabel */
+    DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::Reachable::Id, BOOLEAN, 1, 0), /* Reachable */
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::UniqueID::Id, CHAR_STRING, kUniqueIdSize, 0),
     DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::ConfigurationVersion::Id, INT32U, 4,
                               0), /* Configuration Version */
@@ -565,9 +566,9 @@ Protocols::InteractionModel::Status HandleWriteOnOffAttribute(DeviceOnOff * dev,
     return Protocols::InteractionModel::Status::Success;
 }
 
-Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer)
+Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Device * dev, chip::AttributeId attributeId,
+                                                                           uint8_t * buffer)
 {
-
     ChipLogProgress(DeviceLayer, "HandleWriteBridgedDeviceBasicAttribute: attrId=%d", attributeId);
 
     if ((attributeId == chip::app::Clusters::BridgedDeviceBasicInformation::Attributes::NodeLabel::Id) && (dev->IsReachable()))

--- a/src/app/tests/suites/certification/Test_TC_BRBINFO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BRBINFO_2_1.yaml
@@ -160,7 +160,6 @@ tests:
               type: char_string
               maxLength: 32
 
-    #Issue https://github.com/project-chip/connectedhomeip/issues/23509
     - label: "Step 18: TH writes NodeLabel from the DUT."
       PICS: BRBINFO.S.A0005 && PICS_USER_PROMPT
       verification: |

--- a/src/app/tests/suites/certification/Test_TC_BRBINFO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BRBINFO_2_1.yaml
@@ -161,53 +161,21 @@ tests:
               maxLength: 32
 
     - label: "Step 18: TH writes NodeLabel from the DUT."
-      PICS: BRBINFO.S.A0005 && PICS_USER_PROMPT
-      verification: |
-          ./chip-tool bridgeddevicebasicinformation write node-label '"newnode"' 1 3
-
-          Via the TH (chip-tool), verify the SUCCESS response for NodeLabel attribute write function.
-
-          Current sample apps do not have this implementation. However, if the vendor has implemented it, the below response will be displayed.
-
-          NOTE the quotes: single-quote/double-quote/string/double-quote/single-quote
-
-
-          [1660839701.840432][2444:2449] CHIP:DMG:                         }
-          [1660839701.840505][2444:2449] CHIP:DMG:
-          [1660839701.840578][2444:2449] CHIP:DMG:                         StatusIB =
-          [1660839701.840661][2444:2449] CHIP:DMG:                         {
-          [1660839701.840742][2444:2449] CHIP:DMG:                                 status = 0x00 (SUCCESS),
-          [1660839701.840827][2444:2449] CHIP:DMG:                         },
-          [1660839701.840905][2444:2449] CHIP:DMG:
-          [1660839701.840973][2444:2449] CHIP:DMG:                 },
-      cluster: "LogCommands"
-      command: "UserPrompt"
+      PICS: BRBINFO.S.A0005
+      command: "writeAttribute"
+      attribute: "NodeLabel"
       arguments:
-          values:
-              - name: "message"
-                value: "Please enter 'y' after success"
-              - name: "expectedValue"
-                value: "y"
+          value: "newnode"
 
     - label: "Step 19: TH reads NodeLabel from the DUT"
-      PICS: BRBINFO.S.A0005 && PICS_USER_PROMPT
-      verification: |
-          ./chip-tool bridgeddevicebasicinformation read node-label 1 3
-
-          Via the TH (chip-tool), verify that the NodeLabel attribute value is changed to newnode.
-
-          Current sample apps do not have this implementation. However, if the vendor has implemented it, the below response will be displayed.
-
-          [1657696463.081741][15476:15481] CHIP:TOO: Endpoint: 3 Cluster: 0x0000_0039 Attribute 0x0000_0005 DataVersion: 2577979325
-          [1657696463.081791][15476:15481] CHIP:TOO:   NodeLabel: newnode
-      cluster: "LogCommands"
-      command: "UserPrompt"
-      arguments:
-          values:
-              - name: "message"
-                value: "Please enter 'y' after success"
-              - name: "expectedValue"
-                value: "y"
+      PICS: BRBINFO.S.A0005
+      command: "readAttribute"
+      attribute: "NodeLabel"
+      response:
+          value: "newnode"
+          constraints:
+              type: char_string
+              maxLength: 32
 
     - label:
           "Step 20: TH reads attribute ID 6 from the DUT (matches in ID to


### PR DESCRIPTION
This PR fixes [#23509](https://github.com/project-chip/connectedhomeip/issues/23509)

### Updates

Updates `examples/bridge-app/linux/main.cpp`. Adds `HandleWriteBridgedDeviceBasicAttribute` function in order to handle `NodeLabel` writing. Also makes the attribute `NodeLabel` writable.

### Testing

- Build chip tool (terminal 1):
  ``` bash
  ./scripts/build/build_examples.py --target darwin-arm64-chip-tool build
  ```

- Build bridge app (terminal 1):
  ``` bash
  ./scripts/build/build_examples.py --target darwin-arm64-bridge build
  ```

- Remove commissioning data (terminal 1):

  ``` bash
  rm /tmp/chip_*
  ```

- Run bridge app (terminal 1):

  ``` bash
  ./out/darwin-arm64-bridge/chip-bridge-app
  ```

- Commission (terminal 2):

  ``` bash
  ./out/darwin-arm64-chip-tool/chip-tool pairing onnetwork 1 20202021 
  ```

- Read (terminal 2):

  ``` bash
  ./out/darwin-arm64-chip-tool/chip-tool bridgeddevicebasicinformation read node-label 1 3
  ```

  <img width="564" height="405" alt="image" src="https://github.com/user-attachments/assets/0105b48c-be60-4e02-96bf-5f88ef95f77d" />

- Write (terminal 2):

  ``` bash
  ./out/darwin-arm64-chip-tool/chip-tool bridgeddevicebasicinformation write node-label '"newnode"' 1 3
  ```

  <img width="564" height="401" alt="image" src="https://github.com/user-attachments/assets/b8faf8d4-e744-4eaa-b9a1-c031ca10f5df" />

- Read (terminal 2):

  ``` bash
  ./out/darwin-arm64-chip-tool/chip-tool bridgeddevicebasicinformation read node-label 1 3
  ```

  <img width="564" height="401" alt="image" src="https://github.com/user-attachments/assets/5a464f53-6e2a-4070-b101-5c749b7fb6b4" />
