### PR TITLE
bump macOS runners to macOS 14

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -423,7 +423,7 @@ jobs:
 
     build_darwin:
         name: Build on Darwin (clang, simulated)
-        runs-on: macos-13
+        runs-on: macos-14
         if: github.actor != 'restyled-io[bot]'  && inputs.run-codeql != true
 
         steps:

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -38,7 +38,17 @@ jobs:
 
     strategy:
       matrix:
-        build_variant: [no-ble-no-shell-asan-clang]
+        include:
+        - os: macos-14
+          arch: arm64     # observed, not configured
+          dry-run: true
+          build_variant: no-ble-no-shell-asan-clang
+          chip_tool: ""
+        - os: macos-15
+          arch: arm64     # observed, not configured
+          dry-run: true
+          build_variant: no-ble-no-shell-asan-clang
+          chip_tool: ""
     env:
       BUILD_VARIANT: ${{matrix.build_variant}}
 
@@ -52,7 +62,7 @@ jobs:
       LSAN_OPTIONS: detect_leaks=1 malloc_context_size=40 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
     if: github.actor != 'restyled-io[bot]'
-    runs-on: macos-13
+    runs-on: ${{matrix.os}}
 
     steps:
       - name: Checkout
@@ -89,19 +99,19 @@ jobs:
         run: |
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \
-                --target darwin-x64-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL} \
-                --target darwin-x64-all-clusters-${BUILD_VARIANT} \
-                --target darwin-x64-lock-${BUILD_VARIANT} \
-                --target darwin-x64-ota-provider-${BUILD_VARIANT} \
-                --target darwin-x64-ota-requestor-${BUILD_VARIANT} \
-                --target darwin-x64-tv-app-${BUILD_VARIANT} \
-                --target darwin-x64-bridge-${BUILD_VARIANT} \
-                --target darwin-x64-lit-icd-${BUILD_VARIANT} \
-                --target darwin-x64-microwave-oven-${BUILD_VARIANT} \
-                --target darwin-x64-rvc-${BUILD_VARIANT} \
-                --target darwin-x64-network-manager-${BUILD_VARIANT} \
-                --target darwin-x64-energy-gateway-${BUILD_VARIANT} \
-                --target darwin-x64-energy-management-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL} \
+                --target darwin-${{matrix.arch}}-all-clusters-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-lock-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-ota-provider-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-ota-requestor-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-tv-app-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-bridge-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-lit-icd-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-microwave-oven-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-rvc-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-network-manager-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-energy-gateway-${BUILD_VARIANT} \
+                --target darwin-${{matrix.arch}}-energy-management-${BUILD_VARIANT} \
                 build \
                 --copy-artifacts-to objdir-clone \
              "
@@ -110,30 +120,30 @@ jobs:
           ./scripts/run_in_build_env.sh \
           "./scripts/tests/run_test_suite.py \
              --runner darwin_framework_tool_python \
-             --chip-tool ./out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
+             --chip-tool ./out/darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
              --target-skip-glob '{TestAccessControlConstraints}' \
              run \
              --iterations 1 \
              --test-timeout-seconds 120 \
