### PR TITLE
Use mandatory metadata when possible to reduce copy & paste errors.

### DIFF
--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -49,6 +49,8 @@ inline constexpr uint32_t kRevisionWithoutUniqueId = 3;
 
 // This is NOT the same as the auto-generated attributes:
 // see comment below about UniqueID (which we make behave as optional)
+//
+// TLDR: DO NOT USE kMandatoryMetadata (because unique ID is special for backwards compat builds)
 constexpr DataModel::AttributeEntry kMandatoryAttributes[] = {
     DataModelRevision::kMetadataEntry,
     VendorName::kMetadataEntry,
@@ -404,6 +406,7 @@ CHIP_ERROR BasicInformationCluster::Attributes(const ConcreteClusterPath & path,
 
     AttributeListBuilder listBuilder(builder);
 
+    // NOTE: do NOT use kMandatoryMetadata (see comment on kMandatoryAttributes: UniqueID is special)
     return listBuilder.Append(Span(kMandatoryAttributes), Span(optionalAttributes), mEnabledOptionalAttributes);
 }
 

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -227,14 +227,7 @@ CHIP_ERROR NetworkCommissioningCluster::Attributes(const ConcreteClusterPath & p
     using NetworkCommissioning::Feature;
 
     // mandatory attributes
-    ReturnErrorOnFailure(builder.AppendElements({
-        MaxNetworks::kMetadataEntry,
-        Networks::kMetadataEntry,
-        InterfaceEnabled::kMetadataEntry,
-        LastNetworkingStatus::kMetadataEntry,
-        LastNetworkID::kMetadataEntry,
-        LastConnectErrorValue::kMetadataEntry,
-    }));
+    ReturnErrorOnFailure(builder.AppendElements(kMandatoryMetadata));
 
     // NOTE: thread and wifi are mutually exclusive features
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -16,6 +16,7 @@
  */
 #include "NetworkCommissioningCluster.h"
 
+#include <app/server-cluster/AttributeListBuilder.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/NetworkCommissioning/AttributeIds.h>
 #include <clusters/NetworkCommissioning/CommandIds.h>
@@ -226,36 +227,47 @@ CHIP_ERROR NetworkCommissioningCluster::Attributes(const ConcreteClusterPath & p
     using namespace NetworkCommissioning::Attributes;
     using NetworkCommissioning::Feature;
 
-    // mandatory attributes
-    ReturnErrorOnFailure(builder.AppendElements(kMandatoryMetadata));
+    AttributeListBuilder attributeListBuilder(builder);
+
+    constexpr DataModel::AttributeEntry kOptionalAttributes[] = {
+        ScanMaxTimeSeconds::kMetadataEntry,      //
+        ConnectMaxTimeSeconds::kMetadataEntry,   //
+        SupportedThreadFeatures::kMetadataEntry, //
+        ThreadVersion::kMetadataEntry,           //
+        SupportedWiFiBands::kMetadataEntry,      //
+    };
+
+    chip::app::OptionalAttributeSet<ScanMaxTimeSeconds::Id,      //
+                                    ConnectMaxTimeSeconds::Id,   //
+                                    SupportedThreadFeatures::Id, //
+                                    ThreadVersion::Id,           //
+                                    SupportedWiFiBands::Id       //
+                                    >
+        optionalAttributes;
 
     // NOTE: thread and wifi are mutually exclusive features
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     if (mLogic.Features().Has(Feature::kThreadNetworkInterface))
     {
-        ReturnErrorOnFailure(builder.AppendElements({
-            ScanMaxTimeSeconds::kMetadataEntry,
-            ConnectMaxTimeSeconds::kMetadataEntry,
-            SupportedThreadFeatures::kMetadataEntry,
-            ThreadVersion::kMetadataEntry,
-        }));
+        optionalAttributes.ForceSet<ScanMaxTimeSeconds::Id>();
+        optionalAttributes.ForceSet<ConnectMaxTimeSeconds::Id>();
+        optionalAttributes.ForceSet<SupportedThreadFeatures::Id>();
+        optionalAttributes.ForceSet<ThreadVersion::Id>();
     }
     else
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #if (CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP)
         if (mLogic.Features().Has(Feature::kWiFiNetworkInterface))
     {
-        ReturnErrorOnFailure(builder.AppendElements({
-            ScanMaxTimeSeconds::kMetadataEntry,
-            ConnectMaxTimeSeconds::kMetadataEntry,
-            SupportedWiFiBands::kMetadataEntry,
-        }));
+        optionalAttributes.ForceSet<ScanMaxTimeSeconds::Id>();
+        optionalAttributes.ForceSet<ConnectMaxTimeSeconds::Id>();
+        optionalAttributes.ForceSet<SupportedWiFiBands::Id>();
     }
     else
 #endif // (CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP)
     {}
 
-    return builder.AppendElements(DefaultServerCluster::GlobalAttributes());
+    return attributeListBuilder.Append(Span(kMandatoryMetadata), Span(kOptionalAttributes), optionalAttributes);
 }
 
 } // namespace Clusters

--- a/src/app/clusters/time-format-localization-server/time-format-localization-cluster.cpp
+++ b/src/app/clusters/time-format-localization-server/time-format-localization-cluster.cpp
@@ -27,9 +27,6 @@ namespace app {
 namespace Clusters {
 
 namespace {
-constexpr DataModel::AttributeEntry kMandatoryAttributes[] = {
-    TimeFormatLocalization::Attributes::HourFormat::kMetadataEntry,
-};
 class AutoReleaseIterator
 {
 public:
@@ -103,8 +100,8 @@ TimeFormatLocalizationCluster::TimeFormatLocalizationCluster(EndpointId endpoint
                                                              BitFlags<TimeFormatLocalization::Feature> features,
                                                              TimeFormatLocalization::HourFormatEnum defaultHourFormat,
                                                              TimeFormatLocalization::CalendarTypeEnum defaultCalendarType) :
-    DefaultServerCluster({ endpointId, TimeFormatLocalization::Id }),
-    mFeatures(features), mHourFormat(defaultHourFormat), mCalendarType(defaultCalendarType)
+    DefaultServerCluster({ endpointId, TimeFormatLocalization::Id }), mFeatures(features), mHourFormat(defaultHourFormat),
+    mCalendarType(defaultCalendarType)
 {
     TimeFormatLocalization::CalendarTypeEnum validCalendar = defaultCalendarType;
 
@@ -225,7 +222,8 @@ CHIP_ERROR TimeFormatLocalizationCluster::Attributes(const ConcreteClusterPath &
         optionalAttributeSet.Set<TimeFormatLocalization::Attributes::SupportedCalendarTypes::Id>();
     }
 
-    return listBuilder.Append(Span(kMandatoryAttributes), Span(optionalAttributes), optionalAttributeSet);
+    return listBuilder.Append(Span(TimeFormatLocalization::Attributes::kMandatoryMetadata), Span(optionalAttributes),
+                              optionalAttributeSet);
 }
 
 } // namespace Clusters

--- a/src/app/clusters/time-format-localization-server/time-format-localization-cluster.cpp
+++ b/src/app/clusters/time-format-localization-server/time-format-localization-cluster.cpp
@@ -100,8 +100,8 @@ TimeFormatLocalizationCluster::TimeFormatLocalizationCluster(EndpointId endpoint
                                                              BitFlags<TimeFormatLocalization::Feature> features,
                                                              TimeFormatLocalization::HourFormatEnum defaultHourFormat,
                                                              TimeFormatLocalization::CalendarTypeEnum defaultCalendarType) :
-    DefaultServerCluster({ endpointId, TimeFormatLocalization::Id }), mFeatures(features), mHourFormat(defaultHourFormat),
-    mCalendarType(defaultCalendarType)
+    DefaultServerCluster({ endpointId, TimeFormatLocalization::Id }),
+    mFeatures(features), mHourFormat(defaultHourFormat), mCalendarType(defaultCalendarType)
 {
     TimeFormatLocalization::CalendarTypeEnum validCalendar = defaultCalendarType;
 

--- a/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.cpp
@@ -39,10 +39,6 @@ constexpr DataModel::AcceptedCommandEntry kAcceptedCommands[] = {
     Commands::End::kMetadataEntry,
 };
 
-constexpr DataModel::AttributeEntry kMandatoryAttributes[] = {
-    CurrentSessions::kMetadataEntry,
-};
-
 NodeId GetNodeIdFromCtx(const CommandHandler & commandHandler)
 {
     auto descriptor = commandHandler.GetSubjectDescriptor();
@@ -143,7 +139,7 @@ CHIP_ERROR WebRTCTransportRequestorServer::Attributes(const ConcreteClusterPath 
                                                       ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
 {
     AttributeListBuilder listBuilder(builder);
-    return listBuilder.Append(Span(kMandatoryAttributes), {}, {});
+    return listBuilder.Append(Span(kMandatoryMetadata), {}, {});
 }
 
 uint16_t WebRTCTransportRequestorServer::GenerateSessionId()


### PR DESCRIPTION
#### Summary

- Use the code generated metadata list when possible (only basic info cannot use it yet).
- Update network commissioning to use the new builder for attribute lists (expect a slight flash improvement)

#### Testing

CI should cover it.
Before each replacement I verified that the used value matches the generated kMandatoryMetadata value.
