### PR TITLE
Implement TC_WEBRTC_1_7.py and TC_WEBRTC_1_8.py

### DIFF
--- a/src/python_testing/TC_WEBRTC_1_7.py
+++ b/src/python_testing/TC_WEBRTC_1_7.py
@@ -1,0 +1,294 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+#
+
+import logging
+import random
+
+from mobly import asserts
+from TC_WEBRTC_Utils import WebRTCTestHelper
+from test_plan_support import commission_if_required
+
+from matter import ChipDeviceCtrl
+from matter.ChipDeviceCtrl import TransportPayloadCapability
+from matter.clusters import Objects, WebRTCTransportProvider
+from matter.clusters.Types import NullValue
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter.webrtc import LibdatachannelPeerConnection, WebRTCManager
+
+
+class TC_WEBRTC_1_7(MatterBaseTest, WebRTCTestHelper):
+    def steps_TC_WEBRTC_1_7(self) -> list[TestStep]:
+        steps = [
+            TestStep("precondition-1", commission_if_required(), is_commissioning=True),
+            TestStep("precondition-2", "Confirm no active WebRTC sessions exist in DUT"),
+            TestStep(
+                1,
+                description="TH1 sends the ProvideOffer command with an SDP Offer and null WebRTCSessionID to the DUT.",
+                expectation="DUT responds with ProvideOfferResponse containing allocated WebRTCSessionID. TH1 saves the WebRTCSessionID to be used in a later step.",
+            ),
+            TestStep(
+                2,
+                description="DUT sends Answer command to the TH1/WEBRTCR.",
+                expectation="Verify that Answer command contains the same WebRTCSessionID saved in step 1 and contain a non-empty SDP string.",
+            ),
+            TestStep(3, description="TH1 sends the SUCCESS status code to the DUT."),
+            TestStep(
+                4,
+                description="TH1 sends the ProvideICECandidates command with a its ICE candidates to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                5,
+                description="DUT sends ICECandidates command to the TH1/WEBRTCR.",
+                expectation="Verify that ICECandidates command contains the same WebRTCSessionID saved in step 1 and contain a non-empty ICE candidates.",
+            ),
+            TestStep(
+                6, description="TH1 waits for 5 seconds.", expectation="Verify the WebRTC session has been successfully established."
+            ),
+            TestStep(
+                7,
+                description="TH1 sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                8,
+                description="Commission DUT from TH2.",
+                expectation="Verify that camera is commissioned successfully.",
+            ),
+            TestStep(
+                9,
+                description="Repeat Step 1 to Step 6 with TH2.",
+                expectation="Verify that WebRTC session is established successfully.",
+            ),
+            TestStep(
+                10,
+                description="TH2 sends the EndSession command with the WebRTCSessionID saved in step 9 to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
+        ]
+        return steps
+
+    def desc_TC_WEBRTC_1_7(self) -> str:
+        return "[TC-WEBRTC-1_7] Validate that setting an SDP Offer from multiple test harness controllers successfully initiates multiple WebRTC sessions."
+
+    def pics_TC_WEBRTC_1_7(self) -> list[str]:
+        return ["WEBRTCR.C", "WEBRTCP.S"]
+
+    @property
+    def default_timeout(self) -> int:
+        return 4 * 60  # 4 minutes
+
+    @async_test_body
+    async def test_TC_WEBRTC_1_7(self):
+        self.step("precondition-1")
+
+        endpoint = self.get_endpoint(default=1)
+        webrtc_manager = WebRTCManager(event_loop=self.event_loop)
+        webrtc_peer: LibdatachannelPeerConnection = webrtc_manager.create_peer(
+            node_id=self.dut_node_id, fabric_index=self.default_controller.GetFabricIndexInternal(), endpoint=endpoint
+        )
+
+        self.step("precondition-2")
+        current_sessions = await self.read_single_attribute_check_success(
+            cluster=WebRTCTransportProvider, attribute=WebRTCTransportProvider.Attributes.CurrentSessions, endpoint=endpoint
+        )
+        asserts.assert_equal(len(current_sessions), 0, "Found an existing WebRTC session")
+
+        # Allocate video stream in DUT if possible, to receive actual video stream
+        # This step is not part of test plan
+        aVideoStreamID = await self.allocate_video_stream(endpoint)
+
+        # Test Invokation
+
+        self.step(1)
+        webrtc_peer.create_offer()
+        offer = await webrtc_peer.get_local_offer()
+
+        provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await webrtc_peer.send_command(
+            cmd=WebRTCTransportProvider.Commands.ProvideOffer(
+                webRTCSessionID=NullValue,
+                sdp=offer,
+                streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
+                videoStreamID=aVideoStreamID,
+                originatingEndpointID=1,
+            ),
+            endpoint=endpoint,
+            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+        )
+        session_id = provide_offer_response.webRTCSessionID
+        asserts.assert_true(session_id >= 0, "Invalid response")
+
+        webrtc_manager.session_id_created(session_id, self.dut_node_id)
+
+        self.step(2)
+
+        answer_sessionId, answer = await webrtc_peer.get_remote_answer(timeout_s=30)
+
+        asserts.assert_equal(session_id, answer_sessionId, "ProvideAnswer invoked with wrong session id")
+        asserts.assert_true(len(answer) > 0, "Invalid answer SDP received")
+
+        self.step(3)
+
+        webrtc_peer.set_remote_answer(answer)
+
+        self.step(4)
+        local_candidates = await webrtc_peer.get_local_ice_candidates()
+        local_candidates_struct_list = [
+            Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates
+        ]
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+                webRTCSessionID=answer_sessionId, ICECandidates=local_candidates_struct_list
+            ),
+            endpoint=endpoint,
+            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+        )
+
+        self.step(5)
+        ice_session_id, remote_candidates = await webrtc_peer.get_remote_ice_candidates()
+        asserts.assert_equal(session_id, ice_session_id, "ProvideIceCandidates invoked with wrong session id")
+        asserts.assert_true(len(remote_candidates) > 0, "Invalid remote ice candidates received")
+
+        webrtc_peer.set_remote_ice_candidates(remote_candidates)
+
+        self.step(6)
+        if not await webrtc_peer.check_for_session_establishment():
+            logging.error("Failed to establish webrtc session")
+            raise Exception("Failed to establish webrtc session")
+
+        self.step(7)
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.EndSession(
+                webRTCSessionID=session_id, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup
+            ),
+            endpoint=endpoint,
+            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+        )
+        
+        self.step(8)
+        th2 = await webrtc_create_test_harness_controller(self)
+
+        self.step(9)
+        webrtc_peer2: LibdatachannelPeerConnection = webrtc_manager.create_peer(
+            node_id=self.dut_node_id + 1,
+            fabric_index=th2.GetFabricIndexInternal(),
+            endpoint=endpoint,
+        )
+        webrtc_peer2.create_offer()
+        offer = await webrtc_peer2.get_local_offer()
+        dev_ctrl = th2
+        map_nodeId = self.dut_node_id + 1
+        aVideoStreamId = await self.allocate_video_stream(endpoint, devCtrl=dev_ctrl, node_id=map_nodeId)
+        provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await webrtc_peer2.send_command(
+        cmd=WebRTCTransportProvider.Commands.ProvideOffer(
+            webRTCSessionID=NullValue,
+            sdp=offer,
+            streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
+            originatingEndpointID=1,
+            videoStreamID=aVideoStreamId,
+        ),
+        endpoint=endpoint,
+        payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+        )
+        session_id = provide_offer_response.webRTCSessionID
+        asserts.assert_true(session_id >= 0, "Invalid response")
+        webrtc_manager.session_id_created(session_id, map_nodeId)
+        answer_sessionId, answer = await webrtc_peer2.get_remote_answer(timeout_s=30)
+        webrtc_peer2.set_remote_answer(answer)
+        
+        local_candidates = await webrtc_peer2.get_local_ice_candidates()
+        local_candidates_struct_list = [
+        Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates
+        ]
+        
+        await self.send_single_cmd(
+        cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+            webRTCSessionID=answer_sessionId, ICECandidates=local_candidates_struct_list
+        ),
+        endpoint=endpoint,
+        payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+        dev_ctrl=dev_ctrl,
+        node_id=map_nodeId
+        )
+        
+        ice_session_id, remote_candidates = await webrtc_peer2.get_remote_ice_candidates()
+        webrtc_peer2.set_remote_ice_candidates(remote_candidates)
+        
+        if not await webrtc_peer2.check_for_session_establishment():
+            logging.error("Failed to establish webrtc session for controller 2")
+            raise Exception("Failed to establish webrtc session for controller 2")
+
+        self.step(10)
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.EndSession(
+                webRTCSessionID=session_id, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup
+            ),
+            endpoint=endpoint,
+            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+            dev_ctrl = th2,
+            node_id = map_nodeId,
+        )
+        
+        await webrtc_manager.close_all()
+        
+        
+async def webrtc_create_test_harness_controller(self):
+    self.th1 = self.default_controller
+    self.discriminator = random.randint(0, 4095)
+    params = await self.th1.OpenCommissioningWindow(
+        nodeid=self.dut_node_id, timeout=900, iteration=10000, discriminator=self.discriminator, option=1)
+
+    th2_certificate_authority = (
+        self.certificate_authority_manager.NewCertificateAuthority()
+    )
+    th2_fabric_admin = th2_certificate_authority.NewFabricAdmin(
+        vendorId=0xFFF1, fabricId=self.th1.fabricId + 1
+    )
+
+    self.th2 = th2_fabric_admin.NewController(
+        nodeId=2, useTestCommissioner=True)
+
+    setupPinCode = params.setupPinCode
+
+    await self.th2.CommissionOnNetwork(
+        nodeId=self.dut_node_id+1, setupPinCode=setupPinCode,
+        filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.discriminator)
+
+    return self.th2
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_WEBRTC_1_7.py
+++ b/src/python_testing/TC_WEBRTC_1_7.py
@@ -198,7 +198,7 @@ class TC_WEBRTC_1_7(MatterBaseTest, WebRTCTestHelper):
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
         )