-             --all-clusters-app ./out/darwin-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
-             --lock-app ./out/darwin-x64-lock-${BUILD_VARIANT}/chip-lock-app \
-             --ota-provider-app ./out/darwin-x64-ota-provider-${BUILD_VARIANT}/chip-ota-provider-app \
-             --ota-requestor-app ./out/darwin-x64-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
-             --tv-app ./out/darwin-x64-tv-app-${BUILD_VARIANT}/chip-tv-app \
-             --bridge-app ./out/darwin-x64-bridge-${BUILD_VARIANT}/chip-bridge-app \
-             --microwave-oven-app ./out/darwin-x64-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
-             --rvc-app ./out/darwin-x64-rvc-${BUILD_VARIANT}/chip-rvc-app \
-             --network-manager-app ./out/darwin-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
-             --energy-gateway-app ./out/darwin-x64-energy-gateway-${BUILD_VARIANT}/chip-energy-gateway-app \
-             --energy-management-app ./out/darwin-x64-energy-management-${BUILD_VARIANT}/chip-energy-management-app \
+             --all-clusters-app ./out/darwin-${{matrix.arch}}-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
+             --lock-app ./out/darwin-${{matrix.arch}}-lock-${BUILD_VARIANT}/chip-lock-app \
+             --ota-provider-app ./out/darwin-${{matrix.arch}}-ota-provider-${BUILD_VARIANT}/chip-ota-provider-app \
+             --ota-requestor-app ./out/darwin-${{matrix.arch}}-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
+             --tv-app ./out/darwin-${{matrix.arch}}-tv-app-${BUILD_VARIANT}/chip-tv-app \
+             --bridge-app ./out/darwin-${{matrix.arch}}-bridge-${BUILD_VARIANT}/chip-bridge-app \
+             --microwave-oven-app ./out/darwin-${{matrix.arch}}-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
+             --rvc-app ./out/darwin-${{matrix.arch}}-rvc-${BUILD_VARIANT}/chip-rvc-app \
+             --network-manager-app ./out/darwin-${{matrix.arch}}-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
+             --energy-gateway-app ./out/darwin-${{matrix.arch}}-energy-gateway-${BUILD_VARIANT}/chip-energy-gateway-app \
+             --energy-management-app ./out/darwin-${{matrix.arch}}-energy-management-${BUILD_VARIANT}/chip-energy-management-app \
           "
       - name: Run OTA Test
         run: |
           ./scripts/run_in_build_env.sh \
           "./scripts/tests/run_darwin_framework_ota_test.py \
              run \
-             --darwin-framework-tool ./out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
-             --ota-requestor-app ./out/darwin-x64-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
+             --darwin-framework-tool ./out/darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
+             --ota-requestor-app ./out/darwin-${{matrix.arch}}-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
              --ota-data-file /tmp/rawImage \
              --ota-image-file /tmp/otaImage \
              --ota-destination-file /tmp/downloadedImage \
@@ -158,7 +168,7 @@ jobs:
         if: ${{ failure() && !env.ACT }}
         with:
           name: framework-build-log-darwin-${BUILD_VARIANT_FRAMEWORK_TOOL}
-          path: out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin_framework_build.log
+          path: out/darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin_framework_build.log
       - name: Uploading objdir for debugging
         uses: actions/upload-artifact@v4
         if: ${{ failure() && !env.ACT }}

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -44,11 +44,6 @@ jobs:
           dry-run: true
           build_variant: no-ble-no-shell-asan-clang
           chip_tool: ""
-        - os: macos-15
-          arch: arm64     # observed, not configured
-          dry-run: true
-          build_variant: no-ble-no-shell-asan-clang
-          chip_tool: ""
     env:
       BUILD_VARIANT: ${{matrix.build_variant}}
 

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -39,10 +39,10 @@ jobs:
     framework:
         name: Build framework
         if: github.actor != 'restyled-io[bot]'
-        runs-on: ${{ matrix.os }}
+        
         strategy:
             matrix:
-                os: ${{ github.event_name == 'schedule' && fromJSON('["macos-14", "macos-15", "macos-26"]') || fromJSON('["macos-14"]') }}
+                os: macos-14
                 options: # We don't need a full matrix
                     - flavor: macos-release
                       arguments: -sdk macosx -configuration Release
@@ -52,6 +52,7 @@ jobs:
                       arguments: -sdk appletvos -configuration Debug
                     - flavor: watchos-debug
                       arguments: -sdk watchos -configuration Debug
+        runs-on: ${{ matrix.os }}
         steps:
             - name: Checkout
               uses: actions/checkout@v5
