### PR TITLE
Add persistence logic around allocated streams in Camera AVSM

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
+++ b/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
@@ -91,15 +91,6 @@ public:
                                                         const VideoResolutionStruct & resolution,
                                                         ImageSnapshot & outImageSnapshot) override;
 
-    CHIP_ERROR
-    LoadAllocatedVideoStreams(std::vector<VideoStreamStruct> & allocatedVideoStreams) override;
-
-    CHIP_ERROR
-    LoadAllocatedAudioStreams(std::vector<AudioStreamStruct> & allocatedAudioStreams) override;
-
-    CHIP_ERROR
-    LoadAllocatedSnapshotStreams(std::vector<SnapshotStreamStruct> & allocatedSnapshotStreams) override;
-
     CHIP_ERROR PersistentAttributesLoadedCallback() override;
 
     CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) override;

--- a/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
@@ -257,30 +257,6 @@ Protocols::InteractionModel::Status CameraAVStreamManager::CaptureSnapshot(const
 }
 
 CHIP_ERROR
-CameraAVStreamManager::LoadAllocatedVideoStreams(std::vector<VideoStreamStruct> & allocatedVideoStreams)
-{
-    allocatedVideoStreams.clear();
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR
-CameraAVStreamManager::LoadAllocatedAudioStreams(std::vector<AudioStreamStruct> & allocatedAudioStreams)
-{
-    allocatedAudioStreams.clear();
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR
-CameraAVStreamManager::LoadAllocatedSnapshotStreams(std::vector<SnapshotStreamStruct> & allocatedSnapshotStreams)
-{
-    allocatedSnapshotStreams.clear();
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR
 CameraAVStreamManager::PersistentAttributesLoadedCallback()
 {
     ChipLogDetail(Zcl, "Persistent attributes loaded");

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -66,8 +66,9 @@ static constexpr uint8_t kMaxZones                   = 10;  // Spec has min 1
 static constexpr uint8_t kMaxUserDefinedZones        = 10;  // Spec has min 5
 static constexpr uint8_t kSensitivityMax             = 10;  // Spec has 2 to 10
 
-// StreamIDs typically start from 0 and monotonically increase.
-static constexpr uint16_t kInvalidStreamID = 0xFFFF;
+// StreamIDs typically start from 0 and monotonically increase. Setting
+// Invalid value to a large and practically unused value.
+static constexpr uint16_t kInvalidStreamID = 65500;
 #define INVALID_SPKR_LEVEL (0)
 
 namespace Camera {

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -65,7 +65,7 @@ static constexpr uint16_t kMaxImageRotation          = 359; // Spec constraint
 static constexpr uint8_t kMaxZones                   = 10;  // Spec has min 1
 static constexpr uint8_t kMaxUserDefinedZones        = 10;  // Spec has min 5
 static constexpr uint8_t kSensitivityMax             = 10;  // Spec has 2 to 10
-
+static constexpr uint16_t kInvalidStreamID           = 65500;
 #define INVALID_SPKR_LEVEL (0)
 
 namespace Camera {

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -65,7 +65,9 @@ static constexpr uint16_t kMaxImageRotation          = 359; // Spec constraint
 static constexpr uint8_t kMaxZones                   = 10;  // Spec has min 1
 static constexpr uint8_t kMaxUserDefinedZones        = 10;  // Spec has min 5
 static constexpr uint8_t kSensitivityMax             = 10;  // Spec has 2 to 10
-static constexpr uint16_t kInvalidStreamID           = 65500;
+
+// StreamIDs typically start from 0 and monotonically increase.
+static constexpr uint16_t kInvalidStreamID = 0xFFFF;
 #define INVALID_SPKR_LEVEL (0)
 
 namespace Camera {

--- a/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
@@ -67,15 +67,6 @@ public:
                                                         ImageSnapshot & outImageSnapshot) override;
 
     CHIP_ERROR
-    LoadAllocatedVideoStreams(std::vector<VideoStreamStruct> & allocatedVideoStreams) override;
-
-    CHIP_ERROR
-    LoadAllocatedAudioStreams(std::vector<AudioStreamStruct> & allocatedAudioStreams) override;
-
-    CHIP_ERROR
-    LoadAllocatedSnapshotStreams(std::vector<SnapshotStreamStruct> & allocatedSnapshotStreams) override;
-
-    CHIP_ERROR
     ValidateStreamUsage(StreamUsageEnum streamUsage, Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
                         Optional<DataModel::Nullable<uint16_t>> & audioStreamId) override;
 
@@ -113,6 +104,12 @@ public:
     void SetCameraDeviceHAL(CameraDeviceInterface * aCameraDevice);
 
 private:
+    CHIP_ERROR AllocatedVideoStreamsLoaded();
+
+    CHIP_ERROR AllocatedAudioStreamsLoaded();
+
+    CHIP_ERROR AllocatedSnapshotStreamsLoaded();
+
     CameraDeviceInterface * mCameraDeviceHAL = nullptr;
 };
 

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -1501,7 +1501,7 @@ void CameraDevice::InitializeAudioStreams()
 void CameraDevice::InitializeSnapshotStreams()
 {
     // Create single snapshot stream with typical supported parameters
-    uint16_t streamId;
+    uint16_t streamId = kInvalidStreamID;
     AddSnapshotStream({ ImageCodecEnum::kJpeg,
                         kSnapshotStreamFrameRate /* FrameRate */,
                         { kMinResolutionWidth, kMinResolutionHeight } /* MinResolution*/,
@@ -1522,34 +1522,60 @@ bool CameraDevice::AddSnapshotStream(const CameraAVStreamMgmtDelegate::SnapshotS
     }
 
     uint16_t streamId = 0;
-    for (const auto & s : mSnapshotStreams)
+    // Fetch a new stream ID if the passed ID is kInvalidStreamID, otherwise use
+    // the ID that was passed in. A valid streamID would be passed in when the
+    // stream list is being constructed from the persisted list of allocated
+    // streams that was loaded at Init()
+    if (outStreamID == kInvalidStreamID)
     {
-        // Find the highest existing stream ID.
-        if (s.snapshotStreamParams.snapshotStreamID > streamId)
+        for (const auto & s : mSnapshotStreams)
         {
-            streamId = s.snapshotStreamParams.snapshotStreamID;
+            // Find the highest existing stream ID.
+            if (s.snapshotStreamParams.snapshotStreamID > streamId)
+            {
+                streamId = s.snapshotStreamParams.snapshotStreamID;
+            }
         }
-    }
 
-    // Find a unique stream id, starting from the last used one above, incrementing and wrapping at 65535.
-    for (uint16_t attempts = 0; attempts < kMaxSnapshotStreams; ++attempts)
+        // Find a unique stream id, starting from the last used one above, incrementing and wrapping at 65535.
+        for (uint16_t attempts = 0; attempts < kMaxSnapshotStreams; ++attempts)
+        {
+            auto found = std::find_if(mSnapshotStreams.begin(), mSnapshotStreams.end(), [streamId](const SnapshotStream & s) {
+                return s.snapshotStreamParams.snapshotStreamID == streamId;
+            });
+            if (found == mSnapshotStreams.end())
+            {
+                break;
+            }
+            if (attempts == kMaxSnapshotStreams - 1)
+            {
+                ChipLogError(Camera, "No available slot for stream allocation");
+                return false;
+            }
+            streamId = static_cast<uint16_t>((streamId + 1) % kMaxSnapshotStreams); // Wraps to 0 after max-1
+        }
+
+        outStreamID = streamId;
+    }
+    else
     {
-        auto found = std::find_if(mSnapshotStreams.begin(), mSnapshotStreams.end(), [streamId](const SnapshotStream & s) {
-            return s.snapshotStreamParams.snapshotStreamID == streamId;
+        // Have a sanity check that the passed streamID does not already exist
+        // in the list
+        auto found = std::find_if(mSnapshotStreams.begin(), mSnapshotStreams.end(), [outStreamID](const SnapshotStream & s) {
+            return s.snapshotStreamParams.snapshotStreamID == outStreamID;
         });
+
         if (found == mSnapshotStreams.end())
         {
-            break;
+            streamId = outStreamID;
         }
-        if (attempts == kMaxSnapshotStreams - 1)
+        else
         {
-            ChipLogError(Camera, "No available slot for stream allocation");
+            ChipLogError(Camera, "StreamID %d already exists in the available snapshot stream list", outStreamID);
             return false;
         }
-        streamId = static_cast<uint16_t>((streamId + 1) % kMaxSnapshotStreams); // Wraps to 0 after max-1
     }
 
-    outStreamID                   = streamId;
     SnapshotStream snapshotStream = { { streamId, snapshotStreamAllocateArgs.imageCodec, snapshotStreamAllocateArgs.maxFrameRate,
                                         snapshotStreamAllocateArgs.minResolution, snapshotStreamAllocateArgs.maxResolution,
                                         snapshotStreamAllocateArgs.quality, 0 /* RefCount */ },

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -817,7 +817,7 @@ CameraAVStreamManager::AllocatedSnapshotStreamsLoaded()
 CHIP_ERROR
 CameraAVStreamManager::PersistentAttributesLoadedCallback()
 {
-    ChipLogProgress(Camera, "Successfully loaded persistent attributes");
+    ChipLogDetail(Camera, "Successfully loaded persistent attributes");
 
     CHIP_ERROR err = AllocatedVideoStreamsLoaded();
     if (err != CHIP_NO_ERROR)

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -27,6 +27,7 @@
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
 #include <lib/core/CHIPSafeCasts.h>
+#include <lib/support/CHIPFaultInjection.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <protocols/interaction_model/StatusCode.h>
 
@@ -221,6 +222,9 @@ CHIP_ERROR CameraAVStreamMgmtServer::ReadAndEncodeSupportedStreamUsages(const At
 
 CHIP_ERROR CameraAVStreamMgmtServer::ReadAndEncodeAllocatedVideoStreams(const AttributeValueEncoder::ListEncodeHelper & encoder)
 {
+    CHIP_FAULT_INJECT(chip::FaultInjection::kFault_ClearInMemoryAllocatedVideoStreams, mAllocatedVideoStreams.clear(););
+    CHIP_FAULT_INJECT(chip::FaultInjection::kFault_LoadPersistentCameraAVSMAttributes, LoadPersistentAttributes(););
+
     for (const auto & videoStream : mAllocatedVideoStreams)
     {
         ReturnErrorOnFailure(encoder.Encode(videoStream));
@@ -231,6 +235,9 @@ CHIP_ERROR CameraAVStreamMgmtServer::ReadAndEncodeAllocatedVideoStreams(const At
 
 CHIP_ERROR CameraAVStreamMgmtServer::ReadAndEncodeAllocatedAudioStreams(const AttributeValueEncoder::ListEncodeHelper & encoder)
 {
+    CHIP_FAULT_INJECT(chip::FaultInjection::kFault_ClearInMemoryAllocatedAudioStreams, mAllocatedAudioStreams.clear(););
+    CHIP_FAULT_INJECT(chip::FaultInjection::kFault_LoadPersistentCameraAVSMAttributes, LoadPersistentAttributes(););
+
     for (const auto & audioStream : mAllocatedAudioStreams)
     {
         ReturnErrorOnFailure(encoder.Encode(audioStream));
@@ -241,6 +248,9 @@ CHIP_ERROR CameraAVStreamMgmtServer::ReadAndEncodeAllocatedAudioStreams(const At
 
 CHIP_ERROR CameraAVStreamMgmtServer::ReadAndEncodeAllocatedSnapshotStreams(const AttributeValueEncoder::ListEncodeHelper & encoder)
 {
+    CHIP_FAULT_INJECT(chip::FaultInjection::kFault_ClearInMemoryAllocatedSnapshotStreams, mAllocatedSnapshotStreams.clear(););
+    CHIP_FAULT_INJECT(chip::FaultInjection::kFault_LoadPersistentCameraAVSMAttributes, LoadPersistentAttributes(););
+
     for (const auto & snapshotStream : mAllocatedSnapshotStreams)
     {
         ReturnErrorOnFailure(encoder.Encode(snapshotStream));

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -21,6 +21,8 @@
 #include <app/CommandHandlerInterfaceRegistry.h>
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h>
+#include <app/persistence/AttributePersistenceProvider.h>
+#include <app/persistence/AttributePersistenceProviderInstance.h>
 #include <app/reporting/reporting.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
@@ -1725,7 +1727,7 @@ CHIP_ERROR CameraAVStreamMgmtServer::StoreAllocatedStreams(const std::vector<T> 
     }
 
     auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, attributeId);
-    ReturnErrorOnFailure(GetSafeAttributePersistenceProvider()->SafeWriteValue(path, ByteSpan(buffer, len)));
+    ReturnErrorOnFailure(GetAttributePersistenceProvider()->WriteValue(path, ByteSpan(buffer, len)));
 
     ChipLogProgress(Zcl, "Saved %u %s streams", static_cast<unsigned int>(streams.size()), StreamTypeToString(streamType));
     return CHIP_NO_ERROR;
@@ -1739,7 +1741,7 @@ CHIP_ERROR CameraAVStreamMgmtServer::LoadAllocatedStreams(std::vector<T> & strea
 
     auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, attributeId);
 
-    CHIP_ERROR err = GetSafeAttributePersistenceProvider()->SafeReadValue(path, span);
+    CHIP_ERROR err = GetAttributePersistenceProvider()->ReadValue(path, span);
     if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         streams.clear();

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -397,6 +397,8 @@ CHIP_ERROR CameraAVStreamMgmtServer::RemoveVideoStream(uint16_t videoStreamId)
 
 CHIP_ERROR CameraAVStreamMgmtServer::AddAudioStream(const AudioStreamStruct & audioStream)
 {
+    mAllocatedAudioStreams.push_back(audioStream);
+
     LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedAudioStreams::Id>(), Zcl,
                                "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated audio streams", mEndpointId);
 
@@ -459,6 +461,8 @@ bool CameraAVStreamMgmtServer::IsAllocatedSnapshotStreamReusable(
 
 CHIP_ERROR CameraAVStreamMgmtServer::AddSnapshotStream(const SnapshotStreamStruct & snapshotStream)
 {
+    mAllocatedSnapshotStreams.push_back(snapshotStream);
+
     LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedSnapshotStreams::Id>(), Zcl,
                                "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated snapshot streams", mEndpointId);
 

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -1566,7 +1566,6 @@ void CameraAVStreamMgmtServer::LoadPersistentAttributes()
 
 CHIP_ERROR CameraAVStreamMgmtServer::StoreViewport(const Globals::Structs::ViewportStruct::Type & viewport)
 {
-
     uint8_t buffer[kViewportStructMaxSerializedSize];
     MutableByteSpan bufferSpan(buffer);
     TLV::TLVWriter writer;
@@ -1681,8 +1680,6 @@ struct StreamTraits<Attributes::AllocatedSnapshotStreams::Id>
     static constexpr StreamType kStreamType    = StreamType::kSnapshot;
     static constexpr auto kStreamVectorMember  = &CameraAVStreamMgmtServer::mAllocatedSnapshotStreams;
 };
-
-} // namespace CameraAvStreamManagement
 
 template <AttributeId TAttributeId>
 CHIP_ERROR CameraAVStreamMgmtServer::PersistAndNotify()
@@ -2601,6 +2598,7 @@ bool CameraAVStreamMgmtServer::IsResourceAvailableForStreamAllocation(uint32_t c
     return true;
 }
 
+} // namespace CameraAvStreamManagement
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -1649,6 +1649,9 @@ CHIP_ERROR CameraAVStreamMgmtServer::LoadStreamUsagePriorities()
     return reader.VerifyEndOfContainer();
 }
 
+// Stream helper template struct containing necessary items for the
+// StoreAllocatedStreams and LoadAllocatedStream functions to work on
+// all the 3 stream types.
 template <AttributeId TAttributeId>
 struct StreamTraits;
 

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -324,14 +324,7 @@ CHIP_ERROR CameraAVStreamMgmtServer::AddVideoStream(const VideoStreamStruct & vi
 {
     mAllocatedVideoStreams.push_back(videoStream);
 
-    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedVideoStreams::Id>(), Zcl,
-                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated video streams", mEndpointId);
-
-    auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedVideoStreams::Id);
-    mDelegate.OnAttributeChanged(Attributes::AllocatedVideoStreams::Id);
-    MatterReportingAttributeChangeCallback(path);
-
-    return CHIP_NO_ERROR;
+    return PersistAndNotify<Attributes::AllocatedVideoStreams::Id>();
 }
 
 CHIP_ERROR CameraAVStreamMgmtServer::UpdateVideoStreamRangeParams(VideoStreamStruct & videoStreamToUpdate,
@@ -368,11 +361,7 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateVideoStreamRangeParams(VideoStreamStr
 
     if (wasModified)
     {
-        LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedVideoStreams::Id>(), Zcl,
-                                   "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated video streams", mEndpointId);
-        auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedVideoStreams::Id);
-        mDelegate.OnAttributeChanged(Attributes::AllocatedVideoStreams::Id);
-        MatterReportingAttributeChangeCallback(path);
+        ReturnErrorOnFailure(PersistAndNotify<Attributes::AllocatedVideoStreams::Id>());
     }
 
     return CHIP_NO_ERROR;
@@ -385,28 +374,14 @@ CHIP_ERROR CameraAVStreamMgmtServer::RemoveVideoStream(uint16_t videoStreamId)
                        [&](const VideoStreamStruct & vStream) { return vStream.videoStreamID == videoStreamId; }),
         mAllocatedVideoStreams.end());
 
-    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedVideoStreams::Id>(), Zcl,
-                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated video streams", mEndpointId);
-
-    auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedVideoStreams::Id);
-    mDelegate.OnAttributeChanged(Attributes::AllocatedVideoStreams::Id);
-    MatterReportingAttributeChangeCallback(path);
-
-    return CHIP_NO_ERROR;
+    return PersistAndNotify<Attributes::AllocatedVideoStreams::Id>();
 }
 
 CHIP_ERROR CameraAVStreamMgmtServer::AddAudioStream(const AudioStreamStruct & audioStream)
 {
     mAllocatedAudioStreams.push_back(audioStream);
 
-    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedAudioStreams::Id>(), Zcl,
-                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated audio streams", mEndpointId);
-
-    auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedAudioStreams::Id);
-    mDelegate.OnAttributeChanged(Attributes::AllocatedAudioStreams::Id);
-    MatterReportingAttributeChangeCallback(path);
-
-    return CHIP_NO_ERROR;
+    return PersistAndNotify<Attributes::AllocatedAudioStreams::Id>();
 }
 
 CHIP_ERROR CameraAVStreamMgmtServer::RemoveAudioStream(uint16_t audioStreamId)
@@ -416,14 +391,7 @@ CHIP_ERROR CameraAVStreamMgmtServer::RemoveAudioStream(uint16_t audioStreamId)
                        [&](const AudioStreamStruct & aStream) { return aStream.audioStreamID == audioStreamId; }),
         mAllocatedAudioStreams.end());
 
-    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedAudioStreams::Id>(), Zcl,
-                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated audio streams", mEndpointId);
-
-    auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedAudioStreams::Id);
-    mDelegate.OnAttributeChanged(Attributes::AllocatedAudioStreams::Id);
-    MatterReportingAttributeChangeCallback(path);
-
-    return CHIP_NO_ERROR;
+    return PersistAndNotify<Attributes::AllocatedAudioStreams::Id>();
 }
 
 bool CameraAVStreamMgmtServer::IsAllocatedSnapshotStreamReusable(
@@ -463,14 +431,7 @@ CHIP_ERROR CameraAVStreamMgmtServer::AddSnapshotStream(const SnapshotStreamStruc
 {
     mAllocatedSnapshotStreams.push_back(snapshotStream);
 
-    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedSnapshotStreams::Id>(), Zcl,
-                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated snapshot streams", mEndpointId);
-
-    auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedSnapshotStreams::Id);
-    mDelegate.OnAttributeChanged(Attributes::AllocatedSnapshotStreams::Id);
-    MatterReportingAttributeChangeCallback(path);
-
-    return CHIP_NO_ERROR;
+    return PersistAndNotify<Attributes::AllocatedSnapshotStreams::Id>();
 }
 
 CHIP_ERROR CameraAVStreamMgmtServer::UpdateSnapshotStreamRangeParams(
@@ -501,12 +462,7 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateSnapshotStreamRangeParams(
 
     if (wasModified)
     {
-        LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedSnapshotStreams::Id>(), Zcl,
-                                   "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated snapshot streams", mEndpointId);
-
-        auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedSnapshotStreams::Id);
-        mDelegate.OnAttributeChanged(Attributes::AllocatedSnapshotStreams::Id);
-        MatterReportingAttributeChangeCallback(path);
+        ReturnErrorOnFailure(PersistAndNotify<Attributes::AllocatedSnapshotStreams::Id>());
     }
 
     return CHIP_NO_ERROR;
@@ -519,14 +475,7 @@ CHIP_ERROR CameraAVStreamMgmtServer::RemoveSnapshotStream(uint16_t snapshotStrea
                        [&](const SnapshotStreamStruct & sStream) { return sStream.snapshotStreamID == snapshotStreamId; }),
         mAllocatedSnapshotStreams.end());
 
-    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedSnapshotStreams::Id>(), Zcl,
-                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated snapshot streams", mEndpointId);
-
-    auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedSnapshotStreams::Id);
-    mDelegate.OnAttributeChanged(Attributes::AllocatedSnapshotStreams::Id);
-    MatterReportingAttributeChangeCallback(path);
-
-    return CHIP_NO_ERROR;
+    return PersistAndNotify<Attributes::AllocatedSnapshotStreams::Id>();
 }
 
 CHIP_ERROR CameraAVStreamMgmtServer::UpdateVideoStreamRefCount(uint16_t videoStreamId, bool shouldIncrement)
@@ -1731,6 +1680,19 @@ struct StreamTraits<Attributes::AllocatedSnapshotStreams::Id>
 };
 
 } // namespace CameraAvStreamManagement
+
+template <AttributeId TAttributeId>
+CHIP_ERROR CameraAVStreamMgmtServer::PersistAndNotify()
+{
+    LogAndReturnErrorOnFailure(StoreAllocatedStreams<TAttributeId>(), Zcl,
+                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated streams", mEndpointId);
+
+    auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, TAttributeId);
+    mDelegate.OnAttributeChanged(TAttributeId);
+    MatterReportingAttributeChangeCallback(path);
+
+    return CHIP_NO_ERROR;
+}
 
 template <AttributeId attributeId>
 CHIP_ERROR CameraAVStreamMgmtServer::StoreAllocatedStreams()

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -324,9 +324,8 @@ CHIP_ERROR CameraAVStreamMgmtServer::AddVideoStream(const VideoStreamStruct & vi
 {
     mAllocatedVideoStreams.push_back(videoStream);
 
-    LogAndReturnErrorOnFailure((StoreAllocatedStreams<VideoStreamStruct, kMaxAllocatedVideoStreamsSerializedSize>(
-                                   mAllocatedVideoStreams, Attributes::AllocatedVideoStreams::Id, StreamType::kVideo)),
-                               Zcl, "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated video streams", mEndpointId);
+    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedVideoStreams::Id>(), Zcl,
+                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated video streams", mEndpointId);
 
     auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedVideoStreams::Id);
     mDelegate.OnAttributeChanged(Attributes::AllocatedVideoStreams::Id);
@@ -369,9 +368,8 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateVideoStreamRangeParams(VideoStreamStr
 
     if (wasModified)
     {
-        LogAndReturnErrorOnFailure((StoreAllocatedStreams<VideoStreamStruct, kMaxAllocatedVideoStreamsSerializedSize>(
-                                       mAllocatedVideoStreams, Attributes::AllocatedVideoStreams::Id, StreamType::kVideo)),
-                                   Zcl, "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated video streams", mEndpointId);
+        LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedVideoStreams::Id>(), Zcl,
+                                   "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated video streams", mEndpointId);
         auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedVideoStreams::Id);
         mDelegate.OnAttributeChanged(Attributes::AllocatedVideoStreams::Id);
         MatterReportingAttributeChangeCallback(path);
@@ -387,9 +385,8 @@ CHIP_ERROR CameraAVStreamMgmtServer::RemoveVideoStream(uint16_t videoStreamId)
                        [&](const VideoStreamStruct & vStream) { return vStream.videoStreamID == videoStreamId; }),
         mAllocatedVideoStreams.end());
 
-    LogAndReturnErrorOnFailure((StoreAllocatedStreams<VideoStreamStruct, kMaxAllocatedVideoStreamsSerializedSize>(
-                                   mAllocatedVideoStreams, Attributes::AllocatedVideoStreams::Id, StreamType::kVideo)),
-                               Zcl, "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated video streams", mEndpointId);
+    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedVideoStreams::Id>(), Zcl,
+                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated video streams", mEndpointId);
 
     auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedVideoStreams::Id);
     mDelegate.OnAttributeChanged(Attributes::AllocatedVideoStreams::Id);
@@ -400,11 +397,8 @@ CHIP_ERROR CameraAVStreamMgmtServer::RemoveVideoStream(uint16_t videoStreamId)
 
 CHIP_ERROR CameraAVStreamMgmtServer::AddAudioStream(const AudioStreamStruct & audioStream)
 {
-    mAllocatedAudioStreams.push_back(audioStream);
-
-    LogAndReturnErrorOnFailure((StoreAllocatedStreams<AudioStreamStruct, kMaxAllocatedAudioStreamsSerializedSize>(
-                                   mAllocatedAudioStreams, Attributes::AllocatedAudioStreams::Id, StreamType::kAudio)),
-                               Zcl, "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated audio streams", mEndpointId);
+    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedAudioStreams::Id>(), Zcl,
+                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated audio streams", mEndpointId);
 
     auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedAudioStreams::Id);
     mDelegate.OnAttributeChanged(Attributes::AllocatedAudioStreams::Id);
@@ -420,9 +414,8 @@ CHIP_ERROR CameraAVStreamMgmtServer::RemoveAudioStream(uint16_t audioStreamId)
                        [&](const AudioStreamStruct & aStream) { return aStream.audioStreamID == audioStreamId; }),
         mAllocatedAudioStreams.end());
 
