### PR TITLE
[Fix] Updating TC_CADMIN_1_19 python3 test module to resolve fabric commissioning issue in test step 5b

### DIFF
--- a/src/python_testing/TC_CADMIN_1_19.py
+++ b/src/python_testing/TC_CADMIN_1_19.py
@@ -118,9 +118,10 @@ class TC_CADMIN_1_19(CADMINBaseTest):
 
             self.step("5b")
             # Use a unique fabric ID that won't conflict with existing fabrics
-            fids_ca = self.certificate_authority_manager.NewCertificateAuthority(caIndex=fid + initial_number_of_fabrics + 1)
-            fids_fa = fids_ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=fid + initial_number_of_fabrics + 1)
-            fids = fids_fa.NewController(nodeId=fid + initial_number_of_fabrics + 1)
+            new_fabric_idx = fid + initial_number_of_fabrics + 1
+            fids_ca = self.certificate_authority_manager.NewCertificateAuthority(caIndex=new_fabric_idx)
+            fids_fa = fids_ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=new_fabric_idx)
+            fids = fids_fa.NewController(nodeId=new_fabric_idx)
 
             await fids.CommissionOnNetwork(
                 nodeId=self.dut_node_id, setupPinCode=params.commissioningParameters.setupPinCode,

--- a/src/python_testing/TC_CADMIN_1_19.py
+++ b/src/python_testing/TC_CADMIN_1_19.py
@@ -119,7 +119,7 @@ class TC_CADMIN_1_19(CADMINBaseTest):
             self.step("5b")
             # Use a unique fabric ID that won't conflict with existing fabrics
             new_fabric_idx = fid + initial_number_of_fabrics + 1
-            fids_ca = self.certificate_authority_manager.NewCertificateAuthority(caIndex=new_fabric_idx)
+            fids_ca = self.certificate_authority_manager.NewCertificateAuthority()
             fids_fa = fids_ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=new_fabric_idx)
             fids = fids_fa.NewController(nodeId=new_fabric_idx)
 

--- a/src/python_testing/TC_CADMIN_1_19.py
+++ b/src/python_testing/TC_CADMIN_1_19.py
@@ -43,6 +43,11 @@ from matter.testing.matter_testing import AttributeValue, TestStep, async_test_b
 
 
 class TC_CADMIN_1_19(CADMINBaseTest):
+    # This test can take a long time to run especially in highly congested lab networks since it creates a lot of fabrics and commissions those to the DUT so we need to increase the timeout to run this test.
+    @property
+    def default_timeout(self) -> int:
+        return 600
+
     def steps_TC_CADMIN_1_19(self) -> list[TestStep]:
         return [
             TestStep(1, "Commissioning, already done", is_commissioning=True),
@@ -112,9 +117,10 @@ class TC_CADMIN_1_19(CADMINBaseTest):
             params = await self.open_commissioning_window(dev_ctrl=self.th1, timeout=self.max_window_duration, node_id=self.dut_node_id)
 
             self.step("5b")
-            fids_ca = self.certificate_authority_manager.NewCertificateAuthority(caIndex=fid)
-            fids_fa = fids_ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=fid + 1)
-            fids = fids_fa.NewController(nodeId=fid + 1)
+            # Use a unique fabric ID that won't conflict with existing fabrics
+            fids_ca = self.certificate_authority_manager.NewCertificateAuthority(caIndex=fid + initial_number_of_fabrics + 1)
+            fids_fa = fids_ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=fid + initial_number_of_fabrics + 1)
+            fids = fids_fa.NewController(nodeId=fid + initial_number_of_fabrics + 1)
 
             await fids.CommissionOnNetwork(
                 nodeId=self.dut_node_id, setupPinCode=params.commissioningParameters.setupPinCode,


### PR DESCRIPTION
#### Summary
- Added property function default_timeout to change the value to 600 due to possible congestion in lab environments could make this take significantly longer
- Updated the code in test step 5b to resolve issue filed by Pradeep from GRL in issue #[41126](https://github.com/project-chip/connectedhomeip/issues/41126)

#### Related issues

Fixes: #[41126](https://github.com/project-chip/connectedhomeip/issues/41126)
 
#### Testing

Tested on TH GUI version v2.14-beta2.1+fall2025
<img width="635" height="616" alt="image" src="https://github.com/user-attachments/assets/768cdf3c-7ccd-4a59-ae93-8d2e5e997032" />

Tested in WSL Linux but noticing issue with f-str from latest changes on upstream master
<img width="1196" height="124" alt="image" src="https://github.com/user-attachments/assets/2e955446-3efd-4c33-b428-b629c690ad9b" />

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
