### PR TITLE
Fix  Camera live streaming issue with Web client

### DIFF
--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -89,7 +89,7 @@ public:
     void LiveStreamPrivacyModeChanged(bool privacyModeEnabled);
 
 private:
-    std::string ExtractMidFromSdp(const std::string& sdp, const std::string& mediaType);
+    std::string ExtractMidFromSdp(const std::string & sdp, const std::string & mediaType);
 
     void ScheduleOfferSend(uint16_t sessionId);
 

--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -89,6 +89,8 @@ public:
     void LiveStreamPrivacyModeChanged(bool privacyModeEnabled);
 
 private:
+    std::string ExtractMidFromSdp(const std::string& sdp, const std::string& mediaType);
+
     void ScheduleOfferSend(uint16_t sessionId);
 
     void ScheduleICECandidatesSend(uint16_t sessionId);

--- a/examples/camera-app/linux/include/webrtc-abstract.h
+++ b/examples/camera-app/linux/include/webrtc-abstract.h
@@ -70,7 +70,7 @@ public:
     virtual void CreateAnswer()                                                                     = 0;
     virtual void SetRemoteDescription(const std::string & sdp, SDPType type)                        = 0;
     virtual void AddRemoteCandidate(const std::string & candidate, const std::string & mid)         = 0;
-    virtual std::shared_ptr<WebRTCTrack> AddTrack(MediaType mediaType)                              = 0;
+    virtual std::shared_ptr<WebRTCTrack> AddTrack(MediaType mediaType, const std::string & mid)     = 0;
 };
 
 std::shared_ptr<WebRTCPeerConnection> CreateWebRTCPeerConnection();

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -93,7 +93,7 @@ public:
     // Stops WebRTC peer connection and cleanup
     void Stop();
 
-    void AddTracks(std::string videoMid = "video", std::string audioMid = "audio");
+    void AddTracks(const std::string videoMid = "video", const std::string audioMid = "audio");
 
     // Set video track for the transport
     void SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack);

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -95,12 +95,6 @@ public:
 
     void AddTracks(const std::string & videoMid = "video", const std::string & audioMid = "audio");
 
-    // Set video track for the transport
-    void SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack);
-
-    // Set audio track for the transport
-    void SetAudioTrack(std::shared_ptr<WebRTCTrack> audioTrack);
-
     std::shared_ptr<WebRTCPeerConnection> GetPeerConnection() { return mPeerConnection; }
 
     std::string GetLocalDescription() { return mLocalSdp; }
@@ -137,9 +131,6 @@ private:
     // Local tracks set to send the camera data to remote peer connection object
     std::shared_ptr<WebRTCTrack> mLocalVideoTrack;
     std::shared_ptr<WebRTCTrack> mLocalAudioTrack;
-    // Remote tracks set using onTrack API callback if there is any mismatch in MIDs between local and remote tracks
-    std::shared_ptr<WebRTCTrack> mRemoteVideoTrack;
-    std::shared_ptr<WebRTCTrack> mRemoteAudioTrack;
 
     std::string mLocalSdp;
     SDPType mLocalSdpType;

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -23,6 +23,8 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/ScopedNodeId.h>
 
+#include <string>
+
 using OnTransportLocalDescriptionCallback = std::function<void(const std::string & sdp, SDPType type, const int16_t sessionId)>;
 using OnTransportConnectionStateCallback  = std::function<void(bool connected, const int16_t sessionId)>;
 
@@ -91,7 +93,7 @@ public:
     // Stops WebRTC peer connection and cleanup
     void Stop();
 
-    void AddTracks();
+    void AddTracks(std::string videoMid = "video", std::string audioMid = "audio");
 
     // Set video track for the transport
     void SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack);
@@ -133,6 +135,8 @@ private:
     std::shared_ptr<WebRTCPeerConnection> mPeerConnection;
     std::shared_ptr<WebRTCTrack> mVideoTrack;
     std::shared_ptr<WebRTCTrack> mAudioTrack;
+    std::shared_ptr<WebRTCTrack> mRemoteVideoTrack;
+    std::shared_ptr<WebRTCTrack> mRemoteAudioTrack;
     std::string mLocalSdp;
     SDPType mLocalSdpType;
     std::vector<std::string> mLocalCandidates;

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -93,7 +93,7 @@ public:
     // Stops WebRTC peer connection and cleanup
     void Stop();
 
-    void AddTracks(const std::string videoMid = "video", const std::string audioMid = "audio");
+    void AddTracks(const std::string & videoMid = "video", const std::string & audioMid = "audio");
 
     // Set video track for the transport
     void SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack);

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -133,10 +133,14 @@ private:
     State mState             = State::Idle;
 
     std::shared_ptr<WebRTCPeerConnection> mPeerConnection;
