### PR TITLE
[PAVST] Add missing checks to PAVST 2.3 and address missing delegate logic

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/push-av-stream-transport-delegate-impl.h
+++ b/examples/all-clusters-app/all-clusters-common/include/push-av-stream-transport-delegate-impl.h
@@ -66,7 +66,7 @@ public:
 
     bool ValidateStreamUsage(StreamUsageEnum streamUsage) override;
 
-    bool ValidateSegmentDuration(uint16_t segmentDuration) override;
+    bool ValidateSegmentDuration(uint16_t segmentDuration, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override;
 
     Protocols::InteractionModel::Status SelectAudioStream(StreamUsageEnum streamUsage, uint16_t & audioStreamId) override;
 

--- a/examples/all-clusters-app/all-clusters-common/src/push-av-stream-transport-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/push-av-stream-transport-delegate-impl.cpp
@@ -105,7 +105,8 @@ bool PushAvStreamTransportManager::ValidateStreamUsage(StreamUsageEnum streamUsa
     return true;
 }
 
-bool PushAvStreamTransportManager::ValidateSegmentDuration(uint16_t segmentDuration)
+bool PushAvStreamTransportManager::ValidateSegmentDuration(uint16_t segmentDuration,
+                                                           const Optional<DataModel::Nullable<uint16_t>> & videoStreamId)
 {
     return true;
 }

--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -80,7 +80,7 @@ public:
 
     bool ValidateStreamUsage(StreamUsageEnum streamUsage) override;
 
-    bool ValidateSegmentDuration(uint16_t segmentDuration) override;
+    bool ValidateSegmentDuration(uint16_t segmentDuration, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override;
 
     Protocols::InteractionModel::Status
     ValidateBandwidthLimit(StreamUsageEnum streamUsage, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -363,15 +363,13 @@ bool PushAvStreamTransportManager::ValidateSegmentDuration(uint16_t segmentDurat
     // If the video stream ID is missing or null, error log and return false
     if (!videoStreamId.HasValue())
     {
-        ChipLogError(Camera, "Segment validation requested with no provided stream")
-        return false;
+        ChipLogError(Camera, "Segment validation requested with no provided stream") return false;
     }
     else
     {
         if (videoStreamId.Value().IsNull())
         {
-            ChipLogError(Camera, "Segment validation requested against a Null stream")
-            return false;
+            ChipLogError(Camera, "Segment validation requested against a Null stream") return false;
         }
     }
 

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -366,7 +366,7 @@ bool PushAvStreamTransportManager::ValidateSegmentDuration(uint16_t segmentDurat
         ChipLogError(Camera, "Segment validation requested with no provided stream")
         return false;
     }
-    else 
+    else
     {
         if (videoStreamId.Value().IsNull())
         {

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -153,7 +153,7 @@ public:
      * @param videoStreamId   The video stream to eb validated against
      * @return true if Segment Duration is multiple of KeyFrameInterval for the provided videoStreamId, false otherwise
      */
-    virtual bool ValidateSegmentDuration(uint16_t segmentDuration, 
+    virtual bool ValidateSegmentDuration(uint16_t segmentDuration,
                                          const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) = 0;
 
     /**

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -150,9 +150,11 @@ public:
      * @brief Validates the provided Segment Duration.
      *
      * @param segmentDuration The Segment Duration to validate
-     * @return true if Segment Duration is multiple of KeyFrameInterval, false otherwise
+     * @param videoStreamId   The video stream to eb validated against
+     * @return true if Segment Duration is multiple of KeyFrameInterval for the provided videoStreamId, false otherwise
      */
-    virtual bool ValidateSegmentDuration(uint16_t segmentDuration) = 0;
+    virtual bool ValidateSegmentDuration(uint16_t segmentDuration, 
+                                         const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) = 0;
 
     /**
      * @brief Validates bandwidth requirements against camera's resource management.

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
@@ -799,7 +799,7 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
     }
 
     bool isValidSegmentDuration =
-        mDelegate->ValidateSegmentDuration(transportOptions.containerOptions.CMAFContainerOptions.Value().segmentDuration, 
+        mDelegate->ValidateSegmentDuration(transportOptions.containerOptions.CMAFContainerOptions.Value().segmentDuration,
                                            transportOptionsPtr->videoStreamID);
     if (isValidSegmentDuration == false)
     {

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
@@ -798,9 +798,8 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
         }
     }
 
-    bool isValidSegmentDuration =
-        mDelegate->ValidateSegmentDuration(transportOptions.containerOptions.CMAFContainerOptions.Value().segmentDuration,
-                                           transportOptionsPtr->videoStreamID);
+    bool isValidSegmentDuration = mDelegate->ValidateSegmentDuration(
+        transportOptions.containerOptions.CMAFContainerOptions.Value().segmentDuration, transportOptionsPtr->videoStreamID);
     if (isValidSegmentDuration == false)
     {
         auto segmentDurationStatus = to_underlying(StatusCodeEnum::kInvalidOptions);

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
@@ -799,7 +799,8 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
     }
 
     bool isValidSegmentDuration =
-        mDelegate->ValidateSegmentDuration(transportOptions.containerOptions.CMAFContainerOptions.Value().segmentDuration);
+        mDelegate->ValidateSegmentDuration(transportOptions.containerOptions.CMAFContainerOptions.Value().segmentDuration, 
+                                           transportOptionsPtr->videoStreamID);
     if (isValidSegmentDuration == false)
     {
         auto segmentDurationStatus = to_underlying(StatusCodeEnum::kInvalidOptions);

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -285,7 +285,7 @@ public:
 
     bool ValidateStreamUsage(StreamUsageEnum streamUsage) override { return true; }
 
-    bool ValidateSegmentDuration(uint16_t segmentDuration) override { return true; }
+    bool ValidateSegmentDuration(uint16_t segmentDuration, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override { return true; }
 
     Protocols::InteractionModel::Status
     ValidateBandwidthLimit(StreamUsageEnum streamUsage, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -285,7 +285,10 @@ public:
 
     bool ValidateStreamUsage(StreamUsageEnum streamUsage) override { return true; }
 
-    bool ValidateSegmentDuration(uint16_t segmentDuration, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override { return true; }
+    bool ValidateSegmentDuration(uint16_t segmentDuration, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override
+    {
+        return true;
+    }
 
     Protocols::InteractionModel::Status
     ValidateBandwidthLimit(StreamUsageEnum streamUsage, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,

--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -232,7 +232,7 @@ class PAVSTTestBase:
 
         containerOptions = {
             "containerType": cluster.Enums.ContainerFormatEnum.kCmaf,
-            "CMAFContainerOptions": {"CMAFInterface": cluster.Enums.CMAFInterfaceEnum.kInterface1, "chunkDuration": 4, "segmentDuration": 500,
+            "CMAFContainerOptions": {"CMAFInterface": cluster.Enums.CMAFInterfaceEnum.kInterface1, "chunkDuration": 4, "segmentDuration": 4000,
                                      "sessionGroup": 3, "trackName": " "},
         }
 

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -118,7 +118,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             TestStep(20, "TH sends the AllocatePushTransport command with a AudioStreamID not present in aAllocatedAudioStreams.",
                      "DUT responds with Status Code InvalidStream."),
             TestStep(21, "TH sends the AllocatePushTransport command with both VideoStreamID and AudioStreamID absent.",
-                     "DUT responds with Status Code InvalidArgument."),
+                     "DUT responds with Status Code InvalidCommand."),
             TestStep(22, "TH sends the AllocatePushTransport command with both VideoStreamID and AudioStreamID set to None..",
                      "DUT responds with AllocatePushTransportResponse containing the allocated ConnectionID."),
             TestStep(23, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with the TriggerType = Motion and size of the MotionZones list to be greater than aMaxZones.",

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -513,18 +513,18 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             "CMAFContainerOptions": {"CMAFInterface": pvcluster.Enums.CMAFInterfaceEnum.kInterface1, "chunkDuration": 4, "segmentDuration": 6000,
                                      "sessionGroup": 3, "trackName": " "},
         }
-        status = await self.allocate_one_pushav_transport(endpoint, expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidOptions, 
-                                                          stream_Usage=Clusters.Globals.Enums.StreamUsageEnum.kRecording, tlsEndPoint=tlsEndpointId, 
+        status = await self.allocate_one_pushav_transport(endpoint, expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidOptions,
+                                                          stream_Usage=Clusters.Globals.Enums.StreamUsageEnum.kRecording, tlsEndPoint=tlsEndpointId,
                                                           container_Options=containerOptions, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
         asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidOptions,
-                            "DUT must responds with Status Code InvalidOptions.")
+                             "DUT must responds with Status Code InvalidOptions.")
 
         self.step(34)
-        status = await self.allocate_one_pushav_transport(endpoint, expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidStreamUsage, 
+        status = await self.allocate_one_pushav_transport(endpoint, expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidStreamUsage,
                                                           stream_Usage=Clusters.Globals.Enums.StreamUsageEnum.kInternal,
                                                           tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
         asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidStreamUsage,
-                             "DUT must  responds with Status code InvalidStreamUsage")        
+                             "DUT must  responds with Status code InvalidStreamUsage")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_PAVST_2_3.py
+++ b/src/python_testing/TC_PAVST_2_3.py
@@ -44,6 +44,7 @@ from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
 from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
+from matter.clusters import Globals
 from matter.clusters.Types import Nullable, NullValue
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
@@ -80,64 +81,70 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
                      "Verify the number of PushAV Connections in the list is 0. If not 0, issue DeAllocatePushAVTransport with `ConnectionID to remove any connections."),
             TestStep(2, "TH Reads SupportedFormats attribute from PushAV Stream Transport Cluster on DUT",
                      "Store value as aSupportedFormats."),
-            TestStep(3, "TH Reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
+            TestStep(3, "TH sends the AllocatePushTransport command with valid parameters",
+                     "DUT responds with InvalidInState as no streams have been allocated."),
+            TestStep(4, "TH Reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
                      "Verify that list is not empty. Store value as aAllocatedVideoStreams."),
-            TestStep(4, "TH Reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
+            TestStep(5, "TH Reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
                      "Verify that list is not empty. Store value as aAllocatedAudioStreams."),
-            TestStep(5, "TH sends the AllocatePushTransport command with valid parameters",
+            TestStep(6, "TH sends the AllocatePushTransport command with valid parameters",
                      "DUT responds with AllocatePushTransportResponse containing the allocated ConnectionID, TransportOptions, and TransportStatus in the TransportConfigurationStruct. Store ConnectionID as aConnectionID."),
-            TestStep(6, "TH Reads CurrentConnections attribute from PushAV Stream Transport Cluster on DUT over a large-payload session",
+            TestStep(7, "TH Reads CurrentConnections attribute from PushAV Stream Transport Cluster on DUT over a large-payload session",
                      "Verify the number of PushAV Connections is 1. Verify that the TransportStatus field is Inactive."),
-            TestStep(7, "TH Reads Zones attribute from Zones Management Cluster on DUT, if the zone management cluster is present on this endpoint",
+            TestStep(8, "TH Reads Zones attribute from Zones Management Cluster on DUT, if the zone management cluster is present on this endpoint",
                      "Store value as aZones."),
-            TestStep(8, "TH Reads MaxZones attribute from Zones Management Cluster on DUT, if the zone management cluster is present on this endpoint",
+            TestStep(9, "TH Reads MaxZones attribute from Zones Management Cluster on DUT, if the zone management cluster is present on this endpoint",
                      "Store value as aMaxZones."),
-            TestStep(9, "TH Reads ProvisionedEndpoints attribute from TLS Client Management Cluster on DUT",
+            TestStep(10, "TH Reads ProvisionedEndpoints attribute from TLS Client Management Cluster on DUT",
                      "Store value as aProvisionedEndpoints."),
-            TestStep(10, "TH sends the AllocatePushTransport command with a TLSEndpointID not in aProvisionedEndpoints in the TransportOptions struct.",
+            TestStep(11, "TH sends the AllocatePushTransport command with a TLSEndpointID not in aProvisionedEndpoints in the TransportOptions struct.",
                      "DUT responds with Status Code InvalidTLSEndpoint."),
-            TestStep(11, "TH sends the AllocatePushTransport command with an invalid IngestMethod.",
+            TestStep(12, "TH sends the AllocatePushTransport command with an invalid IngestMethod.",
                      "DUT responds with Status Code ConstraintError."),
-            TestStep(12, "DUT responds with Status Code InvalidURL.",
+            TestStep(13, "DUT responds with Status Code InvalidURL.",
                      "DUT responds with Status Code InvalidURL."),
-            TestStep(13, "TH sends the AllocatePushTransport command with an invalid TriggerType in the TransportTriggerOptions struct field.",
+            TestStep(14, "TH sends the AllocatePushTransport command with an invalid TriggerType in the TransportTriggerOptions struct field.",
                      "DUT responds with Status Code InvalidTriggerType."),
-            TestStep(14, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with an Null Zone within MotionZones.",
+            TestStep(15, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with an Null Zone within MotionZones.",
                      "DUT responds with Status Code Success."),
-            TestStep(15, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with duplicate numeric Zone IDs within MotionZones.",
+            TestStep(16, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with duplicate numeric Zone IDs within MotionZones.",
                      "DUT responds with Status Code AlredyExists."),
-            TestStep(16, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with duplicate Null Zone IDs within MotionZones.",
+            TestStep(17, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with duplicate Null Zone IDs within MotionZones.",
                      "DUT responds with Status Code AlredyExists."),
-            TestStep(17, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with an invalid ZoneID that is not present in aZones.",
+            TestStep(18, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with an invalid ZoneID that is not present in aZones.",
                      "DUT responds with Status Code InvalidZone."),
-            TestStep(18, "TH sends the AllocatePushTransport command with a VideoStreamID not present in aAllocatedVideoStreams.",
+            TestStep(19, "TH sends the AllocatePushTransport command with a VideoStreamID not present in aAllocatedVideoStreams.",
                      "DUT responds with Status Code InvalidStream."),
-            TestStep(19, "TH sends the AllocatePushTransport command with a AudioStreamID not present in aAllocatedAudioStreams.",
+            TestStep(20, "TH sends the AllocatePushTransport command with a AudioStreamID not present in aAllocatedAudioStreams.",
                      "DUT responds with Status Code InvalidStream."),
-            TestStep(20, "TH sends the AllocatePushTransport command with both VideoStreamID and AudioStreamID absent.",
+            TestStep(21, "TH sends the AllocatePushTransport command with both VideoStreamID and AudioStreamID absent.",
                      "DUT responds with Status Code InvalidArgument."),
-            TestStep(21, "TH sends the AllocatePushTransport command with both VideoStreamID and AudioStreamID set to None..",
+            TestStep(22, "TH sends the AllocatePushTransport command with both VideoStreamID and AudioStreamID set to None..",
                      "DUT responds with AllocatePushTransportResponse containing the allocated ConnectionID."),
-            TestStep(22, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with the TriggerType = Motion and size of the MotionZones list to be greater than aMaxZones.",
-                     "DUT responds with ConstraintError."),
-            TestStep(23, "TH sends the AllocatePushTransport command with the TriggerType = Motion and valid value for MotionSensitivity if DUT supports PerZoneSensitivity.",
+            TestStep(23, "If the zone management cluster is present on this endpoint, TH sends the AllocatePushTransport command with the TriggerType = Motion and size of the MotionZones list to be greater than aMaxZones.",
+                     "DUT responds with DynamicConstraintError."),
+            TestStep(24, "TH sends the AllocatePushTransport command with the TriggerType = Motion and valid value for MotionSensitivity if DUT supports PerZoneSensitivity.",
                      "DUT responds with InvalidCommand."),
-            TestStep(24, "TH sends the AllocatePushTransport command with the TriggerType = Motion and MotionSensitivity > 10 if DUT does not support PerZoneSensitivity.",
+            TestStep(25, "TH sends the AllocatePushTransport command with the TriggerType = Motion and MotionSensitivity > 10 if DUT does not support PerZoneSensitivity.",
                      "DUT responds with ConstraintError."),
-            TestStep(25, "TH sends the AllocatePushTransport command with the TriggerType = Motion and MotionTimeControl omitted.",
+            TestStep(26, "TH sends the AllocatePushTransport command with the TriggerType = Motion and MotionTimeControl omitted.",
                      "DUT responds with InvalidCommand."),
-            TestStep(26, "TH sends the AllocatePushTransport command with the TriggerType = Motion and MotionTimeControl struct with InitialDuration = 0.",
+            TestStep(27, "TH sends the AllocatePushTransport command with the TriggerType = Motion and MotionTimeControl struct with InitialDuration = 0.",
                      "DUT responds with ConstraintError."),
-            TestStep(27, "TH sends the AllocatePushTransport command with the TriggerType = Motion and MotionTimeControl struct with MaxDuration = 0.",
+            TestStep(28, "TH sends the AllocatePushTransport command with the TriggerType = Motion and MotionTimeControl struct with MaxDuration = 0.",
                      "DUT responds with ConstraintError."),
-            TestStep(28, "TH deallocates transport allocated in step 5 using DeallocatePushTransport command successfully. TH sends the AllocatePushTransport command with all valid parameters. The TriggerType = Motion and MotionZones and MotionSensitivity fields are present and None.",
+            TestStep(29, "TH deallocates transport allocated in step 5 using DeallocatePushTransport command successfully. TH sends the AllocatePushTransport command with all valid parameters. The TriggerType = Motion and MotionZones and MotionSensitivity fields are present and None.",
                      "DUT responds with AllocatePushTransportResponse containing the allocated ConnectionID."),
-            TestStep(29, "DUT responds with AllocatePushTransportResponse containing the allocated ConnectionID.",
+            TestStep(30, "DUT responds with AllocatePushTransportResponse containing the allocated ConnectionID.",
                      "DUT responds with AllocatePushTransportResponse containing the allocated ConnectionID."),
-            TestStep(30, "TH sends the AllocatePushTransport command with an invalid value for StreamUsage in the TransportOptions struct.",
+            TestStep(31, "TH sends the AllocatePushTransport command with an invalid value for StreamUsage in the TransportOptions struct.",
                      "DUT responds with InvalidCommand."),
-            TestStep(31, "TH sends the AllocatePushTransport command with ContainerType = CMAF and CMAFContainerOptions omitted.",
+            TestStep(32, "TH sends the AllocatePushTransport command with ContainerType = CMAF and CMAFContainerOptions omitted.",
                      "DUT responds with InvalidCommand."),
+            TestStep(33, "TH sends the AllocatePushTransport command with ContainerType = CMAF and CMAFContainerOptions having a segment that is not an exact multiplier of the framerate.",
+                     "DUT responds with InvalidOptions."),
+            TestStep(34, "TH sends the AllocatePushTransport command with an value for StreamUsage not in SupportedStreamUsages.",
+                     "DUT responds with InvalidStreamUsage."),
         ]
 
     @async_test_body
@@ -173,6 +180,29 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_greater_equal(len(supported_formats), 1, "SupportedFormats must not be empty!")
 
         self.step(3)
+        try:
+            status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
+                {
+                    "streamUsage": Globals.Enums.StreamUsageEnum.kRecording,
+                    "videoStreamID": NullValue,
+                    "audioStreamID": NullValue,
+                    "endpointID": tlsEndpointId,
+                    "url": f"https://{host_ip}:1234/streams/1",
+                    "triggerOptions": {"triggerType": 2},
+                    "ingestMethod": 0,
+                    "containerOptions": {
+                        "containerType": 0,
+                        "CMAFContainerOptions": {"CMAFInterface": 0, "segmentDuration": 4000, "chunkDuration": 2000, "sessionGroup": 1, "trackName": "media"}
+                    },
+                    "expiryTime": 5
+                }), endpoint=endpoint)
+            asserts.assert_equal(status, Status.InvalidInState,
+                                 "Unexpected success when the DUT must respond with Status Code InvalidInState.")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.InvalidInState,
+                                 f"DUT must respond with Status Code InvalidInState, received {e.status}.")
+
+        self.step(4)
         aAllocatedVideoStreams = await self.allocate_one_video_stream()
         asserts.assert_greater_equal(
             len(aAllocatedVideoStreams),
@@ -180,7 +210,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             "AllocatedVideoStreams must not be empty",
         )
 
-        self.step(4)
+        self.step(5)
         aAllocatedAudioStreams = await self.allocate_one_audio_stream()
         asserts.assert_greater_equal(
             len(aAllocatedAudioStreams),
@@ -188,13 +218,13 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             "AllocatedAudioStreams must not be empty",
         )
 
-        self.step(5)
+        self.step(6)
         status = await self.allocate_one_pushav_transport(endpoint, tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
         asserts.assert_equal(
             status, Status.Success, "Push AV Transport should be allocated successfully"
         )
 
-        self.step(6)
+        self.step(7)
         current_connections = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=pvcluster, attribute=pvcluster.Attributes.CurrentConnections
         )
@@ -203,26 +233,26 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_equal(current_connections[0].transportStatus,
                              pvcluster.Enums.TransportStatusEnum.kInactive, "TransportStatus must be Inactive")
 
-        self.step(7)
+        self.step(8)
         aZones = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=zmcluster, attribute=zmcluster.Attributes.Zones
         )
         logger.info(f"aZones: {aZones}")
 
-        self.step(8)
+        self.step(9)
         aMaxZones = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=zmcluster, attribute=zmcluster.Attributes.MaxZones
         )
         logger.info(f"aMaxZones: {aMaxZones}")
 
-        self.step(9)
+        self.step(10)
         if self.pics_guard(self.check_pics("PAVST.S")):
             aProvisionedEndpoints = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=tlscluster, attribute=tlscluster.Attributes.ProvisionedEndpoints
             )
             logger.info(f"aProvisionedEndpoints: {aProvisionedEndpoints}")
 
-        self.step(10)
+        self.step(11)
         if self.pics_guard(self.check_pics("PAVST.S")):
             try:
                 status = await self.send_single_cmd(cmd=pvcluster.Commands.AllocatePushTransport(
@@ -246,25 +276,25 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
                 asserts.assert_equal(e.clusterStatus, pvcluster.Enums.StatusCodeEnum.kInvalidTLSEndpoint,
                                      "DUT must responds with Status Code InvalidTLSEndpoint.")
 
-        self.step(11)
+        self.step(12)
         status = await self.allocate_one_pushav_transport(endpoint, ingestMethod=pvcluster.Enums.IngestMethodsEnum.kUnknownEnumValue,
                                                           tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
         asserts.assert_equal(status, Status.ConstraintError,
                              "DUT must respond with Status Code ConstraintError.")
 
-        self.step(12)
+        self.step(13)
         status = await self.allocate_one_pushav_transport(endpoint, expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidURL,
                                                           tlsEndPoint=tlsEndpointId, url=f"https:/{host_ip}:1234/streams/{uploadStreamId}")
         asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidURL,
                              "DUT must respond with Status Code InvalidURL.")
 
-        self.step(13)
+        self.step(14)
         status = await self.allocate_one_pushav_transport(endpoint, triggerType=pvcluster.Enums.TransportTriggerTypeEnum.kUnknownEnumValue,
                                                           tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
         asserts.assert_equal(status, Status.ConstraintError,
                              "DUT must respond with Status Code ConstraintError.")
 
-        self.step(14)
+        self.step(15)
         # Verify a null Zone is handled
         try:
             zoneList = [{"zone": NullValue, "sensitivity": 4}]
@@ -278,7 +308,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             asserts.assert_fail(f"Unexpected error when setting a Zone that is Null (meaning all Zones). Error received {e.status}")
 
         # Duplicate Zone ID rejection
-        self.step(15)
+        self.step(16)
         zoneList = [{"zone": 1, "sensitivity": 4}, {"zone": 2, "sensitivity": 4},
                     {"zone": 3, "sensitivity": 4}, {"zone": 1, "sensitivity": 4}]
         triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
@@ -289,7 +319,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_equal(status, Status.AlreadyExists,
                              "DUT should respond with Status Code AlreadyExists with a Duplicate Zone.")
 
-        self.step(16)
+        self.step(17)
         # Duplicate Zone ID rejection with Nulls
         zoneList = [{"zone": 1, "sensitivity": 4}, {"zone": NullValue, "sensitivity": 4},
                     {"zone": 3, "sensitivity": 4}, {"zone": NullValue, "sensitivity": 4}]
@@ -301,7 +331,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_equal(status, Status.AlreadyExists,
                              "DUT should respond with Status Code AlreadyExists with Duplicate Null Zones.")
 
-        self.step(17)
+        self.step(18)
         try:
             zoneList = [{"zone": 14, "sensitivity": 4}]
             triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
@@ -316,21 +346,21 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             asserts.assert_equal(e.clusterStatus, pvcluster.Enums.StatusCodeEnum.kInvalidZone,
                                  "DUT must responds with Status Code InvalidZone.")
 
-        self.step(18)
+        self.step(19)
         status = await self.allocate_one_pushav_transport(endpoint, videoStream_ID=-1,
                                                           expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidStream,
                                                           tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
         asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidStream,
                              "DUT must  responds with Status Code InvalidStream.")
 
-        self.step(19)
+        self.step(20)
         status = await self.allocate_one_pushav_transport(endpoint, audioStream_ID=-1,
                                                           expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidStream,
                                                           tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
         asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidStream,
                              "DUT must  responds with Status Code InvalidStream.")
 
-        self.step(20)
+        self.step(21)
         try:
             aStreamUsagePriorities = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=avcluster, attribute=avattr.StreamUsagePriorities
@@ -358,13 +388,13 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             asserts.assert_equal(e.status, Status.InvalidCommand,
                                  "DUT must respond with Status Code InvalidCommand.")
 
-        self.step(21)
+        self.step(22)
         status = await self.allocate_one_pushav_transport(endpoint, videoStream_ID=Nullable(), audioStream_ID=Nullable(),
                                                           tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
         asserts.assert_equal(status, Status.Success,
                              "DUT must  responds with Status Code Success.")
 
-        self.step(22)
+        self.step(23)
         # Create a zoneList that is one larger than max zones that we have already read
         zoneList = []
         for i in range(aMaxZones+1):
@@ -379,7 +409,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_equal(status, Status.DynamicConstraintError,
                              "DUT must respond with Status code DynamicConstraintError")
 
-        self.step(23)
+        self.step(24)
         zoneList = []
         triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
                           "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1},
@@ -389,7 +419,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_equal(status, Status.InvalidCommand,
                              "DUT must  responds with Status Code InvalidCommand.")
 
-        self.step(24)
+        self.step(25)
         zoneList = []
         triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
                           "motionTimeControl": {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1},
@@ -399,7 +429,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_equal(status, Status.InvalidCommand,
                              "DUT must  responds with Status Code InvalidCommand.")
 
-        self.step(25)
+        self.step(26)
         zoneList = []
         triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
                           "motionZones": zoneList,
@@ -408,7 +438,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_equal(status, Status.InvalidCommand,
                              "DUT must  responds with Status Code InvalidCommand.")
 
-        self.step(26)
+        self.step(27)
         zoneList = []
         triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
                           "motionZones": zoneList,
@@ -418,7 +448,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_equal(status, Status.ConstraintError,
                              "DUT must  responds with Status code ConstraintError")
 
-        self.step(27)
+        self.step(28)
         zoneList = []
         triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
                           "motionZones": zoneList,
@@ -428,7 +458,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_equal(status, Status.ConstraintError,
                              "DUT must  responds with Status code ConstraintError")
 
-        self.step(28)
+        self.step(29)
         cmd = pvcluster.Commands.DeallocatePushTransport(
             connectionID=aConnectionID
         )
@@ -449,7 +479,7 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         )
         aConnectionID = current_connections[len(current_connections)-1].connectionID
 
-        self.step(29)
+        self.step(30)
         cmd = pvcluster.Commands.DeallocatePushTransport(
             connectionID=aConnectionID
         )
@@ -465,17 +495,36 @@ class TC_PAVST_2_3(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_equal(status, Status.Success,
                              "DUT must  responds with Status Code Success.")
 
-        self.step(30)
+        self.step(31)
         status = await self.allocate_one_pushav_transport(endpoint, stream_Usage=Clusters.Globals.Enums.StreamUsageEnum.kUnknownEnumValue,
                                                           tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
         asserts.assert_equal(status, Status.ConstraintError,
                              "DUT must  responds with Status code ConstraintError")
 
-        self.step(31)
+        self.step(32)
         containerOptions = {"containerType": pvcluster.Enums.ContainerFormatEnum.kCmaf}
         status = await self.allocate_one_pushav_transport(endpoint, container_Options=containerOptions, tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
         asserts.assert_equal(status, Status.InvalidCommand,
                              "DUT must  responds with Status code InvalidCommand")
+
+        self.step(33)
+        containerOptions = {
+            "containerType": pvcluster.Enums.ContainerFormatEnum.kCmaf,
+            "CMAFContainerOptions": {"CMAFInterface": pvcluster.Enums.CMAFInterfaceEnum.kInterface1, "chunkDuration": 4, "segmentDuration": 6000,
+                                     "sessionGroup": 3, "trackName": " "},
+        }
+        status = await self.allocate_one_pushav_transport(endpoint, expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidOptions, 
+                                                          stream_Usage=Clusters.Globals.Enums.StreamUsageEnum.kRecording, tlsEndPoint=tlsEndpointId, 
+                                                          container_Options=containerOptions, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
+        asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidOptions,
+                            "DUT must responds with Status Code InvalidOptions.")
+
+        self.step(34)
+        status = await self.allocate_one_pushav_transport(endpoint, expected_cluster_status=pvcluster.Enums.StatusCodeEnum.kInvalidStreamUsage, 
+                                                          stream_Usage=Clusters.Globals.Enums.StreamUsageEnum.kInternal,
+                                                          tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}")
+        asserts.assert_equal(status, pvcluster.Enums.StatusCodeEnum.kInvalidStreamUsage,
+                             "DUT must  responds with Status code InvalidStreamUsage")        
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Summary

Add missing checks to PAVST 2.3 for spec error cases
Add missing code to delegate that validated segment duration and stream usage 
Correct PUSH AV so stream selection is done against allocated and not available streams

#### Related issues

Partially fixes Push AV compendium issue

#### Testing

Execute Push AV 2.3 via the Python Runner

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
