### PR TITLE
[Silabs] Increase KvsKeyMapCleanup stack to address overflow risk

### DIFF
--- a/src/platform/silabs/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.cpp
@@ -65,7 +65,10 @@ CHIP_ERROR KeyValueStoreManagerImpl::Init(void)
     }
     ReturnErrorOnFailure(error);
 
-    constexpr osThreadAttr_t attr = { .name = "KvsKeyMapCleanupTask", .stack_size = 512 /* bytes */, .priority = osPriorityLow7 };
+    // On series 3, nvm3 security can use up to ~1100 bytes of stack during read/write operations.
+    // Provide enough stack for all platforms. The KvsKeyMapCleanupTask is deleted once the cleanup is completed and the allocated
+    // stack is freed.
+    constexpr osThreadAttr_t attr = { .name = "KvsKeyMapCleanupTask", .stack_size = 1536 /* bytes */, .priority = osPriorityLow7 };
     if (osThreadNew(KvsKeyMapCleanup, nullptr, &attr) == nullptr)
     {
         // We don't need to crash and force a reboot. we will retry at the next reboot


### PR DESCRIPTION
#### Summary
On series 3, nvm3 security can use up to ~1100 bytes of stack during read/write operations.
In some instances, a stack overflow was seen.

KvsKeyMapCleanupTask can execute multiple NVM3 read write operations in a row depending on the state of NVM3 at bootup (usage %, repacks needed, # cleanup actions needed).

 Provide the task with enough stack for all platforms. The task is deleted once the cleanup is completed and the allocated
 stack is freed.

#### Testing
Fill the KVS table. reboot the device on series 3. No stack overflow is seen during the Cleaup run
