### PR TITLE
[docker] Bumped docker image version for nRF Connect SDK update

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-168 : [Telink] Update Docker image (Zephyr update)
+169 : [nrfconnect] Update nRF Connect SDK version to 3.1.0

--- a/integrations/docker/images/stage-2/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nrf-platform/Dockerfile
@@ -3,9 +3,9 @@ ARG VERSION=1
 FROM ghcr.io/project-chip/chip-build:${VERSION} AS build
 
 # Compatible Nordic Connect SDK revision and required tools versions
-ARG NCS_REVISION=v3.0.0
-ARG JLINK_VERSION="JLink_Linux_V818_x86_64"
-ARG WEST_VERSION=1.2.0
+ARG NCS_REVISION=v3.1.0
+ARG JLINK_VERSION="JLink_Linux_V842_x86_64"
+ARG WEST_VERSION=1.4.0
 ARG CMAKE_VERSION=3.25.0
 
 # Requirements to clone SDKs


### PR DESCRIPTION
#### Summary
Increased docker image number and changed tools versions required by the new version of nRF Connect SDK.

#### Testing
Automated testing by workflows