@@ -80,7 +81,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: ${{ github.event_name == 'schedule' && fromJSON('["macos-14", "macos-15", "macos-26"]') || fromJSON('["macos-14"]') }}
+                os: macos-14
                 options: # We don't need a full matrix
                     - flavor: asan
                       arguments:

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -22,8 +22,6 @@ on:
     pull_request:
     merge_group:
     workflow_dispatch:
-    schedule:
-        - cron: '0 2 * * *' # Daily at 2 AM UTC, run job on other macOS versions as well
 
 concurrency:
     group:

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -51,7 +51,7 @@ jobs:
                       arguments: -sdk appletvos -configuration Debug
                     - flavor: watchos-debug
                       arguments: -sdk watchos -configuration Debug
-        runs-on: macos-14
+        runs-on: macos-13
         steps:
             - name: Checkout
               uses: actions/checkout@v5
@@ -77,7 +77,7 @@ jobs:
         name: Run framework tests
         if: github.actor != 'restyled-io[bot]'
         needs: [framework] # serialize to avoid running to many parallel macos runners
-        runs-on: macos-14
+        runs-on: macos-13
         strategy:
             matrix:
                 options: # We don't need a full matrix

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -22,6 +22,8 @@ on:
     pull_request:
     merge_group:
     workflow_dispatch:
+    schedule:
+        - cron: '0 2 * * *' # Daily at 2 AM UTC, run job on other macOS versions as well
 
 concurrency:
     group:
@@ -37,9 +39,10 @@ jobs:
     framework:
         name: Build framework
         if: github.actor != 'restyled-io[bot]'
-        runs-on: macos-13
+        runs-on: ${{ matrix.os }}
         strategy:
             matrix:
+                os: ${{ github.event_name == 'schedule' && fromJSON('[macos-14", "macos-15", "macos-26"]') || fromJSON('["macos-14"]') }}
                 options: # We don't need a full matrix
                     - flavor: macos-release
                       arguments: -sdk macosx -configuration Release
@@ -74,9 +77,10 @@ jobs:
         name: Run framework tests
         if: github.actor != 'restyled-io[bot]'
         needs: [framework] # serialize to avoid running to many parallel macos runners
-        runs-on: macos-13
+        runs-on: ${{ matrix.os }}
         strategy:
             matrix:
+                os: ${{ github.event_name == 'schedule' && fromJSON('["macos-14", "macos-15", "macos-26"]') || fromJSON('["macos-14"]') }}
                 options: # We don't need a full matrix
                     - flavor: asan
                       arguments:

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -110,12 +110,12 @@ jobs:
                   mkdir -p /tmp/darwin/framework-tests
 
                   export TEST_RUNNER_ASAN_OPTIONS=__CURRENT_VALUE__:detect_stack_use_after_return=1
-
+                  echo "Quiet work in progress - artifacts `darwin-tests.log` and `darwin-tests-err.log` will be output."
                   xcodebuild test -target "Matter" -scheme "Matter Framework Tests" \
-                    -resultBundlePath /tmp/darwin/framework-tests/TestResults.xcresult \
-                    -sdk macosx ${{ matrix.options.arguments }} \
-                    GCC_PREPROCESSOR_DEFINITIONS='${inherited} ${{ matrix.options.defines }}' \
-                    > >(tee /tmp/darwin/framework-tests/darwin-tests.log) 2> >(tee /tmp/darwin/framework-tests/darwin-tests-err.log >&2)
+                  -resultBundlePath /tmp/darwin/framework-tests/TestResults.xcresult \
+                  -sdk macosx ${{ matrix.options.arguments }} \
+                  GCC_PREPROCESSOR_DEFINITIONS='${inherited} ${{ matrix.options.defines }}' \
+                  > /tmp/darwin/framework-tests/darwin-tests.log 2> /tmp/darwin/framework-tests/darwin-tests-err.log
             - name: Generate Summary
               if: always()
               working-directory: /tmp

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -42,7 +42,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: ${{ github.event_name == 'schedule' && fromJSON('[macos-14", "macos-15", "macos-26"]') || fromJSON('["macos-14"]') }}
+                os: ${{ github.event_name == 'schedule' && fromJSON('["macos-14", "macos-15", "macos-26"]') || fromJSON('["macos-14"]') }}
                 options: # We don't need a full matrix
                     - flavor: macos-release
                       arguments: -sdk macosx -configuration Release

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -42,7 +42,7 @@ jobs:
         
         strategy:
             matrix:
