### PR TITLE
Increase unit test coverage of `include/platform` by 6.6%

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -73,6 +73,7 @@ if (chip_build_tests) {
       "${chip_root}/src/crypto/tests",
       "${chip_root}/src/data-model-providers/codedriven/endpoint/tests",
       "${chip_root}/src/inet/tests",
+      "${chip_root}/src/include/platform/tests",
       "${chip_root}/src/lib/address_resolve/tests",
       "${chip_root}/src/app/server-cluster/tests",
       "${chip_root}/src/lib/asn1/tests",

--- a/src/include/platform/AttributeList.h
+++ b/src/include/platform/AttributeList.h
@@ -40,6 +40,7 @@ public:
         const T & operator*() const;
         Iterator & operator++();
         bool operator!=(const Iterator & other) const;
+        bool operator==(const Iterator & other) const;
 
     private:
         const AttributeList<T, N> * mAttributeListPtr;
@@ -129,6 +130,12 @@ template <typename T, size_t N>
 inline bool AttributeList<T, N>::Iterator::operator!=(const AttributeList<T, N>::Iterator & other) const
 {
     return mIndex != other.mIndex;
+}
+
+template <typename T, size_t N>
+inline bool AttributeList<T, N>::Iterator::operator==(const AttributeList<T, N>::Iterator & other) const
+{
+    return mIndex == other.mIndex;  
 }
 
 } // namespace DeviceLayer

--- a/src/include/platform/AttributeList.h
+++ b/src/include/platform/AttributeList.h
@@ -129,13 +129,13 @@ inline typename AttributeList<T, N>::Iterator & AttributeList<T, N>::Iterator::o
 template <typename T, size_t N>
 inline bool AttributeList<T, N>::Iterator::operator!=(const AttributeList<T, N>::Iterator & other) const
 {
-    return mIndex != other.mIndex;
+    return !(*this == other);
 }
 
 template <typename T, size_t N>
 inline bool AttributeList<T, N>::Iterator::operator==(const AttributeList<T, N>::Iterator & other) const
 {
-    return mIndex == other.mIndex;
+    return mAttributeListPtr == other.mAttributeListPtr && mIndex == other.mIndex;;
 }
 
 } // namespace DeviceLayer

--- a/src/include/platform/AttributeList.h
+++ b/src/include/platform/AttributeList.h
@@ -135,7 +135,8 @@ inline bool AttributeList<T, N>::Iterator::operator!=(const AttributeList<T, N>:
 template <typename T, size_t N>
 inline bool AttributeList<T, N>::Iterator::operator==(const AttributeList<T, N>::Iterator & other) const
 {
-    return mAttributeListPtr == other.mAttributeListPtr && mIndex == other.mIndex;;
+    return mAttributeListPtr == other.mAttributeListPtr && mIndex == other.mIndex;
+    ;
 }
 
 } // namespace DeviceLayer

--- a/src/include/platform/AttributeList.h
+++ b/src/include/platform/AttributeList.h
@@ -135,7 +135,7 @@ inline bool AttributeList<T, N>::Iterator::operator!=(const AttributeList<T, N>:
 template <typename T, size_t N>
 inline bool AttributeList<T, N>::Iterator::operator==(const AttributeList<T, N>::Iterator & other) const
 {
-    return mIndex == other.mIndex;  
+    return mIndex == other.mIndex;
 }
 
 } // namespace DeviceLayer

--- a/src/include/platform/AttributeList.h
+++ b/src/include/platform/AttributeList.h
@@ -136,7 +136,6 @@ template <typename T, size_t N>
 inline bool AttributeList<T, N>::Iterator::operator==(const AttributeList<T, N>::Iterator & other) const
 {
     return mAttributeListPtr == other.mAttributeListPtr && mIndex == other.mIndex;
-    ;
 }
 
 } // namespace DeviceLayer

--- a/src/include/platform/tests/BUILD.gn
+++ b/src/include/platform/tests/BUILD.gn
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "libIncludePlatformTests"
+
+  test_sources = [
+    "TestAttributeList.cpp"
+  ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/platform"
+  ]
+}

--- a/src/include/platform/tests/BUILD.gn
+++ b/src/include/platform/tests/BUILD.gn
@@ -20,13 +20,9 @@ import("${chip_root}/build/chip/chip_test_suite.gni")
 chip_test_suite("tests") {
   output_name = "libIncludePlatformTests"
 
-  test_sources = [
-    "TestAttributeList.cpp"
-  ]
+  test_sources = [ "TestAttributeList.cpp" ]
 
   cflags = [ "-Wconversion" ]
 
-  public_deps = [
-    "${chip_root}/src/platform"
-  ]
+  public_deps = [ "${chip_root}/src/platform" ]
 }

