### PR TITLE
Support zap version CIPD uploads from CIPD releases.

### DIFF
--- a/scripts/tools/zap/cipd_upload.py
+++ b/scripts/tools/zap/cipd_upload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import os

--- a/scripts/tools/zap/cipd_upload.py
+++ b/scripts/tools/zap/cipd_upload.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+import logging
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from typing import Optional
+
+import click
+from zap_download import DownloadReleasedZap
+
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+
+
+try:
+    import coloredlogs
+    _has_coloredlogs = True
+except ImportError:
+    _has_coloredlogs = False
+
+# Supported log levels, mapping string values required for argument
+# parsing into logging constants
+__LOG_LEVELS__ = {
+    'debug': logging.DEBUG,
+    'info': logging.INFO,
+    'warn': logging.WARN,
+    'fatal': logging.FATAL,
+}
+
+
+def _ZapArchitectures():
+    """Iterates through required releases.
+
+    Returns a tuple:
+      - zap zip 'platform'
+      - zap zip 'arch'
+      - CIPD package tuple
+    """
+
+    yield 'linux', 'arm64', 'linux-arm64'
+    yield 'linux', 'x64', 'linux-amd64'
+    yield 'mac', 'arm64', 'mac-arm64'
+    yield 'mac', 'x64', 'mac-amd64'
+    yield 'win', 'x64', 'windows-amd64'
+
+
+@click.command()
+@click.option(
+    '--log-level',
+    default='INFO',
+    show_default=True,
+    type=click.Choice(__LOG_LEVELS__.keys(), case_sensitive=False),
+    callback=lambda c, p, v: __LOG_LEVELS__[v],
+    help='Determines the verbosity of script output')
+@click.option('--no-temp-clean', is_flag=True)
+@click.option('--version', help='Zap version to use', required=True)
+def main(log_level: str, version: str, no_temp_clean: bool):
+    if _has_coloredlogs:
+        coloredlogs.install(level=log_level, fmt='%(asctime)s %(name)s %(levelname)-7s %(message)s')
+    else:
+        logging.basicConfig(
+            level=log_level,
+            format='%(asctime)s %(name)s %(levelname)-7s %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S'
+        )
+
+    with tempfile.TemporaryDirectory(prefix="zap_", suffix="_cipd", delete=(not no_temp_clean)) as tmpdir:
+        logging.info("Temporary Directory: %s", tmpdir)
+
+        for platform, arch, cipd_dir in _ZapArchitectures():
+            download_dir = f"zap-{platform}-{arch}"
+            download_path = os.path.join(tmpdir, download_dir)
+            logging.info("Downloading %s-%s into %s", platform, arch, download_path)
+            DownloadReleasedZap(download_path, version, platform, arch)
+
+            # Release downloaded, create a CIPD definition and upload it
+            cipd_def_file = f"cipd_{platform}_{arch}.yaml"
+            with open(os.path.join(tmpdir, cipd_def_file), "wt") as f:
+                f.write(f"package: experimental/matter/zap/{cipd_dir}\n")
+                f.write(f"description: ZAP release {version} of {platform}-{arch}\n")
+                f.write("install_mode: copy\n")
+                f.write("data:\n")
+                f.write(f"  - dir: {download_dir}\n")
+
+            cmd = [
+                "cipd",
+                "create",
+                f"-pkg-def={cipd_def_file}",
+                "-tag",
+                f"version:{version}",
+            ]
+            logging.info("Creating CIPD: %s", shlex.join(cmd))
+
+            subprocess.check_call(cmd, cwd=tmpdir)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tools/zap/cipd_upload.py
+++ b/scripts/tools/zap/cipd_upload.py
@@ -6,12 +6,11 @@ import shlex
 import subprocess
 import sys
 import tempfile
-from typing import Optional
 
 import click
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
-from zap_download import DownloadReleasedZap
+from zap_download import DownloadReleasedZap # noqa: E402 isort:skip
 
 
 try:

