### PR TITLE
[Camera] Fix PICS usage in Push AV Integration Test Cases

### DIFF
--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -191,6 +191,26 @@ Protocols::InteractionModel::Status PushAvStreamTransportManager::SetTransportSt
         return Status::Failure;
     }
 
+    if (transportStatus == TransportStatusEnum::kActive)
+    {
+        auto & avsmController = mCameraDevice->GetCameraAVStreamMgmtController();
+        bool isActive;
+        CHIP_ERROR status = avsmController.IsPrivacyModeActive(isActive);
+        if (status == CHIP_NO_ERROR)
+        {
+            if (isActive)
+            {
+                ChipLogError(Camera, "PushAvStreamTransportManager, Cannot set transport status to Active as privacy mode is enabled.");
+                return Status::InvalidInState;
+            }
+        }
+        else
+        {
+            ChipLogError(Camera, "PushAvStreamTransportManager, Failed to retrieve Privacy Mode Status from AVStreamMgmtController.");
+            return Status::Failure;
+        }
+    }
+
     for (uint16_t connectionID : connectionIDList)
     {
         if (mTransportMap.find(connectionID) == mTransportMap.end())

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -196,18 +196,17 @@ Protocols::InteractionModel::Status PushAvStreamTransportManager::SetTransportSt
         auto & avsmController = mCameraDevice->GetCameraAVStreamMgmtController();
         bool isActive;
         CHIP_ERROR status = avsmController.IsPrivacyModeActive(isActive);
-        if (status == CHIP_NO_ERROR)
+        if (status != CHIP_NO_ERROR)
         {
-            if (isActive)
-            {
-                ChipLogError(Camera, "PushAvStreamTransportManager, Cannot set transport status to Active as privacy mode is enabled.");
-                return Status::InvalidInState;
-            }
-        }
-        else
-        {
-            ChipLogError(Camera, "PushAvStreamTransportManager, Failed to retrieve Privacy Mode Status from AVStreamMgmtController.");
+            ChipLogError(Camera,
+                         "PushAvStreamTransportManager, Failed to retrieve Privacy Mode Status from AVStreamMgmtController.");
             return Status::Failure;
+        }
+
+        if (isActive)
+        {
+            ChipLogError(Camera, "PushAvStreamTransportManager, Cannot set transport status to Active as privacy mode is enabled.");
+            return Status::InvalidInState;
         }
     }
 

--- a/src/python_testing/TC_PAVSTI_1_2.py
+++ b/src/python_testing/TC_PAVSTI_1_2.py
@@ -231,7 +231,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
         audioStreamId = allocatedAudioStream.audioStreamID
 
         self.step(5)
-        if self.pics_guard(self.check_pics("AVSM.S.F0003")):
+        if self.pics_guard(self.check_pics("AVSM.S.F03")):
             aFeatureMap = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=avsmCluster, attribute=avsmAttr.FeatureMap
             )
@@ -248,7 +248,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
             )
 
         self.step(6)
-        if self.pics_guard(self.check_pics("AVSM.S.F0003")):
+        if self.pics_guard(self.check_pics("AVSM.S.F03")):
             result = await self.write_single_attribute(
                 avsmAttr.SoftLivestreamPrivacyModeEnabled(True), endpoint_id=endpoint
             )
@@ -287,7 +287,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
         )
 
         self.step(8)
-        if self.pics_guard(self.check_pics("AVSM.S.F0003")):
+        if self.pics_guard(self.check_pics("AVSM.S.F03")):
             try:
                 await self.send_single_cmd(
                     cmd=pushavCluster.Commands.SetTransportStatus(
@@ -306,7 +306,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
                 )
 
         self.step(9)
-        if self.pics_guard(self.check_pics("AVSM.S.F0003")):
+        if self.pics_guard(self.check_pics("AVSM.S.F03")):
             result = await self.write_single_attribute(
                 avsmAttr.SoftRecordingPrivacyModeEnabled(False), endpoint_id=endpoint
             )
@@ -317,7 +317,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
             )
 
         self.step(10)
