### PR TITLE
Add check for commissioning without power on basic comp tests

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
@@ -70,9 +70,10 @@ def is_commissioning_without_power(tlv_data: dict[int, Any]) -> bool:
     # General Commissioning Cluster is always on EP0
     cluster_id = Clusters.GeneralCommissioning.id
     attr_id = Clusters.GeneralCommissioning.Attributes.IsCommissioningWithoutPower.attribute_id
-    if 0 not in tlv_data or cluster_id not in tlv_data[0] or attr_id not in tlv_data[0][cluster_id]:
+    try:
+        return tlv_data[0][cluster_id][attr_id]
+    except KeyError:
         return False
-    return tlv_data[0][cluster_id][attr_id]
 
 
 def MatterTlvToJson(tlv_data: dict[int, Any]) -> dict[str, Any]:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/basic_composition.py
@@ -64,6 +64,17 @@ def arls_populated(tlv_data: dict[int, Any]) -> ArlData:
     return ArlData(have_arl=have_arl, have_carl=have_carl)
 
 
+def is_commissioning_without_power(tlv_data: dict[int, Any]) -> bool:
+    ''' Returns true if the TLV data includes the IsCommissioningWithoutPower attribute and the attribute is set to true'''
+
+    # General Commissioning Cluster is always on EP0
+    cluster_id = Clusters.GeneralCommissioning.id
+    attr_id = Clusters.GeneralCommissioning.Attributes.IsCommissioningWithoutPower.attribute_id
+    if 0 not in tlv_data or cluster_id not in tlv_data[0] or attr_id not in tlv_data[0][cluster_id]:
+        return False
+    return tlv_data[0][cluster_id][attr_id]
+
+
 def MatterTlvToJson(tlv_data: dict[int, Any]) -> dict[str, Any]:
     """Given TLV data for a specific cluster instance, convert to the Matter JSON format."""
 
@@ -236,6 +247,9 @@ class BasicCompositionTests:
             arl_data.have_arl, "ARL cannot be populated for this test - Please follow manufacturer-specific steps to remove the access restrictions and re-run this test")
         asserts.assert_false(
             arl_data.have_carl, "CommissioningARL cannot be populated for this test - Please follow manufacturer-specific steps to remove the access restrictions and re-run this test")
+
+        asserts.assert_false(is_commissioning_without_power(
+            self.endpoints_tlv), "This test cannot be run on devices using an unpowered transport. Commission the device and re-run the test.")
 
     def get_test_name(self) -> str:
         """Return the function name of the caller. Used to create logging entries."""


### PR DESCRIPTION
#### Summary

Devices that are being commissioned over NTL do not have the full data model information available. Therefore, we cannot perform conformance tests for these devices until they are commissioned. Because these tests can normally be run over the commissioning radio, we need a blocker.

IsCommissioningWithoutPower flag is used to indicate whether the current network transport is powered (and hence if it includes the entire device topology).

#### Related issues


#### Testing
Note that I am unable to test this with an NTL device as I do not possess the hardware. I am relying on the TT members to verify this fix on a real device.

Unit test of the function was added, device composition and conformance tests run in the CI and can show that this assertion does not hit for a standard device.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
