### PR TITLE
[Test Step Update] Updating test step 9 to include expire session and allow some time for device to be ready after manual reboot

### DIFF
--- a/src/python_testing/TC_ACL_2_10.py
+++ b/src/python_testing/TC_ACL_2_10.py
@@ -229,15 +229,12 @@ class TC_ACL_2_10(MatterBaseTest):
             # No restart flag file: ask user to manually reboot
             self.wait_for_user_input(prompt_msg="Reboot the DUT. Press Enter when ready.\n")
 
-            # After manual reboot, expire sessions and allow time for device to be ready
+            # After manual reboot, expire previous sessions so that we can re-establish connections
             logging.info("Expiring sessions after manual device reboot")
             self.th1.ExpireSessions(self.dut_node_id)
             self.th2.ExpireSessions(self.dut_node_id)
-            
-            # Wait for device to be fully ready after reboot
-            time.sleep(2)
             logging.info("Manual device reboot completed")
-            
+
         else:
             try:
                 # Create the restart flag file to signal the test runner
@@ -263,7 +260,7 @@ class TC_ACL_2_10(MatterBaseTest):
         # TH1 reads DUT Endpoint 0 AccessControl cluster ACL attribute
         # Result is SUCCESS, value is list of AccessControlExtensionStruct
         # containing 2 elements; must not contain an element with fabricIndex F2
-        #acl_cluster = Clusters.AccessControl
+        # acl_cluster = Clusters.AccessControl
         result1 = await self.read_single_attribute_check_success(dev_ctrl=self.th1, endpoint=0, cluster=acl_cluster, attribute=acl_attribute)
         logging.info("TH1 read result: %s", str(result1))
         asserts.assert_equal(len(result1), 2,

--- a/src/python_testing/TC_ACL_2_10.py
+++ b/src/python_testing/TC_ACL_2_10.py
@@ -228,6 +228,16 @@ class TC_ACL_2_10(MatterBaseTest):
         if not restart_flag_file:
             # No restart flag file: ask user to manually reboot
             self.wait_for_user_input(prompt_msg="Reboot the DUT. Press Enter when ready.\n")
+
+            # After manual reboot, expire sessions and allow time for device to be ready
+            logging.info("Expiring sessions after manual device reboot")
+            self.th1.ExpireSessions(self.dut_node_id)
+            self.th2.ExpireSessions(self.dut_node_id)
+            
+            # Wait for device to be fully ready after reboot
+            time.sleep(2)
+            logging.info("Manual device reboot completed")
+            
         else:
             try:
                 # Create the restart flag file to signal the test runner


### PR DESCRIPTION
#### Summary
- After manual reboot and user has responded that DUT has been rebooted fully when asked, add TH expire session calls to make sure that both TH1 and TH2 fabrics prior sessions were expired so that they could reconnect after DUT  reboot with a 2 second delay

#### Related issues
Fixes: https://github.com/project-chip/connectedhomeip/issues/40882

#### Testing
Verified in local WSL testing environment and testing on following TH version:
- Version: v2.14-beta2+fall2025
- Sha: 323a280

Example results:
<img width="644" height="692" alt="image" src="https://github.com/user-attachments/assets/9687dc56-0590-45ff-8ec7-55063b122e39" />