### PR TITLE
[Chef[ Chatty chef

### DIFF
--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -6,6 +6,7 @@
 #include <app/util/config.h>
 #include <app/util/endpoint-config-api.h>
 #include <lib/core/DataModelTypes.h>
+#include <platform/CHIPDeviceLayer.h>
 
 using chip::app::DataModel::Nullable;
 

--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -564,6 +564,7 @@ static void chattyTemperatureChangeTick(System::Layer * systemLayer, void * data
     }
     TemperatureMeasurement::Attributes::MeasuredValue::Set(kTemperatureMeasurementEndpoint, next);
     ChipLogDetail(NotSpecified, "Temperature set to %d", next.ValueOr(0));
+    parity ^= 1;
     (void) DeviceLayer::SystemLayer().StartTimer(kChatyPeriod, chattyTemperatureChangeTick, nullptr);
 }
 #endif // MATTER_DM_TEMPERATURE_MEASUREMENT_CLUSTER_SERVER_ENDPOINT_COUNT > 0


### PR DESCRIPTION
#### Summary

Adds a temporary change to toggle measured temperature +/- 0.01 C every 0.1 seconds.

One time change not intended for merge.

Device used to test `rootnode_temperaturesensor_Qy1zkNW7c3`.


## Testing
Device logs -

```
[1758680173.209] [9:9] [-] Temperature set to 2351
[1758680173.309] [9:9] [DMG] Endpoint 1, Cluster 0x0000_0402 update version to 28782cd3
[1758680173.309] [9:9] [ZCL] Cluster callback: 0x0000_0402
[1758680173.309] [9:9] [-] Temperature set to 2350
[1758680173.409] [9:9] [DMG] Endpoint 1, Cluster 0x0000_0402 update version to 28782cd4
[1758680173.409] [9:9] [ZCL] Cluster callback: 0x0000_0402
[1758680173.409] [9:9] [-] Temperature set to 2351
[1758680173.509] [9:9] [DMG] Endpoint 1, Cluster 0x0000_0402 update version to 28782cd5
[1758680173.509] [9:9] [ZCL] Cluster callback: 0x0000_0402
[1758680173.509] [9:9] [-] Temperature set to 2350
[1758680173.610] [9:9] [DMG] Endpoint 1, Cluster 0x0000_0402 update version to 28782cd6
[1758680173.610] [9:9] [ZCL] Cluster callback: 0x0000_0402
[1758680173.610] [9:9] [-] Temperature set to 2351
[1758680173.710] [9:9] [DMG] Endpoint 1, Cluster 0x0000_0402 update version to 28782cd7
[1758680173.710] [9:9] [ZCL] Cluster callback: 0x0000_0402
[1758680173.710] [9:9] [-] Temperature set to 2350
```
