### PR TITLE
Address post merge comments for boolean state cluster

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceWithDisplay.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceWithDisplay.cpp
@@ -678,7 +678,7 @@ void SetupPretendDevices()
     AddEndpoint("External");
     AddCluster("Contact Sensor");
     AddAttribute("Contact", "true");
-    auto booleanState = app::Clusters::BooleanState::GetClusterForEndpointIndex(1);
+    auto booleanState = app::Clusters::BooleanState::FindClusterOnEndpoint(1);
     if (booleanState != nullptr)
     {
         booleanState->SetStateValue(true);

--- a/examples/all-clusters-minimal-app/esp32/main/DeviceWithDisplay.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/DeviceWithDisplay.cpp
@@ -543,7 +543,7 @@ void SetupPretendDevices()
     AddEndpoint("External");
     AddCluster("Contact Sensor");
     AddAttribute("Contact", "true");
-    auto booleanState = app::Clusters::BooleanState::GetClusterForEndpointIndex(1);
+    auto booleanState = app::Clusters::BooleanState::FindClusterOnEndpoint(1);
     if (booleanState != nullptr)
     {
         booleanState->SetStateValue(true);

--- a/examples/common/imgui_ui/windows/boolean_state.cpp
+++ b/examples/common/imgui_ui/windows/boolean_state.cpp
@@ -33,7 +33,7 @@ namespace Windows {
 
 void BooleanState::UpdateState()
 {
-    auto booleanState = chip::app::Clusters::BooleanState::GetClusterForEndpointIndex(mEndpointId);
+    auto booleanState = chip::app::Clusters::BooleanState::FindClusterOnEndpoint(mEndpointId);
     VerifyOrReturn(booleanState != nullptr);
 
     if (mTargetState.HasValue())

--- a/examples/common/pigweed/rpc_services/BooleanState.h
+++ b/examples/common/pigweed/rpc_services/BooleanState.h
@@ -44,16 +44,16 @@ public:
         EndpointId endpointId = request.endpoint_id;
         bool newState         = request.state_value;
 
-        EventNumber eventNumber;
+        std::optional<EventNumber> eventNumber;
         {
             DeviceLayer::StackLock lock;
 
-            auto booleanState = app::Clusters::BooleanState::GetClusterForEndpointIndex(endpointId);
+            auto booleanState = app::Clusters::BooleanState::FindClusterOnEndpoint(endpointId);
             VerifyOrReturnError(booleanState != nullptr, pw::Status::InvalidArgument());
-            booleanState->SetStateValue(newState, &eventNumber);
+            eventNumber = booleanState->SetStateValue(newState);
         }
 
-        response.event_number = static_cast<uint64_t>(eventNumber);
+        response.event_number = eventNumber.has_value() ? eventNumber.value() : 0;
         return pw::OkStatus();
 #else
         return pw::Status::InvalidArgument();
@@ -69,7 +69,7 @@ public:
         {
             DeviceLayer::StackLock lock;
 
-            auto booleanState = app::Clusters::BooleanState::GetClusterForEndpointIndex(endpointId);
+            auto booleanState = app::Clusters::BooleanState::FindClusterOnEndpoint(endpointId);
             VerifyOrReturnError(booleanState != nullptr, pw::Status::InvalidArgument());
             state_value = booleanState->GetStateValue();
         }

--- a/examples/common/pigweed/rpc_services/BooleanState.h
+++ b/examples/common/pigweed/rpc_services/BooleanState.h
@@ -53,7 +53,7 @@ public:
             eventNumber = booleanState->SetStateValue(newState);
         }
 
-        response.event_number = eventNumber.has_value() ? eventNumber.value() : 0;
+        response.event_number = eventNumber.value_or(0);
         return pw::OkStatus();
 #else
         return pw::Status::InvalidArgument();

--- a/examples/contact-sensor-app/bouffalolab/common/AppTask.cpp
+++ b/examples/contact-sensor-app/bouffalolab/common/AppTask.cpp
@@ -205,7 +205,7 @@ void AppTask::AppTaskMain(void * pvParameter)
             {
                 stateValueAttrValue = 1;
 
-                auto booleanState = app::Clusters::BooleanState::GetClusterForEndpointIndex(1);
+                auto booleanState = app::Clusters::BooleanState::FindClusterOnEndpoint(1);
                 if (booleanState != nullptr)
                 {
                     booleanState->SetStateValue(stateValueAttrValue);
@@ -216,7 +216,7 @@ void AppTask::AppTaskMain(void * pvParameter)
             {
                 stateValueAttrValue = 0;
 
-                auto booleanState = app::Clusters::BooleanState::GetClusterForEndpointIndex(1);
+                auto booleanState = app::Clusters::BooleanState::FindClusterOnEndpoint(1);
                 if (booleanState != nullptr)
                 {
                     booleanState->SetStateValue(stateValueAttrValue);

--- a/examples/contact-sensor-app/nxp/common/AppTask.cpp
+++ b/examples/contact-sensor-app/nxp/common/AppTask.cpp
@@ -51,7 +51,7 @@ ContactSensorApp::AppTask & ContactSensorApp::AppTask::GetDefaultInstance()
 
 bool ContactSensorApp::AppTask::CheckStateClusterHandler(void)
 {
-    auto booleanState = BooleanState::GetClusterForEndpointIndex(APP_DEVICE_TYPE_ENDPOINT);
+    auto booleanState = BooleanState::FindClusterOnEndpoint(APP_DEVICE_TYPE_ENDPOINT);
     VerifyOrReturnError(booleanState != nullptr, false);
     bool val = booleanState->GetStateValue();
     return val;
@@ -59,7 +59,7 @@ bool ContactSensorApp::AppTask::CheckStateClusterHandler(void)
 
 CHIP_ERROR ContactSensorApp::AppTask::ProcessSetStateClusterHandler(void)
 {
-    auto booleanState = BooleanState::GetClusterForEndpointIndex(APP_DEVICE_TYPE_ENDPOINT);
+    auto booleanState = BooleanState::FindClusterOnEndpoint(APP_DEVICE_TYPE_ENDPOINT);
     VerifyOrReturnError(booleanState != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     bool val = booleanState->GetStateValue();

--- a/examples/contact-sensor-app/telink/src/AppTask.cpp
+++ b/examples/contact-sensor-app/telink/src/AppTask.cpp
@@ -84,7 +84,7 @@ void AppTask::UpdateClusterStateInternal(intptr_t arg)
 
     ChipLogProgress(NotSpecified, "StateValue::Set : %d", newValue);
 
-    auto booleanState = chip::app::Clusters::BooleanState::GetClusterForEndpointIndex(1);
+    auto booleanState = chip::app::Clusters::BooleanState::FindClusterOnEndpoint(1);
     VerifyOrReturn(booleanState != nullptr);
     booleanState->SetStateValue(newValue);
 }
@@ -137,7 +137,7 @@ void AppTask::UpdateDeviceState(void)
 
 void AppTask::UpdateDeviceStateInternal(intptr_t arg)
 {
-    auto booleanState = chip::app::Clusters::BooleanState::GetClusterForEndpointIndex(1);
+    auto booleanState = chip::app::Clusters::BooleanState::FindClusterOnEndpoint(1);
     VerifyOrReturn(booleanState != nullptr);
     auto stateValueAttrValue = booleanState->GetStateValue();
     LedManager::getInstance().setLed(LedManager::EAppLed_App0, stateValueAttrValue);

--- a/examples/lit-icd-app/silabs/src/AppTask.cpp
+++ b/examples/lit-icd-app/silabs/src/AppTask.cpp
@@ -123,7 +123,7 @@ void AppTask::ApplicationEventHandler(AppEvent * aEvent)
     // DO NOT COPY for product logic. LIT ICD app is a test app with very simple application logic to enable testing.
     // The goal of the app is just to enable testing of LIT ICD features without impacting product sample apps.
     PlatformMgr().ScheduleWork([](intptr_t) {
-        auto booleanState = chip::app::Clusters::BooleanState::GetClusterForEndpointIndex(1);
+        auto booleanState = chip::app::Clusters::BooleanState::FindClusterOnEndpoint(1);
         VerifyOrReturn(booleanState != nullptr);
         auto state = booleanState->GetStateValue();
         booleanState->SetStateValue(!state);

--- a/examples/water-leak-detector-app/water-leak-detector-common/src/WaterLeakDetectorManager.cpp
+++ b/examples/water-leak-detector-app/water-leak-detector-common/src/WaterLeakDetectorManager.cpp
@@ -45,7 +45,7 @@ void WaterLeakDetectorManager::InitInstance(EndpointId endpoint)
 
 void WaterLeakDetectorManager::OnLeakDetected(bool detected)
 {
-    auto booleanState = BooleanState::GetClusterForEndpointIndex(sInstance.mEndpoint);
+    auto booleanState = BooleanState::FindClusterOnEndpoint(sInstance.mEndpoint);
     VerifyOrReturn(booleanState != nullptr);
     booleanState->SetStateValue(detected);
     ChipLogDetail(NotSpecified, "Leak status updated to: %d", detected);

--- a/src/app/clusters/boolean-state-server/CodegenIntegration.cpp
+++ b/src/app/clusters/boolean-state-server/CodegenIntegration.cpp
@@ -91,11 +91,11 @@ void MatterBooleanStateClusterServerShutdownCallback(EndpointId endpointId)
 
 namespace chip::app::Clusters::BooleanState {
 
-BooleanStateCluster * GetClusterForEndpointIndex(EndpointId endpointId)
+BooleanStateCluster * FindClusterOnEndpoint(EndpointId endpointId)
 {
     IntegrationDelegate integrationDelegate;
 
-    ServerClusterInterface * booleanState = CodegenClusterIntegration::GetClusterForEndpointIndex(
+    ServerClusterInterface * booleanState = CodegenClusterIntegration::FindClusterOnEndpoint(
         {
             .endpointId                = endpointId,
             .clusterId                 = BooleanState::Id,

--- a/src/app/clusters/boolean-state-server/CodegenIntegration.h
+++ b/src/app/clusters/boolean-state-server/CodegenIntegration.h
@@ -22,6 +22,6 @@
 
 namespace chip::app::Clusters::BooleanState {
 
-BooleanStateCluster * GetClusterForEndpointIndex(EndpointId endpointId);
+BooleanStateCluster * FindClusterOnEndpoint(EndpointId endpointId);
 
 } // namespace chip::app::Clusters::BooleanState

--- a/src/app/clusters/boolean-state-server/boolean-state-cluster.cpp
+++ b/src/app/clusters/boolean-state-server/boolean-state-cluster.cpp
@@ -52,10 +52,10 @@ CHIP_ERROR BooleanStateCluster::Attributes(const ConcreteClusterPath & path,
 
 std::optional<EventNumber> BooleanStateCluster::SetStateValue(bool stateValue)
 {
-    VerifyOrReturnValue(mStateValue != stateValue, std::optional<EventNumber>());
+    VerifyOrReturnValue(mStateValue != stateValue, std::nullopt);
     mStateValue = stateValue;
     NotifyAttributeChanged(StateValue::Id);
-    VerifyOrReturnValue(mContext != nullptr, std::optional<EventNumber>());
+    VerifyOrReturnValue(mContext != nullptr, std::nullopt);
     BooleanState::Events::StateChange::Type event{ stateValue };
     return mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
 }

--- a/src/app/clusters/boolean-state-server/boolean-state-cluster.cpp
+++ b/src/app/clusters/boolean-state-server/boolean-state-cluster.cpp
@@ -50,16 +50,14 @@ CHIP_ERROR BooleanStateCluster::Attributes(const ConcreteClusterPath & path,
     return listBuilder.Append(Span(BooleanState::Attributes::kMandatoryMetadata), {});
 }
 
-void BooleanStateCluster::SetStateValue(bool stateValue, EventNumber * eventNumber)
+std::optional<EventNumber> BooleanStateCluster::SetStateValue(bool stateValue)
 {
-    VerifyOrReturn(mStateValue != stateValue);
+    VerifyOrReturnValue(mStateValue != stateValue, std::optional<EventNumber>());
     mStateValue = stateValue;
     NotifyAttributeChanged(StateValue::Id);
-    VerifyOrReturn(mContext != nullptr);
+    VerifyOrReturnValue(mContext != nullptr, std::optional<EventNumber>());
     BooleanState::Events::StateChange::Type event{ stateValue };
-    auto eventNum = mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
-    VerifyOrReturn(eventNumber != nullptr && eventNum.has_value());
-    *eventNumber = eventNum.value();
+    return mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
 }
 
 } // namespace chip::app::Clusters

--- a/src/app/clusters/boolean-state-server/boolean-state-cluster.h
+++ b/src/app/clusters/boolean-state-server/boolean-state-cluster.h
@@ -33,7 +33,7 @@ public:
 
     // Set a boolean value.
     // If the boolean value was actually modified, an event will be generated.
-    // On success, the return value is an optional containing an EventNumber.
+    // On success, the return value is an optional containing the EventNumber of the event that was generated.
     // On error, the return value is nullopt.
     std::optional<EventNumber> SetStateValue(bool stateValue);
 

--- a/src/app/clusters/boolean-state-server/boolean-state-cluster.h
+++ b/src/app/clusters/boolean-state-server/boolean-state-cluster.h
@@ -31,7 +31,11 @@ public:
                                                 AttributeValueEncoder & encoder) override;
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
-    void SetStateValue(bool stateValue, EventNumber * eventNumber = nullptr);
+    // Set a boolean value
+    // If the boolean value was actually modified, an event will be generated
+    // On success, the return value is an optional containing an EventNumber (alias for uint64_t)
+    // On error, the return value is nullopt
+    std::optional<EventNumber> SetStateValue(bool stateValue);
 
     bool GetStateValue() const { return mStateValue; }
 

--- a/src/app/clusters/boolean-state-server/boolean-state-cluster.h
+++ b/src/app/clusters/boolean-state-server/boolean-state-cluster.h
@@ -33,7 +33,7 @@ public:
 
     // Set a boolean value
     // If the boolean value was actually modified, an event will be generated
-    // On success, the return value is an optional containing an EventNumber (alias for uint64_t)
+    // On success, the return value is an optional containing an EventNumber
     // On error, the return value is nullopt
     std::optional<EventNumber> SetStateValue(bool stateValue);
 

--- a/src/app/clusters/boolean-state-server/boolean-state-cluster.h
+++ b/src/app/clusters/boolean-state-server/boolean-state-cluster.h
@@ -31,10 +31,10 @@ public:
                                                 AttributeValueEncoder & encoder) override;
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
-    // Set a boolean value
-    // If the boolean value was actually modified, an event will be generated
-    // On success, the return value is an optional containing an EventNumber
-    // On error, the return value is nullopt
+    // Set a boolean value.
+    // If the boolean value was actually modified, an event will be generated.
+    // On success, the return value is an optional containing an EventNumber.
+    // On error, the return value is nullopt.
     std::optional<EventNumber> SetStateValue(bool stateValue);
 
     bool GetStateValue() const { return mStateValue; }

--- a/src/app/clusters/boolean-state-server/tests/BUILD.gn
+++ b/src/app/clusters/boolean-state-server/tests/BUILD.gn
@@ -30,6 +30,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/app/clusters/boolean-state-server",
     "${chip_root}/src/app/clusters/testing",
+    "${chip_root}/src/app/server-cluster/testing:testing",
     "${chip_root}/src/lib/support",
   ]
 }

--- a/src/app/clusters/boolean-state-server/tests/TestBooleanStateCluster.cpp
+++ b/src/app/clusters/boolean-state-server/tests/TestBooleanStateCluster.cpp
@@ -152,6 +152,12 @@ TEST_F(TestBooleanStateCluster, StateValue)
             EXPECT_EQ(stateVal, stateValue);
             EXPECT_TRUE(eventNumber.has_value());
 
+            stateValue  = true;
+            eventNumber = booleanState.SetStateValue(stateValue);
+            stateVal    = booleanState.GetStateValue();
+            EXPECT_EQ(stateVal, stateValue);
+            EXPECT_FALSE(eventNumber.has_value());
+
             stateValue  = false;
             eventNumber = booleanState.SetStateValue(stateValue);
             stateVal    = booleanState.GetStateValue();

--- a/src/app/clusters/ota-provider/CodegenIntegration.cpp
+++ b/src/app/clusters/ota-provider/CodegenIntegration.cpp
@@ -96,7 +96,7 @@ void SetDelegate(EndpointId endpointId, OTAProviderDelegate * delegate)
 {
     IntegrationDelegate integrationDelegate;
 
-    ServerClusterInterface * interface = CodegenClusterIntegration::GetClusterForEndpointIndex(
+    ServerClusterInterface * interface = CodegenClusterIntegration::FindClusterOnEndpoint(
         {
             .endpointId                = endpointId,
             .clusterId                 = OtaSoftwareUpdateProvider::Id,

--- a/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
@@ -59,7 +59,7 @@ public:
 PushAvStreamTransportServer * FindClusterOnEndpoint(EndpointId endpointId)
 {
     IntegrationDelegate integrationDelegate;
-    return static_cast<PushAvStreamTransportServer *>(CodegenClusterIntegration::GetClusterForEndpointIndex(
+    return static_cast<PushAvStreamTransportServer *>(CodegenClusterIntegration::FindClusterOnEndpoint(
         {
             .endpointId                = endpointId,
             .clusterId                 = PushAvStreamTransport::Id,

--- a/src/data-model-providers/codegen/ClusterIntegration.cpp
+++ b/src/data-model-providers/codegen/ClusterIntegration.cpp
@@ -147,8 +147,8 @@ void CodegenClusterIntegration::UnregisterServer(const UnregisterServerOptions &
     delegate.ReleaseRegistration(clusterInstanceIndex);
 }
 
-ServerClusterInterface * CodegenClusterIntegration::GetClusterForEndpointIndex(const GetClusterForEndpointIndexOptions & options,
-                                                                               Delegate & delegate)
+ServerClusterInterface * CodegenClusterIntegration::FindClusterOnEndpoint(const FindClusterOnEndpointOptions & options,
+                                                                          Delegate & delegate)
 {
     uint16_t clusterInstanceIndex;
     if (!FindEndpointWithLog(options.endpointId, options.clusterId, options.fixedClusterInstanceCount,

--- a/src/data-model-providers/codegen/ClusterIntegration.h
+++ b/src/data-model-providers/codegen/ClusterIntegration.h
@@ -139,8 +139,8 @@ public:
                                           // indices smaller than this are valid).
     };
 
-    /// Calls 'FindRegistration' on the delegate and returns the address of the cluster for an endpoint index or nullptr if not
-    /// found.
+    /// Calls 'FindRegistration' on the delegate and returns the address of the cluster for the provided endpoint id or nullptr if
+    /// not found.
     static ServerClusterInterface * FindClusterOnEndpoint(const FindClusterOnEndpointOptions & options, Delegate & delegate);
 };
 

--- a/src/data-model-providers/codegen/ClusterIntegration.h
+++ b/src/data-model-providers/codegen/ClusterIntegration.h
@@ -129,7 +129,7 @@ public:
     /// returned to the caller as it is generally not actionable/fixable)
     static void UnregisterServer(const UnregisterServerOptions & options, Delegate & delegate);
 
-    struct GetClusterForEndpointIndexOptions
+    struct FindClusterOnEndpointOptions
     {
         EndpointId endpointId;
         ClusterId clusterId;
@@ -141,8 +141,7 @@ public:
 
     /// Calls 'FindRegistration' on the delegate and returns the address of the cluster for an endpoint index or nullptr if not
     /// found.
-    static ServerClusterInterface * GetClusterForEndpointIndex(const GetClusterForEndpointIndexOptions & options,
-                                                               Delegate & delegate);
+    static ServerClusterInterface * FindClusterOnEndpoint(const FindClusterOnEndpointOptions & options, Delegate & delegate);
 };
 
 } // namespace chip::app


### PR DESCRIPTION
#### Summary

Addressing post merge comments for boolean state cluster.

#### Testing

Tested using chip-all-clusters-app and matter-repl:

matter-repl commands:
await devCtrl.CommissionWithCode("MT:-24J0AFN00KA0648G00", 1)
await devCtrl.ReadAttribute(1, [ Clusters.BooleanState ])

matter-repl response shows the cluster is returning its attributes successfully and the attributes have the expected values.