-                os: [ macos-13, macos-14, macos-15-intel ]
+                os: [ macos-14 ]
                 options: # We don't need a full matrix
                     - flavor: macos-release
                       arguments: -sdk macosx -configuration Release
@@ -81,7 +81,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ macos-13, macos-14, macos-15-intel ]
+                os: [ macos-14 ]
                 options: # We don't need a full matrix
                     - flavor: asan
                       arguments:

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -42,6 +42,7 @@ jobs:
         
         strategy:
             matrix:
+                os: [ macos-13, macos-14, macos-15-intel ]
                 options: # We don't need a full matrix
                     - flavor: macos-release
                       arguments: -sdk macosx -configuration Release
@@ -51,7 +52,7 @@ jobs:
                       arguments: -sdk appletvos -configuration Debug
                     - flavor: watchos-debug
                       arguments: -sdk watchos -configuration Debug
-        runs-on: macos-13
+        runs-on: ${{ matrix.os }}
         steps:
             - name: Checkout
               uses: actions/checkout@v5
@@ -77,9 +78,10 @@ jobs:
         name: Run framework tests
         if: github.actor != 'restyled-io[bot]'
         needs: [framework] # serialize to avoid running to many parallel macos runners
-        runs-on: macos-13
+        runs-on: ${{ matrix.os }}
         strategy:
             matrix:
+                os: [ macos-13, macos-14, macos-15-intel ]
                 options: # We don't need a full matrix
                     - flavor: asan
                       arguments:

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -42,7 +42,6 @@ jobs:
         
         strategy:
             matrix:
-                os: macos-14
                 options: # We don't need a full matrix
                     - flavor: macos-release
                       arguments: -sdk macosx -configuration Release
@@ -52,7 +51,7 @@ jobs:
                       arguments: -sdk appletvos -configuration Debug
                     - flavor: watchos-debug
                       arguments: -sdk watchos -configuration Debug
-        runs-on: ${{ matrix.os }}
+        runs-on: macos-14
         steps:
             - name: Checkout
               uses: actions/checkout@v5
@@ -78,10 +77,9 @@ jobs:
         name: Run framework tests
         if: github.actor != 'restyled-io[bot]'
         needs: [framework] # serialize to avoid running to many parallel macos runners
-        runs-on: ${{ matrix.os }}
+        runs-on: macos-14
         strategy:
             matrix:
-                os: macos-14
                 options: # We don't need a full matrix
                     - flavor: asan
                       arguments:

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -68,7 +68,7 @@ jobs:
 
     build_darwin_fuzzing:
         name: Build on Darwin
-        runs-on: macos-13
+        runs-on: macos-14
         if: github.actor != 'restyled-io[bot]'
 
         steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -449,16 +449,16 @@ jobs:
                       dry-run: true
                       build_variant: no-ble-no-shell-tsan-clang
                       chip_tool: ""
-                    - os: macos-15
-                      arch: arm64     # observed, not configured
-                      dry-run: true
-                      build_variant: no-ble-no-shell-asan-clang
-                      chip_tool: ""
-                      os: macos-15-intel
-                      arch: x64     # observed, not configured
-                      dry-run: true
-                      build_variant: no-ble-no-shell-asan-clang
-                      chip_tool: ""
+                    # - os: macos-15
+                    #   arch: arm64     # observed, not configured
+                    #   dry-run: true
+                    #   build_variant: no-ble-no-shell-asan-clang
+                    #   chip_tool: ""
+                    #   os: macos-15-intel
+                    #   arch: x64     # observed, not configured
+                    #   dry-run: true
+                    #   build_variant: no-ble-no-shell-asan-clang
+                    #   chip_tool: ""
                     # - os: macos-15
                     #   arch: arm64     # observed, not configured
                     #   dry-run: false
