### PR TITLE
Move `#if` logic.

### DIFF
--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -483,6 +483,7 @@ TEST_F(AutoCommissionerTest, NOCChainGenerated_EmptyRCACReturnsInvalidArgument)
 // Ensures extra checks are done with RCAC buffer size
 TEST_F(AutoCommissionerTest, NOCChainGenerated_CorruptedRCACLengthReturnsError)
 {
+    AutoCommissionerTestAccess privateConfigCommissioner(&mCommissioner);
     CHIP_ERROR err =
         privateConfigCommissioner.NOCChainGenerated(kValidNOC, kValidICAC, kCoruptedBufferInvalidRCAC, kValidIpk, kValidNodeId);
 
@@ -493,7 +494,6 @@ TEST_F(AutoCommissionerTest, NOCChainGenerated_CorruptedRCACLengthReturnsError)
 TEST_F(AutoCommissionerTest, NOCChainGenerated_CorruptedNOCLengthReturnsError)
 {
     AutoCommissionerTestAccess privateConfigCommissioner(&mCommissioner);
-
     CHIP_ERROR err =
         privateConfigCommissioner.NOCChainGenerated(kCoruptedBufferInvalidNOC, kValidICAC, kValidRCAC, kValidIpk, kValidNodeId);
 

--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -476,18 +476,13 @@ TEST_F(AutoCommissionerTest, NOCChainGenerated_EmptyRCACReturnsInvalidArgument)
     EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
 }
 
+// On 32-bit systems, NOCChainGenerated cannot fail due to size_t being 32 bits and never exceeding uint32_t,
+// therefore we skip some checks.
+#if SIZE_MAX > UINT32_MAX
+
 // Ensures extra checks are done with RCAC buffer size
 TEST_F(AutoCommissionerTest, NOCChainGenerated_CorruptedRCACLengthReturnsError)
 {
-    // On 32-bit systems, NOCChainGenerated cannot fail due to size_t being 32 bits and never exceeding uint32_t,
-    // therefore we skip this check .
-
-#if SIZE_MAX <= UINT32_MAX
-    GTEST_SKIP() << "Only meaningful on 64-bit systems";
-#endif
-    AutoCommissionerTestAccess privateConfigCommissioner(&mCommissioner);
-    // Use uint32_t for portability on 32-bit systems
-
     CHIP_ERROR err =
         privateConfigCommissioner.NOCChainGenerated(kValidNOC, kValidICAC, kCoruptedBufferInvalidRCAC, kValidIpk, kValidNodeId);
 
@@ -497,10 +492,6 @@ TEST_F(AutoCommissionerTest, NOCChainGenerated_CorruptedRCACLengthReturnsError)
 // Ensures extra checks are done with NOC buffer size
 TEST_F(AutoCommissionerTest, NOCChainGenerated_CorruptedNOCLengthReturnsError)
 {
-#if SIZE_MAX <= UINT32_MAX
-    GTEST_SKIP() << "Only meaningful on 64-bit systems";
-#endif
-
     AutoCommissionerTestAccess privateConfigCommissioner(&mCommissioner);
 
     CHIP_ERROR err =
@@ -508,6 +499,7 @@ TEST_F(AutoCommissionerTest, NOCChainGenerated_CorruptedNOCLengthReturnsError)
 
     EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
 }
+#endif
 
 // Ensures empty NOC certificates aren't admitted
 TEST_F(AutoCommissionerTest, NOCChainGenerated_EmptyNOCReturnsInvalidArgument)

--- a/src/controller/tests/TestAutoCommissioner.cpp
+++ b/src/controller/tests/TestAutoCommissioner.cpp
@@ -477,7 +477,7 @@ TEST_F(AutoCommissionerTest, NOCChainGenerated_EmptyRCACReturnsInvalidArgument)
 }
 
 // On 32-bit systems, NOCChainGenerated cannot fail due to size_t being 32 bits and never exceeding uint32_t,
-// therefore we skip some checks.
+// therefore we skip some tests.
 #if SIZE_MAX > UINT32_MAX
 
 // Ensures extra checks are done with RCAC buffer size


### PR DESCRIPTION
This fixes unreachable code errors for 32-bit systems and also makes the test a bit clearer.

#### Summary

Android builds were failing with:

```
INFO    ../../src/controller/tests/TestAutoCommissioner.cpp:488:59: error: code will never be executed [-Werror,-Wunreachable-code]
INFO      488 |     AutoCommissionerTestAccess privateConfigCommissioner(&mCommissioner);
INFO          |                                                           ^~~~~~~~~~~~~
INFO    ../../src/controller/tests/TestAutoCommissioner.cpp:504:59: error: code will never be executed [-Werror,-Wunreachable-code]
INFO      504 |     AutoCommissionerTestAccess privateConfigCommissioner(&mCommissioner);
```

#### Testing

Trivial update. Re-ran unit tests.