-        
+
         self.step(8)
         th2 = await webrtc_create_test_harness_controller(self)
 
@@ -214,40 +214,40 @@ class TC_WEBRTC_1_7(MatterBaseTest, WebRTCTestHelper):
         map_nodeId = self.dut_node_id + 1
         aVideoStreamId = await self.allocate_video_stream(endpoint, devCtrl=dev_ctrl, node_id=map_nodeId)
         provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await webrtc_peer2.send_command(
-        cmd=WebRTCTransportProvider.Commands.ProvideOffer(
-            webRTCSessionID=NullValue,
-            sdp=offer,
-            streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
-            originatingEndpointID=1,
-            videoStreamID=aVideoStreamId,
-        ),
-        endpoint=endpoint,
-        payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+            cmd=WebRTCTransportProvider.Commands.ProvideOffer(
+                webRTCSessionID=NullValue,
+                sdp=offer,
+                streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
+                originatingEndpointID=1,
+                videoStreamID=aVideoStreamId,
+            ),
+            endpoint=endpoint,
+            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
         )
         session_id = provide_offer_response.webRTCSessionID
         asserts.assert_true(session_id >= 0, "Invalid response")
         webrtc_manager.session_id_created(session_id, map_nodeId)
         answer_sessionId, answer = await webrtc_peer2.get_remote_answer(timeout_s=30)
         webrtc_peer2.set_remote_answer(answer)
