### PR TITLE
[Fix] Updating test steps in TC_ACL_2_9 and TC_ACL_2_10 to resolve issues with Extension not existing on DUT

### DIFF
--- a/src/python_testing/TC_ACL_2_10.py
+++ b/src/python_testing/TC_ACL_2_10.py
@@ -194,7 +194,7 @@ class TC_ACL_2_10(MatterBaseTest):
             result[0].Status, Status.Success, "Write should have succeeded")
 
         self.step(7)
-        if ext_attr_enabled:
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
             # TH1 writes Extension attribute with D_OK_EMPTY
             extension1 = Clusters.AccessControl.Structs.AccessControlExtensionStruct(
                 data=D_OK_EMPTY)
@@ -209,7 +209,7 @@ class TC_ACL_2_10(MatterBaseTest):
                 result[0].Status, Status.Success, "Write should have succeeded")
 
         self.step(8)
-        if ext_attr_enabled:
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
             # TH2 writes Extension attribute with D_OK_SINGLE
             extension2 = Clusters.AccessControl.Structs.AccessControlExtensionStruct(
                 data=D_OK_SINGLE)
@@ -278,7 +278,7 @@ class TC_ACL_2_10(MatterBaseTest):
         # Result is SUCCESS, value is list of AccessControlExtensionStruct
         # containing 1 element; MUST NOT contain an element with FabricIndex `F2`
         # or Data `D_OK_SINGLE`
-        if ext_attr_enabled:
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
             th1_extension_attr = await self.read_single_attribute_check_success(dev_ctrl=self.th1, endpoint=0, cluster=acl_cluster, attribute=extension_attr)
             logging.info("TH1 read extension result: %s", str(th1_extension_attr))
             asserts.assert_equal(len(th1_extension_attr), 1, "Expected exactly one extension attribute")
@@ -305,7 +305,7 @@ class TC_ACL_2_10(MatterBaseTest):
         # Result is SUCCESS, value is list of AccessControlExtensionStruct
         # containing 1 element; MUST NOT contain an element with FabricIndex `F1`
         # or Data `D_OK_EMPTY`
-        if ext_attr_enabled:
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
             th2_extension_attr = await self.read_single_attribute_check_success(dev_ctrl=self.th2, endpoint=0, cluster=acl_cluster, attribute=extension_attr)
             logging.info("TH2 read extension result: %s", str(th2_extension_attr))
             asserts.assert_equal(len(th2_extension_attr), 1, "Expected exactly one extension attribute")
@@ -335,7 +335,7 @@ class TC_ACL_2_10(MatterBaseTest):
                 entry.fabricIndex, f2, "Should not contain entry with FabricIndex F2")
 
         self.step(16)
-        if ext_attr_enabled:
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
             # TH1 reads DUT Endpoint 0 AccessControl cluster Extension attribute
             # Result is SUCCESS, value is list of AccessControlExtensionStruct
             # containing 1 element; MUST NOT contain an element with FabricIndex `F2`

--- a/src/python_testing/TC_ACL_2_10.py
+++ b/src/python_testing/TC_ACL_2_10.py
@@ -101,6 +101,7 @@ class TC_ACL_2_10(MatterBaseTest):
         self.step(1)
         self.th1 = self.default_controller
         self.discriminator = random.randint(0, 4095)
+        self.endpoint = self.get_endpoint()
 
         self.step(2)
         # Read CurrentFabricIndex for TH1
@@ -191,34 +192,36 @@ class TC_ACL_2_10(MatterBaseTest):
             result[0].Status, Status.Success, "Write should have succeeded")
 
         self.step(7)
-        # TH1 writes Extension attribute with D_OK_EMPTY
-        extension1 = Clusters.AccessControl.Structs.AccessControlExtensionStruct(
-            data=D_OK_EMPTY)
-        logging.info(f"Writing extension with data {D_OK_EMPTY.hex()}")
         extension_attr = Clusters.AccessControl.Attributes.Extension
