### PR TITLE
[TC_DEM_2.5.py] - Fixes #41285 - mismatch between step 5 (should be maxDurationAdjustment not minDurationAdjustment)

### DIFF
--- a/src/python_testing/TC_DEM_2_5.py
+++ b/src/python_testing/TC_DEM_2_5.py
@@ -191,7 +191,7 @@ class TC_DEM_2_5(MatterBaseTest, DEMTestBase):
 
         self.step("5")
         slotAdjustments = [Clusters.DeviceEnergyManagement.Structs.SlotAdjustmentStruct(
-            slotIndex=0, duration=forecast.slots[0].minDurationAdjustment)]
+            slotIndex=0, duration=forecast.slots[0].maxDurationAdjustment)]
         await self.send_modify_forecast_request_command(forecast.forecastID, slotAdjustments, Clusters.DeviceEnergyManagement.Enums.AdjustmentCauseEnum.kGridOptimization, expected_status=Status.ConstraintError)
 
         self.step("6")


### PR DESCRIPTION
#### Summary

It was spotted that the test step said one thing, but the code did something slightly different.

This is a minor fix to align / correct the script to align to the test plan.

```
            TestStep("5", "TH sends command ModifyForecastRequest with ForecastID=Forecast.ForecastID,
 SlotAdjustments[0].{SlotIndex=0, Duration=Forecast.Slots[0].MaxDurationAdjustment},
 Cause=GridOptimization",
                     "Verify DUT responds w/ status CONSTRAINT_ERROR(0x87)"),

...

        self.step("5")
        slotAdjustments = [Clusters.DeviceEnergyManagement.Structs.SlotAdjustmentStruct(
-           slotIndex=0, duration=forecast.slots[0].minDurationAdjustment)]
+           slotIndex=0, duration=forecast.slots[0].maxDurationAdjustment)]

```

NOTE that the reason this fails with a 'CONSTRAINT ERROR' is because the command is missing the nominal power. It has nothing to do with the duration which is perfectly valid, so either min or maxDuration could have been used (valid) but the missing nominalPower is what the test is looking to check that the DUT rejects the command.

#### Related issues

Fixes: #41285

#### Testing

Re-tested against local Energy Management App (Linux) and the script to ensure that it still passes.
No change to the SDK.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
