### PR TITLE
Notify DevicePairingDelegate about the SetupPayload used, when available.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1266,7 +1266,8 @@ void DeviceCommissioner::OnSessionEstablished(const SessionHandle & session)
     {
         // If we started with a string payload, then at this point mPairingDelegate is
         // mSetUpCodePairer, and it will provide the right SetupPayload argument to
-        // OnPairingComplete as needed.
+        // OnPairingComplete as needed.  If mPairingDelegate is not
+        // mSetUpCodePairer, then we don't have a SetupPayload to provide.
         mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR, paseParameters, std::nullopt);
     }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -782,7 +782,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
                 {
                     // We already have an open secure session to this device, call the callback immediately and early return.
                     // We don't know what the right RendezvousParameters are here.
-                    mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR, std::nullopt);
+                    mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR, std::nullopt, std::nullopt);
                 }
                 MATTER_LOG_METRIC_END(kMetricDeviceCommissionerPASESession, CHIP_NO_ERROR);
                 return CHIP_NO_ERROR;
@@ -931,7 +931,7 @@ void DeviceCommissioner::OnDiscoveredDeviceOverBleError(void * appState, CHIP_ER
         // A better way to handle it should define a new error code
         if (self->mPairingDelegate != nullptr)
         {
-            self->mPairingDelegate->OnPairingComplete(err, std::nullopt);
+            self->mPairingDelegate->OnPairingComplete(err, std::nullopt, std::nullopt);
         }
     }
 }
@@ -968,7 +968,7 @@ void DeviceCommissioner::OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err
         self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = RendezvousParameters();
         if (self->mPairingDelegate != nullptr)
         {
-            self->mPairingDelegate->OnPairingComplete(err, std::nullopt);
+            self->mPairingDelegate->OnPairingComplete(err, std::nullopt, std::nullopt);
         }
     }
 }
@@ -1217,7 +1217,7 @@ void DeviceCommissioner::RendezvousCleanup(CHIP_ERROR status)
 
         if (mPairingDelegate != nullptr)
         {
-            mPairingDelegate->OnPairingComplete(status, std::nullopt);
+            mPairingDelegate->OnPairingComplete(status, std::nullopt, std::nullopt);
         }
     }
 }
@@ -1264,7 +1264,10 @@ void DeviceCommissioner::OnSessionEstablished(const SessionHandle & session)
     MATTER_LOG_METRIC_END(kMetricDeviceCommissionerPASESession, CHIP_NO_ERROR);
     if (mPairingDelegate != nullptr)
     {
-        mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR, paseParameters);
+        // If we started with a string payload, then at this point mPairingDelegate is
+        // mSetUpCodePairer, and it will provide the right SetupPayload argument to
+        // OnPairingComplete as needed.
+        mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR, paseParameters, std::nullopt);
     }
 
     if (mRunCommissioningAfterConnection)

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -78,7 +78,7 @@ public:
      *                     succeeds and the original input to commissioning was a payload string.
      *                     If the original input represented a concatenated QR code, this will
      *                     represent the actual payload that was used to successfully establish PASE
-     *                     with the commissionee..
+     *                     with the commissionee.
      */
     virtual void OnPairingComplete(CHIP_ERROR error, const std::optional<RendezvousParameters> & rendezvousParameters,
                                    const std::optional<SetupPayload> & setupPayload)

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -23,6 +23,7 @@
 #include <lib/core/NodeId.h>
 #include <lib/support/DLLUtil.h>
 #include <protocols/secure_channel/RendezvousParameters.h>
+#include <setup_payload/SetupPayload.h>
 #include <stdint.h>
 
 #include <optional>
@@ -71,8 +72,16 @@ public:
      *                             If available, this helps identify which exact commissionee PASE
      *                             was established for. This will generally be present only when
      *                             PASE establishment succeeds.
+     *
+     * @param setupPayload The SetupPayload that was used for PASE establishment, if one is
+     *                     available.  This will generally be present only when PASE establishment
+     *                     succeeds and the original input to commissioning was a payload string.
+     *                     If the original input represented a concatenated QR code, this will
+     *                     represent the actual payload that was used to successfully establish PASE
+     *                     with the commissionee..
      */
