### PR TITLE
Upgrade to 2.3.1 autopep8

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -224,7 +224,7 @@ restylers:
           - "**/*.sh"
           - "**/*.bash"
     - name: autopep8
-      image: restyled/restyler-autopep8:v2.3.0
+      image: restyled/restyler-autopep8:v2.3.2
       command:
           - autopep8
           - "--in-place"

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -224,7 +224,7 @@ restylers:
           - "**/*.sh"
           - "**/*.bash"
     - name: autopep8
-      image: restyled/restyler-autopep8:v2.3.2
+      image: restyled/restyler-autopep8:v2.3.1
       command:
           - autopep8
           - "--in-place"


### PR DESCRIPTION
#### Summary
autopep 2.3.0 has a bug with f-string handling, fixed in 2.3.1. This is causing changes to existing code that is breaking pre-3.12 python.

https://github.com/hhatto/autopep8/releases

#### Related issues

#### Testing
See functional run on this sacrificial PR - https://github.com/project-chip/connectedhomeip/actions/runs/18571727766/job/52947011934?pr=41343

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
