### PR TITLE
Set WindowCovering ClusterRevision as external and implement Read handler

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -8674,7 +8674,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0x17;
-    ram      attribute clusterRevision default = 5;
+    callback attribute clusterRevision;
 
     handle command UpOrOpen;
     handle command DownOrClose;

--- a/examples/all-clusters-app/realtek/data_model/all-clusters-app.matter
+++ b/examples/all-clusters-app/realtek/data_model/all-clusters-app.matter
@@ -9021,7 +9021,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0x17;
-    ram      attribute clusterRevision default = 5;
+    callback attribute clusterRevision;
 
     handle command UpOrOpen;
     handle command DownOrClose;

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -6974,7 +6974,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 1;
-    ram      attribute clusterRevision default = 5;
+    callback attribute clusterRevision;
 
     handle command UpOrOpen;
     handle command DownOrClose;

--- a/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
+++ b/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
@@ -2084,7 +2084,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0x17;
-    ram      attribute clusterRevision default = 5;
+    callback attribute clusterRevision;
 
     handle command UpOrOpen;
     handle command DownOrClose;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -9178,7 +9178,7 @@ endpoint 0 {
     persist  attribute mode default = 0x00;
     ram      attribute safetyStatus default = 0x00;
     ram      attribute featureMap default = 0x17;
-    ram      attribute clusterRevision default = 5;
+    callback attribute clusterRevision;
 
     handle command UpOrOpen;
     handle command DownOrClose;

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -9141,7 +9141,7 @@ endpoint 0 {
     persist  attribute mode default = 0x00;
     ram      attribute safetyStatus default = 0x00;
     ram      attribute featureMap default = 0x17;
-    ram      attribute clusterRevision default = 5;
+    callback attribute clusterRevision;
 
     handle command UpOrOpen;
     handle command DownOrClose;

--- a/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
+++ b/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
@@ -4104,7 +4104,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 5;
+    callback attribute clusterRevision;
 
     handle command UpOrOpen;
     handle command DownOrClose;

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -2847,7 +2847,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0x001F;
-    ram      attribute clusterRevision default = 5;
+    callback attribute clusterRevision;
 
     handle command UpOrOpen;
     handle command DownOrClose;
@@ -2933,7 +2933,7 @@ endpoint 2 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0x0017;
-    ram      attribute clusterRevision default = 5;
+    callback attribute clusterRevision;
 
     handle command UpOrOpen;
     handle command DownOrClose;

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
@@ -1837,7 +1837,8 @@
               ZAP_ATTRIBUTE_MASK(READABLE) },                                                          /* Mode */                  \
         { ZAP_SIMPLE_DEFAULT(0x00), 0x0000001A, 2, ZAP_TYPE(BITMAP16), ZAP_ATTRIBUTE_MASK(READABLE) }, /* SafetyStatus */          \
         { ZAP_SIMPLE_DEFAULT(0x17), 0x0000FFFC, 4, ZAP_TYPE(BITMAP32), ZAP_ATTRIBUTE_MASK(READABLE) }, /* FeatureMap */            \
-        { ZAP_SIMPLE_DEFAULT(5), 0x0000FFFD, 2, ZAP_TYPE(INT16U), ZAP_ATTRIBUTE_MASK(READABLE) },      /* ClusterRevision */       \
+        { ZAP_EMPTY_DEFAULT(), 0x0000FFFD, 2, ZAP_TYPE(INT16U),                                                                    \
+          ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(READABLE) }, /* ClusterRevision */                             \
                                                                                                                                    \
         /* Endpoint: 1, Cluster: Pump Configuration and Control (server) */                                                        \
         { ZAP_EMPTY_DEFAULT(), 0x00000000, 2, ZAP_TYPE(INT16S),                                                                    \
@@ -4462,7 +4463,7 @@
       .clusterId = 0x00000102, \
       .attributes = ZAP_ATTRIBUTE_INDEX(541), \
       .attributeCount = 24, \
-      .clusterSize = 43, \
+      .clusterSize = 41, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(ATTRIBUTE_CHANGED_FUNCTION), \
       .functions = chipFuncArrayWindowCoveringServer, \
       .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 225 ), \
@@ -4961,7 +4962,7 @@
 #define GENERATED_ENDPOINT_TYPES                                                                                                   \
     {                                                                                                                              \
         { ZAP_CLUSTER_INDEX(0), 28, 219 },                                                                                         \
-        { ZAP_CLUSTER_INDEX(28), 73, 3444 },                                                                                       \
+        { ZAP_CLUSTER_INDEX(28), 73, 3442 },                                                                                       \
         { ZAP_CLUSTER_INDEX(101), 7, 114 },                                                                                        \
         { ZAP_CLUSTER_INDEX(108), 2, 0 },                                                                                          \
     }
@@ -4975,7 +4976,7 @@ static_assert(ATTRIBUTE_LARGEST <= CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE,
 #define ATTRIBUTE_SINGLETONS_SIZE (0)
 
 // Total size of attribute storage
-#define ATTRIBUTE_MAX_SIZE (3777)
+#define ATTRIBUTE_MAX_SIZE (3775)
 
 // Number of fixed endpoints
 #define FIXED_ENDPOINT_COUNT (4)

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -49,6 +49,8 @@ constexpr size_t kWindowCoveringDelegateTableSize =
     MATTER_DM_WINDOW_COVERING_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 static_assert(kWindowCoveringDelegateTableSize <= kEmberInvalidEndpointIndex, "WindowCovering Delegate table size error");
 
+WindowCoverAttrAccess gAttrAccess;
+
 Delegate * gDelegateTable[kWindowCoveringDelegateTableSize] = { nullptr };
 
 Delegate * GetDelegate(EndpointId endpoint)
@@ -112,7 +114,6 @@ namespace chip {
 namespace app {
 namespace Clusters {
 namespace WindowCovering {
-static WindowCoverAttrAccess gAttrAccess;
 
 CHIP_ERROR WindowCoverAttrAccess::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
 {

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -25,6 +25,7 @@
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
+#include <clusters/WindowCovering/Metadata.h>
 #include <lib/support/TypeTraits.h>
 #include <string.h>
 
@@ -111,6 +112,19 @@ namespace chip {
 namespace app {
 namespace Clusters {
 namespace WindowCovering {
+WindowCoverAttrAccess gAttrAccess;
+
+CHIP_ERROR WindowCoverAttrAccess::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
+{
+    switch (aPath.mAttributeId)
+    {
+    case Attributes::ClusterRevision::Id:
+        return aEncoder.Encode(WindowCovering::kRevision);
+    default:
+        break;
+    }
+    return CHIP_NO_ERROR;
+}
 
 bool HasFeature(chip::EndpointId endpoint, Feature feature)
 {
@@ -974,5 +988,12 @@ MatterWindowCoveringClusterServerAttributeChangedCallback(const app::ConcreteAtt
 /**
  * @brief Cluster Plugin Init Callback
  */
-void MatterWindowCoveringPluginServerInitCallback() {}
-void MatterWindowCoveringPluginServerShutdownCallback() {}
+void MatterWindowCoveringPluginServerInitCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
+}
+
+void MatterWindowCoveringPluginServerShutdownCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -112,7 +112,7 @@ namespace chip {
 namespace app {
 namespace Clusters {
 namespace WindowCovering {
-WindowCoverAttrAccess gAttrAccess;
+static WindowCoverAttrAccess gAttrAccess;
 
 CHIP_ERROR WindowCoverAttrAccess::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
 {

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -19,6 +19,7 @@
 
 #include "window-covering-delegate.h"
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/af-types.h>
 #include <protocols/interaction_model/StatusCode.h>
 
@@ -66,6 +67,18 @@ struct AbsoluteLimits
 {
     uint16_t open;
     uint16_t closed;
+};
+
+/**
+ * @brief  Window Covering Attribute Access Interface.
+ */
+class WindowCoverAttrAccess : public AttributeAccessInterface
+{
+public:
+    // Register for the Window Covering cluster on all endpoints.
+    WindowCoverAttrAccess() : AttributeAccessInterface(Optional<EndpointId>::Missing(), WindowCovering::Id) {}
+
+    CHIP_ERROR Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder) override;
 };
 
 bool HasFeature(chip::EndpointId endpoint, Feature feature);

--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -825,6 +825,7 @@
             "ThermostatSuggestionNotFollowingReason"
         ],
         "Time Format Localization": ["ClusterRevision"],
+        "Window Covering": ["ClusterRevision"],
         "Zone Management": [
             "MaxUserDefinedZones",
             "MaxZones",

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -824,6 +824,7 @@
             "ThermostatSuggestionNotFollowingReason"
         ],
         "Time Format Localization": ["ClusterRevision"],
+        "Window Covering": ["ClusterRevision"],
         "Zone Management": [
             "MaxUserDefinedZones",
             "MaxZones",

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -17238,53 +17238,6 @@ Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value)
 
 } // namespace FeatureMap
 
-namespace ClusterRevision {
-
-Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
-{
-    using Traits = NumericAttributeTraits<uint16_t>;
-    Traits::StorageType temp;
-    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
-    Protocols::InteractionModel::Status status =
-        emberAfReadAttribute(endpoint, Clusters::WindowCovering::Id, Id, readable, sizeof(temp));
-    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    *value = Traits::StorageToWorking(temp);
-    return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<uint16_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::WindowCovering::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
-{
-    using Traits = NumericAttributeTraits<uint16_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::WindowCovering::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
-}
-
-} // namespace ClusterRevision
-
 } // namespace Attributes
 } // namespace WindowCovering
 

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -2778,12 +2778,6 @@ Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value);
 Protocols::InteractionModel::Status Set(EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty);
 } // namespace FeatureMap
 
-namespace ClusterRevision {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value); // int16u
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty);
-} // namespace ClusterRevision
-
 } // namespace Attributes
 } // namespace WindowCovering
 


### PR DESCRIPTION
#### Summary
The Cluster Revision should not be set by a Zap config. It shall follow the spec changes and xml updates we do, based on the spec/alchemy results.

This PR is one of a series I'll complete over the next couple of days. 
What is done :
Set the Cluster Revision attribute of the WindowCovering to always be external by listing the attribute in

```
- src/app/zap-templates/zcl/zcl-with-test-extensions.json
- src/app/zap-templates/zcl/zcl.json
```

Implement the Read handler for the Cluster Revision Attribute in
`src/app/clusters/window-covering-server/window-covering-server.cpp`
Use the generated constant `WindowCovering::kRevision`, from `clusters/WindowCovering/Metadata.h`, as the ClusterRevision value to be encoded.

In a separate commit. I ran ./scripts/tools/zap_regen_all.py to update all .zap and .matter files as the attribute changes from RAM to External


#### Related issues
n/a

#### Testing
Build and commission the SIlabs window-app. Use chip-tool to read the clusterRevision of the Thermostat cluster. 
```
[1759424729.472] [94995:94997] [TOO] Endpoint: 1 Cluster: 0x0000_0102 Attribute 0x0000_FFFD DataVersion: 4188415939
[1759424729.472] [94995:94997] [TOO]   ClusterRevision: 5
```

#### Readability checklist
commit 1 is my manual changes
commit 2 is zap regen changes
