### PR TITLE
Add basic support for concatenated QR codes to MTRSetupPayload.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -260,7 +260,7 @@ MTR_DIRECT_MEMBERS
 
     _payload = payloads[0];
     if (payloads.size() > 1) {
-        _concatenatedQRCode = qrCode;
+        _concatenatedQRCode = [qrCode copy];
     }
     return CHIP_NO_ERROR;
 }

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -213,7 +213,7 @@ MTR_DIRECT_MEMBERS
 
     // When we are initialized from a concatenated QR code, we store the
     // original string and prevent mutation, instead of re-serializing from
-    // _payload (which in that sitation no longer represents all the information
+    // _payload (which in that situation no longer represents all the information
     // in the original string).
     NSString * _Nullable _concatenatedQRCode;
 }
@@ -612,8 +612,8 @@ MTR_DIRECT_MEMBERS
     MTRSetupPayload * other = object;
 
     bool hasConcatenatedQRCode = (_concatenatedQRCode != nil);
-    bool otherHasConcatenatedCRCode = (other->_concatenatedQRCode != nil);
-    if (hasConcatenatedQRCode != otherHasConcatenatedCRCode) {
+    bool otherHasConcatenatedQRCode = (other->_concatenatedQRCode != nil);
+    if (hasConcatenatedQRCode != otherHasConcatenatedQRCode) {
         return NO;
     }
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -17,6 +17,7 @@
 
 #import "MTRSetupPayload_Internal.h"
 
+#import "MTRDefines_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTRFramework.h"
 #import "MTRLogging_Internal.h"
@@ -198,8 +199,9 @@ static NSString * MTRDiscoveryCapabilitiesAsString(MTRDiscoveryCapabilities valu
 
 MTR_DIRECT_MEMBERS
 @implementation MTRSetupPayload {
-    // Apart from the additional logic to handle discriminators detailed below,
-    // this class is simply a wrapper around this underlying SetupPayload.
+    // Apart from the additional logic to handle discriminators and concatenated
+    // QR codes detailed below, this class is simply a wrapper around this
+    // underlying SetupPayload.
     chip::SetupPayload _payload;
 
     // SetupPayload deals with the discriminator value and its shortness as a composite
@@ -208,6 +210,12 @@ MTR_DIRECT_MEMBERS
     // what our API does, so we need to continue to support it. To make this work, we
     // keep track of the potentially-long value that was set by the client.
     NSNumber * _Nullable _shadowDiscriminator;
+
+    // When we are initialized from a concatenated QR code, we store the
+    // original string and prevent mutation, instead of re-serializing from
+    // _payload (which in that sitation no longer represents all the information
+    // in the original string).
+    NSString * _Nullable _concatenatedQRCode;
 }
 
 + (void)initialize
@@ -221,23 +229,47 @@ MTR_DIRECT_MEMBERS
     return ([payload hasPrefix:@"MT:"]) ? [self initWithQRCode:payload] : [self initWithManualPairingCode:payload];
 }
 
-- (CHIP_ERROR)initializeFromQRCode:(NSString *)qrCode
+- (CHIP_ERROR)initializeFromQRCode:(NSString *)qrCode validate:(BOOL)validate
 {
+    using namespace chip;
+
     std::string string([(qrCode ?: @"") UTF8String]); // handle nil gracefully
     chip::QRCodeSetupPayloadParser parser(string);
-    return parser.populatePayload(_payload);
+
+    std::vector<SetupPayload> payloads;
+    CHIP_ERROR err = parser.populatePayloads(payloads);
+    if (err != CHIP_NO_ERROR) {
+        MTR_LOG_ERROR("Failed to parse QR Code payload: %" CHIP_ERROR_FORMAT, err.Format());
+        return err;
+    }
+
+    if (payloads.empty()) {
+        // NOTE: not logging qrCode to avoid logging possible setup passcodes.
+        MTR_LOG_ERROR("Parsing setup payload succeeded but resulted in no payloads");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (validate) {
+        for (auto & payload : payloads) {
+            if (!payload.isValidQRCodePayload(PayloadContents::ValidationMode::kConsume)) {
+                MTR_LOG_ERROR("Invalid QR Code payload");
+                return CHIP_ERROR_INVALID_ARGUMENT;
+            }
+        }
+    }
+
+    _payload = payloads[0];
+    if (payloads.size() > 1) {
+        _concatenatedQRCode = qrCode;
+    }
+    return CHIP_NO_ERROR;
 }
 
 - (nullable instancetype)initWithQRCode:(NSString *)qrCodePayload
 {
     self = [super init];
-    CHIP_ERROR err = [self initializeFromQRCode:qrCodePayload];
+    CHIP_ERROR err = [self initializeFromQRCode:qrCodePayload validate:YES];
     if (err != CHIP_NO_ERROR) {
-        MTR_LOG_ERROR("Failed to parse QR Code payload: %" CHIP_ERROR_FORMAT, err.Format());
-        return nil;
-    }
-    if (!_payload.isValidQRCodePayload(chip::PayloadContents::ValidationMode::kConsume)) {
-        MTR_LOG_ERROR("Invalid QR Code payload");
         return nil;
     }
 
@@ -293,6 +325,10 @@ MTR_DIRECT_MEMBERS
 
 - (void)setVersion:(NSNumber *)version
 {
+    if (_concatenatedQRCode) {
+        MTR_LOG_ERROR("%@ Unable to change version of concatenated QR code", self);
+        return;
+    }
     _payload.version = static_cast<decltype(_payload.version)>(version.unsignedIntegerValue);
 }
 
@@ -303,6 +339,10 @@ MTR_DIRECT_MEMBERS
 
 - (void)setVendorID:(NSNumber *)vendorID
 {
+    if (_concatenatedQRCode) {
+        MTR_LOG_ERROR("%@ Unable to change vendorID of concatenated QR code", self);
+        return;
+    }
     _payload.vendorID = static_cast<decltype(_payload.vendorID)>(vendorID.unsignedIntegerValue);
 }
 
@@ -313,6 +353,10 @@ MTR_DIRECT_MEMBERS
 
 - (void)setProductID:(NSNumber *)productID
 {
+    if (_concatenatedQRCode) {
+        MTR_LOG_ERROR("%@ Unable to change productID of concatenated QR code", self);
+        return;
+    }
     _payload.productID = static_cast<decltype(_payload.productID)>(productID.unsignedIntegerValue);
 }
 
@@ -330,6 +374,10 @@ MTR_DIRECT_MEMBERS
 
 - (void)setCommissioningFlow:(MTRCommissioningFlow)commissioningFlow
 {
+    if (_concatenatedQRCode) {
+        MTR_LOG_ERROR("%@ Unable to change commissioningFlow of concatenated QR code", self);
+        return;
+    }
     _payload.commissioningFlow = static_cast<chip::CommissioningFlow>(commissioningFlow);
 }
 
@@ -351,6 +399,10 @@ MTR_DIRECT_MEMBERS
 
 - (void)setDiscoveryCapabilities:(MTRDiscoveryCapabilities)discoveryCapabilities
 {
+    if (_concatenatedQRCode) {
+        MTR_LOG_ERROR("%@ Unable to change discoveryCapabilities of concatenated QR code", self);
+        return;
+    }
     if (discoveryCapabilities == MTRDiscoveryCapabilitiesUnknown) {
         _payload.rendezvousInformation.ClearValue();
     } else {
@@ -368,6 +420,10 @@ MTR_DIRECT_MEMBERS
 
 - (void)setDiscriminator:(uint16_t)discriminator isShort:(BOOL)isShort
 {
+    if (_concatenatedQRCode) {
+        MTR_LOG_ERROR("%@ Unable to change discriminator of concatenated QR code", self);
+        return;
+    }
     if (isShort) {
         _payload.discriminator.SetShortValue(discriminator & kShortDiscriminatorMask);
         _shadowDiscriminator = @(discriminator); // keep as a shadow value
@@ -392,6 +448,10 @@ MTR_DIRECT_MEMBERS
 
 - (void)setHasShortDiscriminator:(BOOL)hasShortDiscriminator
 {
+    if (_concatenatedQRCode) {
+        MTR_LOG_ERROR("%@ Unable to change hasShortDiscriminator of concatenated QR code", self);
+        return;
+    }
     VerifyOrReturn(hasShortDiscriminator != self.hasShortDiscriminator);
     [self setDiscriminator:self.discriminator.unsignedShortValue isShort:hasShortDiscriminator];
 }
@@ -403,6 +463,10 @@ MTR_DIRECT_MEMBERS
 
 - (void)setSetupPasscode:(NSNumber *)setupPasscode
 {
+    if (_concatenatedQRCode) {
+        MTR_LOG_ERROR("%@ Unable to change setupPasscode of concatenated QR code", self);
+        return;
+    }
     _payload.setUpPINCode = static_cast<decltype(_payload.setUpPINCode)>(setupPasscode.unsignedIntegerValue);
 }
 
@@ -415,6 +479,10 @@ MTR_DIRECT_MEMBERS
 
 - (void)setSerialNumber:(nullable NSString *)serialNumber
 {
+    if (_concatenatedQRCode) {
+        MTR_LOG_ERROR("%@ Unable to change serialNumber of concatenated QR code", self);
+        return;
+    }
     if (serialNumber) {
         NSString * existing = self.serialNumber;
         if (existing) {
@@ -455,11 +523,19 @@ MTR_DIRECT_MEMBERS
 
 - (void)removeVendorElementWithTag:(NSNumber *)tag
 {
+    if (_concatenatedQRCode) {
+        MTR_LOG_ERROR("%@ Unable to modify vendor elements of concatenated QR code", self);
+        return;
+    }
     _payload.removeOptionalVendorData(ValidateVendorTag(tag));
 }
 
 - (void)addOrReplaceVendorElement:(MTROptionalQRCodeInfo *)element
 {
+    if (_concatenatedQRCode) {
+        MTR_LOG_ERROR("%@ Unable to modify vendor elements of concatenated QR code", self);
+        return;
+    }
     MTRVerifyArgumentOrDie(element != nil, @"element");
     CHIP_ERROR err = [element addAsVendorElementTo:_payload];
     VerifyOrDieWithMsg(err == CHIP_NO_ERROR, NotSpecified, "Internal error: %" CHIP_ERROR_FORMAT, err.Format());
@@ -493,6 +569,10 @@ MTR_DIRECT_MEMBERS
 
 - (nullable NSString *)qrCodeStringSkippingValidation:(BOOL)allowInvalid
 {
+    if (_concatenatedQRCode) {
+        return _concatenatedQRCode;
+    }
+
     chip::QRCodeSetupPayloadGenerator generator(_payload);
     generator.SetAllowInvalidPayload(allowInvalid);
     std::string result;
@@ -513,11 +593,16 @@ MTR_DIRECT_MEMBERS
 {
     MTRSetupPayload * copy = [[MTRSetupPayload alloc] initWithSetupPayload:_payload];
     copy->_shadowDiscriminator = _shadowDiscriminator;
+    copy->_concatenatedQRCode = _concatenatedQRCode;
     return copy;
 }
 
 - (NSUInteger)hash
 {
+    if (_concatenatedQRCode) {
+        return _concatenatedQRCode.hash;
+    }
+
     return self.discriminator.unsignedIntegerValue;
 }
 
@@ -525,6 +610,17 @@ MTR_DIRECT_MEMBERS
 {
     VerifyOrReturnValue([object class] == [self class], NO);
     MTRSetupPayload * other = object;
+
+    bool hasConcatenatedQRCode = (_concatenatedQRCode != nil);
+    bool otherHasConcatenatedCRCode = (other->_concatenatedQRCode != nil);
+    if (hasConcatenatedQRCode != otherHasConcatenatedCRCode) {
+        return NO;
+    }
+
+    if (_concatenatedQRCode) {
+        return [_concatenatedQRCode isEqual:other->_concatenatedQRCode];
+    }
+
     VerifyOrReturnValue(_payload == other->_payload, NO);
     VerifyOrReturnValue(MTREqualObjects(_shadowDiscriminator, other->_shadowDiscriminator), NO);
     return YES;
@@ -547,7 +643,7 @@ MTR_DIRECT_MEMBERS
         [result appendFormat:@" commissioningFlow=0x%llx", (unsigned long long) flow];
     }
 
-    [result appendString:@">"];
+    [result appendFormat:@", concatenated: %@>", MTR_YES_NO(_concatenatedQRCode != nil)];
     return result;
 }
 
@@ -592,7 +688,7 @@ static NSString * const MTRSetupPayloadCodingKeyQRCode = @"qr";
     // did not encode it. When present, it carries almost the entire state of the object.
     NSString * qrCode = [coder decodeObjectOfClass:NSString.class forKey:MTRSetupPayloadCodingKeyQRCode];
     if (qrCode != nil) {
-        [self initializeFromQRCode:qrCode];
+        [self initializeFromQRCode:qrCode validate:NO];
     } else {
         self.version = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyVersion];
         self.vendorID = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyVendorID];

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
@@ -353,31 +353,6 @@
     XCTAssertEqualObjects(newPayload.serialNumber, payload.serialNumber);
 }
 
-- (void)_testSerialNumberRoundTrip:(NSString *)payloadString
-{
-    NSError * error;
-    MTRSetupPayload * payload =
-        [MTRSetupPayload setupPayloadWithOnboardingPayload:payloadString
-                                                     error:&error];
-    XCTAssertNil(error);
-    XCTAssertNotNil(payload);
-
-    XCTAssertEqualObjects(payload.serialNumber, @"123456789");
-
-    NSString * serialNumber = @"12345";
-    payload.serialNumber = serialNumber;
-
-    NSString * qrCode = [payload qrCodeString:&error];
-    XCTAssertNil(error);
-    XCTAssertNotNil(qrCode);
-
-    MTRSetupPayload * newPayload = [MTRSetupPayload setupPayloadWithOnboardingPayload:qrCode error:&error];
-    XCTAssertNil(error);
-    XCTAssertNotNil(newPayload);
-
-    XCTAssertEqualObjects(newPayload.serialNumber, serialNumber);
-}
-
 - (void)test31129 // https://github.com/project-chip/connectedhomeip/issues/31129
 {
     MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithSetupPasscode:@99999998 discriminator:@3840];

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
@@ -62,6 +62,27 @@
     XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
 }
 
+- (void)testOnboardingPayloadParser_QRCode_Concatenated_NoError
+{
+    __auto_type * concatenatedQRCode = @"MT:M5L90MP500K64J00000*M5L90MP500OC8010000";
+
+    NSError * error;
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:concatenatedQRCode error:&error];
+
+    XCTAssertNotNil(payload);
+    XCTAssertNil(error);
+
+    XCTAssertFalse(payload.hasShortDiscriminator);
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
+    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
+    XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertEqualObjects(payload.qrCodeString, concatenatedQRCode);
+}
+
 - (void)testOnboardingPayloadParser_QRCode_WrongVersion
 {
     // Same as testOnboardingPayloadParser_QRCode_NoError, but with version set to 5.
@@ -307,6 +328,56 @@
     XCTAssertEqualObjects(newPayload.serialNumber, serialNumber);
 }
 
+- (void)testSerialNumberRoundTripConcatenated
+{
+    NSError * error;
+    MTRSetupPayload * payload =
+        [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0*M5L90MP500K64J00000"
+                                                     error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(payload);
+
+    XCTAssertEqualObjects(payload.serialNumber, @"123456789");
+
+    // NOTE: Don't try writing serialNumber, since we don't support that for
+    // concatenated QR codes.
+
+    NSString * qrCode = [payload qrCodeString:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(qrCode);
+
+    MTRSetupPayload * newPayload = [MTRSetupPayload setupPayloadWithOnboardingPayload:qrCode error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(newPayload);
+
+    XCTAssertEqualObjects(newPayload.serialNumber, payload.serialNumber);
+}
+
+- (void)_testSerialNumberRoundTrip:(NSString *)payloadString
+{
+    NSError * error;
+    MTRSetupPayload * payload =
+        [MTRSetupPayload setupPayloadWithOnboardingPayload:payloadString
+                                                     error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(payload);
+
+    XCTAssertEqualObjects(payload.serialNumber, @"123456789");
+
+    NSString * serialNumber = @"12345";
+    payload.serialNumber = serialNumber;
+
+    NSString * qrCode = [payload qrCodeString:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(qrCode);
+
+    MTRSetupPayload * newPayload = [MTRSetupPayload setupPayloadWithOnboardingPayload:qrCode error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(newPayload);
+
+    XCTAssertEqualObjects(newPayload.serialNumber, serialNumber);
+}
+
 - (void)test31129 // https://github.com/project-chip/connectedhomeip/issues/31129
 {
     MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithSetupPasscode:@99999998 discriminator:@3840];
@@ -330,7 +401,9 @@
              @"34970112332",
              @"641286075300001000016",
              @"MT:M5L90MP500K64J00000",
-             @"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"
+             @"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0",
+             @"MT:M5L90MP500K64J00000*M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0",
+             @"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0*M5L90MP500K64J00000",
          ]) {
         MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:string error:&error];
         XCTAssertNotNil(payload, @"Error: %@", error);
@@ -420,6 +493,20 @@
     copy.serialNumber = @"555-123";
     XCTAssertFalse([copy isEqual:payload]);
     payload.serialNumber = @"555-123";
+    XCTAssertTrue([copy isEqual:payload]);
+    XCTAssertEqual(payload.hash, copy.hash);
+}
+
+- (void)testCopyingAndEqualityConcatenated
+{
+    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithPayload:@"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0*M5L90MP500K64J00000"];
+    XCTAssertFalse(payload.hasShortDiscriminator); // came from a QR code
+    XCTAssert(payload.discriminator.integerValue > 0xf); // can't "accidentally" round-trip through a short discriminator
+
+    MTRSetupPayload * copy = [payload copy];
+    XCTAssertNotIdentical(payload, copy); // MTRSetupPayload is mutable, must be a new object
+
+    XCTAssertTrue([payload isEqual:copy]);
     XCTAssertTrue([copy isEqual:payload]);
     XCTAssertEqual(payload.hash, copy.hash);
 }


### PR DESCRIPTION
This allows an MTRSetupPayload to be initialized from a concatenated QR code,
but does not expose information from anything other than the first onboarding
payload, except via qrCodeString.

#### Testing

Unit tests added.