### PR TITLE
Increase unit test code coverage of controller/ by 4.6% 

### DIFF
--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -94,6 +94,13 @@ public:
     void SetCommissioneeDeviceProxy(CommissioneeDeviceProxy * proxy) { mCommissioner->mCommissioneeDeviceProxy = proxy; }
 
     void SetUTCRequirements(bool requiresUTC) { mCommissioner->mDeviceCommissioningInfo.requiresUTC = requiresUTC; }
+    bool AccessIsScanNeeded() { return mCommissioner->IsScanNeeded(); }
+    bool AccessIsSecondaryNetworkSupported() const { return mCommissioner->IsSecondaryNetworkSupported(); }
+    Controller::ReadCommissioningInfo & GetDeviceCommissioningInfo() { return mCommissioner->mDeviceCommissioningInfo; }
+    void AccessResetTryingSecondaryNetwork() { mCommissioner->ResetTryingSecondaryNetwork(); }
+
+    bool AccessTryingSecondaryNetwork() { return mCommissioner->TryingSecondaryNetwork(); }
+    void AccessTrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
 
     void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
 

--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -45,15 +45,23 @@ public:
     {
         return mCommissioner->GetNextCommissioningStageInternal(currentStage, lastErr);
     }
-    void SetBreadcrumb(uint64_t value) { mCommissioner->mDeviceCommissioningInfo.general.breadcrumb = value; }
-    void SetUTCRequirements(bool requiresUTC) { mCommissioner->mDeviceCommissioningInfo.requiresUTC = requiresUTC; }
-    bool IsScanNeeded() { return mCommissioner->IsScanNeeded(); }
-    bool IsSecondaryNetworkSupported() const { return mCommissioner->IsSecondaryNetworkSupported(); }
-    Controller::ReadCommissioningInfo & GetDeviceCommissioningInfo() { return mCommissioner->mDeviceCommissioningInfo; }
-    void ResetNetworkAttemptType() { mCommissioner->ResetNetworkAttemptType(); }
 
-    bool TryingSecondaryNetwork() const { return mCommissioner->TryingSecondaryNetwork(); }
-    void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
+    void CleanupCommissioning() { mCommissioner->CleanupCommissioning(); }
+
+    CommissioneeDeviceProxy * GetCommissioneeDeviceProxy() { return mCommissioner->GetCommissioneeDeviceProxy(); }
+
+    Optional<System::Clock::Timeout> GetCommandTimeout(DeviceProxy * device, Controller::CommissioningStage stage) const
+    {
+        return mCommissioner->GetCommandTimeout(device, stage);
+    }
+
+    const ByteSpan GetDAC() { return mCommissioner->GetDAC(); }
+
+    Controller::ReadCommissioningInfo & GetDeviceCommissioningInfo() { return mCommissioner->mDeviceCommissioningInfo; }
+
+    EndpointId GetEndpoint(const Controller::CommissioningStage & stage) const { return mCommissioner->GetEndpoint(stage); }
+
+    bool GetNeedsDST() { return mCommissioner->mNeedsDST; }
 
     Controller::CommissioningStage GetNextCommissioningStageNetworkSetup(Controller::CommissioningStage currentStage,
                                                                          CHIP_ERROR & lastErr)
@@ -61,31 +69,43 @@ public:
         return mCommissioner->GetNextCommissioningStageNetworkSetup(currentStage, lastErr);
     }
 
-    EndpointId GetEndpoint(const Controller::CommissioningStage & stage) const { return mCommissioner->GetEndpoint(stage); }
-
-    void CleanupCommissioning() { mCommissioner->CleanupCommissioning(); }
-    const ByteSpan GetDAC() { return mCommissioner->GetDAC(); }
-    const ByteSpan GetPAI() { return mCommissioner->GetPAI(); }
-    CommissioneeDeviceProxy * GetCommissioneeDeviceProxy() { return mCommissioner->GetCommissioneeDeviceProxy(); }
     OperationalDeviceProxy & GetOperationalDeviceProxy() { return mCommissioner->mOperationalDeviceProxy; }
-    bool GetNeedsDST() { return mCommissioner->mNeedsDST; }
-    void SetNeedsDST() { mCommissioner->mNeedsDST = true; }
-    Optional<System::Clock::Timeout> GetCommandTimeout(DeviceProxy * device, Controller::CommissioningStage stage) const
-    {
-        return mCommissioner->GetCommandTimeout(device, stage);
-    }
 
