### PR TITLE
Add CI PICS check in TC_ZONEMGMT_2.4.py for generation of Zone Trigger events that use the app-pipe.

### DIFF
--- a/src/python_testing/TC_ZONEMGMT_2_4.py
+++ b/src/python_testing/TC_ZONEMGMT_2_4.py
@@ -108,6 +108,14 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
                      "Verify that the DUT responds with a NotFound status code"),
         ]
 
+    async def _trigger_motion_event(self, zone_id):
+        # CI: Use app pipe to trigger zone event.
+        # Manual: User should trigger a motion event from the defined zone.
+        if self.is_pics_sdk_ci_only:
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zone_id})
+        else:
+            self.wait_for_user_input(prompt_msg=f"Press enter and generate motion triggered event from zone {zone_id}")
+
     @run_if_endpoint_matches(has_cluster(Clusters.ZoneManagement) and
                              has_cluster(Clusters.CameraAvStreamManagement))
     async def test_TC_ZONEMGMT_2_4(self):
@@ -255,12 +263,7 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
         event_listener = EventSubscriptionHandler(expected_cluster=cluster)
         await event_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30)
         event_delay_seconds = 5.0
-        # CI: Use app pipe to trigger zone event.
-        # Manual: User should trigger a motion event from the defined zone.
-        if self.is_pics_sdk_ci_only:
-            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
-        else:
-            self.wait_for_user_input(prompt_msg=f"Press enter and generate motion triggered event from zone {zoneID1}")
+        await self._trigger_motion_event(zoneID1)
 
         event = event_listener.wait_for_event_report(
             cluster.Events.ZoneTriggered, timeout_sec=event_delay_seconds)
@@ -288,10 +291,7 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
         event_listener = EventSubscriptionHandler(expected_cluster=cluster)
         await event_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30)
         event_delay_seconds = 5.0
-        if self.is_pics_sdk_ci_only:
-            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
-        else:
-            self.wait_for_user_input(prompt_msg=f"Press enter and generate motion triggered event from zone {zoneID1}")
+        await self._trigger_motion_event(zoneID1)
 
         event = event_listener.wait_for_event_report(
             cluster.Events.ZoneTriggered, timeout_sec=event_delay_seconds)
@@ -301,10 +301,7 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
         asserts.assert_equal(event.reason, enums.ZoneEventTriggeredReasonEnum.kMotion, "Unexpected reason on ZoneTriggered")
 
         self.step("4a")
-        if self.is_pics_sdk_ci_only:
-            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
-        else:
-            self.wait_for_user_input(prompt_msg=f"Press enter and generate motion triggered event from zone {zoneID1}")
+        await self._trigger_motion_event(zoneID1)
 
         event_delay_seconds = initDuration + augDuration + 1
 
@@ -319,10 +316,7 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
 
         self.step("5")
         # Repeat Step 3
-        if self.is_pics_sdk_ci_only:
-            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
-        else:
-            self.wait_for_user_input(prompt_msg=f"Press enter and generate motion triggered event from zone {zoneID1}")
+        await self._trigger_motion_event(zoneID1)
 
         event = event_listener.wait_for_event_report(
             cluster.Events.ZoneTriggered, timeout_sec=event_delay_seconds)
@@ -341,7 +335,8 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
                 self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
                 time.sleep(1)
         else:
-          self.wait_for_user_input(prompt_msg=f"Press enter and keep generating motion triggered event from zone {zoneID1} for a period exceeding {maxDuration} seconds")
+            self.wait_for_user_input(
+                prompt_msg=f"Press enter and keep generating motion triggered event from zone {zoneID1} for a period exceeding {maxDuration} seconds")
 
         event_delay_seconds = maxDuration
         event = event_listener.wait_for_event_report(
@@ -355,10 +350,7 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
 
         self.step("5c")
         event_delay_seconds = blindDuration + 1
-        if self.is_pics_sdk_ci_only:
-            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
-        else:
-            self.wait_for_user_input(prompt_msg=f"Press enter and generate motion triggered event from zone {zoneID1}")
+        await self._trigger_motion_event(zoneID1)
 
         event = event_listener.wait_for_event_expect_no_report(timeout_sec=event_delay_seconds)
         logger.info(f"Successfully timed out without receiving any ZoneTriggered event for zone: {zoneID1}")

--- a/src/python_testing/TC_ZONEMGMT_2_4.py
+++ b/src/python_testing/TC_ZONEMGMT_2_4.py
@@ -255,9 +255,13 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
         event_listener = EventSubscriptionHandler(expected_cluster=cluster)
         await event_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30)
         event_delay_seconds = 5.0
