### PR TITLE
Tell DevicePairingDelegate which RendezvousParams actually succeeded for PASE.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -781,7 +781,8 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
                 if (mPairingDelegate)
                 {
                     // We already have an open secure session to this device, call the callback immediately and early return.
-                    mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR);
+                    // We don't know what the right RendezvousParameters are here.
+                    mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR, std::nullopt);
                 }
                 MATTER_LOG_METRIC_END(kMetricDeviceCommissionerPASESession, CHIP_NO_ERROR);
                 return CHIP_NO_ERROR;
@@ -882,6 +883,8 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
     err = device->GetPairing().Pair(*mSystemState->SessionMgr(), params.GetSetupPINCode(), GetLocalMRPConfig(), exchangeCtxt, this);
     SuccessOrExit(err);
 
+    mRendezvousParametersForPASEEstablishment = params;
+
 exit:
     if (err != CHIP_NO_ERROR)
     {
@@ -928,7 +931,7 @@ void DeviceCommissioner::OnDiscoveredDeviceOverBleError(void * appState, CHIP_ER
         // A better way to handle it should define a new error code
         if (self->mPairingDelegate != nullptr)
         {
-            self->mPairingDelegate->OnPairingComplete(err);
+            self->mPairingDelegate->OnPairingComplete(err, std::nullopt);
         }
     }
 }
@@ -965,7 +968,7 @@ void DeviceCommissioner::OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err
         self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = RendezvousParameters();
         if (self->mPairingDelegate != nullptr)
         {
-            self->mPairingDelegate->OnPairingComplete(err);
+            self->mPairingDelegate->OnPairingComplete(err, std::nullopt);
         }
     }
 }
@@ -1214,7 +1217,7 @@ void DeviceCommissioner::RendezvousCleanup(CHIP_ERROR status)
 
         if (mPairingDelegate != nullptr)
         {
-            mPairingDelegate->OnPairingComplete(status);
+            mPairingDelegate->OnPairingComplete(status, std::nullopt);
         }
     }
 }
@@ -1222,6 +1225,8 @@ void DeviceCommissioner::RendezvousCleanup(CHIP_ERROR status)
 void DeviceCommissioner::OnSessionEstablishmentError(CHIP_ERROR err)
 {
     MATTER_LOG_METRIC_END(kMetricDeviceCommissionerPASESession, err);
+
+    mRendezvousParametersForPASEEstablishment.reset();
 
     if (mPairingDelegate != nullptr)
     {
@@ -1239,6 +1244,11 @@ void DeviceCommissioner::OnSessionEstablished(const SessionHandle & session)
     // We are in the callback for this pairing. Reset so we can pair another device.
     mDeviceInPASEEstablishment = nullptr;
 
+    // Make sure to clear out mRendezvousParametersForPASEEstablishment no
+    // matter what.
+    std::optional<RendezvousParameters> paseParameters;
+    paseParameters.swap(mRendezvousParametersForPASEEstablishment);
+
     VerifyOrReturn(device != nullptr, OnSessionEstablishmentError(CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR));
 
     CHIP_ERROR err = device->SetConnected(session);
@@ -1254,7 +1264,7 @@ void DeviceCommissioner::OnSessionEstablished(const SessionHandle & session)
     MATTER_LOG_METRIC_END(kMetricDeviceCommissionerPASESession, CHIP_NO_ERROR);
     if (mPairingDelegate != nullptr)
     {
-        mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR);
+        mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR, paseParameters);
     }
 
     if (mRunCommissioningAfterConnection)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -896,6 +896,16 @@ private:
 
     ObjectPool<CommissioneeDeviceProxy, kNumMaxActiveDevices> mCommissioneeDevicePool;
 
