### PR TITLE
[Camera] Modify implementation to access PushAVStreamTansportServer from Camera app

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/push-av-stream-transport-delegate-impl.h
+++ b/examples/all-clusters-app/all-clusters-common/include/push-av-stream-transport-delegate-impl.h
@@ -91,7 +91,7 @@ public:
     {
         // Handle TLS certificates if needed for implementation
     }
-    void SetPushAvStreamTransportServer(PushAvStreamTransportServerLogic * serverLogic) override
+    void SetPushAvStreamTransportServer(PushAvStreamTransportServer * serverLogic) override
     {
         // Store pointer to server logic if needed for implementation
     }

--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -19,7 +19,6 @@
 #pragma once
 #include <app-common/zap-generated/cluster-enums.h>
 #include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.h>
-#include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.h>
 #include <app/clusters/tls-certificate-management-server/tls-certificate-management-server.h>
 #include <camera-device-interface.h>
 #include <credentials/CHIPCert.h>
@@ -56,7 +55,7 @@ public:
     void Init();
     void SetMediaController(MediaController * mediaController);
     void SetCameraDevice(CameraDeviceInterface * cameraDevice);
-    void SetPushAvStreamTransportServer(PushAvStreamTransportServerLogic * server) override;
+    void SetPushAvStreamTransportServer(PushAvStreamTransportServer * server) override;
 
     // Add missing override keywords and fix signatures
     Protocols::InteractionModel::Status AllocatePushTransport(const TransportOptionsStruct & transportOptions,
@@ -111,9 +110,9 @@ public:
 
 private:
     std::vector<PushAvStream> pushavStreams;
-    MediaController * mMediaController                              = nullptr;
-    CameraDeviceInterface * mCameraDevice                           = nullptr;
-    PushAvStreamTransportServerLogic * mPushAvStreamTransportServer = nullptr;
+    MediaController * mMediaController                         = nullptr;
+    CameraDeviceInterface * mCameraDevice                      = nullptr;
+    PushAvStreamTransportServer * mPushAvStreamTransportServer = nullptr;
 
     AudioStreamStruct mAudioStreamParams;
     VideoStreamStruct mVideoStreamParams;

--- a/examples/camera-app/linux/include/pushav-clip-recorder.h
+++ b/examples/camera-app/linux/include/pushav-clip-recorder.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "pushav-uploader.h"
-#include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.h>
+#include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.h>
 
 #include <algorithm>
 #include <atomic>
@@ -144,7 +144,7 @@ public:
     void SetOnStopCallback(std::function<void()> cb) { mOnStopCallback = std::move(cb); }
 
     // Set the cluster server reference for direct API calls
-    void SetPushAvStreamTransportServer(chip::app::Clusters::PushAvStreamTransportServerLogic * server)
+    void SetPushAvStreamTransportServer(chip::app::Clusters::PushAvStreamTransportServer * server)
     {
         mPushAvStreamTransportServer = server;
     }
@@ -198,8 +198,8 @@ private:
     PushAVUploader * mUploader;
 
     // Cluster server reference for direct API calls
-    chip::app::Clusters::PushAvStreamTransportServerLogic * mPushAvStreamTransportServer = nullptr;
-    uint16_t mConnectionID                                                               = 0;
+    chip::app::Clusters::PushAvStreamTransportServer * mPushAvStreamTransportServer = nullptr;
+    uint16_t mConnectionID                                                          = 0;
     chip::app::Clusters::PushAvStreamTransport::TransportTriggerTypeEnum mTriggerType;
     chip ::Optional<chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum> mReasonType;
 

--- a/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
+++ b/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
@@ -30,7 +30,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/clusters/push-av-stream-transport-server/constants.h>
-#include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.h>
+#include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.h>
 #include <functional>
 #include <memory>
 #include <protocols/interaction_model/StatusCode.h>
@@ -108,7 +108,7 @@ public:
     double GetCurrentlyUsedBandwidthMbps() { return mCurrentlyUsedBandwidthMbps; }
 
     // Set the cluster server reference for direct API calls
-    void SetPushAvStreamTransportServer(chip::app::Clusters::PushAvStreamTransportServerLogic * server)
+    void SetPushAvStreamTransportServer(chip::app::Clusters::PushAvStreamTransportServer * server)
     {
         mPushAvStreamTransportServer = server;
     }
@@ -118,11 +118,11 @@ public:
             timeControl);
 
 private:
