### PR TITLE
[AVSM] Reflect test plan changes to address ballot and QA issues

### DIFF
--- a/src/python_testing/TC_AVSM_2_12.py
+++ b/src/python_testing/TC_AVSM_2_12.py
@@ -641,7 +641,8 @@ class TC_AVSM_2_12(MatterBaseTest):
             statusLightEnabledNew = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=attr.StatusLightEnabled)
             logger.info(f"Rx'd StatusLightEnabled: {statusLightEnabledNew}")
-            asserts.assert_equal(statusLightEnabledNew, not statusLightEnabled, "Value does not match what was written for StatusLightEnabled in step 51")
+            asserts.assert_equal(statusLightEnabledNew, not statusLightEnabled,
+                                 "Value does not match what was written for StatusLightEnabled in step 51")
         else:
             self.skip_step(50)
             self.skip_step(51)
@@ -664,11 +665,13 @@ class TC_AVSM_2_12(MatterBaseTest):
             statusLightBrightnessNew = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=attr.StatusLightBrightness)
             logger.info(f"Rx'd StatusLightBrightness: {statusLightBrightnessNew}")
-            asserts.assert_equal(statusLightBrightnessNew, statusLightBrightnessToWrite, "Value does not match what was written for StatusLightBrightness in step 54")
+            asserts.assert_equal(statusLightBrightnessNew, statusLightBrightnessToWrite,
+                                 "Value does not match what was written for StatusLightBrightness in step 54")
         else:
             self.skip_step(53)
             self.skip_step(54)
             self.skip_step(55)
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_AVSM_2_12.py
+++ b/src/python_testing/TC_AVSM_2_12.py
@@ -37,11 +37,14 @@
 
 import logging
 
+import random
+
 from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.clusters import Globals
 from matter.interaction_model import Status
+from matter.testing import matter_asserts
 from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
 
 logger = logging.getLogger(__name__)
@@ -78,26 +81,62 @@ class TC_AVSM_2_12(MatterBaseTest):
                      "Verify that the DUT response contains a TriStateAutoEnum value. Store value as aNightVision"),
             TestStep(12, "TH writes NightVision attribute with a new value", "DUT responds with a SUCCESS status code."),
             TestStep(13, "TH reads NightVision attribute.", "Verify that the value is the same as was written in Step 12."),
