### PR TITLE
Add extra status to ignore write operations.

### DIFF
--- a/src/app/data-model-provider/ActionReturnStatus.cpp
+++ b/src/app/data-model-provider/ActionReturnStatus.cpp
@@ -104,6 +104,14 @@ CHIP_ERROR ActionReturnStatus::GetUnderlyingError() const
                                 : CHIP_ERROR_IM_GLOBAL_STATUS_VALUE(status->GetStatus());
     }
 
+    if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
+    {
+        if (*status == FixedActionStatus::kWriteSuccessNoop)
+        {
+            return (CHIP_NO_ERROR);
+        }
+    }
+
     chipDie();
 }
 
@@ -117,6 +125,14 @@ ClusterStatusCode ActionReturnStatus::GetStatusCode() const
     if (const CHIP_ERROR * err = std::get_if<CHIP_ERROR>(&mReturnStatus))
     {
         return ClusterStatusCode(*err);
+    }
+
+    if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
+    {
+        if (*status == FixedActionStatus::kWriteSuccessNoop)
+        {
+            return ClusterStatusCode(CHIP_NO_ERROR);
+        }
     }
 
     // all std::variant cases exhausted
@@ -133,6 +149,22 @@ bool ActionReturnStatus::IsSuccess() const
     if (const ClusterStatusCode * status = std::get_if<ClusterStatusCode>(&mReturnStatus))
     {
         return status->IsSuccess();
+    }
+
+    if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
+    {
+        return (*status == FixedActionStatus::kWriteSuccessNoop);
+    }
+
+    // all std::variant cases exhausted
+    chipDie();
+}
+
+bool ActionReturnStatus::IsNoOpSuccess() const
+{
+    if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
+    {
+        return (*status == FixedActionStatus::kWriteSuccessNoop);
     }
 
     // all std::variant cases exhausted

--- a/src/app/data-model-provider/ActionReturnStatus.cpp
+++ b/src/app/data-model-provider/ActionReturnStatus.cpp
@@ -106,7 +106,7 @@ CHIP_ERROR ActionReturnStatus::GetUnderlyingError() const
 
     if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
     {
-        if (*status == FixedActionStatus::kWriteSuccessNoop)
+        if (*status == FixedActionStatus::kWriteSuccessNoOp)
         {
             return (CHIP_NO_ERROR);
         }
@@ -129,7 +129,7 @@ ClusterStatusCode ActionReturnStatus::GetStatusCode() const
 
     if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
     {
-        if (*status == FixedActionStatus::kWriteSuccessNoop)
+        if (*status == FixedActionStatus::kWriteSuccessNoOp)
         {
             return ClusterStatusCode(CHIP_NO_ERROR);
         }
@@ -153,7 +153,7 @@ bool ActionReturnStatus::IsSuccess() const
 
     if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
     {
-        return (*status == FixedActionStatus::kWriteSuccessNoop);
+        return (*status == FixedActionStatus::kWriteSuccessNoOp);
     }
 
     // all std::variant cases exhausted
@@ -164,7 +164,7 @@ bool ActionReturnStatus::IsNoOpSuccess() const
 {
     if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
     {
-        return (*status == FixedActionStatus::kWriteSuccessNoop);
+        return (*status == FixedActionStatus::kWriteSuccessNoOp);
     }
 
     // all std::variant cases exhausted

--- a/src/app/data-model-provider/ActionReturnStatus.cpp
+++ b/src/app/data-model-provider/ActionReturnStatus.cpp
@@ -108,7 +108,7 @@ CHIP_ERROR ActionReturnStatus::GetUnderlyingError() const
     {
         if (*status == FixedActionStatus::kWriteSuccessNoOp)
         {
-            return (CHIP_NO_ERROR);
+            return CHIP_NO_ERROR;
         }
     }
 

--- a/src/app/data-model-provider/ActionReturnStatus.cpp
+++ b/src/app/data-model-provider/ActionReturnStatus.cpp
@@ -166,12 +166,10 @@ bool ActionReturnStatus::IsNoOpSuccess() const
     {
         return (*status == ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
     }
-    else
-    {
-        // NoOp Success only works with FixedStatus, any other type should return false since it is not
-        // supported specifically by the type.
-        return false;
-    }
+
+    // NoOp Success only works with FixedStatus, any other type should return false since it is not
+    // supported specifically by the type.
+    return false;
 }
 
 bool ActionReturnStatus::IsOutOfSpaceEncodingResponse() const

--- a/src/app/data-model-provider/ActionReturnStatus.cpp
+++ b/src/app/data-model-provider/ActionReturnStatus.cpp
@@ -104,9 +104,9 @@ CHIP_ERROR ActionReturnStatus::GetUnderlyingError() const
                                 : CHIP_ERROR_IM_GLOBAL_STATUS_VALUE(status->GetStatus());
     }
 
-    if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
+    if (const ActionReturnStatus::FixedStatus * status = std::get_if<ActionReturnStatus::FixedStatus>(&mReturnStatus))
     {
-        if (*status == FixedActionStatus::kWriteSuccessNoOp)
+        if (*status == ActionReturnStatus::FixedStatus::kWriteSuccessNoOp)
         {
             return CHIP_NO_ERROR;
         }
@@ -127,9 +127,9 @@ ClusterStatusCode ActionReturnStatus::GetStatusCode() const
         return ClusterStatusCode(*err);
     }
 
-    if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
+    if (const ActionReturnStatus::FixedStatus * status = std::get_if<ActionReturnStatus::FixedStatus>(&mReturnStatus))
     {
-        if (*status == FixedActionStatus::kWriteSuccessNoOp)
+        if (*status == ActionReturnStatus::FixedStatus::kWriteSuccessNoOp)
         {
             return ClusterStatusCode(CHIP_NO_ERROR);
         }
@@ -151,9 +151,9 @@ bool ActionReturnStatus::IsSuccess() const
         return status->IsSuccess();
     }
 
-    if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
+    if (const ActionReturnStatus::FixedStatus * status = std::get_if<ActionReturnStatus::FixedStatus>(&mReturnStatus))
     {
-        return (*status == FixedActionStatus::kWriteSuccessNoOp);
+        return (*status == ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
     }
 
     // all std::variant cases exhausted
@@ -162,9 +162,9 @@ bool ActionReturnStatus::IsSuccess() const
 
 bool ActionReturnStatus::IsNoOpSuccess() const
 {
-    if (const FixedActionStatus * status = std::get_if<FixedActionStatus>(&mReturnStatus))
+    if (const ActionReturnStatus::FixedStatus * status = std::get_if<ActionReturnStatus::FixedStatus>(&mReturnStatus))
     {
-        return (*status == FixedActionStatus::kWriteSuccessNoOp);
+        return (*status == ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
     }
 
     // all std::variant cases exhausted

--- a/src/app/data-model-provider/ActionReturnStatus.cpp
+++ b/src/app/data-model-provider/ActionReturnStatus.cpp
@@ -166,9 +166,12 @@ bool ActionReturnStatus::IsNoOpSuccess() const
     {
         return (*status == ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
     }
-
-    // all std::variant cases exhausted
-    chipDie();
+    else
+    {
+        // NoOp Success only works with FixedStatus, any other type should return false since it is not 
+        // supported specifically by the type.
+        return false;
+    }
 }
 
 bool ActionReturnStatus::IsOutOfSpaceEncodingResponse() const

--- a/src/app/data-model-provider/ActionReturnStatus.cpp
+++ b/src/app/data-model-provider/ActionReturnStatus.cpp
@@ -168,7 +168,7 @@ bool ActionReturnStatus::IsNoOpSuccess() const
     }
     else
     {
-        // NoOp Success only works with FixedStatus, any other type should return false since it is not 
+        // NoOp Success only works with FixedStatus, any other type should return false since it is not
         // supported specifically by the type.
         return false;
     }

--- a/src/app/data-model-provider/ActionReturnStatus.h
+++ b/src/app/data-model-provider/ActionReturnStatus.h
@@ -111,7 +111,7 @@ public:
     const char * c_str(StringStorage & storage) const;
 
 private:
-    std::variant<CHIP_ERROR, Protocols::InteractionModel::ClusterStatusCode, FixedStatus> mReturnStatus;
+    std::variant<CHIP_ERROR, Protocols::InteractionModel::ClusterStatusCode, ActionReturnStatus::FixedStatus> mReturnStatus;
 };
 
 } // namespace DataModel

--- a/src/app/data-model-provider/ActionReturnStatus.h
+++ b/src/app/data-model-provider/ActionReturnStatus.h
@@ -46,7 +46,7 @@ class ActionReturnStatus
 public:
     // Provides additional statuses used for specific functionalities not necessarily covered
     // by the existing CHIP_ERROR or InteractionModel::Status
-    enum class FixedStatus 
+    enum class FixedStatus
     {
         kWriteSuccessNoOp,
     };

--- a/src/app/data-model-provider/ActionReturnStatus.h
+++ b/src/app/data-model-provider/ActionReturnStatus.h
@@ -26,6 +26,10 @@ namespace chip {
 namespace app {
 namespace DataModel {
 
+enum class FixedActionStatus 
+{
+    kWriteSuccessNoOp,
+};
 /// An ActionReturnStatus encodes the result of a read/write/invoke.
 ///
 /// Generally such actions result in a StatusIB in the interaction model,
@@ -64,6 +68,7 @@ public:
         mReturnStatus(Protocols::InteractionModel::ClusterStatusCode(status))
     {}
     ActionReturnStatus(Protocols::InteractionModel::ClusterStatusCode status) : mReturnStatus(status) {}
+    ActionReturnStatus(FixedActionStatus status): mReturnStatus(status) {}
 
     /// Constructs a status code. Either returns the underlying code directly
     /// or converts the underlying CHIP_ERROR into a cluster status code.
@@ -89,6 +94,10 @@ public:
     /// Generally this is when the return is based on CHIP_ERROR_NO_MEMORY or CHIP_ERROR_BUFFER_TOO_SMALL
     bool IsOutOfSpaceEncodingResponse() const;
 
+    /// Check if the operation was successful but shouldn't trigger any specific operation
+    /// (e.g. overwriting an attribute with the same value).
+    bool IsNoOpSuccess() const;
+
     // NOTE: operator== will treat a CHIP_GLOBAL_IM_ERROR and a raw cluster status as equal if the statuses match,
     //       even though a CHIP_ERROR has some formatting info like file/line
     bool operator==(const ActionReturnStatus & other) const;
@@ -100,7 +109,7 @@ public:
     const char * c_str(StringStorage & storage) const;
 
 private:
-    std::variant<CHIP_ERROR, Protocols::InteractionModel::ClusterStatusCode> mReturnStatus;
+    std::variant<CHIP_ERROR, Protocols::InteractionModel::ClusterStatusCode, FixedActionStatus> mReturnStatus;
 };
 
 } // namespace DataModel

--- a/src/app/data-model-provider/ActionReturnStatus.h
+++ b/src/app/data-model-provider/ActionReturnStatus.h
@@ -70,7 +70,7 @@ public:
         mReturnStatus(Protocols::InteractionModel::ClusterStatusCode(status))
     {}
     ActionReturnStatus(Protocols::InteractionModel::ClusterStatusCode status) : mReturnStatus(status) {}
-    ActionReturnStatus(FixedStatus status): mReturnStatus(status) {}
+    ActionReturnStatus(FixedStatus status) : mReturnStatus(status) {}
 
     /// Constructs a status code. Either returns the underlying code directly
     /// or converts the underlying CHIP_ERROR into a cluster status code.

--- a/src/app/data-model-provider/ActionReturnStatus.h
+++ b/src/app/data-model-provider/ActionReturnStatus.h
@@ -26,10 +26,6 @@ namespace chip {
 namespace app {
 namespace DataModel {
 
-enum class FixedActionStatus 
-{
-    kWriteSuccessNoOp,
-};
 /// An ActionReturnStatus encodes the result of a read/write/invoke.
 ///
 /// Generally such actions result in a StatusIB in the interaction model,
@@ -48,6 +44,12 @@ enum class FixedActionStatus
 class ActionReturnStatus
 {
 public:
+    // Provides additional statuses used for specific functionalities not necessarily covered
+    // by the existing CHIP_ERROR or InteractionModel::Status
+    enum class FixedStatus 
+    {
+        kWriteSuccessNoOp,
+    };
     /// Provides storage for the c_str() call for the action status.
     struct StringStorage
     {
@@ -68,7 +70,7 @@ public:
         mReturnStatus(Protocols::InteractionModel::ClusterStatusCode(status))
     {}
     ActionReturnStatus(Protocols::InteractionModel::ClusterStatusCode status) : mReturnStatus(status) {}
-    ActionReturnStatus(FixedActionStatus status): mReturnStatus(status) {}
+    ActionReturnStatus(FixedStatus status): mReturnStatus(status) {}
 
     /// Constructs a status code. Either returns the underlying code directly
     /// or converts the underlying CHIP_ERROR into a cluster status code.
@@ -109,7 +111,7 @@ public:
     const char * c_str(StringStorage & storage) const;
 
 private:
-    std::variant<CHIP_ERROR, Protocols::InteractionModel::ClusterStatusCode, FixedActionStatus> mReturnStatus;
+    std::variant<CHIP_ERROR, Protocols::InteractionModel::ClusterStatusCode, FixedStatus> mReturnStatus;
 };
 
 } // namespace DataModel

--- a/src/app/server-cluster/DefaultServerCluster.cpp
+++ b/src/app/server-cluster/DefaultServerCluster.cpp
@@ -136,7 +136,7 @@ CHIP_ERROR DefaultServerCluster::GeneratedCommands(const ConcreteClusterPath & p
 DataModel::ActionReturnStatus DefaultServerCluster::NotifyAttributeChangedIfSuccess(AttributeId attributeId,
                                                                                     DataModel::ActionReturnStatus status)
 {
-    if (status.IsSuccess())
+    if (status.IsSuccess() && !status.IsNoOpSuccess())
     {
         NotifyAttributeChanged(attributeId);
     }


### PR DESCRIPTION
#### Summary

The intention is to have a way to avoid notifying that an attribute changed when a "Write" is performed with the exact same value that was in the attribute.

#### Related issues

This is a simple proposal for #40978.
Fixes #40978

#### Testing

Tested manually with matter-repl and previous functionality should be validated by Unit Tests and integration tests from the CI.

