### PR TITLE
Modify Audio pipeline to support both live stream and clip recording

### DIFF
--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -323,7 +323,7 @@ private:
                            uint16_t & outStreamID);
 
     GstElement * CreateVideoPipeline(const std::string & device, int width, int height, int framerate, CameraError & error);
-    GstElement * CreateAudioPipeline(const std::string & device, int channels, int sampleRate, CameraError & error);
+    GstElement * CreateAudioPipeline(const std::string & device, int channels, int sampleRate, int bitRate, CameraError & error);
     GstElement * CreateSnapshotPipeline(const std::string & device, int width, int height, int quality, int frameRate,
                                         const std::string & filename, CameraError & error);
     CameraError SetV4l2Control(uint32_t controlId, int value);

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -54,6 +54,13 @@ struct VideoAppSinkContext
     uint16_t videoStreamID;
 };
 
+// Context structure to pass both CameraDevice and audioStreamID to the callback
+struct AudioAppSinkContext
+{
+    CameraDevice * device;
+    uint16_t audioStreamID;
+};
+
 // Using Gstreamer video test source's ball animation pattern for the live streaming visual verification.
 // Refer https://gstreamer.freedesktop.org/documentation/videotestsrc/index.html?gi-language=c#GstVideoTestSrcPattern
 
@@ -98,6 +105,46 @@ void DestroyVideoAppSinkContext(gpointer user_data)
 {
     VideoAppSinkContext * context = static_cast<VideoAppSinkContext *>(user_data);
     delete context;
+}
+static GstFlowReturn OnNewAudioSampleFromAppSink(GstAppSink * appsink, gpointer user_data)
+{
+    auto * context     = static_cast<AudioAppSinkContext *>(user_data);
+    auto * self        = context->device;
+    auto audioStreamID = context->audioStreamID;
+
+    GstSample * sample = gst_app_sink_pull_sample(appsink);
+    if (!sample)
+        return GST_FLOW_ERROR;
+
+    GstBuffer * buffer = gst_sample_get_buffer(sample);
+    if (!buffer)
+    {
+        gst_sample_unref(sample);
+        return GST_FLOW_ERROR;
+    }
+
+    // opusenc sends codec headers at start; ignore them
+    if (GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_HEADER))
+    {
+        gst_sample_unref(sample);
+        return GST_FLOW_OK;
+    }
+
+    GstMapInfo map;
+    if (gst_buffer_map(buffer, &map, GST_MAP_READ))
+    {
+        // Send raw Opus frames to the media controller
+        self->GetMediaController().DistributeAudio(reinterpret_cast<const char *>(map.data), map.size, audioStreamID);
+        gst_buffer_unmap(buffer, &map);
+    }
+
+    gst_sample_unref(sample);
+    return GST_FLOW_OK;
+}
+
+static void DestroyAudioAppSinkContext(gpointer user_data)
+{
+    delete static_cast<AudioAppSinkContext *>(user_data);
 }
 
 } // namespace
