### PR TITLE
Sort lists in config data

### DIFF
--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -3,85 +3,88 @@ EnumsNotUsedAsTypeInXML:
     # to this list you prevent incorrectly assuming from code that you are
     # able to use kUnknownEnumValue safely. This happens for derived clusters
     # such as ModeBase where there are CommonTag, DerivedClusterTags, MfgTags.
+    - "DeviceEnergyManagementMode::ModeTag"
     - "DishwasherMode::ModeTag"
+    - "EnergyEvseMode::ModeTag"
     - "LaundryWasherMode::ModeTag"
     - "RefrigeratorAndTemperatureControlledCabinetMode::ModeTag"
-    - "RvcRunMode::ModeTag"
-    - "RvcRunMode::StatusCode"
     - "RvcCleanMode::ModeTag"
     - "RvcCleanMode::StatusCode"
-    - "RvcOperationalState::OperationalStateEnum"
     - "RvcOperationalState::ErrorStateEnum"
-    - "EnergyEvseMode::ModeTag"
+    - "RvcOperationalState::OperationalStateEnum"
+    - "RvcRunMode::ModeTag"
+    - "RvcRunMode::StatusCode"
     - "WaterHeaterMode::ModeTag"
-    - "DeviceEnergyManagementMode::ModeTag"
+# please keep above list sorted to minimize merge conflicts
 
 CommandHandlerInterfaceOnlyClusters:
     # List of clusters that are implemented entirely with
     # CommandHandlerInterface and hence do not need generated command dispatch.
     # This uses asUpperCamelCase versions of the cluster name.
-    - Network Commissioning
-    - Scenes Management
-    - RVC Run Mode
-    - RVC Clean Mode
-    - Service Area
-    - Dishwasher Mode
-    - Laundry Washer Mode
-    - Oven Mode
-    - Oven Cavity Operational State
-    - Refrigerator And Temperature Controlled Cabinet Mode
-    - Operational State
+    - Access Control
+    - Actions
     - Activated Carbon Filter Monitoring
-    - HEPA Filter Monitoring
-    - RVC Operational State
-    - Sample MEI
-    - Microwave Oven Control
-    - Chime
+    - Administrator Commissioning
+    - Basic Information
+    - Boolean State
+    - Camera AV Settings User Level Management
     - Camera AV Stream Management
-    - Push AV Stream Transport
+    - Chime
+    - Closure Control
+    - Closure Dimension
     - Commissioner Control
     - Commodity Price
-    - Energy EVSE
-    - Energy EVSE Mode
+    - Commodity Tariff
     - Device Energy Management
     - Device Energy Management Mode
-    - Electrical Power Measurement
+    - Diagnostic Logs
+    - Dishwasher Mode
     - Electrical Energy Measurement
-    - Wi-Fi Network Management
+    - Electrical Power Measurement
+    - Energy EVSE
+    - Energy EVSE Mode
+    - Ethernet Network Diagnostics
+    - Fixed Label
+    - General Commissioning
+    - General Diagnostics
+    - Group Key Management
+    - HEPA Filter Monitoring
+    - Joint Fabric Administrator
+    - Laundry Washer Mode
+    - Microwave Oven Control
+    - Network Commissioning
+    - Operational State
+    - OTA Software Update Provider
+    - Oven Cavity Operational State
+    - Oven Mode
+    - Push AV Stream Transport
+    - Refrigerator And Temperature Controlled Cabinet Mode
+    - RVC Clean Mode
+    - RVC Operational State
+    - RVC Run Mode
+    - Sample MEI
+    - Scenes Management
+    - Service Area
+    - Software Diagnostics
+    - Soil Measurement
     - Thread Border Router Management
     - Thread Network Directory
-    - TLS Client Management
     - TLS Certificate Management
+    - TLS Client Management
     - Water Heater Management
     - Water Heater Mode
     - WebRTC Transport Provider
     - WebRTC Transport Requestor
-    - General Commissioning
-    - General Diagnostics
-    - Software Diagnostics
-    - Ethernet Network Diagnostics
-    - Group Key Management
     - Wi-Fi Network Diagnostics