-            TestStep(14, "TH reads Viewport attribute.",
+            TestStep(14, "TH reads NightVisionIllum attribute.",
+                     "Verify that the DUT response contains a TriStateAutoEnum value. Store value as aNightVisionIllum"),
+            TestStep(15, "TH writes NightVisionIllum attribute with a new value", "DUT responds with a SUCCESS status code."),
+            TestStep(16, "TH reads NightVisionIllum attribute.", "Verify that the value is the same as was written in Step 15."),
+            TestStep(17, "TH reads Viewport attribute.",
                      "Verify that the DUT response contains a ViewportStruct value. Store value as aViewport"),
-            TestStep(15, "TH writes Viewport attribute with a new value.", "DUT responds with a SUCCESS status code."),
-            TestStep(16, "TH reads Viewport attribute.", "Verify that the value is the same as was written in Step 15."),
-            TestStep(17, "TH reads SpeakerMuted attribute.",
+            TestStep(18, "TH writes Viewport attribute with a new value.", "DUT responds with a SUCCESS status code."),
+            TestStep(19, "TH reads Viewport attribute.", "Verify that the value is the same as was written in Step 18."),
+            TestStep(20, "TH reads SpeakerMuted attribute.",
                      "Verify that the DUT response contains a bool value. Store value as aSpeakerMuted"),
-            TestStep(18, "TH writes SpeakerMuted attribute with value set to !aSpeakerMuted.",
+            TestStep(21, "TH writes SpeakerMuted attribute with value set to !aSpeakerMuted.",
                      "DUT responds with a SUCCESS status code."),
-            TestStep(19, "TH reads SpeakerMuted attribute.", "Verify that the value is the same as was written in Step 18."),
-            TestStep(20, "TH reads MicrophoneMuted attribute.",
+            TestStep(22, "TH reads SpeakerMuted attribute.", "Verify that the value is the same as was written in Step 21."),
+            TestStep(23, "TH reads SpeakerVolumeLevel attribute.",
+                     "Verify that the DUT response is in the range SpeakerMin to SpeakerMax. Store value as aSpeakerVolumeLevel"),
+            TestStep(24, "TH writes SpeakerVolumeLevel attribute with a new value of aSpeakerVolumeLevel.",
+                     "DUT responds with a SUCCESS status code."),
+            TestStep(25, "TH reads SpeakerVolumeLevel attribute.", "Verify that the value is the same as was written in Step 24."),
+            TestStep(26, "TH reads MicrophoneMuted attribute.",
                      "Verify that the DUT response contains a bool value. Store value as aMicrophoneMuted"),
-            TestStep(21, "TH writes MicrophoneMuted attribute with value set to !aMicrophoneMuted.",
+            TestStep(27, "TH writes MicrophoneMuted attribute with value set to !aMicrophoneMuted.",
                      "DUT responds with a SUCCESS status code."),
-            TestStep(22, "TH reads MicrophoneMuted attribute.", "Verify that the value is the same as was written in Step 21."),
-            TestStep(23, "TH reads LocalVideoRecordingEnabled attribute.",
+            TestStep(28, "TH reads MicrophoneMuted attribute.", "Verify that the value is the same as was written in Step 27."),
+            TestStep(29, "TH reads MicrophoneVolumeLevel attribute.",
+                     "Verify that the DUT response is in the range MicrophoneMin to MicrophoneMax. Store value as aMicrophoneVolumeLevel"),
+            TestStep(30, "TH writes MicrophoneVolumeLevel attribute with a new value of aMicrophoneVolumeLevel.",
+                     "DUT responds with a SUCCESS status code."),
+            TestStep(31, "TH reads MicrophoneVolumeLevel attribute.", "Verify that the value is the same as was written in Step 30."),
+            TestStep(32, "TH reads MicrophoneAGCEnabled attribute.",
+                     "Verify that the DUT response contains a bool value. Store value as aMicrophoneAGCEnabled"),
+            TestStep(33, "TH writes MicrophoneAGCEnabled attribute with value set to !aMicrophoneAGCEnabled.",
+                     "DUT responds with a SUCCESS status code."),
+            TestStep(34, "TH reads MicrophoneAGCEnabled attribute.", "Verify that the value is the same as was written in Step 33."),
+            TestStep(35, "TH reads ImageRotation attribute.",
+                     "Verify that the DUT response is not greater than 359. Store value as aImageRotation"),
+            TestStep(36, "TH writes ImageRotation attribute with a new value of aImageRotation.",
+                     "DUT responds with a SUCCESS status code."),
+            TestStep(37, "TH reads ImageRotation attribute.", "Verify that the value is the same as was written in Step 36."),
+            TestStep(38, "TH reads ImageFlipHorizontal attribute.",
+                     "Verify that the DUT response contains a bool value. Store value as aImageFlipHorizontal"),
+            TestStep(39, "TH writes ImageFlipHorizontal attribute with value set to !aImageFlipHorizontal.",
+                     "DUT responds with a SUCCESS status code."),
+            TestStep(40, "TH reads ImageFlipHorizontal attribute.",
+                     "Verify that the value is the same as was written in Step 39."),
+            TestStep(41, "TH reads ImageFlipVertical attribute.",
+                     "Verify that the DUT response contains a bool value. Store value as aImageFlipVertical"),
+            TestStep(42, "TH writes ImageFlipVertical attribute with value set to !aImageFlipVertical.",
+                     "DUT responds with a SUCCESS status code."),
+            TestStep(43, "TH reads ImageFlipVertical attribute.",
+                     "Verify that the value is the same as was written in Step 42."),
+            TestStep(44, "TH reads LocalVideoRecordingEnabled attribute.",
                      "Verify that the DUT response contains a bool value. Store value as aLocalVideoRecordingEnabled"),
-            TestStep(24, "TH writes LocalVideoRecordingEnabled attribute with value set to !aLocalVideoRecordingEnabled.",
+            TestStep(45, "TH writes LocalVideoRecordingEnabled attribute with value set to !aLocalVideoRecordingEnabled.",
                      "DUT responds with a SUCCESS status code."),
-            TestStep(25, "TH reads LocalVideoRecordingEnabled attribute.",
-                     "Verify that the value is the same as was written in Step 24."),
+            TestStep(46, "TH reads LocalVideoRecordingEnabled attribute.",
+                     "Verify that the value is the same as was written in Step 45."),
         ]
 
     @run_if_endpoint_matches(has_cluster(Clusters.CameraAvStreamManagement))
@@ -120,6 +159,7 @@ class TC_AVSM_2_12(MatterBaseTest):
         self.localStorageSupported = aFeatureMap & cluster.Bitmaps.Feature.kLocalStorage
         self.hdrSupported = aFeatureMap & cluster.Bitmaps.Feature.kHighDynamicRange
         self.nightVisionSupported = aFeatureMap & cluster.Bitmaps.Feature.kNightVision
+        self.imagecControlSupported = aFeatureMap & cluster.Bitmaps.Feature.kImageControl
 
         if self.hdrSupported:
             self.step(2)
@@ -211,112 +251,327 @@ class TC_AVSM_2_12(MatterBaseTest):
 
             self.step(13)
             nightVisionNew = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster, attribute=attr.NightVision
-            )
+                endpoint=endpoint, cluster=cluster, attribute=attr.NightVision)
             logger.info(f"Rx'd NightVision: {nightVisionNew}")
             asserts.assert_equal(nightVisionNew, nightVisionToWrite, "Value does not match what was written in step 12")
+
+            # NightVisionIllum is optional, so ensure it is present
+            if await self.attribute_guard(endpoint=endpoint, attribute=attr.NightVisionIllum):
+                self.step(14)
+                nightVisionIllum = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.NightVisionIllum)
+                logger.info(f"Rx'd NightVisionIllum: {nightVisionIllum}")
+
+                self.step(15)
+                nightVisionIllumToWrite = (nightVision + 1) % 3
+                result = await self.write_single_attribute(attr.NightVisionIllum(nightVisionIllumToWrite),
+                                                           endpoint_id=endpoint)
+                asserts.assert_equal(result, Status.Success, "Error when trying to write NightVisionIllum")
+                logger.info(f"Tx'd NightVisionIllum: {nightVisionIllumToWrite}")
+
+                self.step(16)
+                nightVisionIllumNew = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.NightVisionIllum)
+                logger.info(f"Rx'd NightVisionIllum: {nightVisionIllumNew}")
+                asserts.assert_equal(nightVisionIllumNew, nightVisionIllumToWrite, "Value does not match what was written for NightVisionIllum in step 15")
+            else:
+                self.skip_step(14)
+                self.skip_step(15)
+                self.skip_step(16)
         else:
             self.skip_step(11)
             self.skip_step(12)
             self.skip_step(13)
+            self.skip_step(14)
+            self.skip_step(15)
+            self.skip_step(16)
 
         if self.vdoSupported:
-            self.step(14)
+            self.step(17)
             viewport = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=attr.Viewport
             )
             logger.info(f"Rx'd Viewport: {viewport}")
 
-            self.step(15)
+            self.step(18)
             viewportToWrite = Globals.Structs.ViewportStruct(viewport.x1+1, viewport.y1+1, viewport.x2+1, viewport.y2+1)
             result = await self.write_single_attribute(attr.Viewport(viewportToWrite),
                                                        endpoint_id=endpoint)
             asserts.assert_equal(result, Status.Success, "Error when trying to write viewportToWrite")
             logger.info(f"Tx'd Viewport: {viewportToWrite}")
 
-            self.step(16)
+            self.step(19)
             viewportNew = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=attr.Viewport
             )
             logger.info(f"Rx'd Viewport: {viewportNew}")
