### PR TITLE
[NXP] Update BLEManagerCommon and BLE Application Manager, cmake configs

### DIFF
--- a/examples/platform/nxp/common/Kconfig
+++ b/examples/platform/nxp/common/Kconfig
@@ -60,11 +60,17 @@ if CHIP_APP_BLE_MANAGER
             depends on CHIP_NXP_MULTIPLE_BLE_CONNECTIONS && !CHIP_DEVICE_USE_ZEPHYR_BLE
             help
                 Enable application custom MCXW7x BLE manager.
-        
+
         config CHIP_APP_BLE_MANAGER_EMPTY
             bool "App BLE Manager Empty"
             help
                 Enable application BLE manager empty implementation.
+
+        config CHIP_APP_BLE_MANAGER_CUSTOM_EXTERNAL
+            bool "App Custom BLE Manager External"
+            default n
+            help
+                Enable application custom externally linked (e.g from mcuxsdk-examples-matter) BLE manager.
 
     endchoice # CHIP_APP_BLE_MANAGER
 

--- a/examples/platform/nxp/common/app_ble/source/NXPHostBLEApplicationManager.cpp
+++ b/examples/platform/nxp/common/app_ble/source/NXPHostBLEApplicationManager.cpp
@@ -22,7 +22,7 @@
 #include <platform/ConfigurationManager.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/PlatformManager.h>
-#include <src/platform/nxp/common/ble/BLEManagerCommon.h>
+#include <platform/nxp/common/ble/BLEManagerCommon.h>
 
 #include "gatt_db_app_interface.h"
 #include "gatt_db_handles.h"
@@ -59,7 +59,7 @@ void BLEApplicationManager::Init(void)
     CHIP_ERROR err    = CHIP_NO_ERROR;
     auto * bleManager = &chip::DeviceLayer::Internal::BLEMgrImpl();
 
-    bleManager->RegisterAppCallbacks(app_gap_callback, app_gatt_callback);
+    bleManager->RegisterAppCallbacks(nullptr, nullptr, app_gap_callback, app_gatt_callback);
     err = bleManager->AddWriteNotificationHandle((uint16_t) value_uart_stream);
 
     if (err != CHIP_NO_ERROR)

--- a/examples/platform/nxp/common/app_common.cmake
+++ b/examples/platform/nxp/common/app_common.cmake
@@ -85,7 +85,7 @@ if (CONFIG_CHIP_APP_BLE_MANAGER)
         target_sources(app PRIVATE
             ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/app_ble/source/NXPHostBLEApplicationManager.cpp
         )
-    else()
+    elseif(CONFIG_CHIP_APP_BLE_MANAGER_EMPTY)
         target_sources(app PRIVATE
             ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/app_ble/source/BLEApplicationManagerEmpty.cpp
         )

--- a/src/platform/nxp/common/ble/BLEManagerCommon.cpp
+++ b/src/platform/nxp/common/ble/BLEManagerCommon.cpp
@@ -178,6 +178,14 @@ CHIP_ERROR BLEManagerCommon::_Init()
     /* BLE platform code initialization */
     SuccessOrExit(err = InitHostController(&blekw_generic_cb));
 
+    /* Set Default BLE Advertise Data callback*/
+    RegisterAdvDataCallback(blekw_default_adv_data_cb);
+
+    if (sImplInstance && sImplInstance->callbackDelegate.appInitCallback)
+    {
+        sImplInstance->callbackDelegate.appInitCallback();
+    }
+
     /* Register the GATT server callback */
     VerifyOrExit(GattServer_RegisterCallback(blekw_gatt_server_cb) == gBleSuccess_c, err = CHIP_ERROR_INCORRECT_STATE);
 
