### PR TITLE
Update ktfmt and add user-agent to download of ktfmt in zap-regen-all

### DIFF
--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -27,7 +27,6 @@ import sys
 import tempfile
 import time
 import traceback
-from urllib.error import HTTPError
 import urllib.request
 from dataclasses import dataclass
 from enum import Flag, auto


### PR DESCRIPTION
#### Summary

Maven gives us 403 on ktftm download. It seems filtering by user agent.
Changes:

  - consider failing on ktfmt critical instead of silent success with bad data
  - update ktfmt to 0.58 (seems no difference, but newer is probably better)
  - add a user-agent to the download since that seems to fix the 403

#### Testing

Ran zap-regen-all locally.