### PR TITLE
[Python] Lint for unintentional tuples

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -224,7 +224,7 @@ restylers:
           - "**/*.sh"
           - "**/*.bash"
     - name: autopep8
-      image: restyled/restyler-autopep8:v2.0.0
+      image: restyled/restyler-autopep8:v2.3.0
       command:
           - autopep8
           - "--in-place"

--- a/credentials/generate_revocation_set.py
+++ b/credentials/generate_revocation_set.py
@@ -864,7 +864,7 @@ def cli():
 @optgroup.option('--use-test-net-dcld', type=str, default='', metavar='PATH', help="Location of `dcld` binary, to use `dcld` for mirroring TestNet.")
 @optgroup.option('--use-main-net-http', is_flag=True, type=str, help="Use RESTful API with HTTPS against public MainNet observer.")
 @optgroup.option('--use-test-net-http', is_flag=True, type=str, help="Use RESTful API with HTTPS against public TestNet observer.")
-@optgroup.option('--use-local-data', is_flag=True, type=bool, help="Fake response directory: see \" DATA_DIR/",)
+@optgroup.option('--use-local-data', is_flag=True, type=bool, help="Fake response directory: see \" DATA_DIR/")
 @optgroup.group('Required arguments if use-local-data is used', cls=AllOptionGroup)
 @optgroup.option('--certificates', type=click.File('rb'), multiple=True, help='Paths to PEM formated certificates (i.e. PAA) in DCL but missing from the revocation-points-response file.')
 @optgroup.option('--crls', type=click.File('rb'), multiple=True, help='Paths to the crl der files')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E1", "E4", "E7", "E9", "F", "W6"]
+select = ["COM", "E1", "E4", "E7", "E9", "F", "W6"]
 ignore = [
+    "COM812", # Do not enforce trailing commas in multi-line collections
     "E721", # We use it for good reasons
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F"]
+select = ["E1", "E4", "E7", "E9", "F", "W6"]
 ignore = [
     "E721", # We use it for good reasons
 ]

--- a/scripts/examples/tests/test.py
+++ b/scripts/examples/tests/test.py
@@ -40,7 +40,7 @@ def build_actual_output(root: str, out: str) -> List[str]:
     subprocess.run([
         binary,
         project,
-    ], stdout=subprocess.PIPE, check=True, encoding='UTF-8' )
+    ], stdout=subprocess.PIPE, check=True, encoding='UTF-8')
 
     with open(cmake, 'rt') as f:
         for line in f.readlines():

--- a/scripts/examples/tests/test.py
+++ b/scripts/examples/tests/test.py
@@ -40,7 +40,7 @@ def build_actual_output(root: str, out: str) -> List[str]:
     subprocess.run([
         binary,
         project,
-    ], stdout=subprocess.PIPE, check=True, encoding='UTF-8', )
+    ], stdout=subprocess.PIPE, check=True, encoding='UTF-8' )
 
     with open(cmake, 'rt') as f:
         for line in f.readlines():

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -748,7 +748,7 @@ server cluster A = 1 { /* Test comment */ }
                                                ServerClusterInstantiation(
                                                    name="Bar"),
                                            ],
-                                           client_bindings=["Bar", "Test"],)
+                                           client_bindings=["Bar", "Test"])
                                   ])
         self.assertIdlEqual(actual, expected)
 
@@ -783,7 +783,7 @@ server cluster A = 1 { /* Test comment */ }
                                                                           storage=AttributeStorage.CALLBACK, default=True),
                                                ]),
                                            ],
-                                           client_bindings=[],)
+                                           client_bindings=[])
                                   ])
         self.assertIdlEqual(actual, expected)
 
@@ -908,7 +908,7 @@ server cluster A = 1 { /* Test comment */ }
                     ],
                     structs=[
                         Struct(name="MyStruct", fields=[
-                            Field(name="subStruct", code=0, data_type=DataType(name="TestStruct"), qualities=FieldQuality.NULLABLE), ],
+                            Field(name="subStruct", code=0, data_type=DataType(name="TestStruct"), qualities=FieldQuality.NULLABLE) ],
                         ),
                         global_struct,
                     ],

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -908,7 +908,7 @@ server cluster A = 1 { /* Test comment */ }
                     ],
                     structs=[
                         Struct(name="MyStruct", fields=[
-                            Field(name="subStruct", code=0, data_type=DataType(name="TestStruct"), qualities=FieldQuality.NULLABLE) ],
+                            Field(name="subStruct", code=0, data_type=DataType(name="TestStruct"), qualities=FieldQuality.NULLABLE)],
                         ),
                         global_struct,
                     ],

