### PR TITLE
[Darwin] MTRDevice_Concrete readAttributePaths - remove NSMutableSet usage

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -2466,7 +2466,7 @@ static NSString * FormatPossiblyWildcardClusterElement(NSNumber * _Nullable poss
 
 - (NSUInteger)hash
 {
-    return _endpoint.unsignedShortValue ^ _cluster.unsignedLongValue ^ _attribute.unsignedLongValue;
+    return _endpoint.unsignedShortValue ^ (_cluster.unsignedLongValue << 8) ^ (_attribute.unsignedLongValue << 16);
 }
 
 - (id)copyWithZone:(NSZone *)zone
@@ -2593,7 +2593,7 @@ static NSString * const sAttributeIDKey = @"attributeIDKey";
 
 - (NSUInteger)hash
 {
-    return _endpoint.unsignedShortValue ^ _cluster.unsignedLongValue ^ _event.unsignedLongValue;
+    return _endpoint.unsignedShortValue ^ (_cluster.unsignedLongValue << 8) ^ (_event.unsignedLongValue << 16);
 }
 
 - (id)copyWithZone:(NSZone *)zone
@@ -2714,7 +2714,7 @@ static NSString * const sEventAttributeIDKey = @"attributeIDKey";
 
 - (NSUInteger)hash
 {
-    return _endpoint.unsignedShortValue ^ _cluster.unsignedLongValue;
+    return _endpoint.unsignedShortValue ^ (_cluster.unsignedLongValue << 8);
 }
 
 - (id)copyWithZone:(NSZone *)zone
@@ -2804,7 +2804,7 @@ static NSString * const sClusterKey = @"clusterKey";
 
 - (NSUInteger)hash
 {
-    return self.endpoint.unsignedShortValue ^ self.cluster.unsignedLongValue ^ _attribute.unsignedLongValue;
+    return self.endpoint.unsignedShortValue ^ (self.cluster.unsignedLongValue << 8) ^ (_attribute.unsignedLongValue << 16);
 }
 
 - (id)copyWithZone:(NSZone *)zone
@@ -2900,7 +2900,7 @@ static NSString * const sAttributeKey = @"attributeKey";
 
 - (NSUInteger)hash
 {
-    return self.endpoint.unsignedShortValue ^ self.cluster.unsignedLongValue ^ _event.unsignedLongValue;
+    return self.endpoint.unsignedShortValue ^ (self.cluster.unsignedLongValue << 8) ^ (_event.unsignedLongValue << 16);
 }
 
 - (id)copyWithZone:(NSZone *)zone
@@ -2991,7 +2991,7 @@ static NSString * const sEventKey = @"eventKey";
 
 - (NSUInteger)hash
 {
-    return self.endpoint.unsignedShortValue ^ self.cluster.unsignedLongValue ^ _command.unsignedLongValue;
+    return self.endpoint.unsignedShortValue ^ (self.cluster.unsignedLongValue << 8) ^ (_command.unsignedLongValue << 16);
 }
 
 - (id)copyWithZone:(NSZone *)zone

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -3778,7 +3778,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                 continue;
             }
 
