### PR TITLE
Fix for PushAV missing checks reported for PAVST 2.4, 2.7, 2.6

### DIFF
--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
@@ -870,6 +870,13 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::H
         return std::nullopt;
     }
 
+    if (mDelegate->GetTransportBusyStatus(connectionID) == PushAvStreamTransportStatusEnum::kBusy)
+    {
+        ChipLogError(Zcl, "HandleDeallocatePushTransport[ep=%d]: Connection is Busy", mEndpointId);
+        handler.AddStatus(commandPath, Status::Busy);
+        return std::nullopt;
+    }
+
     // Call the delegate
     auto delegateStatus = Protocols::InteractionModel::ClusterStatusCode(mDelegate->DeallocatePushTransport(connectionID));
 

--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -307,7 +307,7 @@ class PAVSTTestBase:
         except InteractionModelError as e:
             if (e.status == Status.Busy):
                 asserts.assert_true(
-                    e.status == Status.NotFound, "Busy Status,Transport is currently uploading data" 
+                    e.status == Status.NotFound, "Busy Status,Transport is currently uploading data"
                 )
             asserts.assert_true(
                 e.status == Status.NotFound, "Unexpected error returned"
@@ -326,7 +326,7 @@ class PAVSTTestBase:
         except InteractionModelError as e:
             if (e.status == Status.Busy):
                 asserts.assert_true(
-                    e.status == Status.NotFound, "Busy Status,Transport is currently uploading data" 
+                    e.status == Status.NotFound, "Busy Status,Transport is currently uploading data"
                 )
             asserts.assert_true(
                 e.status == Status.NotFound, "Unexpected error returned"

--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -305,6 +305,10 @@ class PAVSTTestBase:
             await self.send_single_cmd(cmd=cmd, endpoint=endpoint, dev_ctrl=dev_ctrl)
             return Status.Success
         except InteractionModelError as e:
+            if (e.status == Status.Busy):
+                asserts.assert_true(
+                    e.status == Status.NotFound, "Busy Status,Transport is currently uploading data" 
+                )
             asserts.assert_true(
                 e.status == Status.NotFound, "Unexpected error returned"
             )
@@ -320,6 +324,10 @@ class PAVSTTestBase:
             await self.send_single_cmd(cmd=cmd, endpoint=endpoint, dev_ctrl=dev_ctrl)
             return Status.Success
         except InteractionModelError as e:
+            if (e.status == Status.Busy):
+                asserts.assert_true(
+                    e.status == Status.NotFound, "Busy Status,Transport is currently uploading data" 
+                )
             asserts.assert_true(
                 e.status == Status.NotFound, "Unexpected error returned"
             )
@@ -359,7 +367,7 @@ class PAVSTTestBase:
             return e.status
         pass
 
-    async def psvt_manually_trigger_transport(self, cmd, expected_cluster_status=None, devCtrl=None):
+    async def psvt_manually_trigger_transport(self, cmd, expected_cluster_status=None, devCtrl=None, expected_status=None):
         endpoint = self.get_endpoint(default=1)
         dev_ctrl = self.default_controller
         if (devCtrl is not None):
@@ -373,10 +381,17 @@ class PAVSTTestBase:
                     e.clusterStatus == expected_cluster_status, "Unexpected error returned"
                 )
                 return e.clusterStatus
-            else:
+            elif (e.status == Status.Busy):
                 asserts.assert_true(
-                    e.status == Status.NotFound, "Unexpected error returned"
+                    e.status == Status.NotFound, "Busy Status,Transport is currently uploading data"
                 )
+            else:
+                if (expected_status is not None):
+                    asserts.assert_true(e.status == expected_status, "TUnexpected error returned")
+                else:
+                    asserts.assert_true(
+                        e.status == Status.NotFound, "Unexpected error returned"
+                    )
                 return e.status
         pass
 

--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -306,12 +306,11 @@ class PAVSTTestBase:
             return Status.Success
         except InteractionModelError as e:
             if (e.status == Status.Busy):
+                asserts.fail("Transport is busy, currently uploading data")
+            else:
                 asserts.assert_true(
-                    e.status == Status.NotFound, "Busy Status,Transport is currently uploading data"
+                    e.status == Status.NotFound, "Unexpected error returned"
                 )
-            asserts.assert_true(
-                e.status == Status.NotFound, "Unexpected error returned"
-            )
             return e.status
         pass
 
@@ -325,12 +324,11 @@ class PAVSTTestBase:
             return Status.Success
         except InteractionModelError as e:
             if (e.status == Status.Busy):
+                asserts.fail("Transport is busy, currently uploading data")
+            else:
                 asserts.assert_true(
-                    e.status == Status.NotFound, "Busy Status,Transport is currently uploading data"
+                    e.status == Status.NotFound, "Unexpected error returned"
                 )
-            asserts.assert_true(
-                e.status == Status.NotFound, "Unexpected error returned"
-            )
             return e.status
         pass
 
@@ -382,12 +380,10 @@ class PAVSTTestBase:
                 )
                 return e.clusterStatus
             elif (e.status == Status.Busy):
