### PR TITLE
[Camera] Fix CI flack after Push AV testings enabled  

### DIFF
--- a/examples/camera-app/linux/args.gni
+++ b/examples/camera-app/linux/args.gni
@@ -29,3 +29,6 @@ chip_with_nlfaultinjection = true
 
 matter_enable_tracing_support = true
 matter_enable_camera_server = true
+
+# Disable IPv4 to force IPv6 usage for TCP connections
+chip_inet_config_enable_ipv4 = false


### PR DESCRIPTION
#### Summary

```
[MatterTest] 09-14 12:22:40.911 INFO Resolving CA7A65D2537C5A58:0000000012344321 ...
[MatterTest] 09-14 12:22:40.912 INFO Lookup started for CA7A65D2537C5A58-0000000012344321
[MatterTest] 09-14 12:22:40.912 INFO Avahi resolve found
[MatterTest] 09-14 12:22:40.913 INFO Node ID resolved for CA7A65D2537C5A58-0000000012344321
[MatterTest] 09-14 12:22:40.913 INFO UDP:172.17.0.1%docker0:5540: new best score: 2 (for CA7A65D2537C5A58-0000000012344321)
[MatterTest] 09-14 12:22:40.913 INFO Checking node lookup status for CA7A65D2537C5A58-0000000012344321 after 2 ms
[MatterTest] 09-14 12:22:40.913 INFO Keeping DNSSD lookup active
[MatterTest] 09-14 12:22:41.111 INFO Checking node lookup status for CA7A65D2537C5A58-0000000012344321 after 200 ms
[MatterTest] 09-14 12:22:41.112 INFO Initiating session on local FabricIndex 1 from 0x000000000001B669 -> 0x0000000012344321
[MatterTest] 09-14 12:22:41.112 INFO Connecting over TCP with peer at TCP:172.17.0.1:5540.
[MatterTest] 09-14 12:22:41.112 ERROR src/transport/raw/Tuple.h:175: CHIP Error 0x0000000C: No message handler at src/app/OperationalSessionSetup.cpp:254
[MatterTest] 09-14 12:22:41.113 ERROR Exception occurred in test_TC_PAVSTI_1_1.
```
Looking at the test output, the test is failing because it's trying to establish a TCP connection over IPv4, but the Matter/CHIP stack in this configuration doesn't support TCP over IPv4 for operational communications.

Solution:
Disable IPv4 to force IPv6 usage for TCP connections

#### Testing

Validated by CI