-        if self.pics_guard(self.check_pics("AVSM.S.F0003")):
+        if self.pics_guard(self.check_pics("AVSM.S.F03")):
             result = await self.write_single_attribute(
                 avsmAttr.SoftLivestreamPrivacyModeEnabled(False), endpoint_id=endpoint
             )

--- a/src/python_testing/TC_PAVSTI_1_2.py
+++ b/src/python_testing/TC_PAVSTI_1_2.py
@@ -151,6 +151,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
 
     @async_test_body
     async def test_TC_PAVSTI_1_2(self):
+        PICS_PRIVACY = "AVSM.S.F03"
         endpoint = self.get_endpoint(default=1)
         pushavCluster = Clusters.PushAvStreamTransport
         avsmCluster = Clusters.CameraAvStreamManagement
@@ -231,7 +232,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
         audioStreamId = allocatedAudioStream.audioStreamID
 
         self.step(5)
-        if self.pics_guard(self.check_pics("AVSM.S.F03")):
+        if self.pics_guard(self.check_pics(PICS_PRIVACY)):
             aFeatureMap = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=avsmCluster, attribute=avsmAttr.FeatureMap
             )
@@ -248,7 +249,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
             )
 
         self.step(6)
-        if self.pics_guard(self.check_pics("AVSM.S.F03")):
+        if self.pics_guard(self.check_pics(PICS_PRIVACY)):
             result = await self.write_single_attribute(
                 avsmAttr.SoftLivestreamPrivacyModeEnabled(True), endpoint_id=endpoint
             )
@@ -287,7 +288,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
         )
 
         self.step(8)
-        if self.pics_guard(self.check_pics("AVSM.S.F03")):
+        if self.pics_guard(self.check_pics(PICS_PRIVACY)):
             try:
                 await self.send_single_cmd(
                     cmd=pushavCluster.Commands.SetTransportStatus(
@@ -306,7 +307,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
                 )
 
         self.step(9)
-        if self.pics_guard(self.check_pics("AVSM.S.F03")):
+        if self.pics_guard(self.check_pics(PICS_PRIVACY)):
             result = await self.write_single_attribute(
                 avsmAttr.SoftRecordingPrivacyModeEnabled(False), endpoint_id=endpoint
             )
@@ -317,7 +318,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
             )
 
         self.step(10)
-        if self.pics_guard(self.check_pics("AVSM.S.F03")):
+        if self.pics_guard(self.check_pics(PICS_PRIVACY)):
             result = await self.write_single_attribute(
                 avsmAttr.SoftLivestreamPrivacyModeEnabled(False), endpoint_id=endpoint
             )


### PR DESCRIPTION
This PR:
* Fixes #40923 
* Fixes #40920 
* Fixes TC_PAVSTI_1_2.py to use the correct PICS for Soft Privacy Mode Enabled. The test step was being skipped due to the incorrect PICs code used.
* Updates the `camera-app` to properly check if Soft Privacy Mode is enabled before setting the transport status to Active.
If privacy mode is enabled, the application now correctly returns an `INVALID_IN_STATE` error status.

### Testing
Build python wheel and activate venv:

```
. ./scripts/activate.sh
./scripts/build_python.sh -i out/python_env
source out/python_env/bin/activate
python3 -m pip install -r src/tools/push_av_server/requirements.txt
patch -d $(pip show hypercorn | grep "Location: " | sed "s/Location: //") -p0 < src/tools/push_av_server/hypercorn.patch
```
To run tests:
Launch the camera app
```
rm -rf /tmp/chip_* && ./chip-camera-app
```
Run the test case
```
python3 src/python_testing/TC_PAVSTI_1_<>.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1 --string-arg th_server_app_path:./src/tools/push_av_server/server.py --string-arg host_ip:localhost
```