-        # TODO: Check for self.is_ci
-        # CI call to trigger zone event.
-        self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
+        # CI: Use app pipe to trigger zone event.
+        # Manual: User should trigger a motion event from the defined zone.
+        if self.is_pics_sdk_ci_only:
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
+        else:
+            self.wait_for_user_input(prompt_msg=f"Press enter and generate motion triggered event from zone {zoneID1}")
+
         event = event_listener.wait_for_event_report(
             cluster.Events.ZoneTriggered, timeout_sec=event_delay_seconds)
         asserts.assert_equal(type(event), cluster.Events.ZoneTriggered,
@@ -284,7 +288,11 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
         event_listener = EventSubscriptionHandler(expected_cluster=cluster)
         await event_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30)
         event_delay_seconds = 5.0
-        self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
+        if self.is_pics_sdk_ci_only:
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
+        else:
+            self.wait_for_user_input(prompt_msg=f"Press enter and generate motion triggered event from zone {zoneID1}")
+
         event = event_listener.wait_for_event_report(
             cluster.Events.ZoneTriggered, timeout_sec=event_delay_seconds)
         asserts.assert_equal(type(event), cluster.Events.ZoneTriggered,
@@ -293,7 +301,11 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
         asserts.assert_equal(event.reason, enums.ZoneEventTriggeredReasonEnum.kMotion, "Unexpected reason on ZoneTriggered")
 
         self.step("4a")
-        self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
+        if self.is_pics_sdk_ci_only:
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
+        else:
+            self.wait_for_user_input(prompt_msg=f"Press enter and generate motion triggered event from zone {zoneID1}")
+
         event_delay_seconds = initDuration + augDuration + 1
 
         self.step("4b")
@@ -307,7 +319,11 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
 
         self.step("5")
         # Repeat Step 3
-        self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
+        if self.is_pics_sdk_ci_only:
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
+        else:
+            self.wait_for_user_input(prompt_msg=f"Press enter and generate motion triggered event from zone {zoneID1}")
+
         event = event_listener.wait_for_event_report(
             cluster.Events.ZoneTriggered, timeout_sec=event_delay_seconds)
         asserts.assert_equal(type(event), cluster.Events.ZoneTriggered,
@@ -320,9 +336,12 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
         # time
         # Generate some activity triggers to facilitate advancing of triggerdetectedDuration
         # beyond maxduration
-        for i in range(maxDuration):
-            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
-            time.sleep(1)
+        if self.is_pics_sdk_ci_only:
+            for i in range(maxDuration):
+                self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
+                time.sleep(1)
+        else:
+          self.wait_for_user_input(prompt_msg=f"Press enter and keep generating motion triggered event from zone {zoneID1} for a period exceeding {maxDuration} seconds")
 
         event_delay_seconds = maxDuration
         event = event_listener.wait_for_event_report(
@@ -336,7 +355,11 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
 
         self.step("5c")
         event_delay_seconds = blindDuration + 1
-        self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
+        if self.is_pics_sdk_ci_only:
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
+        else:
+            self.wait_for_user_input(prompt_msg=f"Press enter and generate motion triggered event from zone {zoneID1}")
+
         event = event_listener.wait_for_event_expect_no_report(timeout_sec=event_delay_seconds)
         logger.info(f"Successfully timed out without receiving any ZoneTriggered event for zone: {zoneID1}")
 


### PR DESCRIPTION
#### Summary
Add a CI PICS check for the app-pipe path to trigger a zone event and take a user input for the manual trigger with a real device.

Fix: https://github.com/project-chip/connectedhomeip/issues/41158

#### Testing
Tested locally for the app-pipe usage
* ./chip-camera-app --app-pipe /tmp/app_pipe_zonemgmt
* python3 src/python_testing/TC_ZONEMGMT_2_4.py --endpoint 1 --app-pipe /tmp/app_pipe_zonemgmt --PICS src/app/tests/suites/certification/ci-pics-values
 
#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