-            asserts.assert_equal(viewportNew, viewportToWrite, "Value does not match what was written in step 15")
-        else:
-            self.skip_step(14)
-            self.skip_step(15)
-            self.skip_step(16)
-
-        if self.speakerSupported:
-            self.step(17)
-            speakerMuted = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster, attribute=attr.SpeakerMuted
-            )
-            logger.info(f"Rx'd SpeakerMuted: {speakerMuted}")
-
-            self.step(18)
-            result = await self.write_single_attribute(attr.SpeakerMuted(not speakerMuted),
-                                                       endpoint_id=endpoint)
-            asserts.assert_equal(result, Status.Success, "Error when trying to write SpeakerMuted")
-            logger.info(f"Tx'd SpeakerMuted: {not speakerMuted}")
-
-            self.step(19)
-            speakerMutedNew = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=cluster, attribute=attr.SpeakerMuted
-            )
-            logger.info(f"Rx'd SpeakerMuted: {speakerMutedNew}")
-            asserts.assert_equal(speakerMutedNew, not speakerMuted, "Value does not match what was written in step 18")
+            asserts.assert_equal(viewportNew, viewportToWrite, "Value does not match what was written in step 18")
         else:
             self.skip_step(17)
             self.skip_step(18)
             self.skip_step(19)
 
-        if self.adoSupported:
+        if self.speakerSupported:
             self.step(20)
+            speakerMuted = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.SpeakerMuted
+            )
+            logger.info(f"Rx'd SpeakerMuted: {speakerMuted}")
+
+            self.step(21)
+            result = await self.write_single_attribute(attr.SpeakerMuted(not speakerMuted),
+                                                       endpoint_id=endpoint)
+            asserts.assert_equal(result, Status.Success, "Error when trying to write SpeakerMuted")
+            logger.info(f"Tx'd SpeakerMuted: {not speakerMuted}")
+
+            self.step(22)
+            speakerMutedNew = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.SpeakerMuted
+            )
+            logger.info(f"Rx'd SpeakerMuted: {speakerMutedNew}")
+            asserts.assert_equal(speakerMutedNew, not speakerMuted, "Value does not match what was written in step 21")
+
+            speakerMinLevel = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.SpeakerMinLevel)
+            logger.info(f"Rx'd SpeakerMinLevel: {speakerMinLevel}")
+
+            speakerMaxLevel = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.SpeakerMaxLevel)
+            logger.info(f"Rx'd SpeakerMaxLevel: {speakerMaxLevel}")
+
+            # Only test write of new value if SpeakerMin != SpeakerMax
+            if speakerMinLevel < speakerMaxLevel:
+                self.step(23)
+                speakerVolumeLevel = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.SpeakerVolumeLevel)
+                logger.info(f"Rx'd SpeakerVolumeLevel: {speakerVolumeLevel}")
+                matter_asserts.assert_int_in_range(speakerVolumeLevel, speakerMinLevel, speakerMaxLevel, "Speaker Volume not between SpeakerMin and SpeakerMax")
+
+                self.step(24)
+                newSpeakerVolume = random.randint(speakerMinLevel, speakerMaxLevel)
+                while newSpeakerVolume == speakerVolumeLevel:
+                    newSpeakerVolume = random.randint(speakerMinLevel, speakerMaxLevel)
+
+                result = await self.write_single_attribute(attr.SpeakerVolumeLevel(newSpeakerVolume),
+                                                       endpoint_id=endpoint)
+                asserts.assert_equal(result, Status.Success, "Error when trying to write SpeakerVolumeLevel")
+                logger.info(f"Tx'd SpeakerVolumeLevel: {newSpeakerVolume}")
+
+                self.step(25)
+                speakerVolumeLevelNew = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.SpeakerVolumeLevel)
+                logger.info(f"Rx'd SpeakerVolumeLevel: {speakerVolumeLevelNew}")
+                asserts.assert_equal(speakerVolumeLevelNew, newSpeakerVolume, "Value does not match what was written for SpeakerVolumeLevel in step 24")
+            else:
+                self.skip_step(23)
+                self.skip_step(24)
+                self.skip_step(25)
+        else:
+            self.skip_step(20)
+            self.skip_step(21)
+            self.skip_step(22)
+            self.skip_step(23)
+            self.skip_step(24)
+            self.skip_step(25)
+
+        if self.adoSupported:
+            self.step(26)
             micMuted = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=attr.MicrophoneMuted
             )
             logger.info(f"Rx'd MicrophoneMuted: {micMuted}")
 