--- a/src/include/platform/tests/TestAttributeList.cpp
+++ b/src/include/platform/tests/TestAttributeList.cpp
@@ -72,10 +72,10 @@ TEST_F(TestAttributeList, TestIterator)
 
     EXPECT_EQ(list.add(10), CHIP_NO_ERROR);
     EXPECT_NE(list.begin(), list.end());
-    
+
     EXPECT_EQ(list.add(20), CHIP_NO_ERROR);
     EXPECT_NE(list.begin(), list.end());
-    
+
     EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
     EXPECT_NE(list.begin(), list.end());
 
@@ -83,7 +83,7 @@ TEST_F(TestAttributeList, TestIterator)
 
     auto it = list.begin();
     EXPECT_EQ(*it, 10);
-    
+
     ++it;
     EXPECT_NE(it, list.end());
     EXPECT_EQ(*it, 20);

--- a/src/include/platform/tests/TestAttributeList.cpp
+++ b/src/include/platform/tests/TestAttributeList.cpp
@@ -1,0 +1,99 @@
+#include <pw_unit_test/framework.h>
+
+#include <platform/AttributeList.h>
+
+namespace chip
+{
+namespace DeviceLayer
+{
+
+class TestAttributeList : public ::testing::Test {};
+
+// Test an empty list
+TEST_F(TestAttributeList, TestEmpty)
+{
+    AttributeList<int, 5> list;
+    EXPECT_EQ(list.size(), (size_t)0);
+    EXPECT_EQ(list.begin(), list.end());
+
+    // This will abort/die
+    // list[0];
+}
+
+// Test adding elements and overflow
+TEST_F(TestAttributeList, TestAddAndOverflow)
+{
+    AttributeList<int, 5> list;
+
+    EXPECT_EQ(list.add(10), CHIP_NO_ERROR);
+    EXPECT_EQ(list.size(), (size_t)1);
+
+    EXPECT_EQ(list.add(20), CHIP_NO_ERROR);
+    EXPECT_EQ(list.size(), (size_t)2);
+
+    EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
+    EXPECT_EQ(list.size(), (size_t)3);
+
+    EXPECT_EQ(list.add(40), CHIP_NO_ERROR);
+    EXPECT_EQ(list.size(), (size_t)4);
+
+    EXPECT_EQ(list.add(50), CHIP_NO_ERROR);
+    EXPECT_EQ(list.size(), (size_t)5);
+
+    EXPECT_EQ(list.add(60), CHIP_ERROR_NO_MEMORY);
+    EXPECT_EQ(list.size(), (size_t)5);
+}
+
+// Test operator[]
+TEST_F(TestAttributeList, TestIndexing)
+{
+    AttributeList<int, 5> list;
+
+    EXPECT_EQ(list.add(10), CHIP_NO_ERROR);
+    EXPECT_EQ(list.add(20), CHIP_NO_ERROR);
+    EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
+
+    ASSERT_EQ(list.size(), (size_t)3);
+
+    EXPECT_EQ(list[0], 10);
+    EXPECT_EQ(list[1], 20);
+    EXPECT_EQ(list[2], 30);
+
+    // This will abort/die
+    // list[3];
+}
+
+// Test the iterator methods
+TEST_F(TestAttributeList, TestIterator)
+{
+    AttributeList<int, 5> list;
+
+    EXPECT_EQ(list.begin(), list.end());
+
+    EXPECT_EQ(list.add(10), CHIP_NO_ERROR);
+    EXPECT_NE(list.begin(), list.end());
+    
+    EXPECT_EQ(list.add(20), CHIP_NO_ERROR);
+    EXPECT_NE(list.begin(), list.end());
+    
+    EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
+    EXPECT_NE(list.begin(), list.end());
+
+    ASSERT_EQ(list.size(), (size_t)3);
+
+    auto it = list.begin();
+    EXPECT_EQ(*it, 10);
+    
+    ++it;
+    EXPECT_NE(it, list.end());
+    EXPECT_EQ(*it, 20);
+
+    ++it;
+    EXPECT_EQ(*it, 30);
+
+    ++it;
+    EXPECT_EQ(it, list.end());
+};
+
+}
+}

