### PR TITLE
Darwin: Expose MTRSetupPayload subPayloads and concatenated properties

### DIFF
--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -138,7 +138,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * The individual constituent payloads, if the receiver represents a concatenated payload.
  * @see concatenated
  */
-@property (nonatomic, strong) NSArray<MTRSetupPayload *> * subPayloads;
+@property (nonatomic, strong) NSArray<MTRSetupPayload *> * subPayloads MTR_AVAILABLE(ios(18.5), macos(15.5), watchos(11.5), tvos(18.5));
 
 @property (nonatomic, copy) NSNumber * version;
 @property (nonatomic, copy) NSNumber * vendorID;

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -132,7 +132,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *   act as if the payload was not in fact concatenated, and return the relevant value associated
  *   with the first sub-payload. Mutating such a property will discard the additional sub-payloads.
  */
-@property (nonatomic, readonly, assign, getter=isConcatenated) BOOL concatenated MTR_AVAILABLE(ios(18.5), macos(15.5), watchos(11.5), tvos(18.5));
+@property (nonatomic, readonly, assign, getter=isConcatenated) BOOL concatenated MTR_AVAILABLE(ios(26.2), macos(26.2), watchos(26.2), tvos(26.2));
 
 /**
  * The individual constituent payloads, if the receiver represents a concatenated payload.

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -138,7 +138,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * The individual constituent payloads, if the receiver represents a concatenated payload.
  * @see concatenated
  */
-@property (nonatomic, strong) NSArray<MTRSetupPayload *> * subPayloads MTR_AVAILABLE(ios(18.5), macos(15.5), watchos(11.5), tvos(18.5));
+@property (nonatomic, strong) NSArray<MTRSetupPayload *> * subPayloads MTR_AVAILABLE(ios(26.2), macos(26.2), watchos(26.2), tvos(26.2));
 
 @property (nonatomic, copy) NSNumber * version;
 @property (nonatomic, copy) NSNumber * vendorID;

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -132,7 +132,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *   act as if the payload was not in fact concatenated, and return the relevant value associated
  *   with the first sub-payload. Mutating such a property will discard the additional sub-payloads.
  */
-@property (nonatomic, readonly, assign, getter=isConcatenated) BOOL concatenated;
+@property (nonatomic, readonly, assign, getter=isConcatenated) BOOL concatenated MTR_AVAILABLE(ios(18.5), macos(15.5), watchos(11.5), tvos(18.5));
 
 /**
  * The individual constituent payloads, if the receiver represents a concatenated payload.

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -138,7 +138,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * The individual constituent payloads, if the receiver represents a concatenated payload.
  * @see concatenated
  */
-@property (nonatomic, strong) NSArray<MTRSetupPayload *> *subPayloads;
+@property (nonatomic, strong) NSArray<MTRSetupPayload *> * subPayloads;
 
 @property (nonatomic, copy) NSNumber * version;
 @property (nonatomic, copy) NSNumber * vendorID;

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -121,6 +121,25 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  */
 - (nullable instancetype)initWithPayload:(NSString *)payload MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6));
 
+/**
+ * Whether this object represents a concatenated QR Code payload consisting
+ * of two or more underlying payloads. If YES, then:
+ *
+ * - The constituent payloads are exposed in the `subPayloads` property.
+ *
+ * - Properties other than `subPayloads` and `qrCodeString` (e.g. `vendorID`, `discriminator`)
+ *   are not relevant to a concatenated payload and should not be used. If accessed, they will
+ *   act as if the payload was not in fact concatenated, and return the relevant value associated
+ *   with the first sub-payload. Mutating such a property will discard the additional sub-payloads.
+ */
+@property (nonatomic, readonly, assign, getter=isConcatenated) BOOL concatenated;
+
+/**
+ * The individual constituent payloads, if the receiver represents a concatenated payload.
+ * @see concatenated
+ */
+@property (nonatomic, strong) NSArray<MTRSetupPayload *> *subPayloads;
+
 @property (nonatomic, copy) NSNumber * version;
 @property (nonatomic, copy) NSNumber * vendorID;
 @property (nonatomic, copy) NSNumber * productID;