-        extensions_list1 = [extension1]
-        result = await self.th1.WriteAttribute(
-            self.dut_node_id,
-            [(0, extension_attr(value=extensions_list1))]
-        )
-        logging.info("TH1 write result: %s", str(result))
-        asserts.assert_equal(
-            result[0].Status, Status.Success, "Write should have succeeded")
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
+            # TH1 writes Extension attribute with D_OK_EMPTY
+            extension1 = Clusters.AccessControl.Structs.AccessControlExtensionStruct(
+                data=D_OK_EMPTY)
+            logging.info(f"Writing extension with data {D_OK_EMPTY.hex()}")
+            extensions_list1 = [extension1]
+            result = await self.th1.WriteAttribute(
+                self.dut_node_id,
+                [(0, extension_attr(value=extensions_list1))]
+            )
+            logging.info("TH1 write result: %s", str(result))
+            asserts.assert_equal(
+                result[0].Status, Status.Success, "Write should have succeeded")
 
         self.step(8)
-        # TH2 writes Extension attribute with D_OK_SINGLE
-        extension2 = Clusters.AccessControl.Structs.AccessControlExtensionStruct(
-            data=D_OK_SINGLE)
-        logging.info(f"Writing extension with data {D_OK_SINGLE.hex()}")
-        extensions_list2 = [extension2]
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
+            # TH2 writes Extension attribute with D_OK_SINGLE
+            extension2 = Clusters.AccessControl.Structs.AccessControlExtensionStruct(
+                data=D_OK_SINGLE)
+            logging.info(f"Writing extension with data {D_OK_SINGLE.hex()}")
+            extensions_list2 = [extension2]
 
-        result = await self.th2.WriteAttribute(
-            self.dut_node_id,
-            [(0, extension_attr(value=extensions_list2))]
-        )
-        logging.info("TH2 write result: %s", str(result))
-        asserts.assert_equal(
-            result[0].Status, Status.Success, "Write should have succeeded")
+            result = await self.th2.WriteAttribute(
+                self.dut_node_id,
+                [(0, extension_attr(value=extensions_list2))]
+            )
+            logging.info("TH2 write result: %s", str(result))
+            asserts.assert_equal(
+                result[0].Status, Status.Success, "Write should have succeeded")
 
         self.step(9)
         # Reboot DUT
@@ -274,15 +277,15 @@ class TC_ACL_2_10(MatterBaseTest):
         # Result is SUCCESS, value is list of AccessControlExtensionStruct
         # containing 1 element; MUST NOT contain an element with FabricIndex `F2`
         # or Data `D_OK_SINGLE`
-        extension_attr = Clusters.AccessControl.Attributes.Extension
-        th1_extension_attr = await self.read_single_attribute_check_success(dev_ctrl=self.th1, endpoint=0, cluster=acl_cluster, attribute=extension_attr)
-        logging.info("TH1 read extension result: %s", str(th1_extension_attr))
-        asserts.assert_equal(len(th1_extension_attr), 1, "Expected exactly one extension attribute")
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
+            th1_extension_attr = await self.read_single_attribute_check_success(dev_ctrl=self.th1, endpoint=0, cluster=acl_cluster, attribute=extension_attr)
+            logging.info("TH1 read extension result: %s", str(th1_extension_attr))
+            asserts.assert_equal(len(th1_extension_attr), 1, "Expected exactly one extension attribute")
 
-        # Verify the actual values
-        entry = th1_extension_attr[0]
-        asserts.assert_equal(entry.data, D_OK_EMPTY, "Data should be D_OK_EMPTY")
-        asserts.assert_equal(entry.fabricIndex, f1, "FabricIndex should be F1")
+            # Verify the actual values
+            entry = th1_extension_attr[0]
+            asserts.assert_equal(entry.data, D_OK_EMPTY, "Data should be D_OK_EMPTY")
+            asserts.assert_equal(entry.fabricIndex, f1, "FabricIndex should be F1")
 
         self.step(12)
         # TH2 reads DUT Endpoint 0 AccessControl cluster ACL attribute
@@ -301,14 +304,15 @@ class TC_ACL_2_10(MatterBaseTest):
         # Result is SUCCESS, value is list of AccessControlExtensionStruct
         # containing 1 element; MUST NOT contain an element with FabricIndex `F1`
         # or Data `D_OK_EMPTY`
-        th2_extension_attr = await self.read_single_attribute_check_success(dev_ctrl=self.th2, endpoint=0, cluster=acl_cluster, attribute=extension_attr)
-        logging.info("TH2 read extension result: %s", str(th2_extension_attr))
-        asserts.assert_equal(len(th2_extension_attr), 1, "Expected exactly one extension attribute")
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
+            th2_extension_attr = await self.read_single_attribute_check_success(dev_ctrl=self.th2, endpoint=0, cluster=acl_cluster, attribute=extension_attr)
+            logging.info("TH2 read extension result: %s", str(th2_extension_attr))
+            asserts.assert_equal(len(th2_extension_attr), 1, "Expected exactly one extension attribute")
 
