### PR TITLE
Updated runner   Fix Test Harness (TH) client test execution by adding the --th_client_test argument to the Matter testing infrastructure runner.

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -788,7 +788,7 @@ def parse_matter_test_args(argv: Optional[List[str]] = None):
                              help='List of script_path and class_name pairs for batch test info retrieval')
     basic_group.add_argument('--th-client-test', nargs=2, type=str, metavar=('SCRIPT_PATH', 'CLASS_NAME'),
                              help='Test Harness client test with script path and class name (e.g., sdk/TC_ACE_1_3 TC_ACE_1_3)')
-    basic_group.add_argument('--get_test_info', action="store_true", default=False,
+    basic_group.add_argument('--get-test-info', action="store_true", default=False,
                              help="Retrieve test information (steps, descriptions, PICS) without running tests")
     basic_group.add_argument('--fail-on-skipped', action="store_true", default=False,
                              help="Fail the test if any test cases are skipped")

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -786,8 +786,8 @@ def parse_matter_test_args(argv: Optional[List[str]] = None):
                              help='A list of tests in the test class to execute.')
     basic_group.add_argument('--test-list', nargs='+', type=str, metavar='SCRIPT_CLASS_PAIRS',
                              help='List of script_path and class_name pairs for batch test info retrieval')
-    basic_group.add_argument('--th_client_test', nargs=2, type=str, metavar=('SCRIPT_PATH', 'CLASS_NAME'),
-                             help='Test Helper client test with script path and class name (e.g., sdk/TC_ACE_1_3 TC_ACE_1_3)')
+    basic_group.add_argument('--th-client-test', nargs=2, type=str, metavar=('SCRIPT_PATH', 'CLASS_NAME'),
+                             help='Test Harness client test with script path and class name (e.g., sdk/TC_ACE_1_3 TC_ACE_1_3)')
     basic_group.add_argument('--get_test_info', action="store_true", default=False,
                              help="Retrieve test information (steps, descriptions, PICS) without running tests")
     basic_group.add_argument('--fail-on-skipped', action="store_true", default=False,

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -784,6 +784,12 @@ def parse_matter_test_args(argv: Optional[List[str]] = None):
 
     basic_group.add_argument('--tests', '--test-case', action='append', nargs='+', type=str, metavar='test_NAME',
                              help='A list of tests in the test class to execute.')
+    basic_group.add_argument('--test-list', nargs='+', type=str, metavar='SCRIPT_CLASS_PAIRS',
+                             help='List of script_path and class_name pairs for batch test info retrieval')
+    basic_group.add_argument('--th_client_test', nargs=2, type=str, metavar=('SCRIPT_PATH', 'CLASS_NAME'),
+                             help='Test Helper client test with script path and class name (e.g., sdk/TC_ACE_1_3 TC_ACE_1_3)')
+    basic_group.add_argument('--get_test_info', action="store_true", default=False,
+                             help="Retrieve test information (steps, descriptions, PICS) without running tests")
     basic_group.add_argument('--fail-on-skipped', action="store_true", default=False,
                              help="Fail the test if any test cases are skipped")
     basic_group.add_argument('--trace-to', nargs="*", default=[],


### PR DESCRIPTION
#### Summary
 Test Harness client was unable to execute tests due to missing argument support in the runner. The test_harness_client.py relies on passing script path and class name as separate parameters, but the runner didn't have a dedicated argument to handle this pattern. So we created a new argument `--th_client_test` to indicate this is a test run from TH and also added the support to `--test-list ` and `--get-test-info`.

#### Related issues
https://github.com/project-chip/certification-tool/issues/761

#### Testing
The following tests runs successfully inside container: 

1. `/root/python_testing/scripts/sdk/TC_ACE_1_3.py --commissioning-method on-network  --trace-to json:log  --discriminator 3840 --passcode 20202021 `

2. `/root/python_testing/scripts/sdk/TC_ACE_1_3.py --trace-to json:log  --discriminator 3840 --passcode 20202021 `

3. `/root/python_testing/scripts/sdk/matter_testing_infrastructure/chip/testing/test_harness_client.py --test-list sdk/TC_ACE_1_3 TC_ACE_1_3 sdk/TC_ACE_1_4 TC_ACE_1_4  --get-test-info`

4.`/root/python_testing/scripts/sdk/matter_testing_infrastructure/chip/testing/test_harness_client.py --th_client_test sdk/TC_ACE_1_3 TC_ACE_1_3 --tests test_TC_ACE_1_3 --trace-to json:log --in-test-commissioning-method on-network --discriminator 3840 --passcode 20202021`

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