-    LogAndReturnErrorOnFailure((StoreAllocatedStreams<AudioStreamStruct, kMaxAllocatedAudioStreamsSerializedSize>(
-                                   mAllocatedAudioStreams, Attributes::AllocatedAudioStreams::Id, StreamType::kAudio)),
-                               Zcl, "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated audio streams", mEndpointId);
+    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedAudioStreams::Id>(), Zcl,
+                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated audio streams", mEndpointId);
 
     auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedAudioStreams::Id);
     mDelegate.OnAttributeChanged(Attributes::AllocatedAudioStreams::Id);
@@ -466,11 +459,8 @@ bool CameraAVStreamMgmtServer::IsAllocatedSnapshotStreamReusable(
 
 CHIP_ERROR CameraAVStreamMgmtServer::AddSnapshotStream(const SnapshotStreamStruct & snapshotStream)
 {
-    mAllocatedSnapshotStreams.push_back(snapshotStream);
-
-    LogAndReturnErrorOnFailure((StoreAllocatedStreams<SnapshotStreamStruct, kMaxAllocatedSnapshotStreamsSerializedSize>(
-                                   mAllocatedSnapshotStreams, Attributes::AllocatedSnapshotStreams::Id, StreamType::kSnapshot)),
-                               Zcl, "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated snapshot streams", mEndpointId);
+    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedSnapshotStreams::Id>(), Zcl,
+                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated snapshot streams", mEndpointId);
 
     auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedSnapshotStreams::Id);
     mDelegate.OnAttributeChanged(Attributes::AllocatedSnapshotStreams::Id);
@@ -507,9 +497,8 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateSnapshotStreamRangeParams(
 
     if (wasModified)
     {
-        LogAndReturnErrorOnFailure((StoreAllocatedStreams<SnapshotStreamStruct, kMaxAllocatedSnapshotStreamsSerializedSize>(
-                                       mAllocatedSnapshotStreams, Attributes::AllocatedSnapshotStreams::Id, StreamType::kSnapshot)),
-                                   Zcl, "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated snapshot streams", mEndpointId);
+        LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedSnapshotStreams::Id>(), Zcl,
+                                   "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated snapshot streams", mEndpointId);
 
         auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedSnapshotStreams::Id);
         mDelegate.OnAttributeChanged(Attributes::AllocatedSnapshotStreams::Id);
@@ -526,9 +515,8 @@ CHIP_ERROR CameraAVStreamMgmtServer::RemoveSnapshotStream(uint16_t snapshotStrea
                        [&](const SnapshotStreamStruct & sStream) { return sStream.snapshotStreamID == snapshotStreamId; }),
         mAllocatedSnapshotStreams.end());
 
