### PR TITLE
Update correct TLS end point ID in the response

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/tls-client-management-instance.h
+++ b/examples/all-clusters-app/all-clusters-common/include/tls-client-management-instance.h
@@ -62,6 +62,8 @@ public:
                                                                                  uint16_t endpointID) override;
 
     static inline TlsClientManagementCommandDelegate & GetInstance() { return instance; }
+
+    uint16_t GetEndpointId(Provisioned * provisioned);
 };
 
 } // namespace Clusters

--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -54,6 +54,41 @@ CHIP_ERROR TlsClientManagementCommandDelegate::GetProvisionedEndpointByIndex(End
     return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
 }
 
+uint16_t TlsClientManagementCommandDelegate::GetEndpointId(Provisioned * provisioned)
+{
+    uint16_t ret      = 0;
+    uint16_t totalIds = 0;
+    while (totalIds < UINT16_MAX)
+    {
+        bool idInUse = false;
+        for (const auto & item : mProvisioned)
+        {
+            if (item.payload.endpointID == mNextId)
+            {
+                idInUse = true;
+                totalIds++;
+                if (totalIds == UINT16_MAX)
+                {
+                    break;
+                }
+                mNextId++;
+                if (mNextId == 0)
+                {
+                    mNextId = 1;
+                }
+                break;
+            }
+        }
+        if (!idInUse)
+        {
+            break;
+        }
+    }
+    ret = (totalIds == UINT16_MAX) ? 0 : mNextId;
+
+    return ret;
+}
+
 ClusterStatusCode TlsClientManagementCommandDelegate::ProvisionEndpoint(
     EndpointId matterEndpoint, FabricIndex fabric,
     const TlsClientManagement::Commands::ProvisionEndpoint::DecodableType & provisionReq, uint16_t & endpointID)
@@ -94,7 +129,12 @@ ClusterStatusCode TlsClientManagementCommandDelegate::ProvisionEndpoint(
         provisioned           = &mProvisioned.emplace_back();
         auto & endpointStruct = provisioned->payload;
 
-        endpointStruct.endpointID = mNextId++;
+        uint16_t nextId = GetEndpointId(provisioned);
+        if (nextId == 0)
+        {
+            return ClusterStatusCode(Status::ResourceExhausted);
+        }
+        endpointStruct.endpointID = nextId;
         provisioned->fabric       = fabric;
         endpointID                = endpointStruct.endpointID;
     }

--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -96,11 +96,16 @@ ClusterStatusCode TlsClientManagementCommandDelegate::ProvisionEndpoint(
 
         endpointStruct.endpointID = mNextId++;
         provisioned->fabric       = fabric;
+        endpointID                = endpointStruct.endpointID;
     }
     // Updating existing value
     else if (provisioned == nullptr || provisioned->fabric != fabric)
     {
         return ClusterStatusCode(Status::NotFound);
+    }
+    else
+    {
+        endpointID = provisionReq.endpointID.Value();
     }
 
     auto & endpointStruct = provisioned->payload;


### PR DESCRIPTION
#### Summary
TLS end point id is not updated in the response during provisioning. 
Because of this Controller always getting TLS end point id as 0 and PushAV TLS related TCs are failing.
Fixed the TLS end point assignment.

#### Testing
```
# Build and run camera application
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debu/chip-camera-app

# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run Push AV Integration TC 
python3 src/python_testing/TC_PAVSTI_1_2.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1
```