### PR TITLE
[Silabs] Add deep sleep support for EM4 samples apps

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -128,9 +128,9 @@ extern uint32_t SystemCoreClock;
 #include "SEGGER_SYSVIEW_FreeRTOS.h"
 #endif
 
-#if defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1) 
+#if defined(SL_MATTER_EM4_SLEEP) && (SL_MATTER_EM4_SLEEP == 1)
 void sl_matter_em4_check(uint32_t expected_idle_time_ms);
-#endif // defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1)
+#endif // defined(SL_MATTER_EM4_SLEEP) && (SL_MATTER_EM4_SLEEP == 1)
 
 /*-----------------------------------------------------------
  * Application specific definitions.
@@ -147,9 +147,9 @@ void sl_matter_em4_check(uint32_t expected_idle_time_ms);
 /* Energy saving modes. */
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #define configUSE_TICKLESS_IDLE 1
-#if defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1) 
+#if defined(SL_MATTER_EM4_SLEEP) && (SL_MATTER_EM4_SLEEP == 1)
 #define configPRE_SLEEP_PROCESSING(x) sl_matter_em4_check(x)
-#endif // defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1)
+#endif // defined(SL_MATTER_EM4_SLEEP) && (SL_MATTER_EM4_SLEEP == 1)
 #elif (SLI_SI91X_MCU_INTERFACE && SL_ICD_ENABLED)
 #define configUSE_TICKLESS_IDLE 1
 #define configEXPECTED_IDLE_TIME_BEFORE_SLEEP 70
@@ -157,7 +157,6 @@ void sl_matter_em4_check(uint32_t expected_idle_time_ms);
 #define configPOST_SLEEP_PROCESSING(x)
 #define configPRE_SUPPRESS_TICKS_AND_SLEEP_PROCESSING(x)
 #else
-#error "Power Manager should be present..."
 #define configUSE_TICKLESS_IDLE 0
 #endif // SL_CATALOG_POWER_MANAGER_PRESENT
 

--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -128,6 +128,10 @@ extern uint32_t SystemCoreClock;
 #include "SEGGER_SYSVIEW_FreeRTOS.h"
 #endif
 
+#if defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1) 
+void sl_matter_em4_check(uint32_t expected_idle_time_ms);
+#endif // defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1)
+
 /*-----------------------------------------------------------
  * Application specific definitions.
  *
@@ -143,6 +147,9 @@ extern uint32_t SystemCoreClock;
 /* Energy saving modes. */
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
 #define configUSE_TICKLESS_IDLE 1
+#if defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1) 
+#define configPRE_SLEEP_PROCESSING(x) sl_matter_em4_check(x)
+#endif // defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1)
 #elif (SLI_SI91X_MCU_INTERFACE && SL_ICD_ENABLED)
 #define configUSE_TICKLESS_IDLE 1
 #define configEXPECTED_IDLE_TIME_BEFORE_SLEEP 70
@@ -150,6 +157,7 @@ extern uint32_t SystemCoreClock;
 #define configPOST_SLEEP_PROCESSING(x)
 #define configPRE_SUPPRESS_TICKS_AND_SLEEP_PROCESSING(x)
 #else
+#error "Power Manager should be present..."
 #define configUSE_TICKLESS_IDLE 0
 #endif // SL_CATALOG_POWER_MANAGER_PRESENT
 

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -24,12 +24,24 @@
 
 #include <mbedtls/platform.h>
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#if defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1)
+#include "sl_sleeptimer.h"
+#include <app/icd/server/ICDConfigurationData.h> // nogncheck
+
+#include "em_emu.h"
+#include "em_burtc.h"
+#include "em_cmu.h"
+#endif // defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1)
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
 #ifdef SL_WIFI
 #include <platform/silabs/NetworkCommissioningWiFiDriver.h>
 #include <platform/silabs/wifi/WifiInterface.h> // nogncheck
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 #include <platform/silabs/wifi/icd/WifiSleepManager.h> // nogncheck
+
 #endif                                                 // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 // TODO: We shouldn't need any platform specific includes in this file
@@ -339,9 +351,41 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     return CHIP_NO_ERROR;
 }
 
+#if defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1)
+void OnEM4Trigger(uint32_t duration)
+{
+    CMU_ClockSelectSet(cmuClock_EM4GRPACLK, cmuSelect_ULFRCO);
+    CMU_ClockEnable(cmuClock_BURTC, true);
+    CMU_ClockEnable(cmuClock_BURAM, true);
+  
+    BURTC_Init_TypeDef burtcInit = BURTC_INIT_DEFAULT;
+    burtcInit.compare0Top = true; // reset counter when counter reaches compare value
+    burtcInit.em4comp = true;     // BURTC compare interrupt wakes from EM4 (causes reset)
+    BURTC_Init(&burtcInit);
+  
+    BURTC_CounterReset();
+    BURTC_CompareSet(0, duration);
+  
+    BURTC_IntEnable(BURTC_IEN_COMP);    // compare match
+    NVIC_EnableIRQ(BURTC_IRQn);
+    BURTC_Enable(true);
+    EMU_EM4Init_TypeDef em4Init = EMU_EM4INIT_DEFAULT;
+    EMU_EM4Init(&em4Init);
+    BURTC_CounterReset();
+    EMU_EnterEM4();
+}
+
+#endif // defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1)
 // ================================================================================
 // FreeRTOS Callbacks
 // ================================================================================
