### PR TITLE
NFC tags: Add missing include header

### DIFF
--- a/src/nfc/NFCTag.h
+++ b/src/nfc/NFCTag.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <lib/core/CHIPError.h>
 #include <lib/support/DLLUtil.h>
 #include <system/SystemPacketBuffer.h>


### PR DESCRIPTION
#### Summary

This file was missing an include that was causing build failures.

#### Related issues

https://github.com/project-chip/connectedhomeip/issues/40954
https://github.com/project-chip/connectedhomeip/issues/40953

#### Testing

Tested manually. This is currently blocking the release of the TH for TE2. When I built locally I needed to manually add a package to get this built. I do not want to risk angering the CI with package failure and further block the TE2 TH release on getting this in the CI. I've opened a follow up issue for the NFC team to add the appropriate examples to CI.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