-            self.step(21)
+            self.step(27)
             result = await self.write_single_attribute(attr.MicrophoneMuted(not micMuted),
                                                        endpoint_id=endpoint)
             asserts.assert_equal(result, Status.Success, "Error when trying to write MicrophoneMuted")
             logger.info(f"Tx'd MicrophoneMuted: {not micMuted}")
 
-            self.step(22)
+            self.step(28)
             micMutedNew = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=attr.MicrophoneMuted
             )
             logger.info(f"Rx'd MicrophoneMuted: {micMutedNew}")
-            asserts.assert_equal(micMutedNew, not micMuted, "Value does not match what was written in step 21")
+            asserts.assert_equal(micMutedNew, not micMuted, "Value does not match what was written in step 27")
+
+            micMinLevel = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.MicrophoneMinLevel)
+            logger.info(f"Rx'd MicrophoneMinLevel: {micMinLevel}")
+
+            micMaxLevel = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.MicrophoneMaxLevel)
+            logger.info(f"Rx'd MicrophoneMaxLevel: {micMaxLevel}")
+
+            # Only test write of new value if MicMin != MicMax
+            if micMinLevel < micMaxLevel:
+                self.step(29)
+                micVolumeLevel = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.MicrophoneVolumeLevel)
+                logger.info(f"Rx'd MicrophoneVolumeLevel: {micVolumeLevel}")
+                matter_asserts.assert_int_in_range(micVolumeLevel, micMinLevel, micMaxLevel, "Microphone Volume not between MicMin and MicMax")
+
+                self.step(30)
+                newMicVolume = random.randint(micMinLevel, micMaxLevel)
+                while newMicVolume == micVolumeLevel:
+                    newMicVolume = random.randint(micMinLevel, micMaxLevel)
+
+                result = await self.write_single_attribute(attr.MicrophoneVolumeLevel(newMicVolume),
+                                                       endpoint_id=endpoint)
+                asserts.assert_equal(result, Status.Success, "Error when trying to write MicrophoneVolumeLevel")
+                logger.info(f"Tx'd MicrophoneVolumeLevel: {newMicVolume}")
+
+                self.step(31)
+                micVolumeLevelNew = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.MicrophoneVolumeLevel)
+                logger.info(f"Rx'd MicrophoneVolumeLevel: {micVolumeLevelNew}")
+                asserts.assert_equal(micVolumeLevelNew, newMicVolume, "Value does not match what was written for MicrophoneVolumeLevel in step 30")
+            else:
+                self.skip_step(29)
+                self.skip_step(30)
+                self.skip_step(31)
+
+            # MicrophoneAGCEnabled is optional so ensure it is present
+            if await self.attribute_guard(endpoint=endpoint, attribute=attr.MicrophoneAGCEnabled):
+                self.step(32)
+                micAGCEnabled = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.MicrophoneAGCEnabled)
+                logger.info(f"Rx'd MicrophoneAGCEnabled: {micAGCEnabled}")
+
+                self.step(33)
+                result = await self.write_single_attribute(attr.MicrophoneAGCEnabled(not micAGCEnabled),
+                                                           endpoint_id=endpoint)
+                asserts.assert_equal(result, Status.Success, "Error when trying to write MicrophoneAGCEnabled")
+                logger.info(f"Tx'd MicrophoneAGCEnabled: {not micAGCEnabled}")
+
+                self.step(34)
+                micAGCEnabledNew = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.MicrophoneAGCEnabled)
+                logger.info(f"Rx'd MicrophoneAGCEnabled: {micAGCEnabledNew}")
+                asserts.assert_equal(micAGCEnabledNew, not micAGCEnabled, "Value does not match what was written for MicrophoneAGCEnabled in step 33")
+            else:
+                self.skip_step(32)
+                self.skip_step(33)
+                self.skip_step(34)
         else:
