### PR TITLE
zap_download.py: fix the version prefix

### DIFF
--- a/scripts/tools/zap/zap_download.py
+++ b/scripts/tools/zap/zap_download.py
@@ -182,9 +182,9 @@ def _GetZapVersionToUse(project_root) -> str:
     zap_json = json.load(open(zap_path))
     for package in zap_json.get("packages", []):
         for tag in package.get("tags", []):
-            version_prefix = "version:"
-            if tag.startswith(version_prefix):
-                zap_version = tag.removeprefix(version_prefix)
+            if tag.startswith("version:"):
+                zap_version = tag.removeprefix("version:")
+
                 suffix_index = zap_version.rfind(".")
                 if suffix_index != -1:
                     zap_version = zap_version[:suffix_index]

--- a/scripts/tools/zap/zap_download.py
+++ b/scripts/tools/zap/zap_download.py
@@ -182,8 +182,9 @@ def _GetZapVersionToUse(project_root) -> str:
     zap_json = json.load(open(zap_path))
     for package in zap_json.get("packages", []):
         for tag in package.get("tags", []):
-            if tag.startswith("version:2@"):
-                zap_version = tag.removeprefix("version:2@")
+            version_prefix = "version:"
+            if tag.startswith(version_prefix):
+                zap_version = tag.removeprefix(version_prefix)
                 suffix_index = zap_version.rfind(".")
                 if suffix_index != -1:
                     zap_version = zap_version[:suffix_index]


### PR DESCRIPTION
#### Summary

Running `/scripts/tools/zap/zap_download.py` fails after #40945 changed the versioning scheme of the zap.

Earlier it used to be like `"version:2@v2025.07.24-nightly.1"` (please note the `2@` and it has been removed now.


```
➜  connectedhomeip git:(master) ✗ ./scripts/tools/zap/zap_download.py
Traceback (most recent call last):
  File "/Users/shubhampatil/esp/connectedhomeip/./scripts/tools/zap/zap_download.py", line 266, in <module>
    main()
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/pigweed-venv/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/pigweed-venv/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/pigweed-venv/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/pigweed-venv/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/./scripts/tools/zap/zap_download.py", line 241, in main
    zap_version = _GetZapVersionToUse(sdk_root)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/./scripts/tools/zap/zap_download.py", line 192, in _GetZapVersionToUse
    raise Exception(f"Failed to determine version from {zap_path}")
Exception: Failed to determine version from /Users/shubhampatil/esp/connectedhomeip/scripts/setup/zap.json
```

#### Testing

- Manually ran the script on the host machine and verified that download works build progressed further.

```
➜  connectedhomeip git:(fix-zap-version) ✗ ./scripts/tools/zap/zap_download.py
2025-10-16 12:24:12 root INFO    Found required zap version to be: v2025.09.23-nightly
2025-10-16 12:24:12 root INFO    Fetching: https://github.com/project-chip/zap/releases/download/v2025.09.23-nightly/zap-mac-arm64.zip
2025-10-16 12:25:00 root INFO    Executing ['/usr/bin/unzip', '-oq', '/var/folders/34/_563kfb57rj_9n2x3qc8ng5r0000gn/T/tmprmntfam2.zip'] in /Users/shubhampatil/esp/connectedhomeip/.zap/zap-v2025.09.23-nightly
2025-10-16 12:25:02 root INFO    Done extracting.
export ZAP_INSTALL_PATH=/Users/shubhampatil/esp/connectedhomeip/.zap/zap-v2025.09.23-nightly
```