### PR TITLE
Update libswebsockets to 4.4 stable since main is moving oddly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -251,6 +251,7 @@
 [submodule "third_party/libwebsockets/repo"]
 	path = third_party/libwebsockets/repo
 	url = https://github.com/warmcat/libwebsockets
+	branch = v4.4-stable
 	platforms = linux,darwin,tizen
 [submodule "third_party/imgui/repo"]
 	path = third_party/imgui/repo


### PR DESCRIPTION
#### Summary

The current libwebsockets SHA is not actually in the tree anymore. Looking at libwebsockets commits, the commits in main are often unverified, so I wonder if they are pushed directly from a local repository (which may edit commits) instead of pull requests.

#### Testing

CI will validate if this version works.