### PR TITLE
[Camera] Update push-av-server and Integration TCs to include server ip in subject CN

### DIFF
--- a/src/python_testing/TC_PAVSTI_1_1.py
+++ b/src/python_testing/TC_PAVSTI_1_1.py
@@ -25,7 +25,7 @@
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --string-arg th_server_app_path:${PUSH_AV_SERVER}
-#       --string-arg host_ip:localhost
+#       --string-arg host_ip:127.0.0.1
 #       --commissioning-method on-network
 #       --discriminator 1234
 #       --passcode 20202021
@@ -59,7 +59,10 @@ class TC_PAVSTI_1_1(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
     @async_test_body
     async def setup_class(self):
         th_server_app = self.user_params.get("th_server_app_path", None)
-        self.server = PushAvServerProcess(server_path=th_server_app)
+        self.host_ip = self.user_params.get("host_ip", None)
+        if self.host_ip is None:
+            self.host_ip = self.get_private_ip()
+        self.server = PushAvServerProcess(server_path=th_server_app, server_ip=self.host_ip)
         self.server.start(
             expected_output="Running on https://0.0.0.0:1234",
             timeout=30,
@@ -140,8 +143,7 @@ class TC_PAVSTI_1_1(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
         # Commission DUT - already done
         await self.precondition_one_allocated_video_stream(streamUsage=Globals.Enums.StreamUsageEnum.kRecording)
         await self.precondition_one_allocated_audio_stream(streamUsage=Globals.Enums.StreamUsageEnum.kRecording)
-        host_ip = self.user_params.get("host_ip", None)
-        tlsEndpointId, host_ip = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server, host_ip=host_ip)
+        tlsEndpointId, _ = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server, host_ip=self.host_ip)
         uploadStreamId = self.server.create_stream()
 
         self.step(1)
@@ -216,14 +218,13 @@ class TC_PAVSTI_1_1(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
                     "videoStreamID": videoStreamId,
                     "audioStreamID": audioStreamId,
                     "endpointID": tlsEndpointId,
-                    "url": f"https://{host_ip}:1234/streams/{uploadStreamId}",
+                    "url": f"https://{self.host_ip}:1234/streams/{uploadStreamId}",
                     "triggerOptions": {"triggerType": pushavCluster.Enums.TransportTriggerTypeEnum.kCommand, "maxPreRollLen": 10},
                     "ingestMethod": pushavCluster.Enums.IngestMethodsEnum.kCMAFIngest,
                     "containerFormat": pushavCluster.Enums.ContainerFormatEnum.kCmaf,
                     "containerOptions": {
                         "containerType": pushavCluster.Enums.ContainerFormatEnum.kCmaf,
-                        # TODO: Currently camera-app treats chunkDuration as seconds, revert to ms once fixed.
-                        "CMAFContainerOptions": {"CMAFInterface": 0, "segmentDuration": 4000, "chunkDuration": 2, "sessionGroup": 1, "trackName": "media"},
+                        "CMAFContainerOptions": {"CMAFInterface": 0, "segmentDuration": 4000, "chunkDuration": 2000, "sessionGroup": 1, "trackName": "media"},
                     },
                 }
             ),

--- a/src/python_testing/TC_PAVSTI_1_2.py
+++ b/src/python_testing/TC_PAVSTI_1_2.py
@@ -25,7 +25,7 @@
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --string-arg th_server_app_path:${PUSH_AV_SERVER}
-#       --string-arg host_ip:localhost
+#       --string-arg host_ip:127.0.0.1
 #       --commissioning-method on-network
 #       --discriminator 1234
 #       --passcode 20202021
@@ -60,7 +60,10 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
     @async_test_body
     async def setup_class(self):
         th_server_app = self.user_params.get("th_server_app_path", None)