@@ -499,32 +546,29 @@ GstElement * CameraDevice::CreateVideoPipeline(const std::string & device, int w
 // Helper function to create a GStreamer pipeline
 GstElement * CameraDevice::CreateAudioPipeline(const std::string & device, int channels, int sampleRate, CameraError & error)
 {
+    // Pipeline: source → capsfilter → audioconvert → audioresample → opusenc → appsink
     GstElement * pipeline = gst_pipeline_new("audio-pipeline");
 
-    GstElement * capsfilter   = gst_element_factory_make("capsfilter", "filter");
-    GstElement * audioconvert = gst_element_factory_make("audioconvert", "audio-convert");
-    GstElement * opusenc      = gst_element_factory_make("opusenc", "opus-encoder");
-    GstElement * rtpopuspay   = gst_element_factory_make("rtpopuspay", "rtpopuspay");
-    GstElement * udpsink      = gst_element_factory_make("udpsink", "udpsink");
-
-    GstElement * source = nullptr;
-    // Create elements
 #ifdef AV_STREAM_GST_USE_TEST_SRC
-    source = gst_element_factory_make("audiotestsrc", "source");
+    GstElement * source = gst_element_factory_make("audiotestsrc", "source");
+    g_object_set(source, "wave", 0, "is-live", TRUE, nullptr); // beep 0
 #else
-    source = gst_element_factory_make("pulsesrc", "source");
+    GstElement * source = gst_element_factory_make("pulsesrc", "source");
+    // g_object_set(source, "device", device.c_str(), nullptr);
 #endif
 
-    // Check for any nullptr among the created elements
+    GstElement * acaps   = gst_element_factory_make("capsfilter", "acaps");
+    GstElement * aconv   = gst_element_factory_make("audioconvert", "aconv");
+    GstElement * ares    = gst_element_factory_make("audioresample", "ares");
+    GstElement * opusenc = gst_element_factory_make("opusenc", "opus");
+    GstElement * appsink = gst_element_factory_make("appsink", "appsink");
+
+    // Check creations (same helpers you already use for video)
     const std::vector<std::pair<GstElement *, const char *>> elements = {
-        { pipeline, "pipeline" },          //
-        { source, "source" },              //
-        { capsfilter, "filter" },          //
-        { audioconvert, "audio-convert" }, //
-        { opusenc, "opus-encoder" },       //
-        { rtpopuspay, "rtpopuspay" },      //
-        { udpsink, "udpsink" }             //
+        { pipeline, "pipeline" }, { source, "source" },   { acaps, "acaps" },     { aconv, "aconv" },
+        { ares, "ares" },         { opusenc, "opusenc" }, { appsink, "appsink" },
     };
+
     const bool isElementFactoryMakeFailed = GstreamerPipepline::isGstElementsNull(elements);
 
     // If any element creation failed, log the error and unreference the elements
@@ -533,30 +577,30 @@ GstElement * CameraDevice::CreateAudioPipeline(const std::string & device, int c
         ChipLogError(Camera, "Not all elements could be created.");
 
         // Unreference the elements that were created
-        GstreamerPipepline::unrefGstElements(pipeline, source, capsfilter, audioconvert, opusenc, rtpopuspay, udpsink);
+        GstreamerPipepline::unrefGstElements(pipeline, source, acaps, aconv, ares, opusenc, appsink);
 
         error = CameraError::ERROR_INIT_FAILED;
         return nullptr;
     }
 
     // Create GstCaps for the audio source
-    GstCaps * caps = gst_caps_new_simple("audio/x-raw", "channels", G_TYPE_INT, channels, "rate", G_TYPE_INT, sampleRate, nullptr);
-    g_object_set(capsfilter, "caps", caps, nullptr);
+    GstCaps * caps = gst_caps_new_simple("audio/x-raw", "format", G_TYPE_STRING, "S16LE", "rate", G_TYPE_INT, sampleRate,
+                                         "channels", G_TYPE_INT, 1, nullptr);
+    g_object_set(acaps, "caps", caps, nullptr);
     gst_caps_unref(caps);
 
-    // Set udpsink properties
-    g_object_set(udpsink, "host", STREAM_GST_DEST_IP, "port", AUDIO_STREAM_GST_DEST_PORT, nullptr);
+    // Match controller expectations: Opus @ 64 kbps (kAudioBitrate)
+    g_object_set(opusenc, "bitrate", 64000, "frame-size", 20, "inband-fec", FALSE, "dtx", FALSE, nullptr);
 
-    // Add elements to the pipeline
-    gst_bin_add_many(GST_BIN(pipeline), source, capsfilter, audioconvert, opusenc, rtpopuspay, udpsink, nullptr);
+    // Emit samples to your appsink callback (DistributeAudio → packetizer)
+    g_object_set(appsink, "emit-signals", TRUE, nullptr);
+    g_object_set(source, "do-timestamp", TRUE, nullptr);
 
-    // Link elements
-    if (!gst_element_link_many(source, capsfilter, audioconvert, opusenc, rtpopuspay, udpsink, nullptr))
+    // Build and link
+    gst_bin_add_many(GST_BIN(pipeline), source, acaps, aconv, ares, opusenc, appsink, nullptr);
+    if (!gst_element_link_many(source, acaps, aconv, ares, opusenc, appsink, nullptr))
     {
-        ChipLogError(Camera, "Elements could not be linked.");
-
-        // The pipeline will unref all added elements automatically when you unref the pipeline.
-        gst_object_unref(pipeline);
+        ChipLogError(Camera, "CreateAudioPipeline: link failed");
         error = CameraError::ERROR_INIT_FAILED;
         return nullptr;
     }
@@ -808,6 +852,16 @@ CameraError CameraDevice::StartAudioStream(uint16_t streamID)
         return CameraError::ERROR_AUDIO_STREAM_START_FAILED;
     }
 
+    // Get the appsink and set up callback
+    GstElement * appsink = gst_bin_get_by_name(GST_BIN(audioPipeline), "appsink");
+    if (appsink)
+    {
+        AppSinkContext * context      = new AppSinkContext{ this, streamID };
+        GstAppSinkCallbacks callbacks = { nullptr, nullptr, OnNewAudioSampleFromAppSink };
+        gst_app_sink_set_callbacks(GST_APP_SINK(appsink), &callbacks, context, DestroyAudioAppSinkContext);
+        gst_object_unref(appsink);
+    }
+
     // Start the pipeline
     GstStateChangeReturn result = gst_element_set_state(audioPipeline, GST_STATE_PLAYING);
     if (result == GST_STATE_CHANGE_FAILURE)
@@ -816,6 +870,10 @@ CameraError CameraDevice::StartAudioStream(uint16_t streamID)
         gst_object_unref(audioPipeline);
         it->audioContext = nullptr;
         return CameraError::ERROR_AUDIO_STREAM_START_FAILED;
+    }
+    else
+    {
+        ChipLogProgress(Camera, "Audio Pipeline reached playing state");
     }
 
     // Wait for the pipeline to reach the PLAYING state

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -585,7 +585,7 @@ GstElement * CameraDevice::CreateAudioPipeline(const std::string & device, int c
 
     // Create GstCaps for the audio source
     GstCaps * caps = gst_caps_new_simple("audio/x-raw", "format", G_TYPE_STRING, "S16LE", "rate", G_TYPE_INT, sampleRate,
-                                         "channels", G_TYPE_INT, 1, nullptr);
+                                         "channels", G_TYPE_INT, channels, nullptr);
     g_object_set(acaps, "caps", caps, nullptr);
     gst_caps_unref(caps);
 
