### PR TITLE
Change unit of MaxNetworkBandwidth to bps from Mbps at CameraAVSM initialization from camera-app.

### DIFF
--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -30,6 +30,8 @@ using namespace chip::app::Clusters::CameraAvStreamManagement;
 using namespace chip::app::Clusters::CameraAvSettingsUserLevelManagement;
 using namespace chip::app::Clusters::ZoneManagement;
 
+static constexpr uint32_t kBitsPerMegabit = 1000000;
+
 template <typename T>
 using List   = chip::app::DataModel::List<T>;
 using Status = Protocols::InteractionModel::Status;
@@ -139,7 +141,7 @@ CameraApp::CameraApp(chip::EndpointId aClustersEndpoint, CameraDeviceInterface *
         ? TwoWayTalkSupportTypeEnum::kFullDuplex
         : TwoWayTalkSupportTypeEnum::kNotSupported;
     std::vector<SnapshotCapabilitiesStruct> snapshotCapabilities = mCameraDevice->GetCameraHALInterface().GetSnapshotCapabilities();
-    uint32_t maxNetworkBandwidth                                 = mCameraDevice->GetCameraHALInterface().GetMaxNetworkBandwidth();
+    uint32_t maxNetworkBandwidth = mCameraDevice->GetCameraHALInterface().GetMaxNetworkBandwidth() * kBitsPerMegabit;
     std::vector<StreamUsageEnum> supportedStreamUsages = mCameraDevice->GetCameraHALInterface().GetSupportedStreamUsages();
     std::vector<StreamUsageEnum> streamUsagePriorities = mCameraDevice->GetCameraHALInterface().GetStreamUsagePriorities();
 


### PR DESCRIPTION
#### Summary

Fixes MaxNetworkBandwidth unit issue in https://github.com/project-chip/connectedhomeip/issues/40634

#### Testing
All Camera AVSM tests pass

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
