### PR TITLE
Allow to use chiptest without installing any 3rd party modules

### DIFF
--- a/.github/workflows/cert_test_checks.yaml
+++ b/.github/workflows/cert_test_checks.yaml
@@ -16,8 +16,6 @@ name: Certification test checks
 
 on:
   pull_request:
-    paths:
-      - "src/app/tests/suites/certification/**"
 permissions:
   contents: read
 
@@ -32,11 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        run: |
-          pip3 install --break-system-packages sdbus
       - name: Run checks
         run: |
           python3 scripts/tests/matter_yaml_linter.py

--- a/.github/workflows/cert_test_checks.yaml
+++ b/.github/workflows/cert_test_checks.yaml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # Clone more than one commit because we need HEAD^..HEAD diff
+          fetch-depth: 2
       - name: Run checks
         run: |
           python3 scripts/tests/matter_yaml_linter.py

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -18,7 +18,6 @@ import json
 import logging
 import os
 import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Set
@@ -30,13 +29,8 @@ __all__ = [
     "TestTarget",
     "TestDefinition",
     "ApplicationPaths",
-    "linux",
     "runner",
 ]
-
-# If running on Linux platform load the Linux specific code.
-if sys.platform == "linux":
-    from . import linux
 
 _DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", ".."))

--- a/scripts/tests/requirements.txt
+++ b/scripts/tests/requirements.txt
@@ -6,6 +6,7 @@ colorama
 coloredlogs
 diskcache
 mypy==1.16.0
+sdbus; sys_platform == "linux"
 types-PyYAML
 tabulate
 

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -30,6 +30,10 @@ from chiptest.glob_matcher import GlobMatcher
 from chiptest.test_definition import TestRunTime, TestTag
 from chipyaml.paths_finder import PathsFinder
 
+# If running on Linux platform load the Linux specific code.
+if sys.platform == "linux":
+    import chiptest.linux
+
 DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..', '..'))
 


### PR DESCRIPTION
#### Summary

The `linux` submodule in the `chiptest` is used only by the `scripts/tests/run_test_suite.py`, so there is no need to load it in the `__init__.py`. Also, there are other scripts which use `chiptest`, so it will be nice to allow `chiptest` to be used without platform related stuff.

Problem discovered in https://github.com/project-chip/connectedhomeip/pull/41356

This PR changes the yaml test to always run in order to verify check breaks in case when the test script is modified (not only yaml tests themself). It should be fine because scripts runs within 1-2 seconds. Also, the cloning time should be improved.

#### Testing

CI will verify