### PR TITLE
[FIX][SETRF] Fix for TC-SETRF-2-3.py based on Issue #40970

### DIFF
--- a/src/python_testing/TC_SETRF_2_3.py
+++ b/src/python_testing/TC_SETRF_2_3.py
@@ -290,6 +290,8 @@ class TC_SETRF_2_3(CommodityTariffTestBaseHelper):
         await self.check_next_day_entry_date_attribute(endpoint, self.nextDayEntryDateValue)
         asserts.assert_not_equal(self.nextDayEntryDateValue, nextDayEntryDateValue_previous,
                                  "NextDayEntryDate must change after TestEventTrigger for Change Time Test Event.")
+        asserts.assert_not_equal(self.nextDayEntryDateValue, self.currentDayEntryDateValue,
+                                 "NextDayEntryDate must not be equal to CurrentDayEntryDate after TestEventTrigger for Change Time Test Event.")
 
         self.step("16")
         # TH reads NextDay attribute, expects a DayStruct. Checks that NextDay did not change after TestEventTrigger Change Time Test Event.


### PR DESCRIPTION
#### Summary

This PR is fixing issue #40970.

#### Related issues

Fixes: #40970 

#### Testing

How to test:
Start energy-gateway-app:

```
rm -f /tmp/chip_* ;  ./chip-energy-gateway-app --enable-key 000102030405060708090a0b0c0d0e0f
```

Run test:

```
python src/python_testing/TC_SETRF_2_3.py --endpoint 1 -m on-network -n 1234 -p 20202021 -d 3840 --hex-arg enableKey:00112233445566778899aabbccddeeff --PICS src/app/tests/suites/certification/ci-pics-values
```