--- a/scripts/py_matter_idl/matter/idl/test_zapxml.py
+++ b/scripts/py_matter_idl/matter/idl/test_zapxml.py
@@ -347,7 +347,7 @@ class TestXmlParser(unittest.TestCase):
                          Idl(clusters=[
                              Cluster(name='TestFeatures',
                                      code=20, bitmaps=[bitmap])
-                         ])),
+                         ]))
 
     def testGlobalStruct(self):
         idl = XmlToIdl('''<?xml version="1.0"?>
@@ -447,7 +447,7 @@ class TestXmlParser(unittest.TestCase):
                                              ),
                                              qualities=AttributeQuality.READABLE,
                                              readacl=AccessPrivilege.VIEW,
-                                             writeacl=AccessPrivilege.OPERATE)]), ]))
+                                             writeacl=AccessPrivilege.OPERATE)])]))
 
     def testSkipsNotProcessedFields(self):
         # Zap has extra fields that are generally not processed
@@ -497,7 +497,7 @@ Some copyright here... testing that we skip over comments
                                              ),
                                              qualities=AttributeQuality.READABLE,
                                              readacl=AccessPrivilege.VIEW,
-                                             writeacl=AccessPrivilege.OPERATE)]), ]))
+                                             writeacl=AccessPrivilege.OPERATE)])]))
 
 
 if __name__ == '__main__':

--- a/scripts/py_matter_yamltests/matter/yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/parser.py
@@ -87,8 +87,8 @@ class TestStepEventKeyError(UnknownPathQualifierError):
 
 class PostProcessCheckStatus(Enum):
     '''Indicates the post processing check step status.'''
-    SUCCESS = 'success',
-    WARNING = 'warning',
+    SUCCESS = 'success'
+    WARNING = 'warning'
     ERROR = 'error'
 
 

--- a/scripts/tests/run_fuzztest_coverage.py
+++ b/scripts/tests/run_fuzztest_coverage.py
@@ -137,7 +137,7 @@ def run_fuzz_test(context):
 
     try:
         if context.run_mode == FuzzTestMode.UNIT_TEST_MODE:
-            subprocess.run([context.fuzz_test_binary_path ], env=env, check=True)
+            subprocess.run([context.fuzz_test_binary_path], env=env, check=True)
             logging.info("Fuzz Test Suite executed in Unit Test Mode.\n")
         elif context.run_mode == FuzzTestMode.CONTINUOUS_FUZZ_MODE:
             cmd_args = [context.fuzz_test_binary_path, f"--fuzz={context.selected_fuzz_test_case}"]

--- a/scripts/tests/run_fuzztest_coverage.py
+++ b/scripts/tests/run_fuzztest_coverage.py
@@ -137,7 +137,7 @@ def run_fuzz_test(context):
 
     try:
         if context.run_mode == FuzzTestMode.UNIT_TEST_MODE:
-            subprocess.run([context.fuzz_test_binary_path, ], env=env, check=True)
+            subprocess.run([context.fuzz_test_binary_path ], env=env, check=True)
             logging.info("Fuzz Test Suite executed in Unit Test Mode.\n")
         elif context.run_mode == FuzzTestMode.CONTINUOUS_FUZZ_MODE:
             cmd_args = [context.fuzz_test_binary_path, f"--fuzz={context.selected_fuzz_test_case}"]

--- a/scripts/tools/bouffalolab/generate_factory_data.py
+++ b/scripts/tools/bouffalolab/generate_factory_data.py
@@ -227,7 +227,7 @@ def gen_test_certs(chip_cert: str,
 
         der = Path(pem).with_suffix(".der")
         if not os.path.isfile(der):
-            cmd = [chip_cert, action, pem, der, "--x509-der" ]
+            cmd = [chip_cert, action, pem, der, "--x509-der"]
             subprocess.run(cmd)
 
         return der

--- a/scripts/tools/bouffalolab/generate_factory_data.py
+++ b/scripts/tools/bouffalolab/generate_factory_data.py
@@ -227,7 +227,7 @@ def gen_test_certs(chip_cert: str,
 
         der = Path(pem).with_suffix(".der")
         if not os.path.isfile(der):
-            cmd = [chip_cert, action, pem, der, "--x509-der", ]
+            cmd = [chip_cert, action, pem, der, "--x509-der" ]
             subprocess.run(cmd)
 
         return der

--- a/scripts/tools/memory/memdf/report.py
+++ b/scripts/tools/memory/memdf/report.py
@@ -69,7 +69,7 @@ def postprocess_report_by(config: Config, key: str, info: Mapping) -> None:
     """For --report-by=region, select all sections."""
     assert key == 'report.by'
     if config.get(key) == 'region':
-        config.put('section.select-all', True),
+        config.put('section.select-all', True)
 
 
 REPORT_BY_CONFIG: ConfigDescription = {

--- a/scripts/tools/silabs/FactoryDataProvider.py
+++ b/scripts/tools/silabs/FactoryDataProvider.py
@@ -190,13 +190,13 @@ class FactoryDataWriter:
         # Retrieve the device current nvm3 data in a binary file
         # It will be used as base to add the new credentials
         inputImage = self.TEMP_FILE
-        cmd = ['commander', 'nvm3', 'read', '-o', inputImage ]
+        cmd = ['commander', 'nvm3', 'read', '-o', inputImage]
         self.add_SerialNo_To_CMD(cmd)
         results = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
         if results.returncode != 0:
             # No nvm3 section found. Retrieve the device info
-            cmd = ['commander', 'device', 'info' ]
+            cmd = ['commander', 'device', 'info']
             self.add_SerialNo_To_CMD(cmd)
             try:
                 output = subprocess.check_output(cmd)
@@ -287,14 +287,14 @@ class FactoryDataWriter:
 
         # A tempfile was create/used, delete it.
         if inputImage == self.TEMP_FILE:
-            cmd = ['rm', '-rf', 'tmp_nvm3.s37' ]
+            cmd = ['rm', '-rf', 'tmp_nvm3.s37']
             subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
         results.check_returncode
 
         # Flash the binary if the device is connected
         if isDeviceConnected:
-            cmd = ['commander', 'flash', self.OUT_FILE ]
+            cmd = ['commander', 'flash', self.OUT_FILE]
             self.add_SerialNo_To_CMD(cmd)
             results = subprocess.run(cmd)
 

--- a/scripts/tools/silabs/FactoryDataProvider.py
+++ b/scripts/tools/silabs/FactoryDataProvider.py
@@ -190,13 +190,13 @@ class FactoryDataWriter:
         # Retrieve the device current nvm3 data in a binary file
         # It will be used as base to add the new credentials
         inputImage = self.TEMP_FILE
-        cmd = ['commander', 'nvm3', 'read', '-o', inputImage, ]
+        cmd = ['commander', 'nvm3', 'read', '-o', inputImage ]
         self.add_SerialNo_To_CMD(cmd)
         results = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
         if results.returncode != 0:
             # No nvm3 section found. Retrieve the device info
-            cmd = ['commander', 'device', 'info', ]
+            cmd = ['commander', 'device', 'info' ]
             self.add_SerialNo_To_CMD(cmd)
             try:
                 output = subprocess.check_output(cmd)
@@ -287,14 +287,14 @@ class FactoryDataWriter:
 
         # A tempfile was create/used, delete it.
         if inputImage == self.TEMP_FILE:
-            cmd = ['rm', '-rf', 'tmp_nvm3.s37', ]
+            cmd = ['rm', '-rf', 'tmp_nvm3.s37' ]
             subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
         results.check_returncode
 
         # Flash the binary if the device is connected
         if isDeviceConnected:
-            cmd = ['commander', 'flash', self.OUT_FILE, ]
+            cmd = ['commander', 'flash', self.OUT_FILE ]
             self.add_SerialNo_To_CMD(cmd)
             results = subprocess.run(cmd)
 

--- a/scripts/tools/spake2p/spake2p.py
+++ b/scripts/tools/spake2p/spake2p.py
@@ -36,7 +36,7 @@ INVALID_PASSCODES = [00000000,
                      88888888,
                      99999999,
                      12345678,
-                     87654321 ]
+                     87654321]
 
 # Length of `w0s` and `w1s` elements
 WS_LENGTH = NIST256p.baselen + 8

--- a/scripts/tools/spake2p/spake2p.py
+++ b/scripts/tools/spake2p/spake2p.py
@@ -25,18 +25,20 @@ import struct
 from ecdsa.curves import NIST256p
 
 # Forbidden passcodes as listed in the "5.1.7.1. Invalid Passcodes" section of the Matter spec
-INVALID_PASSCODES = [00000000,
-                     11111111,
-                     22222222,
-                     33333333,
-                     44444444,
-                     55555555,
-                     66666666,
-                     77777777,
-                     88888888,
-                     99999999,
-                     12345678,
-                     87654321]
+INVALID_PASSCODES = [
+    00000000,
+    11111111,
+    22222222,
+    33333333,
+    44444444,
+    55555555,
+    66666666,
+    77777777,
+    88888888,
+    99999999,
+    12345678,
+    87654321,
+]
 
 # Length of `w0s` and `w1s` elements
 WS_LENGTH = NIST256p.baselen + 8

--- a/scripts/tools/spake2p/spake2p.py
+++ b/scripts/tools/spake2p/spake2p.py
@@ -36,7 +36,7 @@ INVALID_PASSCODES = [00000000,
                      88888888,
                      99999999,
                      12345678,
-                     87654321, ]
+                     87654321 ]
 
 # Length of `w0s` and `w1s` elements
 WS_LENGTH = NIST256p.baselen + 8

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -350,8 +350,8 @@ class DeviceProxyWrapper():
         if that happens.
     '''
     class DeviceProxyType(enum.Enum):
-        OPERATIONAL = enum.auto(),
-        COMMISSIONEE = enum.auto(),
+        OPERATIONAL = enum.auto()
+        COMMISSIONEE = enum.auto()
 
     def __init__(self, deviceProxy: ctypes.c_void_p, proxyType, dmLib=None):
         self._deviceProxy = deviceProxy

--- a/src/controller/python/matter/crypto/p256keypair.py
+++ b/src/controller/python/matter/crypto/p256keypair.py
@@ -42,7 +42,7 @@ _pychip_P256Keypair_ECDH_derive_secret_func = CFUNCTYPE(c_bool, py_object, POINT
 P256_PUBLIC_KEY_LENGTH = 2 * 32 + 1
 
 
-@ _pychip_P256Keypair_ECDSA_sign_msg_func
+@_pychip_P256Keypair_ECDSA_sign_msg_func
 def _pychip_ECDSA_sign_msg(self_: 'P256Keypair', message_buf: _Pointer[c_uint8], message_size: int, signature_buf: _Pointer[c_uint8], signature_buf_size: _Pointer[c_size_t]) -> bool:
     res = self_.ECDSA_sign_msg(string_at(message_buf, message_size)[:])
     memmove(signature_buf, res, len(res))
@@ -50,7 +50,7 @@ def _pychip_ECDSA_sign_msg(self_: 'P256Keypair', message_buf: _Pointer[c_uint8],
     return True
 
 
-@ _pychip_P256Keypair_ECDH_derive_secret_func
+@_pychip_P256Keypair_ECDH_derive_secret_func
 def _pychip_ECDH_derive_secret(self_: 'P256Keypair', remote_pubkey: _Pointer[c_uint8], out_secret_buf: _Pointer[c_uint8], out_secret_buf_size: _Pointer[c_uint32]) -> bool:
     res = self_.ECDH_derive_secret(string_at(remote_pubkey, P256_PUBLIC_KEY_LENGTH)[:])
     memmove(out_secret_buf, res, len(res))

--- a/src/controller/python/matter/fault_injection/__init__.py
+++ b/src/controller/python/matter/fault_injection/__init__.py
@@ -6,10 +6,10 @@ from ..native import GetLibraryHandle, HandleFlags, NativeLibraryHandleMethodArg
 
 # Only ChipFaults (defined in src/lib/support/CHIPFaultInjection.h) are supported in this module, Implement others as needed
 class FaultType(IntEnum):
-    Unspecified = 0,
-    SystemFault = 1,
-    InetFault = 2,
-    ChipFault = 3,
+    Unspecified = 0
+    SystemFault = 1
+    InetFault = 2
+    ChipFault = 3
 
 
 # IMPORTANT: CHIPFaultId enum must be kept in sync with the 'Id' enum in src/lib/support/CHIPFaultInjection.h

--- a/src/controller/python/matter/webrtc/browser_webrtc_client.py
+++ b/src/controller/python/matter/webrtc/browser_webrtc_client.py
@@ -115,7 +115,7 @@ class BrowserWebRTCClient:
     def parse_messsage(self, message: dict[str, Any]) -> WebSocketMessage:
         if not self.validate_message(message):
             # return a dummy WebSocketMessage to set exception
-            raise RuntimeError(f"Invalid message received from server {message =}")
+            raise RuntimeError(f"Invalid message received from server {message=}")
         return WebSocketMessage(**message)
 
     def validate_message(self, message: dict[str, Any]) -> bool:

--- a/src/controller/python/matter/yaml/runner.py
+++ b/src/controller/python/matter/yaml/runner.py
@@ -39,13 +39,13 @@ LOGGER = logging.getLogger(__name__)
 
 
 class _ActionStatus(Enum):
-    SUCCESS = 'success',
+    SUCCESS = 'success'
     ERROR = 'error'
 
 
 class _TestFabricId(IntEnum):
-    ALPHA = 1,
-    BETA = 2,
+    ALPHA = 1
+    BETA = 2
     GAMMA = 3
 
 

--- a/src/python_testing/TC_DRLK_2_9.py
+++ b/src/python_testing/TC_DRLK_2_9.py
@@ -158,7 +158,7 @@ class TC_DRLK_2_9(MatterBaseTest, DRLK_COMMON):
             TestStep("36", "TH sends ClearCredential Command to DUT to clear all the credentials.",
                      "Verify that the DUT sends SUCCESS response."),
             TestStep("37", "TH sends ClearAliroReaderConfig Command to DUT.",
-                     "Verify that the DUT sends SUCCESS response."), ]
+                     "Verify that the DUT sends SUCCESS response.") ]
 
         return steps
 

