### PR TITLE
[Fix] Populate Runner Arguments When Not Commissioning

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -781,6 +781,12 @@ def parse_matter_test_args(argv: Optional[List[str]] = None):
 
     basic_group.add_argument('--tests', '--test-case', action='append', nargs='+', type=str, metavar='test_NAME',
                              help='A list of tests in the test class to execute.')
+    basic_group.add_argument('--test-list', nargs='+', type=str, metavar='SCRIPT_CLASS_PAIRS',
+                             help='List of script_path and class_name pairs for batch test info retrieval')
+    basic_group.add_argument('--th-client-test', nargs=2, type=str, metavar=('SCRIPT_PATH', 'CLASS_NAME'),
+                             help='Test Harness client test with script path and class name (e.g., sdk/TC_ACE_1_3 TC_ACE_1_3)')
+    basic_group.add_argument('--get-test-info', action="store_true", default=False,
+                             help="Retrieve test information (steps, descriptions, PICS) without running tests")
     basic_group.add_argument('--fail-on-skipped', action="store_true", default=False,
                              help="Fail the test if any test cases are skipped")
     basic_group.add_argument('--trace-to', nargs="*", default=[],

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -781,12 +781,6 @@ def parse_matter_test_args(argv: Optional[List[str]] = None):
 
     basic_group.add_argument('--tests', '--test-case', action='append', nargs='+', type=str, metavar='test_NAME',
                              help='A list of tests in the test class to execute.')
-    basic_group.add_argument('--test-list', nargs='+', type=str, metavar='SCRIPT_CLASS_PAIRS',
-                             help='List of script_path and class_name pairs for batch test info retrieval')
-    basic_group.add_argument('--th-client-test', nargs=2, type=str, metavar=('SCRIPT_PATH', 'CLASS_NAME'),
-                             help='Test Harness client test with script path and class name (e.g., sdk/TC_ACE_1_3 TC_ACE_1_3)')
-    basic_group.add_argument('--get-test-info', action="store_true", default=False,
-                             help="Retrieve test information (steps, descriptions, PICS) without running tests")
     basic_group.add_argument('--fail-on-skipped', action="store_true", default=False,
                              help="Fail the test if any test cases are skipped")
     basic_group.add_argument('--trace-to', nargs="*", default=[],

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -694,7 +694,7 @@ def populate_commissioning_args(args: argparse.Namespace, config) -> bool:
 
         config.wifi_ssid = args.wifi_ssid
         config.wifi_passphrase = args.wifi_passphrase
-    elif config.commissioning_method == ["ble-thread", "nfc-thread"] or config.in_test_commissioning_method == ["ble-thread", "nfc-thread"]:
+    elif config.commissioning_method in ["ble-thread", "nfc-thread"] or config.in_test_commissioning_method in ["ble-thread", "nfc-thread"]:
         if args.thread_dataset_hex is None:
             print("error: missing --thread-dataset-hex <DATASET_HEX> for --commissioning-method ble-thread or nfc-thread!")
             return False

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -683,7 +683,9 @@ def populate_commissioning_args(args: argparse.Namespace, config) -> bool:
         print("error: Missing --passcode when no --qr-code/--manual-code present!")
         return False
 
-    if config.commissioning_method == "ble-wifi" or config.in_test_commissioning_method == "ble-wifi":
+    wifi_args = ['ble-wifi']
+    thread_args = ['ble-thread', 'nfc-thread']
+    if config.commissioning_method in wifi_args or config.in_test_commissioning_method in wifi_args:
         if args.wifi_ssid is None:
             print("error: missing --wifi-ssid <SSID> for --commissioning-method ble-wifi!")
             return False

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -656,9 +656,6 @@ def populate_commissioning_args(args: argparse.Namespace, config) -> bool:
     if not config.dut_node_ids:
         config.dut_node_ids = [TestingDefaults.DUT_NODE_ID]
 
-    if args.commissioning_method is None:
-        return True
-
     if len(config.dut_node_ids) > len(device_descriptors):
         print("error: More node IDs provided than discriminators")
         return False
@@ -686,7 +683,7 @@ def populate_commissioning_args(args: argparse.Namespace, config) -> bool:
         print("error: Missing --passcode when no --qr-code/--manual-code present!")
         return False
 
-    if config.commissioning_method == "ble-wifi":
+    if config.commissioning_method == "ble-wifi" or config.in_test_commissioning_method == "ble-wifi":
         if args.wifi_ssid is None:
             print("error: missing --wifi-ssid <SSID> for --commissioning-method ble-wifi!")
             return False
@@ -697,7 +694,7 @@ def populate_commissioning_args(args: argparse.Namespace, config) -> bool:
 
         config.wifi_ssid = args.wifi_ssid
         config.wifi_passphrase = args.wifi_passphrase
-    elif config.commissioning_method in ["ble-thread", "nfc-thread"]:
+    elif config.commissioning_method == ["ble-thread", "nfc-thread"] or config.in_test_commissioning_method == ["ble-thread", "nfc-thread"]:
         if args.thread_dataset_hex is None:
             print("error: missing --thread-dataset-hex <DATASET_HEX> for --commissioning-method ble-thread or nfc-thread!")
             return False

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -656,6 +656,10 @@ def populate_commissioning_args(args: argparse.Namespace, config) -> bool:
     if not config.dut_node_ids:
         config.dut_node_ids = [TestingDefaults.DUT_NODE_ID]
 
+    commissioning_method = args.in_test_commissioning_method or args.commissioning_method
+    if not commissioning_method:
+        return True
+
     if len(config.dut_node_ids) > len(device_descriptors):
         print("error: More node IDs provided than discriminators")
         return False
@@ -685,7 +689,7 @@ def populate_commissioning_args(args: argparse.Namespace, config) -> bool:
 
     wifi_args = ['ble-wifi']
     thread_args = ['ble-thread', 'nfc-thread']
-    if config.commissioning_method in wifi_args or config.in_test_commissioning_method in wifi_args:
+    if commissioning_method in wifi_args:
         if args.wifi_ssid is None:
             print("error: missing --wifi-ssid <SSID> for --commissioning-method ble-wifi!")
             return False
@@ -696,7 +700,7 @@ def populate_commissioning_args(args: argparse.Namespace, config) -> bool:
 
         config.wifi_ssid = args.wifi_ssid
         config.wifi_passphrase = args.wifi_passphrase
-    elif config.commissioning_method in thread_args or config.in_test_commissioning_method in thread_args:
+    elif commissioning_method in thread_args:
         if args.thread_dataset_hex is None:
             print("error: missing --thread-dataset-hex <DATASET_HEX> for --commissioning-method ble-thread or nfc-thread!")
             return False

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -696,7 +696,7 @@ def populate_commissioning_args(args: argparse.Namespace, config) -> bool:
 
         config.wifi_ssid = args.wifi_ssid
         config.wifi_passphrase = args.wifi_passphrase
-    elif config.commissioning_method in ["ble-thread", "nfc-thread"] or config.in_test_commissioning_method in ["ble-thread", "nfc-thread"]:
+    elif config.commissioning_method in thread_args or config.in_test_commissioning_method in thread_args:
         if args.thread_dataset_hex is None:
             print("error: missing --thread-dataset-hex <DATASET_HEX> for --commissioning-method ble-thread or nfc-thread!")
             return False


### PR DESCRIPTION
#### Summary

This change updates the python test runner script conditional logic to populate the commissioning arguments even if no `commissioning_method` is provided. That is important for Test Harness flow, that use the runner on two phases (by the `test_harness_client.py` backend script):

- Send command to the runner to start only the commissioning of the DUT before TC execution
- Send a command to the runner to start the Test Case execution without the commissioning

On the second phase above, we start the TC execution with no commissioning information used on the first phase.
This is a problem for instance on some CNET scripts that try to access during the test case the commissioning data used but it's empty unfortunately.

This solution is simply removing the return condition when commissioning_method is empty and populating the Thread and wi-fi data also if `in_test_commissioning_method` is present.


#### Related issues

Fix: https://github.com/project-chip/certification-tool/issues/664
Fix: https://github.com/project-chip/certification-tool/issues/742
Fix: https://github.com/project-chip/certification-tool/issues/746

#### Testing

After changing both SDK container's runner and backend's argument creation utility we could verify a success running for instance the CNET4.12 as shown below:

<img width="1713" height="906" alt="Screenshot 2025-10-06 at 12 16 44" src="https://github.com/user-attachments/assets/866e0619-16a8-4e0a-b240-3a9b17057d1f" />
