### PR TITLE
[FreeRTOS Platform] Allow StopEventLoopTask even if the mEventLoopTask is not created

### DIFF
--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -38,7 +38,7 @@ jobs:
             BUILD_TYPE: esp32-qemu
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]' && github.repository_owner == 'espressif'
+        if: github.actor != 'restyled-io[bot]'
 
         container:
             image: ghcr.io/project-chip/chip-build-esp32-qemu:165

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -455,17 +455,12 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_Shutdown(void)
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_StopEventLoopTask(void)
 {
-    if (mEventLoopTask != NULL)
+    mShouldRunEventLoop.store(false);
+    // Post a no-op event to wake up the event loop if it's blocked on queue receive
+    ChipDeviceEvent noop{ .Type = DeviceEventType::kNoOp };
+    if (mChipEventQueue != NULL)
     {
-        // Signal the event loop to stop
-        mShouldRunEventLoop.store(false);
-
-        // Post a no-op event to wake up the event loop if it's blocked on queue receive
-        ChipDeviceEvent noop{ .Type = DeviceEventType::kNoOp };
-        if (mChipEventQueue != NULL)
-        {
-            xQueueSend(mChipEventQueue, &noop, 0);
-        }
+        xQueueSend(mChipEventQueue, &noop, 0);
     }
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Summary
`StopEventLoopTask` is guarded on `mEventLoopTask` however EventLoop can be managed by some other task. 

#### Related issues

QEMU doesn't get executed on FreeRTOS platforms https://github.com/project-chip/connectedhomeip/actions/runs/17636584674

#### Testing

QEMU should be executed successfully.