### PR TITLE
Clean up old ToDos in the code the stream IDs are already set appropriately.

### DIFF
--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -81,15 +81,12 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
     // Resolve or allocate a VIDEO stream
     if (args.videoStreamId.HasValue())
     {
-        if (args.videoStreamId.Value().IsNull())
+        // Stream has been validated and potentially selected by ValidateStreamUsage()
+        // in the cluster server before invoking this delegate method
+        outSession.videoStreamID = args.videoStreamId.Value();
+        if (!args.videoStreamId.Value().IsNull())
         {
-            // TODO: Automatically select the closest matching video stream for the StreamUsage requested by looking at the and the
-            // server MAY allocate a new video stream if there are available resources.
-        }
-        else
-        {
-            outSession.videoStreamID = args.videoStreamId.Value();
-            videoStreamID            = args.videoStreamId.Value().Value();
+            videoStreamID = args.videoStreamId.Value().Value();
         }
     }
     else
@@ -100,15 +97,12 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
     // Resolve or allocate an AUDIO stream
     if (args.audioStreamId.HasValue())
     {
-        if (args.audioStreamId.Value().IsNull())
+        // Stream has been validated and potentially selected by ValidateStreamUsage()
+        // in the cluster server before invoking this delegate method
+        outSession.audioStreamID = args.audioStreamId.Value();
+        if (!args.audioStreamId.Value().IsNull())
         {
-            // TODO: Automatically select the closest matching audio stream for the StreamUsage requested and the server MAY
-            // allocate a new audio stream if there are available resources.
-        }
-        else
-        {
-            outSession.audioStreamID = args.audioStreamId.Value();
-            audioStreamID            = args.audioStreamId.Value().Value();
+            audioStreamID = args.audioStreamId.Value().Value();
         }
     }
     else
@@ -250,14 +244,12 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
     // Resolve or allocate a VIDEO stream
     if (args.videoStreamId.HasValue())
     {
-        if (args.videoStreamId.Value().IsNull())
+        // Stream has been validated and potentially selected by ValidateStreamUsage()
+        // in the cluster server before invoking this delegate method
+        outSession.videoStreamID = args.videoStreamId.Value();
+        if (!args.videoStreamId.Value().IsNull())
         {
-            // TODO: Automatically select the closest matching video stream for the StreamUsage requested.
-        }
-        else
-        {
-            outSession.videoStreamID = args.videoStreamId.Value();
-            videoStreamID            = args.videoStreamId.Value().Value();
+            videoStreamID = args.videoStreamId.Value().Value();
         }
     }
     else
@@ -268,14 +260,12 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
     // Resolve or allocate an AUDIO stream
     if (args.audioStreamId.HasValue())
     {
-        if (args.audioStreamId.Value().IsNull())
+        // Stream has been validated and potentially selected by ValidateStreamUsage()
+        // in the cluster server before invoking this delegate method
+        outSession.audioStreamID = args.audioStreamId.Value();
+        if (!args.audioStreamId.Value().IsNull())
         {
-            // TODO: Automatically select the closest matching audio stream for the StreamUsage requested
-        }
-        else
-        {
-            outSession.audioStreamID = args.audioStreamId.Value();
-            audioStreamID            = args.audioStreamId.Value().Value();
+            audioStreamID = args.audioStreamId.Value().Value();
         }
     }
     else

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -83,10 +83,11 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
     {
         // Stream has been validated and potentially selected by ValidateStreamUsage()
         // in the cluster server before invoking this delegate method
-        outSession.videoStreamID = args.videoStreamId.Value();
-        if (!args.videoStreamId.Value().IsNull())
+        const auto & videoStreamIdNullable = args.videoStreamId.Value();
+        outSession.videoStreamID           = videoStreamIdNullable;
+        if (!videoStreamIdNullable.IsNull())
         {
-            videoStreamID = args.videoStreamId.Value().Value();
+            videoStreamID = videoStreamIdNullable.Value();
         }
     }
     else
@@ -99,10 +100,11 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
     {
         // Stream has been validated and potentially selected by ValidateStreamUsage()
         // in the cluster server before invoking this delegate method
-        outSession.audioStreamID = args.audioStreamId.Value();
-        if (!args.audioStreamId.Value().IsNull())
+        const auto & audioStreamIdNullable = args.audioStreamId.Value();
+        outSession.audioStreamID           = audioStreamIdNullable;
+        if (!audioStreamIdNullable.IsNull())
         {
-            audioStreamID = args.audioStreamId.Value().Value();
+            audioStreamID = audioStreamIdNullable.Value();
         }
     }
     else
@@ -246,10 +248,11 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
     {
         // Stream has been validated and potentially selected by ValidateStreamUsage()
         // in the cluster server before invoking this delegate method
-        outSession.videoStreamID = args.videoStreamId.Value();
-        if (!args.videoStreamId.Value().IsNull())
+        const auto & videoStreamIdNullable = args.videoStreamId.Value();
+        outSession.videoStreamID           = videoStreamIdNullable;
+        if (!videoStreamIdNullable.IsNull())
         {
-            videoStreamID = args.videoStreamId.Value().Value();
+            videoStreamID = videoStreamIdNullable.Value();
         }
     }
     else
@@ -262,10 +265,11 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
     {
         // Stream has been validated and potentially selected by ValidateStreamUsage()
         // in the cluster server before invoking this delegate method
-        outSession.audioStreamID = args.audioStreamId.Value();
-        if (!args.audioStreamId.Value().IsNull())
+        const auto & audioStreamIdNullable = args.audioStreamId.Value();
+        outSession.audioStreamID           = audioStreamIdNullable;
+        if (!audioStreamIdNullable.IsNull())
         {
-            audioStreamID = args.audioStreamId.Value().Value();
+            audioStreamID = audioStreamIdNullable.Value();
         }
     }
     else


### PR DESCRIPTION
#### Summary

The streams are already selected in the call to validateStreamUsage that the server makes prior to invoking the handles on the delegate for ProvideOffer or SolicitOffer. By the time you get to those old To Do's in the code the stream IDs are already set appropriately.

#### Related issues

Fixes: #41215

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