+
+#ifndef SL_EM4_THRESHOLD_PERCENTAGE
+#define SL_EM4_THRESHOLD_PERCENTAGE 90
+#endif
+
+static_assert(SL_EM4_THRESHOLD_PERCENTAGE > 0 && SL_EM4_THRESHOLD_PERCENTAGE < 100,
+              "SL_EM4_THRESHOLD_PERCENTAGE must be between 1 and 99");
 extern "C" void vApplicationIdleHook(void)
 {
 #if (SLI_SI91X_MCU_INTERFACE && CHIP_CONFIG_ENABLE_ICD_SERVER)
@@ -351,3 +395,22 @@ extern "C" void vApplicationIdleHook(void)
     SiWxPlatformInterface::sl_si91x_uart_power_requirement_handler();
 #endif
 }
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#if defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1) 
+extern "C" void sl_matter_em4_check(uint32_t expected_idle_time_ms)
+{
+    if(chip::ICDConfigurationData::GetInstance().GetICDMode() == chip::ICDConfigurationData::ICDMode::LIT)
+    {
+        uint32_t idleDuration_seconds = chip::ICDConfigurationData::GetInstance().GetIdleModeDuration().count();
+        uint32_t threshold_ms = idleDuration_seconds * SL_EM4_THRESHOLD_PERCENTAGE * 10;   
+        // Since the sleep timer will never match the actual idle time (hardware latency, etc), we set a threshold
+        // Multiply by 10 to converts seconds into milliseconds (e.g. 90% of 1000sec in ms is 1000*90*10 = 900000ms)
+        if (expected_idle_time_ms >= threshold_ms) 
+        {     
+            OnEM4Trigger(expected_idle_time_ms);
+        }
+    }
+}
+#endif // defined(SL_EM4_SLEEP) && (SL_EM4_SLEEP == 1)
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -508,7 +508,7 @@ template("efr32_sdk") {
       "SL_CODE_COMPONENT_OPENTHREAD=openthread",
       "SL_CODE_COMPONENT_INTERRUPT_MANAGER=interrupt_manager",
       "SL_APP_PROPERTIES",
-      "SL_EM4_SLEEP=${sl_em4_sleep}"
+      "SL_MATTER_EM4_SLEEP=${sl_em4_sleep}",
     ]
 
     if (silabs_log_enabled && chip_logging) {
@@ -742,8 +742,8 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform/emdrv/nvm3/src/nvm3_object.c",
       "${efr32_sdk_root}/platform/emdrv/nvm3/src/nvm3_page.c",
       "${efr32_sdk_root}/platform/emdrv/nvm3/src/nvm3_utils.c",
-      "${efr32_sdk_root}/platform/emlib/src/em_cmu.c",
       "${efr32_sdk_root}/platform/emlib/src/em_burtc.c",
+      "${efr32_sdk_root}/platform/emlib/src/em_cmu.c",
       "${efr32_sdk_root}/platform/emlib/src/em_crypto.c",
       "${efr32_sdk_root}/platform/emlib/src/em_emu.c",
       "${efr32_sdk_root}/platform/emlib/src/em_gpio.c",

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -93,6 +93,8 @@ declare_args() {
   sl_enable_test_event_trigger = false
 
   sl_verbose_mode = false
+
+  sl_em4_sleep = false
 }
 
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
@@ -506,6 +508,7 @@ template("efr32_sdk") {
       "SL_CODE_COMPONENT_OPENTHREAD=openthread",
       "SL_CODE_COMPONENT_INTERRUPT_MANAGER=interrupt_manager",
       "SL_APP_PROPERTIES",
+      "SL_EM4_SLEEP=${sl_em4_sleep}"
     ]
 
     if (silabs_log_enabled && chip_logging) {
@@ -740,6 +743,7 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform/emdrv/nvm3/src/nvm3_page.c",
       "${efr32_sdk_root}/platform/emdrv/nvm3/src/nvm3_utils.c",
       "${efr32_sdk_root}/platform/emlib/src/em_cmu.c",
+      "${efr32_sdk_root}/platform/emlib/src/em_burtc.c",
       "${efr32_sdk_root}/platform/emlib/src/em_crypto.c",
       "${efr32_sdk_root}/platform/emlib/src/em_emu.c",
       "${efr32_sdk_root}/platform/emlib/src/em_gpio.c",


### PR DESCRIPTION
#### Summary

Add deep sleep support that shutdown the chip completely for the duration of the Long Idle Time ICD. This reduces the power consumption down to 0.6uA at the cost of RAM retention.

This is a PoC as an SDK issue is actually preventing extra long sleep time.

#### Related issues
None

#### Testing

Locally at Silicon Labs. 
- Compiles, function is reached but because of previously stated issue the EM4Trigger function is never actually called. When called manually device enter EM4 sleep and wakes up at the end of the timer.