-        # Verify the actual values
-        entry2 = th2_extension_attr[0]
-        asserts.assert_equal(entry2.data, D_OK_SINGLE, "Data should be D_OK_SINGLE")
-        asserts.assert_equal(entry2.fabricIndex, f2, "FabricIndex should be F2")
+            # Verify the actual values
+            entry2 = th2_extension_attr[0]
+            asserts.assert_equal(entry2.data, D_OK_SINGLE, "Data should be D_OK_SINGLE")
+            asserts.assert_equal(entry2.fabricIndex, f2, "FabricIndex should be F2")
 
         self.step(14)
         # TH1 removes fabric `F2` from DUT
@@ -330,18 +334,19 @@ class TC_ACL_2_10(MatterBaseTest):
                 entry.fabricIndex, f2, "Should not contain entry with FabricIndex F2")
 
         self.step(16)
-        # TH1 reads DUT Endpoint 0 AccessControl cluster Extension attribute
-        # Result is SUCCESS, value is list of AccessControlExtensionStruct
-        # containing 1 element; MUST NOT contain an element with FabricIndex `F2`
-        # or Data `D_OK_SINGLE`
-        th1_extension_attr2 = await self.read_single_attribute_check_success(dev_ctrl=self.th1, endpoint=0, cluster=acl_cluster, attribute=extension_attr)
-        logging.info("TH1 read extension result: %s", str(th1_extension_attr2))
-        asserts.assert_equal(len(th1_extension_attr2), 1, "Expected exactly one extension attribute")
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
+            # TH1 reads DUT Endpoint 0 AccessControl cluster Extension attribute
+            # Result is SUCCESS, value is list of AccessControlExtensionStruct
+            # containing 1 element; MUST NOT contain an element with FabricIndex `F2`
+            # or Data `D_OK_SINGLE`
+            th1_extension_attr2 = await self.read_single_attribute_check_success(dev_ctrl=self.th1, endpoint=0, cluster=acl_cluster, attribute=extension_attr)
+            logging.info("TH1 read extension result: %s", str(th1_extension_attr2))
+            asserts.assert_equal(len(th1_extension_attr2), 1, "Expected exactly one extension attribute")
 
-        # Verify the attribute, should not contain an entry with FabricIndex F2 or Data D_OK_SINGLE
-        entry3 = th1_extension_attr2[0]
-        asserts.assert_equal(entry3.data, D_OK_EMPTY, "Data should be D_OK_EMPTY")
-        asserts.assert_equal(entry3.fabricIndex, f1, "FabricIndex should be F1")
+            # Verify the attribute, should not contain an entry with FabricIndex F2 or Data D_OK_SINGLE
+            entry3 = th1_extension_attr2[0]
+            asserts.assert_equal(entry3.data, D_OK_EMPTY, "Data should be D_OK_EMPTY")
+            asserts.assert_equal(entry3.fabricIndex, f1, "FabricIndex should be F1")
 
         # Step 17: Write minimum required ACL (admin only)
         self.step(17)

--- a/src/python_testing/TC_ACL_2_10.py
+++ b/src/python_testing/TC_ACL_2_10.py
@@ -103,7 +103,6 @@ class TC_ACL_2_10(MatterBaseTest):
         self.discriminator = random.randint(0, 4095)
         self.endpoint = self.get_endpoint()
         extension_attr = Clusters.AccessControl.Attributes.Extension
-        ext_attr_enabled = await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr)
 
         self.step(2)
         # Read CurrentFabricIndex for TH1

--- a/src/python_testing/TC_ACL_2_10.py
+++ b/src/python_testing/TC_ACL_2_10.py
@@ -102,6 +102,8 @@ class TC_ACL_2_10(MatterBaseTest):
         self.th1 = self.default_controller
         self.discriminator = random.randint(0, 4095)
         self.endpoint = self.get_endpoint()
+        extension_attribute = Clusters.AccessControl.Attributes.Extension
+        ext_attr_enabled = await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute)
 
         self.step(2)
         # Read CurrentFabricIndex for TH1
@@ -192,8 +194,7 @@ class TC_ACL_2_10(MatterBaseTest):
             result[0].Status, Status.Success, "Write should have succeeded")
 
         self.step(7)