--- a/scripts/tools/zap/cipd_upload.py
+++ b/scripts/tools/zap/cipd_upload.py
@@ -10,7 +10,7 @@ import tempfile
 import click
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
-from zap_download import DownloadReleasedZap # noqa: E402 isort:skip
+from zap_download import DownloadReleasedZap  # noqa: E402 isort:skip
 
 
 try:

--- a/scripts/tools/zap/cipd_upload.py
+++ b/scripts/tools/zap/cipd_upload.py
@@ -28,21 +28,15 @@ __LOG_LEVELS__ = {
     'fatal': logging.FATAL,
 }
 
-
-def _ZapArchitectures():
-    """Iterates through required releases.
-
-    Returns a tuple:
-      - zap zip 'platform'
-      - zap zip 'arch'
-      - CIPD package tuple
-    """
-
-    yield 'linux', 'arm64', 'linux-arm64'
-    yield 'linux', 'x64', 'linux-amd64'
-    yield 'mac', 'arm64', 'mac-arm64'
-    yield 'mac', 'x64', 'mac-amd64'
-    yield 'win', 'x64', 'windows-amd64'
+# A list of things to copy. Tuples of
+#  (zap_platform, zap_architecture, cipd_platform)
+__ZAP_ARCHITECTURES__ = [
+    ('linux', 'arm64', 'linux-arm64'),
+    ('linux', 'x64', 'linux-amd64'),
+    ('mac', 'arm64', 'mac-arm64'),
+    ('mac', 'x64', 'mac-amd64'),
+    ('win', 'x64', 'windows-amd64'),
+]
 
 
 @click.command()
@@ -68,7 +62,7 @@ def main(log_level: str, version: str, no_temp_clean: bool):
     with tempfile.TemporaryDirectory(prefix="zap_", suffix="_cipd", delete=(not no_temp_clean)) as tmpdir:
         logging.info("Temporary Directory: %s", tmpdir)
 
-        for platform, arch, cipd_dir in _ZapArchitectures():
+        for platform, arch, cipd_dir in __ZAP_ARCHITECTURES__:
             download_dir = f"zap-{platform}-{arch}"
             download_path = os.path.join(tmpdir, download_dir)
             logging.info("Downloading %s-%s into %s", platform, arch, download_path)

--- a/scripts/tools/zap/cipd_upload.py
+++ b/scripts/tools/zap/cipd_upload.py
@@ -9,9 +9,9 @@ import tempfile
 from typing import Optional
 
 import click
-from zap_download import DownloadReleasedZap
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+from zap_download import DownloadReleasedZap
 
 
 try:

--- a/scripts/tools/zap/cipd_upload.py
+++ b/scripts/tools/zap/cipd_upload.py
@@ -76,23 +76,23 @@ def main(log_level: str, version: str, no_temp_clean: bool):
 
             # Release downloaded, create a CIPD definition and upload it
             cipd_def_file = f"cipd_{platform}_{arch}.yaml"
-            with open(os.path.join(tmpdir, cipd_def_file), "wt") as f:
+            with open(os.path.join(download_path, cipd_def_file), "wt") as f:
                 f.write(f"package: experimental/matter/zap/{cipd_dir}\n")
                 f.write(f"description: ZAP release {version} of {platform}-{arch}\n")
                 f.write("install_mode: copy\n")
                 f.write("data:\n")
-                f.write(f"  - dir: {download_dir}\n")
+                f.write("  - dir: .\n")
 
             cmd = [
                 "cipd",
                 "create",
                 f"-pkg-def={cipd_def_file}",
                 "-tag",
-                f"version:{version}",
+                f"version:{version}.2",
             ]
             logging.info("Creating CIPD: %s", shlex.join(cmd))
 
-            subprocess.check_call(cmd, cwd=tmpdir)
+            subprocess.check_call(cmd, cwd=download_path)
 
 
 if __name__ == '__main__':

--- a/scripts/tools/zap/zap_download.py
+++ b/scripts/tools/zap/zap_download.py
@@ -97,33 +97,42 @@ def _SetupSourceZap(install_directory: str, zap_version: str):
     _ExecuteProcess("npm ci".split(), install_directory)
 
 
