### PR TITLE
[camera-app] Support WebRTC Trickle ICE

### DIFF
--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -129,6 +129,7 @@ private:
     // WebRTC Callbacks
     void OnLocalDescription(const std::string & sdp, SDPType type, const uint16_t sessionId);
     void OnConnectionStateChanged(bool connected, const uint16_t sessionId);
+    void OnTrickleICECandidate(const uint16_t sessionId);
 
     WebrtcTransport * GetTransport(uint16_t sessionId);
 

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -27,6 +27,7 @@
 
 using OnTransportLocalDescriptionCallback = std::function<void(const std::string & sdp, SDPType type, const int16_t sessionId)>;
 using OnTransportConnectionStateCallback  = std::function<void(bool connected, const int16_t sessionId)>;
+using OnTransportICECandidateCallback     = std::function<void(const int16_t sessionId)>;
 
 // Derived class for WebRTC transport
 class WebrtcTransport : public Transport
@@ -65,7 +66,8 @@ public:
 
     ~WebrtcTransport();
 
-    void SetCallbacks(OnTransportLocalDescriptionCallback onLocalDescription, OnTransportConnectionStateCallback onConnectionState);
+    void SetCallbacks(OnTransportLocalDescriptionCallback onLocalDescription, OnTransportConnectionStateCallback onConnectionState,
+                      OnTransportICECandidateCallback onICECandidate = nullptr);
 
     void MoveToState(const State targetState);
     const char * GetStateStr() const;
@@ -126,6 +128,9 @@ public:
     void SetRequestArgs(const RequestArgs & args);
     RequestArgs & GetRequestArgs();
 
+    bool HasSentInitialICECandidates() const { return mHasSentInitialICECandidates; }
+    void SetHasSentInitialICECandidates(bool sent) { mHasSentInitialICECandidates = sent; }
+
 private:
     CommandType mCommandType = CommandType::kUndefined;
     State mState             = State::Idle;
@@ -143,4 +148,7 @@ private:
     RequestArgs mRequestArgs;
     OnTransportLocalDescriptionCallback mOnLocalDescription = nullptr;
     OnTransportConnectionStateCallback mOnConnectionState   = nullptr;
+    OnTransportICECandidateCallback mOnICECandidate         = nullptr;
+
+    bool mHasSentInitialICECandidates = false;
 };

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -137,6 +137,9 @@ public:
     void SetRequestArgs(const RequestArgs & args);
     RequestArgs & GetRequestArgs();
 
+    void SetHasSentInitialICECandidates(bool hasSent) { mHasSentInitialICECandidates = hasSent; }
+    bool GetHasSentInitialICECandidates() const { return mHasSentInitialICECandidates; }
+
 private:
     CommandType mCommandType = CommandType::kUndefined;
     State mState             = State::Idle;

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -109,6 +109,15 @@ public:
 
     std::vector<std::string> GetCandidates() { return mLocalCandidates; }
 
+    // Drain candidates - returns all accumulated candidates and clears the internal list
+    // This prevents resending the same candidates multiple times during trickle ICE
+    std::vector<std::string> DrainCandidates()
+    {
+        std::vector<std::string> candidates = std::move(mLocalCandidates);
+        mLocalCandidates.clear();
+        return candidates;
+    }
+
     void SetCandidates(std::vector<std::string> candidates) { mLocalCandidates = candidates; }
 
     void AddRemoteCandidate(const std::string & candidate, const std::string & mid);

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -128,9 +128,6 @@ public:
     void SetRequestArgs(const RequestArgs & args);
     RequestArgs & GetRequestArgs();
 
-    bool HasSentInitialICECandidates() const { return mHasSentInitialICECandidates; }
-    void SetHasSentInitialICECandidates(bool sent) { mHasSentInitialICECandidates = sent; }
-
 private:
     CommandType mCommandType = CommandType::kUndefined;
     State mState             = State::Idle;

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -914,7 +914,9 @@ CHIP_ERROR WebRTCProviderManager::SendICECandidatesCommand(Messaging::ExchangeMa
         ChipLogError(Camera, "WebTransport not found for the sessionId: %u", sessionId);
         return CHIP_ERROR_INTERNAL;
     }
-    std::vector<std::string> localCandidates = transport->GetCandidates();
+    // Drain candidates to get all accumulated candidates and clear the list
+    // This prevents resending the same candidates during trickle ICE
+    std::vector<std::string> localCandidates = transport->DrainCandidates();
     // Build the command
     WebRTCTransportRequestor::Commands::ICECandidates::Type command;
 

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -133,7 +133,8 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
             [this](const std::string & sdp, SDPType type, const uint16_t sessionId) {
                 this->OnLocalDescription(sdp, type, sessionId);
             },
