### PR TITLE
Parallelize submodule checkout

### DIFF
--- a/.github/actions/checkout-submodules/action.yaml
+++ b/.github/actions/checkout-submodules/action.yaml
@@ -14,6 +14,6 @@ runs:
     - uses: Wandalen/wretry.action@v1.4.10
       name: Checkout submodules
       with:
-        command: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform ${{ inputs.platform }} ${{ inputs.extra-parameters }}
+        command: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --jobs 4 --platform ${{ inputs.platform }} ${{ inputs.extra-parameters }}
         attempt_limit: 3
         attempt_delay: 2000

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -63,7 +63,7 @@ jobs:
             - name: Build tools required for Factory Data
               # Run test for master and all PRs
               run: |
-                  ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
+                  ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --jobs 4 --platform linux
                   ./scripts/build/gn_gen.sh
                   ./scripts/run_in_build_env.sh "ninja -C ./out/$BUILD_TYPE chip-cert chip-tool spake2p"
                   mv ./out/$BUILD_TYPE/chip-cert ./out/$BUILD_TYPE/chip-tool ./out/$BUILD_TYPE/spake2p ./out
@@ -410,7 +410,7 @@ jobs:
             - name: Build tools required for Factory Data
               # Run test for master and all PRs
               run: |
-                  ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
+                  ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --jobs 4 --platform linux
                   ./scripts/build/gn_gen.sh
                   ./scripts/run_in_build_env.sh "ninja -C ./out/$BUILD_TYPE chip-cert chip-tool spake2p"
                   mv ./out/$BUILD_TYPE/chip-cert ./out/$BUILD_TYPE/chip-tool ./out/$BUILD_TYPE/spake2p ./out

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -5,7 +5,7 @@ steps:
           - "-c"
           - |
               git config --global --add safe.directory "*"
-              python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
+              python scripts/checkout_submodules.py --shallow --recursive --jobs 4 --platform esp32 nrfconnect silabs linux android
       id: Submodules
     - name: "ghcr.io/project-chip/chip-build-vscode:169"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -5,7 +5,7 @@ steps:
           - "-c"
           - |
               git config --global --add safe.directory "*"
-              python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
+              python scripts/checkout_submodules.py --shallow --recursive --jobs 4 --platform esp32 nrfconnect silabs linux android
       id: Submodules
     - name: "ghcr.io/project-chip/chip-build-vscode:169"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -140,7 +140,7 @@ RUN mkdir /root/connectedhomeip
 RUN git clone https://github.com/project-chip/connectedhomeip.git /root/connectedhomeip
 WORKDIR /root/connectedhomeip/
 RUN git checkout ${COMMITHASH}
-RUN ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
+RUN ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --jobs 4 --platform linux
 RUN bash scripts/bootstrap.sh
 
 # Stage 2: Build.

--- a/scripts/build/gn_gen_cirque.sh
+++ b/scripts/build/gn_gen_cirque.sh
@@ -30,7 +30,7 @@ env
 cd "$ROOT_PATH"
 
 echo "Ensure submodules for Linux builds are checked out"
-./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
+./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --jobs 4 --platform linux
 
 echo "Setup build environment"
 source "./scripts/activate.sh"

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -220,7 +220,7 @@ find_in_ancestors() {
     fi
 
     # there are environments where these bits are unwanted, unnecessary, or impossible
-    [[ -n $CHIP_NO_SUBMODULES ]] || scripts/checkout_submodules.py --shallow --platform darwin
+    [[ -n $CHIP_NO_SUBMODULES ]] || scripts/checkout_submodules.py --shallow --jobs 4 --platform darwin
     if [[ -z $CHIP_NO_ACTIVATE ]]; then
         # first run bootstrap/activate in an external env to build everything
         env -i PW_ENVSETUP_NO_BANNER=1 PW_ENVSETUP_QUIET=1 bash -c '. scripts/activate.sh'


### PR DESCRIPTION
#### Summary

Run `submodule_checkout.py` with `--jobs 4` for quicker environment preparation. This should slightly decrease CI time among others.

#### Testing

No change to source or object code. I've been using `--jobs` in local workflows and in Jenkins for a long while without issue.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase (CI time should slightly decrease)

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
