### PR TITLE
[Camera] Start the camera with correct camera device

### DIFF
--- a/examples/camera-app/linux/main.cpp
+++ b/examples/camera-app/linux/main.cpp
@@ -40,6 +40,11 @@ void ApplicationInit()
     if (LinuxDeviceOptions::GetInstance().cameraVideoDevice.HasValue())
     {
         std::string videoDevicePath = LinuxDeviceOptions::GetInstance().cameraVideoDevice.Value();
+        // If the path does not start with '/', assume it's a device name and prepend /dev/
+        if (!videoDevicePath.empty() && videoDevicePath[0] != '/')
+        {
+            videoDevicePath = "/dev/" + videoDevicePath;
+        }
         ChipLogDetail(Camera, "Using video device path from options: %s", videoDevicePath.c_str());
         gCameraDevice.SetVideoDevicePath(videoDevicePath);
     }

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -411,6 +411,8 @@ CameraError CameraDevice::InitializeCameraDevice()
         gstreamerInitialized = true;
     }
 
+    ChipLogDetail(Camera, "InitializeCameraDevice: %s", mVideoDevicePath.c_str());
+
     videoDeviceFd = open(mVideoDevicePath.c_str(), O_RDWR);
     if (videoDeviceFd == -1)
     {

--- a/examples/camera-controller/README.md
+++ b/examples/camera-controller/README.md
@@ -149,9 +149,9 @@ Clean up any existing configurations (first-time pairing only):
 sudo rm -rf /tmp/chip_*
 ```
 
-#### Video Format (YUYV Only)
+#### Video Format (`YUYV` Only)
 
-This demo supports only the uncompressed YUYV 4:2:2 pixel format for capture.
+This demo supports only the uncompressed `YUYV` pixel format for capture.
 
 Identify the correct video device first (examples: `video0`, `video1`). You can
 list devices and verify the format support with:

--- a/examples/camera-controller/README.md
+++ b/examples/camera-controller/README.md
@@ -149,8 +149,23 @@ Clean up any existing configurations (first-time pairing only):
 sudo rm -rf /tmp/chip_*
 ```
 
+#### Video Format (YUYV Only)
+
+This demo supports only the uncompressed YUYV 4:2:2 pixel format for capture.
+
+Identify the correct video device first (examples: `video0`, `video1`). You can
+list devices and verify the format support with:
+
 ```
-./out/linux-x64-camera/chip-camera-app
+v4l2-ctl --list-devices
+v4l2-ctl -d /dev/video0 --list-formats-ext | grep -A4 YUYV || true
+```
+
+Launch the camera app explicitly selecting the device (replace `video0` if
+needed):
+
+```
+./out/linux-x64-camera/chip-camera-app --camera-video-device video0
 ```
 
 Terminal 2: Launch and Use the Camera Controller (Client)
@@ -174,12 +189,12 @@ Wait for the command to complete and confirm that commissioning was successful.
 
 3. To start a live video stream from your camera, use the `liveview start`
    command followed by the nodeID you set during pairing. For example, if your
-   nodeID is 1, you can request a stream with a minimum resolution of 800x600
+   nodeID is 1, you can request a stream with a minimum resolution of 640x480
    pixels and a minimum frame rate of 30 frames per second using the command
    below.
 
 ```
-liveview start 1 --min-res-width 800 --min-res-height 600 --min-framerate 30
+liveview start 1 --min-res-width 640 --min-res-height 480 --min-framerate 30
 ```
 
 To see what video formats and resolutions your camera supports, first list the


### PR DESCRIPTION
#### Summary

1. Add the camera device prefix if it is not specified
2. This demo supports only the uncompressed YUYV pixel format for capture. Update the readme to use correct format

#### Related issues

N/A

#### Testing

Validated by CI
