### PR TITLE
Various API updates to new Matter.framework commissioning API.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
@@ -55,7 +55,7 @@ MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
  * 1) The attributes in extraAttributesToRead on MTRCommissioningParameters.
  * 2) The FeatureMap attributes of all Network Commissioning clusters on the commissionee.
  */
-@property (nonatomic, copy, readonly, nullable) NSDictionary<MTRAttributePath *, NSDictionary<NSString *, id> *> * attributes MTR_PROVISIONALLY_AVAILABLE;
+@property (nonatomic, copy, readonly, nullable) NSDictionary<MTRAttributePath *, NSDictionary<NSString *, id> *> * attributes MTR_AVAILABLE(ios(26.2), macos(26.2), watchos(26.2), tvos(26.2));
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
@@ -24,24 +24,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSInteger, MTRCommissioningStage) {
-    // Possible stages that can be reached during commissioning.  The order of
-    // these stages is not guaranteed to be anything in particular, or to match
-    // the numeric order of this enum.  There are no guarantees that any
-    // particular stage will in fact be reached, unless documented otherwise.
-
-    // The commissionee has received network credentials.  This will never be reached
-    // during on-network commissioning.
-    MTRCommissioningStageProvisionedNetworkCredentials = 1,
-
-    // The commissioning operation is about to ask the commissionee to do a Wi-Fi network scan.
-    MTRCommissioningStageWiFiScanStart = 2,
-
-    // The commissioning operation is about to ask the commissionee to do a Thread network scan.
-    MTRCommissioningStageThreadScanStart = 3,
-} MTR_PROVISIONALLY_AVAILABLE;
-
-MTR_PROVISIONALLY_AVAILABLE
+MTR_AVAILABLE(ios(26.2), macos(26.2), watchos(26.2), tvos(26.2))
 @protocol MTRCommissioningDelegate <NSObject>
 @optional
 /**
@@ -81,9 +64,9 @@ MTR_PROVISIONALLY_AVAILABLE
  * * Both error and networks will be nil if no scan was performed.
  */
 - (void)commissioning:(MTRCommissioningOperation *)commissioning
-    needsWiFiNetworkSelectionWithScanResults:(nullable NSArray<MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct *> *)networks
-                                       error:(nullable NSError *)error
-                                  completion:(void (^)(NSData * ssid, NSData * _Nullable credentials))completion;
+    needsWiFiCredentialsWithScanResults:(nullable NSArray<MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct *> *)networks
+                                  error:(nullable NSError *)error
+                             completion:(void (^)(NSData * ssid, NSData * _Nullable credentials))completion;
 
 /**
  * Callback that gets called for a commissionee that supports Thread if Thread
@@ -99,14 +82,23 @@ MTR_PROVISIONALLY_AVAILABLE
  * * Both error and networks will be nil if no scan was performed.
  */
 - (void)commissioning:(MTRCommissioningOperation *)commissioning
-    needsThreadNetworkSelectionWithScanResults:(nullable NSArray<MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct *> *)networks
-                                         error:(nullable NSError *)error
-                                    completion:(void (^)(NSData * operationalDataset))completion;
+    needsThreadCredentialsWithScanResults:(nullable NSArray<MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct *> *)networks
+                                    error:(nullable NSError *)error
+                               completion:(void (^)(NSData * operationalDataset))completion;
 
 /**
- * Notification that a particular commissioning stage has been reached.
+ * Notification that a network scan is starting.  This will only happen if a
+ * network scan is performed during commissioning.
  */
