### PR TITLE
add missing PIN feature check to programming PIN clearing on fabric remove

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -3340,6 +3340,7 @@ bool DoorLockServer::clearFabricFromCredentials(chip::EndpointId endpointId, chi
 
     if (SupportsPIN(endpointId))
     {
+        clearFabricFromCredentials(endpointId, CredentialTypeEnum::kProgrammingPIN, fabricToRemove);
         clearFabricFromCredentials(endpointId, CredentialTypeEnum::kPin, fabricToRemove);
     }
 
@@ -3353,8 +3354,6 @@ bool DoorLockServer::clearFabricFromCredentials(chip::EndpointId endpointId, chi
     {
         clearFabricFromCredentials(endpointId, CredentialTypeEnum::kFace, fabricToRemove);
     }
-
-    clearFabricFromCredentials(endpointId, CredentialTypeEnum::kProgrammingPIN, fabricToRemove);
 
     return true;
 }


### PR DESCRIPTION
#### Summary

A door lock with support for users (USR) but no support for pins (PIN) produces errors when removing a fabric as the `DoorLockServer::clearFabricFromCredentials()` function is not checking for the PIN feature bit when trying to remove the fabric from the (non existing) `CredentialTypeEnum::kProgrammingPIN`.

Therefore e.g. `DRLK-2.13` is failing in this scenario.

#### Testing

Executed `DRLK-2.13`

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
