### PR TITLE
Bump cloudbuild version to docker image 169

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -23,7 +23,7 @@ steps:
           - name: pwenv
             path: /pwenv
       timeout: 900s
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -38,7 +38,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       # ICD device is currently not supported for ESP32 and NRF targets. New rule to compile only ICD
       # linux binary.
       env:
@@ -53,7 +53,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -24,7 +24,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -44,7 +44,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -65,7 +65,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -86,7 +86,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -139,7 +139,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:168"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
#### Summary

Cloudbuild is broken otherwise since #41205 update that requires new docker version.

#### Testing

Trivial change. Cloud builds will verify.