-    LogAndReturnErrorOnFailure((StoreAllocatedStreams<SnapshotStreamStruct, kMaxAllocatedSnapshotStreamsSerializedSize>(
-                                   mAllocatedSnapshotStreams, Attributes::AllocatedSnapshotStreams::Id, StreamType::kSnapshot)),
-                               Zcl, "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated snapshot streams", mEndpointId);
+    LogAndReturnErrorOnFailure(StoreAllocatedStreams<Attributes::AllocatedSnapshotStreams::Id>(), Zcl,
+                               "CameraAVStreamMgmt[ep=%d]: Failed to persist allocated snapshot streams", mEndpointId);
 
     auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedSnapshotStreams::Id);
     mDelegate.OnAttributeChanged(Attributes::AllocatedSnapshotStreams::Id);
@@ -1323,23 +1311,20 @@ void CameraAVStreamMgmtServer::LoadPersistentAttributes()
     }
 
     // Load AllocatedVideoStreams
-    err = LoadAllocatedStreams<VideoStreamStruct, kMaxAllocatedVideoStreamsSerializedSize>(
-        mAllocatedVideoStreams, Attributes::AllocatedVideoStreams::Id, StreamType::kVideo);
+    err = LoadAllocatedStreams<Attributes::AllocatedVideoStreams::Id>();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogDetail(Zcl, "CameraAVStreamMgmt[ep=%d]: Unable to load allocated video streams from the KVS.", mEndpointId);
     }
     // Load AllocatedAudioStreams