-            // Other we build unique list of attributes in this cluster that match requested paths
+            // Otherwise, we build unique list of attributes in this cluster that match requested paths
             NSMutableArray<MTRAttributePath *> * existentAttributesPathsInCluster = [[NSMutableArray alloc] init];
             for (MTRAttributeRequestPath * requestPath in attributePaths) {
                 if (requestPath.endpoint != nil && ![requestPath.endpoint isEqual:clusterPath.endpoint]) {

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -3779,7 +3779,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             }
 
             // Otherwise, we build unique list of attributes in this cluster that match requested paths
-            NSMutableArray<MTRAttributePath *> * existentAttributesPathsInCluster = [[NSMutableArray alloc] init];
+            NSMutableSet<MTRAttributePath *> * existentAttributesPathsInCluster = [[NSMutableSet alloc] init];
             for (MTRAttributeRequestPath * requestPath in attributePaths) {
                 if (requestPath.endpoint != nil && ![requestPath.endpoint isEqual:clusterPath.endpoint]) {
                     continue;
@@ -3791,8 +3791,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                     [existentAttributesPathsInCluster addObject:[MTRAttributePath attributePathWithEndpointID:clusterPath.endpoint clusterID:clusterPath.cluster attributeID:requestPath.attribute]];
                 }
             }
-            NSMutableSet<MTRAttributePath *> * existentAttributesPathsSetInCluster = [NSMutableSet setWithArray:existentAttributesPathsInCluster];
-            [existentPaths addObjectsFromArray:[existentAttributesPathsSetInCluster allObjects]];
+            [existentPaths addObjectsFromArray:[existentAttributesPathsInCluster allObjects]];
         }
     }
 

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -3754,8 +3754,8 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     NSMutableArray<MTRAttributePath *> * existentPaths = [[NSMutableArray alloc] init];
     {
         // Separate paths that ask for wildcard attributes from specific attributes
-        NSMutableArray<MTRAttributeRequestPath *> *wildcardAttributePaths = [[NSMutableArray alloc] init];
-        NSMutableArray<MTRAttributeRequestPath *> *specificAttributePaths = [[NSMutableArray alloc] init];
+        NSMutableArray<MTRAttributeRequestPath *> * wildcardAttributePaths = [[NSMutableArray alloc] init];
+        NSMutableArray<MTRAttributeRequestPath *> * specificAttributePaths = [[NSMutableArray alloc] init];
         for (MTRAttributeRequestPath * requestPath in attributePaths) {
             if (requestPath.attribute == nil) {
                 [wildcardAttributePaths addObject:requestPath];

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -6323,7 +6323,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     [self waitForExpectations:@[ subscriptionExpectation ] timeout:60];
 
     // read wildcard values
-    NSArray *values = [device readAttributePaths:@[[MTRAttributeRequestPath requestPathWithEndpointID:nil clusterID:nil attributeID:nil]]];
+    NSArray * values = [device readAttributePaths:@[ [MTRAttributeRequestPath requestPathWithEndpointID:nil clusterID:nil attributeID:nil] ]];
 
     XCTAssertNotNil(values);
     // Conservatively assume all-clusters-app has more than 100 attributes ready by MTRDevice by subscription establishment time (last count 1308)

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -6305,6 +6305,31 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     }
 }
 
+- (void)test050_readAttributePaths_withWildCardPath
+{
+    __auto_type * device = [MTRDevice deviceWithNodeID:kDeviceId1 deviceController:sController];
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
+
+    XCTestExpectation * subscriptionExpectation = [self expectationWithDescription:@"Subscription has been set up"];
+
+    delegate.onReportEnd = ^{
+        [subscriptionExpectation fulfill];
+    };
+
+    [device setDelegate:delegate queue:queue];
+
+    [self waitForExpectations:@[ subscriptionExpectation ] timeout:60];
+
+    // read wildcard values
+    NSArray *values = [device readAttributePaths:@[[MTRAttributeRequestPath requestPathWithEndpointID:nil clusterID:nil attributeID:nil]]];
+
+    XCTAssertNotNil(values);
+    // Conservatively assume all-clusters-app has more than 100 attributes ready by MTRDevice by subscription establishment time (last count 1308)
+    XCTAssertGreaterThan(values.count, 100);
+}
+
 @end
 
 @interface MTRDeviceEncoderTests : XCTestCase


### PR DESCRIPTION
#### Summary

The `readAttributePaths:` method in MTRDevice_Concrete can be cpu-inefficient with the NSMutableSet usage. This change optimizes the loop with NSMutableArray.

It also changes the hash functions of Path objects to avoid collisions - thanks to @bzbarsky-apple 's suggestion.

#### Testing

Testing is covered by existing unit tests:
- MTRDeviceTests/test017_TestMTRDeviceBasics
- MTRDeviceTests/test020_ReadMultipleAttributes
- MTRDeviceTests/test021_ReadMultipleWildcardPathsIncludeUnsupportedAttribute
- MTRDeviceTests/test022_ReadMultipleConcretePathsIncludeUnsupportedAttribute
- MTRPerControllerStorageTests/testControllerServer