### PR TITLE
[WEBRTCP] Enable flag is_commissioning to true

### DIFF
--- a/src/python_testing/TC_WEBRTCP_2_10.py
+++ b/src/python_testing/TC_WEBRTCP_2_10.py
@@ -51,6 +51,7 @@ class TC_WEBRTCP_2_10(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_10(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success and provides stream IDs"),
             TestStep(2, "TH sends the SolicitOffer command with valid parameters from a specific endpoint ID",
@@ -73,7 +74,12 @@ class TC_WEBRTCP_2_10(MatterBaseTest, WEBRTCPTestBase):
 
     @async_test_body
     async def test_TC_WEBRTCP_2_10(self):
+        """
+        Executes the test steps for validating SolicitOffer OriginatingEndpointID storage.
+        """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.user_params.get("endpoint", 1)
         # Use a specific originating endpoint ID to test storage
         originating_endpoint_id = 5

--- a/src/python_testing/TC_WEBRTCP_2_12.py
+++ b/src/python_testing/TC_WEBRTCP_2_12.py
@@ -56,6 +56,7 @@ class TC_WEBRTCP_2_12(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_12(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success and provides stream IDs"),
             TestStep(2, "TH sends multiple SolicitOffer commands to exhaust the DUT's capacity for WebRTC sessions (DUT-specific limit)",
@@ -84,6 +85,8 @@ class TC_WEBRTCP_2_12(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating SolicitOffer resource exhaustion.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_13.py
+++ b/src/python_testing/TC_WEBRTCP_2_13.py
@@ -61,6 +61,7 @@ class TC_WEBRTCP_2_13(MatterBaseTest, WEBRTCPTestBase):
         Define the step-by-step sequence for the test.
         """
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success"),
             TestStep(2, "Turns ON the physical privacy switch (HardPrivacyModeOn is TRUE)",
@@ -89,9 +90,11 @@ class TC_WEBRTCP_2_13(MatterBaseTest, WEBRTCPTestBase):
     @async_test_body
     async def test_TC_WEBRTCP_2_13(self):
         """
-        Executes the test steps for validating ProvideOffer behavior when physical privacy switch is ON.
+        Executes the test steps for validating ProvideOffer fails when physical privacy switch is ON.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_14.py
+++ b/src/python_testing/TC_WEBRTCP_2_14.py
@@ -58,6 +58,7 @@ class TC_WEBRTCP_2_14(MatterBaseTest, WEBRTCPTestBase):
         Define the step-by-step sequence for the test.
         """
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success"),
             TestStep(2, "TH writes `SoftRecordingPrivacyModeEnabled` to TRUE on CameraAVStreamManagement cluster",
@@ -85,9 +86,11 @@ class TC_WEBRTCP_2_14(MatterBaseTest, WEBRTCPTestBase):
     @async_test_body
     async def test_TC_WEBRTCP_2_14(self):
         """
-        Executes the test steps for validating ProvideOffer behavior with SoftRecordingPrivacyModeEnabled.
+        Executes the test steps for validating ProvideOffer fails with SoftRecordingPrivacyModeEnabled.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_15.py
+++ b/src/python_testing/TC_WEBRTCP_2_15.py
@@ -57,6 +57,7 @@ class TC_WEBRTCP_2_15(MatterBaseTest, WEBRTCPTestBase):
         Define the step-by-step sequence for the test.
         """
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success"),
             TestStep(2, "TH sends the ProvideOffer command with null WebRTCSessionID from a specific endpoint ID",
@@ -84,6 +85,8 @@ class TC_WEBRTCP_2_15(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating ProvideOffer OriginatingEndpointID storage.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
         # Use a specific originating endpoint ID for testing (different from default)
         originating_endpoint = 2

--- a/src/python_testing/TC_WEBRTCP_2_16.py
+++ b/src/python_testing/TC_WEBRTCP_2_16.py
@@ -57,6 +57,7 @@ class TC_WEBRTCP_2_16(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_16(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success and provides stream IDs"),
             TestStep(2, "TH sends multiple ProvideOffer commands to exhaust DUT's session capacity (DUT-specific limit)",
@@ -83,6 +84,8 @@ class TC_WEBRTCP_2_16(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating ProvideOffer resource exhaustion.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_17.py
+++ b/src/python_testing/TC_WEBRTCP_2_17.py
@@ -57,6 +57,7 @@ class TC_WEBRTCP_2_17(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_17(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success and provides stream IDs"),
             TestStep(2, "TH sends the ProvideOffer command with null WebRTCSessionID and valid SDP offer",
@@ -91,6 +92,8 @@ class TC_WEBRTCP_2_17(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating ProvideOffer generates Answer command.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_18.py
+++ b/src/python_testing/TC_WEBRTCP_2_18.py
@@ -56,6 +56,7 @@ class TC_WEBRTCP_2_18(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_18(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success and provides stream IDs"),
             TestStep(2, "TH sends the SolicitOffer command with valid stream IDs",
@@ -90,6 +91,8 @@ class TC_WEBRTCP_2_18(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating ProvideAnswer command processing.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_19.py
+++ b/src/python_testing/TC_WEBRTCP_2_19.py
@@ -57,6 +57,7 @@ class TC_WEBRTCP_2_19(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_19(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success and provides stream IDs"),
             TestStep(2, "TH sends the SolicitOffer command with valid stream IDs",
@@ -91,6 +92,8 @@ class TC_WEBRTCP_2_19(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating ProvideAnswer with invalid session.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_20.py
+++ b/src/python_testing/TC_WEBRTCP_2_20.py
@@ -56,6 +56,7 @@ class TC_WEBRTCP_2_20(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_20(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success and provides stream IDs"),
             TestStep(2, "TH sends the ProvideOffer command with an SDP Offer and null WebRTCSessionID to the DUT",
@@ -90,6 +91,8 @@ class TC_WEBRTCP_2_20(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating ProvideICECandidates command processing.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_21.py
+++ b/src/python_testing/TC_WEBRTCP_2_21.py
@@ -57,6 +57,7 @@ class TC_WEBRTCP_2_21(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_21(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success and provides stream IDs"),
             TestStep(2, "TH sends the ProvideOffer command with an SDP Offer and null WebRTCSessionID to the DUT",
@@ -92,6 +93,8 @@ class TC_WEBRTCP_2_21(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating ProvideICECandidates with invalid session ID.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_22.py
+++ b/src/python_testing/TC_WEBRTCP_2_22.py
@@ -56,6 +56,7 @@ class TC_WEBRTCP_2_22(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_22(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via CameraAVStreamManagement",
                      "Valid stream IDs are obtained"),
             TestStep(2, "TH establishes a valid WebRTC session with DUT",
@@ -88,6 +89,8 @@ class TC_WEBRTCP_2_22(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating EndSession removes session from CurrentSessions.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_23.py
+++ b/src/python_testing/TC_WEBRTCP_2_23.py
@@ -56,6 +56,7 @@ class TC_WEBRTCP_2_23(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_23(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via CameraAVStreamManagement",
                      "Valid stream IDs are obtained"),
             TestStep(2, "TH reads the AllocatedAudioStreams and AllocatedVideoStreams attributes to check reference counts",
@@ -117,6 +118,8 @@ class TC_WEBRTCP_2_23(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating EndSession decrements stream reference counts.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_6.py
+++ b/src/python_testing/TC_WEBRTCP_2_6.py
@@ -54,6 +54,7 @@ class TC_WebRTCP_2_6(MatterBaseTest, WEBRTCPTestBase):
         Define the step-by-step sequence for the test.
         """
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH reads the descriptor cluster on the endpoint containing the WebRTC Transport Provider cluster"),
             TestStep(2, "TH verifies CameraAVStreamManagement cluster (ID 0x0551) is present in the server cluster list"),
         ]
@@ -74,7 +75,8 @@ class TC_WebRTCP_2_6(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating CameraAVStreamManagement cluster presence.
         """
 
-        # Find the endpoint that has WebRTC Transport Provider cluster
+        self.step("precondition")
+        # Commission DUT - already done
         webrtc_endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_7.py
+++ b/src/python_testing/TC_WEBRTCP_2_7.py
@@ -57,6 +57,7 @@ class TC_WebRTCP_2_7(MatterBaseTest, WEBRTCPTestBase):
         Define the step-by-step sequence for the test.
         """
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success"),
             TestStep(2, "Turns ON the physical privacy switch (HardPrivacyModeOn is TRUE)",
@@ -90,6 +91,8 @@ class TC_WebRTCP_2_7(MatterBaseTest, WEBRTCPTestBase):
         Executes the test steps for validating SolicitOffer behavior when physical privacy switch is ON.
         """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.get_endpoint(default=1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_8.py
+++ b/src/python_testing/TC_WEBRTCP_2_8.py
@@ -53,6 +53,7 @@ class TC_WebRTCP_2_8(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_8(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement"),
             TestStep(2, "TH writes SoftRecordingPrivacyModeEnabled to TRUE on CameraAVStreamManagement cluster",
                      "DUT responds with success"),
@@ -78,7 +79,12 @@ class TC_WebRTCP_2_8(MatterBaseTest, WEBRTCPTestBase):
 
     @async_test_body
     async def test_TC_WEBRTCP_2_8(self):
+        """
+        Executes the test steps for validating SolicitOffer fails with SoftRecordingPrivacyModeEnabled.
+        """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.user_params.get("endpoint", 1)
 
         self.step(1)

--- a/src/python_testing/TC_WEBRTCP_2_9.py
+++ b/src/python_testing/TC_WEBRTCP_2_9.py
@@ -51,6 +51,7 @@ class TC_WEBRTCP_2_9(MatterBaseTest, WEBRTCPTestBase):
 
     def steps_TC_WEBRTCP_2_9(self) -> list[TestStep]:
         steps = [
+            TestStep("precondition", "DUT commissioned and streams allocated", is_commissioning=True),
             TestStep(1, "TH allocates both Audio and Video streams via AudioStreamAllocate and VideoStreamAllocate commands to CameraAVStreamManagement",
                      "DUT responds with success and provides stream IDs"),
             TestStep(2, "TH sends the SolicitOffer command with valid parameters and no ICEServers or ICETransportPolicy fields",
@@ -92,7 +93,12 @@ class TC_WEBRTCP_2_9(MatterBaseTest, WEBRTCPTestBase):
 
     @async_test_body
     async def test_TC_WEBRTCP_2_9(self):
+        """
+        Executes the test steps for validating SolicitOffer with ICEServers and ICETransportPolicy.
+        """
 
+        self.step("precondition")
+        # Commission DUT - already done
         endpoint = self.user_params.get("endpoint", 1)
 
         self.step(1)


### PR DESCRIPTION
#### Summary

Some WebRTCP Test Cases under the Python Testing Suite - No Commissioning section instead of the Python Testing Suite. Commissioning is required to execute these Test Cases. However, since they appear under the No Commissioning section, they fail to run from the UI.

This issue occurs because the is_commissioning=True parameter is missing in the corresponding Python scripts. Therefore, the respective Python scripts need to be updated to include this parameter.

#### Related issues
Fixes: #41462


#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