@@ -955,12 +955,12 @@ jobs:
                 - os: macos-14
                   arch: arm64   # observed, not configured
                   build_variant: no-ble-no-wifi-tsan-clang
-                - os: macos-15-intel
-                  arch: x64   # observed, not configured
-                  build_variant: no-ble-no-wifi-tsan-clang`
-                - os: macos-15
-                  arch: arm64   # observed, not configured
-                  build_variant: no-ble-no-wifi-tsan-clang`
+                # - os: macos-15-intel
+                #   arch: x64   # observed, not configured
+                #   build_variant: no-ble-no-wifi-tsan-clang`
+                # - os: macos-15
+                #   arch: arm64   # observed, not configured
+                #   build_variant: no-ble-no-wifi-tsan-clang`
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             TSAN_OPTIONS: "halt_on_error=1"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,8 @@ on:
                 required: false
                 default: ''
                 type: string
+    schedule:
+        - cron: '0 2 * * *' # Daily at 2 AM UTC, run job on other macOS versions as well
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -436,8 +438,38 @@ jobs:
 
         strategy:
             matrix:
-                build_variant: [no-ble-no-shell-asan-clang, no-ble-no-shell-tsan-clang]
-                chip_tool: [""]
+                include:
+                    - os: macos-14
+                      arch: arm64     # observed, not configured
+                      dry-run: true
+                      build_variant: no-ble-no-shell-asan-clang
+                      chip_tool: ""
+                    - os: macos-14
+                      arch: arm64     # observed, not configured
+                      dry-run: true
+                      build_variant: no-ble-no-shell-tsan-clang
+                      chip_tool: ""
+                    # - os: macos-15
+                    #   arch: arm64     # observed, not configured
+                    #   dry-run: true
+                    #   build_variant: no-ble-no-shell-asan-clang
+                    #   chip_tool: ""
+                    # - os: macos-15
+                    #   arch: arm64     # observed, not configured
+                    #   dry-run: false
+                    #   build_variant: no-ble-no-shell-tsan-clang
+                    #   chip_tool: ""
+                    # - os: macos-26
+                    #   arch: arm64     # observed, not configured
+                    #   dry-run: true
+                    #   build_variant: no-ble-no-shell-asan-clang
+                    #   chip_tool: ""
+                    # - os: macos-26
+                    #   arch: arm64     # observed, not configured
+                    #   dry-run: true
+                    #   build_variant: no-ble-no-shell-tsan-clang
+                    #   chip_tool: ""
+        continue-on-error: ${{ matrix.dry-run }}
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}
@@ -445,7 +477,7 @@ jobs:
             LSAN_OPTIONS: detect_leaks=1 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
         if: github.actor != 'restyled-io[bot]'
-        runs-on: macos-13
+        runs-on: ${{ matrix.os }}
 
         steps:
             - name: Checkout
@@ -469,45 +501,46 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                        --target darwin-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT} \
-                        --target darwin-x64-all-clusters-${BUILD_VARIANT} \
-                        --target darwin-x64-lock-${BUILD_VARIANT} \
-                        --target darwin-x64-ota-provider-${BUILD_VARIANT} \
-                        --target darwin-x64-ota-requestor-${BUILD_VARIANT} \
-                        --target darwin-x64-tv-app-${BUILD_VARIANT} \
-                        --target darwin-x64-bridge-${BUILD_VARIANT} \
-                        --target darwin-x64-lit-icd-${BUILD_VARIANT} \
-                        --target darwin-x64-microwave-oven-${BUILD_VARIANT} \
-                        --target darwin-x64-rvc-${BUILD_VARIANT} \
-                        --target darwin-x64-network-manager-${BUILD_VARIANT} \
-                        --target darwin-x64-energy-gateway-${BUILD_VARIANT} \
-                        --target darwin-x64-energy-management-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-all-clusters-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-lock-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-ota-provider-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-ota-requestor-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-tv-app-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-bridge-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-lit-icd-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-microwave-oven-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-rvc-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-network-manager-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-energy-gateway-${BUILD_VARIANT} \
+                        --target darwin-${{matrix.arch}}-energy-management-${BUILD_VARIANT} \
                         build \
                         --copy-artifacts-to objdir-clone \
                      "
 
             - name: Run Tests using the python parser sending commands to chip-tool