-        extension_attr = Clusters.AccessControl.Attributes.Extension
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
+        if ext_attr_enabled:
             # TH1 writes Extension attribute with D_OK_EMPTY
             extension1 = Clusters.AccessControl.Structs.AccessControlExtensionStruct(
                 data=D_OK_EMPTY)
@@ -208,7 +209,7 @@ class TC_ACL_2_10(MatterBaseTest):
                 result[0].Status, Status.Success, "Write should have succeeded")
 
         self.step(8)
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
+        if ext_attr_enabled:
             # TH2 writes Extension attribute with D_OK_SINGLE
             extension2 = Clusters.AccessControl.Structs.AccessControlExtensionStruct(
                 data=D_OK_SINGLE)
@@ -277,7 +278,7 @@ class TC_ACL_2_10(MatterBaseTest):
         # Result is SUCCESS, value is list of AccessControlExtensionStruct
         # containing 1 element; MUST NOT contain an element with FabricIndex `F2`
         # or Data `D_OK_SINGLE`
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
+        if ext_attr_enabled:
             th1_extension_attr = await self.read_single_attribute_check_success(dev_ctrl=self.th1, endpoint=0, cluster=acl_cluster, attribute=extension_attr)
             logging.info("TH1 read extension result: %s", str(th1_extension_attr))
             asserts.assert_equal(len(th1_extension_attr), 1, "Expected exactly one extension attribute")
@@ -304,7 +305,7 @@ class TC_ACL_2_10(MatterBaseTest):
         # Result is SUCCESS, value is list of AccessControlExtensionStruct
         # containing 1 element; MUST NOT contain an element with FabricIndex `F1`
         # or Data `D_OK_EMPTY`
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
+        if ext_attr_enabled:
             th2_extension_attr = await self.read_single_attribute_check_success(dev_ctrl=self.th2, endpoint=0, cluster=acl_cluster, attribute=extension_attr)
             logging.info("TH2 read extension result: %s", str(th2_extension_attr))
             asserts.assert_equal(len(th2_extension_attr), 1, "Expected exactly one extension attribute")
@@ -334,7 +335,7 @@ class TC_ACL_2_10(MatterBaseTest):
                 entry.fabricIndex, f2, "Should not contain entry with FabricIndex F2")
 
         self.step(16)
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr):
+        if ext_attr_enabled:
             # TH1 reads DUT Endpoint 0 AccessControl cluster Extension attribute
             # Result is SUCCESS, value is list of AccessControlExtensionStruct
             # containing 1 element; MUST NOT contain an element with FabricIndex `F2`

--- a/src/python_testing/TC_ACL_2_10.py
+++ b/src/python_testing/TC_ACL_2_10.py
@@ -29,7 +29,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#       --endpoint 1
+#       --endpoint 0
 # === END CI TEST ARGUMENTS ===
 
 
@@ -102,8 +102,8 @@ class TC_ACL_2_10(MatterBaseTest):
         self.th1 = self.default_controller
         self.discriminator = random.randint(0, 4095)
         self.endpoint = self.get_endpoint()
-        extension_attribute = Clusters.AccessControl.Attributes.Extension
-        ext_attr_enabled = await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute)
+        extension_attr = Clusters.AccessControl.Attributes.Extension
+        ext_attr_enabled = await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attr)
 
         self.step(2)
         # Read CurrentFabricIndex for TH1

--- a/src/python_testing/TC_ACL_2_9.py
+++ b/src/python_testing/TC_ACL_2_9.py
@@ -131,7 +131,6 @@ class TC_ACL_2_9(MatterBaseTest):
         self.discriminator = random.randint(0, 4095)
         self.endpoint = self.get_endpoint()
         extension_attribute = Clusters.AccessControl.Attributes.Extension
-        ext_attr_enabled = await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute)
 
         self.step(2)
         # Create TH2 controller
@@ -214,7 +213,7 @@ class TC_ACL_2_9(MatterBaseTest):
 
         self.step(6)
         # TH2 reads DUT Endpoint 0 AccessControl cluster Extension attribute
-        if ext_attr_enabled:
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute):
             await self.read_single_attribute_expect_error(
                 dev_ctrl=self.th2,
                 cluster=Clusters.Objects.AccessControl,
@@ -224,7 +223,7 @@ class TC_ACL_2_9(MatterBaseTest):
             )
 
         self.step(7)
