### PR TITLE
Add transport capability that prefers TCP

### DIFF
--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -298,14 +298,15 @@ CHIP_ERROR OperationalSessionSetup::EstablishConnection(const ResolveResult & re
 {
     auto & config = result.mrpRemoteConfig;
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    if (mTransportPayloadCapability == TransportPayloadCapability::kLargePayload)
+    if (mTransportPayloadCapability == TransportPayloadCapability::kLargePayload ||
+        mTransportPayloadCapability == TransportPayloadCapability::kPreferTCPCompatiblePayload)
     {
         if (result.supportsTcpServer)
         {
             // Set the transport type for carrying large payloads
             mDeviceAddress.SetTransportType(chip::Transport::Type::kTcp);
         }
-        else
+        else if (mTransportPayloadCapability == TransportPayloadCapability::kLargePayload)
         {
             // we should not set the large payload while the TCP support is not enabled
             ChipLogError(

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -1250,7 +1250,8 @@ Optional<SessionHandle> SessionManager::FindSecureSessionForNode(ScopedNodeId pe
             (!type.HasValue() || type.Value() == session->GetSecureSessionType()))
         {
             if (transportPayloadCapability == TransportPayloadCapability::kMRPOrTCPCompatiblePayload ||
-                transportPayloadCapability == TransportPayloadCapability::kLargePayload)
+                transportPayloadCapability == TransportPayloadCapability::kLargePayload ||
+                transportPayloadCapability == TransportPayloadCapability::kPreferTCPCompatiblePayload)
             {
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
                 // Set up a TCP transport based session as standby
@@ -1275,6 +1276,11 @@ Optional<SessionHandle> SessionManager::FindSecureSessionForNode(ScopedNodeId pe
     if (transportPayloadCapability == TransportPayloadCapability::kLargePayload)
     {
         return tcpSession != nullptr ? MakeOptional<SessionHandle>(*tcpSession) : Optional<SessionHandle>::Missing();
+    }
+
+    if (transportPayloadCapability == TransportPayloadCapability::kPreferTCPCompatiblePayload && tcpSession != nullptr)
+    {
+        return MakeOptional<SessionHandle>(*tcpSession);
     }
 
     if (transportPayloadCapability == TransportPayloadCapability::kMRPOrTCPCompatiblePayload)

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -66,15 +66,18 @@ namespace chip {
  */
 enum class TransportPayloadCapability : uint8_t
 {
-    kMRPPayload,               // Transport requires the maximum payload size to fit within a single
-                               // IPv6 packet(1280 bytes).
-    kLargePayload,             // Transport needs to handle payloads larger than the single IPv6
-                               // packet, as supported by MRP. The transport of choice, in this
-                               // case, is TCP.
-    kMRPOrTCPCompatiblePayload // This option provides the ability to use MRP
-                               // as the preferred transport, but use a large
-                               // payload transport if that is already
-                               // available.
+    kMRPPayload,                // Transport requires the maximum payload size to fit within a single
+                                // IPv6 packet(1280 bytes).
+    kLargePayload,              // Transport needs to handle payloads larger than the single IPv6
+                                // packet, as supported by MRP. The transport of choice, in this
+                                // case, is TCP.
+    kMRPOrTCPCompatiblePayload, // This option provides the ability to use MRP
+                                // as the preferred transport, but use a large
+                                // payload transport if that is already
+                                // available.
+    kPreferTCPCompatiblePayload // This option provides the ability to use large
+                                // payloads when available and fallback to MRP
+                                // otherwise.
 };
 /**
  * @brief


### PR DESCRIPTION
Allows a client to request TCP as the default transport, but if the device doesn't support it fallback to UDP.

#### Summary

Matter clients don't want to hard-code lists of devices that would request TCP. Instead they would ask for TCP as the preferred transport, and if that's not supported by the Matter device, fallback to UDP.

#### Testing

CI runs.

Locally tested that client using new flag gets a TCP session.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