--- a/src/python_testing/TC_DRLK_2_9.py
+++ b/src/python_testing/TC_DRLK_2_9.py
@@ -54,8 +54,7 @@ drlkcluster = Clusters.DoorLock
 class TC_DRLK_2_9(MatterBaseTest, DRLK_COMMON):
 
     def steps_TC_DRLK_2_9(self) -> list[TestStep]:
-        steps = [
-
+        return [
             TestStep("1", "TH reads NumberOfTotalUsersSupported attribute.",
                      "Verify that TH is able to read the attribute successfully."),
             TestStep("2a", "TH sends SetUser Command to DUT.", "Verify that the DUT sends SUCCESS response"),
@@ -158,9 +157,8 @@ class TC_DRLK_2_9(MatterBaseTest, DRLK_COMMON):
             TestStep("36", "TH sends ClearCredential Command to DUT to clear all the credentials.",
                      "Verify that the DUT sends SUCCESS response."),
             TestStep("37", "TH sends ClearAliroReaderConfig Command to DUT.",
-                     "Verify that the DUT sends SUCCESS response.")]
-
-        return steps
+                     "Verify that the DUT sends SUCCESS response."),
+        ]
 
     async def read_attributes_from_dut(self, endpoint, cluster, attribute, expected_status: Status = Status.Success):
         try:

