### PR TITLE
[Silabs] Added #ifdef for RTE_UULP_GPIO_1_PIN macro

### DIFF
--- a/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
+++ b/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
@@ -21,7 +21,9 @@
 
 namespace {
 #if defined(ENABLE_CHIP_SHELL) && CHIP_CONFIG_ENABLE_ICD_SERVER
+#ifdef RTE_UULP_GPIO_1_PIN
 bool ps_requirement_added = false;
+#endif // RTE_UULP_GPIO_1_PIN
 #endif // ENABLE_CHIP_SHELL && CHIP_CONFIG_ENABLE_ICD_SERVER
 } // namespace
 
@@ -102,6 +104,7 @@ inline void sl_si91x_btn_event_handler()
 void sl_si91x_uart_power_requirement_handler()
 {
 #ifdef ENABLE_CHIP_SHELL
+#ifdef RTE_UULP_GPIO_1_PIN
     // Checking the UULP PIN 1 status to reinit the UART and not allow the device to go to sleep
     if (sl_si91x_gpio_get_uulp_npss_pin(RTE_UULP_GPIO_1_PIN))
     {
@@ -119,6 +122,7 @@ void sl_si91x_uart_power_requirement_handler()
             ps_requirement_added = false;
         }
     }
+#endif // RTE_UULP_GPIO_1_PIN
 #endif // ENABLE_CHIP_SHELL
 }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -265,6 +265,7 @@ sl_status_t SiWxPlatformInit(void)
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 #ifdef ENABLE_CHIP_SHELL
+#ifdef RTE_UULP_GPIO_1_PIN
     // While using the matter shell with a Low Power Build, GPIO 1 is used to check the UULP PIN 1 status
     // since UART doesn't act as a wakeup source in the UULP mode.
 
@@ -276,6 +277,7 @@ sl_status_t SiWxPlatformInit(void)
 
     // Enable the REN
     RSI_NPSSGPIO_InputBufferEn(RTE_UULP_GPIO_1_PIN, 1);
+#endif // RTE_UULP_GPIO_1_PIN
 #endif // ENABLE_CHIP_SHELL
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #endif // SLI_SI91X_MCU_INTERFACE


### PR DESCRIPTION
#### Summary
Faced build failures for boards - 2708a, 2911a, and 4343a due to RTE_UULP_GPIO_1_PIN macro not being declared. This pin is not present in the schematic of these above mentioned boards. So added `#ifdef` condition checks for files where they are being used.

Tried replacing with other UULP pins as a result build was successful but it failed during commissioning. As there are only 3 common GPIO pins available for all the boards (pins - 0, 2, 3) and all are being used (for LCD, BUTTON, CLK IN, etc.), so using `#ifdef` condition checks will be the generalized solution for now.

In conclusion, due to this hardware limitation these 3 boards will not to able to use matter shell for ICD devices only, just as they couldn't previously, since pin 1 was never available on them.

#### Related issues
N/A

#### Testing
Tested builds for SL-Lock app for boards - 2708a, 2911a, 4338a and 4343a. Tested commissioning and matter shell on brd4338a.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