-    void SetDeviceCommissioneeProxy(CommissioneeDeviceProxy * device) { mCommissioner->mCommissioneeDeviceProxy = device; }
+    const ByteSpan GetPAI() { return mCommissioner->GetPAI(); }
+
+    bool IsScanNeeded() { return mCommissioner->IsScanNeeded(); }
+
+    bool IsSecondaryNetworkSupported() const { return mCommissioner->IsSecondaryNetworkSupported(); }
 
     CHIP_ERROR NOCChainGenerated(ByteSpan noc, ByteSpan icac, ByteSpan rcac, Crypto::IdentityProtectionKeySpan ipk,
                                  NodeId adminSubject)
     {
         return mCommissioner->NOCChainGenerated(noc, icac, rcac, ipk, adminSubject);
     }
+
+    void ResetNetworkAttemptType() { mCommissioner->ResetNetworkAttemptType(); }
+
+    void SetBreadcrumb(uint64_t value) { mCommissioner->mDeviceCommissioningInfo.general.breadcrumb = value; }
+
+    void SetCommissioner(Controller::DeviceCommissioner * commissioner) { mCommissioner->mCommissioner = commissioner; }
+
+    void SetCommissioneeDeviceProxy(CommissioneeDeviceProxy * proxy) { mCommissioner->mCommissioneeDeviceProxy = proxy; }
+
+    void SetUTCRequirements(bool requiresUTC) { mCommissioner->mDeviceCommissioningInfo.requiresUTC = requiresUTC; }
+
+    void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
+
+    bool TryingSecondaryNetwork() const { return mCommissioner->TryingSecondaryNetwork(); }
+
+    void SetNeedsDST() { mCommissioner->mNeedsDST = true; }
+
+    void SetDeviceCommissioneeProxy(CommissioneeDeviceProxy * device) { mCommissioner->mCommissioneeDeviceProxy = device; }
+
     DeviceProxy * GetDeviceProxyForStep(Controller::CommissioningStage nextStage)
     {
         return mCommissioner->GetDeviceProxyForStep(nextStage);
     }
+
     void SetOperationalDeviceProxy(OperationalDeviceProxy & device) { mCommissioner->mOperationalDeviceProxy = std::move(device); }
 
 private:

--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -94,13 +94,13 @@ public:
     void SetCommissioneeDeviceProxy(CommissioneeDeviceProxy * proxy) { mCommissioner->mCommissioneeDeviceProxy = proxy; }
 
     void SetUTCRequirements(bool requiresUTC) { mCommissioner->mDeviceCommissioningInfo.requiresUTC = requiresUTC; }
-    bool AccessIsScanNeeded() { return mCommissioner->IsScanNeeded(); }
-    bool AccessIsSecondaryNetworkSupported() const { return mCommissioner->IsSecondaryNetworkSupported(); }
+    bool IsScanNeeded() { return mCommissioner->IsScanNeeded(); }
+    bool IsSecondaryNetworkSupported() const { return mCommissioner->IsSecondaryNetworkSupported(); }
     Controller::ReadCommissioningInfo & GetDeviceCommissioningInfo() { return mCommissioner->mDeviceCommissioningInfo; }
-    void AccessResetTryingSecondaryNetwork() { mCommissioner->ResetTryingSecondaryNetwork(); }
+    void ResetTryingSecondaryNetwork() { mCommissioner->ResetTryingSecondaryNetwork(); }
 
-    bool AccessTryingSecondaryNetwork() { return mCommissioner->TryingSecondaryNetwork(); }
-    void AccessTrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
+    bool TryingSecondaryNetwork() { return mCommissioner->TryingSecondaryNetwork(); }
+    void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
 
     void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
 

--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -97,9 +97,9 @@ public:
     bool IsScanNeeded() { return mCommissioner->IsScanNeeded(); }
     bool IsSecondaryNetworkSupported() const { return mCommissioner->IsSecondaryNetworkSupported(); }
     Controller::ReadCommissioningInfo & GetDeviceCommissioningInfo() { return mCommissioner->mDeviceCommissioningInfo; }
