### PR TITLE
binding: move bind cluster structures and classes namespace to chip::app::Clusters and add accessingFabricIndex parameter for ListAttributeWriteNotification

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -26,6 +26,8 @@
 #include <lib/core/CHIPError.h>
 #include <platform/CHIPDeviceLayer.h>
 
+using namespace chip::app::Clusters;
+
 #if defined(ENABLE_CHIP_SHELL)
 #include <lib/shell/Engine.h> // nogncheck
 
@@ -40,7 +42,7 @@ static bool sSwitchOnOffState = false;
 static void ToggleSwitchOnOff(bool newState)
 {
     sSwitchOnOffState = newState;
-    chip::BindingManager::GetInstance().NotifyBoundClusterChanged(1, chip::app::Clusters::OnOff::Id, nullptr);
+    Binding::Manager::GetInstance().NotifyBoundClusterChanged(1, OnOff::Id, nullptr);
 }
 
 static CHIP_ERROR SwitchCommandHandler(int argc, char ** argv)
@@ -63,23 +65,22 @@ static void RegisterSwitchCommands()
 {
     static const shell_command_t sSwitchCommand = { SwitchCommandHandler, "switch", "Switch commands. Usage: switch [on|off]" };
     Engine::Root().RegisterCommands(&sSwitchCommand, 1);
-    return;
 }
 #endif // defined(ENABLE_CHIP_SHELL)
 
-static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::OperationalDeviceProxy * peer_device,
+static void BoundDeviceChangedHandler(const Binding::TableEntry & binding, chip::OperationalDeviceProxy * peer_device,
                                       void * context)
 {
     using namespace chip;
     using namespace chip::app;
 
-    if (binding.type == MATTER_MULTICAST_BINDING)
+    if (binding.type == Binding::MATTER_MULTICAST_BINDING)
     {
         ChipLogError(NotSpecified, "Group binding is not supported now");
         return;
     }
 
-    if (binding.type == MATTER_UNICAST_BINDING && binding.local == 1 &&
+    if (binding.type == Binding::MATTER_UNICAST_BINDING && binding.local == 1 &&
         binding.clusterId.value_or(Clusters::OnOff::Id) == Clusters::OnOff::Id)
     {
         auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -113,10 +114,10 @@ static void BoundDeviceContextReleaseHandler(void * context)
 static void InitBindingHandlerInternal(intptr_t arg)
 {
     auto & server = chip::Server::GetInstance();
-    chip::BindingManager::GetInstance().Init(
+    Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
-    chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(BoundDeviceChangedHandler);
-    chip::BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(BoundDeviceContextReleaseHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(BoundDeviceChangedHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(BoundDeviceContextReleaseHandler);
 }
 
 CHIP_ERROR InitBindingHandlers()

--- a/examples/all-clusters-app/ameba/main/include/ColorControlCommands.h
+++ b/examples/all-clusters-app/ameba/main/include/ColorControlCommands.h
@@ -39,7 +39,7 @@ Engine sShellSwitchColorControlReadSubCommands;
 Engine sShellSwitchGroupsColorControlSubCommands;
 #endif // defined(ENABLE_CHIP_SHELL)
 
-void ProcessColorControlUnicastBindingRead(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessColorControlUnicastBindingRead(BindingCommandData * data, const Clusters::Binding::TableEntry & binding,
                                            OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
@@ -321,7 +321,7 @@ void ProcessColorControlUnicastBindingRead(BindingCommandData * data, const Embe
     }
 }
 
-void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const Clusters::Binding::TableEntry & binding,
                                               OperationalDeviceProxy * peer_device)
 {
     using namespace Clusters::ColorControl;
@@ -547,7 +547,7 @@ void ProcessColorControlUnicastBindingCommand(BindingCommandData * data, const E
     }
 }
 
-void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding)
+void ProcessColorControlGroupBindingCommand(BindingCommandData * data, const Clusters::Binding::TableEntry & binding)
 {
     using namespace Clusters::ColorControl;
 

--- a/examples/all-clusters-app/ameba/main/include/IdentifyCommand.h
+++ b/examples/all-clusters-app/ameba/main/include/IdentifyCommand.h
@@ -39,7 +39,7 @@ Engine sShellSwitchIdentifyReadSubCommands;
 Engine sShellSwitchGroupsIdentifySubCommands;
 #endif // defined(ENABLE_CHIP_SHELL)
 
-void ProcessIdentifyUnicastBindingRead(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessIdentifyUnicastBindingRead(BindingCommandData * data, const Clusters::Binding::TableEntry & binding,
                                        OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
@@ -71,7 +71,7 @@ void ProcessIdentifyUnicastBindingRead(BindingCommandData * data, const EmberBin
     }
 }
 
-void ProcessIdentifyUnicastBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessIdentifyUnicastBindingCommand(BindingCommandData * data, const Clusters::Binding::TableEntry & binding,
                                           OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -104,7 +104,7 @@ void ProcessIdentifyUnicastBindingCommand(BindingCommandData * data, const Ember
     }
 }
 
-void ProcessIdentifyGroupBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding)
+void ProcessIdentifyGroupBindingCommand(BindingCommandData * data, const Clusters::Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 

--- a/examples/all-clusters-app/ameba/main/include/LevelControlCommands.h
+++ b/examples/all-clusters-app/ameba/main/include/LevelControlCommands.h
@@ -54,7 +54,7 @@ T from_underlying(std::underlying_type_t<T> value)
 
 } // namespace
 
-void ProcessLevelControlUnicastBindingRead(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessLevelControlUnicastBindingRead(BindingCommandData * data, const Clusters::Binding::TableEntry & binding,
                                            OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
@@ -146,7 +146,7 @@ void ProcessLevelControlUnicastBindingRead(BindingCommandData * data, const Embe
     }
 }
 
-void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const Clusters::Binding::TableEntry & binding,
                                               OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -242,7 +242,7 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
     }
 }
 
-void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding)
+void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Clusters::Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 

--- a/examples/all-clusters-app/ameba/main/include/OnOffCommands.h
+++ b/examples/all-clusters-app/ameba/main/include/OnOffCommands.h
@@ -39,7 +39,7 @@ Engine sShellSwitchOnOffReadSubCommands;
 Engine sShellSwitchGroupsOnOffSubCommands;
 #endif // defined(ENABLE_CHIP_SHELL)
 
-void ProcessOnOffUnicastBindingRead(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessOnOffUnicastBindingRead(BindingCommandData * data, const Clusters::Binding::TableEntry & binding,
                                     OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
@@ -86,7 +86,7 @@ void ProcessOnOffUnicastBindingRead(BindingCommandData * data, const EmberBindin
     }
 }
 
-void ProcessOnOffUnicastBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessOnOffUnicastBindingCommand(BindingCommandData * data, const Clusters::Binding::TableEntry & binding,
                                        OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -145,7 +145,7 @@ void ProcessOnOffUnicastBindingCommand(BindingCommandData * data, const EmberBin
     }
 }
 
-void ProcessOnOffGroupBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding)
+void ProcessOnOffGroupBindingCommand(BindingCommandData * data, const Clusters::Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 

--- a/examples/all-clusters-app/ameba/main/include/ThermostatCommands.h
+++ b/examples/all-clusters-app/ameba/main/include/ThermostatCommands.h
@@ -39,7 +39,7 @@ Engine sShellSwitchThermostatReadSubCommands;
 Engine sShellSwitchGroupsThermostatSubCommands;
 #endif // defined(ENABLE_CHIP_SHELL)
 
-void ProcessThermostatUnicastBindingRead(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessThermostatUnicastBindingRead(BindingCommandData * data, const Clusters::Binding::TableEntry & binding,
                                          OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
@@ -136,7 +136,7 @@ void ProcessThermostatUnicastBindingRead(BindingCommandData * data, const EmberB
     }
 }
 
-void ProcessThermostatUnicastBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessThermostatUnicastBindingCommand(BindingCommandData * data, const Clusters::Binding::TableEntry & binding,
                                             OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -162,7 +162,7 @@ void ProcessThermostatUnicastBindingCommand(BindingCommandData * data, const Emb
     }
 }
 
-void ProcessThermostatGroupBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding)
+void ProcessThermostatGroupBindingCommand(BindingCommandData * data, const Clusters::Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 

--- a/examples/common/server-cluster-shim/ServerClusterShim.cpp
+++ b/examples/common/server-cluster-shim/ServerClusterShim.cpp
@@ -493,7 +493,8 @@ CHIP_ERROR ServerClusterShim::GeneratedCommands(const ConcreteClusterPath & path
     return builder.ReferenceExisting({ serverCluster->generatedCommandList, commandCount });
 }
 
-void ServerClusterShim::ListAttributeWriteNotification(const ConcreteAttributePath & aPath, DataModel::ListWriteOperation opType)
+void ServerClusterShim::ListAttributeWriteNotification(const ConcreteAttributePath & aPath, DataModel::ListWriteOperation opType,
+                                                       FabricIndex accessingFabric)
 {
     AttributeAccessInterface * aai = AttributeAccessInterfaceRegistry::Instance().Get(aPath.mEndpointId, aPath.mClusterId);
 

--- a/examples/common/server-cluster-shim/ServerClusterShim.h
+++ b/examples/common/server-cluster-shim/ServerClusterShim.h
@@ -81,7 +81,8 @@ public:
 
     CHIP_ERROR GeneratedCommands(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<CommandId> & builder) override;
 
-    void ListAttributeWriteNotification(const ConcreteAttributePath & aPath, DataModel::ListWriteOperation opType) override;
+    void ListAttributeWriteNotification(const ConcreteAttributePath & aPath, DataModel::ListWriteOperation opType,
+                                        FabricIndex accessingFabric) override;
 
     CHIP_ERROR EventInfo(const ConcreteEventPath & path, DataModel::EventEntry & eventInfo) override;
 

--- a/examples/light-switch-app/ameba/main/BindingHandler.cpp
+++ b/examples/light-switch-app/ameba/main/BindingHandler.cpp
@@ -31,6 +31,7 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 
 #if CONFIG_ENABLE_CHIP_SHELL
 using Shell::Engine;
@@ -49,7 +50,7 @@ Engine sShellSwitchBindingSubCommands;
 
 namespace {
 
-void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding,
+void ProcessOnOffUnicastBindingCommand(CommandId commandId, const Binding::TableEntry & binding,
                                        OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -83,7 +84,7 @@ void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTa
     }
 }
 
-void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding)
+void ProcessOnOffGroupBindingCommand(CommandId commandId, const Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 
@@ -107,12 +108,12 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const Binding::TableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
 
-    if (binding.type == MATTER_MULTICAST_BINDING && data->isGroup)
+    if (binding.type == Binding::MATTER_MULTICAST_BINDING && data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -121,7 +122,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
             break;
         }
     }
-    else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
+    else if (binding.type == Binding::MATTER_UNICAST_BINDING && !data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -142,10 +143,10 @@ void LightSwitchContextReleaseHandler(void * context)
 void InitBindingHandlerInternal(intptr_t arg)
 {
     auto & server = chip::Server::GetInstance();
-    chip::BindingManager::GetInstance().Init(
+    Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
-    chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
-    chip::BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
 }
 
 #ifdef CONFIG_ENABLE_CHIP_SHELL
@@ -244,13 +245,8 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 2, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_MULTICAST_BINDING;
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->groupId                 = atoi(argv[1]);
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.emplace(6);        // Hardcoded to OnOff cluster for now
-
+    Binding::TableEntry * entry =
+        Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }
@@ -259,14 +255,8 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 3, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_UNICAST_BINDING;
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->nodeId                  = atoi(argv[1]);
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->remote                  = atoi(argv[2]);
-    entry->clusterId.emplace(6); // Hardcode to OnOff cluster for now
-
+    Binding::TableEntry * entry =
+        Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]), std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }
@@ -407,14 +397,14 @@ void SwitchWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "SwitchWorkerFunction - Invalid work data"));
 
     BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
+    Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
 }
 
 void BindingWorkerFunction(intptr_t context)
 {
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "BindingWorkerFunction - Invalid work data"));
 
-    EmberBindingTableEntry * entry = reinterpret_cast<EmberBindingTableEntry *>(context);
+    Binding::TableEntry * entry = reinterpret_cast<Binding::TableEntry *>(context);
     AddBindingEntry(*entry);
 
     Platform::Delete(entry);

--- a/examples/light-switch-app/asr/include/BindingHandler.h
+++ b/examples/light-switch-app/asr/include/BindingHandler.h
@@ -52,9 +52,11 @@ public:
     }
 
 private:
-    static void OnOffProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
-    static void LevelControlProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
-    static void LightSwitchChangedHandler(const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
+    static void OnOffProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &,
+                                    chip::OperationalDeviceProxy *, void *);
+    static void LevelControlProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &,
+                                           chip::OperationalDeviceProxy *, void *);
+    static void LightSwitchChangedHandler(const chip::app::Clusters::Binding::TableEntry &, chip::OperationalDeviceProxy *, void *);
     static void LightSwitchContextReleaseHandler(void * context);
     static void InitInternal(intptr_t);
 

--- a/examples/light-switch-app/asr/src/BindingHandler.cpp
+++ b/examples/light-switch-app/asr/src/BindingHandler.cpp
@@ -27,6 +27,7 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 
 void BindingHandler::Init()
 {
@@ -52,7 +53,7 @@ void BindingHandler::OnInvokeCommandFailure(BindingData & aBindingData, CHIP_ERR
         *data                              = aBindingData;
 
         // Establish new CASE session and retrasmit command that was not applied.
-        error = BindingManager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId,
+        error = Binding::Manager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId,
                                                                         static_cast<void *>(data));
 
         if (CHIP_NO_ERROR != error)
@@ -67,7 +68,7 @@ void BindingHandler::OnInvokeCommandFailure(BindingData & aBindingData, CHIP_ERR
     }
 }
 
-void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindingTableEntry & aBinding,
+void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const Binding::TableEntry & aBinding,
                                          OperationalDeviceProxy * aDevice, void * aContext)
 {
     CHIP_ERROR ret     = CHIP_NO_ERROR;
@@ -143,7 +144,7 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
     }
 }
 
-void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const EmberBindingTableEntry & aBinding,
+void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Binding::TableEntry & aBinding,
                                                 OperationalDeviceProxy * aDevice, void * aContext)
 {
     CHIP_ERROR ret     = CHIP_NO_ERROR;
@@ -192,13 +193,13 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Embe
     }
 }
 
-void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & aBinding, OperationalDeviceProxy * deviceProxy,
+void BindingHandler::LightSwitchChangedHandler(const Binding::TableEntry & aBinding, OperationalDeviceProxy * deviceProxy,
                                                void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingData * data = static_cast<BindingData *>(context);
 
-    if (aBinding.type == MATTER_MULTICAST_BINDING && data->IsGroup)
+    if (aBinding.type == Binding::MATTER_MULTICAST_BINDING && data->IsGroup)
     {
         switch (data->ClusterId)
         {
@@ -213,7 +214,7 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & aB
             break;
         }
     }
-    else if (aBinding.type == MATTER_UNICAST_BINDING && !data->IsGroup)
+    else if (aBinding.type == Binding::MATTER_UNICAST_BINDING && !data->IsGroup)
     {
         switch (data->ClusterId)
         {
@@ -241,20 +242,20 @@ void BindingHandler::InitInternal(intptr_t arg)
 {
     ASR_LOG("Initialize binding Handler");
     auto & server = chip::Server::GetInstance();
-    chip::BindingManager::GetInstance().Init(
+    Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
-    chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
-    chip::BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
     BindingHandler::GetInstance().PrintBindingTable();
 }
 
 bool BindingHandler::IsGroupBound()
 {
-    BindingTable & bindingTable = BindingTable::GetInstance();
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
 
     for (auto & entry : bindingTable)
     {
-        if (MATTER_MULTICAST_BINDING == entry.type)
+        if (Binding::MATTER_MULTICAST_BINDING == entry.type)
         {
             return true;
         }
@@ -264,7 +265,7 @@ bool BindingHandler::IsGroupBound()
 
 void BindingHandler::PrintBindingTable()
 {
-    BindingTable & bindingTable = BindingTable::GetInstance();
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
 
     ASR_LOG("Binding Table size: [%d]:", bindingTable.Size());
     uint8_t i = 0;
@@ -272,7 +273,7 @@ void BindingHandler::PrintBindingTable()
     {
         switch (entry.type)
         {
-        case MATTER_UNICAST_BINDING:
+        case Binding::MATTER_UNICAST_BINDING:
             ASR_LOG("[%d] UNICAST:", i++);
             ASR_LOG("\t\t+ Fabric: %d\n \
             \t+ LocalEndpoint %d \n \
@@ -282,7 +283,7 @@ void BindingHandler::PrintBindingTable()
                     (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId),
                     (int) entry.remote, (int) entry.nodeId);
             break;
-        case MATTER_MULTICAST_BINDING:
+        case Binding::MATTER_MULTICAST_BINDING:
             ASR_LOG("[%d] GROUP:", i++);
             ASR_LOG("\t\t+ Fabric: %d\n \
             \t+ LocalEndpoint %d \n \
@@ -290,7 +291,7 @@ void BindingHandler::PrintBindingTable()
             \t+ GroupId %d",
                     (int) entry.fabricIndex, (int) entry.local, (int) entry.remote, (int) entry.groupId);
             break;
-        case MATTER_UNUSED_BINDING:
+        case Binding::MATTER_UNUSED_BINDING:
             ASR_LOG("[%d] UNUSED", i++);
             break;
         // case MATTER_MANY_TO_ONE_BINDING:
@@ -311,5 +312,5 @@ void BindingHandler::SwitchWorkerHandler(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "SwitchWorkerFunction - Invalid work data"));
 
     BindingData * data = reinterpret_cast<BindingData *>(context);
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->EndpointId, data->ClusterId, static_cast<void *>(data));
+    Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->EndpointId, data->ClusterId, static_cast<void *>(data));
 }

--- a/examples/light-switch-app/asr/src/BindingHandler.cpp
+++ b/examples/light-switch-app/asr/src/BindingHandler.cpp
@@ -54,7 +54,7 @@ void BindingHandler::OnInvokeCommandFailure(BindingData & aBindingData, CHIP_ERR
 
         // Establish new CASE session and retrasmit command that was not applied.
         error = Binding::Manager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId,
-                                                                        static_cast<void *>(data));
+                                                                          static_cast<void *>(data));
 
         if (CHIP_NO_ERROR != error)
         {

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -31,6 +31,7 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 
 #if CONFIG_ENABLE_CHIP_SHELL
 using Shell::Engine;
@@ -49,7 +50,7 @@ Engine sShellSwitchBindingSubCommands;
 
 namespace {
 
-void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding,
+void ProcessOnOffUnicastBindingCommand(CommandId commandId, const Binding::TableEntry & binding,
                                        Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -79,7 +80,7 @@ void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTa
     }
 }
 
-void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding)
+void ProcessOnOffGroupBindingCommand(CommandId commandId, const Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 
@@ -103,12 +104,12 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const Binding::TableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
 
-    if (binding.type == MATTER_MULTICAST_BINDING && data->isGroup)
+    if (binding.type == Binding::MATTER_MULTICAST_BINDING && data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -117,7 +118,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
             break;
         }
     }
-    else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
+    else if (binding.type == Binding::MATTER_UNICAST_BINDING && !data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -140,10 +141,10 @@ void LightSwitchContextReleaseHandler(void * context)
 void InitBindingHandlerInternal(intptr_t arg)
 {
     auto & server = chip::Server::GetInstance();
-    chip::BindingManager::GetInstance().Init(
+    Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
-    chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
-    chip::BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
 }
 
 #ifdef CONFIG_ENABLE_CHIP_SHELL
@@ -242,13 +243,8 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 2, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_MULTICAST_BINDING;
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->groupId                 = atoi(argv[1]);
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.emplace(6);        // Hardcoded to OnOff cluster for now
-
+    Binding::TableEntry * entry =
+        Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }
@@ -257,14 +253,8 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 3, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_UNICAST_BINDING;
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->nodeId                  = atoi(argv[1]);
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->remote                  = atoi(argv[2]);
-    entry->clusterId.emplace(6); // Hardcode to OnOff cluster for now
-
+    Binding::TableEntry * entry =
+        Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]), std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }
@@ -405,14 +395,14 @@ void SwitchWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "SwitchWorkerFunction - Invalid work data"));
 
     BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
