### PR TITLE
ESP32: Implement DiagnosticDataProvider::SupportsWatermarks()

### DIFF
--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -130,6 +130,12 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
+{
+    // esp-idf does not provide a way to reset the watermarks
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR DiagnosticDataProviderImpl::GetRebootCount(uint16_t & rebootCount)
 {
     uint32_t count = 0;

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -107,6 +107,11 @@ DiagnosticDataProviderImpl & DiagnosticDataProviderImpl::GetDefaultInstance()
     return sInstance;
 }
 
+bool DiagnosticDataProviderImpl::SupportsWatermarks()
+{
+    return true;
+}
+
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapFree(uint64_t & currentHeapFree)
 {
     currentHeapFree = esp_get_free_heap_size();

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.h
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.h
@@ -43,6 +43,7 @@ public:
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
+    CHIP_ERROR ResetWatermarks() override;
 
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.h
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.h
@@ -39,6 +39,7 @@ public:
 
     // ===== Methods that implement the PlatformManager abstract interface.
 
+    bool SupportsWatermarks() override;
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;


### PR DESCRIPTION
#### Summary
ESP32 does support watermark feature hence returning true from the implementation.

Looks like API was implemented long back but this API was not implemented resulting feature map value to "0".

#### Testing
- Commissioned the device and read the feature-map and current-heap-high-watermark attributes before and after the change and verified correct values is being read with the change.
```
chip-tool pairing ble-wifi 1 SSID PSK 20202021 3840
chip-tool softwarediagnostics read feature-map 1 0
chip-tool softwarediagnostics read current-heap-high-watermark 1 0
```