-        self.server = PushAvServerProcess(server_path=th_server_app)
+        self.host_ip = self.user_params.get("host_ip", None)
+        if self.host_ip is None:
+            self.host_ip = self.get_private_ip()
+        self.server = PushAvServerProcess(server_path=th_server_app, server_ip=self.host_ip)
         self.server.start(
             expected_output="Running on https://0.0.0.0:1234",
             timeout=30,
@@ -162,8 +165,7 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
         # Commission DUT - already done
         await self.precondition_one_allocated_video_stream(streamUsage=Globals.Enums.StreamUsageEnum.kRecording)
         await self.precondition_one_allocated_audio_stream(streamUsage=Globals.Enums.StreamUsageEnum.kRecording)
-        host_ip = self.user_params.get("host_ip", None)
-        tlsEndpointId, host_ip = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server, host_ip=host_ip)
+        tlsEndpointId, _ = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server, host_ip=self.host_ip)
         uploadStreamId = self.server.create_stream()
 
         self.step(1)
@@ -267,14 +269,13 @@ class TC_PAVSTI_1_2(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
                     "videoStreamID": videoStreamId,
                     "audioStreamID": audioStreamId,
                     "endpointID": tlsEndpointId,
-                    "url": f"https://{host_ip}:1234/streams/{uploadStreamId}",
+                    "url": f"https://{self.host_ip}:1234/streams/{uploadStreamId}",
                     "triggerOptions": {"triggerType": pushavCluster.Enums.TransportTriggerTypeEnum.kContinuous},
                     "ingestMethod": pushavCluster.Enums.IngestMethodsEnum.kCMAFIngest,
                     "containerFormat": pushavCluster.Enums.ContainerFormatEnum.kCmaf,
                     "containerOptions": {
                         "containerType": pushavCluster.Enums.ContainerFormatEnum.kCmaf,
-                        # TODO: Currently camera-app treats chunkDuration as seconds, revert to ms once fixed.
-                        "CMAFContainerOptions": {"CMAFInterface": 0, "segmentDuration": 4000, "chunkDuration": 2, "sessionGroup": 1, "trackName": "media"},
+                        "CMAFContainerOptions": {"CMAFInterface": 0, "segmentDuration": 4000, "chunkDuration": 2000, "sessionGroup": 1, "trackName": "media"},
                     },
                 }
             ),

--- a/src/tools/push_av_server/server.py
+++ b/src/tools/push_av_server/server.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import datetime
+import ipaddress
 import json
 import logging
 import os.path
@@ -263,17 +264,21 @@ class CAHierarchy:
         self,
         dns: str,
         public_key: CertificatePublicKeyTypes,
-        duration: datetime.timedelta
+        duration: datetime.timedelta,
+        ip_address: Optional[str] = None
     ) -> x509.Certificate:
         """
         Generate and sign a certificate.
         """
+        # Use ip_address for Common Name if provided, otherwise use dns
+        common_name = ip_address if ip_address else dns
+
         # Sign certificate
         subject = x509.Name(
             [
                 x509.NameAttribute(NameOID.ORGANIZATION_NAME, "CSA"),
                 x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, "TC_PAVS"),
-                x509.NameAttribute(NameOID.COMMON_NAME, dns),
+                x509.NameAttribute(NameOID.COMMON_NAME, common_name),
             ]
         )
 
@@ -322,8 +327,11 @@ class CAHierarchy:
         )
 
         if self.kind == 'server':
+            san_names = [x509.DNSName(dns)]
+            if ip_address:
+                san_names.append(x509.IPAddress(ipaddress.ip_address(ip_address)))
             builder.add_extension(
-                x509.SubjectAlternativeName([x509.DNSName(dns)]),
+                x509.SubjectAlternativeName(san_names),
                 critical=False,
             )
 
@@ -357,7 +365,7 @@ class CAHierarchy:
 
         return (key_path, cert_bundle_path, False)
 