-- (void)commissioning:(MTRCommissioningOperation *)commissioning reachedCommissioningStage:(MTRCommissioningStage)stage;
+- (void)commissioningStartingNetworkScan:(MTRCommissioningOperation *)commissioning;
+
+/**
+ * Notification that network credentials have been successfully communicated
+ * to the commissionee and it's going to try to join that network.  Note that
+ * for commissionees that are already on-network this notification will not
+ * happen.
+ */
+- (void)commissioningProvisionedNetworkCredentials:(MTRCommissioningOperation *)commissioning;
 
 /**
  * Notification that commissioning has failed.

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-MTR_PROVISIONALLY_AVAILABLE
+MTR_AVAILABLE(ios(26.2), macos(26.2), watchos(26.2), tvos(26.2))
 @interface MTRCommissioningOperation : NSObject
 /**
  * Initialized via initWithParameters:setupPayload:delegate:queue:

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
@@ -349,8 +349,8 @@ static inline void emitMetricForSetupPayload(NSString * payload)
     dispatch_async(_delegateQueue, ^{
         if ([strongDelegate respondsToSelector:@selector(commissioning:provisionedNetworkCredentialsForDeviceID:)]) {
             [strongDelegate commissioning:self provisionedNetworkCredentialsForDeviceID:nodeID];
-        } else if ([strongDelegate respondsToSelector:@selector(commissioning:reachedCommissioningStage:)]) {
-            [strongDelegate commissioning:self reachedCommissioningStage:MTRCommissioningStageProvisionedNetworkCredentials];
+        } else if ([strongDelegate respondsToSelector:@selector(commissioningProvisionedNetworkCredentials:)]) {
+            [strongDelegate commissioningProvisionedNetworkCredentials:self];
         }
     });
 }
@@ -358,13 +358,13 @@ static inline void emitMetricForSetupPayload(NSString * payload)
 #pragma mark - MTRDeviceControllerDelegate_Internal implementatation
 
 - (void)controller:(MTRDeviceController *)controller
-    scannedWiFiNetworks:(nullable NSArray<MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct *> *)networks
-                  error:(nullable NSError *)error
+    needsWiFiCredentialsWithScanResults:(nullable NSArray<MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct *> *)networks
+                                  error:(nullable NSError *)error
 {
     id<MTRCommissioningDelegate> strongDelegate = _delegate;
     dispatch_async(_delegateQueue, ^{
         mtr_weakify(self);
-        [strongDelegate commissioning:self needsWiFiNetworkSelectionWithScanResults:networks error:error completion:^(NSData * ssid, NSData * _Nullable credentials) {
+        [strongDelegate commissioning:self needsWiFiCredentialsWithScanResults:networks error:error completion:^(NSData * ssid, NSData * _Nullable credentials) {
             mtr_strongify(self);
 
             if (!self) {
@@ -396,13 +396,13 @@ static inline void emitMetricForSetupPayload(NSString * payload)
 }
 
 - (void)controller:(MTRDeviceController *)controller
-    scannedThreadNetworks:(nullable NSArray<MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct *> *)networks
-                    error:(nullable NSError *)error
+    needsThreadCredentialsWithScanResults:(nullable NSArray<MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct *> *)networks
+                                    error:(nullable NSError *)error
 {
     id<MTRCommissioningDelegate> strongDelegate = _delegate;
     dispatch_async(_delegateQueue, ^{
         mtr_weakify(self);
-        [strongDelegate commissioning:self needsThreadNetworkSelectionWithScanResults:networks error:error completion:^(NSData * operationalDataset) {
+        [strongDelegate commissioning:self needsThreadCredentialsWithScanResults:networks error:error completion:^(NSData * operationalDataset) {
             mtr_strongify(self);
 
             if (!self) {
@@ -430,13 +430,12 @@ static inline void emitMetricForSetupPayload(NSString * payload)
     });
 }
 
-- (void)controller:(MTRDeviceController *)controller
-    reachedCommissioningStage:(MTRCommissioningStage)stage
+- (void)controllerStartingNetworkScan:(MTRDeviceController *)controller
 {
-    id<MTRCommissioningDelegate> strongDelegate = [self _internalDelegate];
-    if ([strongDelegate respondsToSelector:@selector(commissioning:reachedCommissioningStage:)]) {
+    id<MTRCommissioningDelegate> strongDelegate = _delegate;
+    if ([strongDelegate respondsToSelector:@selector(commissioningStartingNetworkScan:)]) {
         dispatch_async(_delegateQueue, ^{
-            [strongDelegate commissioning:self reachedCommissioningStage:stage];
+            [strongDelegate commissioningStartingNetworkScan:self];
         });
     }
 }

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
@@ -122,7 +122,34 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * The FeatureMap attribute of all Network Commissioning clusters on the commissionee
  * will always be read and does not need to be included in this list.
  */
-@property (nonatomic, copy, nullable) NSArray<MTRAttributeRequestPath *> * extraAttributesToRead MTR_PROVISIONALLY_AVAILABLE;
+@property (nonatomic, copy, nullable) NSArray<MTRAttributeRequestPath *> * extraAttributesToRead MTR_AVAILABLE(ios(26.2), macos(26.2), watchos(26.2), tvos(26.2));
+
+/**
+ * Whether to force a network scan before requesting Wi-Fi credentials.
+ * The default is NO.
+ *
+ * Even if this value is NO a scan may still be performed.
+ *
+ * This value will be ignored if Wi-Fi credentials are provided or not needed.
+ *
+ * NOTE: Not all APIs that take MTRCommissioningParameters pay attention to this
+ * flag.
+ */
+@property (nonatomic, assign) BOOL forceWiFiScan MTR_AVAILABLE(ios(26.2), macos(26.2), watchos(26.2), tvos(26.2));
+
+/**
+ * Whether to force a network scan before requesting Thread credentials.
+ * The default is NO.
+ *
+ * Even if this value is NO a scan may still be performed.
+ *
+ * This value will be ignored if a Thread operational dataset is provided or not
+ * needed.
+ *
+ * NOTE: Not all APIs that take MTRCommissioningParameters pay attention to this
+ * flag.
+ */
+@property (nonatomic, assign) BOOL forceThreadScan MTR_AVAILABLE(ios(26.2), macos(26.2), watchos(26.2), tvos(26.2));
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
@@ -38,6 +38,9 @@ NS_ASSUME_NONNULL_BEGIN
     other.acceptedTermsAndConditions = self.acceptedTermsAndConditions;
     other.acceptedTermsAndConditionsVersion = self.acceptedTermsAndConditionsVersion;
     other.extraAttributesToRead = self.extraAttributesToRead;
