### PR TITLE
[CI] Fix DISABLE_CCACHE in tests workflow to be taken into account in all steps

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -595,7 +595,12 @@ jobs:
                 build-variant: ${{ matrix.build_variant }}
 
             - name: Build python env
-              run: scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv --enable-ccache'
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build_python.sh \
+                      --install_virtual_env out/venv \
+                      $([ "${DISABLE_CCACHE}" != "true" ] && echo --enable-ccache)\
+                    "
 
             - name: Build linux-x64-all-clusters
               env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,15 @@ concurrency:
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
+    DISABLE_CCACHE: ${{ (
+      (github.event_name == 'workflow_dispatch' && inputs.disable_ccache == 'true') ||
+      (contains(github.event.head_commit.message, '[no-ccache]')) ||
+      (github.event_name == 'pull_request' && (
+        contains(github.event.pull_request.title, '[no-ccache]') || 
+        contains(github.event.pull_request.body, '[no-ccache]')
+      ))
+      ) && 'true' || 'false' }}
+    CCACHE_KEY_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && inputs.cache_suffix || '' }}
 
 jobs:
     test_suites_linux:
@@ -55,8 +64,6 @@ jobs:
             CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
             LSAN_OPTIONS: detect_leaks=1
-            DISABLE_CCACHE: true
-            CCACHE_KEY_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && inputs.cache_suffix || '' }}
 
 
         if: github.actor != 'restyled-io[bot]'
@@ -560,7 +567,6 @@ jobs:
         env:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
             BUILD_VARIANT: ${{matrix.build_variant}}
-            DISABLE_CCACHE: true
 
         runs-on: ubuntu-latest
 
@@ -605,7 +611,7 @@ jobs:
                     "
 
             - name: Set pw_launcher ccache flag
-              run: echo "PW_LAUNCHER_CCACHE_FLAG=${{ env.DISABLE_CCACHE == 'true' && '' || '--pw-command-launcher=ccache' }}" >> $GITHUB_ENV
+              run: echo "CCACHE_PW_LAUNCHER_FLAG=${{ env.DISABLE_CCACHE == 'true' && '' || '--pw-command-launcher=ccache' }}" >> $GITHUB_ENV
 
             - name: Build linux-x64-all-clusters
               env:
@@ -613,7 +619,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-all-clusters-${BUILD_VARIANT}-tsan-clang-test
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-all-clusters-${BUILD_VARIANT}-tsan-clang-test
                   "
             # TODO: determine why some apps are tsan and some are not (and does that add runtime overhead? )
@@ -623,7 +629,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-bridge-${BUILD_VARIANT}-tsan-clang-test
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-bridge-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-lock
@@ -632,7 +638,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-lock-${BUILD_VARIANT}-tsan-clang-test
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-lock-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-lit-icd
@@ -641,7 +647,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-lit-icd-${BUILD_VARIANT}-tsan-clang-test
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-lit-icd-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-air-purifier
@@ -650,7 +656,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-air-purifier-${BUILD_VARIANT}-tsan-clang-test
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-air-purifier-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-energy-gateway
@@ -659,7 +665,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-energy-gateway-${BUILD_VARIANT}-tsan-clang-test
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-energy-gateway-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-energy-management
@@ -668,7 +674,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-energy-management-${BUILD_VARIANT}-tsan-clang-test
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-energy-management-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-microwave-oven
@@ -677,7 +683,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-microwave-oven-${BUILD_VARIANT}-tsan-clang-test
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-microwave-oven-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-rvc
@@ -686,7 +692,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-rvc-${BUILD_VARIANT}-tsan-clang-test
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-rvc-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-network-manager
@@ -695,7 +701,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-network-manager-${BUILD_VARIANT}-tsan-clang-test
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-network-manager-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-fabric-admin-rpc
@@ -704,7 +710,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-fabric-admin-rpc-${BUILD_VARIANT}-clang
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-fabric-admin-rpc-${BUILD_VARIANT}-clang"
 
             - name: Build linux-x64-fabric-bridge-rpc
@@ -713,7 +719,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-fabric-bridge-rpc-${BUILD_VARIANT}-clang
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-fabric-bridge-rpc-${BUILD_VARIANT}-clang"
 
             - name: Build linux-x64-fabric-sync