-    std::shared_ptr<WebRTCTrack> mVideoTrack;
-    std::shared_ptr<WebRTCTrack> mAudioTrack;
+
+    // Local tracks set to send the camera data to remote peer connection object
+    std::shared_ptr<WebRTCTrack> mLocalVideoTrack;;
+    std::shared_ptr<WebRTCTrack> mLocalAudioTrack;
+    // Remote tracks set using onTrack API callback if there is any mismatch in MIDs between local and remote tracks
     std::shared_ptr<WebRTCTrack> mRemoteVideoTrack;
     std::shared_ptr<WebRTCTrack> mRemoteAudioTrack;
+
     std::string mLocalSdp;
     SDPType mLocalSdpType;
     std::vector<std::string> mLocalCandidates;

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -135,7 +135,7 @@ private:
     std::shared_ptr<WebRTCPeerConnection> mPeerConnection;
 
     // Local tracks set to send the camera data to remote peer connection object
-    std::shared_ptr<WebRTCTrack> mLocalVideoTrack;;
+    std::shared_ptr<WebRTCTrack> mLocalVideoTrack;
     std::shared_ptr<WebRTCTrack> mLocalAudioTrack;
     // Remote tracks set using onTrack API callback if there is any mismatch in MIDs between local and remote tracks
     std::shared_ptr<WebRTCTrack> mRemoteVideoTrack;

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -282,7 +282,12 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
 
     transport->SetRequestArgs(requestArgs);
     transport->Start();
-    transport->AddTracks();
+    std::string audioMid = ExtractMidFromSdp(args.sdp, "audio");
+    std::string videoMid = ExtractMidFromSdp(args.sdp, "video");
+
+    ChipLogProgress(Camera, "Extracted audioMid: %s, videoMid: %s", audioMid.c_str(), videoMid.c_str());
+
+    transport->AddTracks(videoMid, audioMid);
 
     // Acquire the Video and Audio Streams from the CameraAVStreamManagement
     // cluster and update the reference counts.

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -169,8 +169,7 @@ void WebRTCProviderManager::RegisterWebrtcTransport(uint16_t sessionId)
     mMediaController->RegisterTransport(transport, args.videoStreamId, args.audioStreamId);
 }
 
-std::string WebRTCProviderManager::ExtractMidFromSdp(const std::string & sdp,
-                                                    const std::string & mediaType)
+std::string WebRTCProviderManager::ExtractMidFromSdp(const std::string & sdp, const std::string & mediaType)
 {
     if (sdp.empty() || mediaType.empty())
     {
@@ -193,13 +192,13 @@ std::string WebRTCProviderManager::ExtractMidFromSdp(const std::string & sdp,
 
         if (inTargetBlock)
         {
-            if (line.rfind(midPrefix, 0) == 0)               // line starts with "a=mid:"
+            if (line.rfind(midPrefix, 0) == 0) // line starts with "a=mid:"
                 return line.substr(midPrefix.length());
 
-            if (line.rfind("m=", 0) == 0)                    // next media block – stop searching
+            if (line.rfind("m=", 0) == 0) // next media block – stop searching
                 break;
         }
-        else if (line.rfind(mediaPrefix, 0) == 0)           // found the desired media block
+        else if (line.rfind(mediaPrefix, 0) == 0) // found the desired media block
         {
             inTargetBlock = true;
         }

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -272,11 +272,12 @@ public:
         }
     }
 
-    std::shared_ptr<WebRTCTrack> AddTrack(MediaType mediaType) override
+    std::shared_ptr<WebRTCTrack> AddTrack(MediaType mediaType, const std::string & mid) override
     {
         if (mediaType == MediaType::Video)
         {
-            rtc::Description::Video vMedia("video", rtc::Description::Direction::SendOnly);
+            std::string videoMid = mid.empty() ? "video" : mid;
+            rtc::Description::Video vMedia(videoMid, rtc::Description::Direction::SendOnly);
             vMedia.addH264Codec(kVideoH264PayloadType);
             vMedia.setBitrate(kVideoBitRate);
             vMedia.addSSRC(kSSRC, "video-stream", "stream1", "video-stream");
@@ -286,7 +287,8 @@ public:
 
         if (mediaType == MediaType::Audio)
         {
-            rtc::Description::Audio aMedia("audio", rtc::Description::Direction::SendOnly);
+            std::string audioMid = mid.empty() ? "audio" : mid;
+            rtc::Description::Audio aMedia(audioMid, rtc::Description::Direction::SendOnly);
             aMedia.addOpusCodec(kOpusPayloadType);
             aMedia.setBitrate(kAudioBitRate);
             aMedia.addSSRC(kAudioSSRC, "audio-stream", "stream1", "audio-stream");

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -161,7 +161,7 @@ void WebrtcTransport::Stop()
     }
 }
 
-void WebrtcTransport::AddTracks(std::string videoMid, std::string audioMid)
+void WebrtcTransport::AddTracks(const std::string & videoMid, const std::string & audioMid)
 {
     if (mPeerConnection != nullptr)
     {
@@ -174,14 +174,14 @@ void WebrtcTransport::AddTracks(std::string videoMid, std::string audioMid)
 void WebrtcTransport::SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack)
 {
     ChipLogProgress(Camera, "Setting video track for sessionID: %u", mRequestArgs.sessionId);
-    mVideoTrack = videoTrack;
+    mRemoteVideoTrack = videoTrack;
 }
 
 // Implementation of SetAudioTrack method
 void WebrtcTransport::SetAudioTrack(std::shared_ptr<WebRTCTrack> audioTrack)
 {
     ChipLogProgress(Camera, "Setting audio track for sessionID: %u", mRequestArgs.sessionId);
-    mAudioTrack = audioTrack;
+    mRemoteAudioTrack = audioTrack;
 }
 
 void WebrtcTransport::AddRemoteCandidate(const std::string & candidate, const std::string & mid)

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -158,8 +158,8 @@ void WebrtcTransport::Stop()
         mPeerConnection->Close();
     }
 
-    mLocalVideoTrack = nullptr;
-    mLocalAudioTrack = nullptr;
+    mLocalVideoTrack  = nullptr;
+    mLocalAudioTrack  = nullptr;
     mRemoteVideoTrack = nullptr;
     mRemoteAudioTrack = nullptr;
 }

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -161,12 +161,12 @@ void WebrtcTransport::Stop()
     }
 }
 
