### PR TITLE
Ensure that mDefaultCommissioner is never null on CHIPDeviceController.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -515,10 +515,7 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
     {
         mDefaultCommissioner = params.defaultCommissioner;
     }
-    else
-    {
-        mDefaultCommissioner = &mAutoCommissioner;
-    }
+    // Otherwise leave it pointing to mAutoCommissioner.
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable
     mUdcTransportMgr = chip::Platform::New<UdcTransportMgr>();
@@ -679,11 +676,6 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * se
 {
     MATTER_TRACE_SCOPE("PairDevice", "DeviceCommissioner");
 
-    if (mDefaultCommissioner == nullptr)
-    {
-        ChipLogError(Controller, "No default commissioner is specified");
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
     ReturnErrorOnFailure(mDefaultCommissioner->SetCommissioningParameters(params));
 
     return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kCommission, discoveryType,
@@ -976,11 +968,6 @@ void DeviceCommissioner::OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err
 
 CHIP_ERROR DeviceCommissioner::Commission(NodeId remoteDeviceId, CommissioningParameters & params)
 {
-    if (mDefaultCommissioner == nullptr)
-    {
-        ChipLogError(Controller, "No default commissioner is specified");
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
     ReturnErrorOnFailureWithMetric(kMetricDeviceCommissionerCommission, mDefaultCommissioner->SetCommissioningParameters(params));
     auto errorCode = Commission(remoteDeviceId);
     VerifyOrDoWithMetric(kMetricDeviceCommissionerCommission, CHIP_NO_ERROR == errorCode, errorCode);
@@ -990,12 +977,6 @@ CHIP_ERROR DeviceCommissioner::Commission(NodeId remoteDeviceId, CommissioningPa
 CHIP_ERROR DeviceCommissioner::Commission(NodeId remoteDeviceId)
 {
     MATTER_TRACE_SCOPE("Commission", "DeviceCommissioner");
-
-    if (mDefaultCommissioner == nullptr)
-    {
-        ChipLogError(Controller, "No default commissioner is specified");
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
 
     CommissioneeDeviceProxy * device = FindCommissioneeDevice(remoteDeviceId);
     if (device == nullptr || (!device->IsSecureConnected() && !device->IsSessionSetupInProgress()))
@@ -1037,12 +1018,6 @@ DeviceCommissioner::ContinueCommissioningAfterDeviceAttestation(DeviceProxy * de
                                                                 Credentials::AttestationVerificationResult attestationResult)
 {
     MATTER_TRACE_SCOPE("continueCommissioningDevice", "DeviceCommissioner");
-
-    if (mDefaultCommissioner == nullptr)
-    {
-        ChipLogError(Controller, "No default commissioner is specified");
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
 
     if (device == nullptr || device != mDeviceBeingCommissioned)
     {
@@ -1092,12 +1067,6 @@ DeviceCommissioner::ContinueCommissioningAfterDeviceAttestation(DeviceProxy * de
 CHIP_ERROR DeviceCommissioner::ContinueCommissioningAfterConnectNetworkRequest(NodeId remoteDeviceId)
 {
     MATTER_TRACE_SCOPE("continueCommissioningAfterConnectNetworkRequest", "DeviceCommissioner");
-
-    if (mDefaultCommissioner == nullptr)
-    {
-        ChipLogError(Controller, "No default commissioner is specified");
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
 
     // Move to kEvictPreviousCaseSessions stage since the next stage will be to find the device
     // on the operational network

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -828,11 +828,7 @@ public:
 
     Credentials::DeviceAttestationVerifier * GetDeviceAttestationVerifier() const { return mDeviceAttestationVerifier; }
 
-    Optional<CommissioningParameters> GetCommissioningParameters()
-    {
-        // TODO: Return a non-optional const & to avoid a copy, mDefaultCommissioner is never null
-        return mDefaultCommissioner == nullptr ? NullOptional : MakeOptional(mDefaultCommissioner->GetCommissioningParameters());
-    }
+    const CommissioningParameters & GetCommissioningParameters() { return mDefaultCommissioner->GetCommissioningParameters(); }
 
     CHIP_ERROR UpdateCommissioningParameters(const CommissioningParameters & newParameters)
     {
@@ -1151,7 +1147,7 @@ private:
     SetUpCodePairer mSetUpCodePairer;
     AutoCommissioner mAutoCommissioner;
     CommissioningDelegate * mDefaultCommissioner =
-        nullptr; // Commissioning delegate to call when PairDevice / Commission functions are used
+        &mAutoCommissioner; // Commissioning delegate to call when PairDevice / Commission functions are used
     CommissioningDelegate * mCommissioningDelegate =
         nullptr; // Commissioning delegate that issued the PerformCommissioningStep command
     CompletionStatus mCommissioningCompletionStatus;

--- a/src/controller/jcm/DeviceCommissioner.cpp
+++ b/src/controller/jcm/DeviceCommissioner.cpp
@@ -537,7 +537,7 @@ void DeviceCommissioner::CleanupCommissioning(DeviceProxy * proxy, NodeId nodeId
 
 bool DeviceCommissioner::HasValidCommissioningMode(const Dnssd::CommissionNodeData & nodeData)
 {
-    if (GetCommissioningParameters().HasValue() && GetCommissioningParameters().Value().GetUseJCM().ValueOr(false))
+    if (GetCommissioningParameters().GetUseJCM().ValueOr(false))
     {
         if (nodeData.commissioningMode != to_underlying(Dnssd::CommissioningMode::kEnabledJointFabric))
         {

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.mm
@@ -49,12 +49,11 @@ void MTRDeviceAttestationDelegateBridge::OnDeviceAttestationCompleted(chip::Cont
         attestationChallenge = [NSData data];
     }
 
-    // CommissioningParameters is always available; the DeviceCommissioner API is broken when it
-    // pretends it might not be.  And at this point in commissioning, the various attestation
-    // information received from the device is stored in those commissioning parameters; otherwise
-    // we would not have been called at all.
+    // At this point in commissioning, the various attestation information
+    // received from the device is stored in the controller's commissioning
+    // parameters; otherwise we would not have been called at all.
     chip::Controller::CommissioningParameters commissioningParameters
-        = deviceCommissioner->GetCommissioningParameters().Value();
+        = deviceCommissioner->GetCommissioningParameters();
     NSData * attestationNonce = AsData(commissioningParameters.GetAttestationNonce().Value());
     NSData * elementsTLV = AsData(commissioningParameters.GetAttestationElements().Value());
     NSData * elementsSignature = AsData(commissioningParameters.GetAttestationSignature().Value());

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.mm
@@ -52,8 +52,7 @@ void MTRDeviceAttestationDelegateBridge::OnDeviceAttestationCompleted(chip::Cont
     // At this point in commissioning, the various attestation information
     // received from the device is stored in the controller's commissioning
     // parameters; otherwise we would not have been called at all.
-    chip::Controller::CommissioningParameters commissioningParameters
-        = deviceCommissioner->GetCommissioningParameters();
+    auto & commissioningParameters = deviceCommissioner->GetCommissioningParameters();
     NSData * attestationNonce = AsData(commissioningParameters.GetAttestationNonce().Value());
     NSData * elementsTLV = AsData(commissioningParameters.GetAttestationElements().Value());
     NSData * elementsSignature = AsData(commissioningParameters.GetAttestationSignature().Value());

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -2030,16 +2030,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     }
 
     auto block = ^BOOL {
-        auto optionalParams = self->_cppCommissioner->GetCommissioningParameters();
-        if (!optionalParams.HasValue()) {
-            MTR_LOG_ERROR("%@ Has no commissioning parameters", self);
-            if (error) {
-                *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
-            }
-            return NO;
-        }
-
-        chip::Controller::CommissioningParameters params = optionalParams.Value();
+        chip::Controller::CommissioningParameters params = self->_cppCommissioner->GetCommissioningParameters();
         chip::ByteSpan ssidSpan = AsByteSpan(ssid);
         chip::ByteSpan credentialsSpan;
         if (credentials != nil) {
@@ -2072,16 +2063,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     }
 
     auto block = ^BOOL {
-        auto optionalParams = self->_cppCommissioner->GetCommissioningParameters();
-        if (!optionalParams.HasValue()) {
-            MTR_LOG_ERROR("%@ Has no commissioning parameters", self);
-            if (error) {
-                *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
-            }
-            return NO;
-        }
-
-        chip::Controller::CommissioningParameters params = optionalParams.Value();
+        chip::Controller::CommissioningParameters params = self->_cppCommissioner->GetCommissioningParameters();
         params.SetThreadOperationalDataset(AsByteSpan(operationalDataset));
 
         CHIP_ERROR err = self->_cppCommissioner->UpdateCommissioningParameters(params);


### PR DESCRIPTION
In practice we already ensured this post-init, but just do it in all cases, and remove the various extraneous null-checks.

#### Testing

No actual behavior changes; CI should check that things compile.