### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-167 : [Realtek] Add docker image for Zephyr examples
+168 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
@@ -18,8 +18,8 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 3.3.0; branch: develop_3.3
-ARG ZEPHYR_REVISION=1fe5c43c2d6babfec09dee36e3fde2966d4b5309
-ARG N22_BIN_REVISION=315bd62936f8f86531557c44790a8b70e14866cb
+ARG ZEPHYR_REVISION=f8e451335378fe5005679586eb57b64960f7e607
+ARG N22_BIN_REVISION=d8fcfa278c320ac2a330e6488a308b704887977a
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,8 +18,8 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 4.1.0; branch: develop
-ARG ZEPHYR_REVISION=8392da5697ff59cb91fedc6a45668c2757125f1f
-ARG N22_BIN_REVISION=315bd62936f8f86531557c44790a8b70e14866cb
+ARG ZEPHYR_REVISION=1ce482a5d8846343af3f411532521677339a3630
+ARG N22_BIN_REVISION=d8fcfa278c320ac2a330e6488a308b704887977a
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- soc: telink: common: opus: Add OPUS codec
- telink: soc: pm: fix stack corruption after deep sleep
- soc: telink: common: opus: Fix crash
- samples: net: openthread: Use NVS as settings backend
- soc: telink: common: ot_ext: Add Telink openthread library
- telink: openthread: Use openthread library from submodule


**Changes of N22 binary:**
(latest hash d8fcfa278c320ac2a330e6488a308b704887977a)

- Add OPUS remote driver
- [refactor] : delete SCM file

#### Testing
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully