### PR TITLE
[WEBRTCR] Send command to DUT via websocket in CI

### DIFF
--- a/src/python_testing/TC_WEBRTCRTestBase.py
+++ b/src/python_testing/TC_WEBRTCRTestBase.py
@@ -16,6 +16,7 @@
 #
 
 import logging
+
 import websockets
 
 from matter.testing.matter_testing import MatterBaseTest
@@ -45,14 +46,35 @@ class WEBRTCRTestBase(MatterBaseTest):
         2. Sends the command
         3. Waits for and receives the response
         4. Logs the connection, command, and response status
+
+        Raises:
+            Exception: Re-raises any exceptions after logging them clearly
         """
-        async with websockets.connect(SERVER_URI) as websocket:
-            logging.info(f"Connected to {SERVER_URI}")
+        try:
+            async with websockets.connect(SERVER_URI) as websocket:
+                logging.info(f"Connected to {SERVER_URI}")
 
-            # Send command
-            logging.info(f"Sending command: {command}")
-            await websocket.send(command)
+                # Send command
+                logging.info(f"Sending command: {command}")
+                await websocket.send(command)
 
-            # Receive response
-            await websocket.recv()
-            logging.info("Received command response")
+                # Receive response
+                await websocket.recv()
+                logging.info("Received command response")
+
+        except ConnectionRefusedError as e:
+            logging.error(f"Failed to connect to WebSocket server at {SERVER_URI}: Connection refused. "
+                          f"Is the DUT WebSocket server running? Error: {e}")
+            raise
+
+        except websockets.exceptions.WebSocketException as e:
+            logging.error(f"WebSocket error while communicating with {SERVER_URI}: {e}")
+            raise
+
+        except OSError as e:
+            logging.error(f"Network error while connecting to {SERVER_URI}: {e}")
+            raise
+
+        except Exception as e:
+            logging.error(f"Unexpected error while sending command '{command}' to {SERVER_URI}: {e}")
+            raise

--- a/src/python_testing/TC_WEBRTCRTestBase.py
+++ b/src/python_testing/TC_WEBRTCRTestBase.py
@@ -1,0 +1,66 @@
+#
+#  Copyright (c) 2025 Project CHIP Authors
+#  All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""
+Common base class for WebRTC test cases.
+
+This module provides shared functionality for WebRTC Transport Requestor (WEBRTCR)
+and WebRTC Transport Provider (WEBRTCP) test cases, including WebSocket-based
+command sending functionality.
+"""
+
+import logging
+
+import websockets
+from matter.testing.matter_testing import MatterBaseTest
+
+# WebSocket server URI for sending commands to the DUT
+SERVER_URI = "ws://localhost:9002"
+
+
+class WEBRTCRTestBase(MatterBaseTest):
+    """
+    Base class for WebRTC Transport Requestor test cases.
+    
+    Provides common functionality including:
+    - WebSocket-based command sending to the DUT
+    - Shared SERVER_URI constant
+    """
+
+    async def send_command(self, command):
+        """
+        Send a command to the DUT via WebSocket and wait for response.
+        
+        Args:
+            command: The command string to send to the DUT
+            
+        This method:
+        1. Connects to the WebSocket server at SERVER_URI
+        2. Sends the command
+        3. Waits for and receives the response
+        4. Logs the connection, command, and response status
+        """
+        async with websockets.connect(SERVER_URI) as websocket:
+            logging.info(f"Connected to {SERVER_URI}")
+
+            # Send command
+            logging.info(f"Sending command: {command}")
+            await websocket.send(command)
+
+            # Receive response
+            await websocket.recv()
+            logging.info("Received command response")

--- a/src/python_testing/TC_WEBRTCRTestBase.py
+++ b/src/python_testing/TC_WEBRTCRTestBase.py
@@ -35,7 +35,7 @@ SERVER_URI = "ws://localhost:9002"
 class WEBRTCRTestBase(MatterBaseTest):
     """
     Base class for WebRTC Transport Requestor test cases.
-    
+
     Provides common functionality including:
     - WebSocket-based command sending to the DUT
     - Shared SERVER_URI constant
@@ -44,10 +44,10 @@ class WEBRTCRTestBase(MatterBaseTest):
     async def send_command(self, command):
         """
         Send a command to the DUT via WebSocket and wait for response.
-        
+
         Args:
             command: The command string to send to the DUT
