### PR TITLE
Add event generation tests for Boolean State cluster

### DIFF
--- a/src/app/clusters/boolean-state-server/tests/TestBooleanStateCluster.cpp
+++ b/src/app/clusters/boolean-state-server/tests/TestBooleanStateCluster.cpp
@@ -179,7 +179,6 @@ TEST_F(TestBooleanStateCluster, EventGeneratedOnStateChange)
             // Ensure initial value is false, then change to true and expect an event
             EXPECT_EQ(booleanState.GetStateValue(), false);
             auto eventNumber = booleanState.SetStateValue(true);
-            EXPECT_TRUE(eventNumber.has_value());
 
             auto & logOnlyEvents = context.EventsGenerator();
             using EventType      = chip::app::Clusters::BooleanState::Events::StateChange::Type;
@@ -187,6 +186,7 @@ TEST_F(TestBooleanStateCluster, EventGeneratedOnStateChange)
 
             // Lambda to verify the last emitted event metadata and payload
             auto verifyLastEvent = [&](bool expectedStateValue) {
+                ASSERT_TRUE(eventNumber.has_value());
                 EXPECT_EQ(eventNumber.value(), logOnlyEvents.CurrentEventNumber());
                 EXPECT_EQ(logOnlyEvents.LastOptions().mPath,
                           ConcreteEventPath(endpoint, EventType::GetClusterId(), EventType::GetEventId()));
@@ -199,7 +199,6 @@ TEST_F(TestBooleanStateCluster, EventGeneratedOnStateChange)
 
             // Now, change from true to false and expect an event
             eventNumber = booleanState.SetStateValue(false);
-            EXPECT_TRUE(eventNumber.has_value());
 
             // Verify event with expected false value
             verifyLastEvent(false);
@@ -233,11 +232,11 @@ TEST_F(TestBooleanStateCluster, NoEventWhenValueUnchanged)
             EXPECT_GT(logOnlyEvents.CurrentEventNumber(), initialCount);
 
             // Re-set to the same value (true) and confirm no new event is generated
-            EventNumber before = logOnlyEvents.CurrentEventNumber();
+            EventNumber eventCountAfterChange = logOnlyEvents.CurrentEventNumber();
 
             auto thirdEvent = booleanState.SetStateValue(true);
             EXPECT_FALSE(thirdEvent.has_value());
-            EXPECT_EQ(logOnlyEvents.CurrentEventNumber(), before);
+            EXPECT_EQ(logOnlyEvents.CurrentEventNumber(), eventCountAfterChange);
         });
     }
 }

--- a/src/app/clusters/boolean-state-server/tests/TestBooleanStateCluster.cpp
+++ b/src/app/clusters/boolean-state-server/tests/TestBooleanStateCluster.cpp
@@ -182,7 +182,6 @@ TEST_F(TestBooleanStateCluster, EventGeneratedOnStateChange)
 
             auto & logOnlyEvents = context.EventsGenerator();
             using EventType      = chip::app::Clusters::BooleanState::Events::StateChange::Type;
-            chip::app::Clusters::BooleanState::Events::StateChange::DecodableType decodedEvent;
 
             // Lambda to verify the last emitted event metadata and payload
             auto verifyLastEvent = [&](bool expectedStateValue) {
@@ -190,6 +189,7 @@ TEST_F(TestBooleanStateCluster, EventGeneratedOnStateChange)
                 EXPECT_EQ(eventNumber.value(), logOnlyEvents.CurrentEventNumber());
                 EXPECT_EQ(logOnlyEvents.LastOptions().mPath,
                           ConcreteEventPath(endpoint, EventType::GetClusterId(), EventType::GetEventId()));
+                chip::app::Clusters::BooleanState::Events::StateChange::DecodableType decodedEvent;
                 ASSERT_EQ(logOnlyEvents.DecodeLastEvent(decodedEvent), CHIP_NO_ERROR);
                 EXPECT_EQ(decodedEvent.stateValue, expectedStateValue);
             };
@@ -229,7 +229,7 @@ TEST_F(TestBooleanStateCluster, NoEventWhenValueUnchanged)
             // Change from false -> true and confirm an event occurs
             auto secondEvent = booleanState.SetStateValue(true);
             EXPECT_TRUE(secondEvent.has_value());
-            EXPECT_GT(logOnlyEvents.CurrentEventNumber(), initialCount);
+            EXPECT_EQ(logOnlyEvents.CurrentEventNumber(), initialCount + 1);
 
             // Re-set to the same value (true) and confirm no new event is generated
             EventNumber eventCountAfterChange = logOnlyEvents.CurrentEventNumber();

--- a/src/app/clusters/boolean-state-server/tests/TestBooleanStateCluster.cpp
+++ b/src/app/clusters/boolean-state-server/tests/TestBooleanStateCluster.cpp
@@ -193,6 +193,19 @@ TEST_F(TestBooleanStateCluster, EventGeneratedOnStateChange)
             chip::app::Clusters::BooleanState::Events::StateChange::DecodableType decodedEvent;
             ASSERT_EQ(logOnlyEvents.DecodeLastEvent(decodedEvent), CHIP_NO_ERROR);
             EXPECT_TRUE(decodedEvent.stateValue);
+
+            // Now, change from true to false and expect an event
+            eventNumber = booleanState.SetStateValue(false);
+            EXPECT_TRUE(eventNumber.has_value());
+
+            // Validate the last emitted event metadata and payload for the new event
+            EXPECT_EQ(eventNumber.value(), logOnlyEvents.CurrentEventNumber());
+            EXPECT_EQ(logOnlyEvents.LastOptions().mPath,
+                      ConcreteEventPath(endpoint, EventType::GetClusterId(), EventType::GetEventId()));
+
+            // Decode the last event and verify its contents
+            ASSERT_EQ(logOnlyEvents.DecodeLastEvent(decodedEvent), CHIP_NO_ERROR);
+            EXPECT_FALSE(decodedEvent.stateValue);
         });
     }
 }


### PR DESCRIPTION
#### Summary

This PR add unit tests for event generation behavior in the Boolean State cluster. The tests validate that `StateChange` events are properly emitted when the boolean state value changes and that no redundant events are generated when setting the same value multiple times.

**What was added:**
- `EventGeneratedOnStateChange` test: Verifies that StateChange events are generated with correct metadata (event path, payload) when the state value actually changes
- `NoEventWhenValueUnchanged` test: Ensures no events are emitted when setting unchanged values, preventing unnecessary network traffic

#### Related issues

Main issue: #40967

#### Testing

This PR only adds new unit tests. No changes were made to production code.