-            self.skip_step(20)
-            self.skip_step(21)
-            self.skip_step(22)
+            self.skip_step(26)
+            self.skip_step(27)
+            self.skip_step(28)
+            self.skip_step(29)
+            self.skip_step(30)
+            self.skip_step(31)
+            self.skip_step(32)
+            self.skip_step(33)
+            self.skip_step(34)
+
+        if self.imagecControlSupported:
+            # Attributes are all optional, one must be present, attribute guard for each
+            if await self.attribute_guard(endpoint=endpoint, attribute=attr.ImageRotation):
+                self.step(35)
+                imageRotation = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.ImageRotation)
+                logger.info(f"Rx'd ImageRotation: {imageRotation}")
+
+                self.step(36)
+                newImageRotation = random.randint(0, 359)
+
+                while newImageRotation == imageRotation:
+                    newImageRotation = random.randint(0, 359)
+
+                result = await self.write_single_attribute(attr.ImageRotation(newImageRotation),
+                                                           endpoint_id=endpoint)
+                asserts.assert_equal(result, Status.Success, "Error when trying to write ImageRotation")
+                logger.info(f"Tx'd ImageRotation: {newImageRotation}")
+
+                self.step(37)
+                imageRotationNew = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.ImageRotation)
+                logger.info(f"Rx'd ImageRotation: {imageRotationNew}")
+                asserts.assert_equal(imageRotationNew, newImageRotation, "Value does not match what was written for ImageRotation in step 36")                
+
+            else:
+                self.skip_step(35)
+                self.skip_step(36)
+                self.skip_step(37)
+
+
+            if await self.attribute_guard(endpoint=endpoint, attribute=attr.ImageFlipHorizontal):
+                self.step(38)
+                imageFlipHorizontal = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.ImageFlipHorizontal)
+                logger.info(f"Rx'd ImageFlipHorizontal: {imageFlipHorizontal}")
+
+                self.step(39)
+                result = await self.write_single_attribute(attr.ImageFlipHorizontal(not imageFlipHorizontal),
+                                                           endpoint_id=endpoint)
+                asserts.assert_equal(result, Status.Success, "Error when trying to write ImageFlipHorizontal")
+                logger.info(f"Tx'd ImageFlipHorizontal: {not imageFlipHorizontal}")
+
+                self.step(40)
+                imageFlipHorizontalNew = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.ImageFlipHorizontal)
+                logger.info(f"Rx'd ImageFlipHorizontal: {imageFlipHorizontalNew}")
+                asserts.assert_equal(imageFlipHorizontalNew, not imageFlipHorizontal, "Value does not match what was written for ImageFlipHorizontal in step 39")
+            else:
+                self.skip_step(38)
+                self.skip_step(39)
+                self.skip_step(40)
+
+            if await self.attribute_guard(endpoint=endpoint, attribute=attr.ImageFlipVertical):
+                self.step(41)
+                imageFlipVertical = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.ImageFlipVertical)
+                logger.info(f"Rx'd ImageFlipVertical: {imageFlipVertical}")
+
+                self.step(42)
+                result = await self.write_single_attribute(attr.ImageFlipVertical(not imageFlipVertical),
+                                                           endpoint_id=endpoint)
+                asserts.assert_equal(result, Status.Success, "Error when trying to write ImageFlipVertical")
+                logger.info(f"Tx'd ImageFlipVertical: {not imageFlipVertical}")
+
+                self.step(43)
+                imageFlipVerticalNew = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.ImageFlipVertical)
+                logger.info(f"Rx'd ImageFlipVertical: {imageFlipVerticalNew}")
+                asserts.assert_equal(imageFlipVerticalNew, not imageFlipVertical, "Value does not match what was written for ImageFlipvertical in step 42")
+            else:
+                self.skip_step(41)
+                self.skip_step(42)
+                self.skip_step(43)
+        else:
+            self.skip_step(35)
+            self.skip_step(36)
+            self.skip_step(37)
+            self.skip_step(38)
+            self.skip_step(39)
+            self.skip_step(40)
+            self.skip_step(41)
+            self.skip_step(42)
+            self.skip_step(43)
+
 
         if self.vdoSupported and self.localStorageSupported:
-            self.step(23)
+            self.step(44)
             localVideoRecordingEnabled = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=attr.LocalVideoRecordingEnabled
             )
             logger.info(f"Rx'd LocalVideoRecordingEnabled: {localVideoRecordingEnabled}")
 
-            self.step(24)
+            self.step(45)
             result = await self.write_single_attribute(attr.LocalVideoRecordingEnabled(not localVideoRecordingEnabled),
                                                        endpoint_id=endpoint)
             asserts.assert_equal(result, Status.Success, "Error when trying to write LocalVideoRecordingEnabled")
             logger.info(f"Tx'd LocalVideoRecordingEnabled: {not localVideoRecordingEnabled}")
 
-            self.step(25)
+            self.step(46)
             localVideoRecordingEnabledNew = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=attr.LocalVideoRecordingEnabled
             )
             logger.info(f"Rx'd LocalVideoRecordingEnabled: {localVideoRecordingEnabledNew}")
             asserts.assert_equal(localVideoRecordingEnabledNew, not localVideoRecordingEnabled,
-                                 "Value does not match what was written in step 24")
+                                 "Value does not match what was written in step 45")
         else:
-            self.skip_step(23)
-            self.skip_step(24)
-            self.skip_step(25)
+            self.skip_step(44)
+            self.skip_step(45)
+            self.skip_step(46)
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_AVSM_2_12.py
+++ b/src/python_testing/TC_AVSM_2_12.py
@@ -36,7 +36,6 @@
 # === END CI TEST ARGUMENTS ===
 
 import logging