@@ -856,7 +856,7 @@ CameraError CameraDevice::StartAudioStream(uint16_t streamID)
     GstElement * appsink = gst_bin_get_by_name(GST_BIN(audioPipeline), "appsink");
     if (appsink)
     {
-        AppSinkContext * context      = new AppSinkContext{ this, streamID };
+        AudioAppSinkContext * context = new AudioAppSinkContext{ this, streamID };
         GstAppSinkCallbacks callbacks = { nullptr, nullptr, OnNewAudioSampleFromAppSink };
         gst_app_sink_set_callbacks(GST_APP_SINK(appsink), &callbacks, context, DestroyAudioAppSinkContext);
         gst_object_unref(appsink);

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -546,7 +546,8 @@ GstElement * CameraDevice::CreateVideoPipeline(const std::string & device, int w
 }
 
 // Helper function to create a GStreamer pipeline
-GstElement * CameraDevice::CreateAudioPipeline(const std::string & device, int channels, int sampleRate, int bitRate, CameraError & error)
+GstElement * CameraDevice::CreateAudioPipeline(const std::string & device, int channels, int sampleRate, int bitRate,
+                                               CameraError & error)
 {
     // Pipeline: source → capsfilter → audioconvert → audioresample → opusenc → appsink
     GstElement * pipeline = gst_pipeline_new("audio-pipeline");
@@ -843,7 +844,7 @@ CameraError CameraDevice::StartAudioStream(uint16_t streamID)
 
     int channels   = it->audioStreamParams.channelCount;
     int sampleRate = static_cast<int>(it->audioStreamParams.sampleRate);
-    int bitRate = static_cast<int>(it->audioStreamParams.bitRate);
+    int bitRate    = static_cast<int>(it->audioStreamParams.bitRate);
 
     // Create Gstreamer audio pipeline
     CameraError error          = CameraError::SUCCESS;

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -242,6 +242,7 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
 
     transport->SetRequestArgs(requestArgs);
     transport->Start();
+    transport->AddTracks();
 
     // Acquire the Video and Audio Streams from the CameraAVStreamManagement
     // cluster and update the reference counts.

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -30,7 +30,6 @@ constexpr int kMaxFragmentSize      = 1188; // 1200 (max packet size) - 12 (RTP 
 constexpr int kAudioBitRate         = 64000;
 constexpr int kOpusPayloadType      = 111;
 constexpr int kAudioSSRC            = 43;
-constexpr int kMidExtId             = 3; // Extmap-ID for MID header extension
 
 rtc::Description::Type SDPTypeToRtcType(SDPType type)
 {

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -116,7 +116,7 @@ public:
     {
         // 90 kHz clock for H.264
         mRtpCfg      = std::make_shared<rtc::RtpPacketizationConfig>(kSSRC, "videosrc", kVideoH264PayloadType,
-                                                                     rtc::H264RtpPacketizer::ClockRate);
+                                                                rtc::H264RtpPacketizer::ClockRate);
         mRtpCfg->mid = mTrack->description().mid();
 
         // Setting MTU size to 1200 as default size used in the libdatachannel is 1400

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -233,11 +233,11 @@ void WebrtcTransport::OnTrack(std::shared_ptr<WebRTCTrack> track)
     if (track->GetType() == "video")
     {
         ChipLogProgress(Camera, "Video track updated from remote peer");
-        SetVideoTrack(track);
+        // SetVideoTrack(track);
     }
     else if (track->GetType() == "audio")
     {
         ChipLogProgress(Camera, "audio track updated from remote peer");
-        SetAudioTrack(track);
+        // SetAudioTrack(track);
     }
 }

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -233,11 +233,11 @@ void WebrtcTransport::OnTrack(std::shared_ptr<WebRTCTrack> track)
     if (track->GetType() == "video")
     {
         ChipLogProgress(Camera, "Video track updated from remote peer");
-        // SetVideoTrack(track);
+        SetVideoTrack(track);
     }
     else if (track->GetType() == "audio")
     {
         ChipLogProgress(Camera, "audio track updated from remote peer");
-        // SetAudioTrack(track);
+        SetAudioTrack(track);
     }
 }

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -39,9 +39,16 @@ namespace {
 constexpr int kVideoH264PayloadType = 96; // 96 is just the first value in the dynamic RTP payload‑type range (96‑127).
 constexpr int kVideoBitRate         = 3000;
 
-constexpr const char * kStreamGstDestIp                      = "127.0.0.1";
-constexpr uint16_t kVideoStreamGstDestPort                   = 5000;
-constexpr chip::EndpointId kWebRTCRequesterDynamicEndpointId = 1;
+constexpr int kSSRC                        = 42;
+constexpr const char * kStreamGstDestIp    = "127.0.0.1";
+constexpr uint16_t kVideoStreamGstDestPort = 5000;
+
+// Constants for Audio
+constexpr int kAudioBitRate                = 64000;
+constexpr int kOpusPayloadType             = 111;
+constexpr int kAudioSSRC                   = 43;
+constexpr uint16_t kAudioStreamGstDestPort = 5001;
+constexpr int kMidExtId                    = 7;
 
 const char * GetPeerConnectionStateStr(rtc::PeerConnection::State state)
 {
@@ -233,6 +240,7 @@ void WebRTCManager::Disconnect()
 
     // Reset track
     mTrack.reset();
+    audioTrack.reset();
 
     // Clear state
     mCurrentVideoStreamId = 0;
@@ -308,7 +316,14 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
     mRTPSocket = socket(AF_INET, SOCK_DGRAM, 0);
     if (mRTPSocket == -1)
     {
-        ChipLogError(Camera, "Failed to create RTP socket: %s", strerror(errno));
+        ChipLogError(Camera, "Failed to create RTP Video socket: %s", strerror(errno));
+        return CHIP_ERROR_POSIX(errno);
+    }
+
+    mAudioRTPSocket = socket(AF_INET, SOCK_DGRAM, 0);
+    if (mAudioRTPSocket == -1)
+    {
+        ChipLogError(Camera, "Failed to create RTP Audio socket: %s", strerror(errno));
         return CHIP_ERROR_POSIX(errno);
     }
 
@@ -330,6 +345,29 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
             // This is an RTP packet
             sendto(mRTPSocket, reinterpret_cast<const char *>(message.data()), size_t(message.size()), 0,
                    reinterpret_cast<const struct sockaddr *>(&addr), sizeof(addr));
+        },
+        nullptr);
+
+    // For Audio
+    sockaddr_in audioAddr     = {};
+    audioAddr.sin_family      = AF_INET;
+    audioAddr.sin_addr.s_addr = inet_addr(kStreamGstDestIp);
+    audioAddr.sin_port        = htons(kAudioStreamGstDestPort);
+
+    rtc::Description::Audio audioMedia("audio", rtc::Description::Direction::RecvOnly);
+    audioMedia.addOpusCodec(kOpusPayloadType);
+    audioMedia.setBitrate(kAudioBitRate);
+    audioTrack = mPeerConnection->addTrack(audioMedia);
+
+    auto audioSession = std::make_shared<rtc::RtcpReceivingSession>();
+    audioTrack->setMediaHandler(audioSession);
+
+    audioTrack->onMessage(
+        [this, audioAddr](rtc::binary message) {
+            // This is an RTP Audio packet
+            ChipLogProgress(Camera, "Audio packets size: [%u]", static_cast<unsigned int>(message.size()));
+            sendto(mAudioRTPSocket, reinterpret_cast<const char *>(message.data()), static_cast<size_t>(message.size()), 0,
+                   reinterpret_cast<const struct sockaddr *>(&audioAddr), sizeof(audioAddr));
         },
         nullptr);
 

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -40,16 +40,13 @@ namespace {
 constexpr int kVideoH264PayloadType = 96; // 96 is just the first value in the dynamic RTP payload‑type range (96‑127).
 constexpr int kVideoBitRate         = 3000;
 
-constexpr int kSSRC                        = 42;
 constexpr const char * kStreamGstDestIp    = "127.0.0.1";
 constexpr uint16_t kVideoStreamGstDestPort = 5000;
 
 // Constants for Audio
 constexpr int kAudioBitRate                = 64000;
 constexpr int kOpusPayloadType             = 111;
-constexpr int kAudioSSRC                   = 43;
 constexpr uint16_t kAudioStreamGstDestPort = 5001;
-constexpr int kMidExtId                    = 7;
 
 const char * GetPeerConnectionStateStr(rtc::PeerConnection::State state)
 {

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -19,8 +19,8 @@
 #include "WebRTCManager.h"
 
 #include <commands/interactive/InteractiveCommands.h>
-#include <controller/webrtc/access_control/WebRTCAccessControl.h>
 #include <controller/webrtc/WebRTCTransportRequestorManager.h>
+#include <controller/webrtc/access_control/WebRTCAccessControl.h>
 #include <crypto/RandUtils.h>
 #include <lib/support/StringBuilder.h>
 

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -341,6 +341,7 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
     mTrack->onMessage(
         [this, addr](rtc::binary message) {
             // This is an RTP packet
+            ChipLogProgress(Camera, "Video packets size: [%u]", static_cast<unsigned int>(message.size()));
             sendto(mRTPSocket, reinterpret_cast<const char *>(message.data()), size_t(message.size()), 0,
                    reinterpret_cast<const struct sockaddr *>(&addr), sizeof(addr));
         },

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -20,6 +20,7 @@
 
 #include <commands/interactive/InteractiveCommands.h>
 #include <controller/webrtc/access_control/WebRTCAccessControl.h>
+#include <controller/webrtc/WebRTCTransportRequestorManager.h>
 #include <crypto/RandUtils.h>
 #include <lib/support/StringBuilder.h>
 

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -91,6 +91,7 @@ private:
     std::vector<std::string> mLocalCandidates;
 
     std::shared_ptr<rtc::Track> mTrack;
+    std::shared_ptr<rtc::Track> audioTrack;
 
     // Callback to notify when session is established
     SessionEstablishedCallback mSessionEstablishedCallback;
@@ -99,7 +100,8 @@ private:
     uint16_t mCurrentVideoStreamId = 0;
 
     // UDP socket for RTP forwarding
-    int mRTPSocket = -1;
+    int mRTPSocket      = -1;
+    int mAudioRTPSocket = -1;
 
     // Close and reset the RTP socket
     void CloseRTPSocket();

--- a/src/controller/webrtc/WebRTCClient.h
+++ b/src/controller/webrtc/WebRTCClient.h
@@ -63,9 +63,11 @@ private:
     std::vector<std::string> mLocalCandidates;
 
     std::shared_ptr<rtc::Track> mTrack;
+    std::shared_ptr<rtc::Track> mAudioTrack;
 
     // UDP socket for stream forwarding
-    int mRTPSocket = -1;
+    int mRTPSocket      = -1;
+    int mAudioRTPSocket = -1;
 
     // Close and reset the UDP socket
     void CloseRTPSocket();


### PR DESCRIPTION
#### Summary
This PR ensures the audio pipeline works for both live streaming and clip recording.

#### Testing
* Manual Testing for live stream with audio

1. Launch camera app
```
sudo rm -rf /tmp/chip_*;   ./out/debug/chip-camera-app
```
2. Launch camera controller app
```
./out/linux-x64-camera-controller/chip-camera-controller
```
3. Run commands to allocate AV streams & start live steaming
```
//pairing DUT
pairing code 1 34970112332

//audio stream allocation
cameraavstreammanagement audio-stream-allocate 3 0 2 48000 32000 24 1 1

//video stream allocation
cameraavstreammanagement video-stream-allocate 3 0 30 30 '{ "width":640, "height":480}' '{ "width":640, "height":480}' 10000 10000 4000 1 1 --WatermarkEnabled 1 --OSDEnabled 1

// webrtc commands for live stream
webrtc connect 1 1
webrtc provide-offer --video-stream-id 1 --audio-stream-id 2

```
