### PR TITLE
Add support for concatenated QR codes to chip-tool parse-setup-payload command.

### DIFF
--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.h
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.h
@@ -22,6 +22,7 @@
 #include <setup_payload/SetupPayload.h>
 
 #include <string>
+#include <vector>
 
 class SetupPayloadParseCommand : public Command
 {
@@ -32,6 +33,6 @@ public:
 
 private:
     char * mCode;
-    CHIP_ERROR Parse(std::string codeString, chip::SetupPayload & payload);
-    CHIP_ERROR Print(chip::SetupPayload payload);
+    CHIP_ERROR Parse(std::string codeString, std::vector<chip::SetupPayload> & payloads);
+    CHIP_ERROR Print(const chip::SetupPayload & payload);
 };


### PR DESCRIPTION
#### Testing

Manually tested with `MT:-24J0KCZ16-A6J0K310*-24J0Q12122TGP78J00` as the payload to parse.