-    virtual void OnPairingComplete(CHIP_ERROR error, const std::optional<RendezvousParameters> & rendezvousParameters)
+    virtual void OnPairingComplete(CHIP_ERROR error, const std::optional<RendezvousParameters> & rendezvousParameters,
+                                   const std::optional<SetupPayload> & setupPayload)
     {
         OnPairingComplete(error);
     }

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -386,6 +386,8 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
 
     while (!mDiscoveredParameters.empty())
     {
+        mCurrentPASEPayload.reset();
+
         // Grab the first element from the queue and try connecting to it.
         // Remove it from the queue before we try to connect, in case the
         // connection attempt fails and calls right back into us to try the next
@@ -397,18 +399,17 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
         {
             auto longDiscriminator = *params.mLongDiscriminator;
             // Look for a matching setup passcode.
-            bool found = false;
             for (auto & payload : mSetupPayloads)
             {
                 if (payload.discriminator.MatchesLongDiscriminator(longDiscriminator))
                 {
                     params.SetSetupPINCode(payload.setUpPINCode);
                     params.SetSetupDiscriminator(payload.discriminator);
-                    found = true;
+                    mCurrentPASEPayload = payload;
                     break;
                 }
             }
-            if (!found)
+            if (!mCurrentPASEPayload)
             {
                 ChipLogError(Controller, "SetUpCodePairer: Discovered discriminator %u does not match any of our setup payloads",
                              longDiscriminator);
@@ -424,6 +425,7 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
             {
                 params.SetSetupPINCode(mSetupPayloads[0].setUpPINCode);
                 params.SetSetupDiscriminator(mSetupPayloads[0].discriminator);
+                mCurrentPASEPayload = mSetupPayloads[0];
             }
             else
             {
@@ -466,6 +468,7 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
         }
 
         // Failed to start establishing PASE.  Move on to the next item.
+        mCurrentPASEPayload.reset();
         PASEEstablishmentComplete();
     }
 
@@ -784,7 +787,8 @@ void SetUpCodePairer::OnStatusUpdate(DevicePairingDelegate::Status status)
     }
 }
 
-void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error, const std::optional<RendezvousParameters> & rendezvousParameters)
+void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error, const std::optional<RendezvousParameters> & rendezvousParameters,
+                                        const std::optional<SetupPayload> & setupPayload)
 {
     // Save the pairing delegate so we can notify it.  We want to notify it
     // _after_ we restore the state on the commissioner, in case the delegate
@@ -792,6 +796,10 @@ void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error, const std::optional<Re
     // notified.
     auto * pairingDelegate = mPairingDelegate;
     PASEEstablishmentComplete();
+
+    // Make sure to clear out mCurrentPASEPayload whether we succeeded or failed.
+    std::optional<SetupPayload> pasePayload;
+    pasePayload.swap(mCurrentPASEPayload);
 
     if (CHIP_NO_ERROR == error)
     {
@@ -801,7 +809,13 @@ void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error, const std::optional<Re
         MATTER_LOG_METRIC_END(kMetricSetupCodePairerPairDevice, error);
         if (pairingDelegate != nullptr)
         {
-            pairingDelegate->OnPairingComplete(error, rendezvousParameters);
+            // We don't expect to have a setupPayload passed in here.
+            if (setupPayload)
+            {
+                ChipLogError(Controller,
+                             "Unexpected setupPayload passed to SetUpCodePairer::OnPairingComplete.  Where did it come from?");
+            }
+            pairingDelegate->OnPairingComplete(error, rendezvousParameters, pasePayload);
         }
         return;
     }
@@ -834,7 +848,7 @@ void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error, const std::optional<Re
     MATTER_LOG_METRIC_END(kMetricSetupCodePairerPairDevice, error);
     if (pairingDelegate != nullptr)
     {
-        pairingDelegate->OnPairingComplete(error, rendezvousParameters);
+        pairingDelegate->OnPairingComplete(error, rendezvousParameters, pasePayload);
     }
 }
 

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -123,7 +123,8 @@ public:
 private:
     // DevicePairingDelegate implementation.
     void OnStatusUpdate(DevicePairingDelegate::Status status) override;
-    void OnPairingComplete(CHIP_ERROR error, const std::optional<RendezvousParameters> & rendezvousParameters) override;
+    void OnPairingComplete(CHIP_ERROR error, const std::optional<RendezvousParameters> & rendezvousParameters,
+                           const std::optional<SetupPayload> & setupPayload) override;
     void OnPairingDeleted(CHIP_ERROR error) override;
     void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error) override;
 
@@ -228,6 +229,10 @@ private:
     DiscoveryType mDiscoveryType             = DiscoveryType::kAll;
     std::vector<SetupPayload> mSetupPayloads;
 
+    // The payload we are using for our current PASE connection attempt.  Only
+    // set while we are attempting PASE.
+    std::optional<SetupPayload> mCurrentPASEPayload;
+
     // While we are trying to pair, we intercept the DevicePairingDelegate
     // notifications from mCommissioner.  We want to make sure we send them on
     // to the original pairing delegate, if any.
@@ -244,7 +249,7 @@ private:
 
     // Current thing we are trying to connect to over UDP. If a PASE connection fails with
     // a CHIP_ERROR_TIMEOUT, the discovered parameters will be used to ask the
-    // mdns daemon to invalidate the
+    // mdns daemon to invalidate its caches.
     Optional<SetUpCodePairerParameters> mCurrentPASEParameters;
 
     // mWaitingForPASE is true if we have called either


### PR DESCRIPTION
When we start commissioning or PASE establishment with a string payload, notify the delegate which exact payload was actually used for PASE.  Particularly relevant for concatenated QR codes.

#### Testing

Manual for now, but once Matter.framework starts using this API I will be able to add some automated tests.