### PR TITLE
Use SemanticTag typedefs where those exist.

### DIFF
--- a/src/access/tests/TestProviderDeviceTypeResolver.cpp
+++ b/src/access/tests/TestProviderDeviceTypeResolver.cpp
@@ -67,10 +67,7 @@ public:
     }
 
     // The following methods are not used in this test, but must be implemented as they are pure virtual in the Provider interface.
-    CHIP_ERROR SemanticTags(EndpointId, ReadOnlyBufferBuilder<Clusters::Descriptor::Structs::SemanticTagStruct::Type> &) override
-    {
-        return CHIP_NO_ERROR;
-    }
+    CHIP_ERROR SemanticTags(EndpointId, ReadOnlyBufferBuilder<SemanticTag> &) override { return CHIP_NO_ERROR; }
     CHIP_ERROR ClientClusters(EndpointId, ReadOnlyBufferBuilder<ClusterId> &) override { return CHIP_NO_ERROR; }
     CHIP_ERROR ServerClusters(EndpointId, ReadOnlyBufferBuilder<ServerClusterEntry> &) override { return CHIP_NO_ERROR; }
     CHIP_ERROR Endpoints(ReadOnlyBufferBuilder<EndpointEntry> &) override { return CHIP_NO_ERROR; }

--- a/src/data-model-providers/codedriven/CodeDrivenDataModelProvider.cpp
+++ b/src/data-model-providers/codedriven/CodeDrivenDataModelProvider.cpp
@@ -158,8 +158,7 @@ CHIP_ERROR CodeDrivenDataModelProvider::Endpoints(ReadOnlyBufferBuilder<DataMode
 }
 
 CHIP_ERROR
-CodeDrivenDataModelProvider::SemanticTags(EndpointId endpointId,
-                                          ReadOnlyBufferBuilder<Clusters::Descriptor::Structs::SemanticTagStruct::Type> & out)
+CodeDrivenDataModelProvider::SemanticTags(EndpointId endpointId, ReadOnlyBufferBuilder<SemanticTag> & out)
 {
     EndpointInterface * endpoint = GetEndpointInterface(endpointId);
     VerifyOrReturnError(endpoint != nullptr, CHIP_IM_GLOBAL_STATUS(UnsupportedEndpoint));

--- a/src/data-model-providers/codedriven/CodeDrivenDataModelProvider.h
+++ b/src/data-model-providers/codedriven/CodeDrivenDataModelProvider.h
@@ -80,8 +80,7 @@ public:
 
     /* ProviderMetadataTree implementation */
     CHIP_ERROR Endpoints(ReadOnlyBufferBuilder<DataModel::EndpointEntry> & out) override;
-    CHIP_ERROR SemanticTags(EndpointId endpointId,
-                            ReadOnlyBufferBuilder<Clusters::Descriptor::Structs::SemanticTagStruct::Type> & out) override;
+    CHIP_ERROR SemanticTags(EndpointId endpointId, ReadOnlyBufferBuilder<SemanticTag> & out) override;
     CHIP_ERROR DeviceTypes(EndpointId endpointId, ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) override;
     CHIP_ERROR ClientClusters(EndpointId endpointId, ReadOnlyBufferBuilder<ClusterId> & out) override;
     CHIP_ERROR ServerClusters(EndpointId endpointId, ReadOnlyBufferBuilder<DataModel::ServerClusterEntry> & out) override;

--- a/src/data-model-providers/codedriven/endpoint/SpanEndpoint.cpp
+++ b/src/data-model-providers/codedriven/endpoint/SpanEndpoint.cpp
@@ -51,7 +51,7 @@ SpanEndpoint SpanEndpoint::Builder::Build()
 }
 
 CHIP_ERROR
-SpanEndpoint::SemanticTags(ReadOnlyBufferBuilder<Clusters::Descriptor::Structs::SemanticTagStruct::Type> & out) const
+SpanEndpoint::SemanticTags(ReadOnlyBufferBuilder<SemanticTag> & out) const
 {
     return out.ReferenceExisting(mSemanticTags);
 }


### PR DESCRIPTION
In the data model providers, we have a SemanticTag typedef that we should be using.  That way when we fix SemanticTagStruct to live in the right place, we will need fewer changes.

#### Testing

No behavior changes.  Compilation should work.