### PR TITLE
[Silabs]Bring nvm init and Migration sooner. Use memory allocation and cleanu…

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -205,6 +205,14 @@ void ApplicationStart(void * unused)
 
 void SilabsMatterConfig::AppInit()
 {
+#ifdef SL_WIFI
+    // Init Chip memory management before the stack for Wi-Fi platforms
+    // Because OpenThread needs to use memory allocation during its Key operations, we initialize the memory management for thread
+    // and set the allocation functions inside sl_ot_create_instance, which is called earlier by sl_system_init.
+    mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
+    VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+#endif // SL_WIFI
+
     GetPlatform().Init();
     sMainTaskHandle = osThreadNew(ApplicationStart, nullptr, &kMainTaskAttr);
     ChipLogProgress(DeviceLayer, "Starting scheduler");
@@ -243,12 +251,10 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     ChipLogProgress(DeviceLayer, "Init CHIP Stack");
 
 #ifdef SL_WIFI
-    // Init Chip memory management before the stack
-    // Because OpenThread needs to use memory allocation during its Key operations, we initialize the memory management for thread
-    // and set the allocation functions inside sl_ot_create_instance, which is called earlier by sl_system_init.
-    mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
-    ReturnErrorOnFailure(chip::Platform::MemoryInit());
     ReturnErrorOnFailure(WifiInterface::GetInstance().InitWiFiStack());
+    // Needs to be done post InitWifiStack for 917.
+    // TODO move it in InitWiFiStack
+    GetPlatform().NvmInit();
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     ReturnErrorOnFailure(WifiSleepManager::GetInstance().Init(&WifiInterface::GetInstance(), &WifiInterface::GetInstance()));

--- a/src/platform/silabs/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.cpp
@@ -274,9 +274,10 @@ void KeyValueStoreManagerImpl::KvsMapMigration(void)
 {
 // this migration precedes Series 3, we don't need to run it in that case
 #ifndef _SILICON_LABS_32B_SERIES_3
-    size_t readlen                 = 0;
-    constexpr size_t oldMaxEntries = 120;
-    uint32_t maxStringLen          = 33; // determined by constant PersistentStorageDelegate::kKeyLengthMax + 1 before migration
+    size_t readlen                  = 0;
+    constexpr size_t oldMaxEntries  = 120;
+    constexpr uint32_t maxStringLen = 33; // value of PersistentStorageDelegate::kKeyLengthMax + 1 when migration was added
+    Platform::ScopedMemoryBuffer<char> mKvsStoredKeyString;
     Platform::ScopedMemoryBuffer<char> mKvsStoredKeyString;
     mKvsStoredKeyString.Alloc(oldMaxEntries * maxStringLen);
 
@@ -288,6 +289,7 @@ void KeyValueStoreManagerImpl::KvsMapMigration(void)
 
     if (err == CHIP_NO_ERROR)
     {
+        // Migrate the old String Based KvsKeyMap to the Hash based KvsKeyMap
         for (size_t i = 0; i < std::min(oldMaxEntries, KeyValueStoreManagerImpl::kMaxEntries); i++)
         {
             char * keyString = mKvsStoredKeyString.Get() + (i * maxStringLen);

--- a/src/platform/silabs/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.cpp
@@ -288,7 +288,7 @@ void KeyValueStoreManagerImpl::KvsMapMigration(void)
 
     if (err == CHIP_NO_ERROR)
     {
-        for (uint8_t i = 0; i < std::min(oldMaxEntries, KeyValueStoreManagerImpl::kMaxEntries); i++)
+        for (size_t i = 0; i < std::min(oldMaxEntries, KeyValueStoreManagerImpl::kMaxEntries); i++)
         {
             char * keyString = mKvsStoredKeyString.Get() + (i * maxStringLen);
             if (keyString[0] != 0)

--- a/src/platform/silabs/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.cpp
@@ -278,7 +278,6 @@ void KeyValueStoreManagerImpl::KvsMapMigration(void)
     constexpr size_t oldMaxEntries  = 120;
     constexpr uint32_t maxStringLen = 33; // value of PersistentStorageDelegate::kKeyLengthMax + 1 when migration was added
     Platform::ScopedMemoryBuffer<char> mKvsStoredKeyString;
-    Platform::ScopedMemoryBuffer<char> mKvsStoredKeyString;
     mKvsStoredKeyString.Alloc(oldMaxEntries * maxStringLen);
 
     VerifyOrReturn(mKvsStoredKeyString.Get() != nullptr);

--- a/src/platform/silabs/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.cpp
@@ -24,6 +24,7 @@
 #include "MigrationManager.h"
 #include <cmsis_os2.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/support/ScopedBuffer.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/KeyValueStoreManager.h>
 #include <platform/silabs/SilabsConfig.h>
@@ -51,10 +52,6 @@ KeyValueStoreManagerImpl KeyValueStoreManagerImpl::sInstance;
 
 CHIP_ERROR KeyValueStoreManagerImpl::Init(void)
 {
-    ReturnErrorOnFailure(SilabsConfig::Init());
-
-    Silabs::MigrationManager::GetMigrationInstance().applyMigrations();
-
     memset(mKvsKeyMap, 0, sizeof(mKvsKeyMap));
     size_t outLen    = 0;
     CHIP_ERROR error = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_KvsStringKeyMap,
@@ -275,18 +272,26 @@ void KeyValueStoreManagerImpl::ErasePartition(void)
 
 void KeyValueStoreManagerImpl::KvsMapMigration(void)
 {
-    size_t readlen                                                                        = 0;
-    constexpr uint8_t oldMaxEntires                                                       = 120;
-    char mKvsStoredKeyString[oldMaxEntires][PersistentStorageDelegate::kKeyLengthMax + 1] = { 0 };
-    CHIP_ERROR err =
-        SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_KvsStringKeyMap, reinterpret_cast<uint8_t *>(mKvsStoredKeyString),
-                                         sizeof(mKvsStoredKeyString), readlen);
+// this migration precedes Series 3, we don't need to run it in that case
+#ifndef _SILICON_LABS_32B_SERIES_3
+    size_t readlen                 = 0;
+    constexpr size_t oldMaxEntries = 120;
+    uint32_t maxStringLen          = 33; // determined by constant PersistentStorageDelegate::kKeyLengthMax + 1 before migration
+    Platform::ScopedMemoryBuffer<char> mKvsStoredKeyString;
+    mKvsStoredKeyString.Alloc(oldMaxEntries * maxStringLen);
+
+    VerifyOrReturn(mKvsStoredKeyString.Get() != nullptr);
+
+    CHIP_ERROR err = SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_KvsStringKeyMap,
+                                                      reinterpret_cast<uint8_t *>(mKvsStoredKeyString.Get()),
+                                                      oldMaxEntries * maxStringLen, readlen);
 
     if (err == CHIP_NO_ERROR)
     {
-        for (uint8_t i = 0; i < oldMaxEntires; i++)
+        for (uint8_t i = 0; i < std::min(oldMaxEntries, KeyValueStoreManagerImpl::kMaxEntries); i++)
         {
-            if (mKvsStoredKeyString[i][0] != 0)
+            char * keyString = mKvsStoredKeyString.Get() + (i * maxStringLen);
+            if (keyString[0] != 0)
             {
                 size_t dataLen   = 0;
                 uint32_t nvm3Key = CONVERT_KEYMAP_INDEX_TO_NVM3KEY(i);
@@ -294,14 +299,14 @@ void KeyValueStoreManagerImpl::KvsMapMigration(void)
                 if (SilabsConfig::ConfigValueExists(nvm3Key, dataLen))
                 {
                     // Read old data and prefix it with the string Key for the collision prevention mechanism.
-                    size_t keyStringLen    = strlen(mKvsStoredKeyString[i]);
+                    size_t keyStringLen    = strlen(keyString);
                     uint8_t * prefixedData = static_cast<uint8_t *>(Platform::MemoryAlloc(keyStringLen + dataLen));
                     VerifyOrDie(prefixedData != nullptr);
-                    memcpy(prefixedData, mKvsStoredKeyString[i], keyStringLen);
+                    memcpy(prefixedData, keyString, keyStringLen);
 
                     SilabsConfig::ReadConfigValueBin(nvm3Key, prefixedData + keyStringLen, dataLen, readlen);
                     SilabsConfig::WriteConfigValueBin(nvm3Key, prefixedData, keyStringLen + dataLen);
-                    mKvsKeyMap[i] = KeyValueStoreMgrImpl().hashKvsKeyString(mKvsStoredKeyString[i]);
+                    mKvsKeyMap[i] = KeyValueStoreMgrImpl().hashKvsKeyString(keyString);
                     Platform::MemoryFree(prefixedData);
                 }
             }
@@ -315,6 +320,7 @@ void KeyValueStoreManagerImpl::KvsMapMigration(void)
         // start with a fresh kvs section.
         KeyValueStoreMgrImpl().ErasePartition();
     }
+#endif
 }
 
 void KeyValueStoreManagerImpl::KvsKeyMapCleanup(void * argument)

--- a/src/platform/silabs/MigrationManager.cpp
+++ b/src/platform/silabs/MigrationManager.cpp
@@ -16,6 +16,13 @@
  */
 
 #include "MigrationManager.h"
+#include "sl_component_catalog.h"
+#include "sl_core.h"
+#include <headers/ProvisionManager.h>
+#include <headers/ProvisionStorage.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/ScopedBuffer.h>
+#include <lib/support/Span.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/silabs/SilabsConfig.h>
 #include <stdio.h>
@@ -35,7 +42,6 @@ typedef struct
     func_ptr migrationFunc;
 } migrationData_t;
 
-#define COUNT_OF(A) (sizeof(A) / sizeof((A)[0]))
 static migrationData_t migrationTable[] = {
     { .migrationGroup = 1, .migrationFunc = MigrateKvsMap },
     { .migrationGroup = 2, .migrationFunc = MigrateDacProvider },
@@ -47,13 +53,13 @@ static migrationData_t migrationTable[] = {
 
 } // namespace
 
-void MigrationManager::applyMigrations()
+void MigrationManager::ApplyMigrations()
 {
     uint32_t lastMigationGroupDone = 0;
     SilabsConfig::ReadConfigValue(SilabsConfig::kConfigKey_MigrationCounter, lastMigationGroupDone);
 
     uint32_t completedMigrationGroup = lastMigationGroupDone;
-    for (uint32_t i = 0; i < COUNT_OF(migrationTable); i++)
+    for (uint32_t i = 0; i < MATTER_ARRAY_SIZE(migrationTable); i++)
     {
         if (lastMigationGroupDone < migrationTable[i].migrationGroup)
         {
@@ -67,7 +73,7 @@ void MigrationManager::applyMigrations()
 void MigrationManager::MigrateUint16(uint32_t old_key, uint32_t new_key)
 {
     uint16_t value = 0;
-    if (SilabsConfig::ConfigValueExists(old_key) && (CHIP_NO_ERROR == SilabsConfig::ReadConfigValue(old_key, value)))
+    if (CHIP_NO_ERROR == SilabsConfig::ReadConfigValue(old_key, value))
     {
         if (CHIP_NO_ERROR == SilabsConfig::WriteConfigValue(new_key, value))
         {
@@ -80,7 +86,7 @@ void MigrationManager::MigrateUint16(uint32_t old_key, uint32_t new_key)
 void MigrationManager::MigrateUint32(uint32_t old_key, uint32_t new_key)
 {
     uint32_t value = 0;
-    if (SilabsConfig::ConfigValueExists(old_key) && (CHIP_NO_ERROR == SilabsConfig::ReadConfigValue(old_key, value)))
+    if (CHIP_NO_ERROR == SilabsConfig::ReadConfigValue(old_key, value))
     {
         if (CHIP_NO_ERROR == SilabsConfig::WriteConfigValue(new_key, value))
         {

--- a/src/platform/silabs/MigrationManager.h
+++ b/src/platform/silabs/MigrationManager.h
@@ -30,7 +30,7 @@ public:
      * User should get the object from this getter.
      */
     static MigrationManager & GetMigrationInstance();
-    static void applyMigrations();
+    static void ApplyMigrations();
     static void MigrateUint16(uint32_t old_key, uint32_t new_key);
     static void MigrateUint32(uint32_t old_key, uint32_t new_key);
 

--- a/src/platform/silabs/platformAbstraction/BUILD.gn
+++ b/src/platform/silabs/platformAbstraction/BUILD.gn
@@ -23,6 +23,8 @@ source_set("common") {
     "${chip_root}/src/platform/silabs/platformAbstraction/SilabsPlatform.h",
     "${chip_root}/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h",
   ]
+
+  include_dirs = [ "${chip_root}/src/platform/silabs" ]
   public_deps = [
     "${chip_root}/src/app/icd/server:icd-server-config",
     "${chip_root}/src/lib/core",

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -96,6 +96,7 @@ SilabsPlatform::SilabsButtonCb SilabsPlatform::mButtonCallback = nullptr;
 
 CHIP_ERROR SilabsPlatform::Init(void)
 {
+    NvmInit();
 #ifdef _SILICON_LABS_32B_SERIES_2
     // Read the cause of last reset.
     mRebootCause = RMU_ResetCauseGet();

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.cpp
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.cpp
@@ -19,6 +19,7 @@
 
 #include <lib/support/CodeUtils.h>
 #include <platform/DiagnosticDataProvider.h>
+#include <platform/silabs/MigrationManager.h>
 #include <platform/silabs/SilabsConfig.h>
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
 
@@ -38,6 +39,13 @@ CHIP_ERROR SilabsPlatform::VerifyIfUpdated()
         mRebootCause = to_underlying(BootReasonType::kSoftwareUpdateCompleted);
     }
 
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SilabsPlatform::NvmInit()
+{
+    ReturnErrorOnFailure(Internal::SilabsConfig::Init());
+    Silabs::MigrationManager::GetMigrationInstance().ApplyMigrations();
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -80,6 +80,13 @@ public:
      */
     CHIP_ERROR VerifyIfUpdated();
 
+    /**
+     * @brief Initialize the nvm driver (e.g., NVM3), and execute any needed migrations.
+     *
+     * @return CHIP_ERROR : CHIP_NO_ERROR when succesful, a relevant CHIP_ERROR otherwise.
+     */
+    CHIP_ERROR NvmInit();
+
 private:
     friend SilabsPlatform & GetPlatform(void);
 

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -83,7 +83,7 @@ public:
     /**
      * @brief Initialize the nvm driver (e.g., NVM3), and execute any needed migrations.
      *
-     * @return CHIP_ERROR : CHIP_NO_ERROR when succesful, a relevant CHIP_ERROR otherwise.
+     * @return CHIP_ERROR : CHIP_NO_ERROR when successful, a relevant CHIP_ERROR otherwise.
      */
     CHIP_ERROR NvmInit();
 

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -82,8 +82,6 @@ public:
 
     /**
      * @brief Initialize the nvm driver (e.g., NVM3), and execute any needed migrations.
-     *
-     * @return CHIP_ERROR : CHIP_NO_ERROR when successful, a relevant CHIP_ERROR otherwise.
      */
     CHIP_ERROR NvmInit();
 


### PR DESCRIPTION
…p code

#### Summary
With some news features. nvm storage was used earlier than our migration process.
Modify our init sequence so our possible migration functions are run earlier.

Switch some migration functions to use dynamic allocation to avoid increasing the main/bootup task stack requirements.
ScopedMemoryBuffer is used to ensure allocated memory is freed after the migration.

#### Related issues
N/A

#### Testing
Build and boot EFR32 app. Validate that the Migration table is evaluated, NVM3 is functional (read/writes) and that the Dynamic memory is Allocated and freed


#### Readability checklist
The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
