### PR TITLE
Disable PAVSTI-1.2 test from CI (broken).

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -141,7 +141,7 @@ not_automated:
       reason: Helper methods for Push AV Integration TCs
     - name: TC_TLS_Utils.py
       reason: Helper methods for TC tests dependent on TLS clusters
-    - name: TC_PAVSTI_1_2
+    - name: TC_PAVSTI_1_2.py
       reason: "Broken test after #41352. Issue: https://github.com/project-chip/connectedhomeip/issues/41397"
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -142,7 +142,9 @@ not_automated:
     - name: TC_TLS_Utils.py
       reason: Helper methods for TC tests dependent on TLS clusters
     - name: TC_PAVSTI_1_2.py
-      reason: "Broken test after #41352. Issue: https://github.com/project-chip/connectedhomeip/issues/41397"
+      reason:
+          "Broken test after #41352. Issue:
+          https://github.com/project-chip/connectedhomeip/issues/41397"
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -141,6 +141,8 @@ not_automated:
       reason: Helper methods for Push AV Integration TCs
     - name: TC_TLS_Utils.py
       reason: Helper methods for TC tests dependent on TLS clusters
+    - name: TC_PAVSTI_1_2
+      reason: "Broken test after #41352. Issue: https://github.com/project-chip/connectedhomeip/issues/41397"
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially


### PR DESCRIPTION
#### Summary

Test is flaky (reported in #41397).

#### Related issues

#41397

#### Testing

Test disabling only.
