### PR TITLE
[TC-DGSW-2.2] Updating pics value - PICS should be DWSW.S.E00 instead of just DGSW.S

### DIFF
--- a/src/python_testing/TC_DGSW_2_2.py
+++ b/src/python_testing/TC_DGSW_2_2.py
@@ -74,7 +74,7 @@ class TC_DGSW_2_2(MatterBaseTest):
         return "[TC-DGSW-2.2] Event Functionality with Server as DUT"
 
     def pics_TC_DGSW_2_2(self) -> list[str]:
-        return ["DGSW.S"]
+        return ["DGSW.S.E00"]
 
     def steps_TC_DGSW_2_2(self) -> list[TestStep]:
         steps = [


### PR DESCRIPTION
This PR solves https://github.com/CHIP-Specifications/chip-test-plans/pull/5369#discussion_r2415066794

PICS value updated

### Testing

In the first terminal:
- Clear commissioning data:
  ``` bash
  rm /tmp/chip_*
  ```
- Build all clusters app and python env:
  ``` bash
  ./scripts/build/build_examples.py –-target darwin-arm64-all-clusters build
  ```
  ``` bash
  ./scripts/build_python.sh -i out/python_env
  ```
- Run:
  ``` bash
  ./out/darwin-arm64-all-clusters/chip-all-clusters-app --discriminator 1234 --enable-key 000102030405060708090a0b0c0d0e0f
  ```

In the second terminal:
- Activate Python environment
- Test:
  ``` bash
  python3 src/python_testing/TC_DGSW_2_2.py --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --endpoint 0
  ```