### PR TITLE
[CI Fix] resolve gcovr coverage build failure for template functions with long signatures

### DIFF
--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -304,6 +304,7 @@ if [ "$GENERATE_XML" == true ]; then
         --exclude=".*testing/.*" \
         --include=src/ \
         --gcov-ignore-parse-errors \
+        --merge-mode-functions=merge-use-line-min \
         --xml="$COVERAGE_ROOT"/coverage.xml
 
     XML_INDEX=$(_abspath "$COVERAGE_ROOT/coverage.xml")


### PR DESCRIPTION
#### Summary

- Linux Coverage Build on CI was failing after the integration of this PR: https://github.com/project-chip/connectedhomeip/pull/41459

- The issue is likely due to template functions that have long signatures and end up taking multiple lines in header files.
- this caused gcov to detect those functions at different line numbers (161 vs 162 in log below) due to the multi-line signature. Example Error below:

```
AssertionError: Got function chip::ChipError ComplexArgumentParser::Setup<chip::app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type>(char const*, chip::app::DataModel::List<chip::app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type>&, Json::Value&) in /__w/connectedhomeip/connectedhomeip/examples/chip-tool/commands/clusters/ComplexArgument.h on multiple lines: 161, 162.
```

- Fix: Added `--merge-mode-functions=merge-use-line-min` flag to the gcovr command to tell it to merge coverage data from duplicate template instantiations and use the "smallest" line number when it appears in different lines

#### Testing

Testing in CI
