### PR TITLE
Add support for requesting network credentials without a scan.

### DIFF
--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -279,6 +279,11 @@ public:
     const chip::Optional<char *> & GetStorageDirectory() const { return mStorageDirectory; }
 
 protected:
+    // Utility method to create a ByteSpan from a (mutable) character string we
+    // have, which handles the hex: and str: prefixes as needed.  Returns false
+    // on failure (e.g. invalid hex encoding).
+    static bool OctetStringFromCharString(char * argValue, chip::ByteSpan * value);
+
     // mStorageDirectory lives here so we can just set it in RunAsInteractive.
     chip::Optional<char *> mStorageDirectory;
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -568,7 +568,7 @@ CHIP_ERROR PairingCommand::WiFiCredentialsNeeded(EndpointId endpoint)
                 break;
             }
             ChipLogError(chipTool, "Invalid value for SSID");
-        } while (1);
+        } while (true);
 
         do
         {
@@ -579,7 +579,7 @@ CHIP_ERROR PairingCommand::WiFiCredentialsNeeded(EndpointId endpoint)
                 break;
             }
             ChipLogError(chipTool, "Invalid value for password");
-        } while (1);
+        } while (true);
 
         auto & commissioner            = CurrentCommissioner();
         CommissioningParameters params = commissioner.GetCommissioningParameters();
@@ -618,7 +618,7 @@ CHIP_ERROR PairingCommand::ThreadCredentialsNeeded(EndpointId endpoint)
                 break;
             }
             ChipLogError(chipTool, "Invalid value for operational dataset");
-        } while (1);
+        } while (true);
 
         auto & commissioner            = CurrentCommissioner();
         CommissioningParameters params = commissioner.GetCommissioningParameters();

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -27,6 +27,7 @@
 #include <lib/support/ThreadOperationalDataset.h>
 
 #include <optional>
+#include <thread>
 
 enum class PairingMode
 {
@@ -329,4 +330,10 @@ private:
 
     static void OnCurrentFabricRemove(void * context, NodeId remoteNodeId, CHIP_ERROR status);
     void PersistIcdInfo();
+
+    std::optional<std::thread> mPrompterThread;
+
+    std::string mPromptedSSID;
+    std::string mPromptedPassword;
+    std::string mPromptedOperationalDataset;
 };

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -115,7 +115,9 @@ public:
         case PairingMode::CodePaseOnly:
             AddArgument("payload", &mOnboardingPayload);
             AddArgument("discover-once", 0, 1, &mDiscoverOnce);
-            AddArgument("use-only-onnetwork-discovery", 0, 1, &mUseOnlyOnNetworkDiscovery);
+            AddArgument("use-only-onnetwork-discovery", 0, 1, &mUseOnlyOnNetworkDiscovery,
+                        "Whether to only use DNS-SD for discovery. The default is true if no network credentials are provided, "
+                        "false otherwise.");
             break;
         case PairingMode::Ble:
             AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
@@ -244,6 +246,8 @@ public:
     void OnICDRegistrationComplete(chip::ScopedNodeId deviceId, uint32_t icdCounter) override;
     void OnICDStayActiveComplete(chip::ScopedNodeId deviceId, uint32_t promisedActiveDuration) override;
     void OnCommissioningStageStart(chip::PeerId peerId, chip::Controller::CommissioningStage stageStarting) override;
