### PR TITLE
[ICD] Update ICDM 3.1 Cert test to match test plan to address timeout issues

### DIFF
--- a/src/python_testing/TC_ICDM_3_1.py
+++ b/src/python_testing/TC_ICDM_3_1.py
@@ -163,7 +163,6 @@ class TC_ICDM_3_1(MatterBaseTest):
                     await self._send_single_icdm_command(commands.UnregisterClient(checkInNodeID=client.checkInNodeID))
                 except InteractionModelError as e:
                     asserts.assert_fail(f"Unexpected error returned : {e}")
-                    pass
 
             # Step 4: Read ClientsSupportedPerFabric
             self.step(4)
@@ -183,7 +182,6 @@ class TC_ICDM_3_1(MatterBaseTest):
                     clientType=clientTypeEnum.kEphemeral))
             except InteractionModelError as e:
                 asserts.assert_fail(f"Unexpected error returned : {e}")
-                pass
 
             # Validate response contains the ICDCounter
             asserts.assert_greater_equal(response.ICDCounter, icdCounter,
@@ -226,7 +224,6 @@ class TC_ICDM_3_1(MatterBaseTest):
                             clientType=client["clientType"]))
                     except InteractionModelError as e:
                         asserts.assert_fail(f"Unexpected error returned : {e}")
