### PR TITLE
[Silabs] Removed redefined macro RSI_BLE_MAX_NBR_CENTRALS

### DIFF
--- a/src/platform/silabs/rs911x/rsi_ble_config.h
+++ b/src/platform/silabs/rs911x/rsi_ble_config.h
@@ -104,7 +104,7 @@ extern "C" {
 #define RSI_BLE_MAX_NBR_PERIPHERALS 3
 #endif
 
-#define RSI_BLE_MAX_NBR_CENTRALS 1
+#define RSI_BLE_MAX_NBR_CENTRALS (1)
 #define RSI_BLE_MAX_NBR_ATT_SERV (10)
 
 #define RSI_BLE_GATT_ASYNC_ENABLE (1)
@@ -253,7 +253,6 @@ extern "C" {
 #define NO_OF_VAL_ATT (5) //! Attribute value count
 
 #if (SLI_SI91X_MCU_INTERFACE | EXP_BOARD)
-#define RSI_BLE_MAX_NBR_CENTRALS (1)
 #define FRONT_END_SWITCH_SEL2 BIT(30)
 #define RSI_FEATURE_BIT_MAP                                                                                                        \
     (SL_SI91X_FEAT_ULP_GPIO_BASED_HANDSHAKE | SL_SI91X_FEAT_DEV_TO_HOST_ULP_GPIO_1) //! To set wlan feature select bit map


### PR DESCRIPTION
#### Summary
Removed redefined macro RSI_BLE_MAX_NBR_CENTRALS in rsi_ble_config.h

#### Change overview
In this PR, removed redefined macro RSI_BLE_MAX_NBR_CENTRALS in rsi_ble_config.h
as it is causing build error with components build.

#### Testing
Verified build for 917 SoC.
Verified commissioning with 917 SoC

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
