### PR TITLE
Make the data model target configurable.

### DIFF
--- a/examples/camera-controller/BUILD.gn
+++ b/examples/camera-controller/BUILD.gn
@@ -111,7 +111,6 @@ static_library("camera-controller-utils") {
 
   public_deps = [
     "${chip_root}/examples/common/tracing:commandline",
-    "${chip_root}/src/app:required-privileges",
     "${chip_root}/src/app/server",
     "${chip_root}/src/app/tests/suites/commands/interaction_model",
     "${chip_root}/src/controller/data_model",

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -892,6 +892,7 @@ def main() -> int:
                  f'"CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID={options.pid}", '
                  f'"CONFIG_ENABLE_PW_RPC={int(options.do_rpc)}", '
                  f'"CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME=\\"{str(options.pname)}\\""]'),
+                'chip_app_data_model_target = "//:chef-data-model"',
             ])
 
             uname_resp = shell.run_cmd("uname -m", return_cmd_output=True)

--- a/examples/contact-sensor-app/bouffalolab/bl702l/args.gni
+++ b/examples/contact-sensor-app/bouffalolab/bl702l/args.gni
@@ -27,4 +27,4 @@ chip_error_logging = true
 chip_enable_icd_server = true
 chip_enable_icd_lit = true
 chip_enable_icd_dsls = true
-chip_app_data_model_target = "bouffalolab_contact_sensor"
+chip_app_data_model_target = "//:bouffalolab_contact_sensor"

--- a/examples/contact-sensor-app/bouffalolab/bl702l/args.gni
+++ b/examples/contact-sensor-app/bouffalolab/bl702l/args.gni
@@ -27,3 +27,4 @@ chip_error_logging = true
 chip_enable_icd_server = true
 chip_enable_icd_lit = true
 chip_enable_icd_dsls = true
+chip_app_data_model_target = "bouffalolab_contact_sensor"

--- a/examples/lighting-app/bouffalolab/bl602/args.gni
+++ b/examples/lighting-app/bouffalolab/bl602/args.gni
@@ -32,3 +32,4 @@ pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",
   "$dir_pw_log:impl",
 ]
+chip_app_data_model_target = "//:bouffalolab-lighting"

--- a/examples/lighting-app/bouffalolab/bl616/args.gni
+++ b/examples/lighting-app/bouffalolab/bl616/args.gni
@@ -23,3 +23,4 @@ chip_detail_logging = false
 
 # use -Os instead of -Og
 is_debug = false
+chip_app_data_model_target = "//:bouffalolab-lighting"

--- a/examples/lighting-app/bouffalolab/bl702/args.gni
+++ b/examples/lighting-app/bouffalolab/bl702/args.gni
@@ -32,3 +32,4 @@ pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",
   "$dir_pw_log:impl",
 ]
+chip_app_data_model_target = "//:bouffalolab-lighting"

--- a/examples/lighting-app/bouffalolab/bl702l/args.gni
+++ b/examples/lighting-app/bouffalolab/bl702l/args.gni
@@ -32,3 +32,5 @@ pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",
   "$dir_pw_log:impl",
 ]
+
+chip_app_data_model_target = "//:bouffalolab-lighting"

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -56,6 +56,10 @@ declare_args() {
   chip_im_static_global_interaction_model_engine =
       current_os != "linux" && current_os != "mac" && current_os != "ios" &&
       current_os != "android"
+
+  # Set for integration into build systems: defines visibility
+  # for files that chip_data_model requires.
+  chip_app_data_model_target = "${chip_root}/examples/*"
 }
 
 buildconfig_header("app_buildconfig") {
@@ -350,14 +354,16 @@ source_set("required-privileges") {
   # is part of application code, the visibility is broad. However generally DO NOT USE THIS
   # unless you are creating a new CodegenDataModelProvider based item
   visibility = [
-    "//:*",  # Top-level apps (e.g. //:bouffalolab-lighting does this)
-    "${chip_root}/examples/*",
     "${chip_root}/src/app/util/*",
     "${chip_root}/src/controller/data_model",
     "${chip_root}/src/controller/java:jni",
     "${chip_root}/src/controller/python:ChipDeviceCtrl",
     "${chip_root}/src/data-model-providers/codegen/*",
   ]
+
+  if (chip_app_data_model_target != "") {
+    visibility += [ chip_app_data_model_target ]
+  }
 
   # We still have some strong coupling in this case
   # Eventually dynamic server should be replaced with code-driven and not try

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -354,13 +354,19 @@ source_set("required-privileges") {
   # is part of application code, the visibility is broad. However generally DO NOT USE THIS
   # unless you are creating a new CodegenDataModelProvider based item
   visibility = [
-    "${chip_root}/src/app/util/*",
+    # Test data models: mock models for testing
+    "${chip_root}/examples/common/server-cluster-shim:mock_data_model_with_shim",
+    "${chip_root}/src/app/util/mock/*",
+    "${chip_root}/src/data-model-providers/codegen/tests/*",
+
+    # Controller data models:
+    #   linked by controllers only, never by applications
     "${chip_root}/src/controller/data_model",
     "${chip_root}/src/controller/java:jni",
     "${chip_root}/src/controller/python:ChipDeviceCtrl",
-    "${chip_root}/src/data-model-providers/codegen/*",
   ]
 
+  # Application integration: `chip_data_model` target should be set here
   if (chip_app_data_model_target != "") {
     visibility += [ chip_app_data_model_target ]
   }

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -355,7 +355,10 @@ source_set("required-privileges") {
   # unless you are creating a new CodegenDataModelProvider based item
   visibility = [
     # Test data models: mock models for testing
+    # TODO: Some of these are questionable as they would not work as part of a monolith
+    #       (single app) test build: in particular the energy management bits seem wrong
     "${chip_root}/examples/common/server-cluster-shim:mock_data_model_with_shim",
+    "${chip_root}/examples/energy-management-app/energy-management-common",
     "${chip_root}/src/app/util/mock/*",
     "${chip_root}/src/data-model-providers/codegen/tests/*",
 


### PR DESCRIPTION
This allows integration of the SDK directly in existing GN build systems.

#### Summary

The visibility of the app codegen-required files was restricted to examples and other fixed paths. This makes it harder to integrate the SDK code somewhere where the data model does not reside at the top level or in `examples`.

Update the visibility to allow custom setting.

#### Testing

CI will validate: I made boufalolab as an example that uses this config setting and it compiled on my machine. CI will validate the rest.