### PR TITLE
[Camera] Fix H.264 I-frame detection is failing

### DIFF
--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -418,8 +418,9 @@ GstElement * CameraDevice::CreateSnapshotPipeline(const std::string & device, in
     return nullptr; // Here to avoid compiler warnings, should never reach this point.
 }
 
-// Helper function to create a GStreamer pipeline that ingests MJPEG frames coming
-// from the camera, converted to H.264, and sent to media controller via app sink.
+// Helper function to create a GStreamer pipeline that captures raw video frames from
+// the camera, converts them to I420 format, encodes to H.264, and sends the encoded
+// stream to the media controller via app sink.
 GstElement * CameraDevice::CreateVideoPipeline(const std::string & device, int width, int height, int framerate,
                                                CameraError & error)
 {
@@ -472,8 +473,8 @@ GstElement * CameraDevice::CreateVideoPipeline(const std::string & device, int w
     g_object_set(capsfilter2, "caps", caps2, nullptr);
     gst_caps_unref(caps2);
 
-    // Configure encoder for low‑latency
-    g_object_set(x264enc, "tune", 0, "speed-preset", 1, "key-int-max", framerate * 1, nullptr);
+    // Configure encoder for low‑latency and force IDR at start
+    g_object_set(x264enc, "tune", 0, "speed-preset", 1, "key-int-max", framerate * 1, "insert-vui", TRUE, nullptr);
 
     // Configure appsink for receiving H.264 buffers data
     g_object_set(appsink, "emit-signals", TRUE, nullptr);

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -116,8 +116,6 @@ bool PushAVClipRecorder::IsH264IFrame(const uint8_t * data, unsigned int length)
 {
     unsigned int idx = 0;
     int frameType    = 0;
-    int foundSps     = 0;
-    int foundPps     = 0;
     int foundIdr     = 0;
     bool ret         = false;
 
@@ -135,15 +133,7 @@ bool PushAVClipRecorder::IsH264IFrame(const uint8_t * data, unsigned int length)
             else if ((data[idx + 2] == 0x00) && (data[idx + 3] == 0x01))
                 frameType = data[idx + 4] & 0x1f;
 
-            if (frameType == 7)
-            {
-                foundSps = 1;
-            }
-            else if (frameType == 8)
-            {
-                foundPps = 1;
-            }
-            else if (frameType == 5)
+            if (frameType == 5)
             {
                 foundIdr = 1;
                 break;
@@ -159,9 +149,8 @@ bool PushAVClipRecorder::IsH264IFrame(const uint8_t * data, unsigned int length)
         }
     } while (idx < (length - 4));
 
-    // If we found an IDR frame, it's an I-frame regardless of SPS/PPS presence.
-    // SPS/PPS (Sequence Parameter Set/Picture Parameter Set) may have been sent in previous packets,
-    // or may be provided out-of-band (e.g., sent separately during stream initialization or as part of codec configuration).
+    // If we found an IDR frame, it's an I-frame regardless of SPS/PPS presence
+    // SPS/PPS may have been sent in previous packets or out-of-band
     if (foundIdr == 1)
     {
         ret = true;

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -159,7 +159,9 @@ bool PushAVClipRecorder::IsH264IFrame(const uint8_t * data, unsigned int length)
         }
     } while (idx < (length - 4));
 
-    if (foundSps == 1 && foundPps == 1 && foundIdr == 1)
+    // If we found an IDR frame, it's an I-frame regardless of SPS/PPS presence
+    // SPS/PPS may have been sent in previous packets or out-of-band
+    if (foundIdr == 1)
     {
         ret = true;
     }
@@ -175,6 +177,7 @@ AVPacket * PushAVClipRecorder::CreatePacket(const uint8_t * data, int size, bool
         ChipLogError(Camera, "ERROR: AVPacket allocation failed!");
         return nullptr;
     }
+
     packet->data = static_cast<uint8_t *>(av_malloc(static_cast<size_t>(size)));
     if (!packet->data)
     {
@@ -182,8 +185,10 @@ AVPacket * PushAVClipRecorder::CreatePacket(const uint8_t * data, int size, bool
         av_packet_free(&packet);
         return nullptr;
     }
+
     memcpy(packet->data, data, static_cast<size_t>(size));
     packet->size = size;
+
     if (isVideo)
     {
         if (IsH264IFrame(data, static_cast<unsigned int>(size)))
@@ -192,12 +197,14 @@ AVPacket * PushAVClipRecorder::CreatePacket(const uint8_t * data, int size, bool
             packet->flags        = AV_PKT_FLAG_KEY;
             ChipLogProgress(Camera, "Found I-frame at PTS: %ld", mVideoInfo.mVideoPts);
         }
+
         if (mFoundFirstIFramePts < 0)
         {
             ChipLogError(Camera, "ERROR: First frame is not an I-frame. Dropping packet.");
             av_packet_free(&packet);
             return nullptr;
         }
+
         packet->pts          = mVideoInfo.mVideoPts;
         packet->dts          = mVideoInfo.mVideoDts;
         packet->stream_index = mVideoInfo.mVideoStreamIndex;
@@ -220,6 +227,7 @@ AVPacket * PushAVClipRecorder::CreatePacket(const uint8_t * data, int size, bool
         mAudioInfo.mAudioDts += mAudioInfo.mAudioFrameDuration;
         mAudioInfo.mAudioPts += mAudioInfo.mAudioFrameDuration;
     }
+
     return (mFoundFirstIFramePts < 0) ? nullptr : packet;
 }
 

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -159,8 +159,9 @@ bool PushAVClipRecorder::IsH264IFrame(const uint8_t * data, unsigned int length)
         }
     } while (idx < (length - 4));
 
