### PR TITLE
Add more unit tests for `SoftwareDiagnostics` cluster

### DIFF
--- a/src/app/clusters/software-diagnostics-server/tests/BUILD.gn
+++ b/src/app/clusters/software-diagnostics-server/tests/BUILD.gn
@@ -32,5 +32,6 @@ chip_test_suite("tests") {
     "${chip_root}/src/app/clusters/testing",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/app/server-cluster/testing"
   ]
 }

--- a/src/app/clusters/software-diagnostics-server/tests/BUILD.gn
+++ b/src/app/clusters/software-diagnostics-server/tests/BUILD.gn
@@ -30,8 +30,8 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/app/clusters/software-diagnostics-server",
     "${chip_root}/src/app/clusters/testing",
+    "${chip_root}/src/app/server-cluster/testing",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
-    "${chip_root}/src/app/server-cluster/testing"
   ]
 }

--- a/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
@@ -239,7 +239,7 @@ TEST_F(TestSoftwareDiagnosticsCluster, SoftwareFaultListenerTest)
     fault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(faultData), sizeof(faultData)));
 
     SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(fault);
-    
+
     chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::DecodableType decodedFault;
     ASSERT_EQ(context.EventsGenerator().DecodeLastEvent(decodedFault), CHIP_NO_ERROR);
 

--- a/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
@@ -216,8 +216,13 @@ TEST_F(TestSoftwareDiagnosticsCluster, AttributesAndCommandTest)
         EXPECT_EQ(diag.GetCurrentHighWatermark(value), CHIP_NO_ERROR);
         EXPECT_EQ(value, 456u);
     }
+
+    // Here should be test for ThreadMetrics attribute, but this will be harder to do without a testing
+    // infrastructure for clusters.
 }
 
+// This doesn't really test event generation right now, for it there needs to be a testing infrastructure for clusters.
+// This just tests the global listener functionality.
 TEST_F(TestSoftwareDiagnosticsCluster, SoftwareFaultListenerTest)
 {
     class TestListener : public SoftwareDiagnostics::SoftwareFaultListener

--- a/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
@@ -236,7 +236,7 @@ TEST_F(TestSoftwareDiagnosticsCluster, SoftwareFaultListenerTest)
     fault.id = 1234;
     fault.name.SetValue(CharSpan::fromCharString("test"));
     const char faultData[] = "faultdata";
-    fault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(faultData), sizeof(faultData)));
+    fault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(faultData), strlen(faultData)));
 
     SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(fault);
 

--- a/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
@@ -248,6 +248,8 @@ TEST_F(TestSoftwareDiagnosticsCluster, SoftwareFaultListenerTest)
     ASSERT_TRUE(decodedFault.name.Value().data_equal(fault.name.Value()));
     ASSERT_TRUE(decodedFault.faultRecording.HasValue());
     ASSERT_TRUE(decodedFault.faultRecording.Value().data_equal(fault.faultRecording.Value()));
+
+    cluster.Shutdown();
 }
 
 } // namespace

--- a/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
@@ -55,6 +55,8 @@ public:
     ScopedDiagnosticsProvider(ScopedDiagnosticsProvider &&)                  = delete;
     ScopedDiagnosticsProvider & operator=(ScopedDiagnosticsProvider &&)      = delete;
 
+    T& GetProvider() { return mProvider; }
+
 private:
     DeviceLayer::DiagnosticDataProvider * mOldProvider;
     T mProvider;
@@ -142,9 +144,9 @@ TEST_F(TestSoftwareDiagnosticsCluster, AttributesAndCommandTest)
         ASSERT_TRUE(Testing::EqualAttributeSets(attributesBuilder.TakeBuffer(), expectedBuilder.TakeBuffer()));
 
         // Call the command, and verify it calls through to the provider
-        ASSERT_FALSE(watermarksProvider.resetCalled);
+        ASSERT_FALSE(watermarksProvider.GetProvider().resetCalled);
         ASSERT_EQ(diag.ResetWatermarks(), CHIP_NO_ERROR);
-        ASSERT_TRUE(watermarksProvider.resetCalled);
+        ASSERT_TRUE(watermarksProvider.GetProvider().resetCalled);
     }
 
     {
@@ -238,14 +240,14 @@ TEST_F(TestSoftwareDiagnosticsCluster, SoftwareFaultListenerTest)
 
     SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(fault);
     
-    chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::Type decodedFault;
+    chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::DecodableType decodedFault;
     ASSERT_EQ(context.EventsGenerator().DecodeLastEvent(decodedFault), CHIP_NO_ERROR);
 
     ASSERT_EQ(decodedFault.id, fault.id);
     ASSERT_TRUE(decodedFault.name.HasValue());
-    ASSERT_EQ(decodedFault.name.Value(), fault.name.Value());
+    ASSERT_TRUE(decodedFault.name.Value().data_equal(fault.name.Value()));
     ASSERT_TRUE(decodedFault.faultRecording.HasValue());
-    ASSERT_EQ(decodedFault.faultRecording.Value(), fault.faultRecording.Value());
+    ASSERT_TRUE(decodedFault.faultRecording.Value().data_equal(fault.faultRecording.Value()));
 }
 
 } // namespace

--- a/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
@@ -73,7 +73,7 @@ TEST_F(TestSoftwareDiagnosticsCluster, CompileTest)
     ASSERT_EQ(cluster.GetClusterFlags({ kRootEndpointId, SoftwareDiagnostics::Id }), BitFlags<ClusterQualityFlags>());
 }
 