+    Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
 }
 
 void BindingWorkerFunction(intptr_t context)
 {
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "BindingWorkerFunction - Invalid work data"));
 
-    EmberBindingTableEntry * entry = reinterpret_cast<EmberBindingTableEntry *>(context);
+    Binding::TableEntry * entry = reinterpret_cast<Binding::TableEntry *>(context);
     AddBindingEntry(*entry);
 
     Platform::Delete(entry);

--- a/examples/light-switch-app/genio/src/BindingHandler.cpp
+++ b/examples/light-switch-app/genio/src/BindingHandler.cpp
@@ -243,7 +243,8 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 2, CHIP_ERROR_INVALID_ARGUMENT);
 
-    Binding::TableEntry * entry = Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, std::make_optional<ClusterId>(6));
+    Binding::TableEntry * entry =
+        Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }
@@ -252,7 +253,8 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 3, CHIP_ERROR_INVALID_ARGUMENT);
 
-    Binding::TableEntry * entry = Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]), std::make_optional<ClusterId>(6));
+    Binding::TableEntry * entry =
+        Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]), std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }

--- a/examples/light-switch-app/genio/src/BindingHandler.cpp
+++ b/examples/light-switch-app/genio/src/BindingHandler.cpp
@@ -24,6 +24,7 @@
 #include "controller/InvokeInteraction.h"
 #include "platform/CHIPDeviceLayer.h"
 #include <lib/support/CodeUtils.h>
+#include <optional>
 
 #if defined(ENABLE_CHIP_SHELL)
 #include "lib/shell/Engine.h"
@@ -32,6 +33,7 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 
 #if defined(ENABLE_CHIP_SHELL)
 using Shell::Engine;
@@ -50,7 +52,7 @@ Engine sShellSwitchBindingSubCommands;
 
 namespace {
 
-void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding, DeviceProxy * peer_device)
+void ProcessOnOffUnicastBindingCommand(CommandId commandId, const Binding::TableEntry & binding, DeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
         ChipLogProgress(NotSpecified, "OnOff command succeeds");
@@ -85,7 +87,7 @@ void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTa
     }
 }
 
-void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding)
+void ProcessOnOffGroupBindingCommand(CommandId commandId, const Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 
@@ -110,7 +112,7 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
 }
 
 // void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DeviceProxy * peer_device, void * context)
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const Binding::TableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
@@ -118,7 +120,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
     // Eason+
     ChipLogDetail(AppServer, "LightSwitchChangedHandler~~~~~~~");
 
-    if (binding.type == MATTER_MULTICAST_BINDING && data->isGroup)
+    if (binding.type == Binding::MATTER_MULTICAST_BINDING && data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -127,7 +129,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
             break;
         }
     }
-    else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
+    else if (binding.type == Binding::MATTER_UNICAST_BINDING && !data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -241,13 +243,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 2, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_MULTICAST_BINDING;
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->groupId                 = atoi(argv[1]);
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.emplace(6);        // Hardcoded to OnOff cluster for now
-
+    Binding::TableEntry * entry = Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }
@@ -256,14 +252,7 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 3, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_UNICAST_BINDING;
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->nodeId                  = atoi(argv[1]);
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->remote                  = atoi(argv[2]);
-    entry->clusterId.emplace(6); // Hardcode to OnOff cluster for now
-
+    Binding::TableEntry * entry = Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]), std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }
@@ -395,10 +384,10 @@ static void RegisterSwitchCommands()
 void InitBindingHandlerInternal(intptr_t arg)
 {
     auto & server = chip::Server::GetInstance();
-    chip::BindingManager::GetInstance().Init(
+    Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
-    chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
-    chip::BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
 }
 
 } // namespace
@@ -412,14 +401,14 @@ void SwitchWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "SwitchWorkerFunction - Invalid work data"));
 
     BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
+    Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
 }
 
 void BindingWorkerFunction(intptr_t context)
 {
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "BindingWorkerFunction - Invalid work data"));
 
-    EmberBindingTableEntry * entry = reinterpret_cast<EmberBindingTableEntry *>(context);
+    Binding::TableEntry * entry = reinterpret_cast<Binding::TableEntry *>(context);
     AddBindingEntry(*entry);
 
     Platform::Delete(entry);

--- a/examples/light-switch-app/infineon/cyw30739/include/BindingHandler.h
+++ b/examples/light-switch-app/infineon/cyw30739/include/BindingHandler.h
@@ -54,9 +54,11 @@ public:
     }
 
 private:
-    static void OnOffProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
-    static void LevelControlProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
-    static void LightSwitchChangedHandler(const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
+    static void OnOffProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &,
+                                    chip::OperationalDeviceProxy *, void *);
+    static void LevelControlProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &,
+                                           chip::OperationalDeviceProxy *, void *);
+    static void LightSwitchChangedHandler(const chip::app::Clusters::Binding::TableEntry &, chip::OperationalDeviceProxy *, void *);
     static void LightSwitchContextReleaseHandler(void * context);
     static void InitInternal(intptr_t);
 

--- a/examples/light-switch-app/infineon/cyw30739/src/AppShellCommands.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/AppShellCommands.cpp
@@ -375,7 +375,7 @@ CHIP_ERROR UnicastBindCommandHandler(int argc, char ** argv)
     VerifyOrReturnError(argc == 4, CHIP_ERROR_INVALID_ARGUMENT);
 
     Binding::TableEntry * entry = Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]),
-                                                                     std::make_optional<ClusterId>(atoi(argv[2])));
+                                                                     std::make_optional<ClusterId>(atoi(argv[3])));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingHandler::BindingWorkerHandler, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }

--- a/examples/light-switch-app/infineon/cyw30739/src/AppShellCommands.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/AppShellCommands.cpp
@@ -361,13 +361,8 @@ CHIP_ERROR GroupBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 3, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_MULTICAST_BINDING;
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->groupId                 = atoi(argv[1]);
-    entry->clusterId.emplace(atoi(argv[3]));
-
+    Binding::TableEntry * entry =
+        Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, std::make_optional<ClusterId>(atoi(argv[2])));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingHandler::BindingWorkerHandler, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }
@@ -379,14 +374,8 @@ CHIP_ERROR UnicastBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 4, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_UNICAST_BINDING;
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->nodeId                  = atoi(argv[1]);
-    entry->remote                  = atoi(argv[2]);
-    entry->clusterId.emplace(atoi(argv[3]));
-
+    Binding::TableEntry * entry = Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]),
+                                                                     std::make_optional<ClusterId>(atoi(argv[2])));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingHandler::BindingWorkerHandler, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }

--- a/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
@@ -23,6 +23,7 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 
 void BindingHandler::Init()
 {
@@ -43,7 +44,7 @@ void BindingHandler::OnInvokeCommandFailure(BindingData & aBindingData, CHIP_ERR
         BindingHandler::BindingData * data = Platform::New<BindingHandler::BindingData>();
         *data                              = aBindingData;
         // Establish new CASE session and retrasmit command that was not applied.
-        error = chip::BindingManager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId,
+        error = Binding::Manager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId,
                                                                               static_cast<void *>(data));
 
         if (CHIP_NO_ERROR != error)
@@ -58,7 +59,7 @@ void BindingHandler::OnInvokeCommandFailure(BindingData & aBindingData, CHIP_ERR
     }
 }
 
-void ProcessIdentifyUnicastBindingRead(BindingHandler::BindingData * data, const EmberBindingTableEntry & binding,
+void ProcessIdentifyUnicastBindingRead(BindingHandler::BindingData * data, const Binding::TableEntry & binding,
                                        OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
@@ -84,7 +85,7 @@ void ProcessIdentifyUnicastBindingRead(BindingHandler::BindingData * data, const
     }
 }
 
-void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindingTableEntry & aBinding,
+void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const Binding::TableEntry & aBinding,
                                          OperationalDeviceProxy * aDevice, void * aContext)
 {
     CHIP_ERROR ret     = CHIP_NO_ERROR;
@@ -158,7 +159,7 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
     }
 }
 
-void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const EmberBindingTableEntry & aBinding,
+void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Binding::TableEntry & aBinding,
                                                 OperationalDeviceProxy * aDevice, void * aContext)
 {
     BindingData * data = reinterpret_cast<BindingData *>(aContext);
@@ -207,13 +208,13 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Embe
     }
 }
 
-void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & binding, OperationalDeviceProxy * deviceProxy,
+void BindingHandler::LightSwitchChangedHandler(const Binding::TableEntry & binding, OperationalDeviceProxy * deviceProxy,
                                                void * context)
 {
     VerifyOrReturn(context != nullptr, printf("Invalid context for Light switch handler\n"););
     BindingData * data = static_cast<BindingData *>(context);
 
-    if (binding.type == MATTER_MULTICAST_BINDING && data->IsGroup)
+    if (binding.type == Binding::MATTER_MULTICAST_BINDING && data->IsGroup)
     {
         switch (data->ClusterId)
         {
@@ -228,7 +229,7 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & bi
             break;
         }
     }
-    else if (binding.type == MATTER_UNICAST_BINDING && !data->IsGroup)
+    else if (binding.type == Binding::MATTER_UNICAST_BINDING && !data->IsGroup)
     {
         switch (data->ClusterId)
         {
@@ -260,7 +261,7 @@ void BindingHandler::InitInternal(intptr_t aArg)
     CHIP_ERROR ret = CHIP_NO_ERROR;
     auto & server  = Server::GetInstance();
 
-    ret = BindingManager::GetInstance().Init(
+    ret = Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
     if (CHIP_NO_ERROR != ret)
     {
@@ -269,19 +270,19 @@ void BindingHandler::InitInternal(intptr_t aArg)
     }
     else
     {
-        BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
-        BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
+        Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+        Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
         BindingHandler::GetInstance().PrintBindingTable();
     }
 }
 
 bool BindingHandler::IsGroupBound()
 {
-    BindingTable & bindingTable = BindingTable::GetInstance();
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
 
     for (auto & entry : bindingTable)
     {
-        if (MATTER_MULTICAST_BINDING == entry.type)
+        if (Binding::MATTER_MULTICAST_BINDING == entry.type)
         {
             return true;
         }
@@ -291,7 +292,7 @@ bool BindingHandler::IsGroupBound()
 
 void BindingHandler::PrintBindingTable()
 {
-    BindingTable & bindingTable = BindingTable::GetInstance();
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
 
     printf("Binding Table size: [%d]:\n", bindingTable.Size());
     uint8_t i = 0;
@@ -299,7 +300,7 @@ void BindingHandler::PrintBindingTable()
     {
         switch (entry.type)
         {
-        case MATTER_UNICAST_BINDING:
+        case Binding::MATTER_UNICAST_BINDING:
             printf("[%d] UNICAST:", i++);
             printf("\t\t+ Fabric: %d\n \
             \t+ LocalEndpoint %d \n \
@@ -309,7 +310,7 @@ void BindingHandler::PrintBindingTable()
                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId),
                    (int) entry.remote, (int) entry.nodeId);
             break;
-        case MATTER_MULTICAST_BINDING:
+        case Binding::MATTER_MULTICAST_BINDING:
             printf("[%d] GROUP:", i++);
             printf("\t\t+ Fabric: %d\n \
             \t+ LocalEndpoint %d \n \
@@ -317,7 +318,7 @@ void BindingHandler::PrintBindingTable()
             \t+ GroupId %d \n",
                    (int) entry.fabricIndex, (int) entry.local, (int) entry.remote, (int) entry.groupId);
             break;
-        case MATTER_UNUSED_BINDING:
+        case Binding::MATTER_UNUSED_BINDING:
             printf("[%d] UNUSED", i++);
             break;
         default:
@@ -332,7 +333,7 @@ void BindingHandler::SwitchWorkerHandler(intptr_t context)
 
     BindingHandler::BindingData * data = reinterpret_cast<BindingHandler::BindingData *>(context);
     printf("Notify Bounded Cluster | endpoint: %d cluster: %ld\n", data->EndpointId, data->ClusterId);
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->EndpointId, data->ClusterId, static_cast<void *>(data));
+    Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->EndpointId, data->ClusterId, static_cast<void *>(data));
 
     Platform::Delete(data);
 }
@@ -340,7 +341,7 @@ void BindingHandler::SwitchWorkerHandler(intptr_t context)
 void BindingHandler::BindingWorkerHandler(intptr_t context)
 {
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "BindingHandler::Invalid binding work data\n"));
-    EmberBindingTableEntry * entry = reinterpret_cast<EmberBindingTableEntry *>(context);
+    Binding::TableEntry * entry = reinterpret_cast<Binding::TableEntry *>(context);
     AddBindingEntry(*entry);
 
     Platform::Delete(entry);

--- a/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
@@ -45,7 +45,7 @@ void BindingHandler::OnInvokeCommandFailure(BindingData & aBindingData, CHIP_ERR
         *data                              = aBindingData;
         // Establish new CASE session and retrasmit command that was not applied.
         error = Binding::Manager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId,
-                                                                              static_cast<void *>(data));
+                                                                          static_cast<void *>(data));
 
         if (CHIP_NO_ERROR != error)
         {

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -26,6 +26,7 @@ LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 
 void BindingHandler::Init()
 {
@@ -51,7 +52,7 @@ void BindingHandler::OnInvokeCommandFailure(BindingData & aBindingData, CHIP_ERR
         *data                              = aBindingData;
 
         // Establish new CASE session and retrasmit command that was not applied.
-        error = BindingManager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId,
+        error = Binding::Manager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId,
                                                                         static_cast<void *>(data));
 
         if (CHIP_NO_ERROR != error)
@@ -66,7 +67,7 @@ void BindingHandler::OnInvokeCommandFailure(BindingData & aBindingData, CHIP_ERR
     }
 }
 
-void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindingTableEntry & aBinding,
+void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const Binding::TableEntry & aBinding,
                                          OperationalDeviceProxy * aDevice, void * aContext)
 {
     CHIP_ERROR ret     = CHIP_NO_ERROR;
@@ -142,7 +143,7 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
     }
 }
 
-void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const EmberBindingTableEntry & aBinding,
+void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Binding::TableEntry & aBinding,
                                                 OperationalDeviceProxy * aDevice, void * aContext)
 {
     BindingData * data = reinterpret_cast<BindingData *>(aContext);
@@ -192,13 +193,13 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Embe
     }
 }
 
