### PR TITLE
Update soil-measurement-cluster

### DIFF
--- a/src/app/clusters/soil-measurement-server/soil-measurement-cluster.cpp
+++ b/src/app/clusters/soil-measurement-server/soil-measurement-cluster.cpp
@@ -42,9 +42,9 @@ DataModel::ActionReturnStatus SoilMeasurementCluster::ReadAttribute(const DataMo
     case ClusterRevision::Id:
         return encoder.Encode(SoilMeasurement::kRevision);
     case FeatureMap::Id:
-        return encoder.Encode(static_cast<uint32_t>(0));
+        return encoder.Encode<uint32_t>(0);
     default:
-        return Protocols::InteractionModel::Status::UnreportableAttribute;
+        return Protocols::InteractionModel::Status::UnsupportedAttribute;
     }
 }
 

--- a/src/app/clusters/soil-measurement-server/tests/TestSoilMeasurementCluster.cpp
+++ b/src/app/clusters/soil-measurement-server/tests/TestSoilMeasurementCluster.cpp
@@ -66,69 +66,83 @@ public:
     SoilMoistureMeasuredValue::TypeInfo::Type GetSoilMoistureMeasuredValue() const { return mSoilMoistureMeasuredValue; }
 };
 
+class SoilMeasurementClusterTest
+{
+    SoilMeasurementClusterLocal soilMeasurement;
+
+public:
+    template <typename... Args>
+    SoilMeasurementClusterTest(Args &&... args) : soilMeasurement(std::forward<Args>(args)...)
+    {}
+
+    template <typename F>
+    void Check(F check)
+    {
+        check(soilMeasurement);
+    }
+};
+
 } // namespace
 
 TEST_F(TestSoilMeasurementCluster, AttributeTest)
 {
-    {
-        SoilMeasurementClusterLocal soilMeasurement(kEndpointWithSoilMeasurement, kDefaultSoilMoistureMeasurementLimits);
+    SoilMeasurementClusterTest(kEndpointWithSoilMeasurement, kDefaultSoilMoistureMeasurementLimits)
+        .Check([&](SoilMeasurementClusterLocal & soilMeasurement) {
+            ReadOnlyBufferBuilder<DataModel::AttributeEntry> attributes;
+            ASSERT_EQ(
+                soilMeasurement.Attributes(ConcreteClusterPath(kEndpointWithSoilMeasurement, SoilMeasurement::Id), attributes),
+                CHIP_NO_ERROR);
 
-        ReadOnlyBufferBuilder<DataModel::AttributeEntry> attributes;
-        ASSERT_EQ(soilMeasurement.Attributes(ConcreteClusterPath(kEndpointWithSoilMeasurement, SoilMeasurement::Id), attributes),
-                  CHIP_NO_ERROR);
-
-        ReadOnlyBufferBuilder<DataModel::AttributeEntry> expected;
-        AttributeListBuilder listBuilder(expected);
-        ASSERT_EQ(listBuilder.Append(Span(SoilMeasurement::Attributes::kMandatoryMetadata), {}), CHIP_NO_ERROR);
-        ASSERT_TRUE(Testing::EqualAttributeSets(attributes.TakeBuffer(), expected.TakeBuffer()));
-    }
+            ReadOnlyBufferBuilder<DataModel::AttributeEntry> expected;
+            AttributeListBuilder listBuilder(expected);
+            ASSERT_EQ(listBuilder.Append(Span(SoilMeasurement::Attributes::kMandatoryMetadata), {}), CHIP_NO_ERROR);
+            ASSERT_TRUE(Testing::EqualAttributeSets(attributes.TakeBuffer(), expected.TakeBuffer()));
+        });
 }
 
 TEST_F(TestSoilMeasurementCluster, SoilMoistureMeasuredValue)
 {
-    {
-        SoilMeasurementClusterLocal soilMeasurement(kEndpointWithSoilMeasurement, kDefaultSoilMoistureMeasurementLimits);
+    SoilMeasurementClusterTest(kEndpointWithSoilMeasurement, kDefaultSoilMoistureMeasurementLimits)
+        .Check([&](SoilMeasurementClusterLocal & soilMeasurement) {
+            SoilMoistureMeasuredValue::TypeInfo::Type measuredValue;
+            measuredValue.SetNull();
+            ASSERT_EQ(soilMeasurement.GetSoilMoistureMeasuredValue(), measuredValue);
 
-        SoilMoistureMeasuredValue::TypeInfo::Type measuredValue;
-        measuredValue.SetNull();
-        ASSERT_EQ(soilMeasurement.GetSoilMoistureMeasuredValue(), measuredValue);
+            measuredValue = 50;
+            ASSERT_EQ(soilMeasurement.SetSoilMoistureMeasuredValue(measuredValue), CHIP_NO_ERROR);
+            ASSERT_EQ(soilMeasurement.GetSoilMoistureMeasuredValue(), measuredValue);
 
-        measuredValue = 50;
-        ASSERT_EQ(soilMeasurement.SetSoilMoistureMeasuredValue(measuredValue), CHIP_NO_ERROR);
-        ASSERT_EQ(soilMeasurement.GetSoilMoistureMeasuredValue(), measuredValue);
+            measuredValue = 101;
+            ASSERT_EQ(soilMeasurement.SetSoilMoistureMeasuredValue(measuredValue), CHIP_ERROR_INVALID_ARGUMENT);
 
-        measuredValue = 101;
-        ASSERT_EQ(soilMeasurement.SetSoilMoistureMeasuredValue(measuredValue), CHIP_ERROR_INVALID_ARGUMENT);
+            measuredValue = -1;
+            ASSERT_EQ(soilMeasurement.SetSoilMoistureMeasuredValue(measuredValue), CHIP_ERROR_INVALID_ARGUMENT);
 
-        measuredValue = -1;
-        ASSERT_EQ(soilMeasurement.SetSoilMoistureMeasuredValue(measuredValue), CHIP_ERROR_INVALID_ARGUMENT);
-
-        measuredValue.SetNull();
-        ASSERT_EQ(soilMeasurement.SetSoilMoistureMeasuredValue(measuredValue), CHIP_NO_ERROR);
-        ASSERT_EQ(soilMeasurement.GetSoilMoistureMeasuredValue(), measuredValue);
-    }
+            measuredValue.SetNull();
+            ASSERT_EQ(soilMeasurement.SetSoilMoistureMeasuredValue(measuredValue), CHIP_NO_ERROR);
+            ASSERT_EQ(soilMeasurement.GetSoilMoistureMeasuredValue(), measuredValue);
+        });
 }
 
 TEST_F(TestSoilMeasurementCluster, SoilMoistureMeasurementLimits)
 {
-    {
-        SoilMeasurementClusterLocal soilMeasurement(kEndpointWithSoilMeasurement, kDefaultSoilMoistureMeasurementLimits);
+    SoilMeasurementClusterTest(kEndpointWithSoilMeasurement, kDefaultSoilMoistureMeasurementLimits)
+        .Check([&](SoilMeasurementClusterLocal & soilMeasurement) {
+            const auto & measurementLimits = soilMeasurement.GetSoilMoistureMeasurementLimits();
+            ASSERT_EQ(measurementLimits.measurementType, kDefaultSoilMoistureMeasurementLimits.measurementType);
+            ASSERT_EQ(measurementLimits.measured, kDefaultSoilMoistureMeasurementLimits.measured);
+            ASSERT_EQ(measurementLimits.minMeasuredValue, kDefaultSoilMoistureMeasurementLimits.minMeasuredValue);
+            ASSERT_EQ(measurementLimits.maxMeasuredValue, kDefaultSoilMoistureMeasurementLimits.maxMeasuredValue);
 
-        const auto & measurementLimits = soilMeasurement.GetSoilMoistureMeasurementLimits();
-        ASSERT_EQ(measurementLimits.measurementType, kDefaultSoilMoistureMeasurementLimits.measurementType);
-        ASSERT_EQ(measurementLimits.measured, kDefaultSoilMoistureMeasurementLimits.measured);
-        ASSERT_EQ(measurementLimits.minMeasuredValue, kDefaultSoilMoistureMeasurementLimits.minMeasuredValue);
-        ASSERT_EQ(measurementLimits.maxMeasuredValue, kDefaultSoilMoistureMeasurementLimits.maxMeasuredValue);
-
-        const auto & accuracyRange = measurementLimits.accuracyRanges[0];
-        const auto & defaultRange  = kDefaultSoilMoistureMeasurementLimits.accuracyRanges[0];
-        ASSERT_EQ(accuracyRange.rangeMin, defaultRange.rangeMin);
-        ASSERT_EQ(accuracyRange.rangeMax, defaultRange.rangeMax);
-        ASSERT_EQ(accuracyRange.percentMax.Value(), defaultRange.percentMax.Value());
-        ASSERT_FALSE(accuracyRange.percentMin.HasValue());
-        ASSERT_FALSE(accuracyRange.percentTypical.HasValue());
-        ASSERT_FALSE(accuracyRange.fixedMax.HasValue());
-        ASSERT_FALSE(accuracyRange.fixedMin.HasValue());
-        ASSERT_FALSE(accuracyRange.fixedTypical.HasValue());
-    }
+            const auto & accuracyRange = measurementLimits.accuracyRanges[0];
+            const auto & defaultRange  = kDefaultSoilMoistureMeasurementLimits.accuracyRanges[0];
+            ASSERT_EQ(accuracyRange.rangeMin, defaultRange.rangeMin);
+            ASSERT_EQ(accuracyRange.rangeMax, defaultRange.rangeMax);
+            ASSERT_EQ(accuracyRange.percentMax.Value(), defaultRange.percentMax.Value());
+            ASSERT_FALSE(accuracyRange.percentMin.HasValue());
+            ASSERT_FALSE(accuracyRange.percentTypical.HasValue());
+            ASSERT_FALSE(accuracyRange.fixedMax.HasValue());
+            ASSERT_FALSE(accuracyRange.fixedMin.HasValue());
+            ASSERT_FALSE(accuracyRange.fixedTypical.HasValue());
+        });
 }