+              # tests that failed macOS 15/26 last check: TestGroupMessaging,Test_TC_ACE_1_6,Test_TC_G_*,Test_TC_GRPKEY_*,Test_TC_S_*
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --runner chip_tool_python \
-                     --chip-tool ./out/darwin-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
+                     --chip-tool ./out/darwin-${{matrix.arch}}-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
                      --target-skip-glob '{Test_TC_DGTHREAD_2_1,Test_TC_DGTHREAD_2_2,Test_TC_DGTHREAD_2_3,Test_TC_DGTHREAD_2_4}' \
                      run \
                      --iterations 1 \
                      --test-timeout-seconds 120 \
-                     --all-clusters-app ./out/darwin-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
-                     --lock-app ./out/darwin-x64-lock-${BUILD_VARIANT}/chip-lock-app \
-                     --ota-provider-app ./out/darwin-x64-ota-provider-${BUILD_VARIANT}/chip-ota-provider-app \
-                     --ota-requestor-app ./out/darwin-x64-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
-                     --tv-app ./out/darwin-x64-tv-app-${BUILD_VARIANT}/chip-tv-app \
-                     --bridge-app ./out/darwin-x64-bridge-${BUILD_VARIANT}/chip-bridge-app \
-                     --lit-icd-app ./out/darwin-x64-lit-icd-${BUILD_VARIANT}/lit-icd-app \
-                     --microwave-oven-app ./out/darwin-x64-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
-                     --rvc-app ./out/darwin-x64-rvc-${BUILD_VARIANT}/chip-rvc-app \
-                     --network-manager-app ./out/darwin-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
-                     --energy-gateway-app ./out/darwin-x64-energy-gateway-${BUILD_VARIANT}/chip-energy-gateway-app \
-                     --energy-management-app ./out/darwin-x64-energy-management-${BUILD_VARIANT}/chip-energy-management-app \
+                     --all-clusters-app ./out/darwin-${{matrix.arch}}-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
+                     --lock-app ./out/darwin-${{matrix.arch}}-lock-${BUILD_VARIANT}/chip-lock-app \
+                     --ota-provider-app ./out/darwin-${{matrix.arch}}-ota-provider-${BUILD_VARIANT}/chip-ota-provider-app \
+                     --ota-requestor-app ./out/darwin-${{matrix.arch}}-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
+                     --tv-app ./out/darwin-${{matrix.arch}}-tv-app-${BUILD_VARIANT}/chip-tv-app \
+                     --bridge-app ./out/darwin-${{matrix.arch}}-bridge-${BUILD_VARIANT}/chip-bridge-app \
+                     --lit-icd-app ./out/darwin-${{matrix.arch}}-lit-icd-${BUILD_VARIANT}/lit-icd-app \
+                     --microwave-oven-app ./out/darwin-${{matrix.arch}}-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
+                     --rvc-app ./out/darwin-${{matrix.arch}}-rvc-${BUILD_VARIANT}/chip-rvc-app \
+                     --network-manager-app ./out/darwin-${{matrix.arch}}-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
+                     --energy-gateway-app ./out/darwin-${{matrix.arch}}-energy-gateway-${BUILD_VARIANT}/chip-energy-gateway-app \
+                     --energy-management-app ./out/darwin-${{matrix.arch}}-energy-management-${BUILD_VARIANT}/chip-energy-management-app \
                   "
 
             - name: Run purposeful failure tests using the python parser sending commands to chip-tool