-
 import random
 
 from mobly import asserts

--- a/src/python_testing/TC_AVSM_2_12.py
+++ b/src/python_testing/TC_AVSM_2_12.py
@@ -263,7 +263,7 @@ class TC_AVSM_2_12(MatterBaseTest):
                 logger.info(f"Rx'd NightVisionIllum: {nightVisionIllum}")
 
                 self.step(15)
-                nightVisionIllumToWrite = (nightVision + 1) % 3
+                nightVisionIllumToWrite = (nightVisionIllum + 1) % 3
                 result = await self.write_single_attribute(attr.NightVisionIllum(nightVisionIllumToWrite),
                                                            endpoint_id=endpoint)
                 asserts.assert_equal(result, Status.Success, "Error when trying to write NightVisionIllum")
@@ -531,7 +531,7 @@ class TC_AVSM_2_12(MatterBaseTest):
                 imageFlipVerticalNew = await self.read_single_attribute_check_success(
                     endpoint=endpoint, cluster=cluster, attribute=attr.ImageFlipVertical)
                 logger.info(f"Rx'd ImageFlipVertical: {imageFlipVerticalNew}")
-                asserts.assert_equal(imageFlipVerticalNew, not imageFlipVertical, "Value does not match what was written for ImageFlipvertical in step 42")
+                asserts.assert_equal(imageFlipVerticalNew, not imageFlipVertical, "Value does not match what was written for ImageFlipVertical in step 42")
             else:
                 self.skip_step(41)
                 self.skip_step(42)

--- a/src/python_testing/TC_AVSM_2_12.py
+++ b/src/python_testing/TC_AVSM_2_12.py
@@ -108,12 +108,14 @@ class TC_AVSM_2_12(MatterBaseTest):
                      "Verify that the DUT response is in the range MicrophoneMin to MicrophoneMax. Store value as aMicrophoneVolumeLevel"),
             TestStep(30, "TH writes MicrophoneVolumeLevel attribute with a new value of aMicrophoneVolumeLevel.",
                      "DUT responds with a SUCCESS status code."),
-            TestStep(31, "TH reads MicrophoneVolumeLevel attribute.", "Verify that the value is the same as was written in Step 30."),
+            TestStep(31, "TH reads MicrophoneVolumeLevel attribute.",
+                     "Verify that the value is the same as was written in Step 30."),
             TestStep(32, "TH reads MicrophoneAGCEnabled attribute.",
                      "Verify that the DUT response contains a bool value. Store value as aMicrophoneAGCEnabled"),
             TestStep(33, "TH writes MicrophoneAGCEnabled attribute with value set to !aMicrophoneAGCEnabled.",
                      "DUT responds with a SUCCESS status code."),
-            TestStep(34, "TH reads MicrophoneAGCEnabled attribute.", "Verify that the value is the same as was written in Step 33."),
+            TestStep(34, "TH reads MicrophoneAGCEnabled attribute.",
+                     "Verify that the value is the same as was written in Step 33."),
             TestStep(35, "TH reads ImageRotation attribute.",
                      "Verify that the DUT response is not greater than 359. Store value as aImageRotation"),
             TestStep(36, "TH writes ImageRotation attribute with a new value of aImageRotation.",
@@ -273,7 +275,8 @@ class TC_AVSM_2_12(MatterBaseTest):
                 nightVisionIllumNew = await self.read_single_attribute_check_success(
                     endpoint=endpoint, cluster=cluster, attribute=attr.NightVisionIllum)
                 logger.info(f"Rx'd NightVisionIllum: {nightVisionIllumNew}")
-                asserts.assert_equal(nightVisionIllumNew, nightVisionIllumToWrite, "Value does not match what was written for NightVisionIllum in step 15")
+                asserts.assert_equal(nightVisionIllumNew, nightVisionIllumToWrite,
+                                     "Value does not match what was written for NightVisionIllum in step 15")
             else:
                 self.skip_step(14)
                 self.skip_step(15)
@@ -345,7 +348,8 @@ class TC_AVSM_2_12(MatterBaseTest):
                 speakerVolumeLevel = await self.read_single_attribute_check_success(
                     endpoint=endpoint, cluster=cluster, attribute=attr.SpeakerVolumeLevel)
                 logger.info(f"Rx'd SpeakerVolumeLevel: {speakerVolumeLevel}")
-                matter_asserts.assert_int_in_range(speakerVolumeLevel, speakerMinLevel, speakerMaxLevel, "Speaker Volume not between SpeakerMin and SpeakerMax")
+                matter_asserts.assert_int_in_range(speakerVolumeLevel, speakerMinLevel, speakerMaxLevel,
+                                                   "Speaker Volume not between SpeakerMin and SpeakerMax")
 
                 self.step(24)
                 newSpeakerVolume = random.randint(speakerMinLevel, speakerMaxLevel)
@@ -353,7 +357,7 @@ class TC_AVSM_2_12(MatterBaseTest):
                     newSpeakerVolume = random.randint(speakerMinLevel, speakerMaxLevel)
 
                 result = await self.write_single_attribute(attr.SpeakerVolumeLevel(newSpeakerVolume),
-                                                       endpoint_id=endpoint)
+                                                           endpoint_id=endpoint)
                 asserts.assert_equal(result, Status.Success, "Error when trying to write SpeakerVolumeLevel")
                 logger.info(f"Tx'd SpeakerVolumeLevel: {newSpeakerVolume}")
 
