### PR TITLE
chip-tool should advertise on loopback interface only when running CI tests.

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -158,6 +158,11 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
         port = static_cast<uint16_t>(port + CurrentCommissionerId());
     }
     factoryInitParams.listenPort = port;
+    if (mInterfaceId.HasValue())
+    {
+        factoryInitParams.interfaceId =
+            chip::Inet::InterfaceId(static_cast<chip::Inet::InterfaceId::PlatformType>(mInterfaceId.Value()));
+    }
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryInitParams));
 
     auto systemState = chip::Controller::DeviceControllerFactory::GetInstance().GetSystemState();

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -185,6 +185,8 @@ protected:
 
     ChipDeviceCommissioner & GetCommissioner(std::string identity);
 
+    chip::Optional<int32_t> mInterfaceId;
+
 private:
     CHIP_ERROR MaybeSetUpStack();
     void MaybeTearDownStack();

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.h
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.h
@@ -37,7 +37,10 @@ public:
         mHandler(commandsHandler)
     {
         AddArgument("advertise-operational", 0, 1, &mAdvertiseOperational,
-                    "Advertise operational node over DNS-SD and accept incoming CASE sessions.");
+                    "Advertise operational node over DNS-SD and accept incoming CASE sessions.  Defaults to true.");
+        AddArgument("interface-id", -1, INT32_MAX, &mInterfaceId,
+                    "Specific interface to use for advertising operationally. The exact meaning of this signed integer depends on "
+                    "the platform. Only used when advertise-operational is true.");
     }
 
     /////////// CHIPCommand Interface /////////

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -450,6 +450,7 @@ class TestDefinition:
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \
                     ['--server_arguments', 'interactive server' +
+                        (' --interface-id -1' if test_runtime == TestRunTime.CHIP_TOOL_PYTHON else '') +
                         (' ' if len(tool_storage_args) else '') + ' '.join(tool_storage_args)]
                 pairing_cmd += server_args
                 test_cmd += server_args

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -62,6 +62,7 @@ CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
     // Save our initialization state that we can't recover later from a
     // created-but-shut-down system state.
     mListenPort                = params.listenPort;
+    mInterfaceId               = params.interfaceId;
     mFabricIndependentStorage  = params.fabricIndependentStorage;
     mOperationalKeystore       = params.operationalKeystore;
     mOpCertStore               = params.opCertStore;
@@ -91,6 +92,7 @@ CHIP_ERROR DeviceControllerFactory::ReinitSystemStateIfNecessary()
     params.bleLayer = mSystemState->BleLayer();
 #endif
     params.listenPort                = mListenPort;
+    params.interfaceId               = mInterfaceId;
     params.fabricIndependentStorage  = mFabricIndependentStorage;
     params.enableServerInteractions  = mEnableServerInteractions;
     params.groupDataProvider         = mSystemState->GetGroupDataProvider();
@@ -290,6 +292,11 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         app::DnssdServer::Instance().SetSecuredIPv4Port(
             stateParams.transportMgr->GetTransport().GetImplAtIndex<1>().GetBoundPort());
 #endif // INET_CONFIG_ENABLE_IPV4
+
+        if (params.interfaceId)
+        {
+            app::DnssdServer::Instance().SetInterfaceId(*params.interfaceId);
+        }
 
         //
         // TODO: This is a hack to workaround the fact that we have a bi-polar stack that has controller and server modalities that

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -34,7 +34,10 @@
 #include <credentials/GroupDataProvider.h>
 #include <credentials/OperationalCertificateStore.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <inet/InetInterface.h>
 #include <protocols/secure_channel/SessionResumptionStorage.h>
+
+#include <optional>
 
 namespace chip {
 
@@ -165,6 +168,8 @@ struct FactoryInitParams
     // data model it wants to use. Backwards-compatibility can use `CodegenDataModelProviderInstance`
     // for ember/zap-generated models.
     chip::app::DataModel::Provider * dataModelProvider = nullptr;
+
+    std::optional<Inet::InterfaceId> interfaceId;
 };
 
 class DeviceControllerFactory
@@ -291,6 +296,8 @@ private:
     void ControllerInitialized(const DeviceController & controller);
 
     uint16_t mListenPort;
+    std::optional<Inet::InterfaceId> mInterfaceId;
+
     DeviceControllerSystemState * mSystemState                          = nullptr;
     PersistentStorageDelegate * mFabricIndependentStorage               = nullptr;
     Crypto::OperationalKeystore * mOperationalKeystore                  = nullptr;


### PR DESCRIPTION
When running in interactive mode (which is what CI tests use for running chip-tool based tests), chip-tool advertises operationally.  It was advertising on all interfaces, and it uses the same hostname as the server app, so when it tried to send commands to the server app it could end up with a non-loopback IP.  And this sometimes failed in CI with "Network is unreachable".

This change:

* Adds support to CHIPDeviceControllerFactory init for setting an interface id to use, like Server init already has.
* Adds support to chip-tool to take an "interface-id" optional argument in interactive modes and propagate it through to controller factory init.
* Passes "--interface-id -1" as an argument to chip-tool from the CI test harness.

#### Testing

CI should verify.