### PR TITLE
Move AAI processing BEFORE SCI processing.

### DIFF
--- a/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
@@ -102,14 +102,15 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::ReadAttribute(const Data
 
     // Codegen logic specific: we accept AAI reads BEFORE server cluster interface, so that we are backwards compatible
     // in case some application installed AAI before Server Cluster Interfaces were supported
-    std::optional<CHIP_ERROR> aai_result = TryReadViaAccessInterface(
-        request, AttributeAccessInterfaceRegistry::Instance().Get(request.path.mEndpointId, request.path.mClusterId), encoder);
     const EmberAfAttributeMetadata * attributeMetadata =
         emberAfLocateAttributeMetadata(request.path.mEndpointId, request.path.mClusterId, request.path.mAttributeId);
 
     // we only allow AAI on ember-registered clusters
     if (attributeMetadata)
     {
+        std::optional<CHIP_ERROR> aai_result = TryReadViaAccessInterface(
+            request, AttributeAccessInterfaceRegistry::Instance().Get(request.path.mEndpointId, request.path.mClusterId), encoder);
+
         VerifyOrReturnError(!aai_result.has_value(), *aai_result);
 
         if (auto * cluster = mRegistry.Get(request.path); cluster != nullptr)

--- a/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
@@ -100,6 +100,12 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::ReadAttribute(const Data
                   ChipLogValueMEI(request.path.mClusterId), request.path.mEndpointId, ChipLogValueMEI(request.path.mAttributeId),
                   request.path.mExpanded);
 
+    // Codegen logic specific: we accept AAI reads BEFORE server cluster interface, so that we are backwards compatible
+    // in case some application installed AAI before Server Cluster Interfaces were supported
+    std::optional<CHIP_ERROR> aai_result = TryReadViaAccessInterface(
+        request, AttributeAccessInterfaceRegistry::Instance().Get(request.path.mEndpointId, request.path.mClusterId), encoder);
+    VerifyOrReturnError(!aai_result.has_value(), *aai_result);
+
     if (auto * cluster = mRegistry.Get(request.path); cluster != nullptr)
     {
         return cluster->ReadAttribute(request, encoder);
@@ -112,11 +118,6 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::ReadAttribute(const Data
     // metadata tree. Clients are supposed to validate this (and data version and other flags)
     // This SHOULD NEVER HAPPEN hence the general return code (seemed preferable to VerifyOrDie)
     VerifyOrReturnError(attributeMetadata != nullptr, Status::Failure);
-
-    // Read via AAI
-    std::optional<CHIP_ERROR> aai_result = TryReadViaAccessInterface(
-        request, AttributeAccessInterfaceRegistry::Instance().Get(request.path.mEndpointId, request.path.mClusterId), encoder);
-    VerifyOrReturnError(!aai_result.has_value(), *aai_result);
 
     // At this point, we have to use ember directly to read the data.
     EmberAfAttributeSearchRecord record;

--- a/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
@@ -106,7 +106,7 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::ReadAttribute(const Data
         emberAfLocateAttributeMetadata(request.path.mEndpointId, request.path.mClusterId, request.path.mAttributeId);
 
     // we only allow AAI on ember-registered clusters
-    if (attributeMetadata)
+    if (attributeMetadata != nullptr)
     {
         std::optional<CHIP_ERROR> aai_result = TryReadViaAccessInterface(
             request, AttributeAccessInterfaceRegistry::Instance().Get(request.path.mEndpointId, request.path.mClusterId), encoder);

--- a/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider_Read.cpp
@@ -110,13 +110,12 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::ReadAttribute(const Data
     {
         std::optional<CHIP_ERROR> aai_result = TryReadViaAccessInterface(
             request, AttributeAccessInterfaceRegistry::Instance().Get(request.path.mEndpointId, request.path.mClusterId), encoder);
-
         VerifyOrReturnError(!aai_result.has_value(), *aai_result);
+    }
 
-        if (auto * cluster = mRegistry.Get(request.path); cluster != nullptr)
-        {
-            return cluster->ReadAttribute(request, encoder);
-        }
+    if (auto * cluster = mRegistry.Get(request.path); cluster != nullptr)
+    {
+        return cluster->ReadAttribute(request, encoder);
     }
 
     // ReadAttribute requirement is that request.path is a VALID path inside the provider

--- a/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
@@ -100,12 +100,12 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::WriteAttribute(const Dat
 
     const EmberAfAttributeMetadata * attributeMetadata =
         emberAfLocateAttributeMetadata(request.path.mEndpointId, request.path.mClusterId, request.path.mAttributeId);
-    AttributeAccessInterface * aai =
-        AttributeAccessInterfaceRegistry::Instance().Get(request.path.mEndpointId, request.path.mClusterId);
 
     if (attributeMetadata != nullptr)
     {
         // AAI is only allowed on ember-attributes
+        AttributeAccessInterface * aai =
+            AttributeAccessInterfaceRegistry::Instance().Get(request.path.mEndpointId, request.path.mClusterId);
         std::optional<CHIP_ERROR> aai_result = TryWriteViaAccessInterface(request.path, aai, decoder);
         if (aai_result.has_value())
         {

--- a/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
@@ -112,7 +112,7 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::WriteAttribute(const Dat
         return *aai_result;
     }
 
-    // If ServerClusterInteface is available, it provides the final answer
+    // If ServerClusterInterface is available, it provides the final answer
     if (auto * cluster = mRegistry.Get(request.path); cluster != nullptr)
     {
         return cluster->WriteAttribute(request, decoder);

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -2196,12 +2196,11 @@ TEST_F(TestCodegenModelViaMocks, AttributeAccessInterfaceTakesPrecedenceOverServ
         uint32_t value = 0;
         ASSERT_EQ(ReadU32Attribute(model, kTestAttributePath, value), CHIP_IM_GLOBAL_STATUS(UnsupportedRead));
 
-        // Writes fail because AAI
+        // Writes fail because AAI.
         WriteOperation test(kTestAttributePath);
         test.SetSubjectDescriptor(kAdminSubjectDescriptor);
         AttributeValueDecoder decoder = test.DecoderFor(value);
 
-        // write should succeed
         ASSERT_FALSE(model.WriteAttribute(test.GetRequest(), decoder).IsSuccess());
     }
 

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -2216,6 +2216,9 @@ TEST_F(TestCodegenModelViaMocks, AttributeAccessInterfaceTakesPrecedenceOverServ
         // write should succeed
         ASSERT_TRUE(model.WriteAttribute(test.GetRequest(), decoder).IsSuccess());
     }
+
+    model.Registry().Unregister(&fakeClusterServer);
+    model.Shutdown();
 }
 
 TEST_F(TestCodegenModelViaMocks, EmberAttributeWriteBasicTypes)

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -621,6 +621,7 @@ const MockNodeConfig gTestNodeConfig({
             // Special case handling
             MockAttributeConfig(kAttributeIdReadOnly, ZCL_INT32S_ATTRIBUTE_TYPE, 0),
             MockAttributeConfig(kAttributeIdTimedWrite, ZCL_INT32S_ATTRIBUTE_TYPE, MATTER_ATTRIBUTE_FLAG_WRITABLE | MATTER_ATTRIBUTE_FLAG_READABLE | MATTER_ATTRIBUTE_FLAG_MUST_USE_TIMED_WRITE ),
+            MockAttributeConfig(kAttributeIdFakeAllowsWrite, ZCL_INT32U_ATTRIBUTE_TYPE, 0),
         }),
     }),
     MockEndpointConfig(kMockEndpoint4, {
@@ -2179,7 +2180,8 @@ TEST_F(TestCodegenModelViaMocks, AttributeAccessInterfaceTakesPrecedenceOverServ
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);
 
-    const ConcreteClusterPath kTestClusterPath(kMockEndpoint1, MockClusterId(2));
+    // It is important to have kTestClusterPath be valid ember paths (so we have metadata for them)
+    const ConcreteClusterPath kTestClusterPath(kMockEndpoint3, MockClusterId(4));
     const ConcreteAttributePath kTestAttributePath(kTestClusterPath.mEndpointId, kTestClusterPath.mClusterId,
                                                    kAttributeIdFakeAllowsWrite);
     FakeDefaultServerCluster fakeClusterServer(kTestClusterPath);
@@ -2218,7 +2220,6 @@ TEST_F(TestCodegenModelViaMocks, AttributeAccessInterfaceTakesPrecedenceOverServ
     }
 
     model.Registry().Unregister(&fakeClusterServer);
-    model.Shutdown();
 }
 
 TEST_F(TestCodegenModelViaMocks, EmberAttributeWriteBasicTypes)
@@ -2773,7 +2774,6 @@ TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesWrite)
     }
 
     model.Registry().Unregister(&fakeClusterServer);
-    model.Shutdown();
 }
 
 TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesRead)
@@ -2802,7 +2802,6 @@ TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesRead)
     }
 
     model.Registry().Unregister(&fakeClusterServer);
-    model.Shutdown();
 }
 
 TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesRegistration)
@@ -2889,7 +2888,6 @@ TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesRegistration)
     }
 
     model.Registry().Unregister(&fakeClusterServer);
-    model.Shutdown();
 }
 
 TEST_F(TestCodegenModelViaMocks, EventInfo)
@@ -2928,8 +2926,6 @@ TEST_F(TestCodegenModelViaMocks, EventInfo)
     // once unregistered, go back to the default
     ASSERT_EQ(model.EventInfo({ kMockEndpoint1, MockClusterId(2), kTestEventId }, entry), CHIP_NO_ERROR);
     ASSERT_EQ(entry.readPrivilege, Access::Privilege::kAdminister);
-
-    model.Shutdown();
 }
 
 TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesListClusters)


### PR DESCRIPTION
#### Summary

This allows for more backwards compatibility: AAI processing will preceed SCI, so even if SCI is installed by some `CodegenIntegration.cpp` we allow external applications that used AAI to bypass/override things.

#### Testing

Unit tests updated