--- a/src/python_testing/TC_DRLK_2_9.py
+++ b/src/python_testing/TC_DRLK_2_9.py
@@ -158,7 +158,7 @@ class TC_DRLK_2_9(MatterBaseTest, DRLK_COMMON):
             TestStep("36", "TH sends ClearCredential Command to DUT to clear all the credentials.",
                      "Verify that the DUT sends SUCCESS response."),
             TestStep("37", "TH sends ClearAliroReaderConfig Command to DUT.",
-                     "Verify that the DUT sends SUCCESS response.") ]
+                     "Verify that the DUT sends SUCCESS response.")]
 
         return steps
 

--- a/src/python_testing/TC_EWATERHTR_2_2.py
+++ b/src/python_testing/TC_EWATERHTR_2_2.py
@@ -242,7 +242,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         self.step("5a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("6")
         await self.send_test_event_trigger_water_temperature61C_test_event()
@@ -257,7 +257,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         self.step("7a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("8")
         await self.send_test_event_trigger_off_mode_test_event()
@@ -276,7 +276,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         self.step("9a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("9b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)
@@ -302,7 +302,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         self.step("11a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("11b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)
@@ -336,7 +336,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         self.step("14a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("14b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)
@@ -357,7 +357,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         self.step("16a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("16b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)
@@ -384,7 +384,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         self.step("18a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("18b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)
@@ -395,7 +395,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         self.step("19a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("19b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)
@@ -420,7 +420,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         self.step("21a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("21b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)
@@ -455,7 +455,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         self.step("24a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("24b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)

--- a/src/python_testing/TC_EWATERHTR_2_3.py
+++ b/src/python_testing/TC_EWATERHTR_2_3.py
@@ -199,7 +199,7 @@ class TC_EWATERHTR_2_3(MatterBaseTest, EWATERHTRBase):
         self.step("5a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("5b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)
@@ -223,7 +223,7 @@ class TC_EWATERHTR_2_3(MatterBaseTest, EWATERHTRBase):
         self.step("7a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("7b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)
@@ -256,7 +256,7 @@ class TC_EWATERHTR_2_3(MatterBaseTest, EWATERHTRBase):
         self.step("9a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("9b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)
@@ -294,7 +294,7 @@ class TC_EWATERHTR_2_3(MatterBaseTest, EWATERHTRBase):
         self.step("12a")
         heatDemand = await self.read_whm_attribute_expect_success(attribute="HeatDemand")
         asserts.assert_greater(heatDemand, 0)
-        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types"),
+        asserts.assert_equal(heatDemand & (~heaterTypes), 0, "heatDemand should only be from declared supported types")
 
         self.step("12b")
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)

--- a/src/python_testing/TC_EnergyReporting_Utils.py
+++ b/src/python_testing/TC_EnergyReporting_Utils.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 class EnergyReportingBaseTestHelper:
 
-    async def read_epm_attribute_expect_success(self, attribute: str = "", endpoint: int = None, ):
+    async def read_epm_attribute_expect_success(self, attribute: str = "", endpoint: int = None ):
         cluster = Clusters.Objects.ElectricalPowerMeasurement
         full_attr = getattr(cluster.Attributes, attribute)
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=full_attr)

