### PR TITLE
Remove line split on strings

### DIFF
--- a/src/python_testing/TC_PAVST_2_6.py
+++ b/src/python_testing/TC_PAVST_2_6.py
@@ -88,7 +88,7 @@ class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_true(status == Status.InvalidInState,
                             (f"Unexpected response {status} received on SetTransportStatus "
                              "with privacy mode enabled")
-                           )
+                            )
         await self.write_single_attribute(
             attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftRecordingPrivacyModeEnabled(False),
             endpoint_id=endpoint,

--- a/src/python_testing/TC_PAVST_2_6.py
+++ b/src/python_testing/TC_PAVST_2_6.py
@@ -85,10 +85,10 @@ class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             transportStatus=not aTransportStatus
         )
         status = await self.psvt_set_transport_status(cmd, expected_status=Status.InvalidInState)
-        asserts.assert_true(status == Status.InvalidInState, 
+        asserts.assert_true(status == Status.InvalidInState,
                             (f"Unexpected response {status} received on SetTransportStatus "
                              "with privacy mode enabled")
-        )
+                           )
         await self.write_single_attribute(
             attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftRecordingPrivacyModeEnabled(False),
             endpoint_id=endpoint,

--- a/src/python_testing/TC_PAVST_2_6.py
+++ b/src/python_testing/TC_PAVST_2_6.py
@@ -85,8 +85,7 @@ class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             transportStatus=not aTransportStatus
         )
         status = await self.psvt_set_transport_status(cmd, expected_status=Status.InvalidInState)
-        asserts.assert_true(status == Status.InvalidInState, f"Unexpected response {
-                            status} received on SetTransportStatus with privacy mode enabled")
+        asserts.assert_true(status == Status.InvalidInState, f"Unexpected response {status} received on SetTransportStatus with privacy mode enabled")
         await self.write_single_attribute(
             attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftRecordingPrivacyModeEnabled(False),
             endpoint_id=endpoint,

--- a/src/python_testing/TC_PAVST_2_6.py
+++ b/src/python_testing/TC_PAVST_2_6.py
@@ -85,7 +85,10 @@ class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             transportStatus=not aTransportStatus
         )
         status = await self.psvt_set_transport_status(cmd, expected_status=Status.InvalidInState)
-        asserts.assert_true(status == Status.InvalidInState, f"Unexpected response {status} received on SetTransportStatus with privacy mode enabled")
+        asserts.assert_true(status == Status.InvalidInState, 
+                            (f"Unexpected response {status} received on SetTransportStatus "
+                             "with privacy mode enabled")
+        )
         await self.write_single_attribute(
             attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftRecordingPrivacyModeEnabled(False),
             endpoint_id=endpoint,

--- a/src/python_testing/TC_PAVST_2_7.py
+++ b/src/python_testing/TC_PAVST_2_7.py
@@ -373,8 +373,7 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
                 )
 
             status = await self.psvt_manually_trigger_transport(cmd, expected_status=Status.InvalidInState)
-            asserts.assert_true(status == Status.InvalidInState, f"Unexpected response {
-                                status} received on Manually Triggered push with privacy mode enabled")
+            asserts.assert_true(status == Status.InvalidInState, f"Unexpected response {status} received on Manually Triggered push with privacy mode enabled")
 
             await self.write_single_attribute(
                 attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftRecordingPrivacyModeEnabled(False),

--- a/src/python_testing/TC_PAVST_2_7.py
+++ b/src/python_testing/TC_PAVST_2_7.py
@@ -373,10 +373,10 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
                 )
 
             status = await self.psvt_manually_trigger_transport(cmd, expected_status=Status.InvalidInState)