-    void ResetNetworkAttemptType() { mCommissioner->ResetNetworkAttemptType(); }
+    void ResetTryingSecondaryNetwork() { mCommissioner->ResetTryingSecondaryNetwork(); }
 
-    bool TryingSecondaryNetwork() const { return mCommissioner->TryingSecondaryNetwork(); }
+    bool TryingSecondaryNetwork() { return mCommissioner->TryingSecondaryNetwork(); }
     void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
 
     void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
@@ -117,14 +117,21 @@ public:
     const ByteSpan GetDAC() { return mCommissioner->GetDAC(); }
     const ByteSpan GetPAI() { return mCommissioner->GetPAI(); }
     CommissioneeDeviceProxy * GetCommissioneeDeviceProxy() { return mCommissioner->GetCommissioneeDeviceProxy(); }
-    OperationalDeviceProxy GetOperationalDeviceProxy() { return mCommissioner->mOperationalDeviceProxy; }
+    OperationalDeviceProxy & GetOperationalDeviceProxy() { return mCommissioner->mOperationalDeviceProxy; }
     bool GetNeedsDST() { return mCommissioner->mNeedsDST; }
+    void SetNeedsDST() { mCommissioner->mNeedsDST = true; }
     Optional<System::Clock::Timeout> GetCommandTimeout(DeviceProxy * device, Controller::CommissioningStage stage) const
     {
         return mCommissioner->GetCommandTimeout(device, stage);
     }
 
     void SetDeviceCommissioneeProxy(CommissioneeDeviceProxy * device) { mCommissioner->mCommissioneeDeviceProxy = device; }
+
+    DeviceProxy * GetDeviceProxyForStep(Controller::CommissioningStage nextStage)
+    {
+        return mCommissioner->GetDeviceProxyForStep(nextStage);
+    }
+    void SetOperationalDeviceProxy(OperationalDeviceProxy & device) { mCommissioner->mOperationalDeviceProxy = std::move(device); }
 
 private:
     Controller::AutoCommissioner * mCommissioner = nullptr;

--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -97,9 +97,9 @@ public:
     bool IsScanNeeded() { return mCommissioner->IsScanNeeded(); }
     bool IsSecondaryNetworkSupported() const { return mCommissioner->IsSecondaryNetworkSupported(); }
     Controller::ReadCommissioningInfo & GetDeviceCommissioningInfo() { return mCommissioner->mDeviceCommissioningInfo; }
-    void ResetTryingSecondaryNetwork() { mCommissioner->ResetTryingSecondaryNetwork(); }
+    void ResetNetworkAttemptType() { mCommissioner->ResetNetworkAttemptType(); }
 
-    bool TryingSecondaryNetwork() { return mCommissioner->TryingSecondaryNetwork(); }
+    bool TryingSecondaryNetwork() const { return mCommissioner->TryingSecondaryNetwork(); }
     void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
 
     void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }

--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -99,7 +99,7 @@ public:
     Controller::ReadCommissioningInfo & GetDeviceCommissioningInfo() { return mCommissioner->mDeviceCommissioningInfo; }
     void ResetTryingSecondaryNetwork() { mCommissioner->ResetTryingSecondaryNetwork(); }
 
-    bool TryingSecondaryNetwork() { return mCommissioner->TryingSecondaryNetwork(); }
+    bool TryingSecondaryNetwork() const { return mCommissioner->TryingSecondaryNetwork(); }
     void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
 
     void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }

--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -15,6 +15,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 #pragma once
 
 #include <controller/AutoCommissioner.h>

--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -105,6 +105,26 @@ public:
     void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
 
     bool TryingSecondaryNetwork() const { return mCommissioner->TryingSecondaryNetwork(); }
