### PR TITLE
[NXP][platform][mcxw72] Add CMake build support

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -102,8 +102,10 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
-                      --target nxp-mcxw72-freertos-contact-sensor-low-power \
-                      --target nxp-mcxw72-freertos-lock-app \
+                      --target nxp-mcxw72-freertos-contact-sensor-thread-mtd-low-power-cmake-frdm \
+                      --target nxp-mcxw72-freertos-lighting-thread-cmake-frdm \
+                      --target nxp-mcxw72-freertos-lock-app-thread-mtd-low-power-cmake-frdm \
+                      --target nxp-mcxw72-freertos-contact-sensor-ota-low-power \
                       build \
                   "
 

--- a/examples/contact-sensor-app/nxp/mcxw72/BUILD.gn
+++ b/examples/contact-sensor-app/nxp/mcxw72/BUILD.gn
@@ -93,7 +93,7 @@ mcxw72_sdk("sdk") {
   ]
 
   if (nxp_enable_matter_cli) {
-    defines += [ "BOARD_APP_UART_CLK_FREQ=6000000U" ]
+    defines += [ "gAppUseSerialManager_c=1" ]
   }
 }
 

--- a/examples/lighting-app/nxp/mcxw72/BUILD.gn
+++ b/examples/lighting-app/nxp/mcxw72/BUILD.gn
@@ -93,7 +93,7 @@ mcxw72_sdk("sdk") {
   ]
 
   if (nxp_enable_matter_cli) {
-    defines += [ "BOARD_APP_UART_CLK_FREQ=6000000U" ]
+    defines += [ "gAppUseSerialManager_c=1" ]
   }
 }
 

