### PR TITLE
fix the doc-string in software diagnostic cluster server impl

### DIFF
--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-cluster.h
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-cluster.h
@@ -132,7 +132,7 @@ public:
 private:
     // Encodes the `value` in `encoder`, while handling a potential `readError` that occurred
     // when the input `value` was read:
-    //   - CHIP_ERROR_NOT_IMPLEMENTED results in a 0 being encoded
+    //   - CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE results in a 0 being encoded
     //   - any other read error is just forwarded
     CHIP_ERROR EncodeValue(uint64_t value, CHIP_ERROR readError, AttributeValueEncoder & encoder)
     {


### PR DESCRIPTION
#### Summary
Aligning the doc-string comment with actual implementation

#### Related issues
Fixes #41123

#### Testing
- only fixing comment, hence not required.