-    // If we found an IDR frame, it's an I-frame regardless of SPS/PPS presence
-    // SPS/PPS may have been sent in previous packets or out-of-band
+    // If we found an IDR frame, it's an I-frame regardless of SPS/PPS presence.
+    // SPS/PPS (Sequence Parameter Set/Picture Parameter Set) may have been sent in previous packets,
+    // or may be provided out-of-band (e.g., sent separately during stream initialization or as part of codec configuration).
     if (foundIdr == 1)
     {
         ret = true;

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -132,7 +132,7 @@ void PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStruct & t
 
     mTransportTriggerType   = transportOptions.triggerOptions.triggerType;
     clipInfo.mClipId        = 0;
-    clipInfo.mOutputPath    = "/tmp";
+    clipInfo.mOutputPath    = "/tmp/";
     clipInfo.mInputTimeBase = { 1, 1000000 };
 
     uint8_t audioCodec = static_cast<uint8_t>(mAudioStreamParams.audioCodec);

--- a/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
+++ b/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
@@ -75,7 +75,7 @@ void PushAVUploader::Stop()
 
 void PushAVUploader::AddUploadData(std::string & filename, std::string & url)
 {
-    ChipLogError(Camera, "Added file name %s to queue", filename.c_str());
+    ChipLogProgress(Camera, "Added file name %s to queue", filename.c_str());
     std::lock_guard<std::mutex> lock(mQueueMutex);
     auto data = make_pair(filename, url);
     mAvData.push(data);


### PR DESCRIPTION
#### Summary

Looking at the log output, I can see that the H.264 I-frame detection is failing because it's not finding the required SPS (Sequence Parameter Set), PPS (Picture Parameter Set), and IDR (Instantaneous Decoder Refresh) NAL units in the first frame. The current implementation is looking for NALU types 7 (SPS), 8 (PPS), and 5 (IDR) all within a single frame, but typically these appear in separate packets or the IDR frame doesn't contain SPS/PPS.

Current I-frame detection is too strict. It requires SPS, PPS, and IDR NAL units all to be present in a single packet, but in many H.264 streams:

SPS/PPS are sent separately from IDR frames
Only IDR frames (NALU type 5) are needed to identify I-frames
NALU types 1 (non-IDR slice) and 9 (access unit delimiter) are normal and don't indicate I-frames


#### Testing

```
Run commands to allocate Push AV streams & start clip record
pairing code 1 34970112332

//audio stream allocation
cameraavstreammanagement audio-stream-allocate 3 0 2 48000 32000 24 1 1

//video stream allocation
cameraavstreammanagement video-stream-allocate 3 0 30 30 '{ "width":640, "height":480}' '{ "width":640, "height":480}' 10000 10000 4000 1 1 --WatermarkEnabled 1 --OSDEnabled 1

//push av transport allocation
pushavstreamtransport allocate-push-transport '{"streamUsage":0, "videoStreamID":1, "audioStreamID":2, "endpointID":1, "url":"https://localhost:1234/streams/1", "triggerOptions":{"triggerType":2}, "ingestMethod":0, "containerOptions":{"containerType":0, "CMAFContainerOptions": {"CMAFInterface": 0, "chunkDuration": 4, "segmentDuration": 500, "sessionGroup": 3, "trackName": "main"}}, "expiryTime": 50}' 1 1

// Set transport status to active
pushavstreamtransport set-transport-status 1 0 1 1
```