-    - Camera AV Settings User Level Management
-    - Administrator Commissioning
-    - Actions
-    - Closure Control
-    - Closure Dimension
-    - OTA Software Update Provider
-    - Commodity Tariff
-    - Joint Fabric Administrator
+    - Wi-Fi Network Management
     - Zone Management
-    - Fixed Label
-    - Soil Measurement
-    - Basic Information
-    - Boolean State
-    - Diagnostic Logs
-    - Access Control
+# please keep above list sorted to minimize merge conflicts
 
 # We need a more configurable way of deciding which clusters have which init functions....
 # See https://github.com/project-chip/connectedhomeip/issues/4369
 ClustersWithInitFunctions:
     - Color Control
+    - Fixed Label
     - Groups
     - Identify
     - Level Control
@@ -93,39 +96,42 @@ ClustersWithInitFunctions:
     - Sample MEI
     - Scenes Management
     - Thermostat
-    - Fixed Label
+# please keep above list sorted to minimize merge conflicts
 
 ClustersWithAttributeChangedFunctions:
     - Bridged Device Basic Information
     - Door Lock
+    - Fan Control
     - Identify
     - Pump Configuration and Control
-    - Window Covering
-    - Fan Control
     - Thermostat
+    - Window Covering
+# please keep above list sorted to minimize merge conflicts
 
 ClustersWithShutdownFunctions:
     - Barrier Control
     - Color Control
     - Door Lock
+    - Fixed Label
     - Level Control
     - On/Off
     - Sample MEI
     - Scenes Management
     - Thermostat
-    - Fixed Label
+# please keep above list sorted to minimize merge conflicts
 
 ClustersWithPreAttributeChangeFunctions:
     - Door Lock
-    - Pump Configuration and Control
-    - Thermostat User Interface Configuration
+    - Energy Preference
+    - Fan Control
+    - Laundry Dryer Controls
+    - Laundry Washer Controls
     - Localization Configuration
     - Mode Select
-    - Fan Control
+    - Pump Configuration and Control
     - Thermostat
-    - Energy Preference
-    - Laundry Washer Controls
-    - Laundry Dryer Controls
+    - Thermostat User Interface Configuration
+# please keep above list sorted to minimize merge conflicts
 
 # Code Driven clusters are clusters that implement the ServerClusterInterface.
 # The clusters in this list require Init() and/or Shutdown() callbacks, defined
@@ -136,6 +142,7 @@ CodeDrivenClusters:
     - Basic Information
     - Binding
     - Boolean State
+    - Diagnostic Logs
     - Ethernet Network Diagnostics
     - General Diagnostics
     - Group Key Management
@@ -144,4 +151,4 @@ CodeDrivenClusters:
     - Software Diagnostics
     - Time Format Localization
     - Wi-Fi Network Diagnostics
-    - Diagnostic Logs
+# please keep above list sorted to minimize merge conflicts

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -15,7 +15,7 @@ EnumsNotUsedAsTypeInXML:
     - "RvcRunMode::ModeTag"
     - "RvcRunMode::StatusCode"
     - "WaterHeaterMode::ModeTag"
-# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
+# Please keep the above list sorted alphabetically, to minimize merge conflicts.
 
 CommandHandlerInterfaceOnlyClusters:
     # List of clusters that are implemented entirely with
@@ -78,7 +78,7 @@ CommandHandlerInterfaceOnlyClusters:
     - Wi-Fi Network Diagnostics
     - Wi-Fi Network Management
     - Zone Management
-# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
+# Please keep the above list sorted alphabetically, to minimize merge conflicts.
 
 # We need a more configurable way of deciding which clusters have which init functions....
 # See https://github.com/project-chip/connectedhomeip/issues/4369
@@ -96,7 +96,7 @@ ClustersWithInitFunctions:
     - Sample MEI
     - Scenes Management
     - Thermostat
-# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
+# Please keep the above list sorted alphabetically, to minimize merge conflicts.
 
 ClustersWithAttributeChangedFunctions:
     - Bridged Device Basic Information