-        if ext_attr_enabled:
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute):
             # TH2 writes DUT Endpoint 0 AccessControl cluster Extension attribute, value is an empty list
             new_extension = []
             result3 = await self.th2.WriteAttribute(
@@ -252,7 +251,7 @@ class TC_ACL_2_9(MatterBaseTest):
         await self.read_event_expect_unsupported_access(Clusters.AccessControl.Events.AccessControlEntryChanged)
 
         self.step(12)
-        if ext_attr_enabled:
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute):
             # TH2 reads DUT Endpoint 0 AccessControl cluster AccessControlExtensionChanged event
             await self.read_event_expect_unsupported_access(Clusters.AccessControl.Events.AccessControlExtensionChanged)
 

--- a/src/python_testing/TC_ACL_2_9.py
+++ b/src/python_testing/TC_ACL_2_9.py
@@ -272,5 +272,6 @@ class TC_ACL_2_9(MatterBaseTest):
         removeFabricCmd = Clusters.OperationalCredentials.Commands.RemoveFabric(th2_idx)
         await self.th1.SendCommand(nodeid=self.dut_node_id, endpoint=0, payload=removeFabricCmd)
 
+
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_ACL_2_9.py
+++ b/src/python_testing/TC_ACL_2_9.py
@@ -129,6 +129,7 @@ class TC_ACL_2_9(MatterBaseTest):
         # Create TH1 controller
         self.th1 = self.default_controller
         self.discriminator = random.randint(0, 4095)
+        self.endpoint = self.get_endpoint()
 
         self.step(2)
         # Create TH2 controller
@@ -212,24 +213,26 @@ class TC_ACL_2_9(MatterBaseTest):
         self.step(6)
         # TH2 reads DUT Endpoint 0 AccessControl cluster Extension attribute
         extension_attribute = Clusters.AccessControl.Attributes.Extension
-        await self.read_single_attribute_expect_error(
-            dev_ctrl=self.th2,
-            cluster=Clusters.Objects.AccessControl,
-            attribute=extension_attribute,
-            error=Status.UnsupportedAccess,
-            endpoint=0
-        )
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute):
+            await self.read_single_attribute_expect_error(
+                dev_ctrl=self.th2,
+                cluster=Clusters.Objects.AccessControl,
+                attribute=extension_attribute,
+                error=Status.UnsupportedAccess,
+                endpoint=0
+            )
 
         self.step(7)
-        # TH2 writes DUT Endpoint 0 AccessControl cluster Extension attribute, value is an empty list
-        new_extension = []
-        result3 = await self.th2.WriteAttribute(
-            self.dut_node_id,
-            [(0, extension_attribute(value=new_extension))]
-        )
-        # Add explicit check for UnsupportedAccess error
-        if result3[0].Status != Status.UnsupportedAccess:
-            asserts.fail(f"Expected UnsupportedAccess but got {result3[0].Status}")
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute):
+            # TH2 writes DUT Endpoint 0 AccessControl cluster Extension attribute, value is an empty list
+            new_extension = []
+            result3 = await self.th2.WriteAttribute(
+                self.dut_node_id,
+                [(0, extension_attribute(value=new_extension))]
+            )
+            # Add explicit check for UnsupportedAccess error
+            if result3[0].Status != Status.UnsupportedAccess:
+                asserts.fail(f"Expected UnsupportedAccess but got {result3[0].Status}")
 
         self.step(8)
         # TH2 reads DUT Endpoint 0 AccessControl cluster SubjectsPerAccessControlEntry attribute
@@ -248,8 +251,9 @@ class TC_ACL_2_9(MatterBaseTest):
         await self.read_event_expect_unsupported_access(Clusters.AccessControl.Events.AccessControlEntryChanged)
 
         self.step(12)
-        # TH2 reads DUT Endpoint 0 AccessControl cluster AccessControlExtensionChanged event
-        await self.read_event_expect_unsupported_access(Clusters.AccessControl.Events.AccessControlExtensionChanged)
+        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute):
+            # TH2 reads DUT Endpoint 0 AccessControl cluster AccessControlExtensionChanged event
+            await self.read_event_expect_unsupported_access(Clusters.AccessControl.Events.AccessControlExtensionChanged)
 
         self.step(13)
         # Read the CurrentFabricIndex attribute from the Operational Credentials cluster

