### PR TITLE
[Darwin] MTRPerControllerStorageTests testSubscriptionPoolManyDevices flake fix

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2955,9 +2955,9 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
         os_unfair_lock_unlock(&counterLock);
     }];
 
-    // Make the wait time depend on pool size and device count (can expand number of devices in the future)
+    // Make the wait time depend on device count
     NSArray * expectationsToWait = [subscriptionExpectations.allValues arrayByAddingObject:baseDeviceReadExpectation];
-    [self waitForExpectations:expectationsToWait timeout:(kSubscriptionPoolBaseTimeoutInSeconds * orderedDeviceIDs.count / subscriptionPoolSize)];
+    [self waitForExpectations:expectationsToWait timeout:(kSubscriptionPoolBaseTimeoutInSeconds * orderedDeviceIDs.count)];
 
     XCTAssertEqual(subscriptionDequeueCount, orderedDeviceIDs.count);
 


### PR DESCRIPTION
#### Summary

The calculation of wait time used to take pool size into account as a denominator, but increasing pool size doesn't necessarily improve subscription establishment time. The division is removed to reduce flakiness.

#### Testing

This is a test fix.