-            asserts.assert_true(status == Status.InvalidInState, 
+            asserts.assert_true(status == Status.InvalidInState,
                                 (f"Unexpected response {status} received on Manually Triggered push "
                                  "with privacy mode enabled")
-            )
+                                )
 
             await self.write_single_attribute(
                 attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftRecordingPrivacyModeEnabled(False),

--- a/src/python_testing/TC_PAVST_2_7.py
+++ b/src/python_testing/TC_PAVST_2_7.py
@@ -373,7 +373,10 @@ class TC_PAVST_2_7(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
                 )
 
             status = await self.psvt_manually_trigger_transport(cmd, expected_status=Status.InvalidInState)
-            asserts.assert_true(status == Status.InvalidInState, f"Unexpected response {status} received on Manually Triggered push with privacy mode enabled")
+            asserts.assert_true(status == Status.InvalidInState, 
+                                (f"Unexpected response {status} received on Manually Triggered push "
+                                 "with privacy mode enabled")
+            )
 
             await self.write_single_attribute(
                 attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftRecordingPrivacyModeEnabled(False),

--- a/src/python_testing/TC_WEBRTCR_2_5.py
+++ b/src/python_testing/TC_WEBRTCR_2_5.py
@@ -251,8 +251,7 @@ class TC_WebRTCR_2_5(MatterBaseTest):
         asserts.assert_equal(
             session_read_success,
             True,
-            f"CurrentSessions attribute read {
-                'succeeded with session info' if session_read_success else 'failed or returned incorrect data'}"
+            f"CurrentSessions attribute read {'succeeded with session info' if session_read_success else 'failed or returned incorrect data'}"
         )
 
         # Ensure we have a valid session ID before proceeding
@@ -304,8 +303,7 @@ class TC_WebRTCR_2_5(MatterBaseTest):
         asserts.assert_equal(
             final_read_success,
             True,
-            f"Final CurrentSessions attribute read {
-                'succeeded with empty list' if final_read_success else 'failed or returned non-empty list'}"
+            f"Final CurrentSessions attribute read {'succeeded with empty list' if final_read_success else 'failed or returned non-empty list'}"
         )
 
 

--- a/src/python_testing/TC_WEBRTCR_2_5.py
+++ b/src/python_testing/TC_WEBRTCR_2_5.py
@@ -251,7 +251,8 @@ class TC_WebRTCR_2_5(MatterBaseTest):
         asserts.assert_equal(
             session_read_success,
             True,
-            f"CurrentSessions attribute read {'succeeded with session info' if session_read_success else 'failed or returned incorrect data'}"
+            ("CurrentSessions attribute read "
+             f"{'succeeded with session info' if session_read_success else 'failed or returned incorrect data'}")
         )
 
         # Ensure we have a valid session ID before proceeding
@@ -303,7 +304,8 @@ class TC_WebRTCR_2_5(MatterBaseTest):
         asserts.assert_equal(
             final_read_success,
             True,
-            f"Final CurrentSessions attribute read {'succeeded with empty list' if final_read_success else 'failed or returned non-empty list'}"
+            ("CurrentSessions attribute read"
+             f"{'succeeded with empty list' if final_read_success else 'failed or returned non-empty list'}")
         )
 
 

--- a/src/tools/push_av_server/server.py
+++ b/src/tools/push_av_server/server.py
@@ -592,7 +592,9 @@ class PushAvServer:
                     track_name = stream.get('trackName', None)
                     if track_name and track_name != track_name_in_path:
                         is_valid = False
-                        validation_error_reason = f"Track name mismatch: {track_name_in_path} != {track_name}, must match TrackName provided in ContainerOptions"
+                        validation_error_reason = ("Track name mismatch: "
+                                                   f"{track_name_in_path} != {track_name}, "
+                                                   "must match TrackName provided in ContainerOptions")
 
         dst = self.wd.mkdir("streams", str(stream_id), f"{file_path}.{ext}", is_file=True)
         extended_path = f"{file_path}.{ext}"

--- a/src/tools/push_av_server/server.py
+++ b/src/tools/push_av_server/server.py
@@ -592,8 +592,7 @@ class PushAvServer:
                     track_name = stream.get('trackName', None)
                     if track_name and track_name != track_name_in_path:
                         is_valid = False
-                        validation_error_reason = f"Track name mismatch: {track_name_in_path} != {
-                            track_name}, must match TrackName provided in ContainerOptions"
+                        validation_error_reason = f"Track name mismatch: {track_name_in_path} != {track_name}, must match TrackName provided in ContainerOptions"
 
         dst = self.wd.mkdir("streams", str(stream_id), f"{file_path}.{ext}", is_file=True)
         extended_path = f"{file_path}.{ext}"


### PR DESCRIPTION
#### Summary

Test scripts with breaks in string literals are failing, these were added by the Restyler.  This removes the breaks and formats the strings in a way that keeps the Restyler happy and avoids it taking "breaking" action!

#### Related issues

https://github.com/project-chip/matter-test-scripts/issues/715

#### Testing
Run PAVST 2.6. 2.7, and WEBRTCR 2.5

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
