### PR TITLE
fix leak when we exit Linux App with chip_shell enabled

### DIFF
--- a/src/lib/shell/MainLoopDefault.cpp
+++ b/src/lib/shell/MainLoopDefault.cpp
@@ -212,6 +212,7 @@ void Engine::RunMainLoop()
         if (ReadLine(line, CHIP_SHELL_MAX_LINE_SIZE) == 0u)
         {
             // Stop loop in case of empty read (Ctrl-D).
+            Platform::MemoryFree(line);
             break;
         }
 #if CONFIG_DEVICE_LAYER


### PR DESCRIPTION
#### Summary

- Linux Apps that have Shell Enabled have a small leak when we exit them using ctrl+C.
- Fix: call Free Memory when we break from the loop due to that.

#### Testing

- build `out/linux-x64-tv-app-clang-asan/chip-tv-app `
- run the App and exit it, make sure there is no leak.

#### LeakSanitizer Log

<details>
  <summary>View Log</summary>

```cpp
=================================================================
==1539097==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 256 byte(s) in 1 object(s) allocated from:
    #0 0x602ee81d3664 in malloc ../../../../../../llvm-llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:67:3
    #1 0x602ee83d59de in chip::Platform::MemoryAlloc(unsigned long) /home/aya/repos/connectedhomeip/connectedhomeip/out/linux-x64-tv-app-clang-asan/../../examples/tv-app/linux/third_party/connectedhomeip/src/lib/support/CHIPMem-Malloc.cpp:96:12
    #2 0x602ee8eb5424 in chip::Shell::Engine::RunMainLoop() /home/aya/repos/connectedhomeip/connectedhomeip/out/linux-x64-tv-app-clang-asan/../../examples/tv-app/linux/third_party/connectedhomeip/src/lib/shell/MainLoopDefault.cpp:211:43
    #3 0x602ee8229b95 in ChipLinuxAppMainLoop(AppMainLoopImplementation*)::$_0::operator()() const /home/aya/repos/connectedhomeip/connectedhomeip/out/linux-x64-tv-app-clang-asan/../../examples/tv-app/linux/third_party/connectedhomeip/examples/platform/linux/AppMain.cpp:804:24
    #4 0x602ee8229a12 in decltype(std::declval<ChipLinuxAppMainLoop(AppMainLoopImplementation*)::$_0>()()) std::__2::__invoke[abi:nn210000]<ChipLinuxAppMainLoop(AppMainLoopImplementation*)::$_0>(ChipLinuxAppMainLoop(AppMainLoopImplementation*)::$_0&&) /home/aya/repos/connectedhomeip/connectedhomeip/.environment/cipd/packages/pigweed/bin/../include/c++/v1/__type_traits/invoke.h:179:25
    #5 0x602ee822998a in void std::__2::__thread_execute[abi:nn210000]<std::__2::unique_ptr<std::__2::__thread_struct, std::__2::default_delete<std::__2::__thread_struct>>, ChipLinuxAppMainLoop(AppMainLoopImplementation*)::$_0>(std::__2::tuple<std::__2::unique_ptr<std::__2::__thread_struct, std::__2::default_delete<std::__2::__thread_struct>>, ChipLinuxAppMainLoop(AppMainLoopImplementation*)::$_0>&, std::__2::__tuple_indices<...>) /home/aya/repos/connectedhomeip/connectedhomeip/.environment/cipd/packages/pigweed/bin/../include/c++/v1/__thread/thread.h:159:3
    #6 0x602ee8229591 in void* std::__2::__thread_proxy[abi:nn210000]<std::__2::tuple<std::__2::unique_ptr<std::__2::__thread_struct, std::__2::default_delete<std::__2::__thread_struct>>, ChipLinuxAppMainLoop(AppMainLoopImplementation*)::$_0>>(void*) /home/aya/repos/connectedhomeip/connectedhomeip/.environment/cipd/packages/pigweed/bin/../include/c++/v1/__thread/thread.h:168:3
    #7 0x602ee81d0fb6 in asan_thread_start(void*) ../../../../../../llvm-llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:239:28

SUMMARY: AddressSanitizer: 256 byte(s) leaked in 1 allocation(s).
```


</details>