-    err = LoadAllocatedStreams<AudioStreamStruct, kMaxAllocatedAudioStreamsSerializedSize>(
-        mAllocatedAudioStreams, Attributes::AllocatedAudioStreams::Id, StreamType::kAudio);
+    err = LoadAllocatedStreams<Attributes::AllocatedAudioStreams::Id>();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogDetail(Zcl, "CameraAVStreamMgmt[ep=%d]: Unable to load allocated audio streams from the KVS.", mEndpointId);
     }
 
     // Load AllocatedSnapshotStreams
-    err = LoadAllocatedStreams<SnapshotStreamStruct, kMaxAllocatedSnapshotStreamsSerializedSize>(
-        mAllocatedSnapshotStreams, Attributes::AllocatedSnapshotStreams::Id, StreamType::kSnapshot);
+    err = LoadAllocatedStreams<Attributes::AllocatedSnapshotStreams::Id>();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogDetail(Zcl, "CameraAVStreamMgmt[ep=%d]: Unable to load allocated snapshot streams from the KVS.", mEndpointId);
@@ -1711,57 +1696,89 @@ CHIP_ERROR CameraAVStreamMgmtServer::LoadStreamUsagePriorities()
     return reader.VerifyEndOfContainer();
 }
 
-template <typename T, size_t N>
-CHIP_ERROR CameraAVStreamMgmtServer::StoreAllocatedStreams(const std::vector<T> & streams, AttributeId attributeId,
-                                                           StreamType streamType)
+template <AttributeId TAttributeId>
+struct StreamTraits;
+
+template <>
+struct StreamTraits<Attributes::AllocatedVideoStreams::Id>
 {
-    uint8_t buffer[N];
-    chip::TLV::TLVWriter writer;
-    writer.Init(buffer, sizeof(buffer));
+    using StreamStructType                     = VideoStreamStruct;
+    static constexpr size_t kMaxSerializedSize = kMaxAllocatedVideoStreamsSerializedSize;
+    static constexpr StreamType kStreamType    = StreamType::kVideo;
+    static constexpr auto kStreamVectorMember  = &CameraAVStreamMgmtServer::mAllocatedVideoStreams;
+};
+
+template <>
+struct StreamTraits<Attributes::AllocatedAudioStreams::Id>
+{
+    using StreamStructType                     = AudioStreamStruct;
+    static constexpr size_t kMaxSerializedSize = kMaxAllocatedAudioStreamsSerializedSize;
+    static constexpr StreamType kStreamType    = StreamType::kAudio;
+    static constexpr auto kStreamVectorMember  = &CameraAVStreamMgmtServer::mAllocatedAudioStreams;
+};
+
+template <>
+struct StreamTraits<Attributes::AllocatedSnapshotStreams::Id>
+{
+    using StreamStructType                     = SnapshotStreamStruct;
+    static constexpr size_t kMaxSerializedSize = kMaxAllocatedSnapshotStreamsSerializedSize;
+    static constexpr StreamType kStreamType    = StreamType::kSnapshot;
+    static constexpr auto kStreamVectorMember  = &CameraAVStreamMgmtServer::mAllocatedSnapshotStreams;
+};
+
+} // namespace CameraAvStreamManagement
+
+template <AttributeId attributeId>
+CHIP_ERROR CameraAVStreamMgmtServer::StoreAllocatedStreams()
+{
+    using Traits = StreamTraits<attributeId>;
+
+    uint8_t buffer[Traits::kMaxSerializedSize];
+    TLV::TLVWriter writer;
+    writer.Init(buffer);
 
     TLV::TLVType arrayType;
     ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, arrayType));
 
+    const auto & streams = (*this).*Traits::kStreamVectorMember;
     for (const auto & stream : streams)
     {
-        ReturnErrorOnFailure(DataModel::Encode(writer, chip::TLV::AnonymousTag(), stream));
+        ReturnErrorOnFailure(DataModel::Encode(writer, TLV::AnonymousTag(), stream));
     }
 
     ReturnErrorOnFailure(writer.EndContainer(arrayType));
 
     size_t len = writer.GetLengthWritten();
-    if (len == 0 && !streams.empty())
-    {
-        ChipLogError(Zcl, "TLV encoding produced 0 length for non-empty %s streams", StreamTypeToString(streamType));
-        return CHIP_ERROR_INTERNAL;
-    }
 
     auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, attributeId);
     ReturnErrorOnFailure(GetAttributePersistenceProvider()->WriteValue(path, ByteSpan(buffer, len)));
 
-    ChipLogProgress(Zcl, "Saved %u %s streams", static_cast<unsigned int>(streams.size()), StreamTypeToString(streamType));
+    ChipLogProgress(Zcl, "Saved %u %s streams", static_cast<unsigned int>(streams.size()), StreamTypeToString(Traits::kStreamType));
     return CHIP_NO_ERROR;
 }
 
-template <typename T, size_t N>
-CHIP_ERROR CameraAVStreamMgmtServer::LoadAllocatedStreams(std::vector<T> & streams, AttributeId attributeId, StreamType streamType)
+template <AttributeId attributeId>
+CHIP_ERROR CameraAVStreamMgmtServer::LoadAllocatedStreams()
 {
-    uint8_t buffer[N];
+    using Traits = StreamTraits<attributeId>;
+
+    uint8_t buffer[Traits::kMaxSerializedSize];
     MutableByteSpan span(buffer);
 
-    auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, attributeId);
+    auto path      = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, attributeId);
+    auto & streams = (*this).*Traits::kStreamVectorMember;
 
     CHIP_ERROR err = GetAttributePersistenceProvider()->ReadValue(path, span);
     if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         streams.clear();
-        ChipLogProgress(Zcl, "No persisted %s streams found.", StreamTypeToString(streamType));
+        ChipLogProgress(Zcl, "No persisted %s streams found.", StreamTypeToString(Traits::kStreamType));
         return CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(err);
 
-    chip::TLV::TLVReader reader;
-    reader.Init(span.data(), span.size());
+    TLV::TLVReader reader;
+    reader.Init(span);
 
     ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Array, TLV::AnonymousTag()));
     TLV::TLVType arrayType;
@@ -1770,7 +1787,7 @@ CHIP_ERROR CameraAVStreamMgmtServer::LoadAllocatedStreams(std::vector<T> & strea
     streams.clear();
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
-        T stream;
+        typename Traits::StreamStructType stream;
         ReturnErrorOnFailure(DataModel::Decode(reader, stream));
         streams.push_back(stream);
     }
@@ -1779,7 +1796,8 @@ CHIP_ERROR CameraAVStreamMgmtServer::LoadAllocatedStreams(std::vector<T> & strea
 
     ReturnErrorOnFailure(reader.ExitContainer(arrayType));
 
-    ChipLogProgress(Zcl, "Loaded %u %s streams", static_cast<unsigned int>(streams.size()), StreamTypeToString(streamType));
+    ChipLogProgress(Zcl, "Loaded %u %s streams", static_cast<unsigned int>(streams.size()),
+                    StreamTypeToString(Traits::kStreamType));
 
     return reader.VerifyEndOfContainer();
 }
@@ -2614,7 +2632,6 @@ bool CameraAVStreamMgmtServer::IsResourceAvailableForStreamAllocation(uint32_t c
     return true;
 }
 
-} // namespace CameraAvStreamManagement
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
@@ -90,7 +90,7 @@ constexpr size_t kMaxOneVideoStreamStructSerializedSize =
                                 sizeof(uint8_t)                          // referenceCount
     );
 constexpr size_t kMaxAllocatedVideoStreamsSerializedSize =
-    3 + (CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS * kMaxOneVideoStreamStructSerializedSize);
+    kArrayTlvOverhead + (CHIP_CONFIG_MAX_NUM_CAMERA_VIDEO_STREAMS * kMaxOneVideoStreamStructSerializedSize);
 
 // Calculate SnapshotStreamStruct TLV encoding size
 constexpr size_t kMaxOneSnapshotStructSerializedSize =
@@ -108,7 +108,7 @@ constexpr size_t kMaxOneSnapshotStructSerializedSize =
     );
 // Max size for the TLV-encoded array of SnapshotStreamStruct
 constexpr size_t kMaxAllocatedSnapshotStreamsSerializedSize =
-    3 + (CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS * kMaxOneSnapshotStructSerializedSize);
+    kArrayTlvOverhead + (CHIP_CONFIG_MAX_NUM_CAMERA_SNAPSHOT_STREAMS * kMaxOneSnapshotStructSerializedSize);
 
 // Calculate AudioStreamStruct TLV encoding size
 constexpr size_t kMaxOneAudioStreamStructSerializedSize =
@@ -123,7 +123,7 @@ constexpr size_t kMaxOneAudioStreamStructSerializedSize =
     );
 // Max size for the TLV-encoded array of AudioStreamStruct
 constexpr size_t kMaxAllocatedAudioStreamsSerializedSize =
