### PR TITLE
Add a CompatClusterObjects file, similar to the one we have for enums.

### DIFF
--- a/src/app/common/BUILD.gn
+++ b/src/app/common/BUILD.gn
@@ -54,6 +54,7 @@ static_library("cluster-objects") {
   sources = [
     "${chip_app_zap_dir}/app-common/zap-generated/cluster-objects.cpp",
     "${chip_app_zap_dir}/app-common/zap-generated/cluster-objects.h",
+    "CompatClusterObjects.h",
   ]
 
   public_deps = [

--- a/src/app/common/CompatClusterObjects.h
+++ b/src/app/common/CompatClusterObjects.h
@@ -1,0 +1,46 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * This file contains backwards-compatibility cluster object definitions.  This file
+ * is meant to be included at the end of cluster-objects.h, after all the normal
+ * definitions are available.
+ */
+#pragma once
+
+#ifndef CHIP_INCLUDING_FROM_CLUSTER_OBJECTS
+#error "CompatClusterObjects.h must only be included from cluster-objects.h"
+#endif // CHIP_INCLUDING_FROM_CLUSTER_OBJECTS
+
+namespace chip {
+namespace app {
+namespace Clusters {
+
+// TODO: when fixing
+// https://github.com/project-chip/connectedhomeip/issues/34702, make this
+// namespace alias go the other way.
+
+namespace Globals {
+namespace Structs {
+
+namespace SemanticTagStruct = Descriptor::Structs::SemanticTagStruct;
+
+} // namespace Structs
+} // namespace Globals
+
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/common/CompatEnumNames.h
+++ b/src/app/common/CompatEnumNames.h
@@ -21,7 +21,10 @@
  */
 #pragma once
 
-#include <app-common/zap-generated/cluster-enums.h>
+#ifndef CHIP_INCLUDING_FROM_CLUSTER_ENUMS
+#error "CompatEnumNames.h must only be included from cluster-enums.h"
+#endif // CHIP_INCLUDING_FROM_CLUSTER_ENUMS
+
 #include <lib/support/TypeTraits.h>
 
 namespace chip {

--- a/src/app/zap-templates/templates/app/cluster-enums.h.zapt
+++ b/src/app/zap-templates/templates/app/cluster-enums.h.zapt
@@ -10,5 +10,6 @@
 {{/zcl_clusters}}
 
 // Included at the end, so all our definitions above are available.
+#define CHIP_INCLUDING_FROM_CLUSTER_ENUMS
 #include <app/common/CompatEnumNames.h>
-
+#undef CHIP_INCLUDING_FROM_CLUSTER_ENUMS

--- a/src/app/zap-templates/templates/app/cluster-objects.h.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.h.zapt
@@ -13,7 +13,7 @@
 #include <clusters/{{asUpperCamelCase name}}/Structs.h>
 {{/zcl_clusters}}
 
-#include <app/common/CompatEnumNames.h>
+#include <app-common/zap-generated/cluster-enums.h>
 
 namespace chip {
 namespace app {
@@ -24,3 +24,8 @@ bool CommandHasLargePayload(ClusterId aCluster, CommandId aCommand);
 
 } // namespace app
 } // namespace chip
+
+// Included at the end, so all our definitions above are available.
+#define CHIP_INCLUDING_FROM_CLUSTER_OBJECTS
+#include <app/common/CompatClusterObjects.h>
+#undef CHIP_INCLUDING_FROM_CLUSTER_OBJECTS

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -165,4 +165,6 @@
 #include <clusters/ZoneManagement/Enums.h>
 
 // Included at the end, so all our definitions above are available.
+#define CHIP_INCLUDING_FROM_CLUSTER_ENUMS
 #include <app/common/CompatEnumNames.h>
+#undef CHIP_INCLUDING_FROM_CLUSTER_ENUMS

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -588,7 +588,7 @@
 #include <clusters/ZoneManagement/Events.h>
 #include <clusters/ZoneManagement/Structs.h>
 
-#include <app/common/CompatEnumNames.h>
+#include <app-common/zap-generated/cluster-enums.h>
 
 namespace chip {
 namespace app {
@@ -599,3 +599,8 @@ bool CommandHasLargePayload(ClusterId aCluster, CommandId aCommand);
 
 } // namespace app
 } // namespace chip
+
+// Included at the end, so all our definitions above are available.
+#define CHIP_INCLUDING_FROM_CLUSTER_OBJECTS
+#include <app/common/CompatClusterObjects.h>
+#undef CHIP_INCLUDING_FROM_CLUSTER_OBJECTS


### PR DESCRIPTION
This will let us create a backwards-compat alias for SemanticTagStruct when we move it from Descriptor to global.

#### Testing

No real behavior changes, just adding a namespace alias.  Compilation should succeed.