### PR TITLE
TC-IDM-10.4: Checks for commissionable devices and codes

### DIFF
--- a/src/python_testing/TC_pics_checker.py
+++ b/src/python_testing/TC_pics_checker.py
@@ -92,7 +92,11 @@ class TC_PICS_Checker(MatterBaseTest, BasicCompositionTests):
                 TestStep(5, "For every cluster present in the spec, for every server → client command in the cluster: If the cluster is present on the endpoint and the command id is present in the generated commands list, ensure the PICS code for the generated command is present in the PICS file. Otherwise, ensure the generated command PICS code is not present in the PICS file.", "PICS exactly match for all generated commands in all clusters."),
                 TestStep(6, "For every cluster present in the spec, for every feature in the cluster: If the cluster is present on the endpoint and the feature is marked in the feature map, ensure the PICS code for the feature is present in the PICS file. Otherwise, ensure the feature PICS code is not present in the PICS file.", "PICS exactly match for all features in all clusters."),
                 TestStep(7, "Ensure that the PICS_SDK_CI_ONLY PICS does not appear in the PICS file", "CI PICS is not present"),
-                TestStep(8, "If any of the checks failed, fail the test")]
+                TestStep(8, "If the device has a root node device type on this endpoint, ensure the MCORE.ROLE.COMMISSIONEE PICS code is set",
+                         "PICS is set if root node is present"),
+                TestStep(9, "If the device has any onboarding payload (MCORE.DD.QR or MCORE.DD.NFC), it has the manual pairing code PICS set (MCORE.DD.MANUAL_PC)",
+                         "Manual pairing code PICS is set if QR or NFC is set"),
+                TestStep(10, "If any of the checks failed, fail the test")]
 
     def test_TC_IDM_10_4(self):
         # wildcard read is done in setup_class
@@ -183,6 +187,27 @@ class TC_PICS_Checker(MatterBaseTest, BasicCompositionTests):
             self.success = False
 
         self.step(8)
+        # If there is a root node exposed on this endpoint, COMMISSIONEE must be marked
+        device_types = [dt.deviceType for dt in self.endpoints[self.endpoint_id]
+                        [Clusters.Descriptor][Clusters.Descriptor.Attributes.DeviceTypeList]]
+        # TODO: Getting this from an in-code reference would be good. See https://github.com/project-chip/matter-test-scripts/issues/689
+        root_node_device_type_id = 0x0016
+        if root_node_device_type_id in device_types and not self.check_pics('MCORE.ROLE.COMMISSIONEE'):
+            self.record_error("PICS check", location=UnknownProblemLocation(),
+                              problem="Root node found on endpoint, but MCORE.ROLE.COMMISSIONEE pics is not marked")
+            self.success = False
+
+        self.step(9)
+        # If the device supports a QR code or NFC code, it must also support a manual code per spec 5.7.6
+        # The only way a commissionable device can opt not to have these is if it is an in-field upgrade,
+        # in which case, there is no packaged onboarding code of any type. Subsequent codes generated from
+        # opening a commissioning window are tested as a part of the administrator commissioning test.
+        if (self.check_pics('MCORE.DD.QR') or self.check_pics('MCORE.DD.NFC')) and not self.check_pics('MCORE.DD.MANUAL_PC'):
+            self.record_error("PICS check", location=UnknownProblemLocation(),
+                              problem="Devices that support onboarding payloads must support a manual code")
+            self.success = False
+
+        self.step(10)
         if not self.success:
             self.fail_current_test("At least one PICS error was found for this endpoint")
 

--- a/src/python_testing/test_testing/example_pics_xml_basic_info.xml
+++ b/src/python_testing/test_testing/example_pics_xml_basic_info.xml
@@ -30,6 +30,19 @@ Draft
 			<status>O</status>
 			<support>true</support>
 		</picsItem>