-    3 + (CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS * kMaxOneAudioStreamStructSerializedSize);
+    kArrayTlvOverhead + (CHIP_CONFIG_MAX_NUM_CAMERA_AUDIO_STREAMS * kMaxOneAudioStreamStructSerializedSize);
 
 enum class StreamAllocationAction
 {

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
@@ -70,76 +70,57 @@ constexpr size_t kArrayTlvOverhead = 2;
 
 constexpr size_t kStreamUsagePrioritiesTlvSize = kArrayTlvOverhead + kStreamUsageTlvSize * kNumOfStreamUsageTypes;
 
+// Calculate VideoResolutionStruct TLV encoding size
+constexpr size_t kVideoResolutionStructMaxSerializedSize = TLV::EstimateStructOverhead(sizeof(uint16_t), sizeof(uint16_t));
+
 // Calculate VideoStreamStruct TLV encoding size
-
-// videoStreamID: Tag 0, uint16 -> 1 + 2 = 3
-// streamUsage: Tag 1, enum (uint8) -> 1 + 1 = 2
-// videoCodec: Tag 2, enum (uint8) -> 1 + 1 = 2
-// minFrameRate: Tag 3, uint16 -> 1 + 2 = 3
-// maxFrameRate: Tag 4, uint16 -> 1 + 2 = 3
-// minResolution: Tag 5, Struct -> 1 (tag) + 1 (start) + (1+2) + (1+2) + 1 (end) = 9
-// maxResolution: Tag 6, Struct -> 1 (tag) + 1 (start) + (1+2) + (1+2) + 1 (end) = 9
-// minBitRate: Tag 7, uint32 -> 1 + 4 = 5
-// maxBitRate: Tag 8, uint32 -> 1 + 4 = 5
-// keyFrameInterval: Tag 9, uint16 -> 1 + 2 = 3
-// watermarkEnabled: Tag 10, Optional<bool> -> 1 + 1 = 2 (max)
-// OSDEnabled: Tag 11, Optional<bool> -> 1 + 1 = 2 (max)
-// referenceCount: Tag 12, uint8 -> 1 + 1 = 2
-// Total per `VideoStreamStruct`: 1 (start container) + 50 + 1 (end container) = 52 bytes
-//
-// TLV Overhead for the Vector:
-// 1 (tag for Array) + 1 (start container)
-// N * (52 bytes per struct + 1 byte for AnonymousTag per element)
-// 1 (end container)
-// kMaxAllocatedVideoStreamsSerializedSize = 3 + (CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS * (52 + 1))
-
-constexpr size_t kMaxOneVideoStreamStructSerializedSize = 64; // Conservative estimate
+constexpr size_t kMaxOneVideoStreamStructSerializedSize =
+    TLV::EstimateStructOverhead(sizeof(uint16_t),                        // videoStreamID
+                                sizeof(Globals::StreamUsageEnum),        // streamUsage
+                                sizeof(VideoCodecEnum),                  // videoCodec
+                                sizeof(uint16_t),                        // minFrameRate
+                                sizeof(uint16_t),                        // maxFrameRate
+                                kVideoResolutionStructMaxSerializedSize, // minResolution
+                                kVideoResolutionStructMaxSerializedSize, // maxResolution
+                                sizeof(uint32_t),                        // minBitRate
+                                sizeof(uint32_t),                        // maxBitRate
+                                sizeof(uint16_t),                        // keyFrameInterval
+                                sizeof(bool),                            // watermarkEnabled (Optional<bool>)
+                                sizeof(bool),                            // OSDEnabled (Optional<bool>)
+                                sizeof(uint8_t)                          // referenceCount
+    );
 constexpr size_t kMaxAllocatedVideoStreamsSerializedSize =
     3 + (CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS * kMaxOneVideoStreamStructSerializedSize);
 
-// kSnapshotStreamID (Tag 0): uint16_t -> 1 + 2 = 3
-// kImageCodec (Tag 1): enum (uint8_t) -> 1 + 1 = 2
-// kFrameRate (Tag 2): uint16_t -> 1 + 2 = 3
-// kMinResolution (Tag 3): VideoResolutionStruct -> 1 + 8 = 9
-// kMaxResolution (Tag 4): VideoResolutionStruct -> 1 + 8 = 9
-// kQuality (Tag 5): uint8_t -> 1 + 1 = 2
-// kReferenceCount (Tag 6): uint8_t -> 1 + 1 = 2
-// kEncodedPixels (Tag 7): bool -> 1 + 1 = 2
-// kHardwareEncoder (Tag 8): bool -> 1 + 1 = 2
-// kWatermarkEnabled (Tag 9): Optional<bool> -> 1 + 1 = 2 (max)
-// kOSDEnabled (Tag 10): Optional<bool> -> 1 + 1 = 2 (max)
-
-// Total per `SnapshotStreamStruct`: 1 (start container) + 38 + 1 (end container) = 40 bytes
-
-// TLV Overhead for the Vector:
-// 1 (tag for Array) + 1 (start container)
-// N * (40 bytes per struct + 1 byte for AnonymousTag per element)
-// 1 (end container)
-// kMaxAllocatedSnapshotStreamsSerializedSize = 3 + (CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS * (40 + 1))
-
-constexpr size_t kMaxOneSnapshotStructSerializedSize = 48; // Conservative estimate
+// Calculate SnapshotStreamStruct TLV encoding size
+constexpr size_t kMaxOneSnapshotStructSerializedSize =
+    TLV::EstimateStructOverhead(sizeof(uint16_t),                        // snapshotStreamID
+                                sizeof(ImageCodecEnum),                  // imageCodec
+                                sizeof(uint16_t),                        // frameRate
+                                kVideoResolutionStructMaxSerializedSize, // minResolution
+                                kVideoResolutionStructMaxSerializedSize, // maxResolution
+                                sizeof(uint8_t),                         // quality
+                                sizeof(uint8_t),                         // referenceCount
+                                sizeof(bool),                            // encodedPixels
+                                sizeof(bool),                            // hardwareEncoder
+                                sizeof(bool),                            // watermarkEnabled (Optional<bool>)
+                                sizeof(bool)                             // OSDEnabled (Optional<bool>)
+    );
 // Max size for the TLV-encoded array of SnapshotStreamStruct
 constexpr size_t kMaxAllocatedSnapshotStreamsSerializedSize =
     3 + (CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS * kMaxOneSnapshotStructSerializedSize);
 
-// kAudioStreamID (Tag 0): uint16_t -> 1 + 2 = 3
-// kStreamUsage (Tag 1): enum (uint8_t) -> 1 + 1 = 2
-// kAudioCodec (Tag 2): enum (uint8_t) -> 1 + 1 = 2
-// kChannelCount (Tag 3): uint8_t -> 1 + 1 = 2
-// kSampleRate (Tag 4): uint32_t -> 1 + 4 = 5
-// kBitRate (Tag 5): uint32_t -> 1 + 4 = 5
-// kBitDepth (Tag 6): uint8_t -> 1 + 1 = 2
-// kReferenceCount (Tag 7): uint8_t -> 1 + 1 = 2
-
-// Total per `AudioStreamStruct`: 1 (start container) + 23 + 1 (end container) = 25 bytes
-
-// TLV Overhead for the Vector:
-// 1 (tag for Array) + 1 (start container)
-// N * (40 bytes per struct + 1 byte for AnonymousTag per element)
-// 1 (end container)
-// kMaxAllocatedAudioStreamsSerializedSize = 3 + (CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS * (25 + 1))
-
-constexpr size_t kMaxOneAudioStreamStructSerializedSize = 32; // Conservative estimate
+// Calculate AudioStreamStruct TLV encoding size
+constexpr size_t kMaxOneAudioStreamStructSerializedSize =
+    TLV::EstimateStructOverhead(sizeof(uint16_t),                 // audioStreamID
+                                sizeof(Globals::StreamUsageEnum), // streamUsage
+                                sizeof(AudioCodecEnum),           // audioCodec
+                                sizeof(uint8_t),                  // channelCount
+                                sizeof(uint32_t),                 // sampleRate
+                                sizeof(uint32_t),                 // bitRate
+                                sizeof(uint8_t),                  // bitDepth
+                                sizeof(uint8_t)                   // referenceCount
+    );
 // Max size for the TLV-encoded array of AudioStreamStruct
 constexpr size_t kMaxAllocatedAudioStreamsSerializedSize =
     3 + (CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS * kMaxOneAudioStreamStructSerializedSize);

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
@@ -652,6 +652,9 @@ public:
 
 private:
     template <AttributeId TAttributeId>
+    CHIP_ERROR PersistAndNotify();
+
+    template <AttributeId TAttributeId>
     friend struct StreamTraits;
 
     CameraAVStreamMgmtDelegate & mDelegate;

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
@@ -654,6 +654,8 @@ private:
     template <AttributeId TAttributeId>
     CHIP_ERROR PersistAndNotify();
 
+    // Declared friend so that it can access the private stream vector members
+    // from CameraAVStreamMgmtServer.
     template <AttributeId TAttributeId>
     friend struct StreamTraits;
 

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
@@ -158,6 +158,10 @@ enum class StreamType
     kSnapshot
 };
 
+// Forward declaration for the StreamTraits helper struct.
+template <AttributeId TAttributeId>
+struct StreamTraits;
+
 class CameraAVStreamMgmtServer;
 
 // ImageSnapshot response data for a CaptureSnapshot command.
@@ -666,6 +670,9 @@ public:
     bool IsResourceAvailableForStreamAllocation(uint32_t candidateEncodedPixelRate, bool encoderRequired);
 
 private:
+    template <AttributeId TAttributeId>
+    friend struct StreamTraits;
+
     CameraAVStreamMgmtDelegate & mDelegate;
     EndpointId mEndpointId;
     const BitFlags<Feature> mFeatures;