--- a/src/app/clusters/soil-measurement-server/tests/TestSoilMeasurementCluster.cpp
+++ b/src/app/clusters/soil-measurement-server/tests/TestSoilMeasurementCluster.cpp
@@ -87,7 +87,7 @@ public:
 TEST_F(TestSoilMeasurementCluster, AttributeTest)
 {
     SoilMeasurementClusterTest(kEndpointWithSoilMeasurement, kDefaultSoilMoistureMeasurementLimits)
-        .Check([&](SoilMeasurementClusterLocal & soilMeasurement) {
+        .Check([](SoilMeasurementClusterLocal & soilMeasurement) {
             ReadOnlyBufferBuilder<DataModel::AttributeEntry> attributes;
             ASSERT_EQ(
                 soilMeasurement.Attributes(ConcreteClusterPath(kEndpointWithSoilMeasurement, SoilMeasurement::Id), attributes),
@@ -103,7 +103,7 @@ TEST_F(TestSoilMeasurementCluster, AttributeTest)
 TEST_F(TestSoilMeasurementCluster, SoilMoistureMeasuredValue)
 {
     SoilMeasurementClusterTest(kEndpointWithSoilMeasurement, kDefaultSoilMoistureMeasurementLimits)
-        .Check([&](SoilMeasurementClusterLocal & soilMeasurement) {
+        .Check([](SoilMeasurementClusterLocal & soilMeasurement) {
             SoilMoistureMeasuredValue::TypeInfo::Type measuredValue;
             measuredValue.SetNull();
             ASSERT_EQ(soilMeasurement.GetSoilMoistureMeasuredValue(), measuredValue);
@@ -127,7 +127,7 @@ TEST_F(TestSoilMeasurementCluster, SoilMoistureMeasuredValue)
 TEST_F(TestSoilMeasurementCluster, SoilMoistureMeasurementLimits)
 {
     SoilMeasurementClusterTest(kEndpointWithSoilMeasurement, kDefaultSoilMoistureMeasurementLimits)
-        .Check([&](SoilMeasurementClusterLocal & soilMeasurement) {
+        .Check([](SoilMeasurementClusterLocal & soilMeasurement) {
             const auto & measurementLimits = soilMeasurement.GetSoilMoistureMeasurementLimits();
             ASSERT_EQ(measurementLimits.measurementType, kDefaultSoilMoistureMeasurementLimits.measurementType);
             ASSERT_EQ(measurementLimits.measured, kDefaultSoilMoistureMeasurementLimits.measured);


### PR DESCRIPTION
#### Summary

ReadAttribute() default return value should be UnsupportedAttribute instead of UnreportableAttribute.

#### Testing

Tested using chip-all-clusters-app and matter-repl:

chip-repl commands:
await devCtrl.CommissionWithCode("MT:-24J0AFN00KA0648G00", 1)
await devCtrl.ReadAttribute(1, [ Clusters.SoilMeasurement ])

matter-repl response shows the cluster is returning its attributes successfully and the attributes have the expected values.
This cluster does not support WriteAttribute.

