### PR TITLE
Attempt to fix TCP test failure

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -181,14 +181,14 @@ ActiveTCPConnectionHandle TCPBase::FindInUseConnection(const PeerAddress & addre
         {
             Inet::IPAddress addr;
             uint16_t port;
-            if (conn.IsConnected() && conn.mEndPoint->GetPeerInfo(&addr, &port) != CHIP_NO_ERROR)
+            if (conn.IsConnected())
             {
-                // Failure to get peer information means the connection is bad, re-establish connection
-                CHIP_ERROR err = TryResetConnection(conn);
+                // Failure to get peer information means the connection is bad; close it
+                CHIP_ERROR err = conn.mEndPoint->GetPeerInfo(&addr, &port);
                 if (err != CHIP_NO_ERROR)
                 {
                     CloseConnectionInternal(conn, err, SuppressCallback::No);
-                    continue;
+                    return nullptr;
                 }
             }
 
@@ -724,19 +724,6 @@ void TCPBase::InitEndpoint(const Inet::TCPEndPointHandle & endpoint)
     endpoint->mAppState         = reinterpret_cast<void *>(this);
     endpoint->OnConnectComplete = HandleTCPEndPointConnectComplete;
     endpoint->SetConnectTimeout(mConnectTimeout);
-}
-
-CHIP_ERROR TCPBase::TryResetConnection(ActiveTCPConnectionState & connection)
-{
-    Inet::TCPEndPointHandle endpoint;
-    ReturnErrorOnFailure(mListenSocket->GetEndPointManager().NewEndPoint(endpoint));
-
-    InitEndpoint(endpoint);
-    PeerAddress & addr = connection.mPeerAddr;
-    ReturnErrorOnFailure(endpoint->Connect(addr.GetIPAddress(), addr.GetPort(), addr.GetInterface()));
-    connection.mConnectionState = TCPState::kConnecting;
-    connection.mEndPoint        = endpoint;
-    return CHIP_NO_ERROR;
 }
 
 } // namespace Transport

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -302,7 +302,6 @@ private:
     static void HandleAcceptError(const Inet::TCPEndPointHandle & endPoint, CHIP_ERROR err);
 
     void InitEndpoint(const Inet::TCPEndPointHandle & endpoint);
-    CHIP_ERROR TryResetConnection(ActiveTCPConnectionState & connection);
     CHIP_ERROR PrepareBuffer(System::PacketBufferHandle & msgBuf);
 
     Inet::TCPEndPointHandle mListenSocket;                             ///< TCP socket used by the transport


### PR DESCRIPTION
Attempts to fix failure @ https://github.com/project-chip/connectedhomeip/actions/runs/18569902949/job/52940790064?pr=41485:

```
[ RUN      ] TestTCP.HandleConnCloseCalledTest4
[1760638764.914] [52419:208387:main] [IN] TCP server listening on port 5602 for incoming connections
[1760638764.914] [52419:208387:main] [IN] TransportMgr initialized
[1760638764.914] [52419:208387:main] [IN] Connecting to peer TCP:127.0.0.1:5602.
[1760638764.914] [52419:208387:main] [IN] Connection established successfully with TCP:127.0.0.1:5602.
[1760638764.914] [52419:208387:main] [IN] Closing connection with peer TCP:127.0.0.1:5602.
[1760638764.914] [52419:208387:main] [IN] Accept error: src/inet/TCPEndPointImplSockets.cpp:307: OS Error 0x02000016: Invalid argument
src/transport/raw/tests/TestTCP.cpp:350: Failure
      Expected: mHandleConnectionCloseCalled == true
        Actual: false == true
[  FAILED  ] TestTCP.HandleConnCloseCalledTest4
```

#### Summary

The test failure indicates that it's happening during `HandleIncomingConnection` from `TestTCP::HandleConnectCloseCbCalledTest`, where we are closing connections.

The likely culprit is the attempt to reset/re-connect when a peer closes, which was added in https://github.com/project-chip/connectedhomeip/pull/40817

Instead, we'll simply close the connection rather than trying to re-establish (the test seems to expect that it will get a `HandleConnectionClosed`, which is where it's failing)

#### Testing

Unsure how to test this - the trigger would be the peer trying to re-establish the connection as it's closing, not sure how to setup this test as all TCP tests are using underlying TCP infra & as such this kind of timing may not be possible

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
