### PR TITLE
[NXP] Adding openthread CLI extension for NXP platforms + heap increase for Matter TBR on NXP RW platform

### DIFF
--- a/examples/thermostat/nxp/rt/rw61x/BUILD.gn
+++ b/examples/thermostat/nxp/rt/rw61x/BUILD.gn
@@ -90,9 +90,10 @@ rt_sdk("sdk") {
   include_dirs += [ "${example_platform_dir}/app/project_include/openthread" ]
 
   # For matter with BR feature, increase FreeRTOS heap size and enable TBR cluster
+  # Additionnaly in the context of OTBR support the freeRTOS heap should be big enough to allow to handle a large number of  mDNS packets
   if (chip_enable_wifi && chip_enable_openthread) {
     defines += [
-      "configTOTAL_HEAP_SIZE=(size_t)(170 * 1024)",
+      "configTOTAL_HEAP_SIZE=(size_t)(250 * 1024)",
       "CHIP_DEVICE_CONFIG_ENABLE_TBR=1",
     ]
   }

--- a/examples/thermostat/nxp/rt/rw61x/BUILD.gn
+++ b/examples/thermostat/nxp/rt/rw61x/BUILD.gn
@@ -90,7 +90,7 @@ rt_sdk("sdk") {
   include_dirs += [ "${example_platform_dir}/app/project_include/openthread" ]
 
   # For matter with BR feature, increase FreeRTOS heap size and enable TBR cluster
-  # Additionnaly in the context of OTBR support the freeRTOS heap should be big enough to allow to handle a large number of  mDNS packets
+  # Additionally in the context of OTBR support the freeRTOS heap should be big enough to allow to handle a large number of mDNS packets
   if (chip_enable_wifi && chip_enable_openthread) {
     defines += [
       "configTOTAL_HEAP_SIZE=(size_t)(250 * 1024)",

--- a/third_party/openthread/platforms/nxp/rt/rt1060/BUILD.gn
+++ b/third_party/openthread/platforms/nxp/rt/rt1060/BUILD.gn
@@ -39,6 +39,8 @@ config("openthread_rt1060_config") {
     "${openthread_nxp_root}/examples/utils/cli_addons",
     "${openthread_nxp_root}/examples/utils/cli_addons/ephemeral_key",
     "${openthread_nxp_root}/examples/utils/cli_addons/lwip",
+    "${openthread_nxp_root}/examples/utils/cli_addons/debug",
+    "${openthread_nxp_root}/examples/utils/cli_addons/platform",
   ]
 
   if (chip_enable_wifi && chip_enable_openthread) {
@@ -70,7 +72,9 @@ config("openthread_rt1060_config") {
     if (nxp_enable_matter_cli) {
       defines += [
         "OT_APP_CLI_EPHEMERAL_KEY_ADDON=1",
+        "OT_APP_CLI_DEBUG_ADDON=1",
         "OT_APP_CLI_LWIP_ADDON=1",
+        "OT_APP_CLI_PLATFORM_ADDON=1",
       ]
     }
   }
@@ -131,6 +135,8 @@ source_set("libopenthread-rt1060") {
         "${openthread_nxp_root}/examples/utils/cli_addons/addons_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/ephemeral_key/ephemeral_key_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/lwip/lwip_cli.c",
+        "${openthread_nxp_root}/examples/utils/cli_addons/debug/debug_cli.c",
+        "${openthread_nxp_root}/examples/utils/cli_addons/platform/radio_cli.c",
       ]
     }
 

--- a/third_party/openthread/platforms/nxp/rt/rt1060/BUILD.gn
+++ b/third_party/openthread/platforms/nxp/rt/rt1060/BUILD.gn
@@ -133,9 +133,9 @@ source_set("libopenthread-rt1060") {
     if (nxp_enable_matter_cli) {
       sources += [
         "${openthread_nxp_root}/examples/utils/cli_addons/addons_cli.c",
+        "${openthread_nxp_root}/examples/utils/cli_addons/debug/debug_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/ephemeral_key/ephemeral_key_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/lwip/lwip_cli.c",
-        "${openthread_nxp_root}/examples/utils/cli_addons/debug/debug_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/platform/radio_cli.c",
       ]
     }

--- a/third_party/openthread/platforms/nxp/rt/rt1170/BUILD.gn
+++ b/third_party/openthread/platforms/nxp/rt/rt1170/BUILD.gn
@@ -37,6 +37,8 @@ config("openthread_rt1170_config") {
     "${openthread_nxp_root}/examples/utils/cli_addons",
     "${openthread_nxp_root}/examples/utils/cli_addons/ephemeral_key",
     "${openthread_nxp_root}/examples/utils/cli_addons/lwip",
+    "${openthread_nxp_root}/examples/utils/cli_addons/debug",
+    "${openthread_nxp_root}/examples/utils/cli_addons/platform",
   ]
   defines = [ "OT_PLAT_SPINEL_OVER_SPI" ]
 
@@ -69,7 +71,9 @@ config("openthread_rt1170_config") {
     if (nxp_enable_matter_cli) {
       defines += [
         "OT_APP_CLI_EPHEMERAL_KEY_ADDON=1",
+        "OT_APP_CLI_DEBUG_ADDON=1",
         "OT_APP_CLI_LWIP_ADDON=1",
+        "OT_APP_CLI_PLATFORM_ADDON=1",
       ]
     }
   }
@@ -129,6 +133,8 @@ source_set("libopenthread-rt1170") {
         "${openthread_nxp_root}/examples/utils/cli_addons/addons_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/ephemeral_key/ephemeral_key_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/lwip/lwip_cli.c",
+        "${openthread_nxp_root}/examples/utils/cli_addons/debug/debug_cli.c",
+        "${openthread_nxp_root}/examples/utils/cli_addons/platform/radio_cli.c",
       ]
     }
 

--- a/third_party/openthread/platforms/nxp/rt/rt1170/BUILD.gn
+++ b/third_party/openthread/platforms/nxp/rt/rt1170/BUILD.gn
@@ -131,9 +131,9 @@ source_set("libopenthread-rt1170") {
     if (nxp_enable_matter_cli) {
       sources += [
         "${openthread_nxp_root}/examples/utils/cli_addons/addons_cli.c",
+        "${openthread_nxp_root}/examples/utils/cli_addons/debug/debug_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/ephemeral_key/ephemeral_key_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/lwip/lwip_cli.c",
-        "${openthread_nxp_root}/examples/utils/cli_addons/debug/debug_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/platform/radio_cli.c",
       ]
     }

--- a/third_party/openthread/platforms/nxp/rt/rw61x/BUILD.gn
+++ b/third_party/openthread/platforms/nxp/rt/rw61x/BUILD.gn
@@ -133,11 +133,10 @@ source_set("libopenthread-rw61x") {
     if (nxp_enable_matter_cli) {
       sources += [
         "${openthread_nxp_root}/examples/utils/cli_addons/addons_cli.c",
+        "${openthread_nxp_root}/examples/utils/cli_addons/debug/debug_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/ephemeral_key/ephemeral_key_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/lwip/lwip_cli.c",
-        "${openthread_nxp_root}/examples/utils/cli_addons/debug/debug_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/platform/radio_cli.c",
-
       ]
     }
 

--- a/third_party/openthread/platforms/nxp/rt/rw61x/BUILD.gn
+++ b/third_party/openthread/platforms/nxp/rt/rw61x/BUILD.gn
@@ -39,6 +39,8 @@ config("openthread_rw61x_config") {
     "${openthread_nxp_root}/examples/utils/cli_addons",
     "${openthread_nxp_root}/examples/utils/cli_addons/ephemeral_key",
     "${openthread_nxp_root}/examples/utils/cli_addons/lwip",
+    "${openthread_nxp_root}/examples/utils/cli_addons/debug",
+    "${openthread_nxp_root}/examples/utils/cli_addons/platform",
   ]
 
   include_dirs += [ "${openthread_nxp_root}/src/common/spinel" ]
@@ -72,7 +74,9 @@ config("openthread_rw61x_config") {
     if (nxp_enable_matter_cli) {
       defines += [
         "OT_APP_CLI_EPHEMERAL_KEY_ADDON=1",
+        "OT_APP_CLI_DEBUG_ADDON=1",
         "OT_APP_CLI_LWIP_ADDON=1",
+        "OT_APP_CLI_PLATFORM_ADDON=1",
       ]
     }
   }
@@ -131,6 +135,9 @@ source_set("libopenthread-rw61x") {
         "${openthread_nxp_root}/examples/utils/cli_addons/addons_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/ephemeral_key/ephemeral_key_cli.c",
         "${openthread_nxp_root}/examples/utils/cli_addons/lwip/lwip_cli.c",
+        "${openthread_nxp_root}/examples/utils/cli_addons/debug/debug_cli.c",
+        "${openthread_nxp_root}/examples/utils/cli_addons/platform/radio_cli.c",
+
       ]
     }
 


### PR DESCRIPTION
#### Summary

This pull request introduces the following enhancements:

- Adds new OpenThread CLI extensions to enable retrieval of Spinel statistics.
- Increases the heap size for the Matter-based thermostat application on RW platforms where TBR is supported, allowing for improved handling of a larger volume of mDNS packets.

#### Testing

Following binary has been built:
west build -d build-thermostat-rw-br -b frdmrw612 examples/thermostat/nxp -DCONF_FILE_NAME=prj_thread_ftd_wifi_br_ota.conf
Verification of the new OpenThread CLI extensions was performed using the Matter CLI.