-void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & binding, OperationalDeviceProxy * deviceProxy,
+void BindingHandler::LightSwitchChangedHandler(const Binding::TableEntry & binding, OperationalDeviceProxy * deviceProxy,
                                                void * context)
 {
     VerifyOrReturn(context != nullptr, LOG_ERR("Invalid context for Light switch handler"););
     BindingData * data = static_cast<BindingData *>(context);
 
-    if (binding.type == MATTER_MULTICAST_BINDING && data->IsGroup)
+    if (binding.type == Binding::MATTER_MULTICAST_BINDING && data->IsGroup)
     {
         switch (data->ClusterId)
         {
@@ -213,7 +214,7 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & bi
             break;
         }
     }
-    else if (binding.type == MATTER_UNICAST_BINDING && !data->IsGroup)
+    else if (binding.type == Binding::MATTER_UNICAST_BINDING && !data->IsGroup)
     {
         switch (data->ClusterId)
         {
@@ -242,24 +243,24 @@ void BindingHandler::InitInternal(intptr_t aArg)
     LOG_INF("Initialize binding Handler");
     auto & server = Server::GetInstance();
     if (CHIP_NO_ERROR !=
-        BindingManager::GetInstance().Init(
+        Binding::Manager::GetInstance().Init(
             { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() }))
     {
         LOG_ERR("BindingHandler::InitInternal failed");
     }
 
-    BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
-    BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
     BindingHandler::GetInstance().PrintBindingTable();
 }
 
 bool BindingHandler::IsGroupBound()
 {
-    BindingTable & bindingTable = BindingTable::GetInstance();
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
 
     for (auto & entry : bindingTable)
     {
-        if (MATTER_MULTICAST_BINDING == entry.type)
+        if (Binding::MATTER_MULTICAST_BINDING == entry.type)
         {
             return true;
         }
@@ -269,7 +270,7 @@ bool BindingHandler::IsGroupBound()
 
 void BindingHandler::PrintBindingTable()
 {
-    BindingTable & bindingTable = BindingTable::GetInstance();
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
 
     LOG_INF("Binding Table size: [%d]:", bindingTable.Size());
     uint8_t i = 0;
@@ -277,7 +278,7 @@ void BindingHandler::PrintBindingTable()
     {
         switch (entry.type)
         {
-        case MATTER_UNICAST_BINDING:
+        case Binding::MATTER_UNICAST_BINDING:
             LOG_INF("[%d] UNICAST:", i++);
             LOG_INF("\t\t+ Fabric: %d\n \
             \t+ LocalEndpoint %d \n \
@@ -287,7 +288,7 @@ void BindingHandler::PrintBindingTable()
                     (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId),
                     (int) entry.remote, (int) entry.nodeId);
             break;
-        case MATTER_MULTICAST_BINDING:
+        case Binding::MATTER_MULTICAST_BINDING:
             LOG_INF("[%d] GROUP:", i++);
             LOG_INF("\t\t+ Fabric: %d\n \
             \t+ LocalEndpoint %d \n \
@@ -295,7 +296,7 @@ void BindingHandler::PrintBindingTable()
             \t+ GroupId %d",
                     (int) entry.fabricIndex, (int) entry.local, (int) entry.remote, (int) entry.groupId);
             break;
-        case MATTER_UNUSED_BINDING:
+        case Binding::MATTER_UNUSED_BINDING:
             LOG_INF("[%d] UNUSED", i++);
             break;
         default:
@@ -310,5 +311,5 @@ void BindingHandler::SwitchWorkerHandler(intptr_t aContext)
 
     BindingData * data = reinterpret_cast<BindingData *>(aContext);
     LOG_INF("Notify Bounded Cluster | endpoint: %d cluster: %d", data->EndpointId, data->ClusterId);
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->EndpointId, data->ClusterId, static_cast<void *>(data));
+    Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->EndpointId, data->ClusterId, static_cast<void *>(data));
 }

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -53,7 +53,7 @@ void BindingHandler::OnInvokeCommandFailure(BindingData & aBindingData, CHIP_ERR
 
         // Establish new CASE session and retrasmit command that was not applied.
         error = Binding::Manager::GetInstance().NotifyBoundClusterChanged(aBindingData.EndpointId, aBindingData.ClusterId,
-                                                                        static_cast<void *>(data));
+                                                                          static_cast<void *>(data));
 
         if (CHIP_NO_ERROR != error)
         {

--- a/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
+++ b/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
@@ -51,9 +51,9 @@ public:
     }
 
 private:
-    static void OnOffProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
-    static void LevelControlProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
-    static void LightSwitchChangedHandler(const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
+    static void OnOffProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &, chip::OperationalDeviceProxy *, void *);
+    static void LevelControlProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &, chip::OperationalDeviceProxy *, void *);
+    static void LightSwitchChangedHandler(const chip::app::Clusters::Binding::TableEntry &, chip::OperationalDeviceProxy *, void *);
     static void LightSwitchContextReleaseHandler(void * context);
     static void InitInternal(intptr_t);
 

--- a/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
+++ b/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
@@ -51,8 +51,10 @@ public:
     }
 
 private:
-    static void OnOffProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &, chip::OperationalDeviceProxy *, void *);
-    static void LevelControlProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &, chip::OperationalDeviceProxy *, void *);
+    static void OnOffProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &,
+                                    chip::OperationalDeviceProxy *, void *);
+    static void LevelControlProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &,
+                                           chip::OperationalDeviceProxy *, void *);
     static void LightSwitchChangedHandler(const chip::app::Clusters::Binding::TableEntry &, chip::OperationalDeviceProxy *, void *);
     static void LightSwitchContextReleaseHandler(void * context);
     static void InitInternal(intptr_t);

--- a/examples/light-switch-app/qpg/src/binding-handler.cpp
+++ b/examples/light-switch-app/qpg/src/binding-handler.cpp
@@ -23,10 +23,11 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 
 static bool sEnabled = false;
 
-static void ProcessSwitchUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding,
+static void ProcessSwitchUnicastBindingCommand(CommandId commandId, const Binding::TableEntry & binding,
                                                Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle,
                                                BindingCommandData * data)
 {
@@ -95,7 +96,7 @@ static void ProcessSwitchUnicastBindingCommand(CommandId commandId, const EmberB
     }
 }
 
-static void ProcessSwitchGroupBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding, BindingCommandData * data)
+static void ProcessSwitchGroupBindingCommand(CommandId commandId, const Binding::TableEntry & binding, BindingCommandData * data)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 
@@ -156,12 +157,12 @@ static void ProcessSwitchGroupBindingCommand(CommandId commandId, const EmberBin
     }
 }
 
-static void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
+static void LightSwitchChangedHandler(const Binding::TableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "nullptr pointer passed"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
 
-    if (binding.type == MATTER_MULTICAST_BINDING && data->isGroup)
+    if (binding.type == Binding::MATTER_MULTICAST_BINDING && data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -172,7 +173,7 @@ static void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Op
             break;
         }
     }
-    else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
+    else if (binding.type == Binding::MATTER_UNICAST_BINDING && !data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -202,17 +203,17 @@ static void LightSwitchContextReleaseHandler(void * context)
 
 void InitBindingManager(intptr_t context)
 {
-    auto & server                          = chip::Server::GetInstance();
-    BindingManagerInitParams bindingParams = { &server.GetFabricTable(), server.GetCASESessionManager(),
-                                               &server.GetPersistentStorage() };
-    CHIP_ERROR error                       = BindingManager::GetInstance().Init(bindingParams);
+    auto & server                            = chip::Server::GetInstance();
+    Binding::ManagerInitParams bindingParams = { &server.GetFabricTable(), server.GetCASESessionManager(),
+                                                 &server.GetPersistentStorage() };
+    CHIP_ERROR error                         = Binding::Manager::GetInstance().Init(bindingParams);
     if (error != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "BindingManager initialization failed: %" CHIP_ERROR_FORMAT, error.Format());
         return;
     }
-    BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
-    BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
     sEnabled = true;
 }
 
@@ -228,5 +229,5 @@ void SwitchWorkerFunction(intptr_t context)
         Platform::Delete(data);
     }
 
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
+    Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
 }