-def _SetupReleaseZap(install_directory: str, zap_version: str):
+def _GetDefaultPlatform():
+    match sys.platform:
+        case 'linux':
+            return 'linux'
+        case 'darwin':
+            return 'mac'
+        case 'win32':
+            return 'win'
+        case _:
+            raise Exception('Unknown platform - do not know what zip file to download.')
+
+
+def _GetDefaultArch():
+    arch = None
+
+    match sys.platform:
+        case 'win32':
+            # os.uname is not implemented on Windows, so use an alternative instead.
+            import platform
+            arch = platform.uname().machine
+        case _:
+            arch = os.uname().machine
+
+    if arch == 'x86_64' or arch == 'AMD64':
+        return 'x64'
+
+    # this should be `arm64` ...
+    return arch
+
+
+def DownloadReleasedZap(install_directory: str, zap_version: str, zap_platform: str, zap_arch: str):
     """
     Downloads the given [zap_version] into "[install_directory]/zap-[zap_version]/".
 
     Will download the given release from github releases.
     """
-
-    if sys.platform == 'linux':
-        zap_platform = 'linux'
-        arch = os.uname().machine
-    elif sys.platform == 'darwin':
-        zap_platform = 'mac'
-        arch = os.uname().machine
-    elif sys.platform == 'win32':
-        zap_platform = 'win'
-        # os.uname is not implemented on Windows, so use an alternative instead.
-        import platform
-        arch = platform.uname().machine
-    else:
-        raise Exception('Unknown platform - do not know what zip file to download.')
-
-    if arch == 'arm64':
-        zap_arch = 'arm64'
-    elif arch == 'x86_64' or arch == 'AMD64':
-        zap_arch = 'x64'
-    else:
-        raise Exception(f'Unknown architecture "${arch}" - do not know what zip file to download.')
 
     url = f"https://github.com/project-chip/zap/releases/download/{zap_version}/zap-{zap_platform}-{zap_arch}.zip"
 
@@ -149,7 +158,7 @@ def _SetupReleaseZap(install_directory: str, zap_version: str):
     logging.info("Done extracting.")
 
 
-def _GetZapVersionToUse(project_root):
+def _GetZapVersionToUse(project_root) -> str:
     """
     Heuristic to figure out what zap version should be used.
 
@@ -212,7 +221,9 @@ def _GetZapVersionToUse(project_root):
     type=click.Choice(DownloadType.__members__, case_sensitive=False),
     callback=lambda c, p, v: getattr(DownloadType, v),
     help='What type of zap download to perform')
-def main(log_level: str, sdk_root: str, extract_root: str, zap_version: Optional[str], zap: DownloadType):
+@click.option('--platform', default=_GetDefaultPlatform(), show_default=True, help='ZAP Platform to download')
+@click.option('--arch', default=_GetDefaultArch(), show_default=True, help='ZAP Architecture to download')
+def main(log_level: str, sdk_root: str, extract_root: str, zap_version: Optional[str], zap: DownloadType, platform: str, arch: str):
     if _has_coloredlogs:
         coloredlogs.install(level=log_level, fmt='%(asctime)s %(name)s %(levelname)-7s %(message)s')
     else:
@@ -245,7 +256,7 @@ def main(log_level: str, sdk_root: str, extract_root: str, zap_version: Optional
         # Make sure the results can be used in scripts
         print(f"{export_cmd} ZAP_DEVELOPMENT_PATH={shlex.quote(install_directory)}")
     else:
-        _SetupReleaseZap(install_directory, zap_version)
+        DownloadReleasedZap(install_directory, zap_version, platform, arch)
 
         # Make sure the results can be used in scripts
         print(f"{export_cmd} ZAP_INSTALL_PATH={shlex.quote(install_directory)}")


### PR DESCRIPTION
#### Summary

Add a script that can allow manual CIPD upload into https://chrome-infra-packages.appspot.com/p/experimental/matter/zap

Automated zap release upload to CIPD seem kind of broken lately. Upload them manually for now. This way we get:
  - more control on when we upload (do not have to wait 4 hours for automation)
  - actual content that matches zap releases

#### Testing

Checked that folder actually exists and is tagged as expected.

#40945 has CI passing after this
 