@@ -460,6 +468,23 @@ BLEManagerCommon::ble_err_t BLEManagerCommon::blekw_start_advertising(gapAdverti
 {
     EventBits_t eventBits;
 
+    /* Random address must be used only in matter commissioning, not in subsequent connections */
+    if(!ConfigurationMgr().IsFullyProvisioned())
+    {
+        /************* Create and set the device address *************/
+        if (gBleSuccess_c != Gap_CreateRandomDeviceAddress(NULL, NULL))
+        {
+            return BLE_E_SET_ADV_PARAMS;
+        }
+
+        eventBits = xEventGroupWaitBits(sEventGroup, CHIP_BLE_KW_EVNT_RND_ADDR_SET, pdTRUE, pdTRUE, CHIP_BLE_KW_EVNT_TIMEOUT);
+
+        if (!(eventBits & CHIP_BLE_KW_EVNT_RND_ADDR_SET))
+        {
+            return BLE_E_ADV_PARAMS_FAILED;
+        }
+    }
+
     /************* Set the advertising parameters *************/
     xEventGroupClearBits(sEventGroup, CHIP_BLE_KW_EVNT_ADV_SETUP_FAILED | CHIP_BLE_KW_EVNT_ADV_PAR_SETUP_COMPLETE);
 
@@ -502,18 +527,6 @@ BLEManagerCommon::ble_err_t BLEManagerCommon::blekw_start_advertising(gapAdverti
 
     /************* Start the advertising *************/
     xEventGroupClearBits(sEventGroup, CHIP_BLE_KW_EVNT_ADV_CHANGED | CHIP_BLE_KW_EVNT_ADV_FAILED);
-
-    if (gBleSuccess_c != Gap_CreateRandomDeviceAddress(NULL, NULL))
-    {
-        return BLE_E_SET_ADV_PARAMS;
-    }
-
-    eventBits = xEventGroupWaitBits(sEventGroup, CHIP_BLE_KW_EVNT_RND_ADDR_SET, pdTRUE, pdTRUE, CHIP_BLE_KW_EVNT_TIMEOUT);
-
-    if (!(eventBits & CHIP_BLE_KW_EVNT_RND_ADDR_SET))
-    {
-        return BLE_E_ADV_PARAMS_FAILED;
-    }
 
     /* Start the advertising */
     if (Gap_StartAdvertising(blekw_gap_advertising_cb, blekw_gap_connection_cb) != gBleSuccess_c)
@@ -576,26 +589,17 @@ BLEManagerCommon::ble_err_t BLEManagerCommon::blekw_stop_advertising(void)
 
 CHIP_ERROR BLEManagerCommon::ConfigureAdvertisingData(void)
 {
-    ble_err_t err;
-    CHIP_ERROR chipErr;
-    uint16_t discriminator;
+    ble_err_t err                                         = BLE_OK;
+    CHIP_ERROR chipErr                                    = CHIP_NO_ERROR;
+    uint16_t discriminator                                = 0;
     uint16_t advInterval                                  = 0;
     gapAdvertisingData_t adv                              = { 0 };
-    gapAdStructure_t adv_data[BLEKW_ADV_MAX_NO]           = { { 0 } };
     gapAdStructure_t scan_rsp_data[BLEKW_SCAN_RSP_MAX_NO] = { { 0 } };
-    uint8_t advPayload[BLEKW_MAX_ADV_DATA_LEN]            = { 0 };
     gapScanResponseData_t scanRsp                         = { 0 };
     gapAdvertisingParameters_t adv_params                 = { 0 };
-    uint8_t chipAdvDataFlags                              = (gLeGeneralDiscoverableMode_c | gBrEdrNotSupported_c);
     uint8_t chipOverBleService[2];
-    ChipBLEDeviceIdentificationInfo mDeviceIdInfo = { 0 };
-    uint8_t mDeviceIdInfoLength                   = 0;
 
-    chipErr = GetCommissionableDataProvider()->GetSetupDiscriminator(discriminator);
-    if (chipErr != CHIP_NO_ERROR)
-    {
-        return chipErr;
-    }
+    ReturnErrorOnFailure(GetCommissionableDataProvider()->GetSetupDiscriminator(discriminator));
 
     if (!mFlags.Has(Flags::kDeviceNameSet))
     {
@@ -603,32 +607,14 @@ CHIP_ERROR BLEManagerCommon::ConfigureAdvertisingData(void)
         snprintf(mDeviceName, kMaxDeviceNameLength, "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
     }
 
-    /**************** Prepare advertising data *******************************************/
-    adv.cNumAdStructures = BLEKW_ADV_MAX_NO;
+    VerifyOrReturnError(sImplInstance && sImplInstance->callbackDelegate.gapAdvDataCallback, CHIP_ERROR_INCORRECT_STATE);
 
-    chipErr = ConfigurationMgr().GetBLEDeviceIdentificationInfo(mDeviceIdInfo);
-    SuccessOrExit(chipErr);
-    mDeviceIdInfoLength = sizeof(mDeviceIdInfo);
-
-    if ((mDeviceIdInfoLength + CHIP_ADV_SHORT_UUID_LEN + 1) > BLEKW_MAX_ADV_DATA_LEN)
-    {
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    adv_data[0].length = 0x02;
-    adv_data[0].adType = gAdFlags_c;
-    adv_data[0].aData  = (uint8_t *) (&chipAdvDataFlags);
-
-    adv_data[1].length = static_cast<uint8_t>(mDeviceIdInfoLength + CHIP_ADV_SHORT_UUID_LEN + 1);
-    adv_data[1].adType = gAdServiceData16bit_c;
-    memcpy(advPayload, ShortUUID_CHIPoBLEService, CHIP_ADV_SHORT_UUID_LEN);
-    memcpy(&advPayload[CHIP_ADV_SHORT_UUID_LEN], (void *) &mDeviceIdInfo, mDeviceIdInfoLength);
-    adv_data[1].aData = advPayload;
-
-    adv.aAdStructures = adv_data;
+    adv.aAdStructures = sImplInstance->callbackDelegate.gapAdvDataCallback(&adv.cNumAdStructures);
+    VerifyOrReturnError(adv.aAdStructures, CHIP_ERROR_INCORRECT_STATE);
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
-    ReturnErrorOnFailure(EncodeAdditionalDataTlv());
+    chipErr = EncodeAdditionalDataTlv();
+    SuccessOrExit(chipErr);
 #endif
 
     /**************** Prepare scan response data *******************************************/
@@ -674,10 +660,12 @@ CHIP_ERROR BLEManagerCommon::ConfigureAdvertisingData(void)
     {
         ChipLogProgress(DeviceLayer, "Advertising error 0x%x!", err);
         mFlags.Clear(Flags::kAdvertising);
-        return CHIP_ERROR_INCORRECT_STATE;
+        chipErr = CHIP_ERROR_INCORRECT_STATE;
     }
 
 exit:
+    free(adv.aAdStructures);
+    adv.aAdStructures = nullptr;
     return chipErr;
 }
 
@@ -887,6 +875,13 @@ void BLEManagerCommon::DoBleProcessing(void)
         {
             sImplInstance->HandleForceDisconnect();
         }
+        else if (msg->type == BLE_KW_MSG_APP_EV_CB)
+        {
+            if (msg->handler != NULL)
+            {
+                msg->handler(msg->param);
+            }
+        }
 
         /* Free the message from the queue */
         free(msg);
@@ -894,11 +889,23 @@ void BLEManagerCommon::DoBleProcessing(void)
     }
 }
 
-void BLEManagerCommon::RegisterAppCallbacks(BLECallbackDelegate::GapGenericCallback gapCallback,
+void BLEManagerCommon::RegisterAppCallbacks(BLECallbackDelegate::InitAppCallback appInitCallback,
+                                            BLECallbackDelegate::ConnectionCallback connCallback,
+                                            BLECallbackDelegate::GapGenericCallback gapCallback,
                                             BLECallbackDelegate::GattServerCallback gattCallback)
 {
-    callbackDelegate.gapCallback  = gapCallback;
-    callbackDelegate.gattCallback = gattCallback;
+    callbackDelegate.appInitCallback = appInitCallback;
+    callbackDelegate.connCallback    = connCallback;
+    callbackDelegate.gapCallback     = gapCallback;
+    callbackDelegate.gattCallback    = gattCallback;
+}
+
+void BLEManagerCommon::RegisterAdvDataCallback(BLECallbackDelegate::GapAdvDataCallback gapAdvDataCallback)
+{
+    if (callbackDelegate.gapAdvDataCallback != gapAdvDataCallback)
+    {
+        callbackDelegate.gapAdvDataCallback = gapAdvDataCallback;
+    }
 }
 
 CHIP_ERROR BLEManagerCommon::AddWriteNotificationHandle(uint16_t name)
@@ -1185,14 +1192,18 @@ void BLEManagerCommon::blekw_gap_advertising_cb(gapAdvertisingEvent_t * pAdverti
         /* Set the local synchronization event */
         xEventGroupSetBits(sEventGroup, CHIP_BLE_KW_EVNT_ADV_CHANGED);
     }
-    else
+    else if (pAdvertisingEvent->eventType == gAdvertisingCommandFailed_c)
     {
         /* The advertisement start failed */
-        ChipLogProgress(DeviceLayer, "Advertising failed: event=%d reason=0x%04X\n", pAdvertisingEvent->eventType,
+        ChipLogProgress(DeviceLayer, "Advertising failed: event = %d reason = 0x%04X", pAdvertisingEvent->eventType,
                         pAdvertisingEvent->eventData.failReason);
 
         /* Set the local synchronization event */
         xEventGroupSetBits(sEventGroup, CHIP_BLE_KW_EVNT_ADV_FAILED);
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, "Advertising event = %d", pAdvertisingEvent->eventType);
     }
 }
 
@@ -1200,6 +1211,11 @@ void BLEManagerCommon::blekw_gap_connection_cb(deviceId_t deviceId, gapConnectio
 {
     /* Call BLE Conn Manager */
     BleConnManager_GapPeripheralEvent(deviceId, pConnectionEvent);
+
+    if (sImplInstance && sImplInstance->callbackDelegate.connCallback)
+    {
+        sImplInstance->callbackDelegate.connCallback(deviceId, pConnectionEvent);
+    }
 
     if (pConnectionEvent->eventType == gConnEvtConnected_c)
     {
@@ -1335,6 +1351,50 @@ void BLEManagerCommon::blekw_gatt_server_cb(deviceId_t deviceId, gattServerEvent
         break;
     }
 }
+
+/*
+* free the pointer
+*/
+gapAdStructure_t* BLEManagerCommon::blekw_default_adv_data_cb(uint8_t *size)
+{
+    static uint8_t advPayload[BLEKW_MAX_ADV_DATA_LEN] = { 0 };
+    static uint8_t advDataFlags = (gLeGeneralDiscoverableMode_c | gBrEdrNotSupported_c);
+    ChipBLEDeviceIdentificationInfo mDeviceIdInfo = { 0 };
+    uint8_t mDeviceIdInfoLength                   = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    gapAdStructure_t* adv_data = (gapAdStructure_t*) malloc(BLEKW_ADV_MAX_NO * sizeof(gapAdStructure_t));
+
+    *size = BLEKW_ADV_MAX_NO;
+
+    err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(mDeviceIdInfo);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Cannot get BLE device identification info");
+        return nullptr;
+    }
+
+    mDeviceIdInfoLength = sizeof(mDeviceIdInfo);
+
+    if ((mDeviceIdInfoLength + CHIP_ADV_SHORT_UUID_LEN + 1) > BLEKW_MAX_ADV_DATA_LEN)
+    {
+        ChipLogError(DeviceLayer, "Adv payload too big length");
+        return nullptr;
+    }
+
+    adv_data[0].length = *size;
+    adv_data[0].adType = gAdFlags_c;
+    adv_data[0].aData  = (uint8_t *) (&advDataFlags);
+
+    adv_data[1].length = static_cast<uint8_t>(mDeviceIdInfoLength + CHIP_ADV_SHORT_UUID_LEN + 1);
+    adv_data[1].adType = gAdServiceData16bit_c;
+    memcpy(advPayload, ShortUUID_CHIPoBLEService, CHIP_ADV_SHORT_UUID_LEN);
+    memcpy(&advPayload[CHIP_ADV_SHORT_UUID_LEN], (void *) &mDeviceIdInfo, mDeviceIdInfoLength);
+    adv_data[1].aData = advPayload;
+
+    return adv_data;
+}
+
 /*******************************************************************************
  * Add to message queue functions
  *******************************************************************************/
@@ -1379,6 +1439,26 @@ CHIP_ERROR BLEManagerCommon::blekw_msg_add_att_read(blekw_msg_type_t type, uint8
     att_rd_data            = (blekw_att_read_data_t *) msg->data.data;
     att_rd_data->device_id = device_id;
     att_rd_data->handle    = handle;
+
+    VerifyOrExit(xQueueSend(sBleEventQueue, &msg, 0) == pdTRUE, err = CHIP_ERROR_NO_MEMORY);
+    otTaskletsSignalPending(NULL);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR BLEManagerCommon::AddBleAppMsgHandler(pub_ble_msg_type_t type, blekw_callback_handler_t handler, blekw_callback_param_t param)
+{
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+    blekw_msg_t * msg = NULL;
+
+    /* Allocate a buffer with enough space to store the packet */
+    msg = (blekw_msg_t *) malloc(sizeof(blekw_msg_t));
+    VerifyOrExit(msg, err = CHIP_ERROR_NO_MEMORY);
+
+    msg->type    = (blekw_msg_type_t) type;
+    msg->handler = handler;
+    msg->param   = param;
 
     VerifyOrExit(xQueueSend(sBleEventQueue, &msg, 0) == pdTRUE, err = CHIP_ERROR_NO_MEMORY);
     otTaskletsSignalPending(NULL);

--- a/src/platform/nxp/common/ble/BLEManagerCommon.cpp
+++ b/src/platform/nxp/common/ble/BLEManagerCommon.cpp
@@ -1355,7 +1355,7 @@ void BLEManagerCommon::blekw_gatt_server_cb(deviceId_t deviceId, gattServerEvent
 gapAdStructure_t * BLEManagerCommon::blekw_default_adv_data_cb(uint8_t * size)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    gapAdStructure_t* adv_data;
+    gapAdStructure_t * adv_data;
     static uint8_t advPayload[BLEKW_MAX_ADV_DATA_LEN] = { 0 };
     static uint8_t advDataFlags                       = (gLeGeneralDiscoverableMode_c | gBrEdrNotSupported_c);
     ChipBLEDeviceIdentificationInfo mDeviceIdInfo     = { 0 };
@@ -1378,7 +1378,7 @@ gapAdStructure_t * BLEManagerCommon::blekw_default_adv_data_cb(uint8_t * size)
         return nullptr;
     }
 
-    adv_data = (gapAdStructure_t*) malloc(BLEKW_ADV_MAX_NO * sizeof(gapAdStructure_t));
+    adv_data = (gapAdStructure_t *) malloc(BLEKW_ADV_MAX_NO * sizeof(gapAdStructure_t));
 
     adv_data[0].length = *size;
     adv_data[0].adType = gAdFlags_c;

--- a/src/platform/nxp/common/ble/BLEManagerCommon.cpp
+++ b/src/platform/nxp/common/ble/BLEManagerCommon.cpp
@@ -1352,18 +1352,14 @@ void BLEManagerCommon::blekw_gatt_server_cb(deviceId_t deviceId, gattServerEvent
     }
 }
 
-/*
- * free the pointer
- */
 gapAdStructure_t * BLEManagerCommon::blekw_default_adv_data_cb(uint8_t * size)
 {
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    gapAdStructure_t* adv_data;
     static uint8_t advPayload[BLEKW_MAX_ADV_DATA_LEN] = { 0 };
     static uint8_t advDataFlags                       = (gLeGeneralDiscoverableMode_c | gBrEdrNotSupported_c);
     ChipBLEDeviceIdentificationInfo mDeviceIdInfo     = { 0 };
     uint8_t mDeviceIdInfoLength                       = 0;
-    CHIP_ERROR err                                    = CHIP_NO_ERROR;
-
-    gapAdStructure_t * adv_data = (gapAdStructure_t *) malloc(BLEKW_ADV_MAX_NO * sizeof(gapAdStructure_t));
 
     *size = BLEKW_ADV_MAX_NO;
 
@@ -1382,6 +1378,8 @@ gapAdStructure_t * BLEManagerCommon::blekw_default_adv_data_cb(uint8_t * size)
         return nullptr;
     }
 
+    adv_data = (gapAdStructure_t*) malloc(BLEKW_ADV_MAX_NO * sizeof(gapAdStructure_t));
+
     adv_data[0].length = *size;
     adv_data[0].adType = gAdFlags_c;
     adv_data[0].aData  = (uint8_t *) (&advDataFlags);
@@ -1392,6 +1390,7 @@ gapAdStructure_t * BLEManagerCommon::blekw_default_adv_data_cb(uint8_t * size)
     memcpy(&advPayload[CHIP_ADV_SHORT_UUID_LEN], (void *) &mDeviceIdInfo, mDeviceIdInfoLength);
     adv_data[1].aData = advPayload;
 
+    /* The returned pointer must be freed by the caller. */
     return adv_data;
 }
 

--- a/src/platform/nxp/common/ble/BLEManagerCommon.cpp
+++ b/src/platform/nxp/common/ble/BLEManagerCommon.cpp
@@ -469,7 +469,7 @@ BLEManagerCommon::ble_err_t BLEManagerCommon::blekw_start_advertising(gapAdverti
     EventBits_t eventBits;
 
     /* Random address must be used only in matter commissioning, not in subsequent connections */
-    if(!ConfigurationMgr().IsFullyProvisioned())
+    if (!ConfigurationMgr().IsFullyProvisioned())
     {
         /************* Create and set the device address *************/
         if (gBleSuccess_c != Gap_CreateRandomDeviceAddress(NULL, NULL))
@@ -1353,17 +1353,17 @@ void BLEManagerCommon::blekw_gatt_server_cb(deviceId_t deviceId, gattServerEvent
 }
 
 /*
-* free the pointer
-*/
-gapAdStructure_t* BLEManagerCommon::blekw_default_adv_data_cb(uint8_t *size)
+ * free the pointer
+ */
+gapAdStructure_t * BLEManagerCommon::blekw_default_adv_data_cb(uint8_t * size)
 {
     static uint8_t advPayload[BLEKW_MAX_ADV_DATA_LEN] = { 0 };
-    static uint8_t advDataFlags = (gLeGeneralDiscoverableMode_c | gBrEdrNotSupported_c);
-    ChipBLEDeviceIdentificationInfo mDeviceIdInfo = { 0 };
-    uint8_t mDeviceIdInfoLength                   = 0;
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    static uint8_t advDataFlags                       = (gLeGeneralDiscoverableMode_c | gBrEdrNotSupported_c);
+    ChipBLEDeviceIdentificationInfo mDeviceIdInfo     = { 0 };
+    uint8_t mDeviceIdInfoLength                       = 0;
+    CHIP_ERROR err                                    = CHIP_NO_ERROR;
 
-    gapAdStructure_t* adv_data = (gapAdStructure_t*) malloc(BLEKW_ADV_MAX_NO * sizeof(gapAdStructure_t));
+    gapAdStructure_t * adv_data = (gapAdStructure_t *) malloc(BLEKW_ADV_MAX_NO * sizeof(gapAdStructure_t));
 
     *size = BLEKW_ADV_MAX_NO;
 
@@ -1447,7 +1447,8 @@ exit:
     return err;
 }
 
-CHIP_ERROR BLEManagerCommon::AddBleAppMsgHandler(pub_ble_msg_type_t type, blekw_callback_handler_t handler, blekw_callback_param_t param)
+CHIP_ERROR BLEManagerCommon::AddBleAppMsgHandler(pub_ble_msg_type_t type, blekw_callback_handler_t handler,
+                                                 blekw_callback_param_t param)
 {
     CHIP_ERROR err    = CHIP_NO_ERROR;
     blekw_msg_t * msg = NULL;

--- a/src/platform/nxp/common/ble/BLEManagerCommon.h
+++ b/src/platform/nxp/common/ble/BLEManagerCommon.h
@@ -57,14 +57,14 @@ struct BLECallbackDelegate
     using InitAppCallback    = void (*)(void);
     using ConnectionCallback = void (*)(deviceId_t id, gapConnectionEvent_t * event);
     using GapGenericCallback = void (*)(gapGenericEvent_t * event);
-    using GapAdvDataCallback = gapAdStructure_t* (*)(uint8_t* size);
+    using GapAdvDataCallback = gapAdStructure_t * (*) (uint8_t * size);
     using GattServerCallback = void (*)(deviceId_t id, gattServerEvent_t * event);
 
-    InitAppCallback appInitCallback = nullptr;
-    ConnectionCallback connCallback = nullptr;
-    GapGenericCallback gapCallback  = nullptr;
+    InitAppCallback appInitCallback       = nullptr;
+    ConnectionCallback connCallback       = nullptr;
+    GapGenericCallback gapCallback        = nullptr;
     GapAdvDataCallback gapAdvDataCallback = nullptr;
-    GattServerCallback gattCallback = nullptr;
+    GattServerCallback gattCallback       = nullptr;
 };
 
 typedef enum service_mode_t
@@ -151,7 +151,7 @@ protected:
         BLE_KW_MSG_APP_EV_CB,
     } blekw_msg_type_t;
 
-    typedef void* blekw_callback_param_t;
+    typedef void * blekw_callback_param_t;
     typedef void (*blekw_callback_handler_t)(blekw_callback_param_t param);
 
     typedef struct hk_ble_kw_msg_s
@@ -254,13 +254,12 @@ protected:
     static BLEManagerCommon::ble_err_t blekw_stop_advertising(void);
     static void blekw_gap_advertising_cb(gapAdvertisingEvent_t * pAdvertisingEvent);
     static void blekw_gap_connection_cb(deviceId_t deviceId, gapConnectionEvent_t * pConnectionEvent);
-    static gapAdStructure_t* blekw_default_adv_data_cb(uint8_t *size);
+    static gapAdStructure_t * blekw_default_adv_data_cb(uint8_t * size);
     static void blekw_start_connection_timeout(void);
     static void blekw_stop_connection_timeout(void);
     static CHIP_ERROR blekw_stop_connection_internal(BLE_CONNECTION_OBJECT conId);
 
 public:
-
     typedef enum
     {
         BLE_MSG_APP_EV_CB = blekw_msg_type_t::BLE_KW_MSG_APP_EV_CB,
@@ -276,7 +275,7 @@ public:
     BLECallbackDelegate callbackDelegate;
     void RegisterAppCallbacks(BLECallbackDelegate::InitAppCallback appInitCallback = nullptr,
                               BLECallbackDelegate::ConnectionCallback connCallback = nullptr,
-                              BLECallbackDelegate::GapGenericCallback gapCallback = nullptr,
+                              BLECallbackDelegate::GapGenericCallback gapCallback  = nullptr,
                               BLECallbackDelegate::GattServerCallback gattCallback = nullptr);
 
     void RegisterAdvDataCallback(BLECallbackDelegate::GapAdvDataCallback gapAdvDataCallback);

--- a/src/platform/nxp/common/ble/BLEManagerCommon.h
+++ b/src/platform/nxp/common/ble/BLEManagerCommon.h
@@ -57,7 +57,7 @@ struct BLECallbackDelegate
     using InitAppCallback    = void (*)(void);
     using ConnectionCallback = void (*)(deviceId_t id, gapConnectionEvent_t * event);
     using GapGenericCallback = void (*)(gapGenericEvent_t * event);
-    using GapAdvDataCallback = gapAdStructure_t * (*) (uint8_t * size);
+    using GapAdvDataCallback = gapAdStructure_t * (*) (uint8_t * size); ///< The returned pointer must be freed by the caller.
     using GattServerCallback = void (*)(deviceId_t id, gattServerEvent_t * event);
 
     InitAppCallback appInitCallback       = nullptr;

--- a/src/platform/nxp/common/ble/BLEManagerCommon.h
+++ b/src/platform/nxp/common/ble/BLEManagerCommon.h
@@ -54,10 +54,16 @@ using namespace chip::Ble;
  */
 struct BLECallbackDelegate
 {
+    using InitAppCallback    = void (*)(void);
+    using ConnectionCallback = void (*)(deviceId_t id, gapConnectionEvent_t * event);
     using GapGenericCallback = void (*)(gapGenericEvent_t * event);
+    using GapAdvDataCallback = gapAdStructure_t* (*)(uint8_t* size);
     using GattServerCallback = void (*)(deviceId_t id, gattServerEvent_t * event);
 
+    InitAppCallback appInitCallback = nullptr;
+    ConnectionCallback connCallback = nullptr;
     GapGenericCallback gapCallback  = nullptr;
+    GapAdvDataCallback gapAdvDataCallback = nullptr;
     GattServerCallback gattCallback = nullptr;
 };
 
@@ -142,7 +148,11 @@ protected:
         BLE_KW_MSG_ATT_READ,
         BLE_KW_MSG_ATT_CCCD_WRITTEN,
         BLE_KW_MSG_FORCE_DISCONNECT,
+        BLE_KW_MSG_APP_EV_CB,
     } blekw_msg_type_t;
+
+    typedef void* blekw_callback_param_t;
+    typedef void (*blekw_callback_handler_t)(blekw_callback_param_t param);
 
     typedef struct hk_ble_kw_msg_s
     {
@@ -156,6 +166,9 @@ protected:
             uint8_t data[1];
             char * str;
         } data;
+        blekw_callback_handler_t handler;
+        blekw_callback_param_t param;
+
     } blekw_msg_t;
 
     typedef enum ble_err_t
@@ -241,19 +254,32 @@ protected:
     static BLEManagerCommon::ble_err_t blekw_stop_advertising(void);
     static void blekw_gap_advertising_cb(gapAdvertisingEvent_t * pAdvertisingEvent);
     static void blekw_gap_connection_cb(deviceId_t deviceId, gapConnectionEvent_t * pConnectionEvent);
+    static gapAdStructure_t* blekw_default_adv_data_cb(uint8_t *size);
     static void blekw_start_connection_timeout(void);
     static void blekw_stop_connection_timeout(void);
     static CHIP_ERROR blekw_stop_connection_internal(BLE_CONNECTION_OBJECT conId);
 
 public:
+
+    typedef enum
+    {
+        BLE_MSG_APP_EV_CB = blekw_msg_type_t::BLE_KW_MSG_APP_EV_CB,
+    } pub_ble_msg_type_t;
+
     virtual CHIP_ERROR InitHostController(BLECallbackDelegate::GapGenericCallback cb_fp) = 0;
     virtual BLEManagerCommon * GetImplInstance()                                         = 0;
     virtual CHIP_ERROR ResetController() { return CHIP_NO_ERROR; }
+
+    static CHIP_ERROR AddBleAppMsgHandler(pub_ble_msg_type_t type, blekw_callback_handler_t handler, blekw_callback_param_t param);
     void DoBleProcessing(void);
 
     BLECallbackDelegate callbackDelegate;
-    void RegisterAppCallbacks(BLECallbackDelegate::GapGenericCallback gapCallback,
-                              BLECallbackDelegate::GattServerCallback gattCallback);
+    void RegisterAppCallbacks(BLECallbackDelegate::InitAppCallback appInitCallback = nullptr,
+                              BLECallbackDelegate::ConnectionCallback connCallback = nullptr,
+                              BLECallbackDelegate::GapGenericCallback gapCallback = nullptr,
+                              BLECallbackDelegate::GattServerCallback gattCallback = nullptr);
+
+    void RegisterAdvDataCallback(BLECallbackDelegate::GapAdvDataCallback gapAdvDataCallback);
 
     CHIP_ERROR AddWriteNotificationHandle(uint16_t name);
     CHIP_ERROR AddReadNotificationHandle(uint16_t name);


### PR DESCRIPTION
#### Summary

BLEManagerCommon
- Add BLE application init callback and BLE application connection callback. This allows the application code to do initialization after BLE Host stack finishes initialization and act on BLE connection events.
- Move BLE random address generation before starting advertising.
- Add BLE application message handler registration. This allows the BLE host stack to register a handler based on internal events that should be called from the application task.
- Add register advertising data callback function,
- Add default advertising data callback for matter commissioning.
- Add default nullptr parameters to RegisterAppCallbacks.

Cmake
- Add cmake support to CHIP_APP_BLE_MANAGER for Add BLE Application Manager External (CHIP_APP_BLE_MANAGER_CUSTOM_EXTERNAL). This allows a matter sdk application to add such a manager.

NXPHostBLEApplicationManager
- Update call to RegisterAppCallbacks

#### Testing
- Locally tested commissioning and it passes, advertising still works,
- The other features have been tested with custom platform-specific tests.