--- a/examples/lock-app/nxp/mcxw72/BUILD.gn
+++ b/examples/lock-app/nxp/mcxw72/BUILD.gn
@@ -92,7 +92,7 @@ mcxw72_sdk("sdk") {
   ]
 
   if (nxp_enable_matter_cli) {
-    defines += [ "BOARD_APP_UART_CLK_FREQ=6000000U" ]
+    defines += [ "gAppUseSerialManager_c=1" ]
   }
 
   if (nxp_multiple_ble_connections) {

--- a/examples/platform/nxp/config/prj_thread_mtd_fdata.conf
+++ b/examples/platform/nxp/config/prj_thread_mtd_fdata.conf
@@ -1,0 +1,34 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This file is used to set configs or override default configurations for NXP platforms.
+
+CONFIG_NET_L2_OPENTHREAD=y
+CONFIG_CHIP_IPV4=n
+CONFIG_CHIP_OPENTHREAD_FTD=n
+CONFIG_SLEEPY_END_DEVICE=y
+CONFIG_CHIP_ENABLE_ICD_SUPPORT=y
+CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
+
+# Use factory data provider for device info
+CONFIG_CHIP_FACTORY_DATA=y
+
+# This will generate factory data binaries
+#CONFIG_CHIP_FACTORY_DATA_BUILD=y
+
+# Factory data configuration
+CONFIG_CHIP_FACTORY_DATA_CERT_SOURCE_GENERATED=y
+CONFIG_CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER=y

--- a/examples/platform/nxp/config/prj_thread_mtd_fdata_low_power.conf
+++ b/examples/platform/nxp/config/prj_thread_mtd_fdata_low_power.conf
@@ -1,0 +1,39 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This file is used to set configs or override default configurations for NXP platforms.
+
+CONFIG_NET_L2_OPENTHREAD=y
+CONFIG_CHIP_IPV4=n
+CONFIG_CHIP_OPENTHREAD_FTD=n
+CONFIG_SLEEPY_END_DEVICE=y
+CONFIG_CHIP_LIB_SHELL=n
+CONFIG_NXP_USE_LOW_POWER=y
+CONFIG_CHIP_ENABLE_ICD_SUPPORT=y
+CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
+CONFIG_CHIP_APP_UI_FEEDBACK=n
+CONFIG_CHIP_APP_PLATFORM_LED_ON_OFF=n
+CONFIG_ENABLE_FEEDBACK=n
+
+# Use factory data provider for device info
+CONFIG_CHIP_FACTORY_DATA=y
+
+# This will generate factory data binaries
+#CONFIG_CHIP_FACTORY_DATA_BUILD=y
+
+# Factory data configuration
+CONFIG_CHIP_FACTORY_DATA_CERT_SOURCE_GENERATED=y
+CONFIG_CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER=y

--- a/examples/platform/nxp/config/prj_thread_mtd_ota.conf
+++ b/examples/platform/nxp/config/prj_thread_mtd_ota.conf
@@ -1,0 +1,29 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This file is used to set configs or override default configurations for NXP platforms.
+
+CONFIG_NET_L2_OPENTHREAD=y
+CONFIG_CHIP_IPV4=n
+CONFIG_CHIP_OPENTHREAD_FTD=n
+CONFIG_SLEEPY_END_DEVICE=y
+CONFIG_CHIP_ENABLE_ICD_SUPPORT=y
+CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
+
+# OTA Requestor configs
+CONFIG_CHIP_OTA_REQUESTOR=y
+# Disable OTA Update image build
+# CONFIG_CHIP_OTA_IMAGE_BUILD=n

--- a/examples/platform/nxp/config/prj_thread_mtd_ota_fdata.conf
+++ b/examples/platform/nxp/config/prj_thread_mtd_ota_fdata.conf
@@ -1,0 +1,39 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This file is used to set configs or override default configurations for NXP platforms.
+
+CONFIG_NET_L2_OPENTHREAD=y
+CONFIG_CHIP_IPV4=n
+CONFIG_CHIP_OPENTHREAD_FTD=n
+CONFIG_SLEEPY_END_DEVICE=y
+CONFIG_CHIP_ENABLE_ICD_SUPPORT=y
+CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
+
+# Use factory data provider for device info
+CONFIG_CHIP_FACTORY_DATA=y
+
+# This will generate factory data binaries
+#CONFIG_CHIP_FACTORY_DATA_BUILD=y
+
+# Factory data configuration
+CONFIG_CHIP_FACTORY_DATA_CERT_SOURCE_GENERATED=y
+CONFIG_CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER=y
+
+# OTA Requestor configs
+CONFIG_CHIP_OTA_REQUESTOR=y
+# Disable OTA Update image build
+# CONFIG_CHIP_OTA_IMAGE_BUILD=n

--- a/examples/platform/nxp/config/prj_thread_mtd_ota_fdata_low_power.conf
+++ b/examples/platform/nxp/config/prj_thread_mtd_ota_fdata_low_power.conf
@@ -1,0 +1,44 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This file is used to set configs or override default configurations for NXP platforms.
+
+CONFIG_NET_L2_OPENTHREAD=y
+CONFIG_CHIP_IPV4=n
+CONFIG_CHIP_OPENTHREAD_FTD=n
+CONFIG_SLEEPY_END_DEVICE=y
+CONFIG_CHIP_LIB_SHELL=n
+CONFIG_NXP_USE_LOW_POWER=y
+CONFIG_CHIP_ENABLE_ICD_SUPPORT=y
+CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
+CONFIG_CHIP_APP_UI_FEEDBACK=n
+CONFIG_CHIP_APP_PLATFORM_LED_ON_OFF=n
+CONFIG_ENABLE_FEEDBACK=n
+
+# Use factory data provider for device info
+CONFIG_CHIP_FACTORY_DATA=y
+
+# This will generate factory data binaries
+#CONFIG_CHIP_FACTORY_DATA_BUILD=y
+
+# Factory data configuration
+CONFIG_CHIP_FACTORY_DATA_CERT_SOURCE_GENERATED=y
+CONFIG_CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER=y
+
+# OTA Requestor configs
+CONFIG_CHIP_OTA_REQUESTOR=y
+# Disable OTA Update image build
+# CONFIG_CHIP_OTA_IMAGE_BUILD=n

--- a/examples/platform/nxp/config/prj_thread_mtd_ota_low_power.conf
+++ b/examples/platform/nxp/config/prj_thread_mtd_ota_low_power.conf
@@ -1,0 +1,34 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This file is used to set configs or override default configurations for NXP platforms.
+
+CONFIG_NET_L2_OPENTHREAD=y
+CONFIG_CHIP_IPV4=n
+CONFIG_CHIP_OPENTHREAD_FTD=n
+CONFIG_SLEEPY_END_DEVICE=y
+CONFIG_CHIP_LIB_SHELL=n
+CONFIG_NXP_USE_LOW_POWER=y
+CONFIG_CHIP_ENABLE_ICD_SUPPORT=y
+CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
+CONFIG_CHIP_APP_UI_FEEDBACK=n
+CONFIG_CHIP_APP_PLATFORM_LED_ON_OFF=n
+CONFIG_ENABLE_FEEDBACK=n
+
+# OTA Requestor configs
+CONFIG_CHIP_OTA_REQUESTOR=y
+# Disable OTA Update image build
+# CONFIG_CHIP_OTA_IMAGE_BUILD=n

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -557,9 +557,9 @@ def BuildNxpTarget():
     target.AppendModifier(name="thread", enable_thread=True).ExceptIfRe('zephyr')
     target.AppendModifier(name="matter-shell", enable_shell=True)
     target.AppendModifier(name="factory-build", enable_factory_data_build=True).OnlyIfRe('rt1060|rt1170|rw61x')
-    target.AppendModifier(name="frdm", board_variant=NxpBoardVariant.FRDM).OnlyIfRe('rw61x|mcxw71')
+    target.AppendModifier(name="frdm", board_variant=NxpBoardVariant.FRDM).OnlyIfRe('rw61x|mcxw71|mcxw72')
     target.AppendModifier(name="cmake", build_system=NxpBuildSystem.CMAKE).ExceptIfRe(
-        'laundry-washer').OnlyIfRe('rt1060|rt1170|rw61x|mcxw71')
+        'laundry-washer').OnlyIfRe('rt1060|rt1170|rw61x|mcxw71|mcxw72')
     target.AppendModifier(name="evkc", board_variant=NxpBoardVariant.EVKC).OnlyIfRe('rt1060')
     target.AppendModifier(name="iw416", iw416_transceiver=True).OnlyIfRe('rt1060')
     target.AppendModifier(name="w8801", w8801_transceiver=True).OnlyIfRe('rt1060')

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -380,7 +380,7 @@ class NxpBuilder(GnBuilder):
         if self.se05x_enable:
             flags.append('-DCONFIG_CHIP_SE05X=y')
 
-        if ((self.board == NxpBoard.MCXW71) or (self.board == NxpBoard.MCXW72)):
+        if self.board in (NxpBoard.MCXW71, NxpBoard.MCXW72):
             flags.append('-DCONFIG_MCUX_COMPONENT_middleware.freertos-kernel.config=n')
 
         if self.board == NxpBoard.MCXW72:

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -380,8 +380,11 @@ class NxpBuilder(GnBuilder):
         if self.se05x_enable:
             flags.append('-DCONFIG_CHIP_SE05X=y')
 
-        if self.board == NxpBoard.MCXW71:
+        if ((self.board == NxpBoard.MCXW71) or (self.board == NxpBoard.MCXW72)):
             flags.append('-DCONFIG_MCUX_COMPONENT_middleware.freertos-kernel.config=n')
+
+        if self.board == NxpBoard.MCXW72:
+            flags.append('-Dcore_id=cm33_core0')
 
         build_flags = " ".join(flags)
 


### PR DESCRIPTION
#### Summary

This pull request adds a few fixes and enables the support for building the Matter demo apps using CMake on the NXP MCXW72 platform.

#### Testing

The workflow was updated in order to run test builds of Matter applications for the NXP MCXW72 platform using CMake (instead of "gn") for all future pull requests.
