### PR TITLE
Setup devcontainer so that gdb can work with binaries built outside of it

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -78,10 +78,11 @@ RUN sed -i '/^TIZEN_SDK_DATA_PATH/d' $TIZEN_SDK_ROOT/sdk.info \
     && ln -sf /home/$USERNAME/.tizen-cli-config $TIZEN_SDK_ROOT/tools/.tizen-cli-config \
     && : # last line
 
-RUN [ -n "${LOCAL_WORKSPACE_ROOT}" ] \
+RUN if [ -n "${LOCAL_WORKSPACE_ROOT}" ]; then \
+    true \
     && mkdir -p "$(dirname "${LOCAL_WORKSPACE_ROOT}")" \
     && ln -sf "${WORKSPACE_ROOT}" "${LOCAL_WORKSPACE_ROOT}" \
-    && :
+    ; fi
 
 ENV TIZEN_ROOTFS=/tizen_rootfs
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -80,7 +80,7 @@ RUN sed -i '/^TIZEN_SDK_DATA_PATH/d' $TIZEN_SDK_ROOT/sdk.info \
 
 RUN [ -n "${LOCAL_WORKSPACE_ROOT}" ] \
     && mkdir -p "$(dirname "${LOCAL_WORKSPACE_ROOT}")" \
-    && ln -s "${WORKSPACE_ROOT}" "${LOCAL_WORKSPACE_ROOT}" \
+    && ln -sf "${WORKSPACE_ROOT}" "${LOCAL_WORKSPACE_ROOT}" \
     && :
 
 ENV TIZEN_ROOTFS=/tizen_rootfs

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,6 +22,8 @@ LABEL org.opencontainers.image.source https://github.com/project-chip/connectedh
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
+ARG WORKSPACE_ROOT=/workspaces/connectedhomeip
+ARG LOCAL_WORKSPACE_ROOT
 ENV LANG=en_US.utf8
 
 
@@ -75,6 +77,11 @@ RUN sed -i '/^TIZEN_SDK_DATA_PATH/d' $TIZEN_SDK_ROOT/sdk.info \
     && echo TIZEN_SDK_DATA_PATH=/home/$USERNAME/tizen-sdk-data >> $TIZEN_SDK_ROOT/sdk.info \
     && ln -sf /home/$USERNAME/.tizen-cli-config $TIZEN_SDK_ROOT/tools/.tizen-cli-config \
     && : # last line
+
+RUN [ -n "${LOCAL_WORKSPACE_ROOT}" ] \
+    && mkdir -p "$(dirname "${LOCAL_WORKSPACE_ROOT}")" \
+    && ln -s "${WORKSPACE_ROOT}" "${LOCAL_WORKSPACE_ROOT}" \
+    && :
 
 ENV TIZEN_ROOTFS=/tizen_rootfs
 

--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -21,7 +21,6 @@ CHIP_ROOT="$(realpath "$HERE"/..)"
 BUILD_VERSION=$(sed 's/ .*//' "$CHIP_ROOT/integrations/docker/images/base/chip-build/version")
 IMAGE_TAG="matter-dev-environment:local"
 USER_UID=$UID
-WORKSPACE_ROOT=/workspaces/connectedhomeip
 
 function show_usage() {
     cat <<EOF
@@ -33,7 +32,6 @@ Options:
     -h,--help        Show this help
     -t,--tag         Image tag - default is $IMAGE_TAG
     -u,--uid         User UID - default is $USER_UID
-    -w,--workspace   Path to the workspace inside the Docker container - default is $WORKSPACE_ROOT
     -v,--version     Build version - default is the version of the base chip-build docker image ($BUILD_VERSION)
 EOF
 }
@@ -83,7 +81,6 @@ docker build \
     --pull \
     --build-arg USER_UID="$USER_UID" \
     --build-arg BUILD_VERSION="$BUILD_VERSION" \
-    --build-arg WORKSPACE_ROOT="$WORKSPACE_ROOT" \
     --build-arg LOCAL_WORKSPACE_ROOT="$CHIP_ROOT" \
     --network=host \
     "$HERE"

--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -21,6 +21,7 @@ CHIP_ROOT="$(realpath "$HERE"/..)"
 BUILD_VERSION=$(sed 's/ .*//' "$CHIP_ROOT/integrations/docker/images/base/chip-build/version")
 IMAGE_TAG="matter-dev-environment:local"
 USER_UID=$UID
+WORKSPACE_ROOT=/workspaces/connectedhomeip
 
 function show_usage() {
     cat <<EOF
@@ -30,9 +31,10 @@ Build vscode dev environment docker image.
 
 Options:
     -h,--help        Show this help
-    -t,--tag         Image tag - default is matter-dev-environment:local
-    -u,--uid         User UIDa - default is the current user ID
-    -v,--version     Build version - default is the version of the base chip-build docker image
+    -t,--tag         Image tag - default is $IMAGE_TAG
+    -u,--uid         User UID - default is $USER_UID
+    -w,--workspace   Path to the workspace inside the Docker container - default is $WORKSPACE_ROOT
+    -v,--version     Build version - default is the version of the base chip-build docker image ($BUILD_VERSION)
 EOF
 }
 
@@ -81,5 +83,7 @@ docker build \
     --pull \
     --build-arg USER_UID="$USER_UID" \
     --build-arg BUILD_VERSION="$BUILD_VERSION" \
+    --build-arg WORKSPACE_ROOT="$WORKSPACE_ROOT" \
+    --build-arg LOCAL_WORKSPACE_ROOT="$CHIP_ROOT" \
     --network=host \
     "$HERE"


### PR DESCRIPTION
#### Summary

When using vscode with a devcontainer and trying to debug examples built by running `build_examples.py` outside of the container we end up with vscode being unable to display source code even though it has access to it. This results in an error message similar to this:

<img width="1048" height="1017" alt="Screenshot from 2025-09-17 15-14-22" src="https://github.com/user-attachments/assets/64369ce1-b36f-449d-aa1a-5ba139761a53" />

The reason for this is that the source code paths are different on the host and inside the devcontainer where gdb is executed. In order to solve this issue I slightly changed the way that the devcontainer image is built. It now contains a symlink from the location of the source code on the host into the workspace (/workspaces/connectedhomeip). For example, if we build example code on the host and the source code is located in `/home/m.grela/repos/github.com/enkiusz/connectedhomeip/` a symlink will be created inside the docker container pointing `/home/m.grela/repos/github.com/enkiusz/connectedhomeip/` -> `/workspaces/connectedhomeip`. This way when gdb is executed inside the container by vscode and tries to read source code files from /home/m.grela/repos/github.com/enkiusz/connectedhomeip/ it will find the proper files.

#### Testing

1. Building `linux-x64-lighting` inside a container and debugging it in vscode with a devcontainer active.
2. Building `linux-x64-lighting` on the host and debugging it in vscode with a devcontainer active.
3. (control) Building `linux-x64-lighting` on the host and debugging it in vscode without a devcontainer active.

Other than that this does not affect the build in any way.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

