### PR TITLE
Fix ignore-files option for clang-tidy on linux

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -235,11 +235,6 @@ jobs:
             - name: Find changed files
               id: changed-files
               uses: tj-actions/changed-files@v47
-              with:
-                # Exclude all files under "third_party/"
-                files-ignore: |
-                  third_party/
-
             - name: Clang-tidy validation
               # NOTE: clang-tidy crashes on CodegenDataModel_Write due to Nullable/std::optional check.
               #       See https://github.com/llvm/llvm-project/issues/97426


### PR DESCRIPTION
#### Summary

It turns out arguments were changed and clang-tidy fails to run on linux, it looks like:

<img width="1947" height="1211" alt="image" src="https://github.com/user-attachments/assets/30fa766f-26dc-476a-9939-441b418ccde3" />

Which ends up checking 0 files:

<img width="1153" height="811" alt="image" src="https://github.com/user-attachments/assets/902c6574-8261-4e1c-bf7f-bb65408933fd" />

#### Testing

Trivial change. Darwin clang-tidy does work with the same config (that does not use changed-files)