@@ -106,7 +106,7 @@ ClustersWithAttributeChangedFunctions:
     - Pump Configuration and Control
     - Thermostat
     - Window Covering
-# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
+# Please keep the above list sorted alphabetically, to minimize merge conflicts.
 
 ClustersWithShutdownFunctions:
     - Barrier Control
@@ -118,7 +118,7 @@ ClustersWithShutdownFunctions:
     - Sample MEI
     - Scenes Management
     - Thermostat
-# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
+# Please keep the above list sorted alphabetically, to minimize merge conflicts.
 
 ClustersWithPreAttributeChangeFunctions:
     - Door Lock
@@ -131,7 +131,7 @@ ClustersWithPreAttributeChangeFunctions:
     - Pump Configuration and Control
     - Thermostat
     - Thermostat User Interface Configuration
-# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
+# Please keep the above list sorted alphabetically, to minimize merge conflicts.
 
 # Code Driven clusters are clusters that implement the ServerClusterInterface.
 # The clusters in this list require Init() and/or Shutdown() callbacks, defined
@@ -151,4 +151,4 @@ CodeDrivenClusters:
     - Software Diagnostics
     - Time Format Localization
     - Wi-Fi Network Diagnostics
-# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
+# Please keep the above list sorted alphabetically, to minimize merge conflicts.

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -15,7 +15,7 @@ EnumsNotUsedAsTypeInXML:
     - "RvcRunMode::ModeTag"
     - "RvcRunMode::StatusCode"
     - "WaterHeaterMode::ModeTag"
-# please keep above list sorted to minimize merge conflicts
+# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
 
 CommandHandlerInterfaceOnlyClusters:
     # List of clusters that are implemented entirely with
@@ -78,7 +78,7 @@ CommandHandlerInterfaceOnlyClusters:
     - Wi-Fi Network Diagnostics
     - Wi-Fi Network Management
     - Zone Management
-# please keep above list sorted to minimize merge conflicts
+# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
 
 # We need a more configurable way of deciding which clusters have which init functions....
 # See https://github.com/project-chip/connectedhomeip/issues/4369
@@ -96,7 +96,7 @@ ClustersWithInitFunctions:
     - Sample MEI
     - Scenes Management
     - Thermostat
-# please keep above list sorted to minimize merge conflicts
+# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
 
 ClustersWithAttributeChangedFunctions:
     - Bridged Device Basic Information
@@ -106,7 +106,7 @@ ClustersWithAttributeChangedFunctions:
     - Pump Configuration and Control
     - Thermostat
     - Window Covering
-# please keep above list sorted to minimize merge conflicts
+# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
 
 ClustersWithShutdownFunctions:
     - Barrier Control
@@ -118,7 +118,7 @@ ClustersWithShutdownFunctions:
     - Sample MEI
     - Scenes Management
     - Thermostat
-# please keep above list sorted to minimize merge conflicts
+# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
 
 ClustersWithPreAttributeChangeFunctions:
     - Door Lock
@@ -131,7 +131,7 @@ ClustersWithPreAttributeChangeFunctions:
     - Pump Configuration and Control
     - Thermostat
     - Thermostat User Interface Configuration
-# please keep above list sorted to minimize merge conflicts
+# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.
 
 # Code Driven clusters are clusters that implement the ServerClusterInterface.
 # The clusters in this list require Init() and/or Shutdown() callbacks, defined
@@ -151,4 +151,4 @@ CodeDrivenClusters:
     - Software Diagnostics
     - Time Format Localization
     - Wi-Fi Network Diagnostics
-# please keep above list sorted to minimize merge conflicts
+# Please keep the abolve list sorted alphabetically, to minimize merge conflicts.


### PR DESCRIPTION
Also add a comment to encourage keeping the lists sorted.

#### Summary

Without this, we get conflicts as we migrate or create clusters, as people find it natural to "add at the end".

#### Testing

Trivial change. If CI passes all is good, as codegen stays the same.