-TEST_F(TestSoftwareDiagnosticsCluster, AttributesTest)
+TEST_F(TestSoftwareDiagnosticsCluster, AttributesAndCommandTest)
 {
     {
         // everything returns empty here ..
@@ -103,6 +103,14 @@ TEST_F(TestSoftwareDiagnosticsCluster, AttributesTest)
         {
         public:
             bool SupportsWatermarks() override { return true; }
+
+            CHIP_ERROR ResetWatermarks() override
+            {
+                resetCalled = true;
+                return CHIP_NO_ERROR;
+            }
+
+            bool resetCalled = false;
         };
 
         ScopedDiagnosticsProvider<WatermarksProvider> watermarksProvider;
@@ -130,6 +138,11 @@ TEST_F(TestSoftwareDiagnosticsCluster, AttributesTest)
                   CHIP_NO_ERROR);
 
         ASSERT_TRUE(Testing::EqualAttributeSets(attributesBuilder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+
+        // Call the command, and verify it calls through to the provider
+        ASSERT_FALSE(watermarksProvider.resetCalled);
+        ASSERT_EQ(diag.ResetWatermarks(), CHIP_NO_ERROR);
+        ASSERT_TRUE(watermarksProvider.resetCalled);
     }
 
     {

--- a/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
@@ -17,6 +17,7 @@
 
 #include <app/clusters/software-diagnostics-server/software-diagnostics-cluster.h>
 #include <app/clusters/software-diagnostics-server/software-diagnostics-logic.h>
+#include <app/clusters/software-diagnostics-server/software-fault-listener.h>
 #include <app/clusters/testing/AttributeTesting.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/server-cluster/DefaultServerCluster.h>
@@ -215,6 +216,60 @@ TEST_F(TestSoftwareDiagnosticsCluster, AttributesAndCommandTest)
         EXPECT_EQ(diag.GetCurrentHighWatermark(value), CHIP_NO_ERROR);
         EXPECT_EQ(value, 456u);
     }
+}
+
+TEST_F(TestSoftwareDiagnosticsCluster, SoftwareFaultListenerTest)
+{
+    class TestListener : public SoftwareDiagnostics::SoftwareFaultListener
+    {
+    public:
+        void
+        OnSoftwareFaultDetect(const chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::Type & softwareFault) override
+        {
+            received = softwareFault;
+            called   = true;
+        }
+
+        bool called = false;
+        chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::Type received;
+    };
+
+    TestListener listener;
+
+    // Initially no listener is set
+    ASSERT_EQ(SoftwareDiagnostics::SoftwareFaultListener::GetGlobalListener(), nullptr);
+
+    // Set the listener
+    SoftwareDiagnostics::SoftwareFaultListener::SetGlobalListener(&listener);
+    ASSERT_EQ(SoftwareDiagnostics::SoftwareFaultListener::GetGlobalListener(), &listener);
+
+    // Notify a fault, and verify it is received
+    chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::Type fault;
+    fault.id = 1234;
+    fault.name.SetValue(CharSpan::fromCharString("test"));
+    const char faultData[] = "faultdata";
+    fault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(faultData), sizeof(faultData)));
+
+    SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(fault);
+
+    ASSERT_TRUE(listener.called);
+    ASSERT_EQ(listener.received.id, fault.id);
+    ASSERT_TRUE(listener.received.name.HasValue());
+    ASSERT_EQ(listener.received.name.Value(), fault.name.Value());
+    ASSERT_TRUE(listener.received.faultRecording.HasValue());
+    ASSERT_EQ(listener.received.faultRecording.Value().size(), fault.faultRecording.Value().size());
+    ASSERT_EQ(memcmp(listener.received.faultRecording.Value().data(), fault.faultRecording.Value().data(),
+                     fault.faultRecording.Value().size()),
+              0);
+
+    // Clear the listener
+    SoftwareDiagnostics::SoftwareFaultListener::SetGlobalListener(nullptr);
+    ASSERT_EQ(SoftwareDiagnostics::SoftwareFaultListener::GetGlobalListener(), nullptr);
+
+    // Notify again, and verify nothing is called
+    listener.called = false;
+    SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(fault);
+    ASSERT_FALSE(listener.called);
 }
 
 } // namespace

--- a/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
@@ -55,7 +55,7 @@ public:
     ScopedDiagnosticsProvider(ScopedDiagnosticsProvider &&)                  = delete;
     ScopedDiagnosticsProvider & operator=(ScopedDiagnosticsProvider &&)      = delete;
 
-    T& GetProvider() { return mProvider; }
+    T & GetProvider() { return mProvider; }
 
 private:
     DeviceLayer::DiagnosticDataProvider * mOldProvider;


### PR DESCRIPTION
#### Summary

Add unit tests for the 

- `ResetWatermark` command 
- `SoftwareFault` event 

#### Related issues

#41059 

#### Testing

Adds new unit tests, just needs to pass CI.

#### Notes

There is the attribute `ThreadMetrics` that can be tested but isn't. It needs an `AttributeValueEncoder` and possibly an `AttributeValueDecoder` to be set up to be tested, and this can be made very easy with an infrustructure for this. There is already `TestServerClusterContext` implemented, so a more capable infrastructure can be made from it.