--- a/src/python_testing/TC_EnergyReporting_Utils.py
+++ b/src/python_testing/TC_EnergyReporting_Utils.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 class EnergyReportingBaseTestHelper:
 
-    async def read_epm_attribute_expect_success(self, attribute: str = "", endpoint: int = None ):
+    async def read_epm_attribute_expect_success(self, attribute: str = "", endpoint: int = None):
         cluster = Clusters.Objects.ElectricalPowerMeasurement
         full_attr = getattr(cluster.Attributes, attribute)
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=full_attr)

--- a/src/python_testing/TC_PAVST_2_7.py
+++ b/src/python_testing/TC_PAVST_2_7.py
@@ -289,7 +289,7 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         aAllocatedAudioStreams = await self.allocate_one_audio_stream()
 
         triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kCommand,
-                          "maxPreRollLen": 4000, }
+                          "maxPreRollLen": 4000 }
 
         status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions, tlsEndPoint=tlsEndpointId,
                                                           url=f"https://{host_ip}:1234/streams/{uploadStreamId}")

--- a/src/python_testing/TC_PAVST_2_7.py
+++ b/src/python_testing/TC_PAVST_2_7.py
@@ -289,7 +289,7 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         aAllocatedAudioStreams = await self.allocate_one_audio_stream()
 
         triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kCommand,
