### PR TITLE
Add a DevicePairingDelegate notification for a commissioning stage starting.

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -537,6 +537,11 @@ void PairingCommand::OnICDStayActiveComplete(ScopedNodeId deviceId, uint32_t pro
                     ChipLogValueX64(deviceId.GetNodeId()), promisedActiveDuration);
 }
 
+void PairingCommand::OnCommissioningStageStart(PeerId peerId, CommissioningStage stageStarting)
+{
+    ChipLogDetail(chipTool, "Starting commissioning stage '%s'", StageToString(stageStarting));
+}
+
 void PairingCommand::OnDiscoveredDevice(const Dnssd::CommissionNodeData & nodeData)
 {
     // Ignore nodes with closed commissioning window

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -243,6 +243,7 @@ public:
     void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error) override;
     void OnICDRegistrationComplete(chip::ScopedNodeId deviceId, uint32_t icdCounter) override;
     void OnICDStayActiveComplete(chip::ScopedNodeId deviceId, uint32_t promisedActiveDuration) override;
+    void OnCommissioningStageStart(chip::PeerId peerId, chip::Controller::CommissioningStage stageStarting) override;
 
     /////////// DeviceDiscoveryDelegate Interface /////////
     void OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData) override;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -3133,6 +3133,11 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
                         params.GetCompletionStatus().err.AsString());
     }
 
+    if (mPairingDelegate)
+    {
+        mPairingDelegate->OnCommissioningStageStart(PeerId(GetCompressedFabricId(), proxy->GetDeviceId()), step);
+    }
+
     mCommissioningStepTimeout = timeout;
     mCommissioningStage       = step;
     mCommissioningDelegate    = delegate;

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -153,11 +153,11 @@ public:
      * @brief
      *   Called when a commissioning stage starts.
      *
-     * @param[in] PeerId an identifier for the commissioning process.  This is generally the
+     * @param[in] peerId an identifier for the commissioning process.  This is generally the
      *                   client-provided commissioning identifier before AddNOC and the actual
      *                   NodeID of the node after AddNoc, combined with the compressed fabric ID for
      *                   the fabric doing the commissioning.
-     * @param[in] CommissioningStage the stage being started.
+     * @param[in] stageStarting the stage being started.
      */
     virtual void OnCommissioningStageStart(PeerId peerId, CommissioningStage stageStarting) {}
 };

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -148,6 +148,18 @@ public:
      *            from the time it receives the StayActiveRequest command.
      */
     virtual void OnICDStayActiveComplete(ScopedNodeId icdNodeId, uint32_t promisedActiveDurationMsec) {}
+
+    /**
+     * @brief
+     *   Called when a commissioning stage starts.
+     *
+     * @param[in] PeerId an identifier for the commissioning process.  This is generally the
+     *                   client-provided commissioning identifier before AddNOC and the actual
+     *                   NodeID of the node after AddNoc, combined with the compressed fabric ID for
+     *                   the fabric doing the commissioning.
+     * @param[in] CommissioningStage the stage being started.
+     */
+    virtual void OnCommissioningStageStart(PeerId peerId, CommissioningStage stageStarting) {}
 };
 
 } // namespace Controller


### PR DESCRIPTION
We had notifications for a stage ending, but not for a stage starting.  Because you can't tell which stage will start next from an end notification (without replicating the commissioner state machine), and because some stages can take quite a while, commissioners want to be notified when stages start, not just when they end.

#### Testing

Manual testing using the chip-tool logging I added.