--- a/examples/light-switch-app/realtek/bee/main/LightSwitch.cpp
+++ b/examples/light-switch-app/realtek/bee/main/LightSwitch.cpp
@@ -35,7 +35,7 @@ void LightSwitch::Init()
 
 void LightSwitch::InitiateActionSwitch(chip::EndpointId endpointId, uint8_t action)
 {
-    BindingTable & bindingTable = BindingTable::GetInstance();
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
     if (!bindingTable.Size())
     {
         ChipLogError(DeviceLayer, "bindingTable empty");
@@ -51,7 +51,7 @@ void LightSwitch::InitiateActionSwitch(chip::EndpointId endpointId, uint8_t acti
 
         for (auto & entry : bindingTable)
         {
-            if (endpointId == entry.local && MATTER_MULTICAST_BINDING == entry.type)
+            if (endpointId == entry.local && Binding::MATTER_MULTICAST_BINDING == entry.type)
             {
                 data->IsGroup = true;
                 break;
@@ -105,7 +105,7 @@ void LightSwitch::GenericSwitchReleasePress()
 #if CONFIG_ENABLE_ATTRIBUTE_SUBSCRIBE
 void LightSwitch::SubscribeRequestForOneNode(chip::EndpointId endpointId)
 {
-    BindingTable & bindingTable = BindingTable::GetInstance();
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
 
     if (!bindingTable.Size())
     {
@@ -117,7 +117,7 @@ void LightSwitch::SubscribeRequestForOneNode(chip::EndpointId endpointId)
 
 void LightSwitch::ShutdownSubscribeRequestForOneNode(chip::EndpointId endpointId)
 {
-    BindingTable & bindingTable = BindingTable::GetInstance();
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
     for (auto & entry : bindingTable)
     {
         ChipLogError(DeviceLayer, "entry.local %d", entry.local);

--- a/examples/light-switch-app/realtek/bee/main/include/BindingHandler.h
+++ b/examples/light-switch-app/realtek/bee/main/include/BindingHandler.h
@@ -58,8 +58,9 @@ public:
     }
 
 private:
-    static void OnOffProcessCommand(chip::CommandId, const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
-    static void LightSwitchChangedHandler(const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
+    static void OnOffProcessCommand(chip::CommandId, const chip::app::Clusters::Binding::TableEntry &,
+                                    chip::OperationalDeviceProxy *, void *);
+    static void LightSwitchChangedHandler(const chip::app::Clusters::Binding::TableEntry &, chip::OperationalDeviceProxy *, void *);
     static void LightSwitchContextReleaseHandler(void * context);
     static void InitInternal(intptr_t);
     bool mCaseSessionRecovered = false;

--- a/examples/light-switch-app/silabs/src/BindingHandler.cpp
+++ b/examples/light-switch-app/silabs/src/BindingHandler.cpp
@@ -27,11 +27,12 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::LevelControl;
 
 namespace {
 
-void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding,
+void ProcessOnOffUnicastBindingCommand(CommandId commandId, const Binding::TableEntry & binding,
                                        Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -61,7 +62,7 @@ void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTa
     }
 }
 
-void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding)
+void ProcessOnOffGroupBindingCommand(CommandId commandId, const Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 
@@ -85,7 +86,7 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const Binding::TableEntry & binding,
                                               OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -214,7 +215,7 @@ void ProcessLevelControlUnicastBindingCommand(BindingCommandData * data, const E
     }
 }
 
-void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding)
+void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 
@@ -326,12 +327,12 @@ void ProcessLevelControlGroupBindingCommand(BindingCommandData * data, const Emb
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const Binding::TableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
 
-    if (binding.type == MATTER_MULTICAST_BINDING && data->isGroup)
+    if (binding.type == Binding::MATTER_MULTICAST_BINDING && data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -343,7 +344,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
             break;
         }
     }
-    else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
+    else if (binding.type == Binding::MATTER_UNICAST_BINDING && !data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -368,10 +369,10 @@ void LightSwitchContextReleaseHandler(void * context)
 void InitBindingHandlerInternal(intptr_t arg)
 {
     auto & server = chip::Server::GetInstance();
-    chip::BindingManager::GetInstance().Init(
+    Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
-    chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
-    chip::BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
 }
 
 } // namespace
@@ -385,7 +386,7 @@ void SwitchWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "SwitchWorkerFunction - Invalid work data"));
 
     BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
+    Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
 
     Platform::Delete(data);
 }
@@ -394,7 +395,7 @@ void BindingWorkerFunction(intptr_t context)
 {
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "BindingWorkerFunction - Invalid work data"));
 
-    EmberBindingTableEntry * entry = reinterpret_cast<EmberBindingTableEntry *>(context);
+    Binding::TableEntry * entry = reinterpret_cast<Binding::TableEntry *>(context);
     AddBindingEntry(*entry);
 
     Platform::Delete(entry);

--- a/examples/light-switch-app/silabs/src/ShellCommands.cpp
+++ b/examples/light-switch-app/silabs/src/ShellCommands.cpp
@@ -16,10 +16,11 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <optional>
 #if defined(ENABLE_CHIP_SHELL)
 
-#include "ShellCommands.h"
 #include "BindingHandler.h"
+#include "ShellCommands.h"
 
 #include <app/clusters/bindings/BindingManager.h>
 #include <lib/shell/Engine.h>
@@ -28,6 +29,7 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 
 namespace LightSwitchCommands {
 
@@ -140,13 +142,8 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 2, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_MULTICAST_BINDING;
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->groupId                 = atoi(argv[1]);
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.emplace(6);        // Hardcoded to OnOff cluster for now
-
+    Binding::TableEntry * entry =
+        Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }
@@ -155,14 +152,8 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 3, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_UNICAST_BINDING;
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->nodeId                  = atoi(argv[1]);
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->remote                  = atoi(argv[2]);
-    entry->clusterId.emplace(6); // Hardcode to OnOff cluster for now
-
+    Binding::TableEntry * entry =
+        Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]), std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }

--- a/examples/light-switch-app/telink/include/IdentifyCommand.h
+++ b/examples/light-switch-app/telink/include/IdentifyCommand.h
@@ -27,6 +27,7 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 
 #if defined(CONFIG_CHIP_LIB_SHELL)
 using Shell::Engine;
@@ -39,7 +40,7 @@ Engine sShellSwitchIdentifyReadSubCommands;
 Engine sShellSwitchGroupsIdentifySubCommands;
 #endif // CONFIG_CHIP_LIB_SHELL
 
-void ProcessIdentifyUnicastBindingRead(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessIdentifyUnicastBindingRead(BindingCommandData * data, const Binding::TableEntry & binding,
                                        OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
@@ -71,7 +72,7 @@ void ProcessIdentifyUnicastBindingRead(BindingCommandData * data, const EmberBin
     }
 }
 
-void ProcessIdentifyUnicastBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding,
+void ProcessIdentifyUnicastBindingCommand(BindingCommandData * data, const Binding::TableEntry & binding,
                                           OperationalDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -104,7 +105,7 @@ void ProcessIdentifyUnicastBindingCommand(BindingCommandData * data, const Ember
     }
 }
 
-void ProcessIdentifyGroupBindingCommand(BindingCommandData * data, const EmberBindingTableEntry & binding)
+void ProcessIdentifyGroupBindingCommand(BindingCommandData * data, const Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 

--- a/examples/light-switch-app/telink/src/binding-handler.cpp
+++ b/examples/light-switch-app/telink/src/binding-handler.cpp
@@ -34,6 +34,7 @@ LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 
 #if defined(CONFIG_CHIP_LIB_SHELL)
 using Shell::Engine;
@@ -52,7 +53,7 @@ Engine sShellSwitchBindingSubCommands;
 
 namespace {
 
-void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding,
+void ProcessOnOffUnicastBindingCommand(CommandId commandId, const Binding::TableEntry & binding,
                                        Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -82,7 +83,7 @@ void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTa
     }
 }
 
-void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding)
+void ProcessOnOffGroupBindingCommand(CommandId commandId, const Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
 
@@ -106,7 +107,7 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const Binding::TableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
@@ -115,7 +116,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
     if (data->isReadAttribute)
     {
         // It should always enter here if isReadAttribute is true
-        if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
+        if (binding.type == Binding::MATTER_UNICAST_BINDING && !data->isGroup)
         {
             switch (data->clusterId)
             {
@@ -127,7 +128,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
     }
     else
     {
-        if (binding.type == MATTER_MULTICAST_BINDING && data->isGroup)
+        if (binding.type == Binding::MATTER_MULTICAST_BINDING && data->isGroup)
         {
             switch (data->clusterId)
             {
@@ -139,7 +140,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
                 break;
             }
         }
-        else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
+        else if (binding.type == Binding::MATTER_UNICAST_BINDING && !data->isGroup)
         {
             switch (data->clusterId)
             {
@@ -259,13 +260,8 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 2, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_MULTICAST_BINDING;
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->groupId                 = atoi(argv[1]);
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.emplace(6);        // Hardcoded to OnOff cluster for now
-
+    Binding::TableEntry * entry =
+        Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }
@@ -274,14 +270,8 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
 {
     VerifyOrReturnError(argc == 3, CHIP_ERROR_INVALID_ARGUMENT);
 
-    EmberBindingTableEntry * entry = Platform::New<EmberBindingTableEntry>();
-    entry->type                    = MATTER_UNICAST_BINDING;
-    entry->fabricIndex             = atoi(argv[0]);
-    entry->nodeId                  = atoi(argv[1]);
-    entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->remote                  = atoi(argv[2]);
-    entry->clusterId.emplace(6); // Hardcode to OnOff cluster for now
-
+    Binding::TableEntry * entry =
+        Platform::New<Binding::TableEntry>(atoi(argv[0]), atoi(argv[1]), 1, atoi(argv[2]), std::make_optional<ClusterId>(6));
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
 }
@@ -439,10 +429,10 @@ static void RegisterSwitchCommands()
 void InitBindingHandlerInternal(intptr_t arg)
 {
     auto & server = chip::Server::GetInstance();
-    chip::BindingManager::GetInstance().Init(
+    Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
-    chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
-    chip::BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
 }
 
 } // namespace
@@ -453,11 +443,11 @@ void InitBindingHandlerInternal(intptr_t arg)
 
 bool IsGroupBound()
 {
-    BindingTable & bindingTable = BindingTable::GetInstance();
+    Binding::Table & bindingTable = Binding::Table::GetInstance();
 
     for (auto & entry : bindingTable)
     {
-        if (MATTER_MULTICAST_BINDING == entry.type)
+        if (Binding::MATTER_MULTICAST_BINDING == entry.type)
         {
             return true;
         }
@@ -470,14 +460,14 @@ void SwitchWorkerFunction(intptr_t context)
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "SwitchWorkerFunction - Invalid work data"));
 
     BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
+    Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
 }
 
 void BindingWorkerFunction(intptr_t context)
 {
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "BindingWorkerFunction - Invalid work data"));
 
-    EmberBindingTableEntry * entry = reinterpret_cast<EmberBindingTableEntry *>(context);
+    Binding::TableEntry * entry = reinterpret_cast<Binding::TableEntry *>(context);
     AddBindingEntry(*entry);
 
     Platform::Delete(entry);

--- a/examples/light-switch-app/ti/cc13x4_26x4/src/BindingHandler.cpp
+++ b/examples/light-switch-app/ti/cc13x4_26x4/src/BindingHandler.cpp
@@ -28,10 +28,11 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 
 namespace {
 
-void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding,
+void ProcessOnOffUnicastBindingCommand(CommandId commandId, const Binding::TableEntry & binding,
                                        Messaging::ExchangeManager * exchangeMgr, const SessionHandle & sessionHandle)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -60,7 +61,7 @@ void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTa
     }
 }
 
-void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding)
+void ProcessOnOffGroupBindingCommand(CommandId commandId, const Binding::TableEntry & binding)
 {
     Messaging::ExchangeManager & exchangeMgr = Server::GetInstance().GetExchangeManager();
     switch (commandId)
@@ -83,11 +84,11 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const Binding::TableEntry & binding, OperationalDeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
-    if (binding.type == MATTER_MULTICAST_BINDING && data->isGroup)
+    if (binding.type == Binding::MATTER_MULTICAST_BINDING && data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -98,7 +99,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
             break;
         }
     }
-    else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
+    else if (binding.type == Binding::MATTER_UNICAST_BINDING && !data->isGroup)
     {
         switch (data->clusterId)
         {
@@ -122,13 +123,13 @@ void InitBindingHandlerInternal(intptr_t arg)
     ChipLogProgress(NotSpecified, "Initializing Binding Handler");
     auto & server = chip::Server::GetInstance();
     if (CHIP_NO_ERROR !=
-        BindingManager::GetInstance().Init(
+        Binding::Manager::GetInstance().Init(
             { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() }))
     {
         ChipLogError(NotSpecified, "InitBindingHandlerInternal failed");
     }
-    chip::BindingManager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
-    chip::BindingManager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceChangedHandler(LightSwitchChangedHandler);
+    Binding::Manager::GetInstance().RegisterBoundDeviceContextReleaseHandler(LightSwitchContextReleaseHandler);
 }
 
 } // namespace
@@ -141,13 +142,13 @@ void SwitchWorkerFunction(intptr_t context)
 {
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "SwitchWorkerFunction - Invalid work data"));
     BindingCommandData * data = reinterpret_cast<BindingCommandData *>(context);
-    BindingManager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
+    Binding::Manager::GetInstance().NotifyBoundClusterChanged(data->localEndpointId, data->clusterId, static_cast<void *>(data));
 }
 
 void BindingWorkerFunction(intptr_t context)
 {
     VerifyOrReturn(context != 0, ChipLogError(NotSpecified, "BindingWorkerFunction - Invalid work data"));
-    EmberBindingTableEntry * entry = reinterpret_cast<EmberBindingTableEntry *>(context);
+    Binding::TableEntry * entry = reinterpret_cast<Binding::TableEntry *>(context);
     AddBindingEntry(*entry);
     Platform::Delete(entry);
 }

--- a/examples/thermostat/asr/include/BindingHandler.h
+++ b/examples/thermostat/asr/include/BindingHandler.h
@@ -46,9 +46,11 @@ public:
     static void SubscribeHumidityAttribute(chip::AttributeId attributeId, chip::DeviceProxy * peer_device, void * context);
 
 private:
-    static void ReadTemperatureAttribute(chip::AttributeId, const EmberBindingTableEntry &, chip::DeviceProxy *, void *);
-    static void ReadHumidityAttribute(chip::AttributeId, const EmberBindingTableEntry &, chip::DeviceProxy *, void *);
-    static void ThermostatChangedHandler(const EmberBindingTableEntry &, chip::OperationalDeviceProxy *, void *);
+    static void ReadTemperatureAttribute(chip::AttributeId, const chip::app::Clusters::Binding::TableEntry &, chip::DeviceProxy *,
+                                         void *);
+    static void ReadHumidityAttribute(chip::AttributeId, const chip::app::Clusters::Binding::TableEntry &, chip::DeviceProxy *,
+                                      void *);
+    static void ThermostatChangedHandler(const chip::app::Clusters::Binding::TableEntry &, chip::OperationalDeviceProxy *, void *);
     static void ThermostatContextReleaseHandler(void *);
     static void InitInternal(intptr_t);
 };

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
@@ -102,7 +102,7 @@ JNI_METHOD(jobject, finishStartup)(JNIEnv *, jobject)
     // &server.GetCommissioningWindowManager().SetAppDelegate(??);
 
     // Initialize binding handlers
-    err = chip::BindingManager::GetInstance().Init(
+    err = chip::app::clusters::Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
     VerifyOrReturnValue(err == CHIP_NO_ERROR, support::convertMatterErrorFromCppToJava(err),
                         ChipLogError(AppServer, "Failed to init BindingManager %" CHIP_ERROR_FORMAT, err.Format()));

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
@@ -102,7 +102,7 @@ JNI_METHOD(jobject, finishStartup)(JNIEnv *, jobject)
     // &server.GetCommissioningWindowManager().SetAppDelegate(??);
 
     // Initialize binding handlers
-    err = chip::app::clusters::Binding::Manager::GetInstance().Init(
+    err = chip::app::Clusters::Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
     VerifyOrReturnValue(err == CHIP_NO_ERROR, support::convertMatterErrorFromCppToJava(err),
                         ChipLogError(AppServer, "Failed to init BindingManager %" CHIP_ERROR_FORMAT, err.Format()));

--- a/examples/tv-casting-app/linux/CastingShellCommands.cpp
+++ b/examples/tv-casting-app/linux/CastingShellCommands.cpp
@@ -85,7 +85,7 @@ static CHIP_ERROR PrintAllCommands()
 
 void PrintBindings()
 {
-    for (const auto & binding : BindingTable::GetInstance())
+    for (const auto & binding : chip::app::Clusters::Binding::Table::GetInstance())
     {
         ChipLogProgress(NotSpecified,
                         "Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -580,7 +580,7 @@ CHIP_ERROR PrintAllCommands()
 
 void PrintBindings()
 {
-    for (const auto & binding : chip::BindingTable::GetInstance())
+    for (const auto & binding : chip::app::Clusters::Binding::Table::GetInstance())
     {
         ChipLogProgress(AppServer,
                         "PrintBindings() Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -146,7 +146,7 @@ CHIP_ERROR CastingApp::PostStartRegistrations()
     // &server.GetCommissioningWindowManager().SetAppDelegate(??);
 
     // Initialize binding handlers
-    chip::BindingManager::GetInstance().Init(
+    chip::app::Clusters::Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
 
     // Set FabricDelegate

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -111,7 +111,7 @@ CHIP_ERROR CastingServer::SetRotatingDeviceIdUniqueId(chip::Optional<chip::ByteS
 CHIP_ERROR CastingServer::InitBindingHandlers()
 {
     auto & server = chip::Server::GetInstance();
-    chip::BindingManager::GetInstance().Init(
+    app::Clusters::Binding::Manager::GetInstance().Init(
         { &server.GetFabricTable(), server.GetCASESessionManager(), &server.GetPersistentStorage() });
     return CHIP_NO_ERROR;
 }
@@ -304,14 +304,14 @@ void CastingServer::ReadServerClustersForNode(NodeId nodeId)
         ChipLogError(AppServer, "Init error: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
-    for (const auto & binding : BindingTable::GetInstance())
+    for (const auto & binding : app::Clusters::Binding::Table::GetInstance())
     {
         ChipLogProgress(NotSpecified,
                         "Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64
                         " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                         binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
                         binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
-        if (binding.type == MATTER_UNICAST_BINDING && nodeId == binding.nodeId)
+        if (binding.type == app::Clusters::Binding::MATTER_UNICAST_BINDING && nodeId == binding.nodeId)
         {
             if (!mActiveTargetVideoPlayerInfo.HasEndpoint(binding.remote))
             {
@@ -575,7 +575,7 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
 
             // find targetPeerNodeId from binding table by matching the binding's fabricIndex with the accessing fabricIndex
             // received in BindingsChanged event
-            for (const auto & binding : BindingTable::GetInstance())
+            for (const auto & binding : app::Clusters::Binding::Table::GetInstance())
             {
                 ChipLogProgress(
                     AppServer,
@@ -583,7 +583,8 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
                     " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                     binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
                     binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
-                if (binding.type == MATTER_UNICAST_BINDING && event->BindingsChanged.fabricIndex == binding.fabricIndex)
+                if (binding.type == app::Clusters::Binding::MATTER_UNICAST_BINDING &&
+                    event->BindingsChanged.fabricIndex == binding.fabricIndex)
                 {
                     ChipLogProgress(
                         NotSpecified,
@@ -667,14 +668,14 @@ NodeId CastingServer::GetVideoPlayerNodeForFabricIndex(FabricIndex fabricIndex)
     {
         ChipLogError(AppServer, "GetVideoPlayerNodeForFabricIndex Init error: %" CHIP_ERROR_FORMAT, err.Format());
     }
-    for (const auto & binding : BindingTable::GetInstance())
+    for (const auto & binding : app::Clusters::Binding::Table::GetInstance())
     {
         ChipLogProgress(NotSpecified,
                         "Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64
                         " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                         binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
                         binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
-        if (binding.type == MATTER_UNICAST_BINDING && fabricIndex == binding.fabricIndex)
+        if (binding.type == app::Clusters::Binding::MATTER_UNICAST_BINDING && fabricIndex == binding.fabricIndex)
         {
             ChipLogProgress(NotSpecified, "GetVideoPlayerNodeForFabricIndex nodeId=0x" ChipLogFormatX64,
                             ChipLogValueX64(binding.nodeId));
@@ -693,14 +694,14 @@ FabricIndex CastingServer::GetVideoPlayerFabricIndexForNode(NodeId nodeId)
     {
         ChipLogError(AppServer, "GetVideoPlayerFabricIndexForNode Init error: %" CHIP_ERROR_FORMAT, err.Format());
     }
-    for (const auto & binding : BindingTable::GetInstance())
+    for (const auto & binding : app::Clusters::Binding::Table::GetInstance())
     {
         ChipLogProgress(NotSpecified,
                         "Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64
                         " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                         binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
                         binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
-        if (binding.type == MATTER_UNICAST_BINDING && nodeId == binding.nodeId)
+        if (binding.type == app::Clusters::Binding::MATTER_UNICAST_BINDING && nodeId == binding.nodeId)
         {
             ChipLogProgress(NotSpecified, "GetVideoPlayerFabricIndexForNode fabricIndex=%d nodeId=0x" ChipLogFormatX64,
                             binding.fabricIndex, ChipLogValueX64(binding.nodeId));

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -184,7 +184,7 @@ void ChipDeviceEventHandler::HandleBindingsChangedViaCluster(const chip::DeviceL
 
         // find targetNodeId from binding table by matching the binding's fabricIndex with the accessing fabricIndex
         // received in BindingsChanged event
-        for (const auto & binding : chip::BindingTable::GetInstance())
+        for (const auto & binding : chip::app::Clusters::Binding::Table::GetInstance())
         {
             ChipLogProgress(AppServer,
                             "ChipDeviceEventHandler::HandleBindingsChangedViaCluster() Read cached binding type=%d fabrixIndex=%d "
@@ -192,7 +192,8 @@ void ChipDeviceEventHandler::HandleBindingsChangedViaCluster(const chip::DeviceL
                             " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                             binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
                             binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
-            if (binding.type == MATTER_UNICAST_BINDING && event->BindingsChanged.fabricIndex == binding.fabricIndex)
+            if (binding.type == chip::app::Clusters::Binding::MATTER_UNICAST_BINDING &&
+                event->BindingsChanged.fabricIndex == binding.fabricIndex)
             {
                 ChipLogProgress(AppServer,
                                 "ChipDeviceEventHandler::HandleBindingsChangedViaCluster() Matched accessingFabricIndex with "

--- a/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
@@ -58,9 +58,9 @@ void EndpointListLoader::Initialize(chip::Messaging::ExchangeManager * exchangeM
                     ", targetCastingPlayerFabricIndex: %d",
                     ChipLogValueX64(targetCastingPlayerNodeId), targetCastingPlayerFabricIndex);
 
-    for (const auto & binding : chip::BindingTable::GetInstance())
+    for (const auto & binding : chip::app::Clusters::Binding::Table::GetInstance())
     {
-        if (binding.type == MATTER_UNICAST_BINDING && targetCastingPlayerNodeId == binding.nodeId &&
+        if (binding.type == chip::app::Clusters::Binding::MATTER_UNICAST_BINDING && targetCastingPlayerNodeId == binding.nodeId &&
             targetCastingPlayerFabricIndex == binding.fabricIndex)
         {
             // check to see if we discovered a new endpoint in the bindings
@@ -97,14 +97,14 @@ CHIP_ERROR EndpointListLoader::Load()
 
     int endpointIndex      = -1;
     bool isLoadingRequired = false;
-    for (const auto & binding : chip::BindingTable::GetInstance())
+    for (const auto & binding : chip::app::Clusters::Binding::Table::GetInstance())
     {
         ChipLogProgress(AppServer,
                         "EndpointListLoader::Load() Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64
                         " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                         binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
                         binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
-        if (binding.type == MATTER_UNICAST_BINDING && targetCastingPlayerNodeId == binding.nodeId &&
+        if (binding.type == chip::app::Clusters::Binding::MATTER_UNICAST_BINDING && targetCastingPlayerNodeId == binding.nodeId &&
             targetCastingPlayerFabricIndex == binding.fabricIndex)
         {
             // if we discovered a new Endpoint from the bindings, read its EndpointAttributes

--- a/src/access/tests/TestProviderDeviceTypeResolver.cpp
+++ b/src/access/tests/TestProviderDeviceTypeResolver.cpp
@@ -88,7 +88,7 @@ public:
     {
         return Protocols::InteractionModel::Status::Success;
     }
-    void ListAttributeWriteNotification(const ConcreteAttributePath &, ListWriteOperation) override {}
+    void ListAttributeWriteNotification(const ConcreteAttributePath &, ListWriteOperation, FabricIndex) override {}
     std::optional<ActionReturnStatus> InvokeCommand(const InvokeRequest &, TLV::TLVReader &, CommandHandler *) override
     {
         return Protocols::InteractionModel::Status::Success;

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -260,7 +260,8 @@ void WriteHandler::DeliverListWriteBegin(const ConcreteAttributePath & aPath)
 {
     if (mDataModelProvider != nullptr)
     {
-        mDataModelProvider->ListAttributeWriteNotification(aPath, DataModel::ListWriteOperation::kListWriteBegin);
+        mDataModelProvider->ListAttributeWriteNotification(aPath, DataModel::ListWriteOperation::kListWriteBegin,
+                                                           GetAccessingFabricIndex());
     }
 }
 
@@ -270,7 +271,8 @@ void WriteHandler::DeliverListWriteEnd(const ConcreteAttributePath & aPath, bool
     {
         mDataModelProvider->ListAttributeWriteNotification(aPath,
                                                            writeWasSuccessful ? DataModel::ListWriteOperation::kListWriteSuccess
-                                                                              : DataModel::ListWriteOperation::kListWriteFailure);
+                                                                              : DataModel::ListWriteOperation::kListWriteFailure,
+                                                           GetAccessingFabricIndex());
     }
 }
 

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -27,8 +27,8 @@ class BindingFabricTableDelegate : public chip::FabricTable::Delegate
 {
     void OnFabricRemoved(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex) override
     {
-        chip::BindingTable & bindingTable = chip::BindingTable::GetInstance();
-        auto iter                         = bindingTable.begin();
+        auto & bindingTable = chip::app::Clusters::Binding::Table::GetInstance();
+        auto iter           = bindingTable.begin();
         while (iter != bindingTable.end())
         {
             if (iter->fabricIndex == fabricIndex)
@@ -40,7 +40,7 @@ class BindingFabricTableDelegate : public chip::FabricTable::Delegate
                 ++iter;
             }
         }
-        chip::BindingManager::GetInstance().FabricRemoved(fabricIndex);
+        chip::app::Clusters::Binding::Manager::GetInstance().FabricRemoved(fabricIndex);
     }
 };
 
@@ -48,32 +48,33 @@ BindingFabricTableDelegate gFabricTableDelegate;
 
 } // namespace
 
-namespace {} // namespace
-
 namespace chip {
+namespace app {
+namespace Clusters {
+namespace Binding {
 
-BindingManager BindingManager::sBindingManager;
+Manager Manager::sBindingManager;
 
-CHIP_ERROR BindingManager::UnicastBindingCreated(uint8_t fabricIndex, NodeId nodeId)
+CHIP_ERROR Manager::UnicastBindingCreated(uint8_t fabricIndex, NodeId nodeId)
 {
     return EstablishConnection(ScopedNodeId(nodeId, fabricIndex));
 }
 
-CHIP_ERROR BindingManager::UnicastBindingRemoved(uint8_t bindingEntryId)
+CHIP_ERROR Manager::UnicastBindingRemoved(uint8_t bindingEntryId)
 {
     mPendingNotificationMap.RemoveEntry(bindingEntryId);
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BindingManager::Init(const BindingManagerInitParams & params)
+CHIP_ERROR Manager::Init(const ManagerInitParams & params)
 {
     VerifyOrReturnError(params.mCASESessionManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(params.mFabricTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(params.mStorage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mInitParams = params;
     params.mFabricTable->AddFabricDelegate(&gFabricTableDelegate);
-    BindingTable::GetInstance().SetPersistentStorage(params.mStorage);
-    CHIP_ERROR error = BindingTable::GetInstance().LoadFromStorage();
+    Table::GetInstance().SetPersistentStorage(params.mStorage);
+    CHIP_ERROR error = Table::GetInstance().LoadFromStorage();
     if (error != CHIP_NO_ERROR)
     {
         // This can happen during first boot of the device.
@@ -86,7 +87,7 @@ CHIP_ERROR BindingManager::Init(const BindingManagerInitParams & params)
         // to false.
         if (params.mEstablishConnectionOnInit)
         {
-            for (const EmberBindingTableEntry & entry : BindingTable::GetInstance())
+            for (const TableEntry & entry : Table::GetInstance())
             {
                 if (entry.type == MATTER_UNICAST_BINDING)
                 {
@@ -100,7 +101,7 @@ CHIP_ERROR BindingManager::Init(const BindingManagerInitParams & params)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BindingManager::EstablishConnection(const ScopedNodeId & nodeId)
+CHIP_ERROR Manager::EstablishConnection(const ScopedNodeId & nodeId)
 {
     VerifyOrReturnError(mInitParams.mCASESessionManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -129,7 +130,7 @@ CHIP_ERROR BindingManager::EstablishConnection(const ScopedNodeId & nodeId)
     return mLastSessionEstablishmentError;
 }
 
-void BindingManager::HandleDeviceConnected(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
+void Manager::HandleDeviceConnected(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {
     FabricIndex fabricToRemove = kUndefinedFabricIndex;
     NodeId nodeToRemove        = kUndefinedNodeId;
@@ -138,7 +139,7 @@ void BindingManager::HandleDeviceConnected(Messaging::ExchangeManager & exchange
     // iterator returns things by value anyway.
     for (PendingNotificationEntry pendingNotification : mPendingNotificationMap)
     {
-        EmberBindingTableEntry entry = BindingTable::GetInstance().GetAt(pendingNotification.mBindingEntryId);
+        TableEntry entry = Table::GetInstance().GetAt(pendingNotification.mBindingEntryId);
 
         if (sessionHandle->GetPeer() == ScopedNodeId(entry.nodeId, entry.fabricIndex))
         {
@@ -152,7 +153,7 @@ void BindingManager::HandleDeviceConnected(Messaging::ExchangeManager & exchange
     mPendingNotificationMap.RemoveAllEntriesForNode(ScopedNodeId(nodeToRemove, fabricToRemove));
 }
 
-void BindingManager::HandleDeviceConnectionFailure(const ScopedNodeId & peerId, CHIP_ERROR error)
+void Manager::HandleDeviceConnectionFailure(const ScopedNodeId & peerId, CHIP_ERROR error)
 {
     // Simply release the entry, the connection will be re-established as needed.
     ChipLogError(AppServer, "Failed to establish connection to node 0x" ChipLogFormatX64, ChipLogValueX64(peerId.GetNodeId()));
@@ -163,7 +164,7 @@ void BindingManager::HandleDeviceConnectionFailure(const ScopedNodeId & peerId, 
     // mPendingNotificationMap and CASESessionManager are implemented today.
 }
 
-void BindingManager::FabricRemoved(FabricIndex fabricIndex)
+void Manager::FabricRemoved(FabricIndex fabricIndex)
 {
     mPendingNotificationMap.RemoveAllEntriesForFabric(fabricIndex);
 
@@ -172,7 +173,7 @@ void BindingManager::FabricRemoved(FabricIndex fabricIndex)
     mInitParams.mCASESessionManager->ReleaseSessionsForFabric(fabricIndex);
 }
 
-CHIP_ERROR BindingManager::NotifyBoundClusterChanged(EndpointId endpoint, ClusterId cluster, void * context)
+CHIP_ERROR Manager::NotifyBoundClusterChanged(EndpointId endpoint, ClusterId cluster, void * context)
 {
     VerifyOrReturnError(mInitParams.mFabricTable != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mBoundDeviceChangedHandler != nullptr, CHIP_ERROR_HANDLER_NOT_SET);
@@ -183,7 +184,7 @@ CHIP_ERROR BindingManager::NotifyBoundClusterChanged(EndpointId endpoint, Cluste
 
     bindingContext->IncrementConsumersNumber();
 
-    for (auto iter = BindingTable::GetInstance().begin(); iter != BindingTable::GetInstance().end(); ++iter)
+    for (auto iter = Table::GetInstance().begin(); iter != Table::GetInstance().end(); ++iter)
     {
         if (iter->local == endpoint && (iter->clusterId.value_or(cluster) == cluster))
         {
@@ -207,10 +208,11 @@ exit:
     return error;
 }
 
-namespace app {
-CHIP_ERROR AddBindingEntry(const EmberBindingTableEntry & entry)
+} // namespace Binding
+
+CHIP_ERROR AddBindingEntry(const Binding::TableEntry & entry)
 {
-    CHIP_ERROR err = BindingTable::GetInstance().Add(entry);
+    CHIP_ERROR err = Binding::Table::GetInstance().Add(entry);
     if (err == CHIP_ERROR_NO_MEMORY)
     {
         return CHIP_IM_GLOBAL_STATUS(ResourceExhausted);
@@ -221,9 +223,9 @@ CHIP_ERROR AddBindingEntry(const EmberBindingTableEntry & entry)
         return err;
     }
 
-    if (entry.type == MATTER_UNICAST_BINDING)
+    if (entry.type == Binding::MATTER_UNICAST_BINDING)
     {
-        err = BindingManager::GetInstance().UnicastBindingCreated(entry.fabricIndex, entry.nodeId);
+        err = Binding::Manager::GetInstance().UnicastBindingCreated(entry.fabricIndex, entry.nodeId);
         if (err != CHIP_NO_ERROR)
         {
             // Unicast connection failure can happen if peer is offline. We'll retry connection on-demand.
@@ -235,6 +237,7 @@ CHIP_ERROR AddBindingEntry(const EmberBindingTableEntry & entry)
 
     return CHIP_NO_ERROR;
 }
-} // namespace app
 
+} // namespace Clusters
+} // namespace app
 } // namespace chip

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -25,6 +25,9 @@
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 
 namespace chip {
+namespace app {
+namespace Clusters {
+namespace Binding {
 
 /**
  * Application callback function when a cluster associated with a binding changes.
@@ -39,7 +42,7 @@ namespace chip {
  *
  * The handler is not allowed to hold onto the pointer to the SessionHandler that is passed in.
  */
-using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & binding, OperationalDeviceProxy * peer_device,
+using BoundDeviceChangedHandler = void (*)(const TableEntry & binding, OperationalDeviceProxy * peer_device,
                                            void * context);
 
 /**
@@ -48,7 +51,7 @@ using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & bindin
  */
 using BoundDeviceContextReleaseHandler = PendingNotificationContextReleaseHandler;
 
-struct BindingManagerInitParams
+struct ManagerInitParams
 {
     FabricTable * mFabricTable               = nullptr;
     CASESessionManager * mCASESessionManager = nullptr;
@@ -71,10 +74,10 @@ struct BindingManagerInitParams
  * or watched cluster is changed).
  *
  */
-class BindingManager
+class Manager
 {
 public:
-    BindingManager() {}
+    Manager() {}
 
     void RegisterBoundDeviceChangedHandler(BoundDeviceChangedHandler handler) { mBoundDeviceChangedHandler = handler; }
 
@@ -88,7 +91,7 @@ public:
         mPendingNotificationMap.RegisterPendingNotificationContextReleaseHandler(handler);
     }
 
-    CHIP_ERROR Init(const BindingManagerInitParams & params);
+    CHIP_ERROR Init(const ManagerInitParams & params);
 
     /*
      * Notifies the BindingManager that a new unicast binding is created.
@@ -120,7 +123,7 @@ public:
      */
     CHIP_ERROR NotifyBoundClusterChanged(EndpointId endpoint, ClusterId cluster, void * context);
 
-    static BindingManager & GetInstance() { return sBindingManager; }
+    static Manager & GetInstance() { return sBindingManager; }
 
 private:
     /*
@@ -136,7 +139,7 @@ private:
     class ConnectionCallback
     {
     public:
-        ConnectionCallback(BindingManager & bindingManager) :
+        ConnectionCallback(Manager & bindingManager) :
             mBindingManager(bindingManager), mOnConnectedCallback(HandleDeviceConnected, this),
             mOnConnectionFailureCallback(HandleDeviceConnectionFailure, this)
         {}
@@ -159,18 +162,18 @@ private:
             Platform::Delete(_this);
         }
 
-        BindingManager & mBindingManager;
+        Manager & mBindingManager;
         Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
         Callback::Callback<OnDeviceConnectionFailure> mOnConnectionFailureCallback;
     };
 
-    static BindingManager sBindingManager;
+    static Manager sBindingManager;
 
     CHIP_ERROR EstablishConnection(const ScopedNodeId & nodeId);
 
     PendingNotificationMap mPendingNotificationMap;
     BoundDeviceChangedHandler mBoundDeviceChangedHandler;
-    BindingManagerInitParams mInitParams;
+    ManagerInitParams mInitParams;
 
     void HandleDeviceConnected(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
     void HandleDeviceConnectionFailure(const ScopedNodeId & peerId, CHIP_ERROR error);
@@ -179,7 +182,8 @@ private:
     CHIP_ERROR mLastSessionEstablishmentError;
 };
 
-namespace app {
+} // namespace Binding
+
 /**
  * @brief appends a binding to the list of bindings
  *        This function is to be used when a device wants to add a binding to its own table
@@ -189,7 +193,8 @@ namespace app {
  *
  * @param entry binding to add
  */
-CHIP_ERROR AddBindingEntry(const EmberBindingTableEntry & entry);
-} // namespace app
+CHIP_ERROR AddBindingEntry(const Binding::TableEntry & entry);
 
+} // namespace Clusters
+} // namespace app
 } // namespace chip

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -42,8 +42,7 @@ namespace Binding {
  *
  * The handler is not allowed to hold onto the pointer to the SessionHandler that is passed in.
  */
-using BoundDeviceChangedHandler = void (*)(const TableEntry & binding, OperationalDeviceProxy * peer_device,
-                                           void * context);
+using BoundDeviceChangedHandler = void (*)(const TableEntry & binding, OperationalDeviceProxy * peer_device, void * context);
 
 /**
  * Application callback function when a context used in NotifyBoundClusterChanged will not be needed and should be

--- a/src/app/clusters/bindings/PendingNotificationMap.cpp
+++ b/src/app/clusters/bindings/PendingNotificationMap.cpp
@@ -21,6 +21,9 @@
 #include <app/clusters/bindings/binding-table.h>
 
 namespace chip {
+namespace app {
+namespace Clusters {
+namespace Binding {
 
 CHIP_ERROR PendingNotificationMap::FindLRUConnectPeer(ScopedNodeId & nodeId)
 {
@@ -29,15 +32,15 @@ CHIP_ERROR PendingNotificationMap::FindLRUConnectPeer(ScopedNodeId & nodeId)
     // to the start of the list than the last entry of any other peer.
 
     // First, set up a way to easily track which entries correspond to the same peer.
-    uint8_t bindingWithSamePeer[BindingTable::kMaxBindingEntries];
+    uint8_t bindingWithSamePeer[Table::kMaxBindingEntries];
 
-    for (auto iter = BindingTable::GetInstance().begin(); iter != BindingTable::GetInstance().end(); ++iter)
+    for (auto iter = Table::GetInstance().begin(); iter != Table::GetInstance().end(); ++iter)
     {
         if (iter->type != MATTER_UNICAST_BINDING)
         {
             continue;
         }
-        for (auto checkIter = BindingTable::GetInstance().begin(); checkIter != BindingTable::GetInstance().end(); ++checkIter)
+        for (auto checkIter = Table::GetInstance().begin(); checkIter != Table::GetInstance().end(); ++checkIter)
         {
             if (checkIter->type == MATTER_UNICAST_BINDING && checkIter->fabricIndex == iter->fabricIndex &&
                 checkIter->nodeId == iter->nodeId)
@@ -48,7 +51,7 @@ CHIP_ERROR PendingNotificationMap::FindLRUConnectPeer(ScopedNodeId & nodeId)
         }
     }
 
-    uint16_t lastAppear[BindingTable::kMaxBindingEntries];
+    uint16_t lastAppear[Table::kMaxBindingEntries];
     for (uint16_t & value : lastAppear)
     {
         value = UINT16_MAX;
@@ -61,7 +64,7 @@ CHIP_ERROR PendingNotificationMap::FindLRUConnectPeer(ScopedNodeId & nodeId)
     }
     uint8_t lruBindingEntryIndex;
     uint16_t minLastAppearValue = UINT16_MAX;
-    for (uint8_t i = 0; i < BindingTable::kMaxBindingEntries; i++)
+    for (uint8_t i = 0; i < Table::kMaxBindingEntries; i++)
     {
         if (lastAppear[i] < minLastAppearValue)
         {
@@ -71,8 +74,8 @@ CHIP_ERROR PendingNotificationMap::FindLRUConnectPeer(ScopedNodeId & nodeId)
     }
     if (minLastAppearValue < UINT16_MAX)
     {
-        EmberBindingTableEntry entry = BindingTable::GetInstance().GetAt(static_cast<uint8_t>(lruBindingEntryIndex));
-        nodeId                       = ScopedNodeId(entry.nodeId, entry.fabricIndex);
+        TableEntry entry = Table::GetInstance().GetAt(static_cast<uint8_t>(lruBindingEntryIndex));
+        nodeId           = ScopedNodeId(entry.nodeId, entry.fabricIndex);
         return CHIP_NO_ERROR;
     }
     return CHIP_ERROR_NOT_FOUND;
@@ -81,7 +84,7 @@ CHIP_ERROR PendingNotificationMap::FindLRUConnectPeer(ScopedNodeId & nodeId)
 CHIP_ERROR PendingNotificationMap::AddPendingNotification(uint8_t bindingEntryId, PendingNotificationContext * context)
 {
     RemoveEntry(bindingEntryId);
-    if (mNumEntries == BindingTable::kMaxBindingEntries)
+    if (mNumEntries == Table::kMaxBindingEntries)
     {
         // We know that the RemoveEntry above did not do anything so we don't need to try restoring it.
         return CHIP_ERROR_NO_MEMORY;
@@ -120,7 +123,7 @@ void PendingNotificationMap::RemoveAllEntriesForNode(const ScopedNodeId & nodeId
     uint8_t newEntryCount = 0;
     for (int i = 0; i < mNumEntries; i++)
     {
-        EmberBindingTableEntry entry = BindingTable::GetInstance().GetAt(mPendingBindingEntries[i]);
+        TableEntry entry = Table::GetInstance().GetAt(mPendingBindingEntries[i]);
         if (entry.fabricIndex != nodeId.GetFabricIndex() || entry.nodeId != nodeId.GetNodeId())
         {
             mPendingBindingEntries[newEntryCount] = mPendingBindingEntries[i];
@@ -140,7 +143,7 @@ void PendingNotificationMap::RemoveAllEntriesForFabric(FabricIndex fabric)
     uint8_t newEntryCount = 0;
     for (int i = 0; i < mNumEntries; i++)
     {
-        EmberBindingTableEntry entry = BindingTable::GetInstance().GetAt(mPendingBindingEntries[i]);
+        TableEntry entry = Table::GetInstance().GetAt(mPendingBindingEntries[i]);
         if (entry.fabricIndex != fabric)
         {
             mPendingBindingEntries[newEntryCount] = mPendingBindingEntries[i];
@@ -155,4 +158,7 @@ void PendingNotificationMap::RemoveAllEntriesForFabric(FabricIndex fabric)
     mNumEntries = newEntryCount;
 }
 
+} // namespace Binding
+} // namespace Clusters
+} // namespace app
 } // namespace chip

--- a/src/app/clusters/bindings/PendingNotificationMap.h
+++ b/src/app/clusters/bindings/PendingNotificationMap.h
@@ -20,6 +20,9 @@
 #include <lib/core/DataModelTypes.h>
 
 namespace chip {
+namespace app {
+namespace Clusters {
+namespace Binding {
 
 /**
  * Application callback function when a context used in PendingNotificationEntry will not be needed and should be
@@ -67,7 +70,7 @@ public:
 class PendingNotificationMap
 {
 public:
-    static constexpr uint8_t kMaxPendingNotifications = BindingTable::kMaxBindingEntries;
+    static constexpr uint8_t kMaxPendingNotifications = Table::kMaxBindingEntries;
 
     friend class Iterator;
 
@@ -128,4 +131,7 @@ private:
     uint8_t mNumEntries = 0;
 };
 
+} // namespace Binding
+} // namespace Clusters
+} // namespace app
 } // namespace chip

--- a/src/app/clusters/bindings/binding-cluster.cpp
+++ b/src/app/clusters/bindings/binding-cluster.cpp
@@ -74,34 +74,33 @@ CHIP_ERROR CheckValidBindingList(const EndpointId localEndpoint, const Decodable
 
     // Check binding table size
     uint8_t oldListSize = 0;
-    for (const auto & entry : BindingTable::GetInstance())
+    for (const auto & entry : Binding::Table::GetInstance())
     {
         if (entry.local == localEndpoint && entry.fabricIndex == accessingFabricIndex)
         {
             oldListSize++;
         }
     }
-    VerifyOrReturnError(BindingTable::GetInstance().Size() - oldListSize + listSize <= BindingTable::kMaxBindingEntries,
+    VerifyOrReturnError(Binding::Table::GetInstance().Size() - oldListSize + listSize <= Binding::Table::kMaxBindingEntries,
                         CHIP_IM_GLOBAL_STATUS(ResourceExhausted));
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR CreateBindingEntry(const TargetStructType & entry, EndpointId localEndpoint)
 {
-    EmberBindingTableEntry bindingEntry;
+    Binding::TableEntry bindingEntry;
 
     if (entry.group.HasValue())
     {
-        bindingEntry =
-            EmberBindingTableEntry::ForGroup(entry.fabricIndex, entry.group.Value(), localEndpoint, entry.cluster.std_optional());
+        bindingEntry = Binding::TableEntry(entry.fabricIndex, entry.group.Value(), localEndpoint, entry.cluster.std_optional());
     }
     else
     {
-        bindingEntry = EmberBindingTableEntry::ForNode(entry.fabricIndex, entry.node.Value(), localEndpoint, entry.endpoint.Value(),
-                                                       entry.cluster.std_optional());
+        bindingEntry = Binding::TableEntry(entry.fabricIndex, entry.node.Value(), localEndpoint, entry.endpoint.Value(),
+                                           entry.cluster.std_optional());
     }
 
-    return chip::app::AddBindingEntry(bindingEntry);
+    return AddBindingEntry(bindingEntry);
 }
 
 } // namespace
@@ -117,13 +116,13 @@ DataModel::ActionReturnStatus BindingCluster::ReadAttribute(const DataModel::Rea
     {
     case Binding::Attributes::Binding::Id: {
         return encoder.EncodeList([&](const auto & subEncoder) {
-            for (auto & entry : BindingTable::GetInstance())
+            for (auto & entry : Binding::Table::GetInstance())
             {
                 if (entry.local != request.path.mEndpointId)
                 {
                     continue;
                 }
-                if (entry.type == MATTER_UNICAST_BINDING)
+                if (entry.type == Binding::MATTER_UNICAST_BINDING)
                 {
                     Binding::Structs::TargetStruct::Type value = {
                         .node        = MakeOptional(entry.nodeId),
@@ -134,7 +133,7 @@ DataModel::ActionReturnStatus BindingCluster::ReadAttribute(const DataModel::Rea
                     };
                     ReturnErrorOnFailure(subEncoder.Encode(value));
                 }
-                else if (entry.type == MATTER_MULTICAST_BINDING)
+                else if (entry.type == Binding::MATTER_MULTICAST_BINDING)
                 {
                     Binding::Structs::TargetStruct::Type value = {
                         .node        = NullOptional,
@@ -165,25 +164,26 @@ DataModel::ActionReturnStatus BindingCluster::WriteAttribute(const DataModel::Wr
     switch (request.path.mAttributeId)
     {
     case Binding::Attributes::Binding::Id: {
-        mAccessingFabricIndex = request.GetAccessingFabricIndex();
         if (!request.path.IsListOperation() || request.path.mListOp == ConcreteDataAttributePath::ListOperation::ReplaceAll)
         {
             DecodableBindingListType newBindingList;
 
             ReturnErrorOnFailure(decoder.Decode(newBindingList));
-            ReturnErrorOnFailure(CheckValidBindingList(request.path.mEndpointId, newBindingList, mAccessingFabricIndex));
+            ReturnErrorOnFailure(
+                CheckValidBindingList(request.path.mEndpointId, newBindingList, request.GetAccessingFabricIndex()));
 
             // Clear all entries for the current accessing fabric and endpoint
-            auto bindingTableIter = BindingTable::GetInstance().begin();
-            while (bindingTableIter != BindingTable::GetInstance().end())
+            auto bindingTableIter = Binding::Table::GetInstance().begin();
+            while (bindingTableIter != Binding::Table::GetInstance().end())
             {
-                if (bindingTableIter->local == request.path.mEndpointId && bindingTableIter->fabricIndex == mAccessingFabricIndex)
+                if (bindingTableIter->local == request.path.mEndpointId &&
+                    bindingTableIter->fabricIndex == request.GetAccessingFabricIndex())
                 {
-                    if (bindingTableIter->type == MATTER_UNICAST_BINDING)
+                    if (bindingTableIter->type == Binding::MATTER_UNICAST_BINDING)
                     {
-                        BindingManager::GetInstance().UnicastBindingRemoved(bindingTableIter.GetIndex());
+                        Binding::Manager::GetInstance().UnicastBindingRemoved(bindingTableIter.GetIndex());
                     }
-                    ReturnErrorOnFailure(BindingTable::GetInstance().RemoveAt(bindingTableIter));
+                    ReturnErrorOnFailure(Binding::Table::GetInstance().RemoveAt(bindingTableIter));
                 }
                 else
                 {
@@ -204,7 +204,7 @@ DataModel::ActionReturnStatus BindingCluster::WriteAttribute(const DataModel::Wr
             if (!request.path.IsListOperation())
             {
                 // Notify binding table has changed
-                LogErrorOnFailure(NotifyBindingsChanged());
+                LogErrorOnFailure(NotifyBindingsChanged(request.GetAccessingFabricIndex()));
             }
             return err;
         }
@@ -227,11 +227,12 @@ DataModel::ActionReturnStatus BindingCluster::WriteAttribute(const DataModel::Wr
     return Protocols::InteractionModel::Status::UnsupportedWrite;
 }
 
-void BindingCluster::ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType)
+void BindingCluster::ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType,
+                                                    FabricIndex accessingFabric)
 {
     if (opType == DataModel::ListWriteOperation::kListWriteSuccess)
     {
-        LogErrorOnFailure(NotifyBindingsChanged());
+        LogErrorOnFailure(NotifyBindingsChanged(accessingFabric));
     }
 }
 
@@ -241,10 +242,10 @@ CHIP_ERROR BindingCluster::Attributes(const ConcreteClusterPath & path, ReadOnly
     return listBuilder.Append(Span(Binding::Attributes::kMandatoryMetadata), {});
 }
 
-CHIP_ERROR BindingCluster::NotifyBindingsChanged()
+CHIP_ERROR BindingCluster::NotifyBindingsChanged(FabricIndex accessingFabricIndex)
 {
     DeviceLayer::ChipDeviceEvent event{ .Type            = DeviceLayer::DeviceEventType::kBindingsChangedViaCluster,
-                                        .BindingsChanged = { .fabricIndex = mAccessingFabricIndex } };
+                                        .BindingsChanged = { .fabricIndex = accessingFabricIndex } };
     return chip::DeviceLayer::PlatformMgr().PostEvent(&event);
 }
 

--- a/src/app/clusters/bindings/binding-cluster.h
+++ b/src/app/clusters/bindings/binding-cluster.h
@@ -35,14 +35,13 @@ public:
     DataModel::ActionReturnStatus WriteAttribute(const DataModel::WriteAttributeRequest & request,
                                                  AttributeValueDecoder & decoder) override;
 
-    void ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType) override;
+    void ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType,
+                                        FabricIndex accessingFabric) override;
 
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
 private:
-    CHIP_ERROR NotifyBindingsChanged();
-
-    FabricIndex mAccessingFabricIndex;
+    CHIP_ERROR NotifyBindingsChanged(FabricIndex accessingFabricIndex);
 };
 
 } // namespace Clusters

--- a/src/app/clusters/bindings/binding-table.cpp
+++ b/src/app/clusters/bindings/binding-table.cpp
@@ -22,15 +22,18 @@
 #include <app/clusters/bindings/binding-table.h>
 
 namespace chip {
+namespace app {
+namespace Clusters {
+namespace Binding {
 
-BindingTable BindingTable::sInstance;
+Table Table::sInstance;
 
-BindingTable::BindingTable()
+Table::Table()
 {
     memset(mNextIndex, kNextNullIndex, sizeof(mNextIndex));
 }
 
-CHIP_ERROR BindingTable::Add(const EmberBindingTableEntry & entry)
+CHIP_ERROR Table::Add(const TableEntry & entry)
 {
     if (entry.type == MATTER_UNUSED_BINDING)
     {
@@ -81,14 +84,14 @@ CHIP_ERROR BindingTable::Add(const EmberBindingTableEntry & entry)
     return CHIP_NO_ERROR;
 }
 
-const EmberBindingTableEntry & BindingTable::GetAt(uint8_t index)
+const TableEntry & Table::GetAt(uint8_t index)
 {
     return mBindingTable[index];
 }
 
-CHIP_ERROR BindingTable::SaveEntryToStorage(uint8_t index, uint8_t nextIndex)
+CHIP_ERROR Table::SaveEntryToStorage(uint8_t index, uint8_t nextIndex)
 {
-    EmberBindingTableEntry & entry    = mBindingTable[index];
+    TableEntry & entry    = mBindingTable[index];
     uint8_t buffer[kEntryStorageSize] = { 0 };
     TLV::TLVWriter writer;
     writer.Init(buffer);
@@ -116,7 +119,7 @@ CHIP_ERROR BindingTable::SaveEntryToStorage(uint8_t index, uint8_t nextIndex)
                                      static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
-CHIP_ERROR BindingTable::SaveListInfo(uint8_t head)
+CHIP_ERROR Table::SaveListInfo(uint8_t head)
 {
     uint8_t buffer[kListInfoStorageSize] = { 0 };
     TLV::TLVWriter writer;
@@ -131,7 +134,7 @@ CHIP_ERROR BindingTable::SaveListInfo(uint8_t head)
                                      static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
-CHIP_ERROR BindingTable::LoadFromStorage()
+CHIP_ERROR Table::LoadFromStorage()
 {
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
     uint8_t buffer[kListInfoStorageSize] = { 0 };
@@ -178,11 +181,11 @@ CHIP_ERROR BindingTable::LoadFromStorage()
     return error;
 }
 
-CHIP_ERROR BindingTable::LoadEntryFromStorage(uint8_t index, uint8_t & nextIndex)
+CHIP_ERROR Table::LoadEntryFromStorage(uint8_t index, uint8_t & nextIndex)
 {
     uint8_t buffer[kEntryStorageSize] = { 0 };
     uint16_t size                     = sizeof(buffer);
-    EmberBindingTableEntry entry;
+    TableEntry entry;
 
     ReturnErrorOnFailure(mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::BindingTableEntry(index).KeyName(), buffer, size));
     TLV::TLVReader reader;
@@ -229,7 +232,7 @@ CHIP_ERROR BindingTable::LoadEntryFromStorage(uint8_t index, uint8_t & nextIndex
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BindingTable::RemoveAt(Iterator & iter)
+CHIP_ERROR Table::RemoveAt(Iterator & iter)
 {
     CHIP_ERROR error;
     if (iter.mTable != this || iter.mIndex == kNextNullIndex)
@@ -272,7 +275,7 @@ CHIP_ERROR BindingTable::RemoveAt(Iterator & iter)
     return error;
 }
 
-BindingTable::Iterator BindingTable::begin()
+Table::Iterator Table::begin()
 {
     Iterator iter;
     iter.mTable     = this;
@@ -281,7 +284,7 @@ BindingTable::Iterator BindingTable::begin()
     return iter;
 }
 
-BindingTable::Iterator BindingTable::end()
+Table::Iterator Table::end()
 {
     Iterator iter;
     iter.mTable = this;
@@ -289,7 +292,7 @@ BindingTable::Iterator BindingTable::end()
     return iter;
 }
 
-uint8_t BindingTable::GetNextAvaiableIndex()
+uint8_t Table::GetNextAvaiableIndex()
 {
     for (uint8_t i = 0; i < kMaxBindingEntries; i++)
     {
@@ -301,7 +304,7 @@ uint8_t BindingTable::GetNextAvaiableIndex()
     return kMaxBindingEntries;
 }
 
-BindingTable::Iterator BindingTable::Iterator::operator++()
+Table::Iterator Table::Iterator::operator++()
 {
     if (mIndex != kNextNullIndex)
     {
@@ -311,4 +314,7 @@ BindingTable::Iterator BindingTable::Iterator::operator++()
     return *this;
 }
 
+} // namespace Binding
+} // namespace Clusters
+} // namespace app
 } // namespace chip

--- a/src/app/clusters/bindings/binding-table.cpp
+++ b/src/app/clusters/bindings/binding-table.cpp
@@ -91,7 +91,7 @@ const TableEntry & Table::GetAt(uint8_t index)
 
 CHIP_ERROR Table::SaveEntryToStorage(uint8_t index, uint8_t nextIndex)
 {
-    TableEntry & entry    = mBindingTable[index];
+    TableEntry & entry                = mBindingTable[index];
     uint8_t buffer[kEntryStorageSize] = { 0 };
     TLV::TLVWriter writer;
     writer.Init(buffer);

--- a/src/app/clusters/bindings/binding-table.h
+++ b/src/app/clusters/bindings/binding-table.h
@@ -56,8 +56,8 @@ struct TableEntry
 {
     TableEntry(FabricIndex fabric, NodeId node, EndpointId localEndpoint, EndpointId remoteEndpoint,
                std::optional<ClusterId> cluster) :
-        type(MATTER_UNICAST_BINDING), fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(remoteEndpoint),
-        nodeId(node)
+        type(MATTER_UNICAST_BINDING),
+        fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(remoteEndpoint), nodeId(node)
     {}
 
     TableEntry(FabricIndex fabric, GroupId group, EndpointId localEndpoint, std::optional<ClusterId> cluster) :

--- a/src/app/clusters/bindings/binding-table.h
+++ b/src/app/clusters/bindings/binding-table.h
@@ -56,14 +56,14 @@ struct TableEntry
 {
     TableEntry(FabricIndex fabric, NodeId node, EndpointId localEndpoint, EndpointId remoteEndpoint,
                std::optional<ClusterId> cluster) :
-        type(MATTER_UNICAST_BINDING), fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(remoteEndpoint),
-        nodeId(node)
+        type(MATTER_UNICAST_BINDING),
+        fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(remoteEndpoint), nodeId(node)
     {}
 
     TableEntry(chip::FabricIndex fabric, chip::GroupId group, chip::EndpointId localEndpoint,
-                      std::optional<chip::ClusterId> cluster) :
-        type(MATTER_MULTICAST_BINDING), fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(kInvalidEndpointId),
-        groupId(group)
+               std::optional<chip::ClusterId> cluster) :
+        type(MATTER_MULTICAST_BINDING),
+        fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(kInvalidEndpointId), groupId(group)
     {}
 
     TableEntry() = default;

--- a/src/app/clusters/bindings/binding-table.h
+++ b/src/app/clusters/bindings/binding-table.h
@@ -26,11 +26,15 @@
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <optional>
 
-// TODO: Remove the Ember Prefix and place the class and structure to chip::app::Clusters::Binding namespace.
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace Binding {
+
 /**
- * @brief Defines binding types.
+ * @brief Defines binding entry types.
  */
-enum EmberBindingType : uint8_t
+enum EntryType : uint8_t
 {
     /** A binding that is currently not in use. */
     MATTER_UNUSED_BINDING = 0,
@@ -48,38 +52,24 @@ enum EmberBindingType : uint8_t
  * cluster ID and either the destination EUI64 (for unicast bindings) or the
  * 64-bit group address (for multicast bindings).
  */
-struct EmberBindingTableEntry
+struct TableEntry
 {
-    static EmberBindingTableEntry ForNode(chip::FabricIndex fabric, chip::NodeId node, chip::EndpointId localEndpoint,
-                                          chip::EndpointId remoteEndpoint, std::optional<chip::ClusterId> cluster)
-    {
-        EmberBindingTableEntry entry = {
-            .type        = MATTER_UNICAST_BINDING,
-            .fabricIndex = fabric,
-            .local       = localEndpoint,
-            .clusterId   = cluster,
-            .remote      = remoteEndpoint,
-            .nodeId      = node,
-        };
-        return entry;
-    }
+    TableEntry(FabricIndex fabric, NodeId node, EndpointId localEndpoint, EndpointId remoteEndpoint,
+               std::optional<ClusterId> cluster) :
+        type(MATTER_UNICAST_BINDING), fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(remoteEndpoint),
+        nodeId(node)
+    {}
 
-    static EmberBindingTableEntry ForGroup(chip::FabricIndex fabric, chip::GroupId group, chip::EndpointId localEndpoint,
-                                           std::optional<chip::ClusterId> cluster)
-    {
-        EmberBindingTableEntry entry = {
-            .type        = MATTER_MULTICAST_BINDING,
-            .fabricIndex = fabric,
-            .local       = localEndpoint,
-            .clusterId   = cluster,
-            .remote      = 0,
-            .groupId     = group,
-        };
-        return entry;
-    }
+    TableEntry(chip::FabricIndex fabric, chip::GroupId group, chip::EndpointId localEndpoint,
+                      std::optional<chip::ClusterId> cluster) :
+        type(MATTER_MULTICAST_BINDING), fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(kInvalidEndpointId),
+        groupId(group)
+    {}
+
+    TableEntry() = default;
 
     /** The type of binding. */
-    EmberBindingType type = MATTER_UNUSED_BINDING;
+    EntryType type = MATTER_UNUSED_BINDING;
 
     chip::FabricIndex fabricIndex;
     /** The endpoint on the local node. */
@@ -105,7 +95,7 @@ struct EmberBindingTableEntry
         chip::GroupId groupId;
     };
 
-    bool operator==(EmberBindingTableEntry const & other) const
+    bool operator==(TableEntry const & other) const
     {
         if (type != other.type)
         {
@@ -126,28 +116,26 @@ struct EmberBindingTableEntry
     }
 };
 
-namespace chip {
-
-class BindingTable
+class Table
 {
     friend class Iterator;
 
 public:
     static constexpr size_t kMaxBindingEntries = CHIP_CONFIG_MAX_BINDING_ENTRIES_PER_FABRIC * CHIP_CONFIG_MAX_FABRICS;
-    BindingTable();
+    Table();
 
     class Iterator
     {
-        friend class BindingTable;
+        friend class Table;
 
     public:
-        EmberBindingTableEntry & operator*() { return mTable->mBindingTable[mIndex]; }
+        TableEntry & operator*() { return mTable->mBindingTable[mIndex]; }
 
-        const EmberBindingTableEntry & operator*() const { return mTable->mBindingTable[mIndex]; }
+        const TableEntry & operator*() const { return mTable->mBindingTable[mIndex]; }
 
-        EmberBindingTableEntry * operator->() { return &(mTable->mBindingTable[mIndex]); }
+        TableEntry * operator->() { return &(mTable->mBindingTable[mIndex]); }
 
-        const EmberBindingTableEntry * operator->() const { return &(mTable->mBindingTable[mIndex]); }
+        const TableEntry * operator->() const { return &(mTable->mBindingTable[mIndex]); }
 
         Iterator operator++();
 
@@ -158,14 +146,14 @@ public:
         uint8_t GetIndex() const { return mIndex; }
 
     private:
-        BindingTable * mTable;
+        Table * mTable;
         uint8_t mPrevIndex;
         uint8_t mIndex;
     };
 
-    CHIP_ERROR Add(const EmberBindingTableEntry & entry);
+    CHIP_ERROR Add(const TableEntry & entry);
 
-    const EmberBindingTableEntry & GetAt(uint8_t index);
+    const TableEntry & GetAt(uint8_t index);
 
     // The iter will be moved to the next item in the table after calling RemoveAt.
     CHIP_ERROR RemoveAt(Iterator & iter);
@@ -182,10 +170,10 @@ public:
 
     CHIP_ERROR LoadFromStorage();
 
-    static BindingTable & GetInstance() { return sInstance; }
+    static Table & GetInstance() { return sInstance; }
 
 private:
-    static BindingTable sInstance;
+    static Table sInstance;
 
     static constexpr uint32_t kStorageVersion  = 1;
     static constexpr uint8_t kEntryStorageSize = TLV::EstimateStructOverhead(
@@ -210,7 +198,7 @@ private:
 
     CHIP_ERROR LoadEntryFromStorage(uint8_t index, uint8_t & nextIndex);
 
-    EmberBindingTableEntry mBindingTable[kMaxBindingEntries];
+    TableEntry mBindingTable[kMaxBindingEntries];
     uint8_t mNextIndex[kMaxBindingEntries];
 
     uint8_t mHead = kNextNullIndex;
@@ -220,4 +208,7 @@ private:
     PersistentStorageDelegate * mStorage;
 };
 
+} // namespace Binding
+} // namespace Clusters
+} // namespace app
 } // namespace chip

--- a/src/app/clusters/bindings/binding-table.h
+++ b/src/app/clusters/bindings/binding-table.h
@@ -56,17 +56,27 @@ struct TableEntry
 {
     TableEntry(FabricIndex fabric, NodeId node, EndpointId localEndpoint, EndpointId remoteEndpoint,
                std::optional<ClusterId> cluster) :
-        type(MATTER_UNICAST_BINDING),
-        fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(remoteEndpoint), nodeId(node)
+        type(MATTER_UNICAST_BINDING), fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(remoteEndpoint),
+        nodeId(node)
     {}
 
-    TableEntry(chip::FabricIndex fabric, chip::GroupId group, chip::EndpointId localEndpoint,
-               std::optional<chip::ClusterId> cluster) :
-        type(MATTER_MULTICAST_BINDING),
-        fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(kInvalidEndpointId), groupId(group)
+    TableEntry(FabricIndex fabric, GroupId group, EndpointId localEndpoint, std::optional<ClusterId> cluster) :
+        type(MATTER_MULTICAST_BINDING), fabricIndex(fabric), local(localEndpoint), clusterId(cluster), remote(kInvalidEndpointId),
+        groupId(group)
     {}
 
     TableEntry() = default;
+
+    static TableEntry ForNode(FabricIndex fabric, NodeId node, EndpointId localEndpoint, EndpointId remoteEndpoint,
+                              std::optional<ClusterId> cluster)
+    {
+        return TableEntry(fabric, node, localEndpoint, remoteEndpoint, cluster);
+    }
+
+    static TableEntry ForGroup(FabricIndex fabric, GroupId group, EndpointId localEndpoint, std::optional<ClusterId> cluster)
+    {
+        return TableEntry(fabric, group, localEndpoint, cluster);
+    }
 
     /** The type of binding. */
     EntryType type = MATTER_UNUSED_BINDING;

--- a/src/app/clusters/bindings/tests/TestBindingTable.cpp
+++ b/src/app/clusters/bindings/tests/TestBindingTable.cpp
@@ -22,11 +22,11 @@
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 
-using chip::BindingTable;
+using namespace chip::app::Clusters;
 
 namespace {
 
-void VerifyTableSame(BindingTable & table, const std::vector<EmberBindingTableEntry> & expected)
+void VerifyTableSame(Binding::Table & table, const std::vector<Binding::TableEntry> & expected)
 {
     ASSERT_EQ(table.Size(), expected.size());
     auto iter1 = table.begin();
@@ -40,9 +40,9 @@ void VerifyTableSame(BindingTable & table, const std::vector<EmberBindingTableEn
     EXPECT_EQ(iter1, table.end());
 }
 
-void VerifyRestored(chip::TestPersistentStorageDelegate & storage, const std::vector<EmberBindingTableEntry> & expected)
+void VerifyRestored(chip::TestPersistentStorageDelegate & storage, const std::vector<Binding::TableEntry> & expected)
 {
-    BindingTable restoredTable;
+    Binding::Table restoredTable;
     restoredTable.SetPersistentStorage(&storage);
     EXPECT_EQ(restoredTable.LoadFromStorage(), CHIP_NO_ERROR);
     VerifyTableSame(restoredTable, expected);
@@ -50,7 +50,7 @@ void VerifyRestored(chip::TestPersistentStorageDelegate & storage, const std::ve
 
 TEST(TestBindingTable, TestEmptyBindingTable)
 {
-    BindingTable table;
+    Binding::Table table;
     chip::TestPersistentStorageDelegate testStorage;
     table.SetPersistentStorage(&testStorage);
     EXPECT_EQ(table.Size(), 0u);
@@ -59,21 +59,21 @@ TEST(TestBindingTable, TestEmptyBindingTable)
 
 TEST(TestBindingTable, TestAdd)
 {
-    BindingTable table;
+    Binding::Table table;
     chip::TestPersistentStorageDelegate testStorage;
     table.SetPersistentStorage(&testStorage);
-    EmberBindingTableEntry unusedEntry;
-    unusedEntry.type = MATTER_UNUSED_BINDING;
+    Binding::TableEntry unusedEntry;
+    unusedEntry.type = Binding::MATTER_UNUSED_BINDING;
     EXPECT_EQ(table.Add(unusedEntry), CHIP_ERROR_INVALID_ARGUMENT);
-    for (uint8_t i = 0; i < BindingTable::kMaxBindingEntries; i++)
+    for (uint8_t i = 0; i < Binding::Table::kMaxBindingEntries; i++)
     {
-        EXPECT_EQ(table.Add(EmberBindingTableEntry::ForNode(0, i, 0, 0, std::nullopt)), CHIP_NO_ERROR);
+        EXPECT_EQ(table.Add(Binding::TableEntry(0, i, 0, 0, std::nullopt)), CHIP_NO_ERROR);
     }
-    EXPECT_EQ(table.Add(EmberBindingTableEntry::ForNode(0, 0, 0, 0, std::nullopt)), CHIP_ERROR_NO_MEMORY);
-    EXPECT_EQ(table.Size(), BindingTable::kMaxBindingEntries);
+    EXPECT_EQ(table.Add(Binding::TableEntry(0, 0, 0, 0, std::nullopt)), CHIP_ERROR_NO_MEMORY);
+    EXPECT_EQ(table.Size(), Binding::Table::kMaxBindingEntries);
 
     auto iter = table.begin();
-    for (uint8_t i = 0; i < BindingTable::kMaxBindingEntries; i++)
+    for (uint8_t i = 0; i < Binding::Table::kMaxBindingEntries; i++)
     {
         EXPECT_NE(iter, table.end());
         EXPECT_EQ(iter->nodeId, i);
@@ -85,33 +85,33 @@ TEST(TestBindingTable, TestAdd)
 
 TEST(TestBindingTable, TestRemoveThenAdd)
 {
-    BindingTable table;
+    Binding::Table table;
     chip::TestPersistentStorageDelegate testStorage;
     table.SetPersistentStorage(&testStorage);
-    EXPECT_EQ(table.Add(EmberBindingTableEntry::ForNode(0, 0, 0, 0, std::nullopt)), CHIP_NO_ERROR);
+    EXPECT_EQ(table.Add(Binding::TableEntry(0, 0, 0, 0, std::nullopt)), CHIP_NO_ERROR);
     auto iter = table.begin();
     EXPECT_EQ(table.RemoveAt(iter), CHIP_NO_ERROR);
     EXPECT_EQ(iter, table.end());
     EXPECT_EQ(table.Size(), 0u);
     EXPECT_EQ(table.begin(), table.end());
-    for (uint8_t i = 0; i < BindingTable::kMaxBindingEntries; i++)
+    for (uint8_t i = 0; i < Binding::Table::kMaxBindingEntries; i++)
     {
-        EXPECT_EQ(table.Add(EmberBindingTableEntry::ForNode(0, i, 0, 0, std::nullopt)), CHIP_NO_ERROR);
+        EXPECT_EQ(table.Add(Binding::TableEntry(0, i, 0, 0, std::nullopt)), CHIP_NO_ERROR);
     }
     iter = table.begin();
     ++iter;
     EXPECT_EQ(table.RemoveAt(iter), CHIP_NO_ERROR);
-    EXPECT_EQ(table.Size(), BindingTable::kMaxBindingEntries - 1);
+    EXPECT_EQ(table.Size(), Binding::Table::kMaxBindingEntries - 1);
     EXPECT_EQ(iter->nodeId, 2u);
     EXPECT_EQ(iter.GetIndex(), 2u);
     auto iterCheck = table.begin();
     ++iterCheck;
     EXPECT_EQ(iter, iterCheck);
 
-    EXPECT_EQ(table.Add(EmberBindingTableEntry::ForNode(0, 1, 0, 0, std::nullopt)), CHIP_NO_ERROR);
-    EXPECT_EQ(table.Size(), BindingTable::kMaxBindingEntries);
+    EXPECT_EQ(table.Add(Binding::TableEntry(0, 1, 0, 0, std::nullopt)), CHIP_NO_ERROR);
+    EXPECT_EQ(table.Size(), Binding::Table::kMaxBindingEntries);
     iter = table.begin();
-    for (uint8_t i = 0; i < BindingTable::kMaxBindingEntries - 1; i++)
+    for (uint8_t i = 0; i < Binding::Table::kMaxBindingEntries - 1; i++)
     {
         ++iter;
     }
@@ -121,23 +121,23 @@ TEST(TestBindingTable, TestRemoveThenAdd)
     EXPECT_EQ(iter, table.end());
     iter = table.begin();
     EXPECT_EQ(table.RemoveAt(iter), CHIP_NO_ERROR);
-    EXPECT_EQ(table.Size(), BindingTable::kMaxBindingEntries - 1);
+    EXPECT_EQ(table.Size(), Binding::Table::kMaxBindingEntries - 1);
     EXPECT_EQ(iter, table.begin());
     EXPECT_EQ(iter.GetIndex(), 2u);
     EXPECT_EQ(iter->nodeId, 2u);
-    EXPECT_EQ(table.GetAt(0).type, MATTER_UNUSED_BINDING);
+    EXPECT_EQ(table.GetAt(0).type, Binding::MATTER_UNUSED_BINDING);
 }
 
 TEST(TestBindingTable, TestPersistentStorage)
 {
     chip::TestPersistentStorageDelegate testStorage;
-    BindingTable table;
+    Binding::Table table;
     chip::Optional<chip::ClusterId> cluster = chip::MakeOptional<chip::ClusterId>(static_cast<chip::ClusterId>(UINT16_MAX + 6));
-    std::vector<EmberBindingTableEntry> expected = {
-        EmberBindingTableEntry::ForNode(0, 0, 0, 0, std::nullopt),
-        EmberBindingTableEntry::ForNode(1, 1, 0, 0, cluster.std_optional()),
-        EmberBindingTableEntry::ForGroup(2, 2, 0, std::nullopt),
-        EmberBindingTableEntry::ForGroup(3, 3, 0, cluster.std_optional()),
+    std::vector<Binding::TableEntry> expected = {
+        Binding::TableEntry(0, 0, 0, 0, std::nullopt),
+        Binding::TableEntry(1, 1, 0, 0, cluster.std_optional()),
+        Binding::TableEntry(2, 2, 0, std::nullopt),
+        Binding::TableEntry(3, 3, 0, cluster.std_optional()),
     };
     table.SetPersistentStorage(&testStorage);
     EXPECT_EQ(table.Add(expected[0]), CHIP_NO_ERROR);
@@ -148,7 +148,7 @@ TEST(TestBindingTable, TestPersistentStorage)
 
     // Verify storage untouched if add fails
     testStorage.AddPoisonKey(chip::DefaultStorageKeyAllocator::BindingTableEntry(4).KeyName());
-    EXPECT_NE(table.Add(EmberBindingTableEntry::ForNode(4, 4, 0, 0, std::nullopt)), CHIP_NO_ERROR);
+    EXPECT_NE(table.Add(Binding::TableEntry(4, 4, 0, 0, std::nullopt)), CHIP_NO_ERROR);
     VerifyRestored(testStorage, expected);
     testStorage.ClearPoisonKeys();
 

--- a/src/app/clusters/bindings/tests/TestBindingTable.cpp
+++ b/src/app/clusters/bindings/tests/TestBindingTable.cpp
@@ -132,7 +132,7 @@ TEST(TestBindingTable, TestPersistentStorage)
 {
     chip::TestPersistentStorageDelegate testStorage;
     Binding::Table table;
-    chip::Optional<chip::ClusterId> cluster = chip::MakeOptional<chip::ClusterId>(static_cast<chip::ClusterId>(UINT16_MAX + 6));
+    chip::Optional<chip::ClusterId> cluster   = chip::MakeOptional<chip::ClusterId>(static_cast<chip::ClusterId>(UINT16_MAX + 6));
     std::vector<Binding::TableEntry> expected = {
         Binding::TableEntry(0, 0, 0, 0, std::nullopt),
         Binding::TableEntry(1, 1, 0, 0, cluster.std_optional()),

--- a/src/app/clusters/bindings/tests/TestBindingTable.cpp
+++ b/src/app/clusters/bindings/tests/TestBindingTable.cpp
@@ -67,9 +67,9 @@ TEST(TestBindingTable, TestAdd)
     EXPECT_EQ(table.Add(unusedEntry), CHIP_ERROR_INVALID_ARGUMENT);
     for (uint8_t i = 0; i < Binding::Table::kMaxBindingEntries; i++)
     {
-        EXPECT_EQ(table.Add(Binding::TableEntry(0, i, 0, 0, std::nullopt)), CHIP_NO_ERROR);
+        EXPECT_EQ(table.Add(Binding::TableEntry::ForNode(0, i, 0, 0, std::nullopt)), CHIP_NO_ERROR);
     }
-    EXPECT_EQ(table.Add(Binding::TableEntry(0, 0, 0, 0, std::nullopt)), CHIP_ERROR_NO_MEMORY);
+    EXPECT_EQ(table.Add(Binding::TableEntry::ForNode(0, 0, 0, 0, std::nullopt)), CHIP_ERROR_NO_MEMORY);
     EXPECT_EQ(table.Size(), Binding::Table::kMaxBindingEntries);
 
     auto iter = table.begin();
@@ -88,7 +88,7 @@ TEST(TestBindingTable, TestRemoveThenAdd)
     Binding::Table table;
     chip::TestPersistentStorageDelegate testStorage;
     table.SetPersistentStorage(&testStorage);
-    EXPECT_EQ(table.Add(Binding::TableEntry(0, 0, 0, 0, std::nullopt)), CHIP_NO_ERROR);
+    EXPECT_EQ(table.Add(Binding::TableEntry::ForNode(0, 0, 0, 0, std::nullopt)), CHIP_NO_ERROR);
     auto iter = table.begin();
     EXPECT_EQ(table.RemoveAt(iter), CHIP_NO_ERROR);
     EXPECT_EQ(iter, table.end());
@@ -96,7 +96,7 @@ TEST(TestBindingTable, TestRemoveThenAdd)
     EXPECT_EQ(table.begin(), table.end());
     for (uint8_t i = 0; i < Binding::Table::kMaxBindingEntries; i++)
     {
-        EXPECT_EQ(table.Add(Binding::TableEntry(0, i, 0, 0, std::nullopt)), CHIP_NO_ERROR);
+        EXPECT_EQ(table.Add(Binding::TableEntry::ForNode(0, i, 0, 0, std::nullopt)), CHIP_NO_ERROR);
     }
     iter = table.begin();
     ++iter;
@@ -108,7 +108,7 @@ TEST(TestBindingTable, TestRemoveThenAdd)
     ++iterCheck;
     EXPECT_EQ(iter, iterCheck);
 
-    EXPECT_EQ(table.Add(Binding::TableEntry(0, 1, 0, 0, std::nullopt)), CHIP_NO_ERROR);
+    EXPECT_EQ(table.Add(Binding::TableEntry::ForNode(0, 1, 0, 0, std::nullopt)), CHIP_NO_ERROR);
     EXPECT_EQ(table.Size(), Binding::Table::kMaxBindingEntries);
     iter = table.begin();
     for (uint8_t i = 0; i < Binding::Table::kMaxBindingEntries - 1; i++)
@@ -134,10 +134,10 @@ TEST(TestBindingTable, TestPersistentStorage)
     Binding::Table table;
     chip::Optional<chip::ClusterId> cluster   = chip::MakeOptional<chip::ClusterId>(static_cast<chip::ClusterId>(UINT16_MAX + 6));
     std::vector<Binding::TableEntry> expected = {
-        Binding::TableEntry(0, 0, 0, 0, std::nullopt),
-        Binding::TableEntry(1, 1, 0, 0, cluster.std_optional()),
-        Binding::TableEntry(2, 2, 0, std::nullopt),
-        Binding::TableEntry(3, 3, 0, cluster.std_optional()),
+        Binding::TableEntry::ForNode(0, 0, 0, 0, std::nullopt),
+        Binding::TableEntry::ForNode(1, 1, 0, 0, cluster.std_optional()),
+        Binding::TableEntry::ForGroup(2, 2, 0, std::nullopt),
+        Binding::TableEntry::ForGroup(3, 3, 0, cluster.std_optional()),
     };
     table.SetPersistentStorage(&testStorage);
     EXPECT_EQ(table.Add(expected[0]), CHIP_NO_ERROR);
@@ -148,7 +148,7 @@ TEST(TestBindingTable, TestPersistentStorage)
 
     // Verify storage untouched if add fails
     testStorage.AddPoisonKey(chip::DefaultStorageKeyAllocator::BindingTableEntry(4).KeyName());
-    EXPECT_NE(table.Add(Binding::TableEntry(4, 4, 0, 0, std::nullopt)), CHIP_NO_ERROR);
+    EXPECT_NE(table.Add(Binding::TableEntry::ForNode(4, 4, 0, 0, std::nullopt)), CHIP_NO_ERROR);
     VerifyRestored(testStorage, expected);
     testStorage.ClearPoisonKeys();
 

--- a/src/app/clusters/bindings/tests/TestPendingNotificationMap.cpp
+++ b/src/app/clusters/bindings/tests/TestPendingNotificationMap.cpp
@@ -21,14 +21,9 @@
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <pw_unit_test/framework.h>
 
-using chip::BindingTable;
-using chip::ClusterId;
-using chip::FabricIndex;
-using chip::MakeOptional;
-using chip::NodeId;
-using chip::NullOptional;
-using chip::PendingNotificationEntry;
-using chip::PendingNotificationMap;
+using namespace chip;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::Binding;
 
 namespace {
 
@@ -38,11 +33,11 @@ public:
     static void SetUpTestSuite()
     {
         static chip::TestPersistentStorageDelegate storage;
-        BindingTable::GetInstance().SetPersistentStorage(&storage);
+        Binding::Table::GetInstance().SetPersistentStorage(&storage);
     }
 };
 
-void ClearBindingTable(BindingTable & table)
+void ClearBindingTable(Binding::Table & table)
 {
     auto iter = table.begin();
     while (iter != table.end())
@@ -51,11 +46,11 @@ void ClearBindingTable(BindingTable & table)
     }
 }
 
-void CreateDefaultFullBindingTable(BindingTable & table)
+void CreateDefaultFullBindingTable(Binding::Table & table)
 {
-    for (uint8_t i = 0; i < BindingTable::kMaxBindingEntries; i++)
+    for (uint8_t i = 0; i < Binding::Table::kMaxBindingEntries; i++)
     {
-        table.Add(EmberBindingTableEntry::ForNode(i / 10, i % 5, 0, 0, std::make_optional<ClusterId>(i)));
+        table.Add(Binding::TableEntry(i / 10, i % 5, 0, 0, std::make_optional<ClusterId>(i)));
     }
 }
 
@@ -70,17 +65,17 @@ TEST_F(TestPendingNotificationMap, TestEmptyMap)
 TEST_F(TestPendingNotificationMap, TestAddRemove)
 {
     PendingNotificationMap pendingMap;
-    ClearBindingTable(BindingTable::GetInstance());
-    CreateDefaultFullBindingTable(BindingTable::GetInstance());
-    for (uint8_t i = 0; i < BindingTable::kMaxBindingEntries; i++)
+    ClearBindingTable(Binding::Table::GetInstance());
+    CreateDefaultFullBindingTable(Binding::Table::GetInstance());
+    for (uint8_t i = 0; i < Binding::Table::kMaxBindingEntries; i++)
     {
         EXPECT_EQ(pendingMap.AddPendingNotification(i, nullptr), CHIP_NO_ERROR);
     }
     // Confirm adding in one more element fails
-    EXPECT_EQ(pendingMap.AddPendingNotification(BindingTable::kMaxBindingEntries, nullptr), CHIP_ERROR_NO_MEMORY);
+    EXPECT_EQ(pendingMap.AddPendingNotification(Binding::Table::kMaxBindingEntries, nullptr), CHIP_ERROR_NO_MEMORY);
 
     auto iter = pendingMap.begin();
-    for (uint8_t i = 0; i < BindingTable::kMaxBindingEntries; i++)
+    for (uint8_t i = 0; i < Binding::Table::kMaxBindingEntries; i++)
     {
         PendingNotificationEntry entry = *iter;
         EXPECT_EQ(entry.mBindingEntryId, i);
@@ -91,23 +86,23 @@ TEST_F(TestPendingNotificationMap, TestAddRemove)
     size_t pendingMapCount = 0;
     for (iter = pendingMap.begin(); iter != pendingMap.end(); ++iter)
     {
-        PendingNotificationEntry entry      = *iter;
-        EmberBindingTableEntry bindingEntry = BindingTable::GetInstance().GetAt(entry.mBindingEntryId);
+        PendingNotificationEntry entry   = *iter;
+        Binding::TableEntry bindingEntry = Binding::Table::GetInstance().GetAt(entry.mBindingEntryId);
         pendingMapCount++;
         EXPECT_NE(chip::ScopedNodeId(bindingEntry.nodeId, bindingEntry.fabricIndex), chip::ScopedNodeId());
     }
-    EXPECT_EQ(pendingMapCount, BindingTable::kMaxBindingEntries - 2);
+    EXPECT_EQ(pendingMapCount, Binding::Table::kMaxBindingEntries - 2);
     pendingMap.RemoveAllEntriesForFabric(0);
     pendingMapCount = 0;
     for (iter = pendingMap.begin(); iter != pendingMap.end(); ++iter)
     {
-        PendingNotificationEntry entry      = *iter;
-        EmberBindingTableEntry bindingEntry = BindingTable::GetInstance().GetAt(entry.mBindingEntryId);
+        PendingNotificationEntry entry   = *iter;
+        Binding::TableEntry bindingEntry = Binding::Table::GetInstance().GetAt(entry.mBindingEntryId);
         pendingMapCount++;
         EXPECT_NE(bindingEntry.fabricIndex, 0);
     }
-    EXPECT_EQ(pendingMapCount, BindingTable::kMaxBindingEntries - 10);
-    const FabricIndex maxFabricIndex = static_cast<FabricIndex>(BindingTable::kMaxBindingEntries / 10);
+    EXPECT_EQ(pendingMapCount, Binding::Table::kMaxBindingEntries - 10);
+    const FabricIndex maxFabricIndex = static_cast<FabricIndex>(Binding::Table::kMaxBindingEntries / 10);
     for (FabricIndex index = 1; index <= maxFabricIndex; index++)
     {
         pendingMap.RemoveAllEntriesForFabric(index);
@@ -118,8 +113,8 @@ TEST_F(TestPendingNotificationMap, TestAddRemove)
 TEST_F(TestPendingNotificationMap, TestLRUEntry)
 {
     PendingNotificationMap pendingMap;
-    ClearBindingTable(BindingTable::GetInstance());
-    CreateDefaultFullBindingTable(BindingTable::GetInstance());
+    ClearBindingTable(Binding::Table::GetInstance());
+    CreateDefaultFullBindingTable(Binding::Table::GetInstance());
     EXPECT_EQ(pendingMap.AddPendingNotification(0, nullptr), CHIP_NO_ERROR);
     EXPECT_EQ(pendingMap.AddPendingNotification(1, nullptr), CHIP_NO_ERROR);
     EXPECT_EQ(pendingMap.AddPendingNotification(5, nullptr), CHIP_NO_ERROR);

--- a/src/app/data-model-provider/Provider.h
+++ b/src/app/data-model-provider/Provider.h
@@ -85,7 +85,8 @@ public:
     ///   2) This function will only be called at the beginning and end of a series of consecutive attribute data
     ///   blocks for the same attribute, no matter what list operations those data blocks represent.
     ///   3) The opType argument indicates the type of notification (Start, Failure, Success).
-    virtual void ListAttributeWriteNotification(const ConcreteAttributePath & aPath, ListWriteOperation opType) = 0;
+    virtual void ListAttributeWriteNotification(const ConcreteAttributePath & aPath, ListWriteOperation opType,
+                                                FabricIndex accessingFabric) = 0;
 
     /// `handler` is used to send back the reply.
     ///    - returning `std::nullopt` means that return value was placed in handler directly.

--- a/src/app/server-cluster/ServerClusterInterface.h
+++ b/src/app/server-cluster/ServerClusterInterface.h
@@ -97,7 +97,9 @@ public:
     ///
     /// Precondition:
     ///   - `path` endpoint+cluster part MUST match one of the paths returned by GetPaths.
-    virtual void ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType) {}
+    virtual void ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType,
+                                                FabricIndex accessingFabric)
+    {}
 
     /// Reads the value of an existing attribute.
     ///

--- a/src/app/server-cluster/testing/EmptyProvider.h
+++ b/src/app/server-cluster/testing/EmptyProvider.h
@@ -49,7 +49,7 @@ public:
     CHIP_ERROR AcceptedCommands(const app::ConcreteClusterPath & path,
                                 ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> & builder) override;
     void ListAttributeWriteNotification(const app::ConcreteAttributePath & aPath,
-                                        app::DataModel::ListWriteOperation opType) override
+                                        app::DataModel::ListWriteOperation opType, FabricIndex accessingFabric) override
     {}
 
     void Temporary_ReportAttributeChanged(const app::AttributePathParams & path) override;

--- a/src/app/server-cluster/testing/EmptyProvider.h
+++ b/src/app/server-cluster/testing/EmptyProvider.h
@@ -48,8 +48,8 @@ public:
     CHIP_ERROR GeneratedCommands(const app::ConcreteClusterPath & path, ReadOnlyBufferBuilder<CommandId> & builder) override;
     CHIP_ERROR AcceptedCommands(const app::ConcreteClusterPath & path,
                                 ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> & builder) override;
-    void ListAttributeWriteNotification(const app::ConcreteAttributePath & aPath,
-                                        app::DataModel::ListWriteOperation opType, FabricIndex accessingFabric) override
+    void ListAttributeWriteNotification(const app::ConcreteAttributePath & aPath, app::DataModel::ListWriteOperation opType,
+                                        FabricIndex accessingFabric) override
     {}
 
     void Temporary_ReportAttributeChanged(const app::AttributePathParams & path) override;

--- a/src/app/server-cluster/tests/TestDefaultServerCluster.cpp
+++ b/src/app/server-cluster/tests/TestDefaultServerCluster.cpp
@@ -93,8 +93,8 @@ TEST(TestDefaultServerCluster, ListWriteNotification)
     FakeDefaultServerCluster cluster({ 1, 2 });
 
     // this does not test anything really, except we get 100% coverage and we see that we do not crash
-    cluster.ListAttributeWriteNotification({ 1, 2, 3 }, DataModel::ListWriteOperation::kListWriteBegin);
-    cluster.ListAttributeWriteNotification({ 1, 2, 3 }, DataModel::ListWriteOperation::kListWriteFailure);
+    cluster.ListAttributeWriteNotification({ 1, 2, 3 }, DataModel::ListWriteOperation::kListWriteBegin, 1);
+    cluster.ListAttributeWriteNotification({ 1, 2, 3 }, DataModel::ListWriteOperation::kListWriteFailure, 1);
 }
 
 TEST(TestDefaultServerCluster, AttributesDefault)
@@ -131,9 +131,9 @@ TEST(TestDefaultServerCluster, ListWriteIsANoop)
 
     // this is really for coverage, we are not calling anything useful
     cluster.ListAttributeWriteNotification({ 1 /* endpoint */, 2 /* cluster */, 3 /* attribute */ },
-                                           DataModel::ListWriteOperation::kListWriteBegin);
+                                           DataModel::ListWriteOperation::kListWriteBegin, 1);
     cluster.ListAttributeWriteNotification({ 1 /* endpoint */, 2 /* cluster */, 3 /* attribute */ },
-                                           DataModel::ListWriteOperation::kListWriteSuccess);
+                                           DataModel::ListWriteOperation::kListWriteSuccess, 1);
 }
 
 TEST(TestDefaultServerCluster, CommandsDefault)

--- a/src/data-model-providers/codedriven/CodeDrivenDataModelProvider.cpp
+++ b/src/data-model-providers/codedriven/CodeDrivenDataModelProvider.cpp
@@ -123,11 +123,11 @@ DataModel::ActionReturnStatus CodeDrivenDataModelProvider::WriteAttribute(const 
 }
 
 void CodeDrivenDataModelProvider::ListAttributeWriteNotification(const ConcreteAttributePath & path,
-                                                                 DataModel::ListWriteOperation opType)
+                                                                 DataModel::ListWriteOperation opType, FabricIndex accessingFabric)
 {
     ServerClusterInterface * serverCluster = GetServerClusterInterface(path);
     VerifyOrReturn(serverCluster != nullptr);
-    serverCluster->ListAttributeWriteNotification(path, opType);
+    serverCluster->ListAttributeWriteNotification(path, opType, accessingFabric);
 }
 
 std::optional<DataModel::ActionReturnStatus> CodeDrivenDataModelProvider::InvokeCommand(const DataModel::InvokeRequest & request,

--- a/src/data-model-providers/codedriven/CodeDrivenDataModelProvider.h
+++ b/src/data-model-providers/codedriven/CodeDrivenDataModelProvider.h
@@ -74,7 +74,8 @@ public:
     DataModel::ActionReturnStatus WriteAttribute(const DataModel::WriteAttributeRequest & request,
                                                  AttributeValueDecoder & decoder) override;
 
-    void ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType) override;
+    void ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType,
+                                        FabricIndex accessingFabric) override;
     std::optional<DataModel::ActionReturnStatus> InvokeCommand(const DataModel::InvokeRequest & request,
                                                                TLV::TLVReader & input_arguments, CommandHandler * handler) override;
 

--- a/src/data-model-providers/codedriven/tests/TestCodeDrivenDataModelProvider.cpp
+++ b/src/data-model-providers/codedriven/tests/TestCodeDrivenDataModelProvider.cpp
@@ -59,7 +59,8 @@ class MockServerCluster : public DefaultServerCluster
 public:
     MockServerCluster(std::initializer_list<ConcreteClusterPath> paths, DataVersion dataVersion,
                       BitFlags<DataModel::ClusterQualityFlags> flags) :
-        DefaultServerCluster({ 0, 0 }), mPaths(paths), mDataVersion(dataVersion), mFlags(flags),
+        DefaultServerCluster({ 0, 0 }),
+        mPaths(paths), mDataVersion(dataVersion), mFlags(flags),
         mAttributeEntry(1, BitMask<DataModel::AttributeQualityFlags>(), std::nullopt, std::nullopt)
     {}
 
@@ -177,8 +178,8 @@ public:
     void ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType,
                                         FabricIndex accessingFabric) override
     {
-        mLastListWriteOpPath = path;
-        mLastListWriteOpType = opType;
+        mLastListWriteOpPath            = path;
+        mLastListWriteOpType            = opType;
         mLastListWriteOpAccessingFabric = accessingFabric;
     }
 

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.h
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.h
@@ -67,7 +67,8 @@ public:
     DataModel::ActionReturnStatus WriteAttribute(const DataModel::WriteAttributeRequest & request,
                                                  AttributeValueDecoder & decoder) override;
 
-    void ListAttributeWriteNotification(const ConcreteAttributePath & aPath, DataModel::ListWriteOperation opType) override;
+    void ListAttributeWriteNotification(const ConcreteAttributePath & aPath, DataModel::ListWriteOperation opType,
+                                        FabricIndex accessingFabric) override;
     std::optional<DataModel::ActionReturnStatus> InvokeCommand(const DataModel::InvokeRequest & request,
                                                                TLV::TLVReader & input_arguments, CommandHandler * handler) override;
 

--- a/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider_Write.cpp
@@ -171,9 +171,8 @@ DataModel::ActionReturnStatus CodegenDataModelProvider::WriteAttribute(const Dat
 }
 
 void CodegenDataModelProvider::ListAttributeWriteNotification(const ConcreteAttributePath & aPath,
-                                                              DataModel::ListWriteOperation opType)
+                                                              DataModel::ListWriteOperation opType, FabricIndex accessingFabric)
 {
-
     // NOTE: for backwards compatibility, we process AAI logic BEFORE Server Cluster Interface
     //       so that AttributeAccessInterface logic works if one was installed before Server Cluster Interface
     //       support was introduced in the SDK.
@@ -204,7 +203,7 @@ void CodegenDataModelProvider::ListAttributeWriteNotification(const ConcreteAttr
 
     if (auto * cluster = mRegistry.Get(aPath); cluster != nullptr)
     {
-        cluster->ListAttributeWriteNotification(aPath, opType);
+        cluster->ListAttributeWriteNotification(aPath, opType, accessingFabric);
         return;
     }
 }


### PR DESCRIPTION
#### Summary

- Structure and Class rename: `EmberBindingTableEntry` to `Binding::TableEntry`, `BindingTable` to `Binding::Table`, `BindingManager` to `Binding::Manager`
- Namespace moving: Move all the structures, classes and functions of binding clusters to namespace `chip::app::Clusters`
- Add `accessingFabricIndex` for `ListAttributeWriteNotification` functions in both DataModelProvider and ServerCluster.

#### Related issues

Fixes https://github.com/project-chip/connectedhomeip/issues/40715

#### Testing

The CI test should pass

