### PR TITLE
[v1.4.2] ESP32: fix header path to fix the external platform builds (#40769)

### DIFF
--- a/src/platform/ESP32/ESP32SecureCertDataProvider.h
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
+#include "ESP32FactoryDataProvider.h"
 #include <lib/core/CHIPError.h>
 #include <lib/support/Span.h>
-#include <platform/ESP32/ESP32FactoryDataProvider.h>
 
 #include <esp_secure_cert_tlv_config.h>
 


### PR DESCRIPTION
* ESP32: fix header path to fix the external platform builds

* restyle

#### Summary
Cherry picking #40769 on v1.4.2-branch

#### Testing

- External platform builds are exercised in CI
- Also, manually re-built lighting-app with the app with external platform