-        
+
         local_candidates = await webrtc_peer2.get_local_ice_candidates()
         local_candidates_struct_list = [
-        Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates
+            Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates
         ]
-        
+
         await self.send_single_cmd(
-        cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
-            webRTCSessionID=answer_sessionId, ICECandidates=local_candidates_struct_list
-        ),
-        endpoint=endpoint,
-        payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
-        dev_ctrl=dev_ctrl,
-        node_id=map_nodeId
+            cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+                webRTCSessionID=answer_sessionId, ICECandidates=local_candidates_struct_list
+            ),
+            endpoint=endpoint,
+            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+            dev_ctrl=dev_ctrl,
+            node_id=map_nodeId
         )
-        
+
         ice_session_id, remote_candidates = await webrtc_peer2.get_remote_ice_candidates()
         webrtc_peer2.set_remote_ice_candidates(remote_candidates)
-        
+
         if not await webrtc_peer2.check_for_session_establishment():
             logging.error("Failed to establish webrtc session for controller 2")
             raise Exception("Failed to establish webrtc session for controller 2")
@@ -259,13 +259,13 @@ class TC_WEBRTC_1_7(MatterBaseTest, WebRTCTestHelper):
             ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
-            dev_ctrl = th2,
-            node_id = map_nodeId,
+            dev_ctrl=th2,
+            node_id=map_nodeId,
         )
-        
+
         await webrtc_manager.close_all()
-        
-        
+
+
 async def webrtc_create_test_harness_controller(self):
     self.th1 = self.default_controller
     self.discriminator = random.randint(0, 4095)

