### PR TITLE
Improve MPD file handling in camera app uploader

### DIFF
--- a/examples/camera-app/linux/include/uploader/pushav-uploader.h
+++ b/examples/camera-app/linux/include/uploader/pushav-uploader.h
@@ -65,6 +65,9 @@ public:
     void setCertificateBuffer(const PushAVCertBuffer & certBuffer) { mCertBuffer = certBuffer; }
     void setCertificatePath(const PushAVCertPath & certPath) { mCertPath = certPath; }
 
+    void setMPDPath(const std::pair<std::string, std::string> & path) { mMPDPath = path; }
+    std::pair<std::string, std::string> getMPDPath() const { return mMPDPath; }
+
 private:
     void ProcessQueue();
     void UploadData(std::pair<std::string, std::string> data);
@@ -74,4 +77,5 @@ private:
     std::mutex mQueueMutex;
     std::atomic<bool> mIsRunning;
     std::thread mUploaderThread;
+    std::pair<std::string, std::string> mMPDPath;
 };

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -732,6 +732,7 @@ void PushAVClipRecorder::FinalizeCurrentClip(int reason)
         std::string mpd_path = make_path("%s.mpd");
         if (FileExists(mpd_path) && !FileExists(mpd_path + ".tmp"))
         {
+            mUploader->setMPDPath(std::make_pair(mpd_path, mClipInfo.mUrl));
             CheckAndUploadFile(mpd_path);
             mUploadMPD = false; // Reset flag after successful upload
         }

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -280,7 +280,6 @@ void PushAVClipRecorder::Stop()
         ChipLogError(Camera, "Error recording is not running");
     }
     mDeinitializeRecorder = true;
-    CleanupOutput();
     ChipLogProgress(Camera, "Recording stopped for ID: %s", mClipInfo.mRecorderId.c_str());
 }
 
@@ -394,7 +393,7 @@ int PushAVClipRecorder::StartClipRecording()
         }
         ProcessBuffersAndWrite();
     }
-
+    CleanupOutput();
     ChipLogProgress(Camera, "Recorder thread closing");
     return 0;
 }
@@ -665,9 +664,7 @@ void PushAVClipRecorder::FinalizeCurrentClip(int reason)
 
     if (reason || ((clipLengthInPTS >= clipDuration) && (mClipInfo.mTriggerType != 2)))
     {
-        mClipInfo.mClipId++;
         Stop();
-        mClipInfo.mClipId++;
         mCurrentClipStartPts = currentPts;
     }
 

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -482,10 +482,10 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
         mCanSendVideo = false;
         mCanSendAudio = false;
         mRecorder.reset();
-        ChipLogError(Camera, "Recorder destruction done");
+        ChipLogProgress(Camera, "Recorder destruction done");
         InitializeRecorder();
         mUploader.reset();
-
+        ChipLogProgress(Camera, "Uploader destruction done");
         ChipLogProgress(Camera, "PushAVTransport transport status changed to inactive");
     }
 }

--- a/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
+++ b/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
@@ -229,10 +229,6 @@ void PushAVUploader::AddUploadData(std::string & filename, std::string & url)
     ChipLogProgress(Camera, "Added file name %s to queue", filename.c_str());
     std::lock_guard<std::mutex> lock(mQueueMutex);
     auto data = make_pair(filename, url);
-    if (getMPDPath().first.empty() || getMPDPath().second.empty())
-    {
-        setMPDPath(data);
-    }
     mAvData.push(data);
 }
 


### PR DESCRIPTION
#### Summary
- Add MPD path management to PushAVUploader class
- Ensure final MPD upload before uploader shutdown
- Fix clip recording cleanup flow to avoid double free and updated logging


#### Testing
```
# Build and run camera application
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debu/chip-camera-app

# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run Push AV Cluster TCs 
Example:
python3 src/python_testing/TC_PAVSTI_1_2.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint
```