+    Controller::CommissioningStage GetNextCommissioningStageNetworkSetup(Controller::CommissioningStage currentStage,
+                                                                         CHIP_ERROR & lastErr)
+    {
+        return mCommissioner->GetNextCommissioningStageNetworkSetup(currentStage, lastErr);
+    }
+
+    EndpointId GetEndpoint(const Controller::CommissioningStage & stage) const { return mCommissioner->GetEndpoint(stage); }
+
+    void CleanupCommissioning() { mCommissioner->CleanupCommissioning(); }
+    const ByteSpan GetDAC() { return mCommissioner->GetDAC(); }
+    const ByteSpan GetPAI() { return mCommissioner->GetPAI(); }
+    CommissioneeDeviceProxy * GetCommissioneeDeviceProxy() { return mCommissioner->GetCommissioneeDeviceProxy(); }
+    OperationalDeviceProxy GetOperationalDeviceProxy() { return mCommissioner->mOperationalDeviceProxy; }
+    bool GetNeedsDST() { return mCommissioner->mNeedsDST; }
+    Optional<System::Clock::Timeout> GetCommandTimeout(DeviceProxy * device, Controller::CommissioningStage stage) const
+    {
+        return mCommissioner->GetCommandTimeout(device, stage);
+    }
+
+    void SetDeviceCommissioneeProxy(CommissioneeDeviceProxy * device) { mCommissioner->mCommissioneeDeviceProxy = device; }
 
 private:
     Controller::AutoCommissioner * mCommissioner = nullptr;

--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -97,7 +97,7 @@ public:
     bool IsScanNeeded() { return mCommissioner->IsScanNeeded(); }
     bool IsSecondaryNetworkSupported() const { return mCommissioner->IsSecondaryNetworkSupported(); }
     Controller::ReadCommissioningInfo & GetDeviceCommissioningInfo() { return mCommissioner->mDeviceCommissioningInfo; }
-    void ResetTryingSecondaryNetwork() { mCommissioner->ResetTryingSecondaryNetwork(); }
+    void ResetNetworkAttemptType() { mCommissioner->ResetNetworkAttemptType(); }
 
     bool TryingSecondaryNetwork() const { return mCommissioner->TryingSecondaryNetwork(); }
     void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }

--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -40,8 +40,8 @@ public:
     AutoCommissionerTestAccess() = delete;
     AutoCommissionerTestAccess(Controller::AutoCommissioner * commissioner) : mCommissioner(commissioner) {}
 
-    Controller::CommissioningStage AccessGetNextCommissioningStageInternal(Controller::CommissioningStage currentStage,
-                                                                           CHIP_ERROR & lastErr)
+    Controller::CommissioningStage GetNextCommissioningStageInternal(Controller::CommissioningStage currentStage,
+                                                                     CHIP_ERROR & lastErr)
     {
         return mCommissioner->GetNextCommissioningStageInternal(currentStage, lastErr);
     }