@@ -212,6 +231,9 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * - setupPasscode
  * - discriminator (must be long)
  * - discoveryCapabilities (not MTRDiscoveryCapabilitiesUnknown)
+ *
+ * If this object represents a `concatenated` payload, then this property will
+ * include the QR Code strings of all the underlying `subPayloads.`
  */
 - (NSString * _Nullable)qrCodeString MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6));
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -259,7 +259,7 @@ MTR_DIRECT_MEMBERS
 
     _payload = payloads[0];
     if (payloads.size() > 1) {
-        NSMutableArray<MTRSetupPayload *> *subPayloads = [[NSMutableArray alloc] initWithCapacity:payloads.size()];
+        NSMutableArray<MTRSetupPayload *> * subPayloads = [[NSMutableArray alloc] initWithCapacity:payloads.size()];
         for (auto & payload : payloads) {
             [subPayloads addObject:[[MTRSetupPayload alloc] initWithSetupPayload:payload]];
         }
@@ -555,9 +555,9 @@ typedef NS_OPTIONS(NSUInteger, QRCodeOptions) {
 - (nullable NSString *)qrCodeStringWithOptions:(QRCodeOptions)options
 {
     if (_subPayloads) {
-        NSMutableString *result;
-        for (MTRSetupPayload *subPayload in _subPayloads) {
-            NSString *component = [subPayload qrCodeStringWithOptions:options];
+        NSMutableString * result;
+        for (MTRSetupPayload * subPayload in _subPayloads) {
+            NSString * component = [subPayload qrCodeStringWithOptions:options];
             VerifyOrReturnValue(component != nil, nil);
             if (!result) {
                 result = [component mutableCopy];

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -211,11 +211,10 @@ MTR_DIRECT_MEMBERS
     // keep track of the potentially-long value that was set by the client.
     NSNumber * _Nullable _shadowDiscriminator;
 
-    // When we are initialized from a concatenated QR code, we store the
-    // original string and prevent mutation, instead of re-serializing from
-    // _payload (which in that situation no longer represents all the information
-    // in the original string).
-    NSString * _Nullable _concatenatedQRCode;
+    // When this object represents a concatenated payload, this array contains the
+    // underlying sub-payloads, and `_payload` will be a copy of the first sub-payload,
+    // to provide compatibility with legacy code. Nil if not concatenated.
+    NSArray<MTRSetupPayload *> * _Nullable _subPayloads;
 }
 
 + (void)initialize
@@ -260,7 +259,11 @@ MTR_DIRECT_MEMBERS
 
     _payload = payloads[0];
     if (payloads.size() > 1) {
-        _concatenatedQRCode = [qrCode copy];
+        NSMutableArray<MTRSetupPayload *> *subPayloads = [[NSMutableArray alloc] initWithCapacity:payloads.size()];
+        for (auto & payload : payloads) {
+            [subPayloads addObject:[[MTRSetupPayload alloc] initWithSetupPayload:payload]];
+        }
+        _subPayloads = [subPayloads copy]; // ensure immutability for now since _subPayloads is exposed without copy
     }
     return CHIP_NO_ERROR;
 }
@@ -309,11 +312,21 @@ MTR_DIRECT_MEMBERS
     return self;
 }
 
-- (instancetype)initWithSetupPayload:(chip::SetupPayload)setupPayload
+- (instancetype)initWithSetupPayload:(const chip::SetupPayload &)setupPayload
 {
     self = [super init];
     _payload = setupPayload;
     return self;
+}
+
+- (BOOL)isConcatenated
+{
+    return _subPayloads != nil;
+}
+
+- (NSArray<MTRSetupPayload *> *)subPayloads
+{
+    return _subPayloads ?: @[];
 }
 
 #pragma mark - Mutable properties
@@ -325,10 +338,7 @@ MTR_DIRECT_MEMBERS
 
 - (void)setVersion:(NSNumber *)version
 {
-    if (_concatenatedQRCode) {
-        MTR_LOG_ERROR("%@ Unable to change version of concatenated QR code", self);
-        return;
-    }
+    _subPayloads = nil;
     _payload.version = static_cast<decltype(_payload.version)>(version.unsignedIntegerValue);
 }
 
@@ -339,10 +349,7 @@ MTR_DIRECT_MEMBERS
 
 - (void)setVendorID:(NSNumber *)vendorID
 {
-    if (_concatenatedQRCode) {
-        MTR_LOG_ERROR("%@ Unable to change vendorID of concatenated QR code", self);
-        return;
-    }
+    _subPayloads = nil;
     _payload.vendorID = static_cast<decltype(_payload.vendorID)>(vendorID.unsignedIntegerValue);
 }
 
@@ -353,10 +360,7 @@ MTR_DIRECT_MEMBERS
 
 - (void)setProductID:(NSNumber *)productID
 {
-    if (_concatenatedQRCode) {
-        MTR_LOG_ERROR("%@ Unable to change productID of concatenated QR code", self);
-        return;
-    }
+    _subPayloads = nil;
     _payload.productID = static_cast<decltype(_payload.productID)>(productID.unsignedIntegerValue);
 }
 
@@ -374,10 +378,7 @@ MTR_DIRECT_MEMBERS
 
 - (void)setCommissioningFlow:(MTRCommissioningFlow)commissioningFlow
 {
-    if (_concatenatedQRCode) {
-        MTR_LOG_ERROR("%@ Unable to change commissioningFlow of concatenated QR code", self);
-        return;
-    }
+    _subPayloads = nil;
     _payload.commissioningFlow = static_cast<chip::CommissioningFlow>(commissioningFlow);
 }
 
@@ -399,10 +400,7 @@ MTR_DIRECT_MEMBERS
 
 - (void)setDiscoveryCapabilities:(MTRDiscoveryCapabilities)discoveryCapabilities
 {
-    if (_concatenatedQRCode) {
-        MTR_LOG_ERROR("%@ Unable to change discoveryCapabilities of concatenated QR code", self);
-        return;
-    }
+    _subPayloads = nil;
     if (discoveryCapabilities == MTRDiscoveryCapabilitiesUnknown) {
         _payload.rendezvousInformation.ClearValue();
     } else {
@@ -420,10 +418,7 @@ MTR_DIRECT_MEMBERS
 
 - (void)setDiscriminator:(uint16_t)discriminator isShort:(BOOL)isShort
 {
-    if (_concatenatedQRCode) {
-        MTR_LOG_ERROR("%@ Unable to change discriminator of concatenated QR code", self);
-        return;
-    }
+    _subPayloads = nil;
     if (isShort) {
         _payload.discriminator.SetShortValue(discriminator & kShortDiscriminatorMask);
         _shadowDiscriminator = @(discriminator); // keep as a shadow value
@@ -448,10 +443,7 @@ MTR_DIRECT_MEMBERS
 
 - (void)setHasShortDiscriminator:(BOOL)hasShortDiscriminator
 {
-    if (_concatenatedQRCode) {
-        MTR_LOG_ERROR("%@ Unable to change hasShortDiscriminator of concatenated QR code", self);
-        return;
-    }
+    _subPayloads = nil;
     VerifyOrReturn(hasShortDiscriminator != self.hasShortDiscriminator);
     [self setDiscriminator:self.discriminator.unsignedShortValue isShort:hasShortDiscriminator];
 }
@@ -463,10 +455,7 @@ MTR_DIRECT_MEMBERS
 
 - (void)setSetupPasscode:(NSNumber *)setupPasscode
 {
-    if (_concatenatedQRCode) {
-        MTR_LOG_ERROR("%@ Unable to change setupPasscode of concatenated QR code", self);
-        return;
-    }
+    _subPayloads = nil;
     _payload.setUpPINCode = static_cast<decltype(_payload.setUpPINCode)>(setupPasscode.unsignedIntegerValue);
 }
 
@@ -479,10 +468,7 @@ MTR_DIRECT_MEMBERS
 
 - (void)setSerialNumber:(nullable NSString *)serialNumber
 {
-    if (_concatenatedQRCode) {
-        MTR_LOG_ERROR("%@ Unable to change serialNumber of concatenated QR code", self);
-        return;
-    }
+    _subPayloads = nil;
     if (serialNumber) {
         NSString * existing = self.serialNumber;
         if (existing) {
@@ -523,25 +509,24 @@ MTR_DIRECT_MEMBERS
 
 - (void)removeVendorElementWithTag:(NSNumber *)tag
 {
-    if (_concatenatedQRCode) {
-        MTR_LOG_ERROR("%@ Unable to modify vendor elements of concatenated QR code", self);
-        return;
-    }
+    _subPayloads = nil;
     _payload.removeOptionalVendorData(ValidateVendorTag(tag));
 }
 
 - (void)addOrReplaceVendorElement:(MTROptionalQRCodeInfo *)element
 {
-    if (_concatenatedQRCode) {
-        MTR_LOG_ERROR("%@ Unable to modify vendor elements of concatenated QR code", self);
-        return;
-    }
+    _subPayloads = nil;
     MTRVerifyArgumentOrDie(element != nil, @"element");
     CHIP_ERROR err = [element addAsVendorElementTo:_payload];
     VerifyOrDieWithMsg(err == CHIP_NO_ERROR, NotSpecified, "Internal error: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 #pragma mark - Export methods
+
+typedef NS_OPTIONS(NSUInteger, QRCodeOptions) {
+    SkipValidation = (1 << 0),
+    AsConcatenation = (1 << 1),
+};
 
 - (nullable NSString *)manualEntryCode
 {
@@ -553,7 +538,7 @@ MTR_DIRECT_MEMBERS
 
 - (nullable NSString *)qrCodeString
 {
-    return [self qrCodeStringSkippingValidation:NO];
+    return [self qrCodeStringWithOptions:0];
 }
 
 + (BOOL)isValidSetupPasscode:(NSNumber *)setupPasscode
@@ -567,17 +552,29 @@ MTR_DIRECT_MEMBERS
     return SetupPayload::IsValidSetupPIN(static_cast<uint32_t>(passCode));
 }
 
-- (nullable NSString *)qrCodeStringSkippingValidation:(BOOL)allowInvalid
+- (nullable NSString *)qrCodeStringWithOptions:(QRCodeOptions)options
 {
-    if (_concatenatedQRCode) {
-        return _concatenatedQRCode;
+    if (_subPayloads) {
+        NSMutableString *result;
+        for (MTRSetupPayload *subPayload in _subPayloads) {
+            NSString *component = [subPayload qrCodeStringWithOptions:options];
+            VerifyOrReturnValue(component != nil, nil);
+            if (!result) {
+                result = [component mutableCopy];
+                options |= AsConcatenation;
+            } else {
+                [result appendString:component];
+            }
+        }
+        return result;
     }
 
     chip::QRCodeSetupPayloadGenerator generator(_payload);
-    generator.SetAllowInvalidPayload(allowInvalid);
+    generator.SetAllowInvalidPayload(options & SkipValidation);
+    generator.SetAsConcatenation(options & AsConcatenation);
     std::string result;
     CHIP_ERROR err = generator.payloadBase38RepresentationWithAutoTLVBuffer(result);
-    if (allowInvalid) {
+    if (options & SkipValidation) {
         // Encoding should always work if invalid payloads are allowed
         VerifyOrDieWithMsg(err == CHIP_NO_ERROR, NotSpecified, "Internal error: %" CHIP_ERROR_FORMAT, err.Format());
     } else if (err != CHIP_NO_ERROR) {
@@ -592,35 +589,27 @@ MTR_DIRECT_MEMBERS
 - (id)copyWithZone:(NSZone *)zone
 {
     MTRSetupPayload * copy = [[MTRSetupPayload alloc] initWithSetupPayload:_payload];
-    copy->_shadowDiscriminator = _shadowDiscriminator;
-    copy->_concatenatedQRCode = _concatenatedQRCode;
+    if (_subPayloads) {
+        copy->_subPayloads = [[NSArray alloc] initWithArray:_subPayloads copyItems:YES];
+    } else {
+        copy->_shadowDiscriminator = _shadowDiscriminator; // not relevant if concatenated
+    }
     return copy;
 }
 
 - (NSUInteger)hash
 {
-    if (_concatenatedQRCode) {
-        return _concatenatedQRCode.hash;
-    }
-
+    // The discriminator of the first payload is a good enough hash even if concatenated
     return self.discriminator.unsignedIntegerValue;
 }
 
 - (BOOL)isEqual:(id)object
 {
+    VerifyOrReturnValue(object != self, YES);
     VerifyOrReturnValue([object class] == [self class], NO);
     MTRSetupPayload * other = object;
 
-    bool hasConcatenatedQRCode = (_concatenatedQRCode != nil);
-    bool otherHasConcatenatedQRCode = (other->_concatenatedQRCode != nil);
-    if (hasConcatenatedQRCode != otherHasConcatenatedQRCode) {
-        return NO;
-    }
-
-    if (_concatenatedQRCode) {
-        return [_concatenatedQRCode isEqual:other->_concatenatedQRCode];
-    }
-
+    VerifyOrReturnValue(MTREqualObjects(_subPayloads, other->_subPayloads), NO);
     VerifyOrReturnValue(_payload == other->_payload, NO);
     VerifyOrReturnValue(MTREqualObjects(_shadowDiscriminator, other->_shadowDiscriminator), NO);
     return YES;
@@ -643,7 +632,7 @@ MTR_DIRECT_MEMBERS
         [result appendFormat:@" commissioningFlow=0x%llx", (unsigned long long) flow];
     }
 
-    [result appendFormat:@", concatenated: %@>", MTR_YES_NO(_concatenatedQRCode != nil)];
+    [result appendFormat:@", concatenated: %@>", MTR_YES_NO(self.concatenated)];
     return result;
 }
 
@@ -667,7 +656,7 @@ static NSString * const MTRSetupPayloadCodingKeyQRCode = @"qr";
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
-    [coder encodeObject:[self qrCodeStringSkippingValidation:YES] forKey:MTRSetupPayloadCodingKeyQRCode];
+    [coder encodeObject:[self qrCodeStringWithOptions:SkipValidation] forKey:MTRSetupPayloadCodingKeyQRCode];
     [coder encodeObject:self.version forKey:MTRSetupPayloadCodingKeyVersion];
     [coder encodeObject:self.vendorID forKey:MTRSetupPayloadCodingKeyVendorID];
     [coder encodeObject:self.productID forKey:MTRSetupPayloadCodingKeyProductID];
@@ -698,12 +687,14 @@ static NSString * const MTRSetupPayloadCodingKeyQRCode = @"qr";
         self.serialNumber = [coder decodeObjectOfClass:NSString.class forKey:MTRSetupPayloadCodingKeySerialNumber];
     }
 
-    // The QR code cannot represent short discriminators or the absence of rendevouz
-    //  information, so always decode the state of those properties separately.
-    self.hasShortDiscriminator = ([coder decodeIntegerForKey:MTRSetupPayloadCodingKeyHasShortDiscriminator] != 0);
-    self.discriminator = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyDiscriminator];
-    // For compatibility reasons, keep decoding rendevouzInformation instead of discoveryCapabilities
-    self.rendezvousInformation = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyRendevouzInformation];
+    // The QR code cannot represent short discriminators or the absence of rendezvous
+    // information, so decode the state of those properties separately for stand-alone payloads.
+    if (!self.concatenated) {
+        self.hasShortDiscriminator = ([coder decodeIntegerForKey:MTRSetupPayloadCodingKeyHasShortDiscriminator] != 0);
+        self.discriminator = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyDiscriminator];
+        // For compatibility reasons, keep decoding rendevouzInformation instead of discoveryCapabilities
+        self.rendezvousInformation = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyRendevouzInformation];
+    }
 
     return self;
 }

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -692,7 +692,7 @@ static NSString * const MTRSetupPayloadCodingKeyQRCode = @"qr";
     if (!self.concatenated) {
         self.hasShortDiscriminator = ([coder decodeIntegerForKey:MTRSetupPayloadCodingKeyHasShortDiscriminator] != 0);
         self.discriminator = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyDiscriminator];
-        // For compatibility reasons, keep decoding rendevouzInformation instead of discoveryCapabilities
+        // For compatibility reasons, keep decoding rendezvouzInformation instead of discoveryCapabilities
         self.rendezvousInformation = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyRendevouzInformation];
     }
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 MTR_DIRECT_MEMBERS
 @interface MTRSetupPayload ()
 
-- (instancetype)initWithSetupPayload:(chip::SetupPayload)setupPayload;
+- (instancetype)initWithSetupPayload:(const chip::SetupPayload &)setupPayload;
 - (nullable instancetype)initWithQRCode:(NSString *)qrCodePayload;
 - (nullable instancetype)initWithManualPairingCode:(NSString *)manualCode;
 

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
@@ -72,6 +72,7 @@
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
+    // Non-concatenated properties reflect first payload
     XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
     XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
@@ -80,7 +81,16 @@
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
     XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
+
+    // qrCodeString preserves the full concatenated payload
     XCTAssertEqualObjects(payload.qrCodeString, concatenatedQRCode);
+
+    XCTAssertTrue(payload.concatenated);
+    XCTAssertEqual(payload.subPayloads.count, 2);
+
+    NSArray<NSString *> *parts = [concatenatedQRCode componentsSeparatedByString:@"*"];
+    XCTAssertEqualObjects(payload.subPayloads[0], [[MTRSetupPayload alloc] initWithPayload:parts[0]]);
+    XCTAssertEqualObjects(payload.subPayloads[1], [[MTRSetupPayload alloc] initWithPayload:[@"MT:" stringByAppendingString:parts[1]]]);
 }
 
 - (void)testOnboardingPayloadParser_QRCode_WrongVersion
@@ -147,6 +157,8 @@
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
     XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertFalse(payload.concatenated);
+    XCTAssertEqualObjects(payload.subPayloads, @[]);
 }
 
 - (void)testQRCodeParserWithOptionalData
@@ -405,6 +417,9 @@
         MTRSetupPayload * decoded = [NSKeyedUnarchiver unarchivedObjectOfClass:MTRSetupPayload.class fromData:data error:&error];
         XCTAssertNotNil(decoded, @"Error: %@", error);
 
+        XCTAssertEqual(decoded.concatenated, payload.concatenated);
+        XCTAssertEqualObjects(decoded.subPayloads, payload.subPayloads);
+
         XCTAssertEqualObjects(decoded.version, payload.version);
         XCTAssertEqualObjects(decoded.vendorID, payload.vendorID);
         XCTAssertEqualObjects(decoded.productID, payload.productID);
@@ -484,6 +499,17 @@
     XCTAssertTrue([payload isEqual:copy]);
     XCTAssertTrue([copy isEqual:payload]);
     XCTAssertEqual(payload.hash, copy.hash);
+
+    // The copy is concatenated and all sub-payloads were also copied
+    XCTAssertEqual(copy.concatenated, payload.concatenated);
+    XCTAssertEqual(copy.subPayloads.count, payload.subPayloads.count);
+    [payload.subPayloads enumerateObjectsUsingBlock:^(MTRSetupPayload *subPayload, NSUInteger idx, BOOL *stop) {
+        MTRSetupPayload *subCopy = copy.subPayloads[idx];
+        XCTAssertNotIdentical(subPayload, subCopy);
+        XCTAssertTrue([subPayload isEqual:subCopy]);
+        XCTAssertTrue([subCopy isEqual:subPayload]);
+        XCTAssertEqual(subPayload.hash, subCopy.hash);
+    }];
 }
 
 - (void)testCanParseFutureDiscoveryMethod

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
@@ -88,7 +88,7 @@
     XCTAssertTrue(payload.concatenated);
     XCTAssertEqual(payload.subPayloads.count, 2);
 
-    NSArray<NSString *> *parts = [concatenatedQRCode componentsSeparatedByString:@"*"];
+    NSArray<NSString *> * parts = [concatenatedQRCode componentsSeparatedByString:@"*"];
     XCTAssertEqualObjects(payload.subPayloads[0], [[MTRSetupPayload alloc] initWithPayload:parts[0]]);
     XCTAssertEqualObjects(payload.subPayloads[1], [[MTRSetupPayload alloc] initWithPayload:[@"MT:" stringByAppendingString:parts[1]]]);
 }
@@ -503,8 +503,8 @@
     // The copy is concatenated and all sub-payloads were also copied
     XCTAssertEqual(copy.concatenated, payload.concatenated);
     XCTAssertEqual(copy.subPayloads.count, payload.subPayloads.count);
-    [payload.subPayloads enumerateObjectsUsingBlock:^(MTRSetupPayload *subPayload, NSUInteger idx, BOOL *stop) {
-        MTRSetupPayload *subCopy = copy.subPayloads[idx];
+    [payload.subPayloads enumerateObjectsUsingBlock:^(MTRSetupPayload * subPayload, NSUInteger idx, BOOL * stop) {
+        MTRSetupPayload * subCopy = copy.subPayloads[idx];
         XCTAssertNotIdentical(subPayload, subCopy);
         XCTAssertTrue([subPayload isEqual:subCopy]);
         XCTAssertTrue([subCopy isEqual:subPayload]);

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -113,11 +113,19 @@ public:
      */
     void SetAllowInvalidPayload(bool allow) { mAllowInvalidPayload = allow; }
 
+    /**
+     * When set to true, the encoded payload will start with the delimiter character ('*')
+     * instead of the QR code prefix ("MT:"), suitable for generating concatenated QR codes.
+     * Default is false
+     */
+    void SetAsConcatenation(bool concatenation) { mAsConcatenation = concatenation; }
+
 private:
     CHIP_ERROR generateTLVFromOptionalData(SetupPayload & outPayload, uint8_t * tlvDataStart, uint32_t maxLen,
                                            size_t & tlvDataLengthInBytes);
 
     bool mAllowInvalidPayload = false;
+    bool mAsConcatenation     = false;
 };
 
 /**

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -381,8 +381,6 @@ CHIP_ERROR QRCodeSetupPayloadParser::populatePayloadFromBase38Data(std::string p
 
 CHIP_ERROR QRCodeSetupPayloadParser::populatePayloads(std::vector<SetupPayload> & outPayloads) const
 {
-    constexpr char kPayloadDelimiter = '*';
-
     std::string payload = ExtractPayload(mBase38Representation);
     VerifyOrReturnError(payload.length() != 0, CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -92,7 +92,8 @@ const int kTotalPayloadDataSizeInBits =
 
 const int kTotalPayloadDataSizeInBytes = kTotalPayloadDataSizeInBits / 8;
 
-const char * const kQRCodePrefix = "MT:";
+inline constexpr const char * kQRCodePrefix = "MT:";
+inline constexpr char kPayloadDelimiter     = '*';
 
 /// The rendezvous type this device supports.
 enum class RendezvousInformationFlag : uint8_t


### PR DESCRIPTION
#### Summary

Re-generate the qrCodeString from the actual sub-payloads on demand. This means sub-payloads can be mutated without requiring special handling or API.

Attempting to mutate a concatenated payload object as if it wasn't concatenated drops the concatenated codes, i.e. legacy code that is unaware of concatendated codes (but uses MTRSetupPayload in a mutable way) will simply work on the first code.

#### Testing

Expanded MTRSetupPayloadTests with additional checks.