-                          "maxPreRollLen": 4000 }
+                          "maxPreRollLen": 4000}
 
         status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions, tlsEndPoint=tlsEndpointId,
                                                           url=f"https://{host_ip}:1234/streams/{uploadStreamId}")

--- a/src/python_testing/TC_WEBRTCP_2_5.py
+++ b/src/python_testing/TC_WEBRTCP_2_5.py
@@ -169,7 +169,7 @@ class TC_WebRTCProvider_2_5(MatterBaseTest, WEBRTCPTestBase):
             # Send SolicitOffer with stream usage that isn't supported. Valid audio stream ID, valid video stream ID
             self.step(9)
             notSupportedStreamUsage = next((e for e in Globals.Enums.StreamUsageEnum if e not in aStreamUsagePriorities),
-                                           Globals.Enums.StreamUsageEnum.kUnknownEnumValue,)
+                                           Globals.Enums.StreamUsageEnum.kUnknownEnumValue)
 
             cmd = cluster.Commands.SolicitOffer(
                 streamUsage=notSupportedStreamUsage, originatingEndpointID=endpoint, videoStreamID=videoStreamID, audioStreamID=audioStreamID)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/global_attribute_ids.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/global_attribute_ids.py
@@ -41,33 +41,33 @@ class GlobalAttributeIds(IntEnum):
 
 
 class DeviceTypeIdType(Enum):
-    kInvalid = auto(),
-    kStandard = auto(),
-    kManufacturer = auto(),
-    kTest = auto(),
+    kInvalid = auto()
+    kStandard = auto()
+    kManufacturer = auto()
+    kTest = auto()
 
 
 class ClusterIdType(Enum):
     kInvalid = auto()
-    kStandard = auto(),
-    kManufacturer = auto(),
-    kTest = auto(),
+    kStandard = auto()
+    kManufacturer = auto()
+    kTest = auto()
 
 
 class AttributeIdType(Enum):
     kInvalid = auto()
-    kStandardGlobal = auto(),
-    kStandardNonGlobal = auto(),
-    kManufacturer = auto(),
-    kTest = auto(),
+    kStandardGlobal = auto()
+    kStandardNonGlobal = auto()
+    kManufacturer = auto()
+    kTest = auto()
 
 
 class CommandIdType(Enum):
     kInvalid = auto()
