### PR TITLE
[Camera] Correct checking which does not make sense

### DIFF
--- a/src/python_testing/TC_AVSM_2_15.py
+++ b/src/python_testing/TC_AVSM_2_15.py
@@ -40,7 +40,6 @@ import logging
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.interaction_model import InteractionModelError, Status
 from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
 
 logger = logging.getLogger(__name__)
@@ -126,28 +125,25 @@ class TC_AVSM_2_15(MatterBaseTest):
         logger.info("Fetch feature map to check if WMark and OSD are supported")
         aFeatureMap = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.FeatureMap)
         logger.info(f"Rx'd FeatureMap: {aFeatureMap}")
-        try:
-            watermark = True if (aFeatureMap & cluster.Bitmaps.Feature.kWatermark) != 0 else None
-            osd = True if (aFeatureMap & cluster.Bitmaps.Feature.kOnScreenDisplay) != 0 else None
 
-            snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
-                imageCodec=aSnapshotCapabilities[0].imageCodec,
-                maxFrameRate=aSnapshotCapabilities[0].maxFrameRate,
-                minResolution=aSnapshotCapabilities[0].resolution,
-                maxResolution=aSnapshotCapabilities[0].resolution,
-                quality=90,
-                watermarkEnabled=watermark,
-                OSDEnabled=osd
-            )
-            snpStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
-            logger.info(f"Rx'd SnapshotStreamAllocateResponse: {snpStreamAllocateResponse}")
-            asserts.assert_is_not_none(
-                snpStreamAllocateResponse.snapshotStreamID, "SnapshotStreamAllocateResponse does not contain StreamID"
-            )
-            aSnapshotStreamID = snpStreamAllocateResponse.snapshotStreamID
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
-            pass
+        watermark = True if (aFeatureMap & cluster.Bitmaps.Feature.kWatermark) != 0 else None
+        osd = True if (aFeatureMap & cluster.Bitmaps.Feature.kOnScreenDisplay) != 0 else None
+
+        snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
+            imageCodec=aSnapshotCapabilities[0].imageCodec,
+            maxFrameRate=aSnapshotCapabilities[0].maxFrameRate,
+            minResolution=aSnapshotCapabilities[0].resolution,
+            maxResolution=aSnapshotCapabilities[0].resolution,
+            quality=90,
+            watermarkEnabled=watermark,
+            OSDEnabled=osd
+        )
+        snpStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
+        logger.info(f"Rx'd SnapshotStreamAllocateResponse: {snpStreamAllocateResponse}")
+        asserts.assert_is_not_none(
+            snpStreamAllocateResponse.snapshotStreamID, "SnapshotStreamAllocateResponse does not contain StreamID"
+        )
+        aSnapshotStreamID = snpStreamAllocateResponse.snapshotStreamID
 
         self.step(5)
         aAllocatedSnapshotStreams = await self.read_single_attribute_check_success(
@@ -157,26 +153,22 @@ class TC_AVSM_2_15(MatterBaseTest):
         asserts.assert_equal(len(aAllocatedSnapshotStreams), 1, "The number of allocated snapshot streams in the list is not 1.")
 
         self.step(6)
-        try:
-            snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
-                imageCodec=aSnapshotCapabilities[0].imageCodec,
-                maxFrameRate=aSnapshotCapabilities[0].maxFrameRate,
-                minResolution=aSnapshotCapabilities[0].resolution,
-                maxResolution=aSnapshotCapabilities[0].resolution,
-                quality=90,
-                watermarkEnabled=watermark,
-                OSDEnabled=osd
-            )
-            snpStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
-            logger.info(f"Rx'd SnapshotStreamAllocateResponse: {snpStreamAllocateResponse}")
-            asserts.assert_is_not_none(
-                snpStreamAllocateResponse.snapshotStreamID, "SnapshotStreamAllocateResponse does not contain StreamID"
-            )
-            asserts.assert_equal(snpStreamAllocateResponse.snapshotStreamID, aSnapshotStreamID,
-                                 "The previous snapshot stream is not reused")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
-            pass
+        snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
+            imageCodec=aSnapshotCapabilities[0].imageCodec,
+            maxFrameRate=aSnapshotCapabilities[0].maxFrameRate,
+            minResolution=aSnapshotCapabilities[0].resolution,
+            maxResolution=aSnapshotCapabilities[0].resolution,
+            quality=90,
+            watermarkEnabled=watermark,
+            OSDEnabled=osd
+        )
+        snpStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
+        logger.info(f"Rx'd SnapshotStreamAllocateResponse: {snpStreamAllocateResponse}")
+        asserts.assert_is_not_none(
+            snpStreamAllocateResponse.snapshotStreamID, "SnapshotStreamAllocateResponse does not contain StreamID"
+        )
+        asserts.assert_equal(snpStreamAllocateResponse.snapshotStreamID, aSnapshotStreamID,
+                             "The previous snapshot stream is not reused")
 
         self.step(7)
         aAllocatedSnapshotStreams = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_AVSM_2_15.py
+++ b/src/python_testing/TC_AVSM_2_15.py
@@ -153,15 +153,6 @@ class TC_AVSM_2_15(MatterBaseTest):
         asserts.assert_equal(len(aAllocatedSnapshotStreams), 1, "The number of allocated snapshot streams in the list is not 1.")
 
         self.step(6)
-        snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
-            imageCodec=aSnapshotCapabilities[0].imageCodec,
-            maxFrameRate=aSnapshotCapabilities[0].maxFrameRate,
-            minResolution=aSnapshotCapabilities[0].resolution,
-            maxResolution=aSnapshotCapabilities[0].resolution,
-            quality=90,
-            watermarkEnabled=watermark,
-            OSDEnabled=osd
-        )
         snpStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
         logger.info(f"Rx'd SnapshotStreamAllocateResponse: {snpStreamAllocateResponse}")
         asserts.assert_is_not_none(

--- a/src/python_testing/TC_AVSM_2_9.py
+++ b/src/python_testing/TC_AVSM_2_9.py
@@ -121,14 +121,9 @@ class TC_AVSM_2_9(MatterBaseTest, AVSMTestBase):
                 Status.NotFound,
                 "Unexpected error returned when expecting NOT_FOUND due to videoStreamID set to aStreamIDToDelete + 1",
             )
-            pass
 
         self.step(4)
-        try:
-            await self.send_single_cmd(endpoint=endpoint, cmd=commands.VideoStreamDeallocate(videoStreamID=(aStreamIDToDelete)))
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
-            pass
+        await self.send_single_cmd(endpoint=endpoint, cmd=commands.VideoStreamDeallocate(videoStreamID=(aStreamIDToDelete)))
 
         self.step(5)
         aAllocatedVideoStreams = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_PAVST_2_5.py
+++ b/src/python_testing/TC_PAVST_2_5.py
@@ -204,7 +204,7 @@ class TC_PAVST_2_5(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             endpoint, pvattr.CurrentConnections
         )
         asserts.assert_equal(
-            len(transportConfigs), 0, "TransportConfigurations must not be empty!"
+            len(transportConfigs), 0, "TransportConfigurations must be empty!"
         )
 
 


### PR DESCRIPTION
#### Summary

1. The code is checking if an error status equals Success, which is nonsensical - if there's an InteractionModelError, it means the command failed, not succeeded.

2. If the check is "length is 0" but message is "must not be empty" this does indeed sound off...

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