+		<!-- This also isn't part of basic info, but I added a descriptor for checking some MCORE PICS -->
+		<picsItem>
+			<itemNumber>DESC.S</itemNumber>
+			<feature>Does the device implement the descriptor as a server?</feature>
+			<status>O</status>
+			<support>true</support>
+		</picsItem>
+		<picsItem>
+			<itemNumber>DESC.S.A0000</itemNumber>
+			<feature>Does the device implement the device type list attribute?</feature>
+			<status>O</status>
+			<support>true</support>
+		</picsItem>
 	</usage>
 	<!--PIXIT-->
 	<pixit>

--- a/src/python_testing/test_testing/test_IDM_10_4.py
+++ b/src/python_testing/test_testing/test_IDM_10_4.py
@@ -29,10 +29,11 @@ from matter.testing.runner import MockTestRunner
 # Vendor ID is included on ON in the PICS file
 
 
-def create_read(include_reachable: bool = False, include_max_paths: bool = False, include_vendor_id: bool = True) -> Attribute.AsyncReadTransaction.ReadResponse:
+def create_read(include_reachable: bool = False, include_max_paths: bool = False, include_vendor_id: bool = True, device_type: int = 0x01) -> Attribute.AsyncReadTransaction.ReadResponse:
     # Attribute read here is set to match the example_pics_xml_basic_info.xml in this directory
     bi = Clusters.BasicInformation.Attributes
     lvl = Clusters.LevelControl.Attributes
