### PR TITLE
When running cert tests, log when subprocesses terminate abnormally.

### DIFF
--- a/scripts/tests/chiptest/accessories.py
+++ b/scripts/tests/chiptest/accessories.py
@@ -64,8 +64,11 @@ class AppsRegister:
             accessory.kill()
 
     def killAll(self):
+        ok = True
         for accessory in self.__accessories.values():
-            accessory.kill()
+            # make sure to do kill() on all of our apps, even if some of them returned False
+            ok = accessory.kill() and ok
+        return ok
 
     def start(self, name, args):
         accessory = self.__accessories[name]


### PR DESCRIPTION
Would have been nice to get a log in https://github.com/project-chip/connectedhomeip/actions/runs/18324363815/job/52185052494?pr=41232

#### Testing

CI should verify.