### PR TITLE
[Zephyr] Update Zephyr api to match Zephyr 4.2

### DIFF
--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -44,6 +44,7 @@
 #include <zephyr/random/random.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/version.h>
 
 #ifdef CONFIG_BT_BONDABLE
 #include <zephyr/settings/settings.h>
@@ -75,7 +76,12 @@ const bt_uuid_128 UUID128_CHIPoBLEChar_C3 =
 
 bt_uuid_16 UUID16_CHIPoBLEService = BT_UUID_INIT_16(0xFFF6);
 
-_bt_gatt_ccc CHIPoBLEChar_TX_CCC = BT_GATT_CCC_INITIALIZER(nullptr, BLEManagerImpl::HandleTXCCCWrite, nullptr);
+#if KERNEL_VERSION_MAJOR >= 4 && KERNEL_VERSION_MINOR >= 2
+bt_gatt_ccc_managed_user_data CHIPoBLEChar_TX_CCC =
+    BT_GATT_CCC_MANAGED_USER_DATA_INIT(nullptr, BLEManagerImpl::HandleTXCCCWrite, nullptr);
+#else
+_bt_gatt_ccc CHIPoBLEChar_TX_CCC     = BT_GATT_CCC_INITIALIZER(nullptr, BLEManagerImpl::HandleTXCCCWrite, nullptr);
+#endif
 
 // clang-format off
 

--- a/src/platform/Zephyr/wifi/WiFiManager.cpp
+++ b/src/platform/Zephyr/wifi/WiFiManager.cpp
@@ -35,11 +35,12 @@
 #include <zephyr/version.h>
 
 extern "C" {
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT
 #include <common/defs.h>
 #include <wpa_supplicant/config.h>
 #include <wpa_supplicant/driver_i.h>
 #include <wpa_supplicant/scan.h>
-
+#endif // CONFIG_WIFI_NM_WPA_SUPPLICANT
 // extern function to obtain bssid from status buffer
 // It is defined in zephyr/subsys/net/ip/utils.c
 extern char * net_sprint_ll_addr_buf(const uint8_t * ll, uint8_t ll_len, char * buf, int buflen);
@@ -152,27 +153,45 @@ const Map<wifi_iface_state, WiFiManager::StationStatus, 10>
                               { WIFI_STATE_4WAY_HANDSHAKE, WiFiManager::StationStatus::PROVISIONING },
                               { WIFI_STATE_GROUP_HANDSHAKE, WiFiManager::StationStatus::PROVISIONING },
                               { WIFI_STATE_COMPLETED, WiFiManager::StationStatus::FULLY_PROVISIONED } });
-
-const Map<uint32_t, WiFiManager::NetEventHandler, 5> WiFiManager::sEventHandlerMap({
-    { NET_EVENT_WIFI_SCAN_RESULT, WiFiManager::ScanResultHandler },
-    { NET_EVENT_WIFI_SCAN_DONE, WiFiManager::ScanDoneHandler },
-    { NET_EVENT_WIFI_CONNECT_RESULT, WiFiManager::ConnectHandler },
-    { NET_EVENT_WIFI_DISCONNECT_RESULT, WiFiManager::DisconnectHandler },
-    { NET_EVENT_WIFI_DISCONNECT_COMPLETE, WiFiManager::DisconnectHandler },
-});
-
+#if KERNEL_VERSION_MAJOR >= 4 && KERNEL_VERSION_MINOR >= 2
+void WiFiManager::WifiMgmtEventHandler(net_mgmt_event_callback * cb, uint64_t mgmtEvent, net_if * iface)
+#else
 void WiFiManager::WifiMgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface)
+#endif
 {
     if (iface == Instance().mNetIf)
     {
         Platform::UniquePtr<uint8_t> eventData(new uint8_t[cb->info_length]);
         VerifyOrReturn(eventData);
         memcpy(eventData.get(), cb->info, cb->info_length);
-        sEventHandlerMap[mgmtEvent](std::move(eventData), cb->info_length);
+        switch (mgmtEvent)
+        {
+        case NET_EVENT_WIFI_SCAN_RESULT:
+            WiFiManager::ScanResultHandler(std::move(eventData), cb->info_length);
+            break;
+        case NET_EVENT_WIFI_SCAN_DONE:
+            WiFiManager::ScanDoneHandler(std::move(eventData), cb->info_length);
+            break;
+        case NET_EVENT_WIFI_CONNECT_RESULT:
+            WiFiManager::ConnectHandler(std::move(eventData), cb->info_length);
+            break;
+        case NET_EVENT_WIFI_DISCONNECT_RESULT:
+            WiFiManager::DisconnectHandler(std::move(eventData), cb->info_length);
+            break;
+        case NET_EVENT_WIFI_DISCONNECT_COMPLETE:
+            WiFiManager::DisconnectHandler(std::move(eventData), cb->info_length);
+            break;
+        default:
+            break;
+        }
     }
 }
 
+#if KERNEL_VERSION_MAJOR >= 4 && KERNEL_VERSION_MINOR >= 2
+void WiFiManager::IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint64_t mgmtEvent, net_if * iface)
+#else
 void WiFiManager::IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface)
+#endif
 {
     if (((mgmtEvent == NET_EVENT_IPV6_ADDR_ADD) || (mgmtEvent == NET_EVENT_IPV6_ADDR_DEL)) && cb->info)
     {
@@ -565,8 +584,8 @@ void WiFiManager::DisconnectHandler(Platform::UniquePtr<uint8_t> data, size_t le
         Platform::UniquePtr<uint8_t> safePtr(capturedData);
         uint8_t * rawData          = safePtr.get();
         const wifi_status * status = reinterpret_cast<const wifi_status *>(rawData);
-        uint16_t reason;
-
+        uint16_t reason            = 0;
+#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT
         switch (status->disconn_reason)
         {
         case WIFI_REASON_DISCONN_UNSPECIFIED:
@@ -585,6 +604,9 @@ void WiFiManager::DisconnectHandler(Platform::UniquePtr<uint8_t> data, size_t le
             reason = WLAN_REASON_UNSPECIFIED;
             break;
         }
+#else
+        reason               = status->disconn_reason;
+#endif
         Instance().SetLastDisconnectReason(reason);
 
         ChipLogProgress(DeviceLayer, "WiFi station disconnected");


### PR DESCRIPTION
#### Summary

With Zephyr 4.2 some API were deprecated/updated. Update the necessary files so that everything works with the latest and greatest

Also make WPA_SUPPLICANT related functionality modular.

#### Related issues
None

#### Testing

We were able to successfully compile a Zephyr based sample app with theses changes without triggering any build failure using zephyr 4.2 upstream