@@ -722,7 +728,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-fabric-sync-${BUILD_VARIANT}-clang
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-fabric-sync-${BUILD_VARIANT}-clang"
 
             # TODO: camera app needs clang support
@@ -732,7 +738,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-camera
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-camera"
 
             - name: Build linux-x64-camera-controller
@@ -741,7 +747,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-camera-controller
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-camera-controller"
 
             - name: Build linux-x64-light-data-model-no-unique-id
@@ -750,7 +756,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-light-data-model-no-unique-id-${BUILD_VARIANT}-clang
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-light-data-model-no-unique-id-${BUILD_VARIANT}-clang"
 
             - name: Build linux-x64-terms-and-conditions
@@ -759,7 +765,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-terms-and-conditions
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-terms-and-conditions"
 
             - name: Build linux-x64-python-bindings
@@ -768,7 +774,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-python-bindings-webrtc
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-python-bindings-webrtc"
 
             - name: Build linux-x64-jf-control-app
@@ -777,7 +783,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-jf-control-app
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-jf-control-app"
 
             - name: Build linux-x64-jf-admin-app
@@ -786,7 +792,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-jf-admin-app
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-jf-admin-app"
 
             - name: Build linux-x64-closure-app
@@ -795,7 +801,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test
-                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
+                  ${CCACHE_PW_LAUNCHER_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: ccache stats

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,6 +57,8 @@ jobs:
             LSAN_OPTIONS: detect_leaks=1
             DISABLE_CCACHE: true
             CCACHE_KEY_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && inputs.cache_suffix || '' }}
+            PW_CCACHE_STATUS: ${{ env.DISABLE_CCACHE == 'true' && '' || 'ccache' }}
+
 
         if: github.actor != 'restyled-io[bot]'
         runs-on: ubuntu-latest
@@ -281,7 +283,7 @@ jobs:
                         --target linux-x64-network-manager-${BUILD_VARIANT} \
                         --target linux-x64-energy-gateway-${BUILD_VARIANT} \
                         --target linux-x64-energy-management-${BUILD_VARIANT} \
-                        --pw-command-launcher=ccache \
+                        --pw-command-launcher=${PW_CCACHE_STATUS} \
                         build \
                         --copy-artifacts-to objdir-clone \
                      "
@@ -560,6 +562,8 @@ jobs:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
             BUILD_VARIANT: ${{matrix.build_variant}}
             DISABLE_CCACHE: true
+            PW_CCACHE_STATUS: ${{ env.DISABLE_CCACHE == 'true' && '' || 'ccache' }}
+
 
         runs-on: ubuntu-latest
 
@@ -609,7 +613,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-all-clusters-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-all-clusters-${BUILD_VARIANT}-tsan-clang-test
                   "
             # TODO: determine why some apps are tsan and some are not (and does that add runtime overhead? )
@@ -619,7 +623,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-bridge-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-bridge-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-lock
@@ -628,7 +632,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-lock-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-lock-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-lit-icd
@@ -637,7 +641,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-lit-icd-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-lit-icd-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-air-purifier
@@ -646,7 +650,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-air-purifier-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-air-purifier-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-energy-gateway
@@ -655,7 +659,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-energy-gateway-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-energy-gateway-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-energy-management
@@ -664,7 +668,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-energy-management-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-energy-management-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-microwave-oven
@@ -673,7 +677,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-microwave-oven-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-microwave-oven-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-rvc
@@ -682,7 +686,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-rvc-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-rvc-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-network-manager
@@ -691,7 +695,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-network-manager-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-network-manager-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-fabric-admin-rpc
@@ -700,7 +704,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-fabric-admin-rpc-${BUILD_VARIANT}-clang
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-fabric-admin-rpc-${BUILD_VARIANT}-clang"
 
             - name: Build linux-x64-fabric-bridge-rpc
@@ -709,7 +713,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-fabric-bridge-rpc-${BUILD_VARIANT}-clang
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-fabric-bridge-rpc-${BUILD_VARIANT}-clang"
 
             - name: Build linux-x64-fabric-sync
@@ -718,7 +722,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-fabric-sync-${BUILD_VARIANT}-clang
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-fabric-sync-${BUILD_VARIANT}-clang"
 
             # TODO: camera app needs clang support
@@ -728,7 +732,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-camera
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-camera"
 
             - name: Build linux-x64-camera-controller