--- a/src/controller/tests/AutoCommissionerTestAccess.h
+++ b/src/controller/tests/AutoCommissionerTestAccess.h
@@ -1,19 +1,19 @@
 /*
  *
- *    Copyright (c) 2020-2025 Project CHIP Authors
- *    All rights reserved.
+ *    Copyright (c) 2020-2025 Project CHIP Authors
+ *    All rights reserved.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 #pragma once
 
@@ -45,54 +45,7 @@ public:
     {
         return mCommissioner->GetNextCommissioningStageInternal(currentStage, lastErr);
     }
-
-    Controller::CommissioningParameters & AccessParams() { return mCommissioner->mParams; }
-
-    void CleanupCommissioning() { mCommissioner->CleanupCommissioning(); }
-
-    CommissioneeDeviceProxy * GetCommissioneeDeviceProxy() { return mCommissioner->GetCommissioneeDeviceProxy(); }
-
-    Optional<System::Clock::Timeout> GetCommandTimeout(DeviceProxy * device, Controller::CommissioningStage stage) const
-    {
-        return mCommissioner->GetCommandTimeout(device, stage);
-    }
-
-    const ByteSpan GetDAC() { return mCommissioner->GetDAC(); }
-
-    Controller::ReadCommissioningInfo & GetDeviceCommissioningInfo() { return mCommissioner->mDeviceCommissioningInfo; }
-
-    EndpointId GetEndpoint(const Controller::CommissioningStage & stage) const { return mCommissioner->GetEndpoint(stage); }
-
-    bool GetNeedsDST() { return mCommissioner->mNeedsDST; }
-
-    Controller::CommissioningStage GetNextCommissioningStageNetworkSetup(Controller::CommissioningStage currentStage,
-                                                                         CHIP_ERROR & lastErr)
-    {
-        return mCommissioner->GetNextCommissioningStageNetworkSetup(currentStage, lastErr);
-    }
-
-    OperationalDeviceProxy GetOperationalDeviceProxy() { return mCommissioner->mOperationalDeviceProxy; }
-
-    const ByteSpan GetPAI() { return mCommissioner->GetPAI(); }
-
-    bool IsScanNeeded() { return mCommissioner->IsScanNeeded(); }
-
-    bool IsSecondaryNetworkSupported() const { return mCommissioner->IsSecondaryNetworkSupported(); }
-
-    CHIP_ERROR NOCChainGenerated(ByteSpan noc, ByteSpan icac, ByteSpan rcac, Crypto::IdentityProtectionKeySpan ipk,
-                                 NodeId adminSubject)
-    {
-        return mCommissioner->NOCChainGenerated(noc, icac, rcac, ipk, adminSubject);
-    }
-
-    void ResetNetworkAttemptType() { mCommissioner->ResetNetworkAttemptType(); }
-
     void SetBreadcrumb(uint64_t value) { mCommissioner->mDeviceCommissioningInfo.general.breadcrumb = value; }
-
-    void SetCommissioner(Controller::DeviceCommissioner * commissioner) { mCommissioner->mCommissioner = commissioner; }
-
-    void SetCommissioneeDeviceProxy(CommissioneeDeviceProxy * proxy) { mCommissioner->mCommissioneeDeviceProxy = proxy; }
-
     void SetUTCRequirements(bool requiresUTC) { mCommissioner->mDeviceCommissioningInfo.requiresUTC = requiresUTC; }
     bool IsScanNeeded() { return mCommissioner->IsScanNeeded(); }
     bool IsSecondaryNetworkSupported() const { return mCommissioner->IsSecondaryNetworkSupported(); }
@@ -102,9 +55,6 @@ public:
     bool TryingSecondaryNetwork() const { return mCommissioner->TryingSecondaryNetwork(); }
     void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
 
-    void TrySecondaryNetwork() { mCommissioner->TrySecondaryNetwork(); }
-
-    bool TryingSecondaryNetwork() const { return mCommissioner->TryingSecondaryNetwork(); }
     Controller::CommissioningStage GetNextCommissioningStageNetworkSetup(Controller::CommissioningStage currentStage,
                                                                          CHIP_ERROR & lastErr)
     {
@@ -127,6 +77,11 @@ public:
 
     void SetDeviceCommissioneeProxy(CommissioneeDeviceProxy * device) { mCommissioner->mCommissioneeDeviceProxy = device; }
 
+    CHIP_ERROR NOCChainGenerated(ByteSpan noc, ByteSpan icac, ByteSpan rcac, Crypto::IdentityProtectionKeySpan ipk,
+                                 NodeId adminSubject)
+    {
+        return mCommissioner->NOCChainGenerated(noc, icac, rcac, ipk, adminSubject);
+    }
     DeviceProxy * GetDeviceProxyForStep(Controller::CommissioningStage nextStage)
     {
         return mCommissioner->GetDeviceProxyForStep(nextStage);

--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -790,7 +790,7 @@ TEST_F(AutoCommissionerTest, GetNextCommissioningStageNetworkSetup_ReturnsCorrec
           .wifiEndpoint       = kInvalidEndpointId,
           .threadEndpoint     = kInvalidEndpointId,
           .expectedStage      = CommissioningStage::kCleanup,
-          .expectedError      = CHIP_ERROR_INVALID_ARGUMENT },
+          .expectedError      = CHIP_ERROR_INCORRECT_STATE },
     };
 
     for (const auto & c : cases)
@@ -820,7 +820,7 @@ TEST_F(AutoCommissionerTest, GetNextCommissioningStageNetworkSetup_ReturnsCorrec
         }
         else
         {
-            privateConfigCommissioner.ResetTryingSecondaryNetwork();
+            privateConfigCommissioner.ResetNetworkAttemptType();
         }
 
         ReadCommissioningInfo & commissioningInfo = privateConfigCommissioner.GetDeviceCommissioningInfo();

--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -295,8 +295,7 @@ TEST_F(AutoCommissionerTest, NextCommissioningStage)
 
     for (const auto & stagePair : kStagePairs)
     {
-        CommissioningStage nextStage =
-            privateConfigCommissioner.AccessGetNextCommissioningStageInternal(stagePair.currentStage, err);
+        CommissioningStage nextStage = privateConfigCommissioner.GetNextCommissioningStageInternal(stagePair.currentStage, err);
         EXPECT_EQ(nextStage, stagePair.nextStage);
     }
 }
@@ -308,7 +307,7 @@ TEST_F(AutoCommissionerTest, NextStageStopCommissioning)
     mCommissioner.StopCommissioning();
 
     CHIP_ERROR err           = CHIP_ERROR_INTERNAL;
-    CommissioningStage stage = privateConfigCommissioner.AccessGetNextCommissioningStageInternal(kSecurePairing, err);
+    CommissioningStage stage = privateConfigCommissioner.GetNextCommissioningStageInternal(kSecurePairing, err);
     EXPECT_EQ(stage, kCleanup);
 }
 
@@ -318,7 +317,7 @@ TEST_F(AutoCommissionerTest, NextCommissioningStageAfterError)
     AutoCommissionerTestAccess privateConfigCommissioner(&mCommissioner);
 
     CHIP_ERROR err           = CHIP_ERROR_INTERNAL;
-    CommissioningStage stage = privateConfigCommissioner.AccessGetNextCommissioningStageInternal(kSecurePairing, err);
+    CommissioningStage stage = privateConfigCommissioner.GetNextCommissioningStageInternal(kSecurePairing, err);
     EXPECT_EQ(stage, kCleanup);
 }
 
@@ -329,7 +328,7 @@ TEST_F(AutoCommissionerTest, NextStageReadCommissioningInfo)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     privateConfigCommissioner.SetBreadcrumb(0);
-    CommissioningStage nextStage = privateConfigCommissioner.AccessGetNextCommissioningStageInternal(kReadCommissioningInfo, err);
+    CommissioningStage nextStage = privateConfigCommissioner.GetNextCommissioningStageInternal(kReadCommissioningInfo, err);
 
     EXPECT_EQ(nextStage, kArmFailsafe);
 
@@ -337,8 +336,8 @@ TEST_F(AutoCommissionerTest, NextStageReadCommissioningInfo)
     privateConfigCommissioner.SetBreadcrumb(1);
 
     CommissioningStage nextStageReadCommissioningInfo =
-        privateConfigCommissioner.AccessGetNextCommissioningStageInternal(kReadCommissioningInfo, err);
-    CommissioningStage nextStageSendNOC = privateConfigCommissioner.AccessGetNextCommissioningStageInternal(kSendNOC, err);
+        privateConfigCommissioner.GetNextCommissioningStageInternal(kReadCommissioningInfo, err);
+    CommissioningStage nextStageSendNOC = privateConfigCommissioner.GetNextCommissioningStageInternal(kSendNOC, err);
 
     EXPECT_EQ(nextStageReadCommissioningInfo, nextStageSendNOC);
 }
@@ -351,14 +350,13 @@ TEST_F(AutoCommissionerTest, NextStageConfigureTCAcknowledgments)
 
     privateConfigCommissioner.SetUTCRequirements(true);
 
-    CommissioningStage nextStage =
-        privateConfigCommissioner.AccessGetNextCommissioningStageInternal(kConfigureTCAcknowledgments, err);
+    CommissioningStage nextStage = privateConfigCommissioner.GetNextCommissioningStageInternal(kConfigureTCAcknowledgments, err);
 
     EXPECT_EQ(nextStage, kConfigureUTCTime);
 
     privateConfigCommissioner.SetUTCRequirements(false);
 
-    nextStage = privateConfigCommissioner.AccessGetNextCommissioningStageInternal(kConfigureTCAcknowledgments, err);
+    nextStage = privateConfigCommissioner.GetNextCommissioningStageInternal(kConfigureTCAcknowledgments, err);
 
     EXPECT_EQ(nextStage, kSendPAICertificateRequest);
 }

--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -24,6 +24,7 @@
 #include <credentials/tests/CHIPAttCert_test_vectors.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <cstring>
+#include <lib/core/Optional.h>
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
@@ -910,8 +911,8 @@ TEST_F(AutoCommissionerTest, CleanupCommissioning_ResetsStateAfterTryingSecondar
 
     CommissioningParameters params =
         test_helpers::MakeCommissioningParams(true /* supportsConcurrent */, true /* hasWiFiCreds */, true /* hasThreadDataset */);
