### PR TITLE
[Docker][Silabs]Update silabs docker file and bump image version to use latest silabs…

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-169 : [nrfconnect] Update nRF Connect SDK version to 3.1.0
+170 : [silabs] Update to sisdk 2025.6.2 and WiseConnect sdk 3.5.2 

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -12,8 +12,8 @@ RUN set -x \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line
 
-# Download Simplicity SDK v2025.6.1 (4c4c715)
-RUN git clone --depth=1 --single-branch --branch=v2025.6.1 https://github.com/SiliconLabs/simplicity_sdk.git /tmp/simplicity_sdk \
+# Download Simplicity SDK v2025.6.2 (9932cb1)
+RUN git clone --depth=1 --single-branch --branch=v2025.6.2 https://github.com/SiliconLabs/simplicity_sdk.git /tmp/simplicity_sdk \
     # Deleting files that are not needed to save space
     && rm -rf /tmp/simplicity_sdk/.git /tmp/simplicity_sdk/protocol/flex /tmp/simplicity_sdk/protocol/z-wave /tmp/simplicity_sdk/protocol/zigbee /tmp/simplicity_sdk/protocol/wisun /tmp/simplicity_sdk/util/third_party/tensorflow_extra \
     /tmp/simplicity_sdk/util/third_party/sqlite /tmp/simplicity_sdk/util/third_party/ot-br-posix /tmp/simplicity_sdk/util/third_party/tflite-micro /tmp/simplicity_sdk/util/third_party/tflite-fatfs /tmp/simplicity_sdk/util/third_party/unity_test_framework \
@@ -32,8 +32,8 @@ RUN git clone --depth=1 --single-branch --branch=2.12.0 https://github.com/Silic
     rm -rf .git examples \
     && : # last line
 
-# Clone WiSeConnect SDK v3.5.1 (984fbd4)
-RUN git clone --depth=1 --single-branch --branch=v3.5.1 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
+# Clone WiSeConnect SDK v3.5.2 (02e004c)
+RUN git clone --depth=1 --single-branch --branch=v3.5.2 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
     cd /tmp/wifi_sdk && \
     rm -rf .git examples components/device/stm32 \
     && : # last line


### PR DESCRIPTION
… sdks

#### Summary
New simplicity SDK 2025.6.2 and wise connect 3.5.2 have been released.
Update the Docker image to pull those in.

#### Related issues
n/a

#### Testing
locally build the image with
`docker build --build-arg VERSION=latest -t testing integrations/docker/images/stage-2/chip-build-efr32`
```
Successfully built 8cd6aaf91fb0
Successfully tagged testing:latest
```