@@ -361,7 +365,8 @@ class TC_AVSM_2_12(MatterBaseTest):
                 speakerVolumeLevelNew = await self.read_single_attribute_check_success(
                     endpoint=endpoint, cluster=cluster, attribute=attr.SpeakerVolumeLevel)
                 logger.info(f"Rx'd SpeakerVolumeLevel: {speakerVolumeLevelNew}")
-                asserts.assert_equal(speakerVolumeLevelNew, newSpeakerVolume, "Value does not match what was written for SpeakerVolumeLevel in step 24")
+                asserts.assert_equal(speakerVolumeLevelNew, newSpeakerVolume,
+                                     "Value does not match what was written for SpeakerVolumeLevel in step 24")
             else:
                 self.skip_step(23)
                 self.skip_step(24)
@@ -408,7 +413,8 @@ class TC_AVSM_2_12(MatterBaseTest):
                 micVolumeLevel = await self.read_single_attribute_check_success(
                     endpoint=endpoint, cluster=cluster, attribute=attr.MicrophoneVolumeLevel)
                 logger.info(f"Rx'd MicrophoneVolumeLevel: {micVolumeLevel}")
-                matter_asserts.assert_int_in_range(micVolumeLevel, micMinLevel, micMaxLevel, "Microphone Volume not between MicMin and MicMax")
+                matter_asserts.assert_int_in_range(micVolumeLevel, micMinLevel, micMaxLevel,
+                                                   "Microphone Volume not between MicMin and MicMax")
 
                 self.step(30)
                 newMicVolume = random.randint(micMinLevel, micMaxLevel)
@@ -416,7 +422,7 @@ class TC_AVSM_2_12(MatterBaseTest):
                     newMicVolume = random.randint(micMinLevel, micMaxLevel)
 
                 result = await self.write_single_attribute(attr.MicrophoneVolumeLevel(newMicVolume),
-                                                       endpoint_id=endpoint)
+                                                           endpoint_id=endpoint)
                 asserts.assert_equal(result, Status.Success, "Error when trying to write MicrophoneVolumeLevel")
                 logger.info(f"Tx'd MicrophoneVolumeLevel: {newMicVolume}")
 
@@ -424,7 +430,8 @@ class TC_AVSM_2_12(MatterBaseTest):
                 micVolumeLevelNew = await self.read_single_attribute_check_success(
                     endpoint=endpoint, cluster=cluster, attribute=attr.MicrophoneVolumeLevel)
                 logger.info(f"Rx'd MicrophoneVolumeLevel: {micVolumeLevelNew}")
-                asserts.assert_equal(micVolumeLevelNew, newMicVolume, "Value does not match what was written for MicrophoneVolumeLevel in step 30")
+                asserts.assert_equal(micVolumeLevelNew, newMicVolume,
+                                     "Value does not match what was written for MicrophoneVolumeLevel in step 30")
             else:
                 self.skip_step(29)
                 self.skip_step(30)
@@ -447,7 +454,8 @@ class TC_AVSM_2_12(MatterBaseTest):
                 micAGCEnabledNew = await self.read_single_attribute_check_success(
                     endpoint=endpoint, cluster=cluster, attribute=attr.MicrophoneAGCEnabled)
                 logger.info(f"Rx'd MicrophoneAGCEnabled: {micAGCEnabledNew}")
-                asserts.assert_equal(micAGCEnabledNew, not micAGCEnabled, "Value does not match what was written for MicrophoneAGCEnabled in step 33")
+                asserts.assert_equal(micAGCEnabledNew, not micAGCEnabled,
+                                     "Value does not match what was written for MicrophoneAGCEnabled in step 33")
             else:
                 self.skip_step(32)
                 self.skip_step(33)
@@ -485,13 +493,13 @@ class TC_AVSM_2_12(MatterBaseTest):
                 imageRotationNew = await self.read_single_attribute_check_success(
                     endpoint=endpoint, cluster=cluster, attribute=attr.ImageRotation)
                 logger.info(f"Rx'd ImageRotation: {imageRotationNew}")
-                asserts.assert_equal(imageRotationNew, newImageRotation, "Value does not match what was written for ImageRotation in step 36")                
+                asserts.assert_equal(imageRotationNew, newImageRotation,
+                                     "Value does not match what was written for ImageRotation in step 36")
 
             else:
                 self.skip_step(35)
                 self.skip_step(36)
                 self.skip_step(37)
-
 
             if await self.attribute_guard(endpoint=endpoint, attribute=attr.ImageFlipHorizontal):
                 self.step(38)
@@ -509,7 +517,8 @@ class TC_AVSM_2_12(MatterBaseTest):
                 imageFlipHorizontalNew = await self.read_single_attribute_check_success(
                     endpoint=endpoint, cluster=cluster, attribute=attr.ImageFlipHorizontal)
                 logger.info(f"Rx'd ImageFlipHorizontal: {imageFlipHorizontalNew}")