@@ -737,7 +741,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-camera-controller
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-camera-controller"
 
             - name: Build linux-x64-light-data-model-no-unique-id
@@ -746,7 +750,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-light-data-model-no-unique-id-${BUILD_VARIANT}-clang
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-light-data-model-no-unique-id-${BUILD_VARIANT}-clang"
 
             - name: Build linux-x64-terms-and-conditions
@@ -755,7 +759,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-terms-and-conditions
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-terms-and-conditions"
 
             - name: Build linux-x64-python-bindings
@@ -764,7 +768,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-python-bindings-webrtc
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-python-bindings-webrtc"
 
             - name: Build linux-x64-jf-control-app
@@ -773,7 +777,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-jf-control-app
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-jf-control-app"
 
             - name: Build linux-x64-jf-admin-app
@@ -782,7 +786,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-jf-admin-app
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-jf-admin-app"
 
             - name: Build linux-x64-closure-app
@@ -791,7 +795,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=ccache build --copy-artifacts-to objdir-clone
+                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: ccache stats

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,7 +57,6 @@ jobs:
             LSAN_OPTIONS: detect_leaks=1
             DISABLE_CCACHE: true
             CCACHE_KEY_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && inputs.cache_suffix || '' }}
-            PW_CCACHE_STATUS: ${{ env.DISABLE_CCACHE == 'true' && '' || 'ccache' }}
 
 
         if: github.actor != 'restyled-io[bot]'
@@ -283,7 +282,7 @@ jobs:
                         --target linux-x64-network-manager-${BUILD_VARIANT} \
                         --target linux-x64-energy-gateway-${BUILD_VARIANT} \
                         --target linux-x64-energy-management-${BUILD_VARIANT} \
-                        --pw-command-launcher=${PW_CCACHE_STATUS} \
+                        --pw-command-launcher=$([ "${DISABLE_CCACHE}" != "true" ] && echo ccache) \
                         build \
                         --copy-artifacts-to objdir-clone \
                      "
@@ -562,8 +561,6 @@ jobs:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
             BUILD_VARIANT: ${{matrix.build_variant}}
             DISABLE_CCACHE: true
-            PW_CCACHE_STATUS: ${{ env.DISABLE_CCACHE == 'true' && '' || 'ccache' }}
-
 
         runs-on: ubuntu-latest
 
@@ -607,13 +604,16 @@ jobs:
                       $([ "${DISABLE_CCACHE}" != "true" ] && echo --enable-ccache)\
                     "
 
+            - name: Set pw_launcher ccache flag
+              run: echo "PW_LAUNCHER_CCACHE_FLAG=${{ env.DISABLE_CCACHE == 'true' && '' || '--pw-command-launcher=ccache' }}" >> $GITHUB_ENV
+
             - name: Build linux-x64-all-clusters
               env:
                   CCACHE_DIR: "${{ github.workspace }}/.ccache"
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-all-clusters-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-all-clusters-${BUILD_VARIANT}-tsan-clang-test
                   "
             # TODO: determine why some apps are tsan and some are not (and does that add runtime overhead? )
@@ -623,7 +623,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-bridge-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-bridge-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-lock
@@ -632,7 +632,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-lock-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-lock-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-lit-icd
@@ -641,7 +641,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-lit-icd-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-lit-icd-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-air-purifier
@@ -650,7 +650,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-air-purifier-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-air-purifier-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-energy-gateway
@@ -659,7 +659,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-energy-gateway-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-energy-gateway-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-energy-management
@@ -668,7 +668,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-energy-management-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-energy-management-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-microwave-oven
@@ -677,7 +677,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-microwave-oven-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-microwave-oven-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-rvc
@@ -686,7 +686,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-rvc-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-rvc-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-network-manager
@@ -695,7 +695,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-network-manager-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-network-manager-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: Build linux-x64-fabric-admin-rpc
@@ -704,7 +704,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-fabric-admin-rpc-${BUILD_VARIANT}-clang
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-fabric-admin-rpc-${BUILD_VARIANT}-clang"
 
             - name: Build linux-x64-fabric-bridge-rpc
@@ -713,7 +713,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-fabric-bridge-rpc-${BUILD_VARIANT}-clang
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-fabric-bridge-rpc-${BUILD_VARIANT}-clang"
 
             - name: Build linux-x64-fabric-sync
