### PR TITLE
[TC-TSTAT-4.2] Remove timeout values from atomic request

### DIFF
--- a/src/python_testing/TC_TSTAT_4_2.py
+++ b/src/python_testing/TC_TSTAT_4_2.py
@@ -432,7 +432,7 @@ class TC_TSTAT_4_2(MatterBaseTest):
                 test_presets.remove(builtInPreset)
 
                 # Send the AtomicRequest begin command
-                await self.send_atomic_request_begin_command(timeout=5000, expected_timeout=3000)
+                await self.send_atomic_request_begin_command()
 
                 # Write to the presets attribute after calling AtomicRequest command
                 await self.write_presets(endpoint=endpoint, presets=test_presets)


### PR DESCRIPTION
#### Summary

This PR removes the timeout and expected timeout parameters for the send_atomic_request_begin_command call. These values are not called out in the test plan and should not have been there. All other calls does not specify any timeout parameters.

This was discussed on the 8/9-2025 HVAC TT meeting and this solution was agreed.

#### Related issues

Fixes #40791 
Addresses CCB 4244

#### Testing

Passed test script locally against all-clusters

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