+    other.forceWiFiScan = self.forceWiFiScan;
+    other.forceThreadScan = self.forceThreadScan;
+
     other.preventNetworkScans = self.preventNetworkScans;
 
     return other;

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -162,6 +162,9 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 /**
  * Commission the node with the given node ID.  The node ID must match the node
  * ID that was used to set up the commissioning session.
+ *
+ * NOTE: The forceWiFiScan and forceThreadScan properties of
+ * MTRCommissioningParameters are ignored by this API.
  */
 - (BOOL)commissionNodeWithID:(NSNumber *)nodeID
          commissioningParams:(MTRCommissioningParameters *)commissioningParams

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
@@ -53,6 +53,9 @@ public:
     OnScanNetworksSuccess(const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & dataResponse) override;
     void OnScanNetworksFailure(CHIP_ERROR error) override;
 
+    CHIP_ERROR WiFiCredentialsNeeded(chip::EndpointId endpoint) override;
+    CHIP_ERROR ThreadCredentialsNeeded(chip::EndpointId endpoint) override;
+
     // Other helper methods
     void SetDeviceNodeID(chip::NodeId deviceNodeId);
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate_Internal.h
@@ -15,7 +15,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <Matter/MTRCommissioningDelegate.h>
 #import <Matter/MTRDeviceController.h>
 #import <Matter/MTRDeviceControllerDelegate.h>
 #import <Matter/MTRSetupPayload.h>
@@ -26,13 +25,12 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MTRDeviceControllerDelegate_Internal <MTRDeviceControllerDelegate>
 @required
 - (void)controller:(MTRDeviceController *)controller
-    scannedWiFiNetworks:(nullable NSArray<MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct *> *)networks
-                  error:(nullable NSError *)error;
+    needsWiFiCredentialsWithScanResults:(nullable NSArray<MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct *> *)networks
+                                  error:(nullable NSError *)error;
 - (void)controller:(MTRDeviceController *)controller
-    scannedThreadNetworks:(nullable NSArray<MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct *> *)networks
-                    error:(nullable NSError *)error;
-- (void)controller:(MTRDeviceController *)controller
-    reachedCommissioningStage:(MTRCommissioningStage)stage;
+    needsThreadCredentialsWithScanResults:(nullable NSArray<MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct *> *)networks
+                                    error:(nullable NSError *)error;
+- (void)controllerStartingNetworkScan:(MTRDeviceController *)controller;
 - (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError * _Nullable)error forPayload:(MTRSetupPayload * _Nullable)payload;
 @end
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1139,7 +1139,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         }
         if (commissioningParams.threadOperationalDataset) {
             params.SetThreadOperationalDataset(AsByteSpan(commissioningParams.threadOperationalDataset));
-        } else if (!commissioningParams.preventNetworkScans) {
+        } else if (!commissioningParams.preventNetworkScans && commissioningParams.forceThreadScan) {
             params.SetAttemptThreadNetworkScan(true);
         }
         if (commissioningParams.acceptedTermsAndConditions && commissioningParams.acceptedTermsAndConditionsVersion) {
@@ -1174,7 +1174,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
             }
             chip::Controller::WiFiCredentials wifiCreds(ssid, credentials);
             params.SetWiFiCredentials(wifiCreds);
-        } else if (!commissioningParams.preventNetworkScans) {
+        } else if (!commissioningParams.preventNetworkScans && commissioningParams.forceWiFiScan) {
             params.SetAttemptWiFiNetworkScan(true);
         }
 
@@ -2104,7 +2104,9 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 }
 
 // We never trigger network scans for commissioning that comes through the old
-// APIs, so don't need scannedWiFiNetworks:/scannedThreadNetworks: bits.
+// APIs, and in general don't really support not providing credentials as part
+// of MTRCommissioningParameters, so don't need
+// needsWiFiCredentialsWithScanResults/needsThreadCredentialsWithScanResults bits.
 
 - (void)commissioning:(MTRCommissioningOperation *)commissioning
     succeededForNodeID:(NSNumber *)nodeID


### PR DESCRIPTION
* Instead of having an MTRCommissioningStage that is not in fact a stage (they were more like "events"), just have delegate notifications for the two things we want to notify about for now.
* Address naming of some selectors.
* Implement "credentials needed" callbacks in MTRDeviceControllerDelegateBridge.
* Add a way to force networks scans to MTRCommissioningParameters.
* Update availability annotations for the new APIs.

Fixes https://github.com/project-chip/connectedhomeip/issues/40839

#### Testing

Mostly existing unit testing; some of these things can't really be tested in CI yet and were tested manually.