-            
+
         This method:
         1. Connects to the WebSocket server at SERVER_URI
         2. Sends the command

--- a/src/python_testing/TC_WEBRTCRTestBase.py
+++ b/src/python_testing/TC_WEBRTCRTestBase.py
@@ -15,17 +15,9 @@
 #  limitations under the License.
 #
 
-"""
-Common base class for WebRTC test cases.
-
-This module provides shared functionality for WebRTC Transport Requestor (WEBRTCR)
-and WebRTC Transport Provider (WEBRTCP) test cases, including WebSocket-based
-command sending functionality.
-"""
-
 import logging
-
 import websockets
+
 from matter.testing.matter_testing import MatterBaseTest
 
 # WebSocket server URI for sending commands to the DUT

--- a/src/python_testing/TC_WEBRTCR_2_1.py
+++ b/src/python_testing/TC_WEBRTCR_2_1.py
@@ -21,6 +21,8 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
+#     app: ${CAMERA_CONTROLLER_APP}
+#     app-args: interactive server
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -37,12 +39,15 @@ import random
 import tempfile
 from time import sleep
 
+import websockets
 from mobly import asserts
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
 from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+
+SERVER_URI = "ws://localhost:9002"
 
 
 class TC_WebRTCR_2_1(MatterBaseTest):
@@ -119,6 +124,18 @@ class TC_WebRTCR_2_1(MatterBaseTest):
     def default_timeout(self) -> int:
         return 3 * 60
 
+    async def send_command(self, command):
+        async with websockets.connect(SERVER_URI) as websocket:
+            logging.info(f"Connected to {SERVER_URI}")
+
+            # Send command
+            logging.info(f"Sending command: {command}")
+            await websocket.send(command)
+
+            # Receive response
+            await websocket.recv()
+            logging.info("Received command response")
+
     @async_test_body
     async def test_TC_WebRTCR_2_1(self):
         """
@@ -151,7 +168,7 @@ class TC_WebRTCR_2_1(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
+            await self.send_command(f"pairing onnetwork 1 {passcode}")
             resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)
@@ -200,8 +217,17 @@ class TC_WebRTCR_2_1(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
-            resp = 'Y'
+            self.th_server.set_output_match("NOT_FOUND")
+            self.th_server.event.clear()
+
+            try:
+                await self.send_command("webrtc establish-session 1 --offer-type 1")
+                # Wait up to 90s until the provider logs that the data‑channel opened
+                if not self.th_server.event.wait(90):
+                    raise TimeoutError("PeerConnection is not connected within 90s")
+                resp = 'Y'
+            except TimeoutError:
+                resp = 'N'
         else:
             resp = self.wait_for_user_input(prompt_msg)
 

--- a/src/python_testing/TC_WEBRTCR_2_1.py
+++ b/src/python_testing/TC_WEBRTCR_2_1.py
@@ -39,18 +39,16 @@ import random
 import tempfile
 from time import sleep
 
-import websockets
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-
-SERVER_URI = "ws://localhost:9002"
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_1(MatterBaseTest):
+class TC_WebRTCR_2_1(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -123,18 +121,6 @@ class TC_WebRTCR_2_1(MatterBaseTest):
     @property
     def default_timeout(self) -> int:
         return 3 * 60
-
-    async def send_command(self, command):
-        async with websockets.connect(SERVER_URI) as websocket:
-            logging.info(f"Connected to {SERVER_URI}")
-
-            # Send command
-            logging.info(f"Sending command: {command}")
-            await websocket.send(command)
-
-            # Receive response
-            await websocket.recv()
-            logging.info("Received command response")
 
     @async_test_body
     async def test_TC_WebRTCR_2_1(self):

--- a/src/python_testing/TC_WEBRTCR_2_2.py
+++ b/src/python_testing/TC_WEBRTCR_2_2.py
@@ -21,6 +21,8 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
+#     app: ${CAMERA_CONTROLLER_APP}
+#     app-args: interactive server
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -37,12 +39,15 @@ import random
 import tempfile
 from time import sleep
 
+import websockets
 from mobly import asserts
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
 from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+
+SERVER_URI = "ws://localhost:9002"
 
 
 class TC_WebRTCR_2_2(MatterBaseTest):
@@ -119,6 +124,18 @@ class TC_WebRTCR_2_2(MatterBaseTest):
     def default_timeout(self) -> int:
         return 3 * 60
 
+    async def send_command(self, command):
+        async with websockets.connect(SERVER_URI) as websocket:
+            logging.info(f"Connected to {SERVER_URI}")
+
+            # Send command
+            logging.info(f"Sending command: {command}")
+            await websocket.send(command)
+
+            # Receive response
+            await websocket.recv()
+            logging.info("Received command response")
+
     @async_test_body
     async def test_TC_WebRTCR_2_2(self):
         """