-                asserts.assert_equal(imageFlipHorizontalNew, not imageFlipHorizontal, "Value does not match what was written for ImageFlipHorizontal in step 39")
+                asserts.assert_equal(imageFlipHorizontalNew, not imageFlipHorizontal,
+                                     "Value does not match what was written for ImageFlipHorizontal in step 39")
             else:
                 self.skip_step(38)
                 self.skip_step(39)
@@ -531,7 +540,8 @@ class TC_AVSM_2_12(MatterBaseTest):
                 imageFlipVerticalNew = await self.read_single_attribute_check_success(
                     endpoint=endpoint, cluster=cluster, attribute=attr.ImageFlipVertical)
                 logger.info(f"Rx'd ImageFlipVertical: {imageFlipVerticalNew}")
-                asserts.assert_equal(imageFlipVerticalNew, not imageFlipVertical, "Value does not match what was written for ImageFlipVertical in step 42")
+                asserts.assert_equal(imageFlipVerticalNew, not imageFlipVertical,
+                                     "Value does not match what was written for ImageFlipVertical in step 42")
             else:
                 self.skip_step(41)
                 self.skip_step(42)
@@ -546,7 +556,6 @@ class TC_AVSM_2_12(MatterBaseTest):
             self.skip_step(41)
             self.skip_step(42)
             self.skip_step(43)
-
 
         if self.vdoSupported and self.localStorageSupported:
             self.step(44)

--- a/src/python_testing/TC_AVSM_2_5.py
+++ b/src/python_testing/TC_AVSM_2_5.py
@@ -100,31 +100,36 @@ class TC_AVSM_2_5(MatterBaseTest):
             ),
             TestStep(
                 10,
-                "TH sends the AudioStreamAllocate command with values from step 6 except with ChannelCount set to 16(outside of valid range)",
+                "TH sends the AudioStreamAllocate command with values from step 6 except with ChannelCount set to 0(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
             TestStep(
                 11,
-                "TH sends the AudioStreamAllocate command with values from step 6 except with BitDepth set to 48(outside of valid range)",
+                "TH sends the AudioStreamAllocate command with values from step 6 except with ChannelCount set to 16(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
             TestStep(
                 12,
-                "TH sends the AudioStreamAllocate command with values from step 6 except with Samplerate set to 0(outside of valid range)",
+                "TH sends the AudioStreamAllocate command with values from step 6 except with BitDepth set to 48(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
             TestStep(
                 13,
-                "TH sends the AudioStreamAllocate command with values from step 6 except with BitRate set to 0(outside of valid range)",
+                "TH sends the AudioStreamAllocate command with values from step 6 except with Samplerate set to 0(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
             TestStep(
                 14,
-                "TH sends the AudioStreamAllocate command with values from step 6 except with AudioCodec set to 10(outside of valid range)",
+                "TH sends the AudioStreamAllocate command with values from step 6 except with BitRate set to 0(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
             TestStep(
                 15,
+                "TH sends the AudioStreamAllocate command with values from step 6 except with AudioCodec set to 10(outside of valid range)",
+                "DUT responds with a CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                16,
                 "TH sends the AudioStreamAllocate command with values from step 6 except with SampleRate set to a value not in aMicrophoneCapabilities",
                 "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
             ),
@@ -254,6 +259,26 @@ class TC_AVSM_2_5(MatterBaseTest):
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 audioCodec=aMicrophoneCapabilities.supportedCodecs[0],
+                channelCount=0,
+                sampleRate=aMicrophoneCapabilities.supportedSampleRates[0],
+                bitRate=aBitRate,
+                bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to ChannelCount set to 0(outside of valid range)")
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                Status.ConstraintError,
+                "Unexpected status returned when expecting CONSTRAINT_ERROR due to ChannelCount set to 0(outside of valid range)",
+            )
+            pass
+
+        self.step(11)
+        try:
+            adoStreamAllocateCmd = commands.AudioStreamAllocate(
+                streamUsage=aStreamUsagePriorities[0],
+                audioCodec=aMicrophoneCapabilities.supportedCodecs[0],
                 channelCount=16,
                 sampleRate=aMicrophoneCapabilities.supportedSampleRates[0],
                 bitRate=aBitRate,
@@ -269,7 +294,7 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(11)
+        self.step(12)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
@@ -289,7 +314,7 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(12)
+        self.step(13)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
@@ -309,7 +334,7 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(13)
+        self.step(14)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
@@ -329,7 +354,7 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(14)
+        self.step(15)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
@@ -349,7 +374,7 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(15)
+        self.step(16)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],


### PR DESCRIPTION
#### Summary

QA Issue 5152 identified testing gaps in TCs AVSM 2.5 and 2.12.  This PR addresses these gaps by:
- adding a constraint check in AVSM 2.5
- including the complete set of writeable attributes in AVSM 2.12

#### Related issues

https://github.com/CHIP-Specifications/chip-test-plans/issues/5152

#### Testing

Via the Python Runner execute AVSM 2.5 and AVSM 2.12 as updated

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