--- a/src/python_testing/TC_WEBRTC_1_8.py
+++ b/src/python_testing/TC_WEBRTC_1_8.py
@@ -1,0 +1,209 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+#
+
+import logging
+import random
+
+from mobly import asserts
+from TC_WEBRTC_Utils import WebRTCTestHelper
+from test_plan_support import commission_if_required
+
+from matter import ChipDeviceCtrl
+from matter.ChipDeviceCtrl import TransportPayloadCapability
+from matter.clusters import Objects, WebRTCTransportProvider
+from matter.clusters.Types import NullValue
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter.webrtc import LibdatachannelPeerConnection, WebRTCManager
+
+
+class TC_WEBRTC_1_8(MatterBaseTest, WebRTCTestHelper):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.th2 = None
+    def steps_TC_WEBRTC_1_8(self) -> list[TestStep]:
+        steps = [
+            TestStep("precondition-1", commission_if_required(), is_commissioning=True),
+            TestStep("precondition-2", "Confirm there is an active WebRTC sessions exist in DUT"),
+        ]
+
+        return steps
+
+    def desc_TC_WEBRTC_1_8(self) -> str:
+        return "[TC-WEBRTC-1.8] Validate that providing an existing WebRTC session ID with an SDP Offer successfully triggers the re-offer flow"
+
+    def pics_TC_WEBRTC_1_8(self) -> list[str]:
+        return ["WEBRTCR", "WEBRTCP"]
+
+    @property
+    def default_timeout(self) -> int:
+        return 4 * 60  # 4 minutes
+
+    @async_test_body
+    async def test_TC_WEBRTC_1_8(self):
+        self.step("precondition-1")
+
+        endpoint = self.get_endpoint(default=1)
+        webrtc_manager = WebRTCManager(event_loop=self.event_loop)
+
+        # Create first controller (default) and its peer
+        webrtc_peer1: LibdatachannelPeerConnection = webrtc_manager.create_peer(
+            node_id=self.dut_node_id, fabric_index=self.default_controller.GetFabricIndexInternal(), endpoint=endpoint
+        )
+        # Create second controller with different fabric index
+        th2 = await webrtc_create_test_harness_controller(self)
+        webrtc_peer2: LibdatachannelPeerConnection = webrtc_manager.create_peer(
+            node_id=self.dut_node_id+1,
+            fabric_index=th2.GetFabricIndexInternal(),
+            endpoint=endpoint,
+        )
+
+        # Establish sessions for both peers
+        if not await establish_webrtc_session(webrtc_manager, webrtc_peer1, endpoint, self, devCtrl=None):
+            raise Exception("Failed to create WebRTC session for controller 1")
+        if not await establish_webrtc_session(webrtc_manager, webrtc_peer2, endpoint, self, devCtrl=th2):
+            raise Exception("Failed to create WebRTC session for controller 2")
+
+        # Verify number of sessions on DUT (should be 2)
+        current_sessions = await self.read_single_attribute_check_success(
+            cluster=WebRTCTransportProvider,
+            attribute=WebRTCTransportProvider.Attributes.CurrentSessions,
+            endpoint=endpoint,
+            fabric_filtered=False,
+        )
+        asserts.assert_equal(len(current_sessions), 2 , "Expected 1 WebRTC sessions")
+        # Store session IDs for later cleanup if needed
+        session_ids = [s.id for s in current_sessions]
+        
+        self.step("precondition-2")
+
+        # Close all sessions on DUT
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.EndSession(
+                webRTCSessionID=session_ids[0],
+                reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup,
+            ),
+            endpoint=endpoint,
+            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+        )
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.EndSession(
+                webRTCSessionID=session_ids[1],
+                reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup,
+            ),
+            endpoint=endpoint,
+            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+            dev_ctrl = th2,
+            node_id=self.dut_node_id+1
+        )
+        await webrtc_manager.close_all()
+
+
+async def establish_webrtc_session(webrtc_manager, webrtc_peer, endpoint, self, devCtrl=None):
+    webrtc_peer.create_offer()
+    offer = await webrtc_peer.get_local_offer()
+    dev_ctrl = self.default_controller
+    map_nodeId = self.dut_node_id
+    if (devCtrl is not None):
+        dev_ctrl = devCtrl
+        map_nodeId = self.dut_node_id + 1
+    aVideoStreamId = await self.allocate_video_stream(endpoint, devCtrl=dev_ctrl, node_id=map_nodeId)
+    provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await webrtc_peer.send_command(
+        cmd=WebRTCTransportProvider.Commands.ProvideOffer(
+            webRTCSessionID=NullValue,
+            sdp=offer,
+            streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
+            originatingEndpointID=1,
+            videoStreamID=aVideoStreamId,
+        ),
+        endpoint=endpoint,
+        payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+    )
+    
+    session_id = provide_offer_response.webRTCSessionID
+    asserts.assert_true(session_id>= 0, "Invalid response")
+    webrtc_manager.session_id_created(session_id, map_nodeId)
+
+    answer_sessionId, answer = await webrtc_peer.get_remote_answer(timeout_s=30)
+    webrtc_peer.set_remote_answer(answer)
+
+    local_candidates = await webrtc_peer.get_local_ice_candidates()
+    local_candidates_struct_list = [
+        Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates
+    ]
+    await self.send_single_cmd(
+        cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+            webRTCSessionID=answer_sessionId, ICECandidates=local_candidates_struct_list
+        ),
+        endpoint=endpoint,
+        payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+        dev_ctrl = dev_ctrl,
+        node_id=map_nodeId
+    )
+
+    ice_session_id, remote_candidates = await webrtc_peer.get_remote_ice_candidates()
+    asserts.assert_equal(session_id, ice_session_id, "ProvideIceCandidates invoked with wrong session id")
+    asserts.assert_true(len(remote_candidates) > 0, "Invalid remote ice candidates received")
+    webrtc_peer.set_remote_ice_candidates(remote_candidates)
+
+    return await webrtc_peer.check_for_session_establishment()
+
+async def webrtc_create_test_harness_controller(self):
+    self.th1 = self.default_controller
+    self.discriminator = random.randint(0, 4095)
+    params = await self.th1.OpenCommissioningWindow(
+        nodeid=self.dut_node_id, timeout=900, iteration=10000, discriminator=self.discriminator, option=1)
+
+    th2_certificate_authority = (
+        self.certificate_authority_manager.NewCertificateAuthority()
+    )
+    th2_fabric_admin = th2_certificate_authority.NewFabricAdmin(
+        vendorId=0xFFF1, fabricId=self.th1.fabricId + 1
+    )
+
+    self.th2 = th2_fabric_admin.NewController(
+        nodeId=2, useTestCommissioner=True)
+
+    setupPinCode = params.setupPinCode
+    
+    await self.th2.CommissionOnNetwork(
+        nodeId=self.dut_node_id+1, setupPinCode=setupPinCode,
+        filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.discriminator)
+
+    return self.th2
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_WEBRTC_1_8.py
+++ b/src/python_testing/TC_WEBRTC_1_8.py
@@ -286,6 +286,7 @@ class TC_WEBRTC_1_8(MatterBaseTest, WebRTCTestHelper):
 
         await webrtc_manager.close_all()
 