-    bool mHasAugmented                                                                   = false;
-    bool mStreaming                                                                      = false;
-    std::unique_ptr<PushAVClipRecorder> mRecorder                                        = nullptr;
-    std::unique_ptr<PushAVUploader> mUploader                                            = nullptr;
-    chip::app::Clusters::PushAvStreamTransportServerLogic * mPushAvStreamTransportServer = nullptr;
+    bool mHasAugmented                                                              = false;
+    bool mStreaming                                                                 = false;
+    std::unique_ptr<PushAVClipRecorder> mRecorder                                   = nullptr;
+    std::unique_ptr<PushAVUploader> mUploader                                       = nullptr;
+    chip::app::Clusters::PushAvStreamTransportServer * mPushAvStreamTransportServer = nullptr;
 
     std::chrono::steady_clock::time_point mBlindStartTime;
     PushAVClipRecorder::ClipInfoStruct mClipInfo;

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -63,7 +63,7 @@ void PushAvStreamTransportManager::SetCameraDevice(CameraDeviceInterface * aCame
     mCameraDevice = aCameraDevice;
 }
 
-void PushAvStreamTransportManager::SetPushAvStreamTransportServer(PushAvStreamTransportServerLogic * server)
+void PushAvStreamTransportManager::SetPushAvStreamTransportServer(PushAvStreamTransportServer * server)
 {
     mPushAvStreamTransportServer = server;
 }

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.h
@@ -50,13 +50,58 @@ public:
 
     PushAvStreamTransportServerLogic & GetLogic() { return mLogic; }
 
-    void SetDelegate(PushAvStreamTransportDelegate * delegate) { mLogic.SetDelegate(delegate); }
+    void SetDelegate(PushAvStreamTransportDelegate * delegate)
+    {
+        mLogic.SetDelegate(delegate);
+        if (delegate != nullptr)
+        {
+            delegate->SetPushAvStreamTransportServer(this);
+        }
+    }
 
     void SetTLSClientManagementDelegate(TlsClientManagementDelegate * delegate) { mLogic.SetTLSClientManagementDelegate(delegate); }
 
     void SetTlsCertificateManagementDelegate(TlsCertificateManagementDelegate * delegate)
     {
         mLogic.SetTlsCertificateManagementDelegate(delegate);
+    }
+
+    /**
+     * @brief API for application layer to notify when transport has started
+     *
+     * This should be called by the application layer when a transport begins streaming.
+     * It will generate the appropriate PushTransportBegin event.
+     *
+     * @param connectionID The connection ID of the transport that started
+     * @param triggerType The type of trigger that started the transport
+     * @param activationReason Optional reason for the activation
+     * @return Status::Success if event was generated successfully, failure otherwise
+     */
+    Protocols::InteractionModel::Status
+    NotifyTransportStarted(uint16_t connectionID, PushAvStreamTransport::TransportTriggerTypeEnum triggerType,
+                           Optional<PushAvStreamTransport::TriggerActivationReasonEnum> activationReason =
+                               Optional<PushAvStreamTransport::TriggerActivationReasonEnum>())
+    {
+        return mLogic.NotifyTransportStarted(connectionID, triggerType, activationReason);
+    }
+
+    /**
+     * @brief API for application layer to notify when transport has stopped
+     *
+     * This should be called by the application layer when a transport stops streaming.
+     * It will generate the appropriate PushTransportEnd event.
+     *
+     * @param connectionID The connection ID of the transport that stopped
+     * @param triggerType The type of trigger that started the transport
+     * @param activationReason Optional reason for the deactivation
+     * @return Status::Success if event was generated successfully, failure otherwise
+     */
+    Protocols::InteractionModel::Status
+    NotifyTransportStopped(uint16_t connectionID, PushAvStreamTransport::TransportTriggerTypeEnum triggerType,
+                           Optional<PushAvStreamTransport::TriggerActivationReasonEnum> activationReason =
+                               Optional<PushAvStreamTransport::TriggerActivationReasonEnum>())
+    {
+        return mLogic.NotifyTransportStopped(connectionID, triggerType, activationReason);
     }
 
     CHIP_ERROR Init() { return mLogic.Init(); }

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -31,8 +31,9 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
-// Forward declaration
+// Forward declarations
 class PushAvStreamTransportServerLogic;