-            [this](bool connected, const uint16_t sessionId) { this->OnConnectionStateChanged(connected, sessionId); });
+            [this](bool connected, const uint16_t sessionId) { this->OnConnectionStateChanged(connected, sessionId); },
+            [this](const uint16_t sessionId) { this->OnTrickleICECandidate(sessionId); });
     }
 
     transport->SetRequestArgs(requestArgs);
@@ -297,7 +298,8 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
             [this](const std::string & sdp, SDPType type, const uint16_t sessionId) {
                 this->OnLocalDescription(sdp, type, sessionId);
             },
-            [this](bool connected, const uint16_t sessionId) { this->OnConnectionStateChanged(connected, sessionId); });
+            [this](bool connected, const uint16_t sessionId) { this->OnConnectionStateChanged(connected, sessionId); },
+            [this](const uint16_t sessionId) { this->OnTrickleICECandidate(sessionId); });
     }
 
     // Check resource availability before proceeding
@@ -854,6 +856,13 @@ void WebRTCProviderManager::OnConnectionStateChanged(bool connected, const uint1
     {
         RegisterWebrtcTransport(sessionId);
     }
+}
+
+void WebRTCProviderManager::OnTrickleICECandidate(const uint16_t sessionId)
+{
+    ChipLogProgress(Camera, "Trickle ICE candidate received for session %u", sessionId);
+    // Reuse the existing ICE candidates send mechanism
+    ScheduleICECandidatesSend(sessionId);
 }
 
 CHIP_ERROR WebRTCProviderManager::SendAnswerCommand(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle,

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -128,14 +128,6 @@ const char * WebrtcTransport::GetStateStr() const
 
 void WebrtcTransport::MoveToState(const State targetState)
 {
-    // When transitioning from SendingICECandidates to Idle for the first time, enable trickle ICE mode
-    // (subsequent transitions will be for trickle ICE updates, so we only set the flag once)
-    if (mState == State::SendingICECandidates && targetState == State::Idle && !mHasSentInitialICECandidates)
-    {
-        mHasSentInitialICECandidates = true;
-        ChipLogProgress(Camera, "Initial ICE candidates batch sent for sessionID: %u, trickle ICE enabled", mRequestArgs.sessionId);
-    }
-
     mState = targetState;
     ChipLogProgress(Camera, "WebrtcTransport moving to [ %s ]", GetStateStr());
 }

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -480,6 +480,12 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
     {
         ChipLogError(Camera, "Failed to send ICE candidates: %" CHIP_ERROR_FORMAT, err.Format());
     }
+    else
+    {
+        // Clear the candidates after successful send to prevent resending them during trickle ICE
+        ChipLogProgress(Camera, "Sent %zu ICE candidate(s), clearing list", mLocalCandidates.size());
+        mLocalCandidates.clear();
+    }
 
     return err;
 }

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -483,7 +483,7 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
     else
     {
         // Clear the candidates after successful send to prevent resending them during trickle ICE
-        ChipLogProgress(Camera, "Sent %zu ICE candidate(s), clearing list", mLocalCandidates.size());
+        ChipLogProgress(Camera, "Sent %lu ICE candidate(s), clearing list", mLocalCandidates.size());
         mLocalCandidates.clear();
     }
 

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -99,6 +99,9 @@ private:
     // Track the current video stream ID for the session
     uint16_t mCurrentVideoStreamId = 0;
 
+    // Flag to track if initial ICE candidates batch has been sent
+    bool mHasSentInitialICECandidates = false;
+
     // UDP socket for RTP forwarding
     int mRTPSocket      = -1;
     int mAudioRTPSocket = -1;


### PR DESCRIPTION
#### Summary

Currently, the device gathers the ICECandidates from the underlying WebRTC stack and sends once after the initial Offer/Answer interchange via a ProvideICECandidates() command.

However, there could be more ICE candidates that can trickle up from the WebRTC stack after the initial send. These would get collected in a member list. But would also need to be sent at some point.

A simple approach could be to hook up the up-call from the WebRTC stack to send the ICECandidate right away after the initial list has been dispatched(post Offer/Answer flow). This might be the preferred approach for Livestream setup instead of waiting to accumulate a minimum set of ICE candidates.

#### Related issues

Fixes: #39232 

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
