### PR TITLE
Disable the commodity tariff unit tests.

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -89,7 +89,10 @@ if (chip_build_tests) {
       "${chip_root}/src/transport/retransmit/tests",
       "${chip_root}/src/transport/tests",
       "${chip_root}/src/tracing/esp32_diagnostic_trace/tests",
-      "${chip_root}/src/app/clusters/commodity-tariff-server/tests",
+
+      # TODO: Commodity Tariff unit test is broken
+      #       See  https://github.com/project-chip/connectedhomeip/issues/40932
+      # "${chip_root}/src/app/clusters/commodity-tariff-server/tests",
       "${chip_root}/src/srp/tests",
     ]
 

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -90,8 +90,7 @@ if (chip_build_tests) {
       "${chip_root}/src/transport/tests",
       "${chip_root}/src/tracing/esp32_diagnostic_trace/tests",
 
-      # TODO: Commodity Tariff unit test is broken
-      #       See  https://github.com/project-chip/connectedhomeip/issues/40932
+      # TODO(#40932): Fix and re-enable the Commodity Tariff unit tests.
       # "${chip_root}/src/app/clusters/commodity-tariff-server/tests",
       "${chip_root}/src/srp/tests",
     ]


### PR DESCRIPTION
#### Summary

These tests are broken

#### Testing

Explicitly disabled. Note that we do this to not revert the PRs before TE2, however in the future we will revert them.
See #40932 for the issue of these tests being broken.