@@ -151,7 +168,7 @@ class TC_WebRTCR_2_2(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
+            await self.send_command(f"pairing onnetwork 1 {passcode}")
             resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)
@@ -200,7 +217,17 @@ class TC_WebRTCR_2_2(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
+            self.th_server.set_output_match("NOT_FOUND")
+            self.th_server.event.clear()
+
+            try:
+                await self.send_command("webrtc establish-session 1")
+                # Wait up to 90s until the provider logs that the data‑channel opened
+                if not self.th_server.event.wait(90):
+                    raise TimeoutError("PeerConnection is not connected within 90s")
+                resp = 'Y'
+            except TimeoutError:
+                resp = 'N'
             resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)

--- a/src/python_testing/TC_WEBRTCR_2_2.py
+++ b/src/python_testing/TC_WEBRTCR_2_2.py
@@ -39,18 +39,16 @@ import random
 import tempfile
 from time import sleep
 
-import websockets
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-
-SERVER_URI = "ws://localhost:9002"
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_2(MatterBaseTest):
+class TC_WebRTCR_2_2(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -123,18 +121,6 @@ class TC_WebRTCR_2_2(MatterBaseTest):
     @property
     def default_timeout(self) -> int:
         return 3 * 60
-
-    async def send_command(self, command):
-        async with websockets.connect(SERVER_URI) as websocket:
-            logging.info(f"Connected to {SERVER_URI}")
-
-            # Send command
-            logging.info(f"Sending command: {command}")
-            await websocket.send(command)
-
-            # Receive response
-            await websocket.recv()
-            logging.info("Received command response")
 
     @async_test_body
     async def test_TC_WebRTCR_2_2(self):

--- a/src/python_testing/TC_WEBRTCR_2_2.py
+++ b/src/python_testing/TC_WEBRTCR_2_2.py
@@ -228,7 +228,6 @@ class TC_WebRTCR_2_2(MatterBaseTest):
                 resp = 'Y'
             except TimeoutError:
                 resp = 'N'
-            resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)
 

--- a/src/python_testing/TC_WEBRTCR_2_3.py
+++ b/src/python_testing/TC_WEBRTCR_2_3.py
@@ -38,16 +38,14 @@ import logging
 import os
 import tempfile
 