+    CHIP_ERROR WiFiCredentialsNeeded(chip::EndpointId endpoint) override;
+    CHIP_ERROR ThreadCredentialsNeeded(chip::EndpointId endpoint) override;
 
     /////////// DeviceDiscoveryDelegate Interface /////////
     void OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData) override;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -317,9 +317,8 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStageNetworkSetup(Commi
         // IsSecondaryNetworkSupported() would have tested true.
         //
         // Also, since we got here, we don't (yet) have credentials for the one network technology
-        // the commissionee supports.  , and we do not have credentials for whatever network
-        // technologies it does support.  Go ahead and just try to use that one network technology,
-        // which shoudl be the primary network (on the root endpoint).
+        // the commissionee supports. Go ahead and just try to use that one network technology,
+        // which should be the primary network (on the root endpoint).
         //
         // Note that we don't call TryPrimaryNetwork() here, because that's only used when there
         // will be a secondary network to try.  Which in this case there isn't.
@@ -830,7 +829,7 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             // If we are configured to scan networks, then don't error out.
             // Instead, allow the app to try another network.
             //
-            // TODO: This doesn't actually work, because in order to provide crendentials someone
+            // TODO: This doesn't actually work, because in order to provide credentials someone
             // had to SetWiFiCredentials() or SetThreadOperationalDataset() on our params, so
             // IsScanNeeded() will no longer test true for that network technology.
             if (IsScanNeeded())
@@ -847,7 +846,7 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
         }
 
         auto isNetworkFailureStage = [](CommissioningStage stage) {
-            // If we were somwhere between network setup and and trying to finish up commisioning,
+            // If we were somewhere between network setup and and trying to finish up commissioning,
             // treat that as a network failure stage; trying the secondary network might work
             // better.
             if (stage >= kWiFiNetworkSetup && stage <= kICDSendStayActive)

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -273,36 +273,81 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStage(CommissioningStag
 
 CommissioningStage AutoCommissioner::GetNextCommissioningStageNetworkSetup(CommissioningStage currentStage, CHIP_ERROR & lastErr)
 {
-    if (IsSecondaryNetworkSupported())
+    if (!IsSomeNetworkSupported())
     {
-        if (TryingSecondaryNetwork())
-        {
-            // Try secondary network interface.
-            return mDeviceCommissioningInfo.network.wifi.endpoint == kRootEndpointId ? CommissioningStage::kThreadNetworkSetup
-                                                                                     : CommissioningStage::kWiFiNetworkSetup;
-        }
-        // Try primary network interface
-        return mDeviceCommissioningInfo.network.wifi.endpoint == kRootEndpointId ? CommissioningStage::kWiFiNetworkSetup
-                                                                                 : CommissioningStage::kThreadNetworkSetup;
+        ChipLogError(Controller, "Network setup is needed, but commissionee does not support any network types we know about");
+        lastErr = CHIP_ERROR_INCORRECT_STATE;
+        return CommissioningStage::kCleanup;
     }
 
-    if (mParams.GetWiFiCredentials().HasValue() && mDeviceCommissioningInfo.network.wifi.endpoint != kInvalidEndpointId)
+    enum class NetworkType
     {
-        return CommissioningStage::kWiFiNetworkSetup;
+        kWiFi,
+        kThread,
+    };
+
+    NetworkType networkToUse;
+    if (TryingSecondaryNetwork())
+    {
+        // Try secondary network interface.
+        networkToUse =
+            mDeviceCommissioningInfo.network.wifi.endpoint == kRootEndpointId ? NetworkType::kThread : NetworkType::kWiFi;
     }
-    if (mParams.GetThreadOperationalDataset().HasValue() && mDeviceCommissioningInfo.network.thread.endpoint != kInvalidEndpointId)
+    else if (IsSecondaryNetworkSupported())
     {
+        // Try primary network interface.
+        TryPrimaryNetwork();
+        networkToUse =
+            mDeviceCommissioningInfo.network.wifi.endpoint == kRootEndpointId ? NetworkType::kWiFi : NetworkType::kThread;
+    }
+    else if (mParams.GetWiFiCredentials().HasValue() && mDeviceCommissioningInfo.network.wifi.endpoint != kInvalidEndpointId)
+    {
+        networkToUse = NetworkType::kWiFi;
+    }
+    else if (mParams.GetThreadOperationalDataset().HasValue() &&
+             mDeviceCommissioningInfo.network.thread.endpoint != kInvalidEndpointId)
+    {
+        networkToUse = NetworkType::kThread;
+    }
+    else
+    {
+        // If we have ended up here, then the commissionee does not support trying two different
+        // network technologies.  If it did, then either we would have credentials for one of them
+        // and take one of those branches, or we would not have credentials for either one and
+        // IsSecondaryNetworkSupported() would have tested true.
+        //
+        // Also, since we got here, we don't (yet) have credentials for the one network technology
+        // the commissionee supports.  , and we do not have credentials for whatever network
+        // technologies it does support.  Go ahead and just try to use that one network technology,
+        // which shoudl be the primary network (on the root endpoint).
+        //
+        // Note that we don't call TryPrimaryNetwork() here, because that's only used when there
+        // will be a secondary network to try.  Which in this case there isn't.
+        networkToUse =
+            mDeviceCommissioningInfo.network.wifi.endpoint == kRootEndpointId ? NetworkType::kWiFi : NetworkType::kThread;
+    }
+
+    if (networkToUse == NetworkType::kWiFi)
+    {
+        if (mParams.GetWiFiCredentials().HasValue())
+        {
+            // Just go ahead and set that up.
+            return CommissioningStage::kWiFiNetworkSetup;
+        }
+
+        // We need credentials but don't have them.  We need to ask for those.
+        return CommissioningStage::kRequestWiFiCredentials;
+    }
+
+    // networkToUse must be kThread here.
+    if (mParams.GetThreadOperationalDataset().HasValue())
+    {
+        // Just go ahead and set that up.
         return CommissioningStage::kThreadNetworkSetup;
     }
 
-    ChipLogError(Controller, "Required network information not provided in commissioning parameters");
-    ChipLogError(Controller, "Parameters supplied: wifi (%s) thread (%s)", mParams.GetWiFiCredentials().HasValue() ? "yes" : "no",
-                 mParams.GetThreadOperationalDataset().HasValue() ? "yes" : "no");
-    ChipLogError(Controller, "Device supports: wifi (%s) thread(%s)",
-                 mDeviceCommissioningInfo.network.wifi.endpoint == kInvalidEndpointId ? "no" : "yes",
-                 mDeviceCommissioningInfo.network.thread.endpoint == kInvalidEndpointId ? "no" : "yes");
-    lastErr = CHIP_ERROR_INVALID_ARGUMENT;
-    return CommissioningStage::kCleanup;
+    // We need credentials but don't have them.  We need to ask for those.
+    return CommissioningStage::kRequestThreadCredentials;
 }
 
 CommissioningStage AutoCommissioner::GetNextCommissioningStageInternal(CommissioningStage currentStage, CHIP_ERROR & lastErr)
@@ -457,6 +502,8 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStageInternal(Commissio
             return CommissioningStage::kEvictPreviousCaseSessions;
         }
     case CommissioningStage::kScanNetworks:
+    case CommissioningStage::kRequestWiFiCredentials:
+    case CommissioningStage::kRequestThreadCredentials:
         return CommissioningStage::kNeedsNetworkCreds;
     case CommissioningStage::kNeedsNetworkCreds:
         return GetNextCommissioningStageNetworkSetup(currentStage, lastErr);
@@ -578,9 +625,11 @@ EndpointId AutoCommissioner::GetEndpoint(const CommissioningStage & stage) const
 {
     switch (stage)
     {
+    case CommissioningStage::kRequestWiFiCredentials:
     case CommissioningStage::kWiFiNetworkSetup:
     case CommissioningStage::kWiFiNetworkEnable:
         return mDeviceCommissioningInfo.network.wifi.endpoint;
+    case CommissioningStage::kRequestThreadCredentials:
     case CommissioningStage::kThreadNetworkSetup:
     case CommissioningStage::kThreadNetworkEnable:
         return mDeviceCommissioningInfo.network.thread.endpoint;
@@ -731,10 +780,7 @@ CHIP_ERROR AutoCommissioner::NOCChainGenerated(ByteSpan noc, ByteSpan icac, Byte
 
 void AutoCommissioner::CleanupCommissioning()
 {
-    if (IsSecondaryNetworkSupported() && TryingSecondaryNetwork())
-    {
-        ResetTryingSecondaryNetwork();
-    }
+    ResetNetworkAttemptType();
     mPAI.Free();
     mDAC.Free();
     mCommissioneeDeviceProxy = nullptr;
@@ -783,6 +829,10 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
 
             // If we are configured to scan networks, then don't error out.
             // Instead, allow the app to try another network.
+            //
+            // TODO: This doesn't actually work, because in order to provide crendentials someone
+            // had to SetWiFiCredentials() or SetThreadOperationalDataset() on our params, so
+            // IsScanNeeded() will no longer test true for that network technology.
             if (IsScanNeeded())
             {
                 if (completionStatus.err == CHIP_NO_ERROR)
@@ -796,9 +846,28 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             }
         }
 
-        if (err != CHIP_NO_ERROR && IsSecondaryNetworkSupported() && !TryingSecondaryNetwork() &&
-            completionStatus.failedStage.HasValue() && completionStatus.failedStage.Value() >= kWiFiNetworkSetup &&
-            completionStatus.failedStage.Value() <= kICDSendStayActive)
+        auto isNetworkFailureStage = [](CommissioningStage stage) {
+            // If we were somwhere between network setup and and trying to finish up commisioning,
+            // treat that as a network failure stage; trying the secondary network might work
+            // better.
+            if (stage >= kWiFiNetworkSetup && stage <= kICDSendStayActive)
+            {
+                return true;
+            }
+
+            // If we were trying to request credentials and failed (because our delegate does not
+            // implement that functionality, for example), treat that as a network failure stage and
+            // try the other network type.
+            if (stage == kRequestThreadCredentials || stage == kRequestWiFiCredentials || stage == kNeedsNetworkCreds)
+            {
+                return true;
+            }
+
+            return false;
+        };
+
+        if (err != CHIP_NO_ERROR && TryingPrimaryNetwork() && completionStatus.failedStage.HasValue() &&
+            isNetworkFailureStage(completionStatus.failedStage.Value()))
         {
             // Primary network failed, disable primary network interface and try secondary network interface.
             TrySecondaryNetwork();

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -88,8 +88,9 @@ private:
     CHIP_ERROR VerifyICDRegistrationInfo(const CommissioningParameters & params);
 
     // Helper function to determine whether next stage should be kWiFiNetworkSetup,
-    // kThreadNetworkSetup or kCleanup, depending whether network information has
-    // been provided that matches the thread/wifi endpoint of the target.
+    // kThreadNetworkSetup, kRequestWiFiCredentials, kRequestThreadCredentials, or
+    // kCleanup, depending on whether network information has been provided that matches
+    // the thread/wifi endpoint of the target.
     CommissioningStage GetNextCommissioningStageNetworkSetup(CommissioningStage currentStage, CHIP_ERROR & lastErr);
 
     // Helper function to determine if a scan attempt should be made given the
@@ -103,21 +104,46 @@ private:
                  mDeviceCommissioningInfo.network.thread.endpoint != kInvalidEndpointId));
     };
 
-    // Helper function to Determine whether secondary network interface is supported.
-    // Only true if information is provided for both networks, and the target has endpoint
-    // for wifi and thread.
+    // Helper function to determine whether secondary network interface is supported.
+    // Only true if the target has endpoints for both Wi-Fi and Thread, we can
+    // still talk to it after the first attempt to put it on the network, and
+    // either we have credentials for both network types or we have credentials
+    // for either network type (in which case we will prompt for the credentials).
     bool IsSecondaryNetworkSupported() const
     {
-        return ((mParams.GetSupportsConcurrentConnection().ValueOr(false) && mParams.GetWiFiCredentials().HasValue() &&
-                 mDeviceCommissioningInfo.network.wifi.endpoint != kInvalidEndpointId) &&
-                mParams.GetThreadOperationalDataset().HasValue() &&
-                mDeviceCommissioningInfo.network.thread.endpoint != kInvalidEndpointId);
+        return ((mParams.GetSupportsConcurrentConnection().ValueOr(false) &&
+                 mDeviceCommissioningInfo.network.wifi.endpoint != kInvalidEndpointId &&
+                 mDeviceCommissioningInfo.network.thread.endpoint != kInvalidEndpointId) &&
+                mParams.GetWiFiCredentials().HasValue() == mParams.GetThreadOperationalDataset().HasValue());
     }
 
-    void TrySecondaryNetwork() { mTryingSecondaryNetwork = true; }
-    bool TryingSecondaryNetwork() const { return mTryingSecondaryNetwork; }
-    void ResetTryingSecondaryNetwork() { mTryingSecondaryNetwork = false; }
-    bool mTryingSecondaryNetwork = false;
+    bool IsSomeNetworkSupported() const
+    {
+        return mDeviceCommissioningInfo.network.wifi.endpoint != kInvalidEndpointId ||
+            mDeviceCommissioningInfo.network.thread.endpoint != kInvalidEndpointId;
+    }
+
+    // TryingPrimaryNetwork() and TryingSecondaryNetwork() will only be true if
+    // we decided that a secondary network is supported by our combination of
+    // commissioner and commissionee.
+    enum class NetworkAttemptType : uint8_t
+    {
+        // We will only try one network type.
+        kSingle,
+        // We will try two network types and we are trying the primary right now.
+        kPrimary,
+        // We tried the primary and if failed and we are trying the secondary
+        // now.
+        kSecondary,
+    };
+
+    void TryPrimaryNetwork() { mTryingNetworkType = NetworkAttemptType::kPrimary; }
+    bool TryingPrimaryNetwork() const { return mTryingNetworkType == NetworkAttemptType::kPrimary; }
+    void TrySecondaryNetwork() { mTryingNetworkType = NetworkAttemptType::kSecondary; }
+    bool TryingSecondaryNetwork() const { return mTryingNetworkType == NetworkAttemptType::kSecondary; }
+    void ResetNetworkAttemptType() { mTryingNetworkType = NetworkAttemptType::kSingle; }
+
+    NetworkAttemptType mTryingNetworkType = NetworkAttemptType::kSingle;
 
     bool mStopCommissioning = false;
 

--- a/src/controller/CommissioningDelegate.cpp
+++ b/src/controller/CommissioningDelegate.cpp
@@ -148,6 +148,12 @@ const char * StageToString(CommissioningStage stage)
     case kRemoveThreadNetworkConfig:
         return "RemoveThreadNetworkConfig";
 
+    case kRequestWiFiCredentials:
+        return "RequestWiFiCredentials";
+
+    case kRequestThreadCredentials:
+        return "RequestThreadCredentials";
+
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
     case kUnpoweredPhaseComplete:
         return "UnpoweredPhaseComplete";

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -88,7 +88,9 @@ enum CommissioningStage : uint8_t
     kRemoveWiFiNetworkConfig,         ///< Remove Wi-Fi network config.
     kRemoveThreadNetworkConfig,       ///< Remove Thread network config.
     kConfigureTCAcknowledgments,      ///< Send SetTCAcknowledgements (0x30:6) command to the device
-    kCleanup,                         ///< Call delegates with status, free memory, clear timers and state/
+    kRequestWiFiCredentials,          ///< Wi-Fi credentials are needed; ask for those.
+    kRequestThreadCredentials,        ///< Thread credentials are needed; ask for those.
+    kCleanup,                         ///< Call delegates with status, free memory, clear timers and state.
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
     kUnpoweredPhaseComplete, ///< Commissioning completed until connect network for unpowered commissioning (NFC)
 #endif

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -63,19 +63,27 @@ enum CommissioningStage : uint8_t
     kConfigureTrustedTimeSource, ///< Configure a trusted time source if one is required and available (must be done after SendNOC)
     kICDGetRegistrationInfo,     ///< Waiting for the higher layer to provide ICD registration informations.
     kICDRegistration,            ///< Register for ICD management
-    kWiFiNetworkSetup,           ///< Send AddOrUpdateWiFiNetwork (0x31:2) command to the device
-    kThreadNetworkSetup,         ///< Send AddOrUpdateThreadNetwork (0x31:3) command to the device
-    kFailsafeBeforeWiFiEnable,   ///< Extend the fail-safe before doing kWiFiNetworkEnable
-    kFailsafeBeforeThreadEnable, ///< Extend the fail-safe before doing kThreadNetworkEnable
-    kWiFiNetworkEnable,          ///< Send ConnectNetwork (0x31:6) command to the device for the WiFi network
-    kThreadNetworkEnable,        ///< Send ConnectNetwork (0x31:6) command to the device for the Thread network
-    kEvictPreviousCaseSessions,  ///< Evict previous stale case sessions from a commissioned device with this node ID before
+
+    // NOTE: If any new steps are added between kWiFiNetworkSetup and kICDSendStayActive, double-check
+    // whether the logic in AutoCommissioner::CommissioningStepFinished that checks for "network
+    // failure" conditions still makes sense.
+    kWiFiNetworkSetup,             ///< Send AddOrUpdateWiFiNetwork (0x31:2) command to the device
+    kThreadNetworkSetup,           ///< Send AddOrUpdateThreadNetwork (0x31:3) command to the device
+    kFailsafeBeforeWiFiEnable,     ///< Extend the fail-safe before doing kWiFiNetworkEnable
+    kFailsafeBeforeThreadEnable,   ///< Extend the fail-safe before doing kThreadNetworkEnable
+    kWiFiNetworkEnable,            ///< Send ConnectNetwork (0x31:6) command to the device for the WiFi network
+    kThreadNetworkEnable,          ///< Send ConnectNetwork (0x31:6) command to the device for the Thread network
+    kEvictPreviousCaseSessions,    ///< Evict previous stale case sessions from a commissioned device with this node ID before
     kFindOperationalForStayActive, ///< Perform operational discovery and establish a CASE session with the device for ICD
                                    ///< StayActive command
     kFindOperationalForCommissioningComplete, ///< Perform operational discovery and establish a CASE session with the device for
                                               ///< Commissioning Complete command
     kSendComplete,                            ///< Send CommissioningComplete (0x30:4) command to the device
     kICDSendStayActive,                       ///< Send Keep Alive to ICD
+    // NOTE: If any new steps are added between kWiFiNetworkSetup and kICDSendStayActive, double-check
+    // whether the logic in AutoCommissioner::CommissioningStepFinished that checks for "network
+    // failure" conditions still makes sense.
+
     /// Send ScanNetworks (0x31:0) command to the device.
     /// ScanNetworks can happen anytime after kArmFailsafe.
     kScanNetworks,

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -188,6 +188,28 @@ public:
      * @param[in] stageStarting the stage being started.
      */
     virtual void OnCommissioningStageStart(PeerId peerId, CommissioningStage stageStarting) {}
+
+    /**
+     * @brief
+     *   Called when Wi-Fi credentials are needed.  If the call returns
+     *   CHIP_NO_ERROR, commissioning will pause until NetworkCredentialsReady()
+     *   is called on the CHIPDeviceController.  This call must happen
+     *   asynchronously, after WiFiCredentialsNeeded has returned.
+     *
+     * @param[in] endpoint the endpoint that hosts the Network Commissioning cluster the credentials are needed for.
+     */
+    virtual CHIP_ERROR WiFiCredentialsNeeded(EndpointId endpoint) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    /**
+     * @brief
+     *   Called when Thread credentials are needed.  If the call returns
+     *   CHIP_NO_ERROR, commissioning will pause until NetworkCredentialsReady()
+     *   is called on the CHIPDeviceController.  This call must happen
+     *   asynchronously, after ThreadCredentialsNeeded has returned.
+     *
+     * @param[in] endpoint the endpoint that hosts the Network Commissioning cluster the credentials are needed for.
+     */
+    virtual CHIP_ERROR ThreadCredentialsNeeded(EndpointId endpoint) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 };
 
 } // namespace Controller


### PR DESCRIPTION
Before this change, CHIPDeviceController only supported two modes of operation: providing network credentials up front to commisisoning, or doing a network scan and then asking the delegate for credentials.

This change adds a third mode: once we have determined which network technologies the commissionee supports, requesting credentials for those specific network technologies without doing a scan.  This avoid the need for commissionees to find unnecessary credentials up front while still allowing them to provide the credentials the commissionee can actually use.

#### Testing

Tested that `chip-tool pairing code` can now be used to commission a Wi-Fi commissionee, as long as `--use-only-onnetwork-discovery false` is passed to ensure that it does BLE discovery even though no network credentials have been provided.