-void WebrtcTransport::AddTracks()
+void WebrtcTransport::AddTracks(std::string videoMid, std::string audioMid)
 {
     if (mPeerConnection != nullptr)
     {
-        mVideoTrack = mPeerConnection->AddTrack(MediaType::Video);
-        mAudioTrack = mPeerConnection->AddTrack(MediaType::Audio);
+        mVideoTrack = mPeerConnection->AddTrack(MediaType::Video, videoMid);
+        mAudioTrack = mPeerConnection->AddTrack(MediaType::Audio, audioMid);
     }
 }
 

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -158,8 +158,8 @@ void WebrtcTransport::Stop()
         mPeerConnection->Close();
     }
 
-    mLocalVideoTrack  = nullptr;
-    mLocalAudioTrack  = nullptr;
+    mLocalVideoTrack = nullptr;
+    mLocalAudioTrack = nullptr;
 }
 
 void WebrtcTransport::AddTracks(const std::string & videoMid, const std::string & audioMid)
@@ -217,6 +217,7 @@ void WebrtcTransport::OnConnectionStateChanged(bool connected)
 
 void WebrtcTransport::OnTrack(std::shared_ptr<WebRTCTrack> track)
 {
-    // Only logging the track addition here as it's not used in the current implementation. In future, we can add functionality to handle
+    // Only logging the track addition here as it's not used in the current implementation. In future, we can add functionality to
+    // handle
     ChipLogProgress(Camera, "Remote track added for the sessionID: %u, type: %s", mRequestArgs.sessionId, track->GetType().c_str());
 }

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -69,18 +69,18 @@ WebrtcTransport::RequestArgs & WebrtcTransport::GetRequestArgs()
 
 void WebrtcTransport::SendVideo(const char * data, size_t size, uint16_t videoStreamID)
 {
-    if (mVideoTrack)
+    if (mLocalVideoTrack)
     {
-        mVideoTrack->SendData(data, size);
+        mLocalVideoTrack->SendData(data, size);
     }
 }
 
 // Implementation of SendAudio method
 void WebrtcTransport::SendAudio(const char * data, size_t size, uint16_t audioStreamID)
 {
-    if (mAudioTrack)
+    if (mLocalAudioTrack)
     {
-        mAudioTrack->SendData(data, size);
+        mLocalAudioTrack->SendData(data, size);
     }
 }
 
