### PR TITLE
[Crypto] Add missing PSA include

### DIFF
--- a/src/crypto/PSAKeyAllocator.h
+++ b/src/crypto/PSAKeyAllocator.h
@@ -25,6 +25,8 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/TypeTraits.h>
 
+#include <psa/crypto.h>
+
 namespace chip {
 namespace Crypto {
 


### PR DESCRIPTION
#### Summary

Add a missing include so that the related defines are declared properly. Without it, it may cause compilation issue with PSA related defines.

#### Related issues

None

#### Testing

Tested by building Silicon labs zephyr samples app. Since this header is also included in other PSA related files it shouldn't cause any problem.

