### PR TITLE
[Quick Fix] Resolving SyntaxError noticed with f-str in python3 commissioning submodule

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
@@ -144,7 +144,7 @@ async def commission_device(
 
     if commissioning_info.tc_version_to_simulate is not None and commissioning_info.tc_user_response_to_simulate is not None:
         LOGGER.debug(
-            f"Setting TC Acknowledgements to version {commissioning_info.tc_version_to_simulate} with user response" +
+            f"Setting TC Acknowledgements to version {commissioning_info.tc_version_to_simulate} with user response "
             f"{commissioning_info.tc_user_response_to_simulate}."
         )
         dev_ctrl.SetTCAcknowledgements(commissioning_info.tc_version_to_simulate, commissioning_info.tc_user_response_to_simulate)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
@@ -144,8 +144,8 @@ async def commission_device(
 
     if commissioning_info.tc_version_to_simulate is not None and commissioning_info.tc_user_response_to_simulate is not None:
         LOGGER.debug(
-            f"Setting TC Acknowledgements to version {commissioning_info.tc_version_to_simulate} with user response {
-                commissioning_info.tc_user_response_to_simulate}."
+            f"Setting TC Acknowledgements to version {commissioning_info.tc_version_to_simulate} with user response" +
+            f"{commissioning_info.tc_user_response_to_simulate}."
         )
         dev_ctrl.SetTCAcknowledgements(commissioning_info.tc_version_to_simulate, commissioning_info.tc_user_response_to_simulate)
 


### PR DESCRIPTION
#### Summary

Quick fix to resolve issue noticed with SyntaxError with f-str formatting in commissioning submodule
<img width="1196" height="124" alt="image" src="https://github.com/user-attachments/assets/84e5a113-c7bf-4ce5-9655-47f815917483" />

#### Testing

Noticed during testing in latest master branch of WSL Linux 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
