### PR TITLE
[Backport-v1.4] Add Version-Independent Generic APIs for Insights 

### DIFF
--- a/src/tracing/esp32_trace/BUILD.gn
+++ b/src/tracing/esp32_trace/BUILD.gn
@@ -33,7 +33,9 @@ static_library("backend") {
     "counter.h",
     "esp32_tracing.cpp",
     "esp32_tracing.h",
+    "matter_esp_insights.h",
   ]
+
   if (matter_enable_esp_insights_system_stats) {
     sources += [
       "insights_sys_stats.cpp",

--- a/src/tracing/esp32_trace/esp32_tracing.cpp
+++ b/src/tracing/esp32_trace/esp32_tracing.cpp
@@ -16,10 +16,10 @@
  *    limitations under the License.
  */
 
+#include "matter_esp_insights.h"
 #include <algorithm>
 #include <esp_err.h>
 #include <esp_heap_caps.h>
-#include <esp_insights.h>
 #include <esp_log.h>
 #include <memory>
 #include <tracing/backend.h>
@@ -201,17 +201,17 @@ void ESP32Backend::LogMetricEvent(const MetricEvent & event)
     {
     case ValueType::kInt32:
         ESP_LOGI("mtr", "The value of %s is %ld ", event.key(), event.ValueInt32());
-        esp_diag_metrics_add_int(event.key(), event.ValueInt32());
+        matter_esp_insights_add_int("SYS_MTR", event.key(), event.ValueInt32());
         break;
 
     case ValueType::kUInt32:
         ESP_LOGI("mtr", "The value of %s is %lu ", event.key(), event.ValueUInt32());
-        esp_diag_metrics_add_uint(event.key(), event.ValueUInt32());
+        matter_esp_insights_add_uint("SYS_MTR", event.key(), event.ValueUInt32());
         break;
 
     case ValueType::kChipErrorCode:
         ESP_LOGI("mtr", "The value of %s is error with code %lu ", event.key(), event.ValueErrorCode());
-        esp_diag_metrics_add_uint(event.key(), event.ValueErrorCode());
+        matter_esp_insights_add_uint("SYS_MTR", event.key(), event.ValueErrorCode());
         break;
 
     case ValueType::kUndefined:

--- a/src/tracing/esp32_trace/insights_sys_stats.cpp
+++ b/src/tracing/esp32_trace/insights_sys_stats.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "insights_sys_stats.h"
-#include <esp_diagnostics_metrics.h>
+#include "matter_esp_insights.h"
 #include <esp_err.h>
 #include <esp_log.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -39,7 +39,7 @@ void InsightsSystemMetrics::SamplingHandler(Layer * systemLayer, void * context)
     count_t * highwatermarks = GetHighWatermarks();
     for (int i = 0; i < System::Stats::kNumEntries; i++)
     {
-        esp_err_t err = esp_diag_metrics_add_uint(instance->mLabels[i], static_cast<uint32_t>(highwatermarks[i]));
+        esp_err_t err = matter_esp_insights_add_uint("SYS_MTR", instance->mLabels[i], static_cast<uint32_t>(highwatermarks[i]));
         if (err != ESP_OK)
         {
             ESP_LOGE(kTag, "Failed to add the metric:%s, err:%d", instance->mLabels[i], err);

--- a/src/tracing/esp32_trace/matter_esp_insights.h
+++ b/src/tracing/esp32_trace/matter_esp_insights.h
@@ -1,0 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ */
+
+#pragma once
+#include <esp_diagnostics_metrics.h>
+
+esp_err_t matter_esp_insights_add_uint([[maybe_unused]] const char * tag, const char * key, uint32_t u)
+{
+#ifdef CONFIG_ESP_INSIGHTS_META_VERSION_10
+    return esp_diag_metrics_add_uint(key, u);
+#else
+    return esp_diag_metrics_report_uint(tag, key, u);
+#endif
+}
+
+esp_err_t matter_esp_insights_add_int([[maybe_unused]] const char * tag, const char * key, int32_t i)
+{
+#ifdef CONFIG_ESP_INSIGHTS_META_VERSION_10
+    return esp_diag_metrics_add_int(key, i);
+#else
+    return esp_diag_metrics_report_int(tag, key, i);
+#endif
+}


### PR DESCRIPTION
### Changes

Backported changes from [#41021](https://github.com/project-chip/connectedhomeip/pull/41021)
Fixes build failure related to insights integration.
Related Issue: [esp-rainmaker#359](https://github.com/espressif/esp-rainmaker/issues/359)

### Testing
Successfully built the lighting app with esp-insights enabled.
Verified commissioning works as expected.
CI passes.