### PR TITLE
Hotfix merge conflict. Re-run zap_regen_all

### DIFF
--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
@@ -4963,7 +4963,7 @@
 #define GENERATED_ENDPOINT_TYPES                                                                                                   \
     {                                                                                                                              \
         { ZAP_CLUSTER_INDEX(0), 28, 219 },                                                                                         \
-        { ZAP_CLUSTER_INDEX(28), 73, 3442 },                                                                                       \
+        { ZAP_CLUSTER_INDEX(28), 73, 3440 },                                                                                       \
         { ZAP_CLUSTER_INDEX(101), 7, 114 },                                                                                        \
         { ZAP_CLUSTER_INDEX(108), 2, 0 },                                                                                          \
     }
@@ -4977,7 +4977,7 @@ static_assert(ATTRIBUTE_LARGEST <= CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE,
 #define ATTRIBUTE_SINGLETONS_SIZE (0)
 
 // Total size of attribute storage
-#define ATTRIBUTE_MAX_SIZE (3775)
+#define ATTRIBUTE_MAX_SIZE (3773)
 
 // Number of fixed endpoints
 #define FIXED_ENDPOINT_COUNT (4)


### PR DESCRIPTION
#### Summary
ZAP Template generation CI is failing on master. Merge conflict seems to have occured between two PR changing generated files.

Re-ran the zap_regen_all script and pushed the diff

#### Related issues
n/a

#### Testing
CI to confirm ZAP generation is now ok

