### PR TITLE
TC-IDM-14.1: Add (root-node-restricted clusters)

### DIFF
--- a/src/python_testing/TC_DeviceConformance.py
+++ b/src/python_testing/TC_DeviceConformance.py
@@ -491,14 +491,15 @@ class DeviceConformanceTests(BasicCompositionTests):
 
     def check_root_node_restricted_clusters(self) -> list[ProblemNotice]:
         # TODO: Are these marked in the spec? Time sync and ACL have specific notes, but can be determine this from the data model files?
-        root_node_restricted_clusters = [Clusters.AccessControl, Clusters.TimeSynchronization,
-                                         Clusters.TlsCertificateManagement, Clusters.TlsClientManagement]
+        root_node_restricted_clusters = {Clusters.AccessControl, Clusters.TimeSynchronization,
+                                         Clusters.TlsCertificateManagement, Clusters.TlsClientManagement}
         problems = []
-        for cluster in root_node_restricted_clusters:
-            for endpoint_id, endpoint in self.endpoints.items():
-                if endpoint_id == 0:
-                    continue
-                if cluster in endpoint.keys():
+        for endpoint_id, endpoint in self.endpoints.items():
+            if endpoint_id == 0:
+                continue
+
+            for cluster in endpoint.keys():
+                if cluster in root_node_restricted_clusters:
                     problems.append(ProblemNotice("TC-IDM-14.1", location=ClusterPathLocation(endpoint_id=endpoint_id, cluster_id=cluster.id),
                                                   severity=ProblemSeverity.ERROR, problem=f"Root-node-restricted cluster {cluster} appears on non-root-node endpoint"))
         return problems

--- a/src/python_testing/TC_DeviceConformance.py
+++ b/src/python_testing/TC_DeviceConformance.py
@@ -30,7 +30,7 @@
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#       --tests test_TC_IDM_10_2 test_TC_IDM_10_6 test_TC_DESC_2_3
+#       --tests test_TC_IDM_10_2 test_TC_IDM_10_6 test_TC_DESC_2_3 test_TC_IDM_14_1
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -489,6 +489,20 @@ class DeviceConformanceTests(BasicCompositionTests):
                             problem=f"Multiple non-superset application device types found on EP {endpoint_num} ({application_device_type_ids})"))
         return problems
 
+    def check_root_node_restricted_clusters(self) -> list[ProblemNotice]:
+        # TODO: Are these marked in the spec? Time sync and ACL have specific notes, but can be determine this from the data model files?
+        root_node_restricted_clusters = [Clusters.AccessControl, Clusters.TimeSynchronization,
+                                         Clusters.TlsCertificateManagement, Clusters.TlsClientManagement]
+        problems = []
+        for cluster in root_node_restricted_clusters:
+            for endpoint_id, endpoint in self.endpoints.items():
+                if endpoint_id == 0:
+                    continue
+                if cluster in endpoint.keys():
+                    problems.append(ProblemNotice("TC-IDM-14.1", location=ClusterPathLocation(endpoint_id=endpoint_id, cluster_id=cluster.id),
+                                                  severity=ProblemSeverity.ERROR, problem=f"Root-node-restricted cluster {cluster} appears on non-root-node endpoint"))
+        return problems
+
 
 class TC_DeviceConformance(MatterBaseTest, DeviceConformanceTests):
     @async_test_body
@@ -526,6 +540,25 @@ class TC_DeviceConformance(MatterBaseTest, DeviceConformanceTests):
         self.problems.extend(problems)
         if not success:
             self.fail_current_test("Problems with Device type revisions on one or more endpoints")