+
 async def webrtc_create_test_harness_controller(self):
     self.th1 = self.default_controller
     self.discriminator = random.randint(0, 4095)

--- a/src/python_testing/TC_WEBRTC_1_8.py
+++ b/src/python_testing/TC_WEBRTC_1_8.py
@@ -35,6 +35,7 @@
 # === END CI TEST ARGUMENTS ===
 #
 
+import logging
 import random
 
 from mobly import asserts
@@ -50,23 +51,79 @@ from matter.webrtc import LibdatachannelPeerConnection, WebRTCManager
 
 
 class TC_WEBRTC_1_8(MatterBaseTest, WebRTCTestHelper):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.th2 = None
-
     def steps_TC_WEBRTC_1_8(self) -> list[TestStep]:
         steps = [
             TestStep("precondition-1", commission_if_required(), is_commissioning=True),
-            TestStep("precondition-2", "Confirm there is an active WebRTC sessions exist in DUT"),
+            TestStep("precondition-2", "Confirm no active WebRTC sessions exist in DUT"),
+            TestStep(
+                1,
+                description="Commission DUT from TH2.",
+                expectation="Verify that camera is commissioned successfully.",
+            ),
+            TestStep(
+                2,
+                description="TH1 sends the ProvideOffer command with an SDP Offer and null WebRTCSessionID to the DUT.",
+                expectation="DUT responds with ProvideOfferResponse containing allocated WebRTCSessionID. TH1 saves the WebRTCSessionID to be used in a later step.",
+            ),
+            TestStep(
+                3,
+                description="DUT sends Answer command to the TH1/WEBRTCR.",
+                expectation="Verify that Answer command contains the same WebRTCSessionID saved in step 2 and contain a non-empty SDP string.",
+            ),
+            TestStep(
+                4,
+                description="TH1 sends the SUCCESS status code to the DUT."
+            ),
+            TestStep(
+                5,
+                description="TH2 sends the ProvideOffer command with an SDP Offer and null WebRTCSessionID to the DUT.",
+                expectation="DUT responds with ProvideOfferResponse containing allocated WebRTCSessionID. TH2 saves the WebRTCSessionID to be used in a later step.",
+            ),
+            TestStep(
+                6,
+                description="DUT sends Answer command to the TH2/WEBRTCR.",
+                expectation="Verify that Answer command contains the same WebRTCSessionID saved in step 5 and contain a non-empty SDP string.",
+            ),
+            TestStep(
+                7,
+                description="TH2 sends the SUCCESS status code to the DUT."
+            ),
+            TestStep(
+                8,
+                description="Either or both TH1 and DUT exchange ICE candidates if ICE candidates are not shared in  the SDP Offer / Answer.",
+            ),
+            TestStep(
+                9,
+                description="Either or both TH2 and DUT exchange ICE candidates if ICE candidates are not shared in  the SDP Offer / Answer.",
+            ),
+            TestStep(
+                10,
+                description="TH1 waits for 5 seconds.",
+                expectation="Verify the WebRTC session has been successfully established.",
+            ),
+            TestStep(
+                11,
+                description="TH2 waits for 5 seconds.",
+                expectation="Verify the WebRTC session has been successfully established.",
+            ),
+            TestStep(
+                12,
+                description="TH1 sends EndSession command with the WebRTCSessionID saved in step 2 to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                13,
+                description="TH2 sends EndSession command with the WebRTCSessionID saved in step 5 to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
         ]
-
         return steps
 
     def desc_TC_WEBRTC_1_8(self) -> str:
-        return "[TC-WEBRTC-1.8] Validate that providing an existing WebRTC session ID with an SDP Offer successfully triggers the re-offer flow"
+        return "[TC-WEBRTC-1_8] Validate that setting an SDP Offer simultaneously from multiple camera controllers successfully initiates multiple WebRTC sessions."
 
     def pics_TC_WEBRTC_1_8(self) -> list[str]:
-        return ["WEBRTCR", "WEBRTCP"]
+        return ["WEBRTCR.C", "WEBRTCP.S"]
 
     @property
     def default_timeout(self) -> int:
@@ -79,108 +136,155 @@ class TC_WEBRTC_1_8(MatterBaseTest, WebRTCTestHelper):
         endpoint = self.get_endpoint(default=1)
         webrtc_manager = WebRTCManager(event_loop=self.event_loop)
 
-        # Create first controller (default) and its peer
+        self.step("precondition-2")
+        current_sessions = await self.read_single_attribute_check_success(
+            cluster=WebRTCTransportProvider, attribute=WebRTCTransportProvider.Attributes.CurrentSessions, endpoint=endpoint
+        )
+        asserts.assert_equal(len(current_sessions), 0, "Found an existing WebRTC session")
+
+        self.step(1)
+        th2 = await webrtc_create_test_harness_controller(self)
         webrtc_peer1: LibdatachannelPeerConnection = webrtc_manager.create_peer(
             node_id=self.dut_node_id, fabric_index=self.default_controller.GetFabricIndexInternal(), endpoint=endpoint
         )
-        # Create second controller with different fabric index
-        th2 = await webrtc_create_test_harness_controller(self)
         webrtc_peer2: LibdatachannelPeerConnection = webrtc_manager.create_peer(
             node_id=self.dut_node_id+1,
             fabric_index=th2.GetFabricIndexInternal(),
             endpoint=endpoint,
         )
 
-        # Establish sessions for both peers
-        if not await establish_webrtc_session(webrtc_manager, webrtc_peer1, endpoint, self, devCtrl=None):
-            raise Exception("Failed to create WebRTC session for controller 1")
-        if not await establish_webrtc_session(webrtc_manager, webrtc_peer2, endpoint, self, devCtrl=th2):
-            raise Exception("Failed to create WebRTC session for controller 2")
+        self.step(2)
+        webrtc_peer1.create_offer()
+        offer = await webrtc_peer1.get_local_offer()
 
-        # Verify number of sessions on DUT (should be 2)
-        current_sessions = await self.read_single_attribute_check_success(
-            cluster=WebRTCTransportProvider,
-            attribute=WebRTCTransportProvider.Attributes.CurrentSessions,
-            endpoint=endpoint,
-            fabric_filtered=False,
-        )
-        asserts.assert_equal(len(current_sessions), 2, "Expected 1 WebRTC sessions")
-        # Store session IDs for later cleanup if needed
-        session_ids = [s.id for s in current_sessions]
-
-        self.step("precondition-2")
-
-        # Close all sessions on DUT
-        await self.send_single_cmd(
-            cmd=WebRTCTransportProvider.Commands.EndSession(
-                webRTCSessionID=session_ids[0],
-                reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup,
+        aVideoStreamID1 = await self.allocate_video_stream(endpoint)
+        provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await webrtc_peer1.send_command(
+            cmd=WebRTCTransportProvider.Commands.ProvideOffer(
+                webRTCSessionID=NullValue,
+                sdp=offer,
+                streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
+                videoStreamID=aVideoStreamID1,
+                originatingEndpointID=1,
             ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
         )
+        session_id1 = provide_offer_response.webRTCSessionID
+        asserts.assert_true(session_id1 >= 0, "Invalid response")
+
+        webrtc_manager.session_id_created(session_id1, self.dut_node_id)
+
+        self.step(3)
+
+        answer_sessionId1, answer1 = await webrtc_peer1.get_remote_answer(timeout_s=30)
+
+        asserts.assert_equal(session_id1, answer_sessionId1, "ProvideAnswer invoked with wrong session id")
+        asserts.assert_true(len(answer1) > 0, "Invalid answer SDP received")
+
+        self.step(4)
+        webrtc_peer1.set_remote_answer(answer1)
+
+        self.step(5)
+        webrtc_peer2.create_offer()
+        offer = await webrtc_peer2.get_local_offer()
+        dev_ctrl = th2
+        map_nodeId = self.dut_node_id + 1
+        aVideoStreamId2 = await self.allocate_video_stream(endpoint, devCtrl=dev_ctrl, node_id=map_nodeId)
+
+        provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await webrtc_peer2.send_command(
+            cmd=WebRTCTransportProvider.Commands.ProvideOffer(
+                webRTCSessionID=NullValue,
+                sdp=offer,
+                streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
+                originatingEndpointID=1,
+                videoStreamID=aVideoStreamId2,
+            ),
+            endpoint=endpoint,
+            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+        )
+        session_id2 = provide_offer_response.webRTCSessionID
+        asserts.assert_true(session_id2 >= 0, "Invalid response")
+        webrtc_manager.session_id_created(session_id2, map_nodeId)
+
+        self.step(6)
+        answer_sessionId2, answer2 = await webrtc_peer2.get_remote_answer(timeout_s=30)
+        asserts.assert_equal(session_id2, answer_sessionId2, "ProvideAnswer invoked with wrong session id")
+        asserts.assert_true(len(answer2) > 0, "Invalid answer SDP received")
+
+        self.step(7)
+        webrtc_peer2.set_remote_answer(answer2)
+
+        self.step(8)
+        local_candidates1 = await webrtc_peer1.get_local_ice_candidates()
+        local_candidates_struct_list1 = [
+            Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates1
+        ]
+        if (len(local_candidates_struct_list1) > 0):
+            await self.send_single_cmd(
+                cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+                    webRTCSessionID=answer_sessionId1, ICECandidates=local_candidates_struct_list1
+                ),
+                endpoint=endpoint,
+                payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+            )
+        else:
+            ice_session_id1, remote_candidates1 = await webrtc_peer1.get_remote_ice_candidates()
+            asserts.assert_equal(session_id1, ice_session_id1, "ProvideIceCandidates invoked with wrong session id")
+            asserts.assert_true(len(remote_candidates1) > 0, "Invalid remote ice candidates received")
+
+            webrtc_peer1.set_remote_ice_candidates(remote_candidates1)
+
+        self.step(9)
+        local_candidates2 = await webrtc_peer2.get_local_ice_candidates()
+        local_candidates_struct_list2 = [
+            Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates2
+        ]
+        if (len(local_candidates_struct_list2) > 0):
+            await self.send_single_cmd(
+                cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+                    webRTCSessionID=answer_sessionId2, ICECandidates=local_candidates_struct_list2
+                ),
+                endpoint=endpoint,
+                payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+                dev_ctrl=dev_ctrl,
+                node_id=map_nodeId
+            )
+        else:
+            ice_session_id2, remote_candidates2 = await webrtc_peer2.get_remote_ice_candidates()
+            asserts.assert_true(len(remote_candidates2) > 0, "Invalid remote ice candidates received")
+            webrtc_peer2.set_remote_ice_candidates(remote_candidates2)
+
+        self.step(10)
+        if not await webrtc_peer1.check_for_session_establishment():
+            logging.error("Failed to establish webrtc session")
+            raise Exception("Failed to establish webrtc session")
+
+        self.step(11)
+        if not await webrtc_peer2.check_for_session_establishment():
+            logging.error("Failed to establish webrtc session")
+            raise Exception("Failed to establish webrtc session")
+
+        self.step(12)
         await self.send_single_cmd(
             cmd=WebRTCTransportProvider.Commands.EndSession(
-                webRTCSessionID=session_ids[1],
-                reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup,
+                webRTCSessionID=session_id1, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup
+            ),
+            endpoint=endpoint,
+            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+        )
+
+        self.step(13)
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.EndSession(
+                webRTCSessionID=session_id2, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup
             ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
             dev_ctrl=th2,
-            node_id=self.dut_node_id+1
+            node_id=map_nodeId,
         )
+
         await webrtc_manager.close_all()
-
-
-async def establish_webrtc_session(webrtc_manager, webrtc_peer, endpoint, self, devCtrl=None):
-    webrtc_peer.create_offer()
-    offer = await webrtc_peer.get_local_offer()
-    dev_ctrl = self.default_controller
-    map_nodeId = self.dut_node_id
-    if (devCtrl is not None):
-        dev_ctrl = devCtrl
-        map_nodeId = self.dut_node_id + 1
-    aVideoStreamId = await self.allocate_video_stream(endpoint, devCtrl=dev_ctrl, node_id=map_nodeId)
-    provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await webrtc_peer.send_command(
-        cmd=WebRTCTransportProvider.Commands.ProvideOffer(
-            webRTCSessionID=NullValue,
-            sdp=offer,
-            streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
-            originatingEndpointID=1,
-            videoStreamID=aVideoStreamId,
-        ),
-        endpoint=endpoint,
-        payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
-    )
-
-    session_id = provide_offer_response.webRTCSessionID
-    asserts.assert_true(session_id >= 0, "Invalid response")
-    webrtc_manager.session_id_created(session_id, map_nodeId)
-
-    answer_sessionId, answer = await webrtc_peer.get_remote_answer(timeout_s=30)
-    webrtc_peer.set_remote_answer(answer)
-
-    local_candidates = await webrtc_peer.get_local_ice_candidates()
-    local_candidates_struct_list = [
-        Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates
-    ]
-    await self.send_single_cmd(
-        cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
-            webRTCSessionID=answer_sessionId, ICECandidates=local_candidates_struct_list
-        ),
-        endpoint=endpoint,
-        payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
-        dev_ctrl=dev_ctrl,
-        node_id=map_nodeId
-    )
-
-    ice_session_id, remote_candidates = await webrtc_peer.get_remote_ice_candidates()
-    asserts.assert_equal(session_id, ice_session_id, "ProvideIceCandidates invoked with wrong session id")
-    asserts.assert_true(len(remote_candidates) > 0, "Invalid remote ice candidates received")
-    webrtc_peer.set_remote_ice_candidates(remote_candidates)
-
-    return await webrtc_peer.check_for_session_establishment()
-
 
 async def webrtc_create_test_harness_controller(self):
     self.th1 = self.default_controller

--- a/src/python_testing/TC_WEBRTC_1_8.py
+++ b/src/python_testing/TC_WEBRTC_1_8.py
@@ -35,7 +35,6 @@
 # === END CI TEST ARGUMENTS ===
 #
 
-import logging
 import random
 
 from mobly import asserts

--- a/src/python_testing/TC_WEBRTC_1_8.py
+++ b/src/python_testing/TC_WEBRTC_1_8.py
@@ -54,6 +54,7 @@ class TC_WEBRTC_1_8(MatterBaseTest, WebRTCTestHelper):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.th2 = None
+
     def steps_TC_WEBRTC_1_8(self) -> list[TestStep]:
         steps = [
             TestStep("precondition-1", commission_if_required(), is_commissioning=True),
@@ -104,10 +105,10 @@ class TC_WEBRTC_1_8(MatterBaseTest, WebRTCTestHelper):
             endpoint=endpoint,
             fabric_filtered=False,
         )
-        asserts.assert_equal(len(current_sessions), 2 , "Expected 1 WebRTC sessions")
+        asserts.assert_equal(len(current_sessions), 2, "Expected 1 WebRTC sessions")
         # Store session IDs for later cleanup if needed
         session_ids = [s.id for s in current_sessions]
-        
+
         self.step("precondition-2")
 
         # Close all sessions on DUT
@@ -126,7 +127,7 @@ class TC_WEBRTC_1_8(MatterBaseTest, WebRTCTestHelper):
             ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
-            dev_ctrl = th2,
+            dev_ctrl=th2,
             node_id=self.dut_node_id+1
         )
         await webrtc_manager.close_all()