@@ -846,11 +853,18 @@ private:
     CHIP_ERROR StoreStreamUsagePriorities();
     CHIP_ERROR LoadStreamUsagePriorities();
 
-    template <typename T, size_t N>
-    CHIP_ERROR StoreAllocatedStreams(const std::vector<T> & streams, AttributeId attributeId, StreamType streamType);
+    template <AttributeId attributeId>
+    CHIP_ERROR StoreAllocatedStreams();
 
-    template <typename T, size_t N>
-    CHIP_ERROR LoadAllocatedStreams(std::vector<T> & streams, AttributeId attributeId, StreamType streamType);
+    /**
+     * @brief
+     *  A templatized function that loads the allocated streams of a certain type from persistent storage.
+     *
+     * @tparam attributeId The attribute Id of the allocated stream list.
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, otherwise another CHIP_ERROR.
+     */
+    template <AttributeId attributeId>
+    CHIP_ERROR LoadAllocatedStreams();
 
     void ModifyVideoStream(const uint16_t streamID, const Optional<bool> waterMarkEnabled, const Optional<bool> osdEnabled);
 

--- a/src/controller/python/matter/fault_injection/__init__.py
+++ b/src/controller/python/matter/fault_injection/__init__.py
@@ -51,7 +51,10 @@ class CHIPFaultId(IntEnum):
     CASECorruptSigma2Signature = 31
     ModifyWebRTCICECandidatesSessionId = 32
     EmptyWebRTCICECandidatesList = 33
-
+    ClearInMemoryAllocatedVideoStreams = 34
+    ClearInMemoryAllocatedAudioStreams = 35
+    ClearInMemoryAllocatedSnapshotStreams = 36
+    LoadPersistedAllocatedVideoStreams = 37
 
 # END-IF-CHANGE-ALSO-CHANGE(/src/lib/support/CHIPFaultInjection.h)
 # IMPORTANT: CHIPFaultId enum above must be kept in sync with the 'Id' enum in src/lib/support/CHIPFaultInjection.h

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2002,6 +2002,16 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #ifndef CHIP_CONFIG_TLS_MAX_ROOT_PER_FABRIC_CERTS_TABLE_SIZE
 #define CHIP_CONFIG_TLS_MAX_ROOT_PER_FABRIC_CERTS_TABLE_SIZE 5
 #endif // CHIP_CONFIG_TLS_MAX_ROOT_PER_FABRIC_CERTS_TABLE_SIZE
+
+/**
+ * @def CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS
+ *
+ * @brief The maximum number of camera streams for each
+ *        type(Audio/Video/Snapshot) per device
+ */
+#ifndef CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS
+#define CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS 8
+#endif // CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS
 /**
  * @}
  */

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2004,14 +2004,31 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif // CHIP_CONFIG_TLS_MAX_ROOT_PER_FABRIC_CERTS_TABLE_SIZE
 
 /**
- * @def CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS
+ * @def CHIP_CONFIG_MAX_NUM_CAMERA_VIDEO_STREAMS
  *
- * @brief The maximum number of camera streams for each
- *        type(Audio/Video/Snapshot) per device
+ * @brief The maximum number of video streams per device
  */
-#ifndef CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS
-#define CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS 8
-#endif // CHIP_CONFIG_MAX_NUM_CAMERA_STREAMS
+#ifndef CHIP_CONFIG_MAX_NUM_CAMERA_VIDEO_STREAMS
+#define CHIP_CONFIG_MAX_NUM_CAMERA_VIDEO_STREAMS 8
+#endif // CHIP_CONFIG_MAX_NUM_CAMERA_VIDEO_STREAMS
+
+/**
+ * @def CHIP_CONFIG_MAX_NUM_CAMERA_AUDIO_STREAMS
+ *
+ * @brief The maximum number of audio streams per device
+ */
+#ifndef CHIP_CONFIG_MAX_NUM_CAMERA_AUDIO_STREAMS
+#define CHIP_CONFIG_MAX_NUM_CAMERA_AUDIO_STREAMS 8
+#endif // CHIP_CONFIG_MAX_NUM_CAMERA_AUDIO_STREAMS
+
+/**
+ * @def CHIP_CONFIG_MAX_NUM_CAMERA_SNAPSHOT_STREAMS
+ *
+ * @brief The maximum number of snapshot streams per device
+ */
+#ifndef CHIP_CONFIG_MAX_NUM_CAMERA_SNAPSHOT_STREAMS
+#define CHIP_CONFIG_MAX_NUM_CAMERA_SNAPSHOT_STREAMS 8
+#endif // CHIP_CONFIG_MAX_NUM_CAMERA_SNAPSHOT_STREAMS
 /**
  * @}
  */

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -80,7 +80,11 @@ namespace FaultInjection {
     X(CASECorruptSigma2ICAC, 30)                         /**< Send Sigma2 with invalid responderICAC */                            \
     X(CASECorruptSigma2Signature, 31)                    /**< Send Sigma2 with invalid signature */                                \
     X(ModifyWebRTCICECandidatesSessionId, 32)            /**< Modify session ID in outgoing WebRTC ICECandidates command */        \
-    X(EmptyWebRTCICECandidatesList, 33)                  /**< Empty Candidates List in outgoing WebRTC ICECandidates command */
+    X(EmptyWebRTCICECandidatesList, 33)                  /**< Empty Candidates List in outgoing WebRTC ICECandidates command */    \
+    X(ClearInMemoryAllocatedVideoStreams, 34)            /**< Empty in-memory allocated video streams during attribute read */     \
+    X(ClearInMemoryAllocatedAudioStreams, 35)            /**< Empty in-memory allocated audio streams during attribute read */     \
+    X(ClearInMemoryAllocatedSnapshotStreams, 36)         /**< Empty in-memory allocated snapshot streams during attribute read */  \
+    X(LoadPersistentCameraAVSMAttributes, 37)            /**< Load persisted Camera AVSM attributes during attribute read */
 
 // END-IF-CHANGE-ALSO-CHANGE(src/controller/python/matter/fault_injection/__init__.py)
 // WARNING: When adding/modifying Faults to the below macro, make sure the changes are duplicated to the CHIPFaultId enum in the
@@ -120,6 +124,14 @@ static_assert(kFault_ModifyWebRTCICECandidatesSessionId == 32,
               "Test plan specification and automation code relies on this value being 32");
 static_assert(kFault_EmptyWebRTCICECandidatesList == 33,
               "Test plan specification and automation code relies on this value being 33");
+static_assert(kFault_ClearInMemoryAllocatedVideoStreams == 34,
+              "Test plan specification and automation code relies on this value being 34");
+static_assert(kFault_ClearInMemoryAllocatedAudioStreams == 35,
+              "Test plan specification and automation code relies on this value being 35");
+static_assert(kFault_ClearInMemoryAllocatedSnapshotStreams == 36,
+              "Test plan specification and automation code relies on this value being 36");
+static_assert(kFault_LoadPersistentCameraAVSMAttributes == 37,
+              "Test plan specification and automation code relies on this value being 37");
 
 DLL_EXPORT nl::FaultInjection::Manager & GetManager();
 

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -257,7 +257,7 @@
         if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
         {                                                                                                                          \
             ChipLogError(MOD, MSG ": %" CHIP_ERROR_FORMAT, ##__VA_ARGS__, __err.Format());                                         \
-            return _err;                                                                                                           \
+            return __err;                                                                                                          \
         }                                                                                                                          \
     } while (false)
 

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -239,7 +239,7 @@
  *  @def LogAndReturnErrorOnFailure(expr)
  *
  *  @brief
- *    If expr returns something than CHIP_NO_ERROR, lg a chip message for the specified module
+ *    If expr returns something than CHIP_NO_ERROR, log a chip message for the specified module
  *    in the 'Error' category and return the error.
  *
  *  Example usage:

--- a/src/python_testing/TC_AVSM_2_13.py
+++ b/src/python_testing/TC_AVSM_2_13.py
@@ -250,6 +250,17 @@ class TC_AVSM_2_13(MatterBaseTest):
         logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
         asserts.assert_equal(len(aAllocatedVideoStreams), 1, "The number of allocated video streams in the list is not 1")
 
+        # Clear all allocated streams
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+
+        for stream in aAllocatedVideoStreams:
+            try:
+                await self.send_single_cmd(endpoint=endpoint, cmd=commands.VideoStreamDeallocate(videoStreamID=(stream.videoStreamID)))
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_AVSM_2_14.py
+++ b/src/python_testing/TC_AVSM_2_14.py
@@ -188,6 +188,17 @@ class TC_AVSM_2_14(MatterBaseTest):
         logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
         asserts.assert_equal(len(aAllocatedAudioStreams), 1, "The number of allocated audio streams in the list is not 1.")
 
+        # Clear all allocated streams
+        aAllocatedAudioStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedAudioStreams
+        )
+
+        for stream in aAllocatedAudioStreams:
+            try:
+                await self.send_single_cmd(endpoint=endpoint, cmd=commands.AudioStreamDeallocate(audioStreamID=(stream.audioStreamID)))
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_AVSM_2_15.py
+++ b/src/python_testing/TC_AVSM_2_15.py
@@ -40,6 +40,7 @@ import logging
 from mobly import asserts
 
 import matter.clusters as Clusters
+from matter.interaction_model import InteractionModelError, Status
 from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
 
 logger = logging.getLogger(__name__)

--- a/src/python_testing/TC_AVSM_2_15.py
+++ b/src/python_testing/TC_AVSM_2_15.py
@@ -168,6 +168,17 @@ class TC_AVSM_2_15(MatterBaseTest):
         logger.info(f"Rx'd AllocatedSnapshotStreams: {aAllocatedSnapshotStreams}")
         asserts.assert_equal(len(aAllocatedSnapshotStreams), 1, "The number of allocated snapshot streams in the list is not 1.")
 