+class PushAvStreamTransportServer;
 
 /**
  * @brief Defines interfaces for implementing application-specific logic for the PushAvStreamTransport Delegate.
@@ -272,13 +273,13 @@ public:
     /**
      * @brief Sets the PushAvStreamTransportServerLogic instance for the delegate.
      *
-     * This method is called by the PushAvStreamTransportServerLogic to provide
-     * the delegate with a pointer to the server logic instance. This allows the
-     * delegate to interact with the server logic, for example, to generate events.
+     * This method is called by the PushAvStreamTransportServer to provide
+     * the delegate with a pointer to the server instance. This allows the
+     * delegate to interact with the server, for example, to generate events.
      *
-     * @param serverLogic A pointer to the PushAvStreamTransportServerLogic instance.
+     * @param server A pointer to the PushAvStreamTransportServer instance.
      */
-    virtual void SetPushAvStreamTransportServer(PushAvStreamTransportServerLogic * serverLogic) = 0;
+    virtual void SetPushAvStreamTransportServer(PushAvStreamTransportServer * server) = 0;
 };
 } // namespace Clusters
 } // namespace app

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
@@ -596,19 +596,9 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
             handler.AddClusterSpecificFailure(commandPath, status);
             return std::nullopt;
         });
-
         // Use heap allocation for large certificate buffers to reduce stack usage
-        std::unique_ptr<PersistentStore<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES>> rootCertBuffer{ new (
-            std::nothrow) PersistentStore<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES>() };
-        std::unique_ptr<PersistentStore<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES>> clientCertBuffer{ new (
-            std::nothrow) PersistentStore<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES>() };
-
-        if (!rootCertBuffer || !clientCertBuffer)
-        {
-            ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Memory allocation failed for certificate buffers", mEndpointId);
-            handler.AddStatus(commandPath, Status::ResourceExhausted);
-            return std::nullopt;
-        }
+        auto rootCertBuffer   = std::make_unique<PersistentStore<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES>>();
+        auto clientCertBuffer = std::make_unique<PersistentStore<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES>>();
 
         Tls::CertificateTable::BufferedClientCert clientCertEntry(*clientCertBuffer);
         Tls::CertificateTable::BufferedRootCert rootCertEntry(*rootCertBuffer);

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
@@ -596,9 +596,12 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
             handler.AddClusterSpecificFailure(commandPath, status);
             return std::nullopt;
         });
+
         // Use heap allocation for large certificate buffers to reduce stack usage
-        auto rootCertBuffer   = std::make_unique<PersistentStore<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES>>();
-        auto clientCertBuffer = std::make_unique<PersistentStore<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES>>();
+        std::unique_ptr<PersistentStore<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES>> rootCertBuffer{ new (
+            std::nothrow) PersistentStore<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES>() };
+        std::unique_ptr<PersistentStore<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES>> clientCertBuffer{ new (
+            std::nothrow) PersistentStore<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES>() };
 
         if (!rootCertBuffer || !clientCertBuffer)
         {

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.h
@@ -31,40 +31,7 @@ public:
             ChipLogError(Zcl, "Push AV Stream Transport : Trying to set delegate to null");
             return;
         }