+    // While we have an ongoing PASE attempt (i.e. after calling Pair() on the
+    // PASESession), track which RendezvousParameters we used for that attempt.
+    // This allows us to notify delegates about which thing it was we actually
+    // established PASE with, especially in the context of concatenated QR
+    // codes.
+    //
+    // This member only has a value while we are in the middle of session
+    // establishment.
+    std::optional<RendezvousParameters> mRendezvousParametersForPASEEstablishment;
+
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable
     Protocols::UserDirectedCommissioning::UserDirectedCommissioningServer * mUdcServer = nullptr;
     // mUdcTransportMgr is for insecure communication (ex. user directed commissioning)

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -22,7 +22,10 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/NodeId.h>
 #include <lib/support/DLLUtil.h>
+#include <protocols/secure_channel/RendezvousParameters.h>
 #include <stdint.h>
+
+#include <optional>
 
 namespace chip {
 namespace Controller {
@@ -57,6 +60,22 @@ public:
      * @param error Error cause, if any
      */
     virtual void OnPairingComplete(CHIP_ERROR error) {}
+
+    /**
+     * @brief
+     *   Called when PASE session establishment is complete (with success or error)
+     *
+     * @param error Error cause, if any
+     *
+     * @param rendezvousParameters The RendezvousParameters that were used for PASE establishment.
+     *                             If available, this helps identify which exact commissionee PASE
+     *                             was established for. This will generally be present only when
+     *                             PASE establishment succeeds.
+     */
+    virtual void OnPairingComplete(CHIP_ERROR error, const std::optional<RendezvousParameters> & rendezvousParameters)
+    {
+        OnPairingComplete(error);
+    }
 
     /**
      * @brief

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -403,6 +403,7 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
                 if (payload.discriminator.MatchesLongDiscriminator(longDiscriminator))
                 {
                     params.SetSetupPINCode(payload.setUpPINCode);
+                    params.SetSetupDiscriminator(payload.discriminator);
                     found = true;
                     break;
                 }
@@ -422,6 +423,7 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
             if (mSetupPayloads.size() == 1)
             {
                 params.SetSetupPINCode(mSetupPayloads[0].setUpPINCode);
+                params.SetSetupDiscriminator(mSetupPayloads[0].discriminator);
             }
             else
             {
@@ -782,7 +784,7 @@ void SetUpCodePairer::OnStatusUpdate(DevicePairingDelegate::Status status)
     }
 }
 
-void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error)
+void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error, const std::optional<RendezvousParameters> & rendezvousParameters)
 {
     // Save the pairing delegate so we can notify it.  We want to notify it
     // _after_ we restore the state on the commissioner, in case the delegate
@@ -799,7 +801,7 @@ void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error)
         MATTER_LOG_METRIC_END(kMetricSetupCodePairerPairDevice, error);
         if (pairingDelegate != nullptr)
         {
-            pairingDelegate->OnPairingComplete(error);
+            pairingDelegate->OnPairingComplete(error, rendezvousParameters);
         }
         return;
     }
@@ -832,7 +834,7 @@ void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error)
     MATTER_LOG_METRIC_END(kMetricSetupCodePairerPairDevice, error);
     if (pairingDelegate != nullptr)
     {
-        pairingDelegate->OnPairingComplete(error);
+        pairingDelegate->OnPairingComplete(error, rendezvousParameters);
     }
 }
 

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -123,7 +123,7 @@ public:
 private:
     // DevicePairingDelegate implementation.
     void OnStatusUpdate(DevicePairingDelegate::Status status) override;
-    void OnPairingComplete(CHIP_ERROR error) override;
+    void OnPairingComplete(CHIP_ERROR error, const std::optional<RendezvousParameters> & rendezvousParameters) override;
     void OnPairingDeleted(CHIP_ERROR error) override;
     void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error) override;
 


### PR DESCRIPTION
When using concatenated QR codes, this lets API consumers know which of the multiple payloads actually succeeded.

#### Testing

Manually tested that a DevicePairingDelegate is notified with the relevant information.  We don't have a great way to do CI tests for this so far, but I will add some on top of Matter.framework once we start using this notification there.