--- a/src/python_testing/TC_ACL_2_9.py
+++ b/src/python_testing/TC_ACL_2_9.py
@@ -28,7 +28,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#       --endpoint 1
+#       --endpoint 0
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/TC_ACL_2_9.py
+++ b/src/python_testing/TC_ACL_2_9.py
@@ -130,6 +130,8 @@ class TC_ACL_2_9(MatterBaseTest):
         self.th1 = self.default_controller
         self.discriminator = random.randint(0, 4095)
         self.endpoint = self.get_endpoint()
+        extension_attribute = Clusters.AccessControl.Attributes.Extension
+        ext_attr_enabled = await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute)
 
         self.step(2)
         # Create TH2 controller
@@ -212,8 +214,7 @@ class TC_ACL_2_9(MatterBaseTest):
 
         self.step(6)
         # TH2 reads DUT Endpoint 0 AccessControl cluster Extension attribute
-        extension_attribute = Clusters.AccessControl.Attributes.Extension
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute):
+        if ext_attr_enabled:
             await self.read_single_attribute_expect_error(
                 dev_ctrl=self.th2,
                 cluster=Clusters.Objects.AccessControl,
@@ -223,7 +224,7 @@ class TC_ACL_2_9(MatterBaseTest):
             )
 
         self.step(7)
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute):
+        if ext_attr_enabled:
             # TH2 writes DUT Endpoint 0 AccessControl cluster Extension attribute, value is an empty list
             new_extension = []
             result3 = await self.th2.WriteAttribute(
@@ -251,7 +252,7 @@ class TC_ACL_2_9(MatterBaseTest):
         await self.read_event_expect_unsupported_access(Clusters.AccessControl.Events.AccessControlEntryChanged)
 
         self.step(12)
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=extension_attribute):
+        if ext_attr_enabled:
             # TH2 reads DUT Endpoint 0 AccessControl cluster AccessControlExtensionChanged event
             await self.read_event_expect_unsupported_access(Clusters.AccessControl.Events.AccessControlExtensionChanged)
 
@@ -270,7 +271,6 @@ class TC_ACL_2_9(MatterBaseTest):
         # TH1 sends the RemoveFabric command to the DUT with the FabricIndex set to th2_idx
         removeFabricCmd = Clusters.OperationalCredentials.Commands.RemoveFabric(th2_idx)
         await self.th1.SendCommand(nodeid=self.dut_node_id, endpoint=0, payload=removeFabricCmd)
-
 
 if __name__ == "__main__":
     default_matter_test_main()


### PR DESCRIPTION
#### Summary
- Added attribute_guard() to test steps 6, 7, and 12 to verify that the attribute exists on endpoint for ACL_2_9
- Added attribute_guard() to test steps 7, 8, 11, 13, and 16 to verify that the Extension attribute exists on endpoint for ACL_2_10

#### Related issues

- Fixes issue: #[41124](https://github.com/project-chip/connectedhomeip/issues/41124)

#### Testing

- Python3 test modules TC_ACL_2_9 and TC_ACL_2_10 validated on 

**Attached images from testing completed in TH GUI:**

**TC_ACL_2_9 Screenshots**

TC_ACL_2_9-all-clusters_all-steps-pass:
<img width="654" height="870" alt="TC_ACL_2_9-all-clusters_all-steps-pass" src="https://github.com/user-attachments/assets/a4d38f86-b97d-4df7-8114-1b9261de0cfb" />

TC_ACL-2 9_rvc-app_extension-attribute-steps-skipped:
<img width="643" height="550" alt="TC_ACL-2 9_rvc-app_extension-attribute-steps-skipped" src="https://github.com/user-attachments/assets/259204a6-2d5b-4df9-bb9d-424f0f8dc091" />

**TC_ACL_2_10 Screenshots**

TC_ACL_2_10-all-clusters_all-steps-pass:
<img width="642" height="691" alt="TC_ACL_2_10-all-clusters_all-steps-pass" src="https://github.com/user-attachments/assets/12ca731a-ae40-4ac4-8a7f-a113a8b76b59" />

TC_ACL-2 10_rvc-app_extension-attribute-steps-skipped:**
<img width="635" height="681" alt="TC_ACL-2 10_rvc-app_extension-attribute-steps-skipped" src="https://github.com/user-attachments/assets/0f867dcc-14fa-4ed0-8d70-80236ec62261" />

#### Readability checklist

-   [X ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