-        mDelegate->SetPushAvStreamTransportServer(this);
     }
-
-    /**
-     * @brief API for application layer to notify when transport has started
-     *
-     * This should be called by the application layer when a transport begins streaming.
-     * It will generate the appropriate PushTransportBegin event.
-     *
-     * @param connectionID The connection ID of the transport that started
-     * @param triggerType The type of trigger that started the transport
-     * @param activationReason Optional reason for the activation
-     * @return Status::Success if event was generated successfully, failure otherwise
-     */
-    Protocols::InteractionModel::Status
-    NotifyTransportStarted(uint16_t connectionID, PushAvStreamTransport::TransportTriggerTypeEnum triggerType,
-                           Optional<PushAvStreamTransport::TriggerActivationReasonEnum> activationReason =
-                               Optional<PushAvStreamTransport::TriggerActivationReasonEnum>());
-
-    /**
-     * @brief API for application layer to notify when transport has stopped
-     *
-     * This should be called by the application layer when a transport stops streaming.
-     * It will generate the appropriate PushTransportEnd event.
-     *
-     * @param connectionID The connection ID of the transport that stopped
-     * @param triggerType The type of trigger that started the transport
-     * @param activationReason Optional reason for the deactivation
-     * @return Status::Success if event was generated successfully, failure otherwise
-     */
-    Protocols::InteractionModel::Status
-    NotifyTransportStopped(uint16_t connectionID, PushAvStreamTransport::TransportTriggerTypeEnum triggerType,
-                           Optional<PushAvStreamTransport::TriggerActivationReasonEnum> activationReason =
-                               Optional<PushAvStreamTransport::TriggerActivationReasonEnum>());
 
     void SetTLSClientManagementDelegate(TlsClientManagementDelegate * delegate)
     {
@@ -85,6 +52,17 @@ public:
             return;
         }
     }
+
+    Protocols::InteractionModel::Status
+    NotifyTransportStarted(uint16_t connectionID, PushAvStreamTransport::TransportTriggerTypeEnum triggerType,
+                           Optional<PushAvStreamTransport::TriggerActivationReasonEnum> activationReason =
+                               Optional<PushAvStreamTransport::TriggerActivationReasonEnum>());
+
+    Protocols::InteractionModel::Status
+    NotifyTransportStopped(uint16_t connectionID, PushAvStreamTransport::TransportTriggerTypeEnum triggerType,
+                           Optional<PushAvStreamTransport::TriggerActivationReasonEnum> activationReason =
+                               Optional<PushAvStreamTransport::TriggerActivationReasonEnum>());
+
     enum class UpsertResultEnum : uint8_t
     {
         kInserted = 0x00,

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -377,7 +377,7 @@ public:
         // No-op implementation for tests
     }
 
-    void SetPushAvStreamTransportServer(PushAvStreamTransportServerLogic * serverLogic) override
+    void SetPushAvStreamTransportServer(PushAvStreamTransportServer * server) override
     {
         // No-op implementation for tests
     }


### PR DESCRIPTION
#### Summary
Fixes: #40980

[1] PushAvStreamTransportServerLogic is the internal implementation of PushAvStreamTransportServer, we should not expose it directly to the application

Originally posted by @yufengwangca in https://github.com/project-chip/connectedhomeip/pull/40840#discussion_r2345037811

[2] Those public APIs to application should exist in PushAvStreamTransportServer, do it in the follow-up PR is ok

Originally posted by @yufengwangca https://github.com/project-chip/connectedhomeip/pull/40840#discussion_r2345041848

[3] Those smart pointers will only be non-null if the allocation succeeds. If the allocation fails, an exception will be thrown, and the if block's error logging path will never be executed. The intended error handling logic is unreachable.

If you want to keep the existing if (!ptr) error-checking logic, you must use the nothrow version of new, which does return nullptr on allocation failure instead of throwing an exception.


#### Testing

Validated by CI