-                        pass
 
                     # Validate response contains the ICDCounter
                     asserts.assert_greater_equal(response.ICDCounter, icdCounter,
@@ -270,7 +267,6 @@ class TC_ICDM_3_1(MatterBaseTest):
                 await self._send_single_icdm_command(commands.UnregisterClient(checkInNodeID=kStep2CheckInNodeId))
             except InteractionModelError as e:
                 asserts.assert_fail(f"Unexpected error returned : {e}")
-                pass
 
             # Step 13: Read RegisteredClients, verify Step 6 client is not present
             self.step(13)
@@ -286,7 +282,6 @@ class TC_ICDM_3_1(MatterBaseTest):
                     await self._send_single_icdm_command(commands.UnregisterClient(checkInNodeID=client["checkInNodeID"]))
                 except InteractionModelError as e:
                     asserts.assert_fail(f"Unexpected error returned : {e}")
-                    pass
 
                 registeredClients = await self._read_icdm_attribute_expect_success(attributes.RegisteredClients)
                 for remainingClient in registeredClients:
@@ -313,7 +308,6 @@ class TC_ICDM_3_1(MatterBaseTest):
                     await self._send_single_icdm_command(commands.UnregisterClient(checkInNodeID=client.checkInNodeID))
             except InteractionModelError as e:
                 asserts.assert_fail(f"Unexpected error returned : {e}")
-                pass
             finally:
                 self.send_test_event_triggers(eventTrigger=ICDTestEventTriggerOperations.kRemoveActiveModeReq)
 

--- a/src/python_testing/TC_ICDM_3_1.py
+++ b/src/python_testing/TC_ICDM_3_1.py
@@ -143,7 +143,6 @@ class TC_ICDM_3_1(MatterBaseTest):
             self.step(1)
             featureMap = await self._read_icdm_attribute_expect_success(attributes.FeatureMap)
             if featureMap & features.kCheckInProtocolSupport == 0:
-                asserts.assert_fail("WHAT THE FUCK")
                 self.mark_all_remaining_steps_skipped("2a")
                 return
 

--- a/src/python_testing/TC_ICDM_3_1.py
+++ b/src/python_testing/TC_ICDM_3_1.py
@@ -44,10 +44,9 @@
 
 import logging
 import os
-
-from mobly import asserts
 from enum import IntEnum
 
+from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status

--- a/src/python_testing/TC_ICDM_3_1.py
+++ b/src/python_testing/TC_ICDM_3_1.py
@@ -27,7 +27,7 @@
 #       --discriminator 1234
 #       --passcode 20202021
 #       --KVS kvs1
-#       --trace-to json:${TRACE_APP}.json
+#       --trace-to json:${TRACE_TEST_JSON}-app.json
 #       --enable-key 000102030405060708090a0b0c0d0e0f
 #     script-args: >
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_ICDM_3_1.py
+++ b/src/python_testing/TC_ICDM_3_1.py
@@ -23,12 +23,18 @@
 # test-runner-runs:
 #   run1:
 #     app: ${LIT_ICD_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-args: >
+#       --discriminator 1234
+#       --passcode 20202021
+#       --KVS kvs1
+#       --trace-to json:${TRACE_APP}.json
+#       --enable-key 000102030405060708090a0b0c0d0e0f
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network
 #       --discriminator 1234
 #       --passcode 20202021
+#       --hex-arg enableKey:000102030405060708090a0b0c0d0e0f
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
@@ -40,6 +46,8 @@ import logging
 import os
 
 from mobly import asserts
+from enum import IntEnum
+
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
@@ -53,6 +61,15 @@ cluster = Clusters.Objects.IcdManagement
 commands = cluster.Commands
 monitoredRegistration = cluster.Structs.MonitoringRegistrationStruct
 clientTypeEnum = cluster.Enums.ClientTypeEnum
+features = cluster.Bitmaps.Feature
+
+
+class ICDTestEventTriggerOperations(IntEnum):
+    kAddActiveModeReq = 0x0046000000000001
+    kRemoveActiveModeReq = 0x0046000000000002
+    kInvalidateHalfCounterValues = 0x0046000000000003
+    kInvalidateAllCounterValues = 0x0046000000000004
+    kForceMaximumCheckInBackOffState = 0x0046000000000005
 
 
 # Step 2 Registration entry
@@ -81,22 +98,24 @@ class TC_ICDM_3_1(MatterBaseTest):
 
     def steps_TC_ICDM_3_1(self) -> list[TestStep]:
         steps = [
-            TestStep(0, "Commissioning, already done",
-                     is_commissioning=True),
-            TestStep("1a", "TH reads from the DUT the RegisteredClients attribute. RegisteredClients is empty."),
-            TestStep("1b", "TH reads from the DUT the ClientsSupportedPerFabric attribute."),
-            TestStep("1c", "TH reads from the DUT the ICDCounter attribute."),
-            TestStep(2, "TH sends RegisterClient command."),
-            TestStep(3, "TH reads from the DUT the RegisteredClients attribute."),
-            TestStep(4, "If len(RegisteredClients) is less than ClientsSupportedPerFabric, TH repeats RegisterClient command with different CheckInNodeID(s) until the number of entries in RegisteredClients equals ClientsSupportedPerFabric."),
-            TestStep(5, "TH reads from the DUT the RegisteredClients attribute."),
-            TestStep(6, "TH sends RegisterClient command with a different CheckInNodeID."),
-            TestStep(7, "TTH sends UnregisterClient command with the CheckInNodeID from Step 6."),
-            TestStep(8, "TH sends UnregisterClient command with the CheckInNodeID from Step 2."),
+            TestStep(0, "Commissioning, already done", is_commissioning=True),
+            TestStep(1, "TH reads from the DUT the FeatureMap. If the CIP feature is not supported on the cluster, skip all remaining steps"),
+            TestStep("2a", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster."),
+            TestStep("2b", "TH sends TestEventTrigger command to General Diagnostics Cluster on Endpoint 0 with EnableKey field set to PIXIT.ICDM.S.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to PIXIT.ICDM.S.TEST_EVENT_TRIGGER for the Active Mode requirement."),
+            TestStep(3, "TH reads from the DUT the RegisteredClients attribute. If not empty, TH sends command UnregisterClient to clear all clients in RegisteredClients."),
+            TestStep(4, "TH reads from the DUT the ClientsSupportedPerFabric attribute."),
+            TestStep(5, "TH reads from the DUT the ICDCounter attribute."),
+            TestStep(6, "TH sends RegisterClient command. - CheckInNodeID: registering client’s node ID - MonitoredSubject: MonitoredSubID - Key: shared secret between the client and the ICD - ClientType : Ephemeral(1)."),
+            TestStep(7, "TH reads from the DUT the RegisteredClients attribute."),
+            TestStep(8, "If len(RegisteredClients) is less than ClientsSupportedPerFabric, TH repeats RegisterClient command with different CheckInNodeID(s) and the Permanent(0) ClientType until the number of entries in RegisteredClients equals ClientsSupportedPerFabric."),
             TestStep(9, "TH reads from the DUT the RegisteredClients attribute."),
-            TestStep(10, "Repeat Step 8-9 with the rest of CheckInNodeIDs from the list of RegisteredClients from Step 4, if any."),
-            TestStep(11, "TH reads from the DUT the RegisteredClients attribute."),
-            TestStep(12, "TH sends UnregisterClient command with the CheckInNodeID from Step 2."),
+            TestStep(10, "TH sends RegisterClient command with a different CheckInNodeID."),
+            TestStep(11, "TH sends UnregisterClient command with the CheckInNodeID from Step 10."),
+            TestStep(12, "TH sends UnregisterClient command with the CheckInNodeID from Step 6."),
+            TestStep(13, "TH reads from the DUT the RegisteredClients attribute."),
+            TestStep(14, "Repeat Step 12-13 with the rest of CheckInNodeIDs from the list of RegisteredClients from Step 8, if any."),
+            TestStep(15, "TH reads from the DUT the RegisteredClients attribute."),
+            TestStep(16, "TH sends UnregisterClient command with the CheckInNodeID from Step 6."),
         ]
         return steps
 
@@ -104,7 +123,6 @@ class TC_ICDM_3_1(MatterBaseTest):
         """ This function returns a list of PICS for this test case that must be True for the test to be run"""
         pics = [
             "ICDM.S",
-            "ICDM.S.F00"
         ]
         return pics
 
@@ -114,48 +132,65 @@ class TC_ICDM_3_1(MatterBaseTest):
 
     @async_test_body
     async def test_TC_ICDM_3_1(self):
-
         cluster = Clusters.Objects.IcdManagement
         attributes = cluster.Attributes
 
-        # Pre-Condition: Commissioning
+        # Step 0: Commissioning (already done)
         self.step(0)
 
-        # Empty RegisteredClients attribute for all registrations
-        self.step("1a")
-        registeredClients = await self._read_icdm_attribute_expect_success(
-            attributes.RegisteredClients)
+        # Step 1: FeatureMap check (skip if not supported)
+        self.step(1)
+        featureMap = await self._read_icdm_attribute_expect_success(attributes.FeatureMap)
+        if featureMap & features.kCheckInProtocolSupport > 0:
+            self.mark_all_remaining_steps_skipped("2a")
+            return
 
+        # Step 2a: Read TestEventTriggersEnabled from General Diagnostics Cluster
+        self.step("2a")
+        self.check_test_event_triggers_enabled()
+
+        # Step 2b: Send TestEventTrigger command to General Diagnostics Cluster
+        self.step("2b")
+        self.send_test_event_triggers(eventTrigger=ICDTestEventTriggerOperations.kAddActiveModeReq)
+
+        # Step 3: Read RegisteredClients, clear if not empty
+        self.step(3)
+        registeredClients = await self._read_icdm_attribute_expect_success(attributes.RegisteredClients)
         for client in registeredClients:
             try:
                 await self._send_single_icdm_command(commands.UnregisterClient(checkInNodeID=client.checkInNodeID))
             except InteractionModelError as e:
-                asserts.assert_equal(
-                    e.status, Status.Success, "Unexpected error returned")
+                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
                 pass
 
-        self.step("1b")
-        clientsSupportedPerFabric = await self._read_icdm_attribute_expect_success(
-            attributes.ClientsSupportedPerFabric)
+        # Step 4: Read ClientsSupportedPerFabric
+        self.step(4)
+        clientsSupportedPerFabric = await self._read_icdm_attribute_expect_success(attributes.ClientsSupportedPerFabric)
 
-        self.step("1c")
+        # Step 5: Read ICDCounter
+        self.step(5)
         icdCounter = await self._read_icdm_attribute_expect_success(attributes.ICDCounter)
 
-        self.step(2)
+        # Step 6: RegisterClient (Ephemeral)
+        self.step(6)
         try:
-            response = await self._send_single_icdm_command(commands.RegisterClient(checkInNodeID=kStep2CheckInNodeId, monitoredSubject=kStep2MonitoredSubjectStep2, key=kStep2Key, clientType=clientTypeEnum.kEphemeral))
+            response = await self._send_single_icdm_command(commands.RegisterClient(
+                checkInNodeID=kStep2CheckInNodeId,
+                monitoredSubject=kStep2MonitoredSubjectStep2,
+                key=kStep2Key,
+                clientType=clientTypeEnum.kEphemeral))
         except InteractionModelError as e:
-            asserts.assert_equal(
-                e.status, Status.Success, "Unexpected error returned")
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
         # Validate response contains the ICDCounter
         asserts.assert_greater_equal(response.ICDCounter, icdCounter,
                                      "The ICDCounter in the response does not match the read ICDCounter.")
 
-        self.step(3)
-        registeredClients = await self._read_icdm_attribute_expect_success(
-            attributes.RegisteredClients)
+        # Step 7: Read RegisteredClients, verify entry
+        self.step(7)
+        registeredClients = await self._read_icdm_attribute_expect_success(attributes.RegisteredClients)
+
         # Validate list size
         asserts.assert_equal(len(registeredClients), 1,
                              "The expected length of RegisteredClients is 1. List has the wrong size.")
@@ -168,8 +203,9 @@ class TC_ICDM_3_1(MatterBaseTest):
         asserts.assert_equal(
             registeredClients[0].clientType, clientTypeEnum.kEphemeral, "The read attribute does not match the registered value.")
 
-        self.step(4)
-        if (len(registeredClients) < clientsSupportedPerFabric):
+        # Step 8: Fill RegisteredClients to ClientsSupportedPerFabric with Permanent clients
+        self.step(8)
+        if len(registeredClients) < clientsSupportedPerFabric:
             newClients = []
             # Generate new clients data
             for i in range(clientsSupportedPerFabric - len(registeredClients)):
@@ -179,22 +215,23 @@ class TC_ICDM_3_1(MatterBaseTest):
                     "key": os.urandom(16),
                     "clientType": clientTypeEnum.kPermanent
                 })
