### PR TITLE
[Darwin] fix incorrect backtick use in quiet work message

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -113,7 +113,7 @@ jobs:
                   mkdir -p /tmp/darwin/framework-tests
 
                   export TEST_RUNNER_ASAN_OPTIONS=__CURRENT_VALUE__:detect_stack_use_after_return=1
-                  echo "Quiet work in progress - artifacts `darwin-tests.log` and `darwin-tests-err.log` will be output."
+                  echo "Quiet work in progress - artifacts 'darwin-tests.log' and 'darwin-tests-err.log' will be output."
                   xcodebuild test -target "Matter" -scheme "Matter Framework Tests" \
                   -resultBundlePath /tmp/darwin/framework-tests/TestResults.xcresult \
                   -sdk macosx ${{ matrix.options.arguments }} \


### PR DESCRIPTION
#### Summary

In `darwin.yaml` I accidentally used backticks to set off the filenames that will be used for artifacts which results in them being interpreted as commands.  Thankfully no harm, but the resultant log messages are confusing.

example:
```
/Users/runner/work/_temp/1701a92f-6325-4e07-b064-7f13179e9266.sh: line 4: darwin-tests.log: command not found
/Users/runner/work/_temp/1701a92f-6325-4e07-b064-7f13179e9266.sh: line 4: darwin-tests-err.log: command not found
Quiet work in progress - artifacts  and  will be output.
```

#### Testing

CI change only

- [ ] checked in CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase
