### PR TITLE
[Darwin] MTRDeviceTests/test038_MTRDeviceMultipleDelegatesInterestedPaths flake fix

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -4466,7 +4466,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Delegate 4
     XCTestExpectation * gotReportEnd4 = [self expectationWithDescription:@"Report end for delegate 4"];
     __auto_type * delegate4 = [[MTRDeviceTestDelegateWithSubscriptionSetupOverride alloc] init];
-    delegate3.skipSetupSubscription = YES;
+    delegate4.skipSetupSubscription = YES;
     __weak __auto_type weakDelegate4 = delegate4;
     __block NSUInteger attributesReceived4 = 0;
     delegate4.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * data) {


### PR DESCRIPTION
#### Summary

The `test038_MTRDeviceMultipleDelegatesInterestedPaths` test in `MTRDeviceTests` for darwin is flaky and can sometimes fail. This is a copy/paste bug and needs a fix in the test itself.

#### Related issues

Fixes #41337

#### Testing

This fixes the test itself.