@@ -516,13 +549,13 @@ jobs:
                   "./scripts/tests/run_test_suite.py \
                      --runner chip_tool_python \
                      --include-tags PURPOSEFUL_FAILURE \
-                     --chip-tool ./out/darwin-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
+                     --chip-tool ./out/darwin-${{matrix.arch}}-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
                      run \
                      --iterations 1 \
                      --expected-failures 3 \
                      --keep-going \
                      --test-timeout-seconds 120 \
-                     --all-clusters-app ./out/darwin-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
+                     --all-clusters-app ./out/darwin-${{matrix.arch}}-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
                   "
 
             - name: Uploading core files
@@ -913,13 +946,22 @@ jobs:
 
         strategy:
             matrix:
-                build_variant: [no-ble-no-wifi-tsan-clang]
+                include:
+                - os: macos-14
+                  arch: arm64   # observed, not configured
+                  build_variant: no-ble-no-wifi-tsan-clang
+                - os: macos-15
+                  arch: arm64   # observed, not configured
+                  build_variant: no-ble-no-wifi-tsan-clang
+                # - os: macos-26
+                #   arch: arm64   # observed, not configured
+                #   build_variant: no-ble-no-wifi-tsan-clang
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             TSAN_OPTIONS: "halt_on_error=1"
 
         if: github.actor != 'restyled-io[bot]'
-        runs-on: macos-13
+        runs-on: ${{ matrix.os }}
 
         steps:
             - name: Checkout
@@ -944,14 +986,14 @@ jobs:
                   scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv'
                   ./scripts/run_in_build_env.sh \
                    "./scripts/build/build_examples.py \
-                      --target darwin-x64-all-clusters-${BUILD_VARIANT}-test \
+                      --target darwin-${{matrix.arch}}-all-clusters-${BUILD_VARIANT}-test \
                       build \
                       --copy-artifacts-to objdir-clone \
                    "
             - name: Run Tests
               if: false # disable darwin test runs for now as they were very flaky in the past
               run: |
-                  scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --app out/darwin-x64-all-clusters-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app --factory-reset --quiet --app-args "--discriminator 3840 --interface-id -1" --script-args "-t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
+                  scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --app out/darwin-${{matrix.arch}}-all-clusters-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app --factory-reset --quiet --app-args "--discriminator 3840 --interface-id -1" --script-args "-t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
             - name: Uploading core files
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -441,12 +441,10 @@ jobs:
                 include:
                     - os: macos-14
                       arch: arm64     # observed, not configured
-                      dry-run: true
                       build_variant: no-ble-no-shell-asan-clang
                       chip_tool: ""
                     - os: macos-14
                       arch: arm64     # observed, not configured
-                      dry-run: true
                       build_variant: no-ble-no-shell-tsan-clang
                       chip_tool: ""
                     # - os: macos-15
@@ -474,7 +472,6 @@ jobs:
                     #   dry-run: true
                     #   build_variant: no-ble-no-shell-tsan-clang
                     #   chip_tool: ""
-        continue-on-error: ${{ matrix.dry-run }}
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,8 +34,6 @@ on:
                 required: false
                 default: ''
                 type: string
-    schedule:
-        - cron: '0 2 * * *' # Daily at 2 AM UTC, run job on other macOS versions as well
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -449,11 +449,16 @@ jobs:
                       dry-run: true
                       build_variant: no-ble-no-shell-tsan-clang
                       chip_tool: ""
-                    # - os: macos-15
-                    #   arch: arm64     # observed, not configured
-                    #   dry-run: true
-                    #   build_variant: no-ble-no-shell-asan-clang
-                    #   chip_tool: ""
+                    - os: macos-15
+                      arch: arm64     # observed, not configured
+                      dry-run: true
+                      build_variant: no-ble-no-shell-asan-clang
+                      chip_tool: ""
+                      os: macos-15-intel
+                      arch: x64     # observed, not configured
+                      dry-run: true
+                      build_variant: no-ble-no-shell-asan-clang
+                      chip_tool: ""
                     # - os: macos-15
                     #   arch: arm64     # observed, not configured
                     #   dry-run: false