--- a/src/include/platform/tests/TestAttributeList.cpp
+++ b/src/include/platform/tests/TestAttributeList.cpp
@@ -13,7 +13,7 @@ class TestAttributeList : public ::testing::Test
 TEST_F(TestAttributeList, TestEmpty)
 {
     AttributeList<int, 5> list;
-    EXPECT_EQ(list.size(), (size_t) 0);
+    EXPECT_EQ(list.size(), 0u);
     EXPECT_EQ(list.begin(), list.end());
 
     // This will abort/die
@@ -26,22 +26,22 @@ TEST_F(TestAttributeList, TestAddAndOverflow)
     AttributeList<int, 5> list;
 
     EXPECT_EQ(list.add(10), CHIP_NO_ERROR);
-    EXPECT_EQ(list.size(), (size_t) 1);
+    EXPECT_EQ(list.size(), 1u);
 
     EXPECT_EQ(list.add(20), CHIP_NO_ERROR);
-    EXPECT_EQ(list.size(), (size_t) 2);
+    EXPECT_EQ(list.size(), 2u);
 
     EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
-    EXPECT_EQ(list.size(), (size_t) 3);
+    EXPECT_EQ(list.size(), 3u);
 
     EXPECT_EQ(list.add(40), CHIP_NO_ERROR);
-    EXPECT_EQ(list.size(), (size_t) 4);
+    EXPECT_EQ(list.size(), 4u);
 
     EXPECT_EQ(list.add(50), CHIP_NO_ERROR);
-    EXPECT_EQ(list.size(), (size_t) 5);
+    EXPECT_EQ(list.size(), 5u);
 
     EXPECT_EQ(list.add(60), CHIP_ERROR_NO_MEMORY);
-    EXPECT_EQ(list.size(), (size_t) 5);
+    EXPECT_EQ(list.size(), 5u);
 }
 
 // Test operator[]
@@ -53,7 +53,7 @@ TEST_F(TestAttributeList, TestIndexing)
     EXPECT_EQ(list.add(20), CHIP_NO_ERROR);
     EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
 
-    ASSERT_EQ(list.size(), (size_t) 3);
+    ASSERT_EQ(list.size(), 3u);
 
     EXPECT_EQ(list[0], 10);
     EXPECT_EQ(list[1], 20);
@@ -76,7 +76,7 @@ TEST_F(TestAttributeList, TestIterator)
     EXPECT_EQ(list.add(20), CHIP_NO_ERROR);
     EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
 
-    ASSERT_EQ(list.size(), (size_t) 3);
+    ASSERT_EQ(list.size(), 3u);
 
     auto it = list.begin();
     EXPECT_EQ(*it, 10);

--- a/src/include/platform/tests/TestAttributeList.cpp
+++ b/src/include/platform/tests/TestAttributeList.cpp
@@ -74,10 +74,7 @@ TEST_F(TestAttributeList, TestIterator)
     EXPECT_NE(list.begin(), list.end());
 
     EXPECT_EQ(list.add(20), CHIP_NO_ERROR);
-    EXPECT_NE(list.begin(), list.end());
-
     EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
-    EXPECT_NE(list.begin(), list.end());
 
     ASSERT_EQ(list.size(), (size_t) 3);
 
@@ -94,6 +91,42 @@ TEST_F(TestAttributeList, TestIterator)
     ++it;
     EXPECT_EQ(it, list.end());
 };
+
+// Test range-based for loop
+TEST_F(TestAttributeList, TestRangeBasedFor)
+{
+    AttributeList<int, 5> list;
+    EXPECT_EQ(list.add(10), CHIP_NO_ERROR);
+    EXPECT_EQ(list.add(20), CHIP_NO_ERROR);
+    EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
+
+    int expected_values[] = { 10, 20, 30 };
+    int i = 0;
+    for (const auto & val : list)
+    {
+        ASSERT_LT(i, 3);
+        EXPECT_EQ(val, expected_values[i]);
+        i++;
+    }
+    EXPECT_EQ(i, 3);
+}
+
+// Test iterators from different lists
+TEST_F(TestAttributeList, TestIteratorFromDifferentLists)
+{
+    AttributeList<int, 5> list1;
+    AttributeList<int, 5> list2;
+
+    // Both iterators will have index 0, but point to different lists.
+    // They should not be equal.
+    EXPECT_NE(list1.begin(), list2.begin());
+
+    EXPECT_EQ(list1.add(10), CHIP_NO_ERROR);
+    EXPECT_EQ(list2.add(20), CHIP_NO_ERROR);
+
+    // Both iterators will have index 0, but point to different lists.
+    EXPECT_NE(list1.begin(), list2.begin());
+}
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/include/platform/tests/TestAttributeList.cpp
+++ b/src/include/platform/tests/TestAttributeList.cpp
@@ -2,18 +2,18 @@
 
 #include <platform/AttributeList.h>
 