@@ -93,13 +93,13 @@ void WebrtcTransport::SendAudioVideo(const char * data, size_t size, uint16_t vi
 // Implementation of CanSendVideo method
 bool WebrtcTransport::CanSendVideo()
 {
-    return mVideoTrack != nullptr;
+    return mLocalVideoTrack != nullptr;
 }
 
 // Implementation of CanSendAudio method
 bool WebrtcTransport::CanSendAudio()
 {
-    return mAudioTrack != nullptr;
+    return mLocalAudioTrack != nullptr;
 }
 
 const char * WebrtcTransport::GetStateStr() const
@@ -153,20 +153,24 @@ void WebrtcTransport::Start()
 
 void WebrtcTransport::Stop()
 {
-    mVideoTrack = nullptr;
-    mAudioTrack = nullptr;
     if (mPeerConnection != nullptr)
     {
         mPeerConnection->Close();
     }
+
+    mLocalVideoTrack = nullptr;
+    mLocalAudioTrack = nullptr;
+    mRemoteVideoTrack = nullptr;
+    mRemoteAudioTrack = nullptr;
 }
 
 void WebrtcTransport::AddTracks(const std::string & videoMid, const std::string & audioMid)
 {
     if (mPeerConnection != nullptr)
     {
-        mVideoTrack = mPeerConnection->AddTrack(MediaType::Video, videoMid);
-        mAudioTrack = mPeerConnection->AddTrack(MediaType::Audio, audioMid);
+        // Adding local tracks to send audio/video data to remote peer
+        mLocalVideoTrack = mPeerConnection->AddTrack(MediaType::Video, videoMid);
+        mLocalAudioTrack = mPeerConnection->AddTrack(MediaType::Audio, audioMid);
     }
 }
 

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -160,8 +160,6 @@ void WebrtcTransport::Stop()
 
     mLocalVideoTrack  = nullptr;
     mLocalAudioTrack  = nullptr;
-    mRemoteVideoTrack = nullptr;
-    mRemoteAudioTrack = nullptr;
 }
 
 void WebrtcTransport::AddTracks(const std::string & videoMid, const std::string & audioMid)
@@ -172,20 +170,6 @@ void WebrtcTransport::AddTracks(const std::string & videoMid, const std::string 
         mLocalVideoTrack = mPeerConnection->AddTrack(MediaType::Video, videoMid);
         mLocalAudioTrack = mPeerConnection->AddTrack(MediaType::Audio, audioMid);
     }
-}
-
-// Implementation of SetVideoTrack method
-void WebrtcTransport::SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack)
-{
-    ChipLogProgress(Camera, "Setting video track for sessionID: %u", mRequestArgs.sessionId);
-    mRemoteVideoTrack = videoTrack;
-}
-
-// Implementation of SetAudioTrack method
-void WebrtcTransport::SetAudioTrack(std::shared_ptr<WebRTCTrack> audioTrack)
-{
-    ChipLogProgress(Camera, "Setting audio track for sessionID: %u", mRequestArgs.sessionId);
-    mRemoteAudioTrack = audioTrack;
 }
 
 void WebrtcTransport::AddRemoteCandidate(const std::string & candidate, const std::string & mid)
@@ -233,15 +217,6 @@ void WebrtcTransport::OnConnectionStateChanged(bool connected)
 
 void WebrtcTransport::OnTrack(std::shared_ptr<WebRTCTrack> track)
 {
-    ChipLogProgress(Camera, "Track received for sessionID: %u, type: %s", mRequestArgs.sessionId, track->GetType().c_str());
-    if (track->GetType() == "video")
-    {
-        ChipLogProgress(Camera, "Video track updated from remote peer");
-        SetVideoTrack(track);
-    }
-    else if (track->GetType() == "audio")
-    {
-        ChipLogProgress(Camera, "audio track updated from remote peer");
-        SetAudioTrack(track);
-    }
+    // Only logging the track addition here as it's not used in the current implementation. In future, we can add functionality to handle
+    ChipLogProgress(Camera, "Remote track added for the sessionID: %u, type: %s", mRequestArgs.sessionId, track->GetType().c_str());
 }


### PR DESCRIPTION
#### Summary

This PR fixes the live streaming failure issue happening with Camera and Web and Android clients.
There is mismatch between the local and remote tracks (sdp offer) mids. Hence Libdatachannel is not sending correct track ids in the sdp answer which leads to streaming failure.

Setting local tracks mids matching to remote tracking mids to resolve the issue.

#### Testing
1.  Manual testing of live streaming between camera app and camera controller
##### Launch camera app
```
sudo rm -rf /tmp/chip_*;   ./out/debug/chip-camera-app
```
##### Launch camera controller app
```
./out/linux-x64-camera-controller/chip-camera-controller
```
##### Run commands to  start live steaming
```
//pairing DUT
pairing code 1 34970112332
// start live stream
liveview start 1
```
2.  Manual testing of live streaming between camera app and test harness web client

##### Expected Result
```
- Live streaming should be successful
- MIDs in sdp offer and sdp Answer should be same
```