@@ -950,6 +955,12 @@ jobs:
                 - os: macos-14
                   arch: arm64   # observed, not configured
                   build_variant: no-ble-no-wifi-tsan-clang
+                - os: macos-15-intel
+                  arch: x64   # observed, not configured
+                  build_variant: no-ble-no-wifi-tsan-clang`
+                - os: macos-15
+                  arch: arm64   # observed, not configured
+                  build_variant: no-ble-no-wifi-tsan-clang`
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             TSAN_OPTIONS: "halt_on_error=1"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -440,36 +440,9 @@ jobs:
                     - os: macos-14
                       arch: arm64     # observed, not configured
                       build_variant: no-ble-no-shell-asan-clang
-                      chip_tool: ""
                     - os: macos-14
                       arch: arm64     # observed, not configured
                       build_variant: no-ble-no-shell-tsan-clang
-                      chip_tool: ""
-                    # - os: macos-15
-                    #   arch: arm64     # observed, not configured
-                    #   dry-run: true
-                    #   build_variant: no-ble-no-shell-asan-clang
-                    #   chip_tool: ""
-                    #   os: macos-15-intel
-                    #   arch: x64     # observed, not configured
-                    #   dry-run: true
-                    #   build_variant: no-ble-no-shell-asan-clang
-                    #   chip_tool: ""
-                    # - os: macos-15
-                    #   arch: arm64     # observed, not configured
-                    #   dry-run: false
-                    #   build_variant: no-ble-no-shell-tsan-clang
-                    #   chip_tool: ""
-                    # - os: macos-26
-                    #   arch: arm64     # observed, not configured
-                    #   dry-run: true
-                    #   build_variant: no-ble-no-shell-asan-clang
-                    #   chip_tool: ""
-                    # - os: macos-26
-                    #   arch: arm64     # observed, not configured
-                    #   dry-run: true
-                    #   build_variant: no-ble-no-shell-tsan-clang
-                    #   chip_tool: ""
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -950,12 +950,6 @@ jobs:
                 - os: macos-14
                   arch: arm64   # observed, not configured
                   build_variant: no-ble-no-wifi-tsan-clang
-                - os: macos-15
-                  arch: arm64   # observed, not configured
-                  build_variant: no-ble-no-wifi-tsan-clang
-                # - os: macos-26
-                #   arch: arm64   # observed, not configured
-                #   build_variant: no-ble-no-wifi-tsan-clang
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             TSAN_OPTIONS: "halt_on_error=1"

--- a/scripts/tests/chiptest/lsan-mac-suppressions.txt
+++ b/scripts/tests/chiptest/lsan-mac-suppressions.txt
@@ -83,3 +83,15 @@ leak:nw_parameters_create_secure_udp
 leak:nw_path_create_evaluator_for_listener
 leak:nw_listener_handle_new_path_on_queue
 leak:nw_endpoint_create_host
+
+# ignore thread-local storage leaks
+# macOS 14
+leak:_instantiateTLVs
+# macOS 15
+leak:dyld::ThreadLocalVariables::instantiateVariable
+
+# ignore (maybe false-positive?) leaks in macOS key value store init
+leak:KeyValueStoreManagerImpl::Init
+
+# ignore float to string conversion bigalloc pooling
+leak:__Balloc_D2A


### PR DESCRIPTION

#### Summary

- macOS 14+ runners use `arm64` rather than `x64`; are substantially faster
- macOS 13 runners will be discontinued in a few months
- also provide matrix infrastructure to run multiple jobs across OS versions as needed during migration periods and on schedules to ensure stability

#### Testing

CI changes only.

#### Readability checklist

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase
