### PR TITLE
[Camera]Fix TC_PAVST_2_3.py and fabric index check failure

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -153,6 +153,7 @@ ClusterStatusCode TlsClientManagementCommandDelegate::ProvisionEndpoint(
     endpointStruct.port  = provisionReq.port;
     endpointStruct.caid  = provisionReq.caid;
     endpointStruct.ccdid = provisionReq.ccdid;
+    endpointStruct.SetFabricIndex(fabric);
 
     return ClusterStatusCode(Status::Success);
 }

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -220,19 +220,27 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
 
         self.step(10)
         if self.pics_guard(self.check_pics("PAVST.S")):
-            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
-                {"streamUsage": 0,
-                 "videoStreamID": 1,
-                 "audioStreamID": 1,
-                 "endpointID": 5,
-                 "url": "https://{host_ip}:1234/streams/1",
-                 "triggerOptions": {"triggerType": 2},
-                 "ingestMethod": 0,
-                 "containerOptions": {"containerType": 0, "CMAFContainerOptions": {"chunkDuration": 4}},
-                 "expiryTime": 5
-                 }), endpoint=endpoint)
-            asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidTLSEndpoint,
-                                 "DUT must respond with Status Code InvalidTLSEndpoint.")
+            try:
+                status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
+                    {
+                        "streamUsage": 0,
+                        "videoStreamID": 1,
+                        "audioStreamID": 1,
+                        "endpointID": 5,
+                        "url": f"https://{host_ip}:1234/streams/1",
+                        "triggerOptions": {"triggerType": 2},
+                        "ingestMethod": 0,
+                        "containerOptions": {
+                            "containerType": 0,
+                            "CMAFContainerOptions": {"CMAFInterface": 0, "segmentDuration": 4000, "chunkDuration": 2000, "sessionGroup": 1, "trackName": "media"}
+                        },
+                        "expiryTime": 5
+                    }), endpoint=endpoint)
+                asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidTLSEndpoint,
+                                     "DUT must responds with Status Code InvalidTLSEndpoint.")
+            except InteractionModelError as e:
+                asserts.assert_equal(e.clusterStatus, pvcluster.Enums.StatusCodeEnum.kInvalidTLSEndpoint,
+                                     "DUT must responds with Status Code InvalidTLSEndpoint.")
 
         self.step(11)
         status = await self.allocate_one_pushav_transport(endpoint, ingestMethod=pvcluster.Enums.IngestMethodsEnum.kUnknownEnumValue,


### PR DESCRIPTION
The below error is seen when reading ProvisionedTlsEndpoints in camera-app:
```
[1758519104.447] [1115767:1115767] [DMG] Failed to read attribute: src/app/AttributeValueEncoder.h:100: CHIP Error 0x00000071: Invalid Fabric Index
[1758519104.447] [1115767:1115767] [DMG] Fail to retrieve data, roll back and encode status on clusterId: 0x0000_0802, attributeId: 0x0000_0001err = src/app/AttributeValueEncoder.h:100: CHIP Error 0x00000071: Invalid Fabric Index
```
This PR:
- Adds a fix to set fabric index when forming the TLS `endpointStruct`.
- Fix TC_PAVST_2_3.py

Fixes: https://github.com/project-chip/connectedhomeip/issues/40995

### Testing

```
. ./scripts/activate.sh
./scripts/build_python.sh -i out/python_env
source out/python_env/bin/activate
python3 -m pip install -r src/tools/push_av_server/requirements.txt
patch -d $(pip show hypercorn | grep "Location: " | sed "s/Location: //") -p0 < src/tools/push_av_server/hypercorn.patch
```

To run tests:

Launch the camera app
```
rm -rf /tmp/0-1_clip_0* && rm -rf /tmp/chip_* && ./chip-camera-app
```

Run the test case
```
python3 src/python_testing/TC_PAVST_2_3.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1 --string-arg th_server_app_path:./src/tools/push_av_server/server.py --string-arg host_ip:127.0.0.1
```