-    def gen_keypair(self, dns: str, override=False, duration: datetime.timedelta = datetime.timedelta(hours=1)) -> tuple[Path, Path, bool]:
+    def gen_keypair(self, dns: str, override=False, duration: datetime.timedelta = datetime.timedelta(hours=1), ip_address: Optional[str] = None) -> tuple[Path, Path, bool]:
         """
         Generate a private key as well as the associated certificate signed by this CA
         hierarchy. Returns the path to the key, cert, and whether it was reused or not.
@@ -375,7 +383,7 @@ class CAHierarchy:
         key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
         # Sign certificate
-        cert = self._sign_cert(dns, key.public_key(), duration)
+        cert = self._sign_cert(dns, key.public_key(), duration, ip_address=ip_address)
 
         # Save that information to disk
         (key_path, cert_bundle_path) = self._save_cert(dns, cert, key, bundle_root=True)
@@ -650,17 +658,17 @@ class PushAvServer:
 class PushAvContext:
     """Hold the context for a full Push AV Server including temporary disk, CA hierarchies and web server"""
 
-    def __init__(self, host: Optional[str], port: Optional[int], working_directory: Optional[str], dns: Optional[str], strict_mode: bool):
+    def __init__(self, host: Optional[str], port: Optional[int], working_directory: Optional[str], dns: Optional[str], server_ip: Optional[str], strict_mode: bool):
         self.directory = WorkingDirectory(working_directory)
         self.host = host
         self.port = port
-        self.dns = "localhost" if dns is None else f"{dns}._http._tcp_.local."
+        self.dns = "localhost" if dns is None else f"{dns}._http._tcp.local."
         self.strict_mode = strict_mode
 
         # Create CA hierarchies (for webserver and devices)
         self.device_hierarchy = CAHierarchy(self.directory.mkdir("certs", "device"), "device", "client")
         self.server_hierarchy = CAHierarchy(self.directory.mkdir("certs", "server"), "server", "server")
-        (self.server_key_file, self.server_cert_file, _) = self.server_hierarchy.gen_keypair(self.dns, override=True)
+        (self.server_key_file, self.server_cert_file, _) = self.server_hierarchy.gen_keypair(self.dns, override=True, ip_address=server_ip)
 
         # mDNS configuration. Registration only happen if the dns isn't localhost.
         self.zeroconf = Zeroconf()
@@ -739,12 +747,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--dns", help="A mDNS record to adversise, or none if left empty."
     )
+    parser.add_argument("--server-ip", help="The IP address of the server to include in the SSL certificate.")
     parser.add_argument("--strict-mode", action='store_true',
                         help="When enabled, upload must happen on the path described by the Matter specification")
 
     args = parser.parse_args()
 
-    ctx = PushAvContext(args.host, args.port, args.working_directory, args.dns, args.strict_mode)
+    ctx = PushAvContext(args.host, args.port, args.working_directory, args.dns, args.server_ip, args.strict_mode)
 
     shutdown_event = asyncio.Event()
 


### PR DESCRIPTION
Since push-av in camera-app now uses provisioned TLS certificates, when uploading the video streams to push_av_server, we see the below error:
```
SSL: certificate subject name 'localhost' does not match target host name '192.168.1.148'
```
This PR:
* Introduces a server-ip option in push_av_server to be able to be able to include in subject CN of server certificate.
* Updates the PAVSTI TCs to provide the same to the PushAVServerSubprocess .

### Testing

```
. ./scripts/activate.sh
./scripts/build_python.sh -i out/python_env
source out/python_env/bin/activate
python3 -m pip install -r src/tools/push_av_server/requirements.txt
patch -d $(pip show hypercorn | grep "Location: " | sed "s/Location: //") -p0 < src/tools/push_av_server/hypercorn.patch
```

To run tests:

Launch the camera app
```
rm -rf /tmp/0-1_clip_0* && rm -rf /tmp/chip_* && ./chip-camera-app
```

Run the test case
```
python3 src/python_testing/TC_PAVSTI_1_<>.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1 --string-arg th_server_app_path:./src/tools/push_av_server/server.py --string-arg host_ip:127.0.0.1
```

