### PR TITLE
[Ameba][v1.4-branch] Add OnConnectWiFiNetworkFailed to AmebaWiFiDriver

### DIFF
--- a/src/platform/Ameba/NetworkCommissioningDriver.h
+++ b/src/platform/Ameba/NetworkCommissioningDriver.h
@@ -110,6 +110,7 @@ public:
 
     CHIP_ERROR ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen);
     void OnConnectWiFiNetwork();
+    void OnConnectWiFiNetworkFailed(uint16_t reason);
     void OnScanWiFiNetworkDone();
     void OnNetworkStatusChange();
 

--- a/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
@@ -172,6 +172,34 @@ void AmebaWiFiDriver::OnConnectWiFiNetwork()
     }
 }
 
+void AmebaWiFiDriver::OnConnectWiFiNetworkFailed(uint16_t reason)
+{
+    if (mpConnectCallback)
+    {
+        Status status;
+        switch (reason)
+        {
+        case RTW_NONE_NETWORK:
+            status = Status::kNetworkNotFound;
+            break;
+        case RTW_CONNECT_FAIL:
+#if defined(CONFIG_PLATFORM_8710C)
+        case RTW_4WAY_HANDSHAKE_TIMEOUT:
+#endif
+        case RTW_WRONG_PASSWORD:
+            status = Status::kAuthFailure;
+            break;
+        case RTW_DHCP_FAIL:
+        case RTW_UNKNOWN:
+        default:
+            status = Status::kUnknownError;
+            break;
+        }
+        mpConnectCallback->OnResult(status, CharSpan(), 0);
+        mpConnectCallback = nullptr;
+    }
+}
+
 void AmebaWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callback)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
@@ -189,6 +217,7 @@ exit:
     {
         networkingStatus = Status::kUnknownError;
     }
+
     if (networkingStatus != Status::kSuccess)
     {
         ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));


### PR DESCRIPTION
#### Summary

* OnConnectWiFiNetworkFailed is called when Ameba failed to connect into the network
* This fixes issue when chip-tool failed to commission Ameba after one failed attempt with incorrect password

#### Testing

##### Before changes
1. Perform commissioning with an incorrect password.
2. Observe that chip-tool reports a failure.
3. Retry commissioning with the correct password.
4. chip-tool still reports an error.
5. Wait for a while, then try commissioning again with the correct password.
6. Successfully connected.
##### After changes
1. Perform commissioning with an incorrect password.
2. Observe that chip-tool reports a failure.
3. Retry commissioning with the correct password.
4. Successfully connected.
