### PR TITLE
Add an indirection for the CodegenProcessingConfig.

### DIFF
--- a/src/data-model-providers/codegen/BUILD.gn
+++ b/src/data-model-providers/codegen/BUILD.gn
@@ -24,11 +24,18 @@ declare_args() {
       current_os == "ios"
 }
 
-buildconfig_header("processing-config") {
-  header = "CodegenProcessingConfig.h"
+buildconfig_header("processing-buildconfig") {
+  header = "CodegenProcessingBuildConfig.h"
   header_dir = "codegen"
 
   defines = [ "CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS=${chip_enable_codegen_integration_lookup_errors}" ]
+
+  visibility = [ ":processing-config" ]
+}
+
+source_set("processing-config") {
+  sources = [ "CodegenProcessingConfig.h" ]
+  deps = [ ":processing-buildconfig" ]
 }
 
 # This source set is TIGHLY coupled with code-generated data models

--- a/src/data-model-providers/codegen/ClusterIntegration.cpp
+++ b/src/data-model-providers/codegen/ClusterIntegration.cpp
@@ -21,8 +21,7 @@
 #include <app/util/attribute-table.h>
 #include <app/util/endpoint-config-api.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
-
-#include <codegen/CodegenProcessingConfig.h>
+#include <data-model-providers/codegen/CodegenProcessingConfig.h>
 
 #include <limits>
 

--- a/src/data-model-providers/codegen/CodegenProcessingConfig.h
+++ b/src/data-model-providers/codegen/CodegenProcessingConfig.h
@@ -1,0 +1,20 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#if CHIP_HAVE_CONFIG_H
+#include <codegen/CodegenProcessingBuildConfig.h>
+#endif


### PR DESCRIPTION
#### Summary

This allows us to respect not having a CHIP_HAVE_CONFIG_H defined for third_party integrations.

This is the same as we do for other config files (e.g. access):
https://github.com/project-chip/connectedhomeip/blob/master/src/access/BUILD.gn#L30
https://github.com/project-chip/connectedhomeip/blob/master/src/access/AccessConfig.h#L20

#### Testing

CI should still pass. There is no expected functionality change.