### PR TITLE
[SILABS] Adds fixes with respect to Wi-Fi state management and fallback values

### DIFF
--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -163,6 +163,8 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
     wifiConfig.security = WFX_SEC_WPA2;
 
     ChipLogProgress(NetworkProvisioning, "Setting up connection for WiFi SSID: %s", NullTerminated(ssid, ssidLen).c_str());
+    // Resetting the retry connection state machine for a new access point connection
+    WifiInterface::GetInstance().ResetConnectionRetryInterval();
     // Configure the WFX WiFi interface.
     WifiInterface::GetInstance().SetWifiCredentials(wifiConfig);
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled));

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -557,7 +557,7 @@ void WifiInterfaceImpl::ProcessEvent(WiseconnectWifiInterface::WifiPlatformEvent
     {
     case WiseconnectWifiInterface::WifiPlatformEvent::kStationConnect:
         ChipLogDetail(DeviceLayer, "WifiPlatformEvent::kStationConnect");
-        wfx_rsi.dev_state.Set(WifiInterface::WifiState::kStationConnected);
+        wfx_rsi.dev_state.Set(WifiInterface::WifiState::kStationConnected).Clear(WifiInterface::WifiState::kStationConnecting);
         ResetConnectivityNotificationFlags();
         break;
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -322,7 +322,7 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
         }
 
 #if WIFI_ENABLE_SECURITY_WPA3_TRANSITION
-        security = SL_WIFI_WPA3;
+        security = SL_WIFI_WPA3_TRANSITION;
 #else
         security = SL_WIFI_WPA_WPA2_MIXED;
 #endif /* WIFI_ENABLE_SECURITY_WPA3_TRANSITION */

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -742,9 +742,9 @@ sl_status_t WifiInterfaceImpl::JoinCallback(sl_wifi_event_t event, char * result
         wfx_rsi.dev_state.Clear(WifiState::kStationConnecting);
         if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
         {
-            // Returning SL_STATUS_IN_PROGRESS here is intentional: if a failed event is encountered while sl_net_up is still in progress,
-            // we do not want to report a final failure yet, as the connection process may still be ongoing and the final outcome
-            // will be determined once sl_net_up completes. This prevents premature error handling by higher layers.
+            // Returning SL_STATUS_IN_PROGRESS here is intentional: if a failed event is encountered while sl_net_up is still in
+            // progress, we do not want to report a final failure yet, as the connection process may still be ongoing and the final
+            // outcome will be determined once sl_net_up completes. This prevents premature error handling by higher layers.
             return SL_STATUS_IN_PROGRESS;
         }
     }

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -557,7 +557,8 @@ void WifiInterfaceImpl::ProcessEvent(WiseconnectWifiInterface::WifiPlatformEvent
     {
     case WiseconnectWifiInterface::WifiPlatformEvent::kStationConnect:
         ChipLogDetail(DeviceLayer, "WifiPlatformEvent::kStationConnect");
-        wfx_rsi.dev_state.Set(WifiInterface::WifiState::kStationConnected).Clear(WifiInterface::WifiState::kStationConnecting);
+        wfx_rsi.dev_state.Set(WifiInterface::WifiState::kStationConnected);
+        wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnecting);
         ResetConnectivityNotificationFlags();
         break;
 
@@ -741,6 +742,9 @@ sl_status_t WifiInterfaceImpl::JoinCallback(sl_wifi_event_t event, char * result
         wfx_rsi.dev_state.Clear(WifiState::kStationConnecting);
         if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
         {
+            // Returning SL_STATUS_IN_PROGRESS here is intentional: if a failed event is encountered while sl_net_up is still in progress,
+            // we do not want to report a final failure yet, as the connection process may still be ongoing and the final outcome
+            // will be determined once sl_net_up completes. This prevents premature error handling by higher layers.
             return SL_STATUS_IN_PROGRESS;
         }
     }

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -106,6 +106,9 @@ void WifiInterface::NotifyConnection(const MacAddress & ap)
     evt.body.channel = wfx_rsi.ap_chan;
 #endif
     std::copy(ap.begin(), ap.end(), evt.body.mac);
+    // Resetting the retry connection state machine for a successful connection
+    // NOTE: This is required in case an access point gets disconnected after a successful connection.
+    ResetConnectionRetryInterval();
 
     HandleWFXSystemEvent((sl_wfx_generic_message_t *) &evt);
 }
@@ -174,6 +177,12 @@ void WifiInterface::ScheduleConnectionAttempt()
 
     ChipLogProgress(DeviceLayer, "ScheduleConnectionAttempt : Next attempt after %d Seconds", retryInterval);
     retryInterval += retryInterval;
+}
+
+void WifiInterface::ResetConnectionRetryInterval()
+{
+    ChipLogDetail(DeviceLayer, "ScheduleConnectionAttempts: Resetting state to default");
+    retryInterval = kWlanMinRetryIntervalsInSec;
 }
 
 } // namespace Silabs

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -181,7 +181,7 @@ void WifiInterface::ScheduleConnectionAttempt()
 
 void WifiInterface::ResetConnectionRetryInterval()
 {
-    ChipLogDetail(DeviceLayer, "ScheduleConnectionAttempts: Resetting state to default");
+    ChipLogDetail(DeviceLayer, "ResetConnectionRetryInterval: Resetting state to default");
     retryInterval = kWlanMinRetryIntervalsInSec;
 }
 

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -353,6 +353,11 @@ public:
         return static_cast<uint32_t>(1UL << chip::to_underlying(chip::app::Clusters::NetworkCommissioning::WiFiBandEnum::k2g4));
     }
 
+    /**
+     * @brief Function resets reconnection attempt interval back to the minimum value
+     */
+    void ResetConnectionRetryInterval();
+
 protected:
     /**
      * @brief Function notifies the PlatformManager that an IPv6 event occured on the WiFi interface.


### PR DESCRIPTION
#### Summary

This PR aims to solve few issues seen on the Silabs Wi-Fi platform:
 - The fallback value of the DUT in case of failure of the Wi-Fi scan command does not envelop lot of devices.
 - The device was not reconnecting to access point, once the device got disconnected after a successful join.
 - The device would not reset the retry timer after a successful join to access point.
 - The device gets disconnected from the access point while negotiating IP address, and does not join back.

#### Related issues

N/A

#### Testing

Tested locally using the DUT and access point and simulating the conditions by rebooting the access point.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
