### PR TITLE
[NXP][doc][platform] Updating platform guides to specify the default build configuration

### DIFF
--- a/docs/platforms/nxp/nxp_rt1060_guide.md
+++ b/docs/platforms/nxp/nxp_rt1060_guide.md
@@ -2,31 +2,31 @@
 
 <hr>
 
-- [MATTER NXP RT1060 Applications Guide](#matter-nxp-rt1060-applications-guide)
-  - [Introduction](#introduction)
-    - [Supported configurations](#supported-configurations)
-    - [Hardware requirements RT1060 + transceiver](#hardware-requirements-rt1060--transceiver)
-      - [Hardware requirements RT1060+IW416](#hardware-requirements-rt1060iw416)
-      - [Hardware requirements RT1060+88W8801](#hardware-requirements-rt106088w8801)
-      - [Hardware requirements RT1060 + K32W0](#hardware-requirements-rt1060--k32w0)
-      - [Hardware requirements RT1060-EVK-C + IW612 / IW610](#hardware-requirements-rt1060-evk-c--iw612--iw610)
-      - [Hardware requirements RT1060 + 88W8801 + K32W0x1DK6](#hardware-requirements-rt1060--88w8801--k32w0x1dk6)
-  - [Building](#building)
-    - [CMake Build System](#cmake-build-system)
-    - [GN Build System](#gn-build-system)
-      - [Building with Matter over Wifi configuration on RT1060 + transceiver](#building-with-matter-over-wifi-configuration-on-rt1060--transceiver)
-      - [Build with Matter over Thread configuration on RT1060 + transceiver](#build-with-matter-over-thread-configuration-on-rt1060--transceiver)
-        - [Build with Matter over Thread configuration on RT1060 + K32W0](#build-with-matter-over-thread-configuration-on-rt1060--k32w0)
-        - [Build with Matter over Thread configuration on RT1060-EVK-C + IW612](#build-with-matter-over-thread-configuration-on-rt1060-evk-c--iw612)
-        - [Build with Matter over Wi-Fi + OpenThread Border Router configuration on RT1060-EVK-C + IW612](#build-with-matter-over-wi-fi--openthread-border-router-configuration-on-rt1060-evk-c--iw612)
-        - [Build with Matter over Wi-Fi + OpenThread Border Router configuration on RT1060 + 88W8801 + K32W0x1DK6](#build-with-matter-over-wi-fi--openthread-border-router-configuration-on-rt1060--88w8801--k32w0x1dk6)
-      - [General Information](#general-information)
-  - [Manufacturing data](#manufacturing-data)
-  - [Flashing and debugging](#flashing-and-debugging)
-  - [Testing the example](#testing-the-example)
-    - [UART details](#uart-details)
-  - [OTA Software Update](#ota-software-update)
-  - [Thread Border Router overview](#thread-border-router-overview)
+-   [MATTER NXP RT1060 Applications Guide](#matter-nxp-rt1060-applications-guide)
+    -   [Introduction](#introduction)
+        -   [Supported configurations](#supported-configurations)
+        -   [Hardware requirements RT1060 + transceiver](#hardware-requirements-rt1060--transceiver)
+            -   [Hardware requirements RT1060+IW416](#hardware-requirements-rt1060iw416)
+            -   [Hardware requirements RT1060+88W8801](#hardware-requirements-rt106088w8801)
+            -   [Hardware requirements RT1060 + K32W0](#hardware-requirements-rt1060--k32w0)
+            -   [Hardware requirements RT1060-EVK-C + IW612 / IW610](#hardware-requirements-rt1060-evk-c--iw612--iw610)
+            -   [Hardware requirements RT1060 + 88W8801 + K32W0x1DK6](#hardware-requirements-rt1060--88w8801--k32w0x1dk6)
+    -   [Building](#building)
+        -   [CMake Build System](#cmake-build-system)
+        -   [GN Build System](#gn-build-system)
+            -   [Building with Matter over Wifi configuration on RT1060 + transceiver](#building-with-matter-over-wifi-configuration-on-rt1060--transceiver)
+            -   [Build with Matter over Thread configuration on RT1060 + transceiver](#build-with-matter-over-thread-configuration-on-rt1060--transceiver)
+                -   [Build with Matter over Thread configuration on RT1060 + K32W0](#build-with-matter-over-thread-configuration-on-rt1060--k32w0)
+                -   [Build with Matter over Thread configuration on RT1060-EVK-C + IW612](#build-with-matter-over-thread-configuration-on-rt1060-evk-c--iw612)
+                -   [Build with Matter over Wi-Fi + OpenThread Border Router configuration on RT1060-EVK-C + IW612](#build-with-matter-over-wi-fi--openthread-border-router-configuration-on-rt1060-evk-c--iw612)
+                -   [Build with Matter over Wi-Fi + OpenThread Border Router configuration on RT1060 + 88W8801 + K32W0x1DK6](#build-with-matter-over-wi-fi--openthread-border-router-configuration-on-rt1060--88w8801--k32w0x1dk6)
+            -   [General Information](#general-information)
+    -   [Manufacturing data](#manufacturing-data)
+    -   [Flashing and debugging](#flashing-and-debugging)
+    -   [Testing the example](#testing-the-example)
+        -   [UART details](#uart-details)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Thread Border Router overview](#thread-border-router-overview)
 
 <a name="intro"></a>
 
@@ -65,7 +65,9 @@ Matter over Wi-Fi with Openthread Border Router support :
 -   RT1060-EVK-C + IW612 (Wi-Fi + 15.4 + BLE)
 -   RT1060-EVK-C + IW610 (Wi-Fi + 15.4 + BLE)
 
-> **Note:** For CMake builds, Matter over Wi-Fi with `RT1060-EVK-C + IW612` is the default configuration when no `prj_<flavour>.conf` file and no transceiver option is specified in the [build](#cmake-build-system).
+> **Note:** For CMake builds, Matter over Wi-Fi with `RT1060-EVK-C + IW612` is
+> the default configuration when no `prj_<flavour>.conf` file and no transceiver
+> option is specified in the [build](#cmake-build-system).
 
 ### Hardware requirements RT1060 + transceiver
 

--- a/docs/platforms/nxp/nxp_rt1060_guide.md
+++ b/docs/platforms/nxp/nxp_rt1060_guide.md
@@ -65,7 +65,7 @@ Matter over Wi-Fi with Openthread Border Router support :
 -   RT1060-EVK-C + IW612 (Wi-Fi + 15.4 + BLE)
 -   RT1060-EVK-C + IW610 (Wi-Fi + 15.4 + BLE)
 
-> **Note:** For CMake builds, Matter over Wi-Fi with `RT1060-EVK-C + IW612` is the default configuration when no `prj_<flavour>.conf` file and no transceiver option is specified in the build.
+> **Note:** For CMake builds, Matter over Wi-Fi with `RT1060-EVK-C + IW612` is the default configuration when no `prj_<flavour>.conf` file and no transceiver option is specified in the [build](#cmake-build-system).
 
 ### Hardware requirements RT1060 + transceiver
 

--- a/docs/platforms/nxp/nxp_rt1060_guide.md
+++ b/docs/platforms/nxp/nxp_rt1060_guide.md
@@ -2,31 +2,31 @@
 
 <hr>
 
--   [MATTER NXP RT1060 Applications Guide](#matter-nxp-rt1060-applications-guide)
-    -   [Introduction](#introduction)
-        -   [Supported configurations](#supported-configurations)
-        -   [Hardware requirements RT1060 + transceiver](#hardware-requirements-rt1060--transceiver)
-            -   [Hardware requirements RT1060+IW416](#hardware-requirements-rt1060iw416)
-            -   [Hardware requirements RT1060+88W8801](#hardware-requirements-rt106088w8801)
-            -   [Hardware requirements RT1060 + K32W0](#hardware-requirements-rt1060--k32w0)
-            -   [Hardware requirements RT1060-EVK-C + IW612 / IW610](#hardware-requirements-rt1060-evk-c--iw612--iw610)
-            -   [Hardware requirements RT1060 + 88W8801 + K32W0x1DK6](#hardware-requirements-rt1060--88w8801--k32w0x1dk6)
-    -   [Building](#building)
-        -   [CMake Build System](#cmake-build-system)
-        -   [GN Build System](#gn-build-system)
-            -   [Building with Matter over Wifi configuration on RT1060 + transceiver](#building-with-matter-over-wifi-configuration-on-rt1060--transceiver)
-            -   [Build with Matter over Thread configuration on RT1060 + transceiver](#build-with-matter-over-thread-configuration-on-rt1060--transceiver)
-                -   [Build with Matter over Thread configuration on RT1060 + K32W0](#build-with-matter-over-thread-configuration-on-rt1060--k32w0)
-                -   [Build with Matter over Thread configuration on RT1060-EVK-C + IW612](#build-with-matter-over-thread-configuration-on-rt1060-evk-c--iw612)
-                -   [Build with Matter over Wi-Fi + OpenThread Border Router configuration on RT1060-EVK-C + IW612](#build-with-matter-over-wi-fi--openthread-border-router-configuration-on-rt1060-evk-c--iw612)
-                -   [Build with Matter over Wi-Fi + OpenThread Border Router configuration on RT1060 + 88W8801 + K32W0x1DK6](#build-with-matter-over-wi-fi--openthread-border-router-configuration-on-rt1060--88w8801--k32w0x1dk6)
-            -   [General Information](#general-information)
-    -   [Manufacturing data](#manufacturing-data)
-    -   [Flashing and debugging](#flashing-and-debugging)
-    -   [Testing the example](#testing-the-example)
-        -   [UART details](#uart-details)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Thread Border Router overview](#thread-border-router-overview)
+- [MATTER NXP RT1060 Applications Guide](#matter-nxp-rt1060-applications-guide)
+  - [Introduction](#introduction)
+    - [Supported configurations](#supported-configurations)
+    - [Hardware requirements RT1060 + transceiver](#hardware-requirements-rt1060--transceiver)
+      - [Hardware requirements RT1060+IW416](#hardware-requirements-rt1060iw416)
+      - [Hardware requirements RT1060+88W8801](#hardware-requirements-rt106088w8801)
+      - [Hardware requirements RT1060 + K32W0](#hardware-requirements-rt1060--k32w0)
+      - [Hardware requirements RT1060-EVK-C + IW612 / IW610](#hardware-requirements-rt1060-evk-c--iw612--iw610)
+      - [Hardware requirements RT1060 + 88W8801 + K32W0x1DK6](#hardware-requirements-rt1060--88w8801--k32w0x1dk6)
+  - [Building](#building)
+    - [CMake Build System](#cmake-build-system)
+    - [GN Build System](#gn-build-system)
+      - [Building with Matter over Wifi configuration on RT1060 + transceiver](#building-with-matter-over-wifi-configuration-on-rt1060--transceiver)
+      - [Build with Matter over Thread configuration on RT1060 + transceiver](#build-with-matter-over-thread-configuration-on-rt1060--transceiver)
+        - [Build with Matter over Thread configuration on RT1060 + K32W0](#build-with-matter-over-thread-configuration-on-rt1060--k32w0)
+        - [Build with Matter over Thread configuration on RT1060-EVK-C + IW612](#build-with-matter-over-thread-configuration-on-rt1060-evk-c--iw612)
+        - [Build with Matter over Wi-Fi + OpenThread Border Router configuration on RT1060-EVK-C + IW612](#build-with-matter-over-wi-fi--openthread-border-router-configuration-on-rt1060-evk-c--iw612)
+        - [Build with Matter over Wi-Fi + OpenThread Border Router configuration on RT1060 + 88W8801 + K32W0x1DK6](#build-with-matter-over-wi-fi--openthread-border-router-configuration-on-rt1060--88w8801--k32w0x1dk6)
+      - [General Information](#general-information)
+  - [Manufacturing data](#manufacturing-data)
+  - [Flashing and debugging](#flashing-and-debugging)
+  - [Testing the example](#testing-the-example)
+    - [UART details](#uart-details)
+  - [OTA Software Update](#ota-software-update)
+  - [Thread Border Router overview](#thread-border-router-overview)
 
 <a name="intro"></a>
 
@@ -64,6 +64,8 @@ Matter over Wi-Fi with Openthread Border Router support :
 -   RT1060 + 88W8801 + K32W0x1DK6
 -   RT1060-EVK-C + IW612 (Wi-Fi + 15.4 + BLE)
 -   RT1060-EVK-C + IW610 (Wi-Fi + 15.4 + BLE)
+
+> **Note:** For CMake builds, Matter over Wi-Fi with `RT1060-EVK-C + IW612` is the default configuration when no `prj_<flavour>.conf` file and no transceiver option is specified in the build.
 
 ### Hardware requirements RT1060 + transceiver
 

--- a/docs/platforms/nxp/nxp_rt1170_guide.md
+++ b/docs/platforms/nxp/nxp_rt1170_guide.md
@@ -47,7 +47,7 @@ over Thread on RT1170 :
 
 -   RT1170 + IW612 (Wi-Fi + BLE + 15.4)
 
-> **Note:** For CMake builds, Matter over Wi-Fi is the default configuration when no `prj_<flavour>.conf` file is specified in the build.
+> **Note:** For CMake builds, Matter over Wi-Fi is the default configuration when no `prj_<flavour>.conf` file is specified in the [build](#cmake-build-system).
 
 ### Supported build systems
 

--- a/docs/platforms/nxp/nxp_rt1170_guide.md
+++ b/docs/platforms/nxp/nxp_rt1170_guide.md
@@ -2,26 +2,26 @@
 
 <hr>
 
--   [MATTER NXP RT1170 Applications Guide](#matter-nxp-rt1170-applications-guide)
-    -   [Introduction](#introduction)
-        -   [Supported configurations](#supported-configurations)
-        -   [Supported build systems](#supported-build-systems)
-        -   [Hardware requirements for RT1170 + IW612](#hardware-requirements-for-rt1170--iw612)
-            -   [Hardware rework for SPI support on MIMXRT1170-EVK-B](#hardware-rework-for-spi-support-on-mimxrt1170-evk-b)
-            -   [Board settings (Spinel over SPI, I2C, BLE over UART)](#board-settings-spinel-over-spi-i2c-ble-over-uart)
-    -   [Building](#building)
-        -   [CMake Build System](#cmake-build-system)
-        -   [GN Build System](#gn-build-system)
-            -   [Building with Matter over Wifi configuration on RT1170 + IW612](#building-with-matter-over-wifi-configuration-on-rt1170--iw612)
-            -   [Building with Matter over Thread configuration on RT1170 + IW612](#building-with-matter-over-thread-configuration-on-rt1170--iw612)
-            -   [Building with Matter over Wifi + OpenThread Border Router configuration on RT1170 + IW612](#building-with-matter-over-wifi--openthread-border-router-configuration-on-rt1170--iw612)
-        -   [General information](#general-information)
-    -   [Manufacturing data](#manufacturing-data)
-    -   [Flashing and debugging](#flashing-and-debugging)
-    -   [Testing the example](#testing-the-example)
-        -   [UART details](#uart-details)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Thread Border Router overview](#thread-border-router-overview)
+- [MATTER NXP RT1170 Applications Guide](#matter-nxp-rt1170-applications-guide)
+  - [Introduction](#introduction)
+    - [Supported configurations](#supported-configurations)
+    - [Supported build systems](#supported-build-systems)
+    - [Hardware requirements for RT1170 + IW612](#hardware-requirements-for-rt1170--iw612)
+      - [Hardware rework for SPI support on MIMXRT1170-EVK-B](#hardware-rework-for-spi-support-on-mimxrt1170-evk-b)
+      - [Board settings (Spinel over SPI, I2C, BLE over UART)](#board-settings-spinel-over-spi-i2c-ble-over-uart)
+  - [Building](#building)
+    - [CMake Build System](#cmake-build-system)
+    - [GN Build System](#gn-build-system)
+      - [Building with Matter over Wifi configuration on RT1170 + IW612](#building-with-matter-over-wifi-configuration-on-rt1170--iw612)
+      - [Building with Matter over Thread configuration on RT1170 + IW612](#building-with-matter-over-thread-configuration-on-rt1170--iw612)
+      - [Building with Matter over Wifi + OpenThread Border Router configuration on RT1170 + IW612](#building-with-matter-over-wifi--openthread-border-router-configuration-on-rt1170--iw612)
+    - [General information](#general-information)
+  - [Manufacturing data](#manufacturing-data)
+  - [Flashing and debugging](#flashing-and-debugging)
+  - [Testing the example](#testing-the-example)
+    - [UART details](#uart-details)
+  - [OTA Software Update](#ota-software-update)
+  - [Thread Border Router overview](#thread-border-router-overview)
 
 ## Introduction
 
@@ -46,6 +46,8 @@ Here are listed configurations that allow to support Matter over Wi-Fi & Matter
 over Thread on RT1170 :
 
 -   RT1170 + IW612 (Wi-Fi + BLE + 15.4)
+
+> **Note:** For CMake builds, Matter over Wi-Fi is the default configuration when no `prj_<flavour>.conf` file is specified in the build.
 
 ### Supported build systems
 

--- a/docs/platforms/nxp/nxp_rt1170_guide.md
+++ b/docs/platforms/nxp/nxp_rt1170_guide.md
@@ -2,26 +2,26 @@
 
 <hr>
 
-- [MATTER NXP RT1170 Applications Guide](#matter-nxp-rt1170-applications-guide)
-  - [Introduction](#introduction)
-    - [Supported configurations](#supported-configurations)
-    - [Supported build systems](#supported-build-systems)
-    - [Hardware requirements for RT1170 + IW612](#hardware-requirements-for-rt1170--iw612)
-      - [Hardware rework for SPI support on MIMXRT1170-EVK-B](#hardware-rework-for-spi-support-on-mimxrt1170-evk-b)
-      - [Board settings (Spinel over SPI, I2C, BLE over UART)](#board-settings-spinel-over-spi-i2c-ble-over-uart)
-  - [Building](#building)
-    - [CMake Build System](#cmake-build-system)
-    - [GN Build System](#gn-build-system)
-      - [Building with Matter over Wifi configuration on RT1170 + IW612](#building-with-matter-over-wifi-configuration-on-rt1170--iw612)
-      - [Building with Matter over Thread configuration on RT1170 + IW612](#building-with-matter-over-thread-configuration-on-rt1170--iw612)
-      - [Building with Matter over Wifi + OpenThread Border Router configuration on RT1170 + IW612](#building-with-matter-over-wifi--openthread-border-router-configuration-on-rt1170--iw612)
-    - [General information](#general-information)
-  - [Manufacturing data](#manufacturing-data)
-  - [Flashing and debugging](#flashing-and-debugging)
-  - [Testing the example](#testing-the-example)
-    - [UART details](#uart-details)
-  - [OTA Software Update](#ota-software-update)
-  - [Thread Border Router overview](#thread-border-router-overview)
+-   [MATTER NXP RT1170 Applications Guide](#matter-nxp-rt1170-applications-guide)
+    -   [Introduction](#introduction)
+        -   [Supported configurations](#supported-configurations)
+        -   [Supported build systems](#supported-build-systems)
+        -   [Hardware requirements for RT1170 + IW612](#hardware-requirements-for-rt1170--iw612)
+            -   [Hardware rework for SPI support on MIMXRT1170-EVK-B](#hardware-rework-for-spi-support-on-mimxrt1170-evk-b)
+            -   [Board settings (Spinel over SPI, I2C, BLE over UART)](#board-settings-spinel-over-spi-i2c-ble-over-uart)
+    -   [Building](#building)
+        -   [CMake Build System](#cmake-build-system)
+        -   [GN Build System](#gn-build-system)
+            -   [Building with Matter over Wifi configuration on RT1170 + IW612](#building-with-matter-over-wifi-configuration-on-rt1170--iw612)
+            -   [Building with Matter over Thread configuration on RT1170 + IW612](#building-with-matter-over-thread-configuration-on-rt1170--iw612)
+            -   [Building with Matter over Wifi + OpenThread Border Router configuration on RT1170 + IW612](#building-with-matter-over-wifi--openthread-border-router-configuration-on-rt1170--iw612)
+        -   [General information](#general-information)
+    -   [Manufacturing data](#manufacturing-data)
+    -   [Flashing and debugging](#flashing-and-debugging)
+    -   [Testing the example](#testing-the-example)
+        -   [UART details](#uart-details)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Thread Border Router overview](#thread-border-router-overview)
 
 ## Introduction
 
@@ -47,7 +47,9 @@ over Thread on RT1170 :
 
 -   RT1170 + IW612 (Wi-Fi + BLE + 15.4)
 
-> **Note:** For CMake builds, Matter over Wi-Fi is the default configuration when no `prj_<flavour>.conf` file is specified in the [build](#cmake-build-system).
+> **Note:** For CMake builds, Matter over Wi-Fi is the default configuration
+> when no `prj_<flavour>.conf` file is specified in the
+> [build](#cmake-build-system).
 
 ### Supported build systems
 

--- a/docs/platforms/nxp/nxp_rw61x_guide.md
+++ b/docs/platforms/nxp/nxp_rw61x_guide.md
@@ -25,7 +25,9 @@ The examples support:
 -   Matter over Openthread
 -   Matter over Wi-Fi with OpenThread Border Router support.
 
-> **Note:** For CMake builds, Matter over Wi-Fi is the default configuration when no `prj_<flavour>.conf` file is specified in the [build](#cmake-build-system).
+> **Note:** For CMake builds, Matter over Wi-Fi is the default configuration
+> when no `prj_<flavour>.conf` file is specified in the
+> [build](#cmake-build-system).
 
 ### Supported build systems
 

--- a/docs/platforms/nxp/nxp_rw61x_guide.md
+++ b/docs/platforms/nxp/nxp_rw61x_guide.md
@@ -25,6 +25,8 @@ The examples support:
 -   Matter over Openthread
 -   Matter over Wi-Fi with OpenThread Border Router support.
 
+> **Note:** For CMake builds, Matter over Wi-Fi is the default configuration when no `prj_<flavour>.conf` file is specified in the build.
+
 ### Supported build systems
 
 RW61x platform supports two different build systems to generate the application

--- a/docs/platforms/nxp/nxp_rw61x_guide.md
+++ b/docs/platforms/nxp/nxp_rw61x_guide.md
@@ -25,7 +25,7 @@ The examples support:
 -   Matter over Openthread
 -   Matter over Wi-Fi with OpenThread Border Router support.
 
-> **Note:** For CMake builds, Matter over Wi-Fi is the default configuration when no `prj_<flavour>.conf` file is specified in the build.
+> **Note:** For CMake builds, Matter over Wi-Fi is the default configuration when no `prj_<flavour>.conf` file is specified in the [build](#cmake-build-system).
 
 ### Supported build systems
 


### PR DESCRIPTION
#### Summary

The aim of this PR is to document the default build configuration for NXP platforms, in case no project configuration file (prj_<flavour>.conf) is specified in the CMake build command line.

#### Testing
N/A