@@ -722,7 +722,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-fabric-sync-${BUILD_VARIANT}-clang
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-fabric-sync-${BUILD_VARIANT}-clang"
 
             # TODO: camera app needs clang support
@@ -732,7 +732,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-camera
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-camera"
 
             - name: Build linux-x64-camera-controller
@@ -741,7 +741,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-camera-controller
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-camera-controller"
 
             - name: Build linux-x64-light-data-model-no-unique-id
@@ -750,7 +750,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-light-data-model-no-unique-id-${BUILD_VARIANT}-clang
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-light-data-model-no-unique-id-${BUILD_VARIANT}-clang"
 
             - name: Build linux-x64-terms-and-conditions
@@ -759,7 +759,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-terms-and-conditions
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-terms-and-conditions"
 
             - name: Build linux-x64-python-bindings
@@ -768,7 +768,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-python-bindings-webrtc
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-python-bindings-webrtc"
 
             - name: Build linux-x64-jf-control-app
@@ -777,7 +777,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-jf-control-app
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-jf-control-app"
 
             - name: Build linux-x64-jf-admin-app
@@ -786,7 +786,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-jf-admin-app
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-jf-admin-app"
 
             - name: Build linux-x64-closure-app
@@ -795,7 +795,7 @@ jobs:
               run: >-
                   ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py
                   --target linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test
-                  --pw-command-launcher=${PW_CCACHE_STATUS} build --copy-artifacts-to objdir-clone
+                  ${PW_LAUNCHER_CCACHE_FLAG} build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test"
 
             - name: ccache stats

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,7 @@ jobs:
             CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
             LSAN_OPTIONS: detect_leaks=1
-            DISABLE_CCACHE: ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_ccache == 'true') && 'true' || (contains(github.event.head_commit.message, '[no-ccache]') && 'true') || 'false' }}
+            DISABLE_CCACHE: true
             CCACHE_KEY_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && inputs.cache_suffix || '' }}
 
         if: github.actor != 'restyled-io[bot]'
@@ -559,6 +559,7 @@ jobs:
         env:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
             BUILD_VARIANT: ${{matrix.build_variant}}
+            DISABLE_CCACHE: true
 
         runs-on: ubuntu-latest
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -607,12 +607,12 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build_python.sh \
                       --install_virtual_env out/venv \
-                      $([ "${DISABLE_CCACHE}" != "true" ] && echo --enable-ccache)\
+                      $([ "${DISABLE_CCACHE}" != "true" ] && echo --enable-ccache) \
                     "
 
             - name: Set pw_launcher ccache flag
               run: |
-                if [ "${{ env.DISABLE_CCACHE }}" = "true" ]; then
+                if [ "${DISABLE_CCACHE}" = "true" ]; then
                   echo "CCACHE_PW_LAUNCHER_FLAG=" >> $GITHUB_ENV
                 else
                   echo "CCACHE_PW_LAUNCHER_FLAG=--pw-command-launcher=ccache" >> $GITHUB_ENV

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -611,7 +611,12 @@ jobs:
                     "
 
             - name: Set pw_launcher ccache flag
-              run: echo "CCACHE_PW_LAUNCHER_FLAG=${{ env.DISABLE_CCACHE == 'true' && '' || '--pw-command-launcher=ccache' }}" >> $GITHUB_ENV
+              run: |
+                if [ "${{ env.DISABLE_CCACHE }}" = "true" ]; then
+                  echo "CCACHE_PW_LAUNCHER_FLAG=" >> $GITHUB_ENV
+                else
+                  echo "CCACHE_PW_LAUNCHER_FLAG=--pw-command-launcher=ccache" >> $GITHUB_ENV
+                fi
 
             - name: Build linux-x64-all-clusters
               env:


### PR DESCRIPTION
#### Summary

- Currently, we are able to run tests.yaml with  `DISABLE_CCACHE` in case of issues or for testing. However two issues are there which are fixed:

1. Some Jobs and Steps within tests.yaml were not configured to take `DISABLE_CCACHE` variable into account:
    - notably, `Build python env` step in REPL job and all steps that used `--pw-command-launcher=ccache` 

2. Allow `DISABLE_CCACHE=true` to be triggered based on having `[no-ccache]` in PR body and PR title. It seems before this was not possible




#### Testing

CI will test this

[no-ccache]