+        # Clear all allocated streams
+        aAllocatedSnapshotStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedSnapshotStreams
+        )
+
+        for stream in aAllocatedSnapshotStreams:
+            try:
+                await self.send_single_cmd(endpoint=endpoint, cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=(stream.snapshotStreamID)))
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_AVSM_2_3.py
+++ b/src/python_testing/TC_AVSM_2_3.py
@@ -183,6 +183,17 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
         if osdSupport and aHardwareEncoder:
             asserts.assert_equal(aAllocatedSnapshotStreams[0].OSDEnabled, not aOSD, "OSDEnabled is not equal to !aOSD")
 
+        # Clear all allocated streams
+        aAllocatedSnapshotStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedSnapshotStreams
+        )
+
+        for stream in aAllocatedSnapshotStreams:
+            try:
+                await self.send_single_cmd(endpoint=endpoint, cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=(stream.snapshotStreamID)))
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_AVSM_2_5.py
+++ b/src/python_testing/TC_AVSM_2_5.py
@@ -394,6 +394,17 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
+        # Clear all allocated streams
+        aAllocatedAudioStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedAudioStreams
+        )
+
+        for stream in aAllocatedAudioStreams:
+            try:
+                await self.send_single_cmd(endpoint=endpoint, cmd=commands.AudioStreamDeallocate(audioStreamID=(stream.audioStreamID)))
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_AVSM_2_8.py
+++ b/src/python_testing/TC_AVSM_2_8.py
@@ -172,6 +172,17 @@ class TC_AVSM_2_8(MatterBaseTest, AVSMTestBase):
         if osdSupport:
             asserts.assert_equal(aAllocatedVideoStreams[0].OSDEnabled, not aOSD, "OSDEnabled is not !aOSD")
 
+        # Clear all allocated streams
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+
+        for stream in aAllocatedVideoStreams:
+            try:
+                await self.send_single_cmd(endpoint=endpoint, cmd=commands.VideoStreamDeallocate(videoStreamID=(stream.videoStreamID)))
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_AVSM_VideoStreamsPersistence.py
+++ b/src/python_testing/TC_AVSM_VideoStreamsPersistence.py
@@ -1,0 +1,318 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import logging
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters import Globals
+from matter.interaction_model import InteractionModelError, Status
+from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
+
+logger = logging.getLogger(__name__)
+
+
+class TC_AVSM_VideoStreamsPersistence(MatterBaseTest):
+    def desc_TC_AVSM_VideoStreamsPersistence(self) -> str:
+        return "[TC-AVSM-VideoStreamsPersistence] Validate Video Streams Persistence functionality with Server as DUT"
+
+    def pics_TC_AVSM_VideoStreamsPersistence(self):
+        return ["AVSM.S"]
+
+    def steps_TC_AVSM_VideoStreamsPersistence(self) -> list[TestStep]:
+        return [
+            TestStep("precondition", "Commissioning, already done", is_commissioning=True),
+            TestStep(1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT", "Verify VDO is supported."),
+            TestStep(
+                2,
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify the number of allocated video streams in the list is 0.",
+            ),
+            TestStep(
+                3,
+                "TH reads StreamUsagePriorities attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Store this value in aStreamUsagePriorities.",
+            ),
+            TestStep(
+                4,
+                "TH reads RateDistortionTradeOffPoints attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Store this value in aRateDistortionTradeOffPoints.",
+            ),
+            TestStep(
+                5,
+                "TH reads MinViewportResolution attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Store this value in aMinViewportRes.",
+            ),
+            TestStep(
+                6,
+                "TH reads VideoSensorParams attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Store this value in aVideoSensorParams.",
+            ),
+            TestStep(
+                7,
+                "TH reads MaxEncodedPixelRate attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Store this value in aMaxEncodedPixelRate.",
+            ),
+            TestStep(
+                8,
+                "If the watermark feature is supported, set aWatermark to True, otherwise set this to Null.",
+            ),
+            TestStep(
+                9,
+                "If the OSD feature is supported, set aOSD to True, otherwise set this to Null.",
+            ),
+            TestStep(
+                10,
+                "TH sets StreamUsage from aStreamUsagePriorities. TH sets VideoCodec, MinResolution, MaxResolution, MinBitRate, MaxBitRate conforming with aRateDistortionTradeOffPoints. TH sets MinFrameRate, MaxFrameRate conforming with aVideoSensorParams. TH sets the KeyFrameInterval = 4000. TH sets WatermarkEnabled to aWatermark, TH also sets OSDEnabled to aOSD. TH sends the VideoStreamAllocate command with these arguments.",
+                "DUT responds with VideoStreamAllocateResponse command with a valid VideoStreamID. Store this as myStreamID",
+            ),
+            TestStep(
+                11,
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify the number of allocated video streams in the list is 1.",
+            ),
+            TestStep(
+                12,
+                "TH injects kFault_ClearInMemoryAllocatedVideoStreams on DUT.",
+            ),
+            TestStep(
+                13,
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify the number of allocated video streams in the list is 0.",
+            ),
+            TestStep(
+                14,
+                "TH injects kFault_LoadPersistentCameraAVSMAttributes on DUT.",
+            ),
+            TestStep(
+                15,
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify the number of allocated video streams in the list is 1.",
+                "Verify the individual fields of allocated video stream is as was allocated in step 10.",
+            ),
+        ]
+
+    @run_if_endpoint_matches(
+        has_feature(Clusters.CameraAvStreamManagement, Clusters.CameraAvStreamManagement.Bitmaps.Feature.kVideo)
+    )
+    async def test_TC_AVSM_VideoStreamsPersistence(self):
+        endpoint = self.get_endpoint(default=1)
+        cluster = Clusters.CameraAvStreamManagement
+        attr = Clusters.CameraAvStreamManagement.Attributes
+        commands = Clusters.CameraAvStreamManagement.Commands
+
+        self.step("precondition")
+        # Commission DUT - already done
+
+        self.step(1)
+        aFeatureMap = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.FeatureMap)
+        logger.info(f"Rx'd FeatureMap: {aFeatureMap}")
+        vdoSupport = aFeatureMap & cluster.Bitmaps.Feature.kVideo
+        asserts.assert_equal(vdoSupport, cluster.Bitmaps.Feature.kVideo, "Video Feature is not supported.")
+
+        self.step(2)
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+        logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
+        asserts.assert_equal(len(aAllocatedVideoStreams), 0, "The number of allocated video streams in the list is not 0")
+
+        self.step(3)
+        aStreamUsagePriorities = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.StreamUsagePriorities
+        )
+        logger.info(f"Rx'd StreamUsagePriorities: {aStreamUsagePriorities}")
+
+        self.step(4)
+        aRateDistortionTradeOffPoints = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.RateDistortionTradeOffPoints
+        )
+        logger.info(f"Rx'd RateDistortionTradeOffPoints: {aRateDistortionTradeOffPoints}")
+
+        self.step(5)
+        aMinViewportRes = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.MinViewportResolution
+        )
+        logger.info(f"Rx'd MinViewportResolution: {aMinViewportRes}")
+
+        self.step(6)
+        aVideoSensorParams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.VideoSensorParams
+        )
+        logger.info(f"Rx'd VideoSensorParams: {aVideoSensorParams}")
+
+        self.step(7)
+        aMaxEncodedPixelRate = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.MaxEncodedPixelRate
+        )
+        logger.info(f"Rx'd MaxEncodedPixelRate: {aMaxEncodedPixelRate}")
+
+        # Check for watermark and OSD features
+        self.step(8)
+        watermark = True if (aFeatureMap & cluster.Bitmaps.Feature.kWatermark) != 0 else None
+
+        self.step(9)
+        osd = True if (aFeatureMap & cluster.Bitmaps.Feature.kOnScreenDisplay) != 0 else None
+
+        self.step(10)
+        myStreamID = 0
+        try:
+            asserts.assert_greater(len(aStreamUsagePriorities), 0, "StreamUsagePriorities is empty")
+            asserts.assert_greater(len(aRateDistortionTradeOffPoints), 0, "RateDistortionTradeOffPoints is empty")
+            videoStreamAllocateCmd = commands.VideoStreamAllocate(
+                streamUsage=aStreamUsagePriorities[0],
+                videoCodec=aRateDistortionTradeOffPoints[0].codec,
+                minFrameRate=30,  # An acceptable value for min frame rate
+                maxFrameRate=aVideoSensorParams.maxFPS,
+                minResolution=aMinViewportRes,
+                maxResolution=cluster.Structs.VideoResolutionStruct(
+                    width=aVideoSensorParams.sensorWidth, height=aVideoSensorParams.sensorHeight
+                ),
+                minBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
+                maxBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
+                keyFrameInterval=4000,
+                watermarkEnabled=watermark,
+                OSDEnabled=osd,
+            )
+            videoStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
+            logger.info(f"Rx'd VideoStreamAllocateResponse: {videoStreamAllocateResponse}")
+            asserts.assert_is_not_none(
+                videoStreamAllocateResponse.videoStreamID, "VideoStreamAllocateResponse does not contain StreamID"
+            )
+            myStreamID = videoStreamAllocateResponse.videoStreamID
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
+
+        self.step(11)
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+        logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
+        asserts.assert_equal(len(aAllocatedVideoStreams), 1, "The number of allocated video streams in the list is not 1")
+
+        self.step(12)
+        logging.info("Injecting kFault_ClearInMemoryAllocatedVideoStreams on DUT")
+
+        # --- Fault‑Injection cluster (mfg‑specific 0xFFF1_FC06) ---
+        # Use FailAtFault to activate the chip‑layer fault exactly once
+        #
+        #  • faultType = kChipFault (0x03)  – always used for CHIP faults
+        #  • id        = FaultInjection.Id.kFault_ClearInMemoryAllocatedVideoStreams
+        #  • numCallsToSkip = 0  – trigger on the very next call
+        #  • numCallsToFail = 1  – inject once, then auto‑clear
+        #  • takeMutex      = False  – single‑threaded app, no lock needed
+        #
+        command = Clusters.FaultInjection.Commands.FailAtFault(
+            type=Clusters.FaultInjection.Enums.FaultType.kChipFault,
+            id=34,  # kFault_ClearInMemoryAllocatedVideoStreams
+            numCallsToFail=1,
+            takeMutex=False,
+        )
+        await self.default_controller.SendCommand(
+            nodeid=self.dut_node_id,
+            endpoint=0,  # Fault‑Injection cluster lives on EP0
+            payload=command,
+        )
+        #sleep(1)
+
+        self.step(13)
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+        logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
+        asserts.assert_equal(len(aAllocatedVideoStreams), 0, "Allocated video streams is not empty")
+
+
+        self.step(14)
+        logging.info("Injecting kFault_LoadPersistentCameraAVSMAttributes on DUT")
+        # --- Fault‑Injection cluster (mfg‑specific 0xFFF1_FC06) ---
+        # Use FailAtFault to activate the chip‑layer fault exactly once
+        #
+        #  • faultType = kChipFault (0x03)  – always used for CHIP faults
+        #  • id        = FaultInjection.Id.kFault_LoadPersistentCameraAVSMAttributes
+        #  • numCallsToSkip = 0  – trigger on the very next call
+        #  • numCallsToFail = 1  – inject once, then auto‑clear
+        #  • takeMutex      = False  – single‑threaded app, no lock needed
+        #
+        command = Clusters.FaultInjection.Commands.FailAtFault(
+            type=Clusters.FaultInjection.Enums.FaultType.kChipFault,
+            id=37,  # kFault_LoadPersistentCameraAVSMAttributes
+            numCallsToFail=1,
+            takeMutex=False,
+        )
+        await self.default_controller.SendCommand(
+            nodeid=self.dut_node_id,
+            endpoint=0,  # Fault‑Injection cluster lives on EP0
+            payload=command,
+        )
+        #sleep(1)
+
+        self.step(15)
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+        logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
+        asserts.assert_equal(len(aAllocatedVideoStreams), 1, "Allocated video streams is not empty")
+
+        ##### Validate fields in Video Stream that was stored #####
+        asserts.assert_equal(aAllocatedVideoStreams[0].streamUsage, aStreamUsagePriorities[0], "Stream Usage does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].videoCodec, aRateDistortionTradeOffPoints[0].codec, "Video codec does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].minFrameRate, 30, "MinFrameRate does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].maxFrameRate, aVideoSensorParams.maxFPS, "MaxFrameRate does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].minResolution, aMinViewportRes, "MinResolution does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].maxResolution.width, aVideoSensorParams.sensorWidth, "MaxResolution does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].maxResolution.height, aVideoSensorParams.sensorHeight, "MaxResolution does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].minBitRate, aRateDistortionTradeOffPoints[0].minBitRate, "MinBitRate does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].maxBitRate, aRateDistortionTradeOffPoints[0].minBitRate, "MaxBitRate does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].keyFrameInterval, 4000, "KeyFrameInterval does not match")
+
+        # Clear all allocated streams
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+
+        for stream in aAllocatedVideoStreams:
+            try:
+                await self.send_single_cmd(endpoint=endpoint, cmd=commands.VideoStreamDeallocate(videoStreamID=(stream.videoStreamID)))
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_AVSM_VideoStreamsPersistence.py
+++ b/src/python_testing/TC_AVSM_VideoStreamsPersistence.py
@@ -40,7 +40,6 @@ import logging
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.clusters import Globals
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
 