-    kStandardGlobal = auto(),
-    kScopedNonGlobal = auto(),
-    kManufacturer = auto(),
-    kTest = auto(),
+    kStandardGlobal = auto()
+    kScopedNonGlobal = auto()
+    kManufacturer = auto()
+    kTest = auto()
 
 
 # ID helper classes - this allows us to use the values from the prefix and suffix table directly

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
@@ -240,7 +240,7 @@ DEVICE_TYPE_NAME_FIXES = {0x010b: 'Dimmable Plug-In Unit', 0x010a: 'On/Off Plug-
 
 # fuzzy match to name because some of the old specs weren't careful here
 def _fuzzy_name(to_fuzz: str):
-    to_fuzz = re.sub("\(.*?\)|\[.*?\]", "", to_fuzz)
+    to_fuzz = re.sub(r"\(.*?\)|\[.*?\]", "", to_fuzz)
     return to_fuzz.lower().strip().replace(' ', '').replace('/', '')
 
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
@@ -1233,11 +1233,13 @@ def dm_from_spec_version(specification_version: uint) -> PrebuiltDataModelDirect
         # The expression (specification_version & uint(0xFFFF00FF)) might be inferred as int by mypy.
         specification_version = typing.cast(uint, specification_version & uint(0xFFFF00FF))
 
-    version_to_dm = {0x01030000: PrebuiltDataModelDirectory.k1_3,
-                     0x01040000: PrebuiltDataModelDirectory.k1_4,
-                     0x01040100: PrebuiltDataModelDirectory.k1_4_1,
-                     0x01040200: PrebuiltDataModelDirectory.k1_4_2,
-                     0x01050000: PrebuiltDataModelDirectory.k1_5, }
+    version_to_dm = {
+        0x01030000: PrebuiltDataModelDirectory.k1_3,
+        0x01040000: PrebuiltDataModelDirectory.k1_4,
+        0x01040100: PrebuiltDataModelDirectory.k1_4_1,
+        0x01040200: PrebuiltDataModelDirectory.k1_4_2,
+        0x01050000: PrebuiltDataModelDirectory.k1_5,
+    }
 
     if specification_version not in version_to_dm.keys():
         raise ConformanceException(f"Unknown specification_version 0x{specification_version:08X}")

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -354,9 +354,9 @@ def get_qr() -> str:
 
 
 class SetupCodeType(Enum):
-    UNKNOWN = auto(),
-    QR = auto(),
-    MANUAL = auto(),
+    UNKNOWN = auto()
+    QR = auto()
+    MANUAL = auto()
 
 
 def get_setup_code() -> (str, bool):

--- a/src/python_testing/test_testing/test_TC_ICDM_2_1_full_pics.py
+++ b/src/python_testing/test_testing/test_TC_ICDM_2_1_full_pics.py
@@ -194,7 +194,7 @@ TEST_CASES = [
 
 def main():
     pics = {"ICDM.S.A0000": True, "ICDM.S.A0001": True, "ICDM.S.A0002": True, "ICDM.S.A0003": True, "ICDM.S.A0004": True,
-            "ICDM.S.A0005": True, "ICDM.S.A0006": True, "ICDM.S.A0007": True, "ICDM.S.A0008": True, "ICDM.S.A0009": True, }
+            "ICDM.S.A0005": True, "ICDM.S.A0006": True, "ICDM.S.A0007": True, "ICDM.S.A0008": True, "ICDM.S.A0009": True }
 
     return run_tests(pics, 'TC_ICDM_2_1', TEST_CASES, 'test_TC_ICDM_2_1')
 

--- a/src/python_testing/test_testing/test_TC_ICDM_2_1_full_pics.py
+++ b/src/python_testing/test_testing/test_TC_ICDM_2_1_full_pics.py
@@ -194,7 +194,7 @@ TEST_CASES = [
 
 def main():
     pics = {"ICDM.S.A0000": True, "ICDM.S.A0001": True, "ICDM.S.A0002": True, "ICDM.S.A0003": True, "ICDM.S.A0004": True,
-            "ICDM.S.A0005": True, "ICDM.S.A0006": True, "ICDM.S.A0007": True, "ICDM.S.A0008": True, "ICDM.S.A0009": True }
+            "ICDM.S.A0005": True, "ICDM.S.A0006": True, "ICDM.S.A0007": True, "ICDM.S.A0008": True, "ICDM.S.A0009": True}
 
     return run_tests(pics, 'TC_ICDM_2_1', TEST_CASES, 'test_TC_ICDM_2_1')
 

--- a/src/python_testing/test_testing/test_TC_ICDM_2_1_min_pics.py
+++ b/src/python_testing/test_testing/test_TC_ICDM_2_1_min_pics.py
@@ -29,7 +29,7 @@ TEST_CASES = [
 
 def main():
     pics = {"ICDM.S.A0000": True, "ICDM.S.A0001": True, "ICDM.S.A0002": True, "ICDM.S.A0003": False, "ICDM.S.A0004": False,
-            "ICDM.S.A0005": False, "ICDM.S.A0006": False, "ICDM.S.A0007": False, "ICDM.S.A0008": False, "ICDM.S.A0009": False, }
+            "ICDM.S.A0005": False, "ICDM.S.A0006": False, "ICDM.S.A0007": False, "ICDM.S.A0008": False, "ICDM.S.A0009": False }
 
     return run_tests(pics, 'TC_ICDM_2_1', TEST_CASES, 'test_TC_ICDM_2_1')
 

--- a/src/python_testing/test_testing/test_TC_ICDM_2_1_min_pics.py
+++ b/src/python_testing/test_testing/test_TC_ICDM_2_1_min_pics.py
@@ -29,7 +29,7 @@ TEST_CASES = [
 
 def main():
     pics = {"ICDM.S.A0000": True, "ICDM.S.A0001": True, "ICDM.S.A0002": True, "ICDM.S.A0003": False, "ICDM.S.A0004": False,
-            "ICDM.S.A0005": False, "ICDM.S.A0006": False, "ICDM.S.A0007": False, "ICDM.S.A0008": False, "ICDM.S.A0009": False }
+            "ICDM.S.A0005": False, "ICDM.S.A0006": False, "ICDM.S.A0007": False, "ICDM.S.A0008": False, "ICDM.S.A0009": False}
 
     return run_tests(pics, 'TC_ICDM_2_1', TEST_CASES, 'test_TC_ICDM_2_1')
 

--- a/src/setup_payload/python/SetupPayload.py
+++ b/src/setup_payload/python/SetupPayload.py
@@ -52,8 +52,8 @@ qrcode_format = BitStruct(
 
 
 class CommissioningFlow(enum.IntEnum):
-    Standard = 0,
-    UserIntent = 1,
+    Standard = 0
+    UserIntent = 1
     Custom = 2
 
 

--- a/src/test_driver/linux-cirque/helper/CHIPTestBase.py
+++ b/src/test_driver/linux-cirque/helper/CHIPTestBase.py
@@ -285,7 +285,7 @@ class CHIPVirtualHome:
     def wait_for_device_output(self, device_id, pattern, timeout=1):
         due = time.time() + timeout
         while True:
-            if self.sequenceMatch(self.get_device_log(device_id).decode(), [pattern, ]):
+            if self.sequenceMatch(self.get_device_log(device_id).decode(), [pattern ]):
                 return True
             if time.time() < due:
                 time.sleep(1)

--- a/src/test_driver/linux-cirque/helper/CHIPTestBase.py
+++ b/src/test_driver/linux-cirque/helper/CHIPTestBase.py
@@ -285,7 +285,7 @@ class CHIPVirtualHome:
     def wait_for_device_output(self, device_id, pattern, timeout=1):
         due = time.time() + timeout
         while True:
-            if self.sequenceMatch(self.get_device_log(device_id).decode(), [pattern ]):
+            if self.sequenceMatch(self.get_device_log(device_id).decode(), [pattern]):
                 return True
             if time.time() < due:
                 time.sleep(1)

--- a/src/tools/push_av_server/server.py
+++ b/src/tools/push_av_server/server.py
@@ -690,7 +690,7 @@ class PushAvContext:
         pas = PushAvServer(self.directory, self.device_hierarchy, strict_mode)
         self.app.include_router(pas.router)
 
-    async def start(self, shutdown_trigger: Optional[Callable[..., Awaitable]] = None,):
+    async def start(self, shutdown_trigger: Optional[Callable[..., Awaitable]] = None):
         """
         Start the PUSH AV server. Note that method do not check if a server is already running.
         """


### PR DESCRIPTION
#### Summary

Adding a comma at the end of the line might have catastrophic consequences in Python - it creates one-element tuple. This PR adds lint check for such typos. Also it bumps autopep8 version for better reformatting.

#### Testing

CI will verify.