-                asserts.assert_true(
-                    e.status == Status.NotFound, "Busy Status,Transport is currently uploading data"
-                )
+                asserts.fail("Transport is busy, currently uploading data")
             else:
                 if (expected_status is not None):
-                    asserts.assert_true(e.status == expected_status, "TUnexpected error returned")
+                    asserts.assert_true(e.status == expected_status, "Unexpected error returned")
                 else:
                     asserts.assert_true(
                         e.status == Status.NotFound, "Unexpected error returned"

--- a/src/python_testing/TC_PAVST_2_6.py
+++ b/src/python_testing/TC_PAVST_2_6.py
@@ -44,6 +44,7 @@ from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
 from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
+from matter.clusters.Types import Nullable
 from matter.interaction_model import Status
 from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
                                            run_if_endpoint_matches)
@@ -103,6 +104,11 @@ class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             ),
             TestStep(
                 6,
+                "TH1 sends the SetTransportStatus  command with ConnectionID = Null.",
+                "DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                7,
                 "TH1 Reads CurrentConnections attribute from PushAV Stream Transport Cluster on DUT.",
                 "Verify that the TransportStatus is set to !aTransportStatus in the TransportConfiguration corresponding to aConnectionID.",
             )
@@ -205,6 +211,16 @@ class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             "DUT responds with SUCCESS status code.")
 
         self.step(6)
+        cmd = pvcluster.Commands.SetTransportStatus(
+            connectionID=Nullable(),
+            transportStatus=not aTransportStatus
+        )
+        status = await self.psvt_set_transport_status(cmd)
+        asserts.assert_true(
+            status == Status.Success,
+            "DUT responds with SUCCESS status code.")
+
+        self.step(7)
         transportConfigs = await self.read_pavst_attribute_expect_success(
             endpoint, pvattr.CurrentConnections
         )

--- a/src/python_testing/TC_PAVST_2_7.py
+++ b/src/python_testing/TC_PAVST_2_7.py
@@ -133,6 +133,11 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             ),
             TestStep(
                 12,
+                "TH1 sends the ManuallyTriggerTransport command with ConnectionID = aConnectionID and TimeControl field is omitted.",
+                "DUT responds with DYNAMIC_CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                13,
                 "TH1 sends the ManuallyTriggerTransport command with ConnectionID = aConnectionID.",
                 "DUT responds with SUCCESS status code.",
             ),
@@ -316,6 +321,17 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             "DUT responds with SUCCESS status code.")
 
         self.step(12)
+        cmd = pvcluster.Commands.ManuallyTriggerTransport(
+            connectionID=aConnectionID,
+            activationReason=pvcluster.Enums.TriggerActivationReasonEnum.kUserInitiated,
+        )
+        status = await self.psvt_manually_trigger_transport(cmd, expected_status=Status.DynamicConstraintError)
+        asserts.assert_true(
+            status == Status.DynamicConstraintError,
+            "DUT responds with DynamicConstraintError status code.",
+        )
+
+        self.step(13)
         timeControl = {"initialDuration": 1, "augmentationDuration": 1, "maxDuration": 1, "blindDuration": 1}
         cmd = pvcluster.Commands.ManuallyTriggerTransport(
             connectionID=aConnectionID,


### PR DESCRIPTION
#### Summary
This  PR fixes below missing checks:

[TC-PAVST-2.4] ModifyPushTransport SHALL fail with a BUSY status code if the specified transport is currently uploading data. The test plan does not attempt to modify an active transport.

[TC-PAVST-2.7] Untested failure behaviors:
The command SHALL fail with INVALID_IN_STATE if a privacy mode is active (e.g., HardPrivacyModeOn is true) .
The command SHALL fail with a BUSY status code if the transport is already transmitting.
The command SHALL fail with DYNAMIC_CONSTRAINT_ERROR if the trigger type is Command and the TimeControl field is omitted from the command payload.

[TC-PAVST-2.6] mandatory but untested behaviors:
The ability to pass a null ConnectionID to modify the status of all transports belonging to the calling fabric is not tested .
The side effects of changing the status are not verified. For example, setting the status to Inactive SHALL cause any queued uploads to be removed and any in-progress uploads to be cancelled. Setting a Continuous transport to Active SHALL cause transmission to begin immediately.


#### Related issues

Fixes: https://github.com/CHIP-Specifications/chip-test-plans/issues/5440
Fixes: https://github.com/CHIP-Specifications/chip-test-plans/issues/5485

#### Testing
```
# Build and run camera application
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debug/chip-camera-app

# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run Push AV TC
Example:
python3 src/python_testing/TC_PAVST_2_7.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1
```