### PR TITLE
Refactor specification version handling in `spec_parsing.py`

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
@@ -1063,7 +1063,7 @@ def dm_from_spec_version(specification_version: uint) -> PrebuiltDataModelDirect
     # However, 1.3 allowed the dot to be any value
     if specification_version < uint(0x01040000):
         # The expression (specification_version & uint(0xFFFF00FF)) might be inferred as int by mypy.
-        specification_version = uint(int(specification_version) & int(uint(0xFFFF00FF)))
+        specification_version = typing.cast(uint, specification_version & uint(0xFFFF00FF))
 
     version_to_dm = {0x01030000: PrebuiltDataModelDirectory.k1_3,
                      0x01040000: PrebuiltDataModelDirectory.k1_4,


### PR DESCRIPTION
### Summary

This pull request refactors the handling of specification_version to better align with mypy's static type checking. There are no changes to functionality.

### Related issues

https://github.com/project-chip/matter-test-scripts/issues/683

### Testing

Local testing: 

`./scripts/build_python.sh --enable_wifi_paf false -i out/python_env && source out/python_env/bin/activate && mypy --config-file=src/python_testing/matter_testing_infrastructure/mypy.ini src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py`

and checking there are no errors from mypy

### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