@@ -152,9 +153,9 @@ async def establish_webrtc_session(webrtc_manager, webrtc_peer, endpoint, self, 
         endpoint=endpoint,
         payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
     )
-    
+
     session_id = provide_offer_response.webRTCSessionID
-    asserts.assert_true(session_id>= 0, "Invalid response")
+    asserts.assert_true(session_id >= 0, "Invalid response")
     webrtc_manager.session_id_created(session_id, map_nodeId)
 
     answer_sessionId, answer = await webrtc_peer.get_remote_answer(timeout_s=30)
@@ -170,7 +171,7 @@ async def establish_webrtc_session(webrtc_manager, webrtc_peer, endpoint, self, 
         ),
         endpoint=endpoint,
         payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
-        dev_ctrl = dev_ctrl,
+        dev_ctrl=dev_ctrl,
         node_id=map_nodeId
     )
 
@@ -180,6 +181,7 @@ async def establish_webrtc_session(webrtc_manager, webrtc_peer, endpoint, self, 
     webrtc_peer.set_remote_ice_candidates(remote_candidates)
 
     return await webrtc_peer.check_for_session_establishment()
+
 
 async def webrtc_create_test_harness_controller(self):
     self.th1 = self.default_controller
@@ -198,7 +200,7 @@ async def webrtc_create_test_harness_controller(self):
         nodeId=2, useTestCommissioner=True)
 
     setupPinCode = params.setupPinCode
