### PR TITLE
ESP32: fix nimble initialization for ESP32-P4 and add instruction doc for ESP-Hosted

### DIFF
--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -40,3 +40,8 @@ dependencies:
         version: "^0.7.0"
         rules:
             - if: "target in [esp32p4]"
+
+    espressif/esp_hosted:
+        version: "~2"
+        rules:
+            - if: "target in [esp32p4]"

--- a/docs/platforms/esp32/esp_hosted.md
+++ b/docs/platforms/esp32/esp_hosted.md
@@ -1,0 +1,21 @@
+# ESP-Hosted Instruction
+
+For SoCs that do not include a built-in Wi-Fi radio (such as the ESP32-P4), it is still possible to run Matter-over-Wi-Fi by using the [esp-hosted](https://github.com/espressif/esp-hosted) component together with a slave Wi-Fi and Bluetooth co-processor.
+
+The following guide describes how to setup esp-hosted and configure the slave co-processor for [ESP32-P4 Function_EV_Board](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html).
+
+## Setup the slave co-processor
+
+Please refer to the [Falsh ESP32-C6](https://github.com/espressif/esp-hosted-mcu/blob/main/docs/esp32_p4_function_ev_board.md#5-flashing-esp32-c6) section for detailed instructions on flashing the slave co-processor firmware to the ESP32-C6 on the ESP32-P4 Function_EV_Board.
+
+## Build Matter firmare for Host MCU
+
+The [all-clusters-app](../../../examples/all-clusters-app/esp32/README.md) example can be used as the Matter firmare for ESP32-P4. After flashing the slave co-processor, set the target, build and flash the firmware as shown below:
+
+```
+idf.py set-target esp32p4
+idf.py build
+idf.py -p <port> erase-flash flash monitor
+```
+
+Once flashed, the device can be commissioned by a Matter commissioner.

--- a/docs/platforms/esp32/esp_hosted.md
+++ b/docs/platforms/esp32/esp_hosted.md
@@ -10,7 +10,7 @@ Please refer to the [Falsh ESP32-C6](https://github.com/espressif/esp-hosted-mcu
 
 ## Build Matter firmare for Host MCU
 
-The [all-clusters-app](../../../examples/all-clusters-app/esp32/README.md) example can be used as the Matter firmare for ESP32-P4. After flashing the slave co-processor, set the target, build and flash the firmware as shown below:
+The [all-clusters-app](../../../examples/all-clusters-app/esp32/README.md) example can be used as the Matter firmware for ESP32-P4. After flashing the slave co-processor, set the target, build and flash the firmware as shown below:
 
 ```
 idf.py set-target esp32p4

--- a/docs/platforms/esp32/esp_hosted.md
+++ b/docs/platforms/esp32/esp_hosted.md
@@ -8,7 +8,7 @@ The following guide describes how to setup esp-hosted and configure the slave co
 
 Please refer to the [Flash ESP32-C6](https://github.com/espressif/esp-hosted-mcu/blob/main/docs/esp32_p4_function_ev_board.md#5-flashing-esp32-c6) section for detailed instructions on flashing the slave co-processor firmware to the ESP32-C6 on the ESP32-P4 Function_EV_Board.
 
-## Build Matter firmare for Host MCU
+## Build Matter firmware for Host MCU
 
 The [all-clusters-app](../../../examples/all-clusters-app/esp32/README.md) example can be used as the Matter firmware for ESP32-P4. After flashing the slave co-processor, set the target, build and flash the firmware as shown below:
 

--- a/docs/platforms/esp32/esp_hosted.md
+++ b/docs/platforms/esp32/esp_hosted.md
@@ -1,16 +1,26 @@
 # ESP-Hosted Instruction
 
-For SoCs that do not include a built-in Wi-Fi radio (such as the ESP32-P4), it is still possible to run Matter-over-Wi-Fi by using the [esp-hosted](https://github.com/espressif/esp-hosted) component together with a slave Wi-Fi and Bluetooth co-processor.
+For SoCs that do not include a built-in Wi-Fi radio (such as the ESP32-P4), it
+is still possible to run Matter-over-Wi-Fi by using the
+[esp-hosted](https://github.com/espressif/esp-hosted) component together with a
+slave Wi-Fi and Bluetooth co-processor.
 
-The following guide describes how to setup esp-hosted and configure the slave co-processor for [ESP32-P4 Function_EV_Board](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html).
+The following guide describes how to setup esp-hosted and configure the slave
+co-processor for
+[ESP32-P4 Function_EV_Board](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html).
 
 ## Setup the slave co-processor
 
-Please refer to the [Flash ESP32-C6](https://github.com/espressif/esp-hosted-mcu/blob/main/docs/esp32_p4_function_ev_board.md#5-flashing-esp32-c6) section for detailed instructions on flashing the slave co-processor firmware to the ESP32-C6 on the ESP32-P4 Function_EV_Board.
+Please refer to the
+[Flash ESP32-C6](https://github.com/espressif/esp-hosted-mcu/blob/main/docs/esp32_p4_function_ev_board.md#5-flashing-esp32-c6)
+section for detailed instructions on flashing the slave co-processor firmware to
+the ESP32-C6 on the ESP32-P4 Function_EV_Board.
 
 ## Build Matter firmware for Host MCU
 
-The [all-clusters-app](../../../examples/all-clusters-app/esp32/README.md) example can be used as the Matter firmware for ESP32-P4. After flashing the slave co-processor, set the target, build and flash the firmware as shown below:
+The [all-clusters-app](../../../examples/all-clusters-app/esp32/README.md)
+example can be used as the Matter firmware for ESP32-P4. After flashing the
+slave co-processor, set the target, build and flash the firmware as shown below:
 
 ```
 idf.py set-target esp32p4

--- a/docs/platforms/esp32/esp_hosted.md
+++ b/docs/platforms/esp32/esp_hosted.md
@@ -6,7 +6,7 @@ The following guide describes how to setup esp-hosted and configure the slave co
 
 ## Setup the slave co-processor
 
-Please refer to the [Falsh ESP32-C6](https://github.com/espressif/esp-hosted-mcu/blob/main/docs/esp32_p4_function_ev_board.md#5-flashing-esp32-c6) section for detailed instructions on flashing the slave co-processor firmware to the ESP32-C6 on the ESP32-P4 Function_EV_Board.
+Please refer to the [Flash ESP32-C6](https://github.com/espressif/esp-hosted-mcu/blob/main/docs/esp32_p4_function_ev_board.md#5-flashing-esp32-c6) section for detailed instructions on flashing the slave co-processor firmware to the ESP32-C6 on the ESP32-P4 Function_EV_Board.
 
 ## Build Matter firmare for Host MCU
 

--- a/docs/platforms/esp32/index.md
+++ b/docs/platforms/esp32/index.md
@@ -20,3 +20,4 @@ example on ESP32 series of SoCs
 -   [BLE Settings](ble_settings.md)
 -   [Providers](providers.md)
 -   [Configuration Options](config_options.md)
+-   [ESP-Hosted Instruction](esp_hosted.md)

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -946,13 +946,13 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     // init bt controller
     if (ESP_OK != esp_hosted_bt_controller_init())
     {
-        ESP_LOGW("INFO", "failed to init bt controller");
+        ESP_LOGW(TAG, "failed to init bt controller");
     }
 
     // enable bt controller
     if (ESP_OK != esp_hosted_bt_controller_enable())
     {
-        ESP_LOGW("INFO", "failed to enable bt controller");
+        ESP_LOGW(TAG, "failed to enable bt controller");
     }
 #endif
 

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -944,15 +944,19 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     esp_hosted_connect_to_slave();
 
     // init bt controller
-    if (ESP_OK != esp_hosted_bt_controller_init())
+    err = MapBLEError(esp_hosted_bt_controller_init());
+    if (err != CHIP_NO_ERROR)
     {
-        ESP_LOGW(TAG, "failed to init bt controller");
+        ChipLogError(Ble, "esp_hosted_bt_controller_init() failed: %" CHIP_ERROR_FORMAT, err.Format());
+        ExitNow();
     }
 
     // enable bt controller
-    if (ESP_OK != esp_hosted_bt_controller_enable())
+    err = MapBLEError(esp_hosted_bt_controller_enable());
+    if (err != CHIP_NO_ERROR)
     {
-        ESP_LOGW(TAG, "failed to enable bt controller");
+        ChipLogError(Ble, "esp_hosted_bt_controller_enable() failed: %" CHIP_ERROR_FORMAT, err.Format());
+        ExitNow();
     }
 #endif
 


### PR DESCRIPTION
#### Summary

The esp-hosted has been updated to v2.5.11, we should enable the BLE controller on co-processor manually for ESP32-P4, as described in https://github.com/espressif/esp-hosted-mcu/blob/main/docs/migration_guide.md#migrating-to-v252

#### Related issues

N/A

#### Testing

Tested matter commissioning with ESP32-P4 Function EV board using the all-clusters-app.