+    desc = Clusters.Descriptor.Attributes
     attrs_bi = {bi.DataModelRevision: 1,
                 bi.VendorName: 'testVendor',
                 bi.ProductName: 'testProduct',
@@ -69,18 +70,31 @@ def create_read(include_reachable: bool = False, include_max_paths: bool = False
     attrs_lvl[lvl.GeneratedCommandList] = []
     attrs_lvl[lvl.FeatureMap] = 0
 
+    attrs_desc = {}
+    attrs_desc[desc.DeviceTypeList] = [Clusters.Descriptor.Structs.DeviceTypeStruct(deviceType=device_type, revision=1)]
+    attrs_desc[desc.AttributeList] = [a.attribute_id for a in attrs_desc.keys()]
+    attrs_desc[desc.AcceptedCommandList] = []
+    attrs_desc[desc.GeneratedCommandList] = []
+    attrs_desc[desc.FeatureMap] = 0
+
     resp = Attribute.AsyncReadTransaction.ReadResponse({}, [], {})
-    resp.attributes = {0: {Clusters.BasicInformation: attrs_bi, Clusters.LevelControl: attrs_lvl}}
+    resp.attributes = {0: {Clusters.Descriptor: attrs_desc, Clusters.BasicInformation: attrs_bi, Clusters.LevelControl: attrs_lvl}}
 
     tlv_attrs_bi = {a.attribute_id: value for a, value in attrs_bi.items()}
     tlv_attrs_lvl = {a.attribute_id: value for a, value in attrs_lvl.items()}
-    resp.tlvAttributes = {0: {Clusters.BasicInformation.id: tlv_attrs_bi, Clusters.LevelControl.id: tlv_attrs_lvl}}
+    tlv_attrs_desc = {a.attribute_id: value for a, value in attrs_desc.items()}
+    tlv_attrs_desc[desc.DeviceTypeList.attribute_id] = [d.ToTLV() for d in attrs_desc[desc.DeviceTypeList]]
+    resp.tlvAttributes = {0: {Clusters.Descriptor.id: tlv_attrs_desc,
+                              Clusters.BasicInformation.id: tlv_attrs_bi, Clusters.LevelControl.id: tlv_attrs_lvl}}
 
+    print(resp)
     return resp
 
 
 def main():
     # TODO: add the same test for commands and features
+
+    ROOT_NODE_DEVICE_TYPE = 0x16
 
     script_dir = Path(__file__).resolve().parent
     with open(script_dir / 'example_pics_xml_basic_info.xml') as f:
@@ -91,7 +105,6 @@ def main():
 
     # Success, include vendor ID, which IS in the pics file, and neither of the incorrect ones
     resp = create_read()
-    print(resp)
     if not test_runner.run_test_with_mock_read(resp):
         failures.append("Test case failure: Vendor ID included - expected pass")
 
@@ -110,10 +123,59 @@ def main():
     if test_runner.run_test_with_mock_read(resp):
         failures.append("Test case failure: MaxPathsPerInvoke included but not in PICS- expected failure")
 
+    # If we make the device type a root node, this test should fail because MCORE.ROLE.COMMISSIONEE needs to be set
+    resp = create_read(device_type=ROOT_NODE_DEVICE_TYPE)
+    if test_runner.run_test_with_mock_read(resp):
+        failures.append("Test case failure: MCORE.ROLE.COMMISSIONEE is not included for a root node device - expected failure")
+
+    # If we add the MCORE.ROLE.COMMISSIONEE PICS, this should pass again.
+    pics['MCORE.ROLE.COMMISSIONEE'] = True
+    test_runner.config.pics = pics
+    resp = create_read(device_type=ROOT_NODE_DEVICE_TYPE)
+    if not test_runner.run_test_with_mock_read(resp):
+        failures.append("Test case failure: MCORE.ROLE.COMMISSIONEE is included for a root node device - expected success")
+
+    # If we add a QR code PICS with no manual, it should fail
+    pics['MCORE.DD.QR'] = True
+    test_runner.config.pics = pics
+    resp = create_read(device_type=ROOT_NODE_DEVICE_TYPE)
+    if test_runner.run_test_with_mock_read(resp):
+        failures.append("Test case failure: QR code with no manual code - expected failure")
+
+    # If we add the manual code, it should pass again
+    pics['MCORE.DD.MANUAL_PC'] = True
+    test_runner.config.pics = pics
+    resp = create_read(device_type=ROOT_NODE_DEVICE_TYPE)
+    if not test_runner.run_test_with_mock_read(resp):
+        failures.append("Test case failure: QR code with manual code - expected success")
+
+    # NFC only with no manual should fail
+    pics['MCORE.DD.QR'] = False
+    pics['MCORE.DD.MANUAL_PC'] = False
+    pics['MCORE.DD.NFC'] = True
+    test_runner.config.pics = pics
+    resp = create_read(device_type=ROOT_NODE_DEVICE_TYPE)
+    if test_runner.run_test_with_mock_read(resp):
+        failures.append("Test case failure: NFC code with no manual code - expected failure")
+
+    # If we add the manual code again, it should pass
+    pics['MCORE.DD.MANUAL_PC'] = True
+    test_runner.config.pics = pics
+    resp = create_read(device_type=ROOT_NODE_DEVICE_TYPE)
+    if not test_runner.run_test_with_mock_read(resp):
+        failures.append("Test case failure: NFC code with manual code - expected success")
+
+    # All three should also be fine.
+    pics['MCORE.DD.QR'] = True
+    test_runner.config.pics = pics
+    resp = create_read(device_type=ROOT_NODE_DEVICE_TYPE)
+    if not test_runner.run_test_with_mock_read(resp):
+        failures.append("Test case failure: NFC and QR code with manual code - expected success")
+
     pics['PICS_SDK_CI_ONLY'] = True
     test_runner.config.pics = pics
     # This is a success case for the attributes (as seen above), but the test should fail because the CI PICS is added
-    resp = create_read()
+    resp = create_read(device_type=ROOT_NODE_DEVICE_TYPE)
     if test_runner.run_test_with_mock_read(resp):
         failures.append("Test case failure: SDK CI PICS is included - expected failure")
 


### PR DESCRIPTION
#### Summary

Adds two new checks to the PICS check test to ensure that devices with a root node have the commissionee PICS marked and devices that have any onboarding payload include a manual code.

#### Related issues

https://github.com/CHIP-Specifications/chip-test-plans/pull/5557
https://github.com/CHIP-Specifications/chip-test-plans/pull/5581

#### Testing

Tests for negative and positive cases added to the test_TC_IDM_10_4 meta-test.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