-    
+
     await self.th2.CommissionOnNetwork(
         nodeId=self.dut_node_id+1, setupPinCode=setupPinCode,
         filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.discriminator)

--- a/src/python_testing/TC_WEBRTC_Utils.py
+++ b/src/python_testing/TC_WEBRTC_Utils.py
@@ -62,7 +62,7 @@ class WebRTCTestHelper:
             logging.error(f"Failed to allocate audio stream. {e}")
             return None
 
-    async def allocate_video_stream(self, endpoint):
+    async def allocate_video_stream(self, endpoint, devCtrl=None, node_id=None):
         """Try to allocate a video stream from the camera device. Returns the stream ID if successful, otherwise None."""
         attrs = CameraAvStreamManagement.Attributes
         try:
@@ -78,6 +78,12 @@ class WebRTCTestHelper:
             )
             aMinViewportRes = await self.read_avstr_attribute_expect_success(endpoint, attrs.MinViewportResolution)
             aVideoSensorParams = await self.read_avstr_attribute_expect_success(endpoint, attrs.VideoSensorParams)
+            dev_ctrl = self.default_controller
+
+            if (node_id is None):
+                node_id = self.dut_node_id
+            if (devCtrl is not None):
+                dev_ctrl = devCtrl
 
             response = await self.send_single_cmd(
                 cmd=CameraAvStreamManagement.Commands.VideoStreamAllocate(
@@ -96,6 +102,8 @@ class WebRTCTestHelper:
                     OSDEnabled=osd,
                 ),
                 endpoint=endpoint,
+                dev_ctrl=dev_ctrl,
+                node_id=node_id
             )
             return response.videoStreamID
 


### PR DESCRIPTION
#### Summary
This PR implements TC_WEBRTC_1_7.py and TC_WEBRTC_1.8.py to verify the successful WebRTC session creation by Camera (DUT) device when multiple Test Harness controller issue WebRTC provider commands with SDP offer.

Scenarios:

[1] Successful WebRTC session is created when the second Camera controller issues SDP offer after first Camera controllers' session is ended
[2] Successful WebRTC session is created when the second Camera controller issues SDP offer before first Camera controller's session is ended


#### Testing
```
# Build and run camera application
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debu/chip-camera-app

# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run WebRTC 1.7 TC, WebRTC 1.8 TC
Example:
python3 src/python_testing/TC_WEBRTC_1_7.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1

python3 src/python_testing/TC_WEBRTC_1_8.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1
```