### PR TITLE
[Darwin] MTRDeviceTests test048_MTRDeviceResubscribeOnSubscriptionPool flake fix

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -6198,7 +6198,10 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Now we can set up waiting for onSubscriptionPoolWorkComplete from the test
     XCTestExpectation * subscriptionPoolWorkCompleteForTriggerTestExpectation = [self expectationWithDescription:@"_triggerResubscribeWithReason work completed"];
+    __weak __auto_type weakDelegate = delegate;
     delegate.onSubscriptionPoolWorkComplete = ^{
+        __strong __auto_type strongDelegate = weakDelegate;
+        strongDelegate.onSubscriptionPoolWorkComplete = nil;
         [subscriptionPoolWorkCompleteForTriggerTestExpectation fulfill];
     };
 


### PR DESCRIPTION
#### Summary

Sometimes the `subscriptionPoolWorkCompleteForTriggerTestExpectation` expectation gets fulfilled more than once, due to timing of _clearSubscriptionPoolWorkWithProvidedDelegate getting called in more places. This test fixes the callback to nil itself to avoid that issue.

#### Testing

This is a test fix.