-namespace chip
-{
-namespace DeviceLayer
-{
+namespace chip {
+namespace DeviceLayer {
 
-class TestAttributeList : public ::testing::Test {};
+class TestAttributeList : public ::testing::Test
+{
+};
 
 // Test an empty list
 TEST_F(TestAttributeList, TestEmpty)
 {
     AttributeList<int, 5> list;
-    EXPECT_EQ(list.size(), (size_t)0);
+    EXPECT_EQ(list.size(), (size_t) 0);
     EXPECT_EQ(list.begin(), list.end());
 
     // This will abort/die
@@ -26,22 +26,22 @@ TEST_F(TestAttributeList, TestAddAndOverflow)
     AttributeList<int, 5> list;
 
     EXPECT_EQ(list.add(10), CHIP_NO_ERROR);
-    EXPECT_EQ(list.size(), (size_t)1);
+    EXPECT_EQ(list.size(), (size_t) 1);
 
     EXPECT_EQ(list.add(20), CHIP_NO_ERROR);
-    EXPECT_EQ(list.size(), (size_t)2);
+    EXPECT_EQ(list.size(), (size_t) 2);
 
     EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
-    EXPECT_EQ(list.size(), (size_t)3);
+    EXPECT_EQ(list.size(), (size_t) 3);
 
     EXPECT_EQ(list.add(40), CHIP_NO_ERROR);
-    EXPECT_EQ(list.size(), (size_t)4);
+    EXPECT_EQ(list.size(), (size_t) 4);
 
     EXPECT_EQ(list.add(50), CHIP_NO_ERROR);
-    EXPECT_EQ(list.size(), (size_t)5);
+    EXPECT_EQ(list.size(), (size_t) 5);
 
     EXPECT_EQ(list.add(60), CHIP_ERROR_NO_MEMORY);
-    EXPECT_EQ(list.size(), (size_t)5);
+    EXPECT_EQ(list.size(), (size_t) 5);
 }
 
 // Test operator[]
@@ -53,7 +53,7 @@ TEST_F(TestAttributeList, TestIndexing)
     EXPECT_EQ(list.add(20), CHIP_NO_ERROR);
     EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
 
-    ASSERT_EQ(list.size(), (size_t)3);
+    ASSERT_EQ(list.size(), (size_t) 3);
 
     EXPECT_EQ(list[0], 10);
     EXPECT_EQ(list[1], 20);
@@ -79,7 +79,7 @@ TEST_F(TestAttributeList, TestIterator)
     EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
     EXPECT_NE(list.begin(), list.end());
 
-    ASSERT_EQ(list.size(), (size_t)3);
+    ASSERT_EQ(list.size(), (size_t) 3);
 
     auto it = list.begin();
     EXPECT_EQ(*it, 10);
@@ -95,5 +95,5 @@ TEST_F(TestAttributeList, TestIterator)
     EXPECT_EQ(it, list.end());
 };
 
-}
-}
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/include/platform/tests/TestAttributeList.cpp
+++ b/src/include/platform/tests/TestAttributeList.cpp
@@ -101,7 +101,7 @@ TEST_F(TestAttributeList, TestRangeBasedFor)
     EXPECT_EQ(list.add(30), CHIP_NO_ERROR);
 
     int expected_values[] = { 10, 20, 30 };
-    int i = 0;
+    int i                 = 0;
     for (const auto & val : list)
     {
         ASSERT_LT(i, 3);


### PR DESCRIPTION
#### Summary

This PR adds 

1. `operator==` to the `Attributelist::Iterator` class (this is needed for using `EXPECT_EQ` on iterators in unit testing).
2. Unit tests for the file `AttributeList.h` in the `include/platform` folder changing the coverage of the file from 0 to 100% thus bumping the overall coverage of `include/platform` from 40.3% to 46.9%.

#### Local (Linux) Coverage Impact of `include/platform`

| Metric   | Before | After | Diff  |
|----------|--------|-------|-------|
| Line     | 40.3%  | 46.9% | +6.6% |
| Function | 33.5%  | 36.8% | +3.3% |

#### Related issues

#37235

#### Testing

Just new unit tests, so only the CI needs to pass. 

