### PR TITLE
Fix clang compile on all example apps

### DIFF
--- a/examples/common/pigweed/rpc_services/JointFabric.h
+++ b/examples/common/pigweed/rpc_services/JointFabric.h
@@ -44,7 +44,7 @@ private:
     {
         OwnershipTransferContext * data = reinterpret_cast<OwnershipTransferContext *>(arg);
         chip::JFAMgr().FinalizeCommissioning(data->mNodeId, data->mJCM, data->mTrustedIcacPublicKeyBSerialized,
-                                       data->mPeerAdminJFAdminClusterEndpointId);
+                                             data->mPeerAdminJFAdminClusterEndpointId);
         chip::Platform::Delete(data);
     }
 

--- a/examples/common/pigweed/rpc_services/JointFabric.h
+++ b/examples/common/pigweed/rpc_services/JointFabric.h
@@ -5,13 +5,11 @@
 #include <crypto/CHIPCryptoPAL.h>
 #include <platform/CHIPDeviceLayer.h>
 
-using namespace chip;
-using namespace chip::Crypto;
-
 namespace joint_fabric_service {
 
-class JointFabric : public pw_rpc::nanopb::JointFabric::Service<JointFabric>, public JFARpc
+class JointFabric : public pw_rpc::nanopb::JointFabric::Service<JointFabric>, public chip::JFARpc
 {
+
 public:
     /*RPC from jfc-client to jfa-server */
     ::pw::Status TransferOwnership(const ::OwnershipContext & request, ::pw_protobuf_Empty & response);
@@ -19,25 +17,25 @@ public:
     ::pw::Status ResponseStream(const ::Response & ResponseBytes, ::pw_protobuf_Empty & response);
 
     /* JFARpc overrides */
-    CHIP_ERROR GetICACCSRForJF(MutableByteSpan & icacCSR);
+    CHIP_ERROR GetICACCSRForJF(chip::MutableByteSpan & icacCSR);
     void CloseStreams();
 
 private:
     struct OwnershipTransferContext
     {
-        OwnershipTransferContext(uint64_t nodeId, bool jcm, ByteSpan trustedIcacPublicKeyB,
+        OwnershipTransferContext(uint64_t nodeId, bool jcm, chip::ByteSpan trustedIcacPublicKeyB,
                                  uint16_t peerAdminJFAdminClusterEndpointId) :
             mNodeId(nodeId),
             mJCM(jcm), mPeerAdminJFAdminClusterEndpointId(peerAdminJFAdminClusterEndpointId)
         {
-            memcpy(keyRawBytes, trustedIcacPublicKeyB.data(), kP256_PublicKey_Length);
+            memcpy(keyRawBytes, trustedIcacPublicKeyB.data(), chip::Crypto::kP256_PublicKey_Length);
             mTrustedIcacPublicKeyBSerialized = keyRawBytes;
         }
 
         uint64_t mNodeId;
         bool mJCM;
-        uint8_t keyRawBytes[kP256_PublicKey_Length] = { 0 };
-        P256PublicKey mTrustedIcacPublicKeyBSerialized;
+        uint8_t keyRawBytes[chip::Crypto::kP256_PublicKey_Length] = { 0 };
+        chip::Crypto::P256PublicKey mTrustedIcacPublicKeyBSerialized;
 
         uint16_t mPeerAdminJFAdminClusterEndpointId;
     };
@@ -45,9 +43,9 @@ private:
     static void FinalizeCommissioningWork(intptr_t arg)
     {
         OwnershipTransferContext * data = reinterpret_cast<OwnershipTransferContext *>(arg);
-        JFAMgr().FinalizeCommissioning(data->mNodeId, data->mJCM, data->mTrustedIcacPublicKeyBSerialized,
+        chip::JFAMgr().FinalizeCommissioning(data->mNodeId, data->mJCM, data->mTrustedIcacPublicKeyBSerialized,
                                        data->mPeerAdminJFAdminClusterEndpointId);
-        Platform::Delete(data);
+        chip::Platform::Delete(data);
     }
 
     ServerWriter<::RequestOptions> rpcGetStream;

--- a/examples/jf-admin-app/linux/JFAManager.cpp
+++ b/examples/jf-admin-app/linux/JFAManager.cpp
@@ -31,6 +31,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::Controller;
 using namespace chip::Crypto;
+using namespace chip::app::Clusters::JointFabricAdministrator;
 
 constexpr uint8_t kJFAvailableShift = 0;
 constexpr uint8_t kJFAdminShift     = 1;
@@ -216,7 +217,7 @@ void JFAManager::OnConnectionFailure(void * context, const ScopedNodeId & peerId
 
 CHIP_ERROR JFAManager::AnnounceJointFabricAdministrator()
 {
-    JointFabricAdministrator::Commands::AnnounceJointFabricAdministrator::Type request;
+    Commands::AnnounceJointFabricAdministrator::Type request;
 
     if (!mExchangeMgr)
     {
@@ -251,7 +252,7 @@ void JFAManager::OnAnnounceJointFabricAdministratorFailure(void * context, CHIP_
 
 CHIP_ERROR JFAManager::SendICACSRRequest()
 {
-    JointFabricAdministrator::Commands::ICACCSRRequest::Type request;
+    Commands::ICACCSRRequest::Type request;
 
     if (!mExchangeMgr)
     {
@@ -265,7 +266,7 @@ CHIP_ERROR JFAManager::SendICACSRRequest()
 }
 
 void JFAManager::OnSendICACSRRequestResponse(void * context,
-                                             const JointFabricAdministrator::Commands::ICACCSRResponse::DecodableType & icaccsr)
+                                             const Commands::ICACCSRResponse::DecodableType & icaccsr)
 {
     JFAManager * jfaManagerCore = static_cast<JFAManager *>(context);
     VerifyOrDie(jfaManagerCore != nullptr);

--- a/examples/jf-admin-app/linux/JFAManager.cpp
+++ b/examples/jf-admin-app/linux/JFAManager.cpp
@@ -265,8 +265,7 @@ CHIP_ERROR JFAManager::SendICACSRRequest()
     return cluster.InvokeCommand(request, this, OnSendICACSRRequestResponse, OnSendICACSRRequestFailure);
 }
 
-void JFAManager::OnSendICACSRRequestResponse(void * context,
-                                             const Commands::ICACCSRResponse::DecodableType & icaccsr)
+void JFAManager::OnSendICACSRRequestResponse(void * context, const Commands::ICACCSRResponse::DecodableType & icaccsr)
 {
     JFAManager * jfaManagerCore = static_cast<JFAManager *>(context);
     VerifyOrDie(jfaManagerCore != nullptr);

--- a/examples/jf-control-app/commands/pairing/PairingCommand.h
+++ b/examples/jf-control-app/commands/pairing/PairingCommand.h
@@ -261,9 +261,9 @@ public:
 
     /////////// JCMTrustVerificationDelegate /////////
     void OnProgressUpdate(JCMDeviceCommissioner & commissioner, JCMTrustVerificationStage stage, JCMTrustVerificationInfo & info,
-                          JCMTrustVerificationError error);
-    void OnAskUserForConsent(JCMDeviceCommissioner & commissioner, JCMTrustVerificationInfo & info);
-    void OnVerifyVendorId(JCMDeviceCommissioner & commissioner, JCMTrustVerificationInfo & info);
+                          JCMTrustVerificationError error) override;
+    void OnAskUserForConsent(JCMDeviceCommissioner & commissioner, JCMTrustVerificationInfo & info) override;
+    void OnVerifyVendorId(JCMDeviceCommissioner & commissioner, JCMTrustVerificationInfo & info) override;
 
 private:
     CHIP_ERROR RunInternal(NodeId remoteId);

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -217,7 +217,7 @@ int main(int argc, char * argv[])
     {
         struct sigaction sa = {};
         sa.sa_handler       = StopSignalHandler;
-        sa.sa_flags         = SA_RESETHAND;
+        sa.sa_flags         = static_cast<int>(SA_RESETHAND);
         sigaction(SIGINT, &sa, nullptr);
         sigaction(SIGTERM, &sa, nullptr);
     }

--- a/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
@@ -154,7 +154,7 @@ void JointFabricAdministratorGlobalInstance::HandleOJCW(HandlerContext & ctx,
     using namespace chip::app::Clusters::JointFabricAdministrator;
 
     Optional<StatusCodeEnum> status = Optional<StatusCodeEnum>::Missing();
-    Status globalStatus                                       = Status::Success;
+    Status globalStatus             = Status::Success;
     Spake2pVerifier verifier;
 
     ChipLogProgress(Zcl, "Received command to open joint commissioning window");
@@ -168,21 +168,16 @@ void JointFabricAdministratorGlobalInstance::HandleOJCW(HandlerContext & ctx,
     VerifyOrExit(failSafeContext.IsFailSafeFullyDisarmed(), status.Emplace(StatusCodeEnum::kBusy));
 
     VerifyOrExit(!commissionMgr.IsCommissioningWindowOpen(), status.Emplace(StatusCodeEnum::kBusy));
-    VerifyOrExit(iterations >= kSpake2p_Min_PBKDF_Iterations,
-                 status.Emplace(StatusCodeEnum::kPAKEParameterError));
-    VerifyOrExit(iterations <= kSpake2p_Max_PBKDF_Iterations,
-                 status.Emplace(StatusCodeEnum::kPAKEParameterError));
-    VerifyOrExit(salt.size() >= kSpake2p_Min_PBKDF_Salt_Length,
-                 status.Emplace(StatusCodeEnum::kPAKEParameterError));
-    VerifyOrExit(salt.size() <= kSpake2p_Max_PBKDF_Salt_Length,
-                 status.Emplace(StatusCodeEnum::kPAKEParameterError));
+    VerifyOrExit(iterations >= kSpake2p_Min_PBKDF_Iterations, status.Emplace(StatusCodeEnum::kPAKEParameterError));
+    VerifyOrExit(iterations <= kSpake2p_Max_PBKDF_Iterations, status.Emplace(StatusCodeEnum::kPAKEParameterError));
+    VerifyOrExit(salt.size() >= kSpake2p_Min_PBKDF_Salt_Length, status.Emplace(StatusCodeEnum::kPAKEParameterError));
+    VerifyOrExit(salt.size() <= kSpake2p_Max_PBKDF_Salt_Length, status.Emplace(StatusCodeEnum::kPAKEParameterError));
 
     VerifyOrExit(commissioningTimeout <= commissionMgr.MaxCommissioningTimeout(), globalStatus = Status::InvalidCommand);
     VerifyOrExit(commissioningTimeout >= commissionMgr.MinCommissioningTimeout(), globalStatus = Status::InvalidCommand);
     VerifyOrExit(discriminator <= kMaxDiscriminatorValue, globalStatus = Status::InvalidCommand);
 
-    VerifyOrExit(verifier.Deserialize(pakeVerifier) == CHIP_NO_ERROR,
-                 status.Emplace(StatusCodeEnum::kPAKEParameterError));
+    VerifyOrExit(verifier.Deserialize(pakeVerifier) == CHIP_NO_ERROR, status.Emplace(StatusCodeEnum::kPAKEParameterError));
     VerifyOrExit(commissionMgr.OpenJointCommissioningWindow(commissioningTimeout, discriminator, verifier, iterations, salt,
                                                             fabricIndex, fabricInfo->GetVendorId()) == CHIP_NO_ERROR,
                  status.Emplace(StatusCodeEnum::kPAKEParameterError));

--- a/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
@@ -151,7 +151,9 @@ void JointFabricAdministratorGlobalInstance::HandleOJCW(HandlerContext & ctx,
     auto & iterations         = commandData.iterations;
     auto & salt               = commandData.salt;
 
-    Optional<JointFabricAdministrator::StatusCodeEnum> status = Optional<JointFabricAdministrator::StatusCodeEnum>::Missing();
+    using namespace chip::app::Clusters::JointFabricAdministrator;
+
+    Optional<StatusCodeEnum> status = Optional<StatusCodeEnum>::Missing();
     Status globalStatus                                       = Status::Success;
     Spake2pVerifier verifier;
 
@@ -162,28 +164,28 @@ void JointFabricAdministratorGlobalInstance::HandleOJCW(HandlerContext & ctx,
     auto & failSafeContext        = Server::GetInstance().GetFailSafeContext();
     auto & commissionMgr          = Server::GetInstance().GetCommissioningWindowManager();
 
-    VerifyOrExit(fabricInfo != nullptr, status.Emplace(JointFabricAdministrator::StatusCodeEnum::kPAKEParameterError));
-    VerifyOrExit(failSafeContext.IsFailSafeFullyDisarmed(), status.Emplace(JointFabricAdministrator::StatusCodeEnum::kBusy));
+    VerifyOrExit(fabricInfo != nullptr, status.Emplace(StatusCodeEnum::kPAKEParameterError));
+    VerifyOrExit(failSafeContext.IsFailSafeFullyDisarmed(), status.Emplace(StatusCodeEnum::kBusy));
 
-    VerifyOrExit(!commissionMgr.IsCommissioningWindowOpen(), status.Emplace(JointFabricAdministrator::StatusCodeEnum::kBusy));
+    VerifyOrExit(!commissionMgr.IsCommissioningWindowOpen(), status.Emplace(StatusCodeEnum::kBusy));
     VerifyOrExit(iterations >= kSpake2p_Min_PBKDF_Iterations,
-                 status.Emplace(JointFabricAdministrator::StatusCodeEnum::kPAKEParameterError));
+                 status.Emplace(StatusCodeEnum::kPAKEParameterError));
     VerifyOrExit(iterations <= kSpake2p_Max_PBKDF_Iterations,
-                 status.Emplace(JointFabricAdministrator::StatusCodeEnum::kPAKEParameterError));
+                 status.Emplace(StatusCodeEnum::kPAKEParameterError));
     VerifyOrExit(salt.size() >= kSpake2p_Min_PBKDF_Salt_Length,
-                 status.Emplace(JointFabricAdministrator::StatusCodeEnum::kPAKEParameterError));
+                 status.Emplace(StatusCodeEnum::kPAKEParameterError));
     VerifyOrExit(salt.size() <= kSpake2p_Max_PBKDF_Salt_Length,
-                 status.Emplace(JointFabricAdministrator::StatusCodeEnum::kPAKEParameterError));
+                 status.Emplace(StatusCodeEnum::kPAKEParameterError));
 
     VerifyOrExit(commissioningTimeout <= commissionMgr.MaxCommissioningTimeout(), globalStatus = Status::InvalidCommand);
     VerifyOrExit(commissioningTimeout >= commissionMgr.MinCommissioningTimeout(), globalStatus = Status::InvalidCommand);
     VerifyOrExit(discriminator <= kMaxDiscriminatorValue, globalStatus = Status::InvalidCommand);
 
     VerifyOrExit(verifier.Deserialize(pakeVerifier) == CHIP_NO_ERROR,
-                 status.Emplace(JointFabricAdministrator::StatusCodeEnum::kPAKEParameterError));
+                 status.Emplace(StatusCodeEnum::kPAKEParameterError));
     VerifyOrExit(commissionMgr.OpenJointCommissioningWindow(commissioningTimeout, discriminator, verifier, iterations, salt,
                                                             fabricIndex, fabricInfo->GetVendorId()) == CHIP_NO_ERROR,
-                 status.Emplace(JointFabricAdministrator::StatusCodeEnum::kPAKEParameterError));
+                 status.Emplace(StatusCodeEnum::kPAKEParameterError));
     ChipLogProgress(Zcl, "Commissioning window is now open");
 
 exit:


### PR DESCRIPTION
#### Summary
Fix clang compile issues in the example apps.  Several example apps are not exercised in the CI but are used in the certification harness build.  Enabling clang builds opens up a new cross compile path for the chip-test-bins; that will be considerably faster for building arm64 binaries on an x64 host.

#### Testing

Ran the builds for example apps using both the default compiler and clang on both arm64 and x64:

* linux-{arm64,x64}-chip-tool-ipv6only-platform-mdns-nfc-commission-{clang,gcc} 
* linux-{arm64,x64}-shell-ipv6only-platform-mdns-{clang,gcc} 
* linux-{arm64,x64}-chip-cert-ipv6only-platform-mdns-{clang,gcc} 
* linux-{arm64,x64}-air-purifier-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-all-clusters-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-all-clusters-ipv6only-nlfaultinject-{clang,gcc} 
* linux-{arm64,x64}-all-clusters-minimal-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-bridge-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-tv-app-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-tv-casting-app-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-light-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-thermostat-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-ota-provider-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-ota-requestor-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-lock-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-simulated-app1-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-lit-icd-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-energy-gateway-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-energy-management-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-microwave-oven-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-rvc-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-fabric-bridge-rpc-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-fabric-admin-rpc-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-light-data-model-no-unique-id-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-network-manager-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-terms-and-conditions-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-water-leak-detector-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-camera-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-camera-controller-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-closure-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-jf-control-app-ipv6only-{clang,gcc} 
* linux-{arm64,x64}-jf-admin-app-ipv6only-{clang,gcc} 

CI will additionally run the required tests.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
