### PR TITLE
Documentation for mocked BLE-WiFi commissioning

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -368,7 +368,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --runner chip_tool_python \
-                     --target TestCommissionerNodeId \
+                     --target TestOperationalState \
                      --chip-tool ./out/linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
                      run \
                      --iterations 1 \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,7 @@ version = "1.0.0"
 extensions = [
     "myst_parser",
     "external_content",
+    "sphinxcontrib.mermaid",
 ]
 exclude_patterns = [
     "_build",
@@ -61,7 +62,7 @@ suppress_warnings = [
     "myst.xref_missing",
 ]
 myst_enable_extensions = ["html_image"]
-
+myst_fence_as_directive = ["mermaid"]
 
 # -- Options for external_content --------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 docutils==0.21.2
 Sphinx==8.2.3
 sphinx-book-theme
+sphinxcontrib-mermaid
 myst-parser>=2.0.0
 breathe>=4.34
 pydata-sphinx-theme==0.16.1

--- a/docs/testing/fuzz_testing.md
+++ b/docs/testing/fuzz_testing.md
@@ -51,7 +51,7 @@ for an example of a simple fuzz test.
 
     -   Example
 
-        ```gn
+        ```
         import("${chip_root}/build/chip/fuzz_test.gni")
 
         if (enable_fuzz_test_targets) {
@@ -85,7 +85,7 @@ for an example of a simple fuzz test.
 
     -   Add Fuzzing Target like that
 
-        ```gn
+        ```
         if (enable_fuzz_test_targets) {
             group("fuzz_tests") {
             deps = [

--- a/docs/testing/fuzz_testing.md
+++ b/docs/testing/fuzz_testing.md
@@ -22,7 +22,7 @@ test. Each fuzzer function is defined using
 
 The Fuzzer must be located in a Test Folder : `src/some_directory/tests/`
 
-```
+```cpp
 #include <cstddef>
 #include <cstdint>
 
@@ -39,7 +39,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t len)
 
     return 0;
 }
-
 ```
 
 See
@@ -52,7 +51,7 @@ for an example of a simple fuzz test.
 
     -   Example
 
-        ```
+        ```gn
         import("${chip_root}/build/chip/fuzz_test.gni")
 
         if (enable_fuzz_test_targets) {
@@ -86,7 +85,7 @@ for an example of a simple fuzz test.
 
     -   Add Fuzzing Target like that
 
-        ```
+        ```gn
         if (enable_fuzz_test_targets) {
             group("fuzz_tests") {
             deps = [
@@ -104,11 +103,11 @@ for an example of a simple fuzz test.
         ```
 
 -   Build all fuzzers
-    ```
+    ```shell
     ./scripts/build/build_examples.py --target <host>-<compiler>-tests-asan-libfuzzer-clang build
     ```
     e.g.
-    ```
+    ```shell
     ./scripts/build/build_examples.py --target darwin-arm64-tests-asan-libfuzzer-clang build
     ```
     \*\* Make sure to put the right host and compiler
@@ -263,14 +262,14 @@ There are several ways to run the tests:
 
 1.  Unit-test mode (where the inputs are only fuzzed for a second):
 
-```bash
+```shell
 ./fuzz-chip-cert-pw
 ```
 
 2.  Continuous fuzzing mode; we need to first list the tests, then specify the
     FuzzTestCase to run:
 
-```bash
+```console
 $ ./fuzz-chip-cert-pw --list_fuzz_tests
 [.] Sanitizer coverage enabled. Counter map size: 11134, Cmp map size: 262144
 [*] Fuzz test: ChipCert.ChipCertFuzzer
@@ -281,20 +280,19 @@ $ ./fuzz-chip-cert-pw --fuzz=ChipCert.DecodeChipCertFuzzer
 
 3. Running all Tests in a TestSuite for a specific time, e.g for 10 minutes
 
-```bash
-#both Fuzz Tests will be run for 10 minutes each
+```shell
+# both Fuzz Tests will be run for 10 minutes each
 ./fuzz-chip-cert-pw --fuzz_for=10m
 ```
 
 4. For Help
 
-```bash
+```shell
 # FuzzTest related help
 ./fuzz-chip-cert-pw --helpfull
 
 # gtest related help
 ./fuzz-chip-cert-pw --help
-
 ```
 
 ### Coverage Report Generation

--- a/docs/testing/integration_test_utilities.md
+++ b/docs/testing/integration_test_utilities.md
@@ -110,7 +110,6 @@ CHIP_ERROR CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec,
    CHIP_FAULT_INJECT(FaultInjection::kFault_CASEServerBusy, busy = true);
    if (busy)
    {
-…
 ```
 
 ### Fault Injection cluster

--- a/docs/testing/integration_test_utilities.md
+++ b/docs/testing/integration_test_utilities.md
@@ -99,7 +99,7 @@ To add new fault injection code paths:
 
 ### Fault Injection example
 
-```
+```cpp
 CHIP_ERROR CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec,
    const PayloadHeader & payloadHeader,
                                         System::PacketBufferHandle && payload)

--- a/docs/testing/integration_tests.md
+++ b/docs/testing/integration_tests.md
@@ -131,7 +131,6 @@ flowchart TD
     org.bluez.hci0 --- DUT
     org.bluez.hci1 --- CONTROLLER
 
-
 ```
 
 In order to run tests with mocked BLE and Wi-Fi connectivity and Linux network

--- a/docs/testing/integration_tests.md
+++ b/docs/testing/integration_tests.md
@@ -44,3 +44,105 @@ way that is understandable, readable, and has the features you need
         (certs, commissioning, etc), less plumbing if you need to add features,
         can use python libraries
     -   cons: more complex, can be harder to read
+
+## Running integration tests locally
+
+When integration tests are run locally, the test runner (YAML or python) needs
+to mock network connectivity between the controller and the device under test,
+so that all tests can be run without actual hardware. In case of a simple test
+case when a single device is tested with on-network commissioning, nothing
+special is needed - the controller can connect to the device directly over the
+local (loopback) network interface. However, for more complex test cases that
+involve multiple devices or other than on-network commissioning (e.g. ble-wifi
+or ble-thread), some additional setup is needed.
+
+### Running tests in Linux network namespaces
+
+The simplest way to mock more complex network topologies is to use Linux network
+namespaces. Each device (controller or DUT) is run in its own network namespace,
+which allows them to have their own network interfaces and corresponding IP
+addresses.
+
+For convenience, there is a script that can set up network namespaces and run a
+test case in them:
+
+```shell
+# Build the chip-tool and chip-all-clusters-app if not done already
+scripts/build/build_examples.py --target linux-x64-chip-tool --target linux-x64-all-clusters build
+# Run the TestOperationalState test case in the Linux network namespaces
+scripts/tests/run_test_suite.py --runner chip_tool_python \
+    --chip-tool out/linux-x64-chip-tool/chip-tool \
+    --target TestOperationalState \
+    --log-level=debug \
+    run
+```
+
+### Running tests with mocked BLE and Wi-Fi connectivity
+
+For more complex commissioning flows that involve BLE and Wi-Fi, the test runner
+needs to mock BLE and Wi-Fi connectivity as well. On Linux, BLE and Wi-Fi are
+provided by the BlueZ stack and WPA supplicant, respectively. The SDK uses D-Bus
+to interact with these services. This allows the test runner to mock BLE and
+Wi-Fi connectivity by simply mocking used D-Bus APIs of these services.
+
+Additionally, the Matter specification forbids device to advertise on more than
+one network type at a time, so in case of ble-wifi commissioning, the DUT shall
+not be accessible over Wi-Fi until it is commissioned. This can be achieved by
+using Linux network namespaces as described above, but instead of setting up
+network interfaces before commissioning, the test runner assigns IP address to
+the DUT's network interface only after mock Wi-Fi connection is associated.
+
+See the diagram below for an overview of the setup:
+
+```mermaid
+flowchart TD
+
+    subgraph Mocked BlueZ
+        BA1[adapter1<br>00:00:00:11:11:11]
+        BA2[adapter2<br>00:00:00:22:22:22]
+    end
+
+    subgraph Mocked WPA supplicant
+        WL0[wlan0]
+    end
+
+    subgraph Test D-Bus system bus
+        direction TB
+        org.bluez.hci0[org.bluez.Adapter<br>hci0]
+        org.bluez.hci1[org.bluez.Adapter<br>hci1]
+        fi.w1[fi.w1.wpa_supplicant1.Interface<br>wlan0]
+    end
+
+    BA1 --- org.bluez.hci0
+    BA2 --- org.bluez.hci1
+    WL0 --- fi.w1
+
+    subgraph ETH["TOOL network namespace"]
+        CONTROLLER[chip-tool]
+        ETH0[eth0<br>fd00:0:1:1::2]
+    end
+
+    subgraph WLAN["DUT network namespace"]
+        DUT[chip-all-clusters-app]
+        WLAN0[wlan0<br>not assigned]
+    end
+
+    fi.w1 --- DUT
+    org.bluez.hci0 --- DUT
+    org.bluez.hci1 --- CONTROLLER
+
+
+```
+
+In order to run tests with mocked BLE and Wi-Fi connectivity and Linux network
+namespaces use the `--ble-wifi` option to the `run` command of the
+`scripts/tests/run_test_suite.py` script:
+
+```shell
+# Run the TestOperationalState test case with ble-wifi commissioning
+scripts/tests/run_test_suite.py --runner chip_tool_python \
+    --chip-tool out/linux-x64-chip-tool/chip-tool \
+    --target TestOperationalState \
+    --log-level=debug \
+    run --ble-wifi
+```

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -45,7 +45,7 @@ Python tests located in src/python_testing
 
 ### A simple test
 
-```
+```python
 # See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
 # for details about the block below.
 #
@@ -321,7 +321,7 @@ callbacks are called on update.
 
 Example for setting callbacks:
 
-```
+```python
 cb = EventSubscriptionHandler(cluster, cluster_id, event_id)
 
 urgent = 1
@@ -345,7 +345,7 @@ PyChipError
 
 Example:
 
-```
+```python
 res = await devCtrl.WriteAttribute(nodeid=0, attributes=[(0,Clusters.BasicInformation.Attributes.NodeLabel("Test"))])
 asserts.assert_equal(ret[0].status, Status.Success, “write failed”)
 ```
@@ -532,11 +532,11 @@ Note: The name of the pipe can be anything while is a valid file path.
 
 Example of usage:
 
-```bash
-First run the app with the desired app-pipe path:
+```shell
+# First run the app with the desired app-pipe path:
 ./out/darwin-arm64-all-clusters/chip-all-clusters-app --app-pipe  /tmp/ref_alm_2_2
 
-Then execute the test with the app-pipe argument with the value defined while running the app.
+# Then execute the test with the app-pipe argument with the value defined while running the app.
 python3 src/python_testing/TC_REFALM_2_2.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00  --PICS src/app/tests/suites/certification/ci-pics-values --app-pipe /tmp/ref_alm_2_2  --int-arg PIXIT.REFALM.AlarmThreshold:1
 ```
 
@@ -682,15 +682,15 @@ First ensure the device is in commissioning mode. Then run the test against the
 device by supplying either the QR code, the manual pairing code or the
 discriminator / password pair.
 
-```
+```shell
 python3 TC_DeviceConformance.py --qr-code MT:-24J0AFN00KA0648G00
 ```
 
-```
+```shell
 python3 TC_DeviceConformance.py --manual-code 34970112332
 ```
 
-```
+```shell
 python3 TC_DeviceConformance.py --discriminator 3840 --passcode 20202021
 ```
 
@@ -699,7 +699,7 @@ python3 TC_DeviceConformance.py --discriminator 3840 --passcode 20202021
 If the device has already been commissioned into the python testing fabric, you
 can run the test directly
 
-```
+```shell
 python3 TC_DeviceConformance.py
 ```
 
@@ -712,7 +712,7 @@ using the `--commissioning-method` flag and the `--qr-code`, `--manual-code` or
 
 For example:
 
-```
+```shell
 python3 TC_DeviceConformance.py --discriminator 3840 --passcode 20202021 --commissioning-method on-network
 ```
 
@@ -736,7 +736,7 @@ the device, they can also be run against a MatterTlvJson machine readable file
 without requiring the device to be physically present. To run against a
 previously generated MatterTlvJson device dump file:
 
-```
+```shell
 python3 TC_DeviceConformance.py --string-arg test_from_file:device_dump_0xFFF1_0x8001_1.json
 ```
 
@@ -744,7 +744,7 @@ You can generate a MatterTlvJson file for a device by leveraging the
 certification test that generates these (TC-IDM-12.1, implemented in
 TC_DeviceBasicComposition.py).
 
-```
+```shell
 python3 TC_DeviceBasicComposition.py --qr-code MT:-24J0AFN00KA0648G00 --tests test_TC_IDM_12_1
 ```
 

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -71,18 +71,16 @@ class TC_MYTEST_1_1(MatterBaseTest):
     async def test_TC_MYTEST_1_1(self):
 
         vendor_name = await self.read_single_attribute_check_success(
-            dev_ctrl=self.default_controller, <span style="color:#38761D"># defaults to
-self.default_controlller</span>
-            node_id = self.dut_node_id, <span style="color:#38761D"># defaults to
-self.dut_node_id</span>
+            dev_ctrl=self.default_controller,  # defaults to self.default_controller
+            node_id = self.dut_node_id,  # defaults to self.dut_node_id
             cluster=Clusters.BasicInformation,
             attribute=Clusters.BasicInformation.Attributes.VendorName,
-            endpoint = 0, <span style="color:#38761D">#defaults to 0</span>
+            endpoint = 0,  # defaults to 0
         )
-        asserts.assert_equal(vendor_name, “Test vendor name”, “Unexpected vendor name”)
+        asserts.assert_equal(vendor_name, "Test vendor name", "Unexpected vendor name")
 
 if __name__ == "__main__":
-default_matter_test_main()
+    default_matter_test_main()
 ```
 
 ---
@@ -347,7 +345,7 @@ Example:
 
 ```python
 res = await devCtrl.WriteAttribute(nodeid=0, attributes=[(0,Clusters.BasicInformation.Attributes.NodeLabel("Test"))])
-asserts.assert_equal(ret[0].status, Status.Success, “write failed”)
+asserts.assert_equal(ret[0].status, Status.Success, "write failed")
 ```
 
 ### [SendCommand](./ChipDeviceCtrlAPI.md#sendcommand)

--- a/docs/testing/unit_testing.md
+++ b/docs/testing/unit_testing.md
@@ -311,7 +311,7 @@ own text context class.
 
     -   Example
 
-        ```cpp
+        ```
         chip_test_suite("tests") {
             output_name = "libSomethingTests"
 

--- a/docs/testing/unit_testing.md
+++ b/docs/testing/unit_testing.md
@@ -24,7 +24,7 @@ The following example demonstrates how to use pw_unit_test to write a simple
 unit test. Each test function is defined using `TEST(NameOfFunction)`. The set
 of test functions in a given source file is called a "suite".
 
-```
+```cpp
 #include <pw_unit_test/framework.h>
 
 TEST(YourTestFunction1)
@@ -65,7 +65,7 @@ functions will be defined with `TEST_F(NameOfTestContext, NameOfFunction)`. The
 following example demonstrates how to use pw_unit_test to write a unit test that
 uses fixtures and setup/teardown behavior.
 
-```
+```cpp
 #include <pw_unit_test/framework.h>
 
 class YourTestContext : public ::testing::Test
@@ -140,7 +140,7 @@ that you can derive your test context from. It provides a network layer and a
 system layer and two secure sessions connected with each other. The following
 example demonstrates this.
 
-```
+```cpp
 #include <app/tests/AppTestContext.h>
 
 class YourTestContext : public Test::AppContext
@@ -225,7 +225,7 @@ own text context class.
 
 -   Try to use as specific an assertion as possible. For example use these
 
-    ```
+    ```cpp
     EXPECT_EQ(result, 3);
     EXPECT_GT(result, 1);
     EXPECT_STREQ(myString, "hello");
@@ -233,7 +233,7 @@ own text context class.
 
     instead of these
 
-    ```
+    ```cpp
     EXPECT_TRUE(result == 3);
     EXPECT_TRUE(result > 1);
     EXPECT_EQ(strcmp(myString, "hello"), 0);
@@ -248,7 +248,7 @@ own text context class.
     you want to prevent the test from continuing, check the value of
     `HasFailure()` and stop execution if true. Example:
 
-    ```
+    ```cpp
     void Subroutine()
     {
         ASSERT_EQ(1, 2);  // Fatal failure.
@@ -311,7 +311,7 @@ own text context class.
 
     -   Example
 
-        ```
+        ```cpp
         chip_test_suite("tests") {
             output_name = "libSomethingTests"
 
@@ -394,7 +394,7 @@ publicly inheriting from it.
 
 -   Example
 
-```
+```cpp
     #include <system/RAIIMockClock.h>
 
     // ...

--- a/docs/testing/yaml.md
+++ b/docs/testing/yaml.md
@@ -29,7 +29,7 @@ that is used to display the test easily in the test harness.
 
 The following shows a test step sending a simple command with no arguments.
 
-```
+```yaml
     - label: "This label gets printed"
       cluster: "On/Off"
       command: "On"
@@ -46,7 +46,7 @@ also be overwritten in the individual test steps.
 
 The following shows how to send a command with arguments:
 
-```
+```yaml
     - label: "This label gets printed before the test step"
       command: "MoveToColor"
       arguments:
@@ -82,7 +82,7 @@ a special command that requires an additional "attribute" tag.
 The following YAML would appear as a test step, and shows how to read an
 attribute.
 
-```
+```yaml
 - label: "TH reads the ClusterRevision from DUT"
   command: "readAttribute"
   attribute: "ClusterRevision"
@@ -91,7 +91,7 @@ attribute.
 The following YAML would appear as a test step and shows how to write an
 attribute. Commands to write attributes always require an argument: tag.
 
-```
+```yaml
 - label: "Write example attribute"
   command: "writeAttribute"
   attribute: "ExampleAttribute"
@@ -108,7 +108,7 @@ sub-tags.
 The following shows a simple response parsing with two (somewhat redundant)
 checks.
 
-```
+```yaml
 - label: "TH reads the ClusterRevision from DUT"
   command: "readAttribute"
   attribute: "ClusterRevision"
@@ -137,7 +137,7 @@ structs: `{field1:value, field2:value}`
 
 lists of structs:
 
-```
+```yaml
 [
 
 {field1:value, field2:value, optionalfield:value},
@@ -162,7 +162,7 @@ Some of the more common functionality is shown below:
 Establishing a connection to the DUT. This is the first step in nearly every
 test.
 
-```
+```yaml
     - label: "Establish a connection to the DUT"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
@@ -174,7 +174,7 @@ test.
 
 Wait for a user action:
 
-```
+```yaml
     - label: "Do a simple user prompt message. Expect 'y' to pass."
       cluster: "LogCommands"
       command: "UserPrompt"
@@ -188,7 +188,7 @@ Wait for a user action:
 
 Wait for a time:
 
-```
+```yaml
     - label: "Wait for 5S"
       cluster: "DelayCommands"
       command: "WaitForMs"
@@ -211,7 +211,7 @@ in the test harness.
 To declare config variables in the config section, use a label with the desired
 name, then provide the type and defaultValue tags as sub-tags.
 
-```
+```yaml
 config:
     nodeId: 0x12344321
     cluster: "Unit Testing"
@@ -223,7 +223,7 @@ config:
 
 Variables can also be saved from responses:
 
-```
+```yaml
     - label: "Send Test Add Arguments Command"
       command: "TestAddArguments"
       arguments:
@@ -241,7 +241,7 @@ Variables can also be saved from responses:
 
 Variables can then be used in later steps:
 
-```
+```yaml
     - label: "Send Test Add Arguments Command"
       command: "TestAddArguments"
       arguments:
@@ -317,13 +317,13 @@ before using any YAML runner script.
 
 First activate the matter environment using either
 
-```
+```shell
 . ./scripts/bootstrap.sh
 ```
 
 or
 
-```
+```shell
 . ./scripts/activate.sh
 ```
 
@@ -332,16 +332,15 @@ subsequent setups as it is faster.
 
 Next build the python wheels and create a venv
 
-```
+```shell
 ./scripts/build_python.sh -i out/python_env
 source out/python_env/bin/activate
 ```
 
 Compile chip-tool:
 
-```
+```shell
 ./scripts/build/build_examples.py --target linux-x64-chip-tool build
-
 ```
 
 NOTE: use the target appropriate to your system
@@ -350,7 +349,7 @@ NOTE: use the target appropriate to your system
 can be used to run tests against a commissioned DUT (commissioned by chip-tool).
 To commission a DUT using chip-tool use the pairing command. For example:
 
-```
+```shell
 ./out/linux-x64-chip-tool/chip-tool pairing code 0x12344321 MT:-24J0AFN00KA0648G00
 ```
 
@@ -359,25 +358,23 @@ MT:-24J0AFN00KA0648G00 is the QR code.
 
 The chiptool.py tool can then be used to run the tests. For example:
 
-```
+```shell
 ./scripts/tests/chipyaml/chiptool.py tests Test_TC_OO_2_1 --server_path ./out/linux-x64-chip-tool/chip-tool
-
 ```
 
 NOTE: substitute the appropriate test name and chip-tool path as appropriate.
 
 A list of available tests can be generated using:
 
-```
+```shell
 ./scripts/tests/chipyaml/chiptool.py list
 ```
 
 Config variables can be passed to chiptool.py after the script by separating
 with --
 
-```
+```shell
 ./scripts/tests/chipyaml/chiptool.py tests Test_TC_OO_2_1 --server_path ./out/linux-x64-chip-tool/chip-tool -- nodeId 0x12344321
-
 ```
 
 Each test defines a default endpoint to target. Root node cluster tests run

--- a/docs/testing/yaml.md
+++ b/docs/testing/yaml.md
@@ -30,9 +30,9 @@ that is used to display the test easily in the test harness.
 The following shows a test step sending a simple command with no arguments.
 
 ```yaml
-    - label: "This label gets printed"
-      cluster: "On/Off"
-      command: "On"
+- label: "This label gets printed"
+  cluster: "On/Off"
+  command: "On"
 ```
 
 -   label - label to print before performing the test step
@@ -47,20 +47,20 @@ also be overwritten in the individual test steps.
 The following shows how to send a command with arguments:
 
 ```yaml
-    - label: "This label gets printed before the test step"
-      command: "MoveToColor"
-      arguments:
-          values:
-              - name: "ColorX"
-                value: 32768
-              - name: "ColorY"
-                value: 19660
-              - name: "TransitionTime"
-                value: 0
-              - name: "OptionsMask"
-                value: 0
-              - name: "OptionsOverride"
-                value: 0
+- label: "This label gets printed before the test step"
+  command: "MoveToColor"
+  arguments:
+      values:
+          - name: "ColorX"
+            value: 32768
+          - name: "ColorY"
+            value: 19660
+          - name: "TransitionTime"
+            value: 0
+          - name: "OptionsMask"
+            value: 0
+          - name: "OptionsOverride"
+            value: 0
 ```
 
 -   label - label to print before performing the test step
@@ -96,7 +96,7 @@ attribute. Commands to write attributes always require an argument: tag.
   command: "writeAttribute"
   attribute: "ExampleAttribute"
   arguments:
-    value: 1
+      value: 1
 ```
 
 #### Parsing Responses
@@ -113,9 +113,9 @@ checks.
   command: "readAttribute"
   attribute: "ClusterRevision"
   response:
-    value: 1
-    constraints:
-      minValue: 1
+      value: 1
+      constraints:
+          minValue: 1
 ```
 
 The following tags can be used to parse the response
@@ -139,11 +139,9 @@ lists of structs:
 
 ```yaml
 [
+    { field1:value, field2:value, optionalfield:value },
 
-{field1:value, field2:value, optionalfield:value},
-
-{field1:value, field2:value},
-
+    { field1:value, field2:value },
 ]
 ```
 
@@ -163,39 +161,39 @@ Establishing a connection to the DUT. This is the first step in nearly every
 test.
 
 ```yaml
-    - label: "Establish a connection to the DUT"
-      cluster: "DelayCommands"
-      command: "WaitForCommissionee"
-      arguments:
-          values:
-              - name: "nodeId"
-                value: nodeId
+- label: "Establish a connection to the DUT"
+  cluster: "DelayCommands"
+  command: "WaitForCommissionee"
+  arguments:
+      values:
+          - name: "nodeId"
+            value: nodeId
 ```
 
 Wait for a user action:
 
 ```yaml
-    - label: "Do a simple user prompt message. Expect 'y' to pass."
-      cluster: "LogCommands"
-      command: "UserPrompt"
-      arguments:
-          values:
-              - name: "message"
-                value: "Please enter 'y' for success"
-              - name: "expectedValue"
-                value: "y"
+- label: "Do a simple user prompt message. Expect 'y' to pass."
+  cluster: "LogCommands"
+  command: "UserPrompt"
+  arguments:
+      values:
+          - name: "message"
+            value: "Please enter 'y' for success"
+          - name: "expectedValue"
+            value: "y"
 ```
 
 Wait for a time:
 
 ```yaml
-    - label: "Wait for 5S"
-      cluster: "DelayCommands"
-      command: "WaitForMs"
-      arguments:
-          values:
-              - name: "ms"
-                value: 5000
+- label: "Wait for 5S"
+  cluster: "DelayCommands"
+  command: "WaitForMs"
+  arguments:
+      values:
+          - name: "ms"
+            value: 5000
 ```
 
 A full description of the available pseudo-clusters and their commands is
@@ -224,36 +222,36 @@ config:
 Variables can also be saved from responses:
 
 ```yaml
-    - label: "Send Test Add Arguments Command"
-      command: "TestAddArguments"
-      arguments:
-          values:
-              - name: "arg1"
-                value: 3
-              - name: "arg2"
-                value: 17
-      response:
-          values:
-              - name: "returnValue"
-                saveAs: TestAddArgumentDefaultValue
-                value: 20
+- label: "Send Test Add Arguments Command"
+  command: "TestAddArguments"
+  arguments:
+      values:
+          - name: "arg1"
+            value: 3
+          - name: "arg2"
+            value: 17
+  response:
+      values:
+          - name: "returnValue"
+            saveAs: TestAddArgumentDefaultValue
+            value: 20
 ```
 
 Variables can then be used in later steps:
 
 ```yaml
-    - label: "Send Test Add Arguments Command"
-      command: "TestAddArguments"
-      arguments:
-          values:
-              - name: "arg1"
-                value: 3
-              - name: "arg2"
-                value: 17
-      response:
-          values:
-              - name: "returnValue"
-                value: TestAddArgumentDefaultValue
+- label: "Send Test Add Arguments Command"
+  command: "TestAddArguments"
+  arguments:
+      values:
+          - name: "arg1"
+            value: 3
+          - name: "arg2"
+            value: 17
+  response:
+      values:
+          - name: "returnValue"
+            value: TestAddArgumentDefaultValue
 ```
 
 Tags where variables can be used are noted in the

--- a/scripts/tests/chiptest/linux.py
+++ b/scripts/tests/chiptest/linux.py
@@ -102,7 +102,7 @@ class IsolatedNetworkNamespace:
         "ip link set dev {app_link_name}-switch up",
         # Force IPv6 to use ULAs that we control.
         "ip netns exec app ip -6 addr flush {app_link_name}",
-        "ip netns exec app ip -6 a add fd00:0:1:1::3/64 dev {app_link_name}",
+        "ip netns exec app ip -6 a add fd00:0:1:1::1/64 dev {app_link_name}",
 
     ]
 

--- a/scripts/tests/chiptest/linux.py
+++ b/scripts/tests/chiptest/linux.py
@@ -244,7 +244,19 @@ class BluetoothMock(subprocess.Popen):
 
 
 class WpaSupplicantMock(threading.Thread):
-    """Mock server for WpaSupplicant D-Bus API."""
+    """Mock server for WpaSupplicant D-Bus API.
+
+    This mock runs on its own thread and exposes a minimal subset of the
+    WpaSupplicant D-Bus API to allow Matter devices to interact with it.
+    It allows to create only one interface with one mocked network on it.
+
+    Network SSID and password need to be provided when creating the mock.
+    However, as for now, the password is not actually used for anything, so
+    any password will work and allow to perform AP association. During the
+    association process, between the "associated" and "completed" states,
+    the provided IsolatedNetworkNamespace instance is used to bring up the
+    link to simulate network connectivity.
+    """
 
     class Wpa(sdbus.DbusInterfaceCommonAsync,
               interface_name="fi.w1.wpa_supplicant1"):


### PR DESCRIPTION
#### Summary

This is a follow-up for https://github.com/project-chip/connectedhomeip/pull/39454

Also, the test case for ble-wifi was changed from `TestCommissionerNodeId` to `TestOperationalState` because it runs 1.5 second faster.

Other changes:

- Add missing codeblock language specifiers in docs/testing
- Align IP6 with IP4 for DUT

#### Testing

CI will verify