### PR TITLE
Revert "Parallelize submodule checkout (#41335)"

### DIFF
--- a/.github/actions/checkout-submodules/action.yaml
+++ b/.github/actions/checkout-submodules/action.yaml
@@ -14,6 +14,6 @@ runs:
     - uses: Wandalen/wretry.action@v1.4.10
       name: Checkout submodules
       with:
-        command: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --jobs 4 --platform ${{ inputs.platform }} ${{ inputs.extra-parameters }}
+        command: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform ${{ inputs.platform }} ${{ inputs.extra-parameters }}
         attempt_limit: 3
         attempt_delay: 2000

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -63,7 +63,7 @@ jobs:
             - name: Build tools required for Factory Data
               # Run test for master and all PRs
               run: |
-                  ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --jobs 4 --platform linux
+                  ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
                   ./scripts/build/gn_gen.sh
                   ./scripts/run_in_build_env.sh "ninja -C ./out/$BUILD_TYPE chip-cert chip-tool spake2p"
                   mv ./out/$BUILD_TYPE/chip-cert ./out/$BUILD_TYPE/chip-tool ./out/$BUILD_TYPE/spake2p ./out
@@ -410,7 +410,7 @@ jobs:
             - name: Build tools required for Factory Data
               # Run test for master and all PRs
               run: |
-                  ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --jobs 4 --platform linux
+                  ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
                   ./scripts/build/gn_gen.sh
                   ./scripts/run_in_build_env.sh "ninja -C ./out/$BUILD_TYPE chip-cert chip-tool spake2p"
                   mv ./out/$BUILD_TYPE/chip-cert ./out/$BUILD_TYPE/chip-tool ./out/$BUILD_TYPE/spake2p ./out

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -5,7 +5,7 @@ steps:
           - "-c"
           - |
               git config --global --add safe.directory "*"
-              python scripts/checkout_submodules.py --shallow --recursive --jobs 4 --platform esp32 nrfconnect silabs linux android
+              python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
     - name: "ghcr.io/project-chip/chip-build-vscode:169"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -5,7 +5,7 @@ steps:
           - "-c"
           - |
               git config --global --add safe.directory "*"
-              python scripts/checkout_submodules.py --shallow --recursive --jobs 4 --platform esp32 nrfconnect silabs linux android
+              python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
     - name: "ghcr.io/project-chip/chip-build-vscode:169"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -140,7 +140,7 @@ RUN mkdir /root/connectedhomeip
 RUN git clone https://github.com/project-chip/connectedhomeip.git /root/connectedhomeip
 WORKDIR /root/connectedhomeip/
 RUN git checkout ${COMMITHASH}
-RUN ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --jobs 4 --platform linux
+RUN ./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 RUN bash scripts/bootstrap.sh
 
 # Stage 2: Build.

--- a/scripts/build/gn_gen_cirque.sh
+++ b/scripts/build/gn_gen_cirque.sh
@@ -30,7 +30,7 @@ env
 cd "$ROOT_PATH"
 
 echo "Ensure submodules for Linux builds are checked out"
-./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --jobs 4 --platform linux
+./scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform linux
 
 echo "Setup build environment"
 source "./scripts/activate.sh"

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -220,7 +220,7 @@ find_in_ancestors() {
     fi
 
     # there are environments where these bits are unwanted, unnecessary, or impossible
-    [[ -n $CHIP_NO_SUBMODULES ]] || scripts/checkout_submodules.py --shallow --jobs 4 --platform darwin
+    [[ -n $CHIP_NO_SUBMODULES ]] || scripts/checkout_submodules.py --shallow --platform darwin
     if [[ -z $CHIP_NO_ACTIVATE ]]; then
         # first run bootstrap/activate in an external env to build everything
         env -i PW_ENVSETUP_NO_BANNER=1 PW_ENVSETUP_QUIET=1 bash -c '. scripts/activate.sh'


### PR DESCRIPTION
This reverts commit 82e6d0e81312375f4aa959165df1c40a4094e5c2.

#### Summary

When running git clone with --jobs github does not fail gracefully when DNS fails. If after that the checkout is started again it seemingly finishes correctly. This is not true however as some submodules end up with empty workdirs. This has caused at least one job to fail: https://github.com/project-chip/connectedhomeip/actions/runs/18407027799/job/52449279674

#### Testing

Steps to reproduce the problem:

Start devcontainer:

```
git config --add safe.directory '*'
docker run --rm -u $(id -u):$(id -g) -it -v $HOME/repos/github.com/project-chip/connectedhomeip:/workspaces/connectedhomeip -w /workspaces/connectedhomeip ghcr.io/project-chip/chip-build-vscode:170`
```

Start parallel checkout:

```
scripts/checkout_submodules.py --shallow --jobs 4 --platform darwin; echo $?
```

After around 10 seconds cut off DNS (run all `iptables` commands outside of the docker container):

```
iptables -I FORWARD -p udp --dport 53 -m state --state NEW -j REJECT
```

Wait for the checkout to fail as expected:
```
I have no name!@118d1ec9228b:/workspaces/connectedhomeip$ scripts/checkout_submodules.py --shallow --jobs 4 --platform darwin; echo $?
Checking out: nlassert, nlio, mbedtls, qrcode, pigweed, openthread, nanopb, third_party/jsoncpp/repo, editline, third_party/boringssl/repo/src, third_party/libwebsockets/repo, perfetto, third_party/abseil-cpp/src, third_party/fuzztest, third_party/googletest, third_party/libdatachannel/repo, third_party/libtrustymatter/repo
fatal: unable to access 'https://github.com/abseil/abseil-cpp.git/': Could not resolve host: github.com
fatal: unable to access 'https://github.com/abseil/abseil-cpp.git/': Could not resolve host: github.com
fatal: Fetched in submodule path 'third_party/abseil-cpp/src', but it did not contain 9ac7062b1860d895fb5a8cbf58c3e9ef8f674b5f. Direct fetching of that commit failed.
Traceback (most recent call last):
  File "/workspaces/connectedhomeip/scripts/checkout_submodules.py", line 187, in <module>
    main()
  File "/workspaces/connectedhomeip/scripts/checkout_submodules.py", line 179, in main
    checkout_modules(selected_modules, args.shallow,
  File "/workspaces/connectedhomeip/scripts/checkout_submodules.py", line 123, in checkout_modules
    subprocess.check_call(cmd + module_paths)
  File "/usr/lib/python3.12/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['git', '-c', 'core.symlinks=true', '-C', '/workspaces/connectedhomeip', 'submodule', '--quiet', 'update', '--init', '--depth', '1', '--jobs', '4', 'third_party/nlassert/repo', 'third_party/nlio/repo', 'third_party/mbedtls/repo', 'examples/common/QRCode/repo', 'third_party/pigweed/repo', 'third_party/openthread/repo', 'third_party/nanopb/repo', 'third_party/jsoncpp/repo', 'third_party/editline/repo', 'third_party/boringssl/repo/src', 'third_party/libwebsockets/repo', 'third_party/perfetto/repo', 'third_party/abseil-cpp/src', 'third_party/fuzztest', 'third_party/googletest', 'third_party/libdatachannel/repo', 'third_party/libtrustymatter/repo']' returned non-zero exit status 128.
```

Enable DNS again and start a new checkout:

```
iptables -D FORWARD 1
scripts/checkout_submodules.py --shallow --jobs 4 --platform darwin; echo $?
```

This checkout succeeds like expected:

```
I have no name!@118d1ec9228b:/workspaces/connectedhomeip$ scripts/checkout_submodules.py --shallow --jobs 4 --platform darwin; echo $?
Checking out: nlassert, nlio, mbedtls, qrcode, pigweed, openthread, nanopb, third_party/jsoncpp/repo, editline, third_party/boringssl/repo/src, third_party/libwebsockets/repo, perfetto, third_party/abseil-cpp/src, third_party/fuzztest, third_party/googletest, third_party/libdatachannel/repo, third_party/libtrustymatter/repo
0
````

But some submodules have empty workdirs:

```
I have no name!@118d1ec9228b:/workspaces/connectedhomeip$ while read p; do echo -n "$p: "; ls -l $p | grep -v -e '^total ' -e '\.$' | wc -l; done
third_party/nlassert/repo
third_party/nlio/repo
third_party/mbedtls/repo
examples/common/QRCode/repo
third_party/pigweed/repo
third_party/openthread/repo
third_party/nanopb/repo
third_party/jsoncpp/repo
third_party/editline/repo
third_party/boringssl/repo/src
third_party/libwebsockets/repo
third_party/perfetto/repo
third_party/abseil-cpp/src
third_party/fuzztest
third_party/googletest
third_party/libdatachannel/repo
third_party/libtrustymatter/repo
third_party/nlassert/repo: 0
third_party/nlio/repo: 0
third_party/mbedtls/repo: 24
examples/common/QRCode/repo: 7
third_party/pigweed/repo: 230
third_party/openthread/repo: 20
third_party/nanopb/repo: 32
third_party/jsoncpp/repo: 0
third_party/editline/repo: 0
third_party/boringssl/repo/src: 32
third_party/libwebsockets/repo: 26
third_party/perfetto/repo: 39
third_party/abseil-cpp/src: 18
third_party/fuzztest: 19
third_party/googletest: 15
third_party/libdatachannel/repo: 14
```
`third_party/nlassert/repo`, `third_party/nlio/repo`, `third_party/jsoncpp/repo` and `third_party/editline/repo` have empty workdirs.

If you repeat the steps above without `--jobs` the problem does not occur.

This looks to be a bug in git.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