-    mParams.SetDAC(TestCerts::sTestCert_DAC_FFF1_8000_0000_Cert);
-    mParams.SetPAI(TestCerts::sTestCert_PAI_FFF1_8000_Cert);
+    mParams.SetDAC(chip::TestCerts::sTestCert_DAC_FFF1_8000_0000_Cert);
+    mParams.SetPAI(chip::TestCerts::sTestCert_PAI_FFF1_8000_Cert);
     EXPECT_EQ(mCommissioner.SetCommissioningParameters(mParams), CHIP_NO_ERROR);
 
     AutoCommissionerTestAccess privateConfigCommissioner(&mCommissioner);

--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -622,12 +622,8 @@ inline CommissioningParameters MakeCommissioningParams(bool supportsConcurrent =
     }
     if (hasThreadDataset)
     {
-        static uint8_t ThreadDataset[] = {
-            0x00, 0x11, 0x22, 0x33,
-            0x44, 0x55, 0x66, 0x77,
-            0x88, 0x99, 0xAA, 0xBB,
-            0xCC, 0xDD, 0xEE, 0xFF
-        };
+        static uint8_t ThreadDataset[] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                           0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
         params.SetThreadOperationalDataset(ByteSpan(ThreadDataset));
     }
     return params;
@@ -918,16 +914,15 @@ TEST_F(AutoCommissionerTest, CleanupCommissioning_ResetsStateAfterTryingSecondar
 
     Transport::SecureSessionTable sessionTable;
     sessionTable.Init();
-    Transport::SecureSession testSession(
-    sessionTable,
-    Transport::SecureSession::Type::kPASE, // Session type
-    1234,          // localSessionId
-    0x1111,        // localNodeId
-    0x2222,        // peerNodeId
-    CATValues(),   // peerCATs
-    5678,          // peerSessionId
-    1,             // fabric index
-    GetDefaultMRPConfig() // MRP config
+    Transport::SecureSession testSession(sessionTable,
+                                         Transport::SecureSession::Type::kPASE, // Session type
+                                         1234,                                  // localSessionId
+                                         0x1111,                                // localNodeId
+                                         0x2222,                                // peerNodeId
+                                         CATValues(),                           // peerCATs
+                                         5678,                                  // peerSessionId
+                                         1,                                     // fabric index
+                                         GetDefaultMRPConfig()                  // MRP config
     );
     SessionHandle sessionHandle(testSession);
     OperationalDeviceProxy operationalProxy(&exchangeMgr, sessionHandle);


### PR DESCRIPTION
#### Summary
This pull request enhances the test coverage for the `controller/` by adding a suite of new unit tests. These tests focus on verifying the correctness of the internal logic related to `AutoCommissioner`.

#### Implementation Notes

**The new tests validate the following functionality:**

- Network Selection Logic (`IsSecondaryNetworkSupported`, `GetNextCommissioningStageNetworkSetup`): Ensures the commissioner correctly determines whether to use a primary or secondary network (Wi-Fi vs. Thread) based on device capabilities, provided credentials, and network availability.

- State Management and Cleanup (`CleanupCommissioning_ResetsStateAfterTryingSecondaryNetwork`): Confirms that all internal states (e.g., device proxies, commissioning info, network flags) are correctly reset to their default values after a commissioning attempt.

- Command Timeout Calculation (`GetCommandTimeout_*`): Validates that the correct timeout values are calculated for commissioning steps, considering whether an active secure session exists.

- Device Proxy Selection (`GetDeviceProxyForStep_ReturnsCorrectProxy`): Checks that the commissioner correctly selects between the `CommissioneeDeviceProxy` (for early-stage commands) and the `OperationalDeviceProxy` (for later-stage commands) depending on the commissioning stage.

#### Related issues
Fixes: [#40902](https://github.com/project-chip/connectedhomeip/issues/40902)

#### Testing

This PR adds new unit tests in `TestAutoCommissioner.cpp` no change to production code.
#### Local (Linux) Coverage Impact of `/controller`

| Metric   | Before | After | Delta   |
|----------|--------|-------|---------|
| Line     | 19.1%  |23.7 % | +4,6%  |
| Function |25.7%  |33.2% | +7.5%   |
#### Local (Linux) Coverage Impact of `/AutoCommissioner.cpp`
| Metric   | Before | After | Delta   |
|----------|--------|-------|---------|
| Line     | 35.2%  |44.7% | +9.5%  |
| Function | 42.9%  | 54.5 % | +11.6%   |
