### PR TITLE
For AVSM 2.16 and 2.17 tests. ensure Privacy(if supported) modes are disabled prior to issuing the WebRTC ProvideOffer commands.

### DIFF
--- a/src/python_testing/TC_AVSM_2_16.py
+++ b/src/python_testing/TC_AVSM_2_16.py
@@ -188,7 +188,7 @@ class TC_AVSM_2_16(MatterBaseTest, AVSMTestBase):
             softLivestreamPrivMode = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=attr.SoftLivestreamPrivacyModeEnabled
             )
-            asserts.assert_false(softLivestreamPrivMode, "SoftLivestreamPrivacyModeOn should be False")
+            asserts.assert_false(softLivestreamPrivMode, "SoftLivestreamPrivacyModeEnabled should be False")
 
             result = await self.write_single_attribute(attr.SoftRecordingPrivacyModeEnabled(False), endpoint_id=endpoint)
             asserts.assert_equal(result, Status.Success, "Error when trying to write SoftRecordingPrivacyModeEnabled")
@@ -197,7 +197,7 @@ class TC_AVSM_2_16(MatterBaseTest, AVSMTestBase):
             softRecordingPrivMode = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=attr.SoftRecordingPrivacyModeEnabled
             )
-            asserts.assert_false(softRecordingPrivMode, "SoftRecordingPrivacyModeOn should be False")
+            asserts.assert_false(softRecordingPrivMode, "SoftRecordingPrivacyModeEnabled should be False")
 
         self.step(4)
         # Establish WebRTC via Provide Offer/Answer

--- a/src/python_testing/TC_AVSM_2_16.py
+++ b/src/python_testing/TC_AVSM_2_16.py
@@ -21,7 +21,7 @@
 # test-runner-runs:
 #   run1:
 #     app: ${CAMERA_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/avsm_2_16_fifo
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network
@@ -31,6 +31,7 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #       --endpoint 1
+#       --app-pipe /tmp/avsm_2_16_fifo
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_AVSM_2_16.py
+++ b/src/python_testing/TC_AVSM_2_16.py
@@ -177,6 +177,28 @@ class TC_AVSM_2_16(MatterBaseTest, AVSMTestBase):
         aAudioStreamID = aAllocatedAudioStreams[0].audioStreamID
         aAudioRefCount = aAllocatedAudioStreams[0].referenceCount
 
+        # Ensure privacy modes are not enabled before issuing WebRTC
+        # ProvideOffer command
+        self.privacySupport = (aFeatureMap & cluster.Bitmaps.Feature.kPrivacy) > 0
+        if self.privacySupport:
+            result = await self.write_single_attribute(attr.SoftLivestreamPrivacyModeEnabled(False), endpoint_id=endpoint)
+            asserts.assert_equal(result, Status.Success, "Error when trying to write SoftLivestreamPrivacyModeEnabled")
+            logger.info(f"Tx'd : SoftLivestreamPrivacyModeEnabled{False}")
+
+            softLivestreamPrivMode = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.SoftLivestreamPrivacyModeEnabled
+            )
+            asserts.assert_false(softLivestreamPrivMode, "SoftLivestreamPrivacyModeOn should be False")
+
+            result = await self.write_single_attribute(attr.SoftRecordingPrivacyModeEnabled(False), endpoint_id=endpoint)
+            asserts.assert_equal(result, Status.Success, "Error when trying to write SoftRecordingPrivacyModeEnabled")
+            logger.info(f"Tx'd : SoftRecordingPrivacyModeEnabled{False}")
+
+            softRecordingPrivMode = await self.read_single_attribute_check_success(
+                endpoint=endpoint, cluster=cluster, attribute=attr.SoftRecordingPrivacyModeEnabled
+            )
+            asserts.assert_false(softRecordingPrivMode, "SoftRecordingPrivacyModeOn should be False")
+
         self.step(4)
         # Establish WebRTC via Provide Offer/Answer
         webrtc_manager = WebRTCManager(event_loop=self.event_loop)