+
+    def steps_TC_IDM_14_1(self):
+        return [TestStep(0, "TH performs a wildcard read of all attributes and endpoints on the device"),
+                TestStep(1, """ For each root-node-restricted cluster in the list, ensure the cluster does not appear on any endpoint that is not the root node.
+                                List of root-node-restricted clusters:
+
+                                * ACL
+                                * Time Synchronization
+                                * TLS Certificate Management
+                                * TLS Client Management
+                         """, "No root-node-restricted clusters appear on non-root endpoints")]
+
+    def test_TC_IDM_14_1(self):
+        self.step(0)  # wildcard read - done in setup
+        self.step(1)
+        problems = self.check_root_node_restricted_clusters()
+        if problems:
+            self.problems.extend(problems)
+            self.fail_current_test("One or more root-node-restricted clusters appear on non-root-node endpoints")
 
     def steps_TC_DESC_2_3(self):
         return [TestStep(0, "TH performs a wildcard read of all attributes on all endpoints on the device"),

--- a/src/python_testing/TestConformanceTest.py
+++ b/src/python_testing/TestConformanceTest.py
@@ -397,7 +397,7 @@ class TestConformanceTest(MatterBaseTest, DeviceConformanceTests):
         for cluster in root_node_restricted_clusters:
             self.endpoints[0][cluster] = {}
         problems = self.check_root_node_restricted_clusters()
-        asserts.assert_equal(len(problems), 0, f"Unexpected problem with all clusters on EP0")
+        asserts.assert_equal(len(problems), 0, "Unexpected problem with all clusters on EP0")
 
         # Adding on ep 1 should cause errors
         self.endpoints[1] = {}
@@ -405,7 +405,7 @@ class TestConformanceTest(MatterBaseTest, DeviceConformanceTests):
             self.endpoints[1][cluster] = {}
         problems = self.check_root_node_restricted_clusters()
         asserts.assert_equal(len(problems), len(root_node_restricted_clusters),
-                             f"Did not see expected problems with all clusters on EP1")
+                             "Did not see expected problems with all clusters on EP1")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TestConformanceTest.py
+++ b/src/python_testing/TestConformanceTest.py
@@ -372,6 +372,41 @@ class TestConformanceTest(MatterBaseTest, DeviceConformanceTests):
         run_check_with_expected_failure(msg_suffix, expected_location, ProblemType.kMandatoryNotPresent)
         self.endpoints_tlv[0][cluster_id][accepted_cmd_id] = old_cmds
 
+    def test_root_node_restricted_clusters(self):
+        def check_cluster(cluster):
+            self.endpoints = {0: {cluster: {}}}
+            problems = self.check_root_node_restricted_clusters()
+            asserts.assert_equal(len(problems), 0, f"Unexpected problem with {cluster} on EP0")
+
+            self.endpoints[1] = {cluster: {}}
+            problems = self.check_root_node_restricted_clusters()
+            asserts.assert_equal(len(problems), 1, f"Did not see expected problem with {cluster} on EP1")
+
+            # random endpoint
+            self.endpoints[13] = {cluster: {}}
+            problems = self.check_root_node_restricted_clusters()
+            asserts.assert_equal(len(problems), 2, f"Did not see both endpoint problems listed with {cluster}")
+
+        root_node_restricted_clusters = [Clusters.AccessControl, Clusters.TimeSynchronization,
+                                         Clusters.TlsCertificateManagement, Clusters.TlsClientManagement]
+        for cluster in root_node_restricted_clusters:
+            check_cluster(cluster)
+
+        # check all together on EP0
+        self.endpoints = {0: {}}
+        for cluster in root_node_restricted_clusters:
+            self.endpoints[0][cluster] = {}
+        problems = self.check_root_node_restricted_clusters()
+        asserts.assert_equal(len(problems), 0, f"Unexpected problem with all clusters on EP0")
+
+        # Adding on ep 1 should cause errors
+        self.endpoints[1] = {}
+        for cluster in root_node_restricted_clusters:
+            self.endpoints[1][cluster] = {}
+        problems = self.check_root_node_restricted_clusters()
+        asserts.assert_equal(len(problems), len(root_node_restricted_clusters),
+                             f"Did not see expected problems with all clusters on EP1")
+
 
 if __name__ == "__main__":
     default_matter_test_main()


### PR DESCRIPTION
#### Summary

Adds a test to ensure that clusters that are restricted to the root node appear only on the root node.

#### Related issues

https://github.com/CHIP-Specifications/chip-test-plans/issues/5512
https://github.com/CHIP-Specifications/chip-test-plans/pull/5514

#### Testing
Added unit tests for the test failure conditions, test is running against the door lock on the CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