--- a/src/python_testing/TC_AVSM_VideoStreamsPersistence.py
+++ b/src/python_testing/TC_AVSM_VideoStreamsPersistence.py
@@ -214,7 +214,6 @@ class TC_AVSM_VideoStreamsPersistence(MatterBaseTest):
             )
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
-            pass
 
         self.step(11)
         aAllocatedVideoStreams = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_AVSM_VideoStreamsPersistence.py
+++ b/src/python_testing/TC_AVSM_VideoStreamsPersistence.py
@@ -99,7 +99,7 @@ class TC_AVSM_VideoStreamsPersistence(MatterBaseTest):
             TestStep(
                 10,
                 "TH sets StreamUsage from aStreamUsagePriorities. TH sets VideoCodec, MinResolution, MaxResolution, MinBitRate, MaxBitRate conforming with aRateDistortionTradeOffPoints. TH sets MinFrameRate, MaxFrameRate conforming with aVideoSensorParams. TH sets the KeyFrameInterval = 4000. TH sets WatermarkEnabled to aWatermark, TH also sets OSDEnabled to aOSD. TH sends the VideoStreamAllocate command with these arguments.",
-                "DUT responds with VideoStreamAllocateResponse command with a valid VideoStreamID. Store this as myStreamID",
+                "DUT responds with VideoStreamAllocateResponse command with a valid VideoStreamID.",
             ),
             TestStep(
                 11,
@@ -190,7 +190,6 @@ class TC_AVSM_VideoStreamsPersistence(MatterBaseTest):
         osd = True if (aFeatureMap & cluster.Bitmaps.Feature.kOnScreenDisplay) != 0 else None
 
         self.step(10)
-        myStreamID = 0
         try:
             asserts.assert_greater(len(aStreamUsagePriorities), 0, "StreamUsagePriorities is empty")
             asserts.assert_greater(len(aRateDistortionTradeOffPoints), 0, "RateDistortionTradeOffPoints is empty")
@@ -214,7 +213,6 @@ class TC_AVSM_VideoStreamsPersistence(MatterBaseTest):
             asserts.assert_is_not_none(
                 videoStreamAllocateResponse.videoStreamID, "VideoStreamAllocateResponse does not contain StreamID"
             )
-            myStreamID = videoStreamAllocateResponse.videoStreamID
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
@@ -249,7 +247,6 @@ class TC_AVSM_VideoStreamsPersistence(MatterBaseTest):
             endpoint=0,  # Fault‑Injection cluster lives on EP0
             payload=command,
         )
-        #sleep(1)
 
         self.step(13)
         aAllocatedVideoStreams = await self.read_single_attribute_check_success(
@@ -257,7 +254,6 @@ class TC_AVSM_VideoStreamsPersistence(MatterBaseTest):
         )
         logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
         asserts.assert_equal(len(aAllocatedVideoStreams), 0, "Allocated video streams is not empty")
-
 
         self.step(14)
         logging.info("Injecting kFault_LoadPersistentCameraAVSMAttributes on DUT")
@@ -281,7 +277,6 @@ class TC_AVSM_VideoStreamsPersistence(MatterBaseTest):
             endpoint=0,  # Fault‑Injection cluster lives on EP0
             payload=command,
         )
-        #sleep(1)
 
         self.step(15)
         aAllocatedVideoStreams = await self.read_single_attribute_check_success(
@@ -292,14 +287,19 @@ class TC_AVSM_VideoStreamsPersistence(MatterBaseTest):
 
         ##### Validate fields in Video Stream that was stored #####
         asserts.assert_equal(aAllocatedVideoStreams[0].streamUsage, aStreamUsagePriorities[0], "Stream Usage does not match")
-        asserts.assert_equal(aAllocatedVideoStreams[0].videoCodec, aRateDistortionTradeOffPoints[0].codec, "Video codec does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].videoCodec,
+                             aRateDistortionTradeOffPoints[0].codec, "Video codec does not match")
         asserts.assert_equal(aAllocatedVideoStreams[0].minFrameRate, 30, "MinFrameRate does not match")
         asserts.assert_equal(aAllocatedVideoStreams[0].maxFrameRate, aVideoSensorParams.maxFPS, "MaxFrameRate does not match")
         asserts.assert_equal(aAllocatedVideoStreams[0].minResolution, aMinViewportRes, "MinResolution does not match")
-        asserts.assert_equal(aAllocatedVideoStreams[0].maxResolution.width, aVideoSensorParams.sensorWidth, "MaxResolution does not match")
-        asserts.assert_equal(aAllocatedVideoStreams[0].maxResolution.height, aVideoSensorParams.sensorHeight, "MaxResolution does not match")
-        asserts.assert_equal(aAllocatedVideoStreams[0].minBitRate, aRateDistortionTradeOffPoints[0].minBitRate, "MinBitRate does not match")
-        asserts.assert_equal(aAllocatedVideoStreams[0].maxBitRate, aRateDistortionTradeOffPoints[0].minBitRate, "MaxBitRate does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].maxResolution.width,
+                             aVideoSensorParams.sensorWidth, "MaxResolution does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].maxResolution.height,
+                             aVideoSensorParams.sensorHeight, "MaxResolution does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].minBitRate,
+                             aRateDistortionTradeOffPoints[0].minBitRate, "MinBitRate does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].maxBitRate,
+                             aRateDistortionTradeOffPoints[0].minBitRate, "MaxBitRate does not match")
         asserts.assert_equal(aAllocatedVideoStreams[0].keyFrameInterval, 4000, "KeyFrameInterval does not match")
 
         # Clear all allocated streams


### PR DESCRIPTION
#### Summary
* Add templatized Store and Load functions for allocated Video/Audio/Snapshot streams.
  -- Invoke Store functions on Add/Modify/Remove stream functions -- Invoke Load functions from initial Load persistent  
      attributes call in Init().
* Mark the corresponding stream in HAL as allocated after loading from persisted state.
  -- Consolidate delegate APIs around loading of allocated streams. -- Use the PersistentAttributesLoadedCallback() API to  
      signal the HAL to start corresponding loaded streams.


#### Testing
* chip-camera-app commissioned with camera-controller
* allocate streams from camera-controller, restart chip-camera-app and read allocated streams attribute.
* deallocate streams from camera-controller, restart chip-camera-app and read allocated streams attribute.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