--- a/src/python_testing/TC_AVSM_2_17.py
+++ b/src/python_testing/TC_AVSM_2_17.py
@@ -79,7 +79,7 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 4,
-                "TH writes attribute `SoftLivestreamPrivacyModeEnabled` to false in the CameraAVStreamManagement Cluster on DUT.",
+                "TH writes attribute `SoftLivestreamPrivacyModeEnabled` and `SoftRecordingPrivacyEnabled` to false in the CameraAVStreamManagement Cluster on DUT.",
                 "DUT responds with Success",
             ),
             TestStep(
@@ -218,6 +218,20 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
         result = await self.write_single_attribute(attr.SoftLivestreamPrivacyModeEnabled(False), endpoint_id=endpoint)
         asserts.assert_equal(result, Status.Success, "Error when trying to write SoftLivestreamPrivacyModeEnabled")
         logger.info(f"Tx'd : SoftLivestreamPrivacyModeEnabled{False}")
+
+        softLivestreamPrivMode = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.SoftLivestreamPrivacyModeEnabled
+        )
+        asserts.assert_false(softLivestreamPrivMode, "SoftLivestreamPrivacyModeOn should be False")
+
+        result = await self.write_single_attribute(attr.SoftRecordingPrivacyModeEnabled(False), endpoint_id=endpoint)
+        asserts.assert_equal(result, Status.Success, "Error when trying to write SoftRecordingPrivacyModeEnabled")
+        logger.info(f"Tx'd : SoftRecordingPrivacyModeEnabled{False}")
+
+        softRecordingPrivMode = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.SoftRecordingPrivacyModeEnabled
+        )
+        asserts.assert_false(softRecordingPrivMode, "SoftRecordingPrivacyModeOn should be False")
 
         self.step(5)
         current_sessions = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_AVSM_2_17.py
+++ b/src/python_testing/TC_AVSM_2_17.py
@@ -21,7 +21,7 @@
 # test-runner-runs:
 #   run1:
 #     app: ${CAMERA_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/avsm_2_17_fifo
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network
@@ -31,6 +31,7 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #       --endpoint 1
+#       --app-pipe /tmp/avsm_2_17_fifo
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_AVSM_2_17.py
+++ b/src/python_testing/TC_AVSM_2_17.py
@@ -79,7 +79,7 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 4,
-                "TH writes attribute `SoftLivestreamPrivacyModeEnabled` and `SoftRecordingPrivacyEnabled` to false in the CameraAVStreamManagement Cluster on DUT.",
+                "TH writes attribute `SoftLivestreamPrivacyModeEnabled` and `SoftRecordingPrivacyModeEnabled` to false in the CameraAVStreamManagement Cluster on DUT.",
                 "DUT responds with Success",
             ),
             TestStep(
@@ -222,7 +222,7 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
         softLivestreamPrivMode = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.SoftLivestreamPrivacyModeEnabled
         )
-        asserts.assert_false(softLivestreamPrivMode, "SoftLivestreamPrivacyModeOn should be False")
+        asserts.assert_false(softLivestreamPrivMode, "SoftLivestreamPrivacyModeEnabled should be False")
 
         result = await self.write_single_attribute(attr.SoftRecordingPrivacyModeEnabled(False), endpoint_id=endpoint)
         asserts.assert_equal(result, Status.Success, "Error when trying to write SoftRecordingPrivacyModeEnabled")
@@ -231,7 +231,7 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
         softRecordingPrivMode = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.SoftRecordingPrivacyModeEnabled
         )
-        asserts.assert_false(softRecordingPrivMode, "SoftRecordingPrivacyModeOn should be False")
+        asserts.assert_false(softRecordingPrivMode, "SoftRecordingPrivacyModeEnabled should be False")
 
         self.step(5)
         current_sessions = await self.read_single_attribute_check_success(


### PR DESCRIPTION
#### Summary
This is to get around any remnant attribute state on Privacy modes if they have not been cleared properly prior to running these tests.

#### Testing
Execute AVSM_2.16 and AVSM_2.17 test scripts against the chip-camera-app

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
