### PR TITLE
[AVSM] Use different method for user prompts

### DIFF
--- a/src/python_testing/TC_AVSM_2_16.py
+++ b/src/python_testing/TC_AVSM_2_16.py
@@ -209,7 +209,8 @@ class TC_AVSM_2_16(MatterBaseTest, AVSMTestBase):
             if self.is_pics_sdk_ci_only:
                 self.write_to_app_pipe({"Name": "SetHardPrivacyModeOn", "Value": False})
             else:
-                self.wait_for_user_input("Please ensure that the physical privacy switch on the device is OFF, then press Enter to continue...")
+                self.wait_for_user_input(
+                    "Please ensure that the physical privacy switch on the device is OFF, then press Enter to continue...")
 
             # Verify the attribute reflects the privacy switch state
             hard_privacy_mode = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_AVSM_2_16.py
+++ b/src/python_testing/TC_AVSM_2_16.py
@@ -204,10 +204,12 @@ class TC_AVSM_2_16(MatterBaseTest, AVSMTestBase):
         if await self.attribute_guard(endpoint=endpoint, attribute=attr.HardPrivacyModeOn):
             # For CI: Use app pipe to simulate physical privacy switch being turned on
             # For manual testing: User should physically turn on the privacy switch
+            logger.info("HardPrivacy is supported")
+
             if self.is_pics_sdk_ci_only:
                 self.write_to_app_pipe({"Name": "SetHardPrivacyModeOn", "Value": False})
             else:
-                input("Please ensure that the physical privacy switch on the device is OFF, then press Enter to continue...")
+                self.wait_for_user_input("Please ensure that the physical privacy switch on the device is OFF, then press Enter to continue...")
 
             # Verify the attribute reflects the privacy switch state
             hard_privacy_mode = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_AVSM_2_17.py
+++ b/src/python_testing/TC_AVSM_2_17.py
@@ -241,7 +241,7 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
             if self.is_pics_sdk_ci_only:
                 self.write_to_app_pipe({"Name": "SetHardPrivacyModeOn", "Value": False})
             else:
-                input("Please ensure that the physical privacy switch on the device is OFF, then press Enter to continue...")
+                self.wait_for_user_input("Please ensure that the physical privacy switch on the device is OFF, then press Enter to continue...")
 
             # Verify the attribute reflects the privacy switch state
             hard_privacy_mode = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_AVSM_2_17.py
+++ b/src/python_testing/TC_AVSM_2_17.py
@@ -241,7 +241,8 @@ class TC_AVSM_2_17(MatterBaseTest, AVSMTestBase):
             if self.is_pics_sdk_ci_only:
                 self.write_to_app_pipe({"Name": "SetHardPrivacyModeOn", "Value": False})
             else:
-                self.wait_for_user_input("Please ensure that the physical privacy switch on the device is OFF, then press Enter to continue...")
+                self.wait_for_user_input(
+                    "Please ensure that the physical privacy switch on the device is OFF, then press Enter to continue...")
 
             # Verify the attribute reflects the privacy switch state
             hard_privacy_mode = await self.read_single_attribute_check_success(


### PR DESCRIPTION
#### Summary

QA is reporting TH hangs with AVSM 2.16 and 2.17; believe that it's due to the incorrect method being used for the UI prompt.

#### Related issues

https://github.com/project-chip/certification-tool/issues/771

#### Testing

Run AVSM 2.16 and 2.17 with PICS set to exercise non-CI code.  Double check with PICS = CI and the app-pipe. 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