-
             for client in newClients:
                 try:
-                    response = await self._send_single_icdm_command(commands.RegisterClient(checkInNodeID=client["checkInNodeID"], monitoredSubject=client["monitoredSubject"], key=client["key"], clientType=client["clientType"]))
+                    response = await self._send_single_icdm_command(commands.RegisterClient(
+                        checkInNodeID=client["checkInNodeID"],
+                        monitoredSubject=client["monitoredSubject"],
+                        key=client["key"],
+                        clientType=client["clientType"]))
                 except InteractionModelError as e:
-                    asserts.assert_equal(
-                        e.status, Status.Success, "Unexpected error returned")
+                    asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
                     pass
-
                 # Validate response contains the ICDCounter
                 asserts.assert_greater_equal(response.ICDCounter, icdCounter,
                                              "The ICDCounter in the response does not match the read ICDCounter.")
 
-        self.step(5)
-        registeredClients = await self._read_icdm_attribute_expect_success(
-            attributes.RegisteredClients)
+        # Step 9: Read RegisteredClients
+        self.step(9)
+        registeredClients = await self._read_icdm_attribute_expect_success(attributes.RegisteredClients)
 
         # Validate list size
         asserts.assert_equal(len(registeredClients[1:]), len(newClients),
@@ -208,65 +245,65 @@ class TC_ICDM_3_1(MatterBaseTest):
             asserts.assert_equal(
                 client.clientType, expectedClient["clientType"], "The read attribute does not match the registered value.")
 
-        self.step(6)
+        # Step 10: RegisterClient with a different CheckInNodeID (should fail RESOURCE_EXHAUSTED)
+        self.step(10)
         try:
-            response = await self._send_single_icdm_command(commands.RegisterClient(checkInNodeID=0xFFFF, monitoredSubject=0xFFFF, key=os.urandom(16), clientType=clientTypeEnum.kPermanent))
+            await self._send_single_icdm_command(commands.RegisterClient(
+                checkInNodeID=0xFFFF,
+                monitoredSubject=0xFFFF,
+                key=os.urandom(16),
+                clientType=clientTypeEnum.kPermanent))
         except InteractionModelError as e:
-            asserts.assert_equal(
-                e.status, Status.ResourceExhausted, "Unexpected error returned")
+            asserts.assert_equal(e.status, Status.ResourceExhausted, "Unexpected error returned")
             pass
 
-        self.step(7)
+        # Step 11: UnregisterClient with CheckInNodeID from Step 10 (should fail NOT_FOUND)
+        self.step(11)
         try:
             await self._send_single_icdm_command(commands.UnregisterClient(checkInNodeID=0xFFFF))
         except InteractionModelError as e:
-            asserts.assert_equal(
-                e.status, Status.NotFound, "Unexpected error returned")
+            asserts.assert_equal(e.status, Status.NotFound, "Unexpected error returned")
             pass
 
-        self.step(8)
-        try:
-            await self._send_single_icdm_command(commands.UnregisterClient(checkInNodeID=kStep2CheckInNodeId))
-        except InteractionModelError as e:
-            asserts.assert_equal(
-                e.status, Status.Success, "Unexpected error returned")
-            pass
-
-        self.step(9)
-        registeredClients = await self._read_icdm_attribute_expect_success(
-            attributes.RegisteredClients)
-
-        for client in registeredClients:
-            asserts.assert_not_equal(client.checkInNodeID, kStep2CheckInNodeId,
-                                     "CheckInNodeID was unregistered. It should not be present in the attribute list.")
-
-        self.step(10)
-        for client in newClients:
-            try:
-                await self._send_single_icdm_command(commands.UnregisterClient(checkInNodeID=client["checkInNodeID"]))
-            except InteractionModelError as e:
-                asserts.assert_equal(
-                    e.status, Status.Success, "Unexpected error returned")
-                pass
-
-            registeredClients = await self._read_icdm_attribute_expect_success(attributes.RegisteredClients)
-            for remainingClient in registeredClients:
-                asserts.assert_not_equal(remainingClient.checkInNodeID, client["checkInNodeID"],
-                                         "CheckInNodeID was unregistered. It should not be present in the attribute list.")
-
-        self.step(11)
-        registeredClients = await self._read_icdm_attribute_expect_success(
-            attributes.RegisteredClients)
-
-        asserts.assert_true(
-            not registeredClients, "This list should empty. An element did not get deleted.")
-
+        # Step 12: UnregisterClient with CheckInNodeID from Step 6
         self.step(12)
         try:
             await self._send_single_icdm_command(commands.UnregisterClient(checkInNodeID=kStep2CheckInNodeId))
         except InteractionModelError as e:
-            asserts.assert_equal(
-                e.status, Status.NotFound, "Unexpected error returned")
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
+
+        # Step 13: Read RegisteredClients, verify Step 6 client is not present
+        self.step(13)
+        registeredClients = await self._read_icdm_attribute_expect_success(attributes.RegisteredClients)
+        for client in registeredClients:
+            asserts.assert_not_equal(client.checkInNodeID, kStep2CheckInNodeId,
+                                     "CheckInNodeID was unregistered. It should not be present in the attribute list.")
+
+        # Step 14: Repeat Step 12-13 for remaining clients from Step 8
+        self.step(14)
+        for client in newClients:
+            try:
+                await self._send_single_icdm_command(commands.UnregisterClient(checkInNodeID=client["checkInNodeID"]))
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+                pass
+            registeredClients = await self._read_icdm_attribute_expect_success(attributes.RegisteredClients)
+            for remainingClient in registeredClients:
+                asserts.assert_not_equal(
+                    remainingClient.checkInNodeID, client["checkInNodeID"], "CheckInNodeID was unregistered. It should not be present in the attribute list.")
+
+        # Step 15: Read RegisteredClients, should be empty
+        self.step(15)
+        registeredClients = await self._read_icdm_attribute_expect_success(attributes.RegisteredClients)
+        asserts.assert_true(not registeredClients, "This list should be empty. An element did not get deleted.")
+
+        # Step 16: UnregisterClient with CheckInNodeID from Step 6 (should fail NOT_FOUND)
+        self.step(16)
+        try:
+            await self._send_single_icdm_command(commands.UnregisterClient(checkInNodeID=kStep2CheckInNodeId))
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.NotFound, "Unexpected error returned")
             pass
 
 


### PR DESCRIPTION
#### Summary

PR updates ICDM 3.1 Cert test to match the test plan update.
Related PR: https://github.com/CHIP-Specifications/chip-test-plans/pull/5511

#### Related issues

ICDM 3.1 validates the register and unregister functionnality associated with the Check-In Protocol feature. 
The issue was the test was not written in a way to take into account that products that support the Check-In Protocol feature are usually LIT devices. This means that once they receive a registration, they transitions to long sleeps which can cause the cert to fail if the timings are correct.

Note to reviewers: It looks like a lot of changes due to the indent change for the post condition. The PR is quite small in practice.

#### Testing

- CI
- Ran the updated script against a LIT ICD Light Switch to make sure the test can pass for devices that can go to sleep.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
