### PR TITLE
fix typos in comments in DiagnosticDataProvider interface and software

### DIFF
--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-cluster.h
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-cluster.h
@@ -130,7 +130,7 @@ public:
     }
 
 private:
-    // Encodes the `value` in `encoder`, while handling a potential `readError` that occured
+    // Encodes the `value` in `encoder`, while handling a potential `readError` that occurred
     // when the input `value` was read:
     //   - CHIP_ERROR_NOT_IMPLEMENTED results in a 0 being encoded
     //   - any other read error is just forwarded

--- a/src/app/clusters/software-diagnostics-server/software-fault-listener.h
+++ b/src/app/clusters/software-diagnostics-server/software-fault-listener.h
@@ -37,7 +37,7 @@ public:
     virtual void
     OnSoftwareFaultDetect(const chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::Type & softwareFault) = 0;
 
-    /// Returs the set global listener (if any). May return nullptr if no such listener is set.
+    /// Returns the set global listener (if any). May return nullptr if no such listener is set.
     static SoftwareFaultListener * GetGlobalListener();
 
     /// Set the global software fault listener, returns the old value

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -191,7 +191,7 @@ public:
     virtual CHIP_ERROR GetAverageWearCount(uint32_t & averageWearCount);
 
     /*
-     * Get the linked list of network interfaces of the current plaform. After usage, each caller of GetNetworkInterfaces
+     * Get the linked list of network interfaces of the current platform. After usage, each caller of GetNetworkInterfaces
      * needs to release the network interface list it gets via ReleaseNetworkInterfaces.
      *
      */
@@ -202,7 +202,7 @@ public:
      * Software Diagnostics methods.
      */
 
-    /// Feature support - this returns support gor GetCurrentHeapHighWatermark and ResetWatermarks()
+    /// Feature support - this returns support for GetCurrentHeapHighWatermark and ResetWatermarks()
     virtual bool SupportsWatermarks() { return false; }
 
     virtual CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree);
@@ -211,7 +211,7 @@ public:
     virtual CHIP_ERROR ResetWatermarks();
 
     /*
-     * Get the linked list of thread metrics of the current plaform. After usage, each caller of GetThreadMetrics
+     * Get the linked list of thread metrics of the current platform. After usage, each caller of GetThreadMetrics
      * needs to release the thread metrics list it gets via ReleaseThreadMetrics.
      *
      */


### PR DESCRIPTION
diagnostics cluster server impl

#### Summary

Fixed few typos in comments in software-diagnostics-cluster-server-impl and DiagnosticDataProvider interface

#### Testing
- comments change only