-import websockets
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-
-SERVER_URI = "ws://localhost:9002"
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_3(MatterBaseTest):
+class TC_WebRTCR_2_3(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -118,18 +116,6 @@ class TC_WebRTCR_2_3(MatterBaseTest):
     @property
     def default_timeout(self) -> int:
         return 3 * 60
-
-    async def send_command(self, command):
-        async with websockets.connect(SERVER_URI) as websocket:
-            logging.info(f"Connected to {SERVER_URI}")
-
-            # Send command
-            logging.info(f"Sending command: {command}")
-            await websocket.send(command)
-
-            # Receive response
-            await websocket.recv()
-            logging.info("Received command response")
 
     @async_test_body
     async def test_TC_WebRTCR_2_3(self):

--- a/src/python_testing/TC_WEBRTCR_2_4.py
+++ b/src/python_testing/TC_WEBRTCR_2_4.py
@@ -38,16 +38,14 @@ import logging
 import os
 import tempfile
 
-import websockets
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-
-SERVER_URI = "ws://localhost:9002"
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_4(MatterBaseTest):
+class TC_WebRTCR_2_4(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -118,18 +116,6 @@ class TC_WebRTCR_2_4(MatterBaseTest):
     @property
     def default_timeout(self) -> int:
         return 3 * 60
-
-    async def send_command(self, command):
-        async with websockets.connect(SERVER_URI) as websocket:
-            logging.info(f"Connected to {SERVER_URI}")
-
-            # Send command
-            logging.info(f"Sending command: {command}")
-            await websocket.send(command)
-
-            # Receive response
-            await websocket.recv()
-            logging.info("Received command response")
 
     @async_test_body
     async def test_TC_WebRTCR_2_4(self):

--- a/src/python_testing/TC_WEBRTCR_2_5.py
+++ b/src/python_testing/TC_WEBRTCR_2_5.py
@@ -39,17 +39,15 @@ import random
 import tempfile
 from time import sleep
 
-import websockets
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-
-SERVER_URI = "ws://localhost:9002"
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_5(MatterBaseTest):
+class TC_WebRTCR_2_5(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -127,18 +125,6 @@ class TC_WebRTCR_2_5(MatterBaseTest):
     @property
     def default_timeout(self) -> int:
         return 5 * 60
-
-    async def send_command(self, command):
-        async with websockets.connect(SERVER_URI) as websocket:
-            logging.info(f"Connected to {SERVER_URI}")
-
-            # Send command
-            logging.info(f"Sending command: {command}")
-            await websocket.send(command)
-
-            # Receive response
-            await websocket.recv()
-            logging.info("Received command response")
 
     @async_test_body
     async def test_TC_WebRTCR_2_5(self):

--- a/src/python_testing/TC_WEBRTCR_2_5.py
+++ b/src/python_testing/TC_WEBRTCR_2_5.py
@@ -21,6 +21,8 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
+#     app: ${CAMERA_CONTROLLER_APP}
+#     app-args: interactive server
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -37,11 +39,14 @@ import random
 import tempfile
 from time import sleep
 
+import websockets
 from mobly import asserts
 
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
 from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+
+SERVER_URI = "ws://localhost:9002"
 
 
 class TC_WebRTCR_2_5(MatterBaseTest):
@@ -123,6 +128,18 @@ class TC_WebRTCR_2_5(MatterBaseTest):
     def default_timeout(self) -> int:
         return 5 * 60
 
+    async def send_command(self, command):
+        async with websockets.connect(SERVER_URI) as websocket:
+            logging.info(f"Connected to {SERVER_URI}")
+
+            # Send command
+            logging.info(f"Sending command: {command}")
+            await websocket.send(command)
+
+            # Receive response
+            await websocket.recv()
+            logging.info("Received command response")
+
     @async_test_body
     async def test_TC_WebRTCR_2_5(self):
         """
@@ -155,7 +172,7 @@ class TC_WebRTCR_2_5(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
+            await self.send_command(f"pairing onnetwork 1 {passcode}")
             resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)
@@ -203,8 +220,17 @@ class TC_WebRTCR_2_5(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: establish session via websocket
-            resp = 'Y'
+            self.th_server.set_output_match("PeerConnection State: Connected")
+            self.th_server.event.clear()
+
+            try:
+                await self.send_command("webrtc establish-session 1")
+                # Wait up to 90s until the provider logs that the data‑channel opened
+                if not self.th_server.event.wait(90):
+                    raise TimeoutError("PeerConnection is not connected within 90s")
+                resp = 'Y'
+            except TimeoutError:
+                resp = 'N'
         else:
             resp = self.wait_for_user_input(prompt_msg)
 

--- a/src/python_testing/TC_WEBRTCR_2_6.py
+++ b/src/python_testing/TC_WEBRTCR_2_6.py
@@ -39,18 +39,16 @@ import random
 import tempfile
 from time import sleep
 
-import websockets
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-
-SERVER_URI = "ws://localhost:9002"
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_6(MatterBaseTest):
+class TC_WebRTCR_2_6(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -124,18 +122,6 @@ class TC_WebRTCR_2_6(MatterBaseTest):
     @property
     def default_timeout(self) -> int:
         return 3 * 60
-
-    async def send_command(self, command):
-        async with websockets.connect(SERVER_URI) as websocket:
-            logging.info(f"Connected to {SERVER_URI}")
-
-            # Send command
-            logging.info(f"Sending command: {command}")
-            await websocket.send(command)
-
-            # Receive response
-            await websocket.recv()
-            logging.info("Received command response")
 
     @async_test_body
     async def test_TC_WebRTCR_2_6(self):

--- a/src/python_testing/TC_WEBRTCR_2_6.py
+++ b/src/python_testing/TC_WEBRTCR_2_6.py
@@ -230,7 +230,6 @@ class TC_WebRTCR_2_6(MatterBaseTest):
                 resp = 'Y'
             except TimeoutError:
                 resp = 'N'
-            resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)
 

--- a/src/python_testing/TC_WEBRTCR_2_7.py
+++ b/src/python_testing/TC_WEBRTCR_2_7.py
@@ -39,18 +39,16 @@ import random
 import tempfile
 from time import sleep
 
-import websockets
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-
-SERVER_URI = "ws://localhost:9002"
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_7(MatterBaseTest):
+class TC_WebRTCR_2_7(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -124,18 +122,6 @@ class TC_WebRTCR_2_7(MatterBaseTest):
     @property
     def default_timeout(self) -> int:
         return 3 * 60
-
-    async def send_command(self, command):
-        async with websockets.connect(SERVER_URI) as websocket:
-            logging.info(f"Connected to {SERVER_URI}")
-
-            # Send command
-            logging.info(f"Sending command: {command}")
-            await websocket.send(command)
-
-            # Receive response
-            await websocket.recv()
-            logging.info("Received command response")
 
     @async_test_body
     async def test_TC_WebRTCR_2_7(self):
@@ -230,7 +216,7 @@ class TC_WebRTCR_2_7(MatterBaseTest):
                 resp = 'Y'
             except TimeoutError:
                 resp = 'N'
-            resp = 'Y'
+            # Removed unconditional assignment to preserve try/except outcome
         else:
             resp = self.wait_for_user_input(prompt_msg)
 

--- a/src/python_testing/TC_WEBRTCR_2_7.py
+++ b/src/python_testing/TC_WEBRTCR_2_7.py
@@ -216,7 +216,6 @@ class TC_WebRTCR_2_7(WEBRTCRTestBase):
                 resp = 'Y'
             except TimeoutError:
                 resp = 'N'
-            # Removed unconditional assignment to preserve try/except outcome
         else:
             resp = self.wait_for_user_input(prompt_msg)
 

--- a/src/python_testing/TC_WEBRTCR_2_7.py
+++ b/src/python_testing/TC_WEBRTCR_2_7.py
@@ -21,6 +21,8 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
+#     app: ${CAMERA_CONTROLLER_APP}
+#     app-args: interactive server
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -37,12 +39,15 @@ import random
 import tempfile
 from time import sleep
 
+import websockets
 from mobly import asserts
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
 from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+
+SERVER_URI = "ws://localhost:9002"
 
 
 class TC_WebRTCR_2_7(MatterBaseTest):
@@ -120,6 +125,18 @@ class TC_WebRTCR_2_7(MatterBaseTest):
     def default_timeout(self) -> int:
         return 3 * 60
 
+    async def send_command(self, command):
+        async with websockets.connect(SERVER_URI) as websocket:
+            logging.info(f"Connected to {SERVER_URI}")
+
+            # Send command
+            logging.info(f"Sending command: {command}")
+            await websocket.send(command)
+
+            # Receive response
+            await websocket.recv()
+            logging.info("Received command response")
+
     @async_test_body
     async def test_TC_WebRTCR_2_7(self):
         """
@@ -152,7 +169,7 @@ class TC_WebRTCR_2_7(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
+            await self.send_command(f"pairing onnetwork 1 {passcode}")
             resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)
@@ -202,7 +219,17 @@ class TC_WebRTCR_2_7(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
+            self.th_server.set_output_match("CONSTRAINT_ERROR")
+            self.th_server.event.clear()
+
+            try:
+                await self.send_command("webrtc establish-session 1")
+                # Wait up to 90s until the provider logs that the data‑channel opened
+                if not self.th_server.event.wait(90):
+                    raise TimeoutError("PeerConnection is not connected within 90s")
+                resp = 'Y'
+            except TimeoutError:
+                resp = 'N'
             resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -130,6 +130,9 @@ not_automated:
       reason: Depends on a browser peer for webrtc. CI is not supported.
     - name: TC_CHIMETestBase.py
       reason: Shared code for the Chime Cluster, not a standalone test.
+    - name: TC_WEBRTCRTestBase.py
+      reason:
+          Shared code for the WebRTC Requestor Cluster, not a standalone test.
     - name: TC_WEBRTCPTestBase.py
       reason:
           Shared code for the WebRTC Provider Cluster, not a standalone test.


### PR DESCRIPTION
#### Summary

Currently, we skips certain manual steps in CI for WEBRTCR test cases.
Send command to DUT via websocket to simulate those manual steps in CI

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
