### PR TITLE
[Camera] Clears WebRTC session on peer connection end

### DIFF
--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -105,6 +105,8 @@ private:
 
     void RegisterWebrtcTransport(uint16_t sessionId);
 
+    void UnregisterWebrtcTransport(uint16_t sessionId);
+
     CHIP_ERROR SendOfferCommand(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle,
                                 uint16_t sessionId);
 

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -892,11 +892,13 @@ void WebRTCProviderManager::OnConnectionStateChanged(bool connected, const uint1
         // cluster and update the reference counts.
         ReleaseAudioVideoStreams(sessionId);
 
+        // Capture args before unregistering in case the transport is invalidated
+        WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
+
         // Unregister the transport from the media controller
         UnregisterWebrtcTransport(sessionId);
 
         // Remove from session maps
-        WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
         mSessionIdMap.erase(ScopedNodeId(args.peerNodeId, args.fabricIndex));
 
         // Remove from current sessions list in the WebRTC Transport Provider

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -875,7 +875,14 @@ void WebRTCProviderManager::OnConnectionStateChanged(bool connected, const uint1
     WebrtcTransport * transport = GetTransport(sessionId);
     if (transport == nullptr)
     {
-        ChipLogError(Camera, "Transport not found for session %u during connection state change", sessionId);
+        if (connected)
+        {
+            ChipLogError(Camera, "Transport not found for session %u during connection state change (connected)", sessionId);
+        }
+        else
+        {
+            ChipLogProgress(Camera, "Transport not found for session %u during disconnect; session may have already been cleaned up", sessionId);
+        }
         return;
     }
 

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -872,26 +872,22 @@ void WebRTCProviderManager::OnConnectionStateChanged(bool connected, const uint1
 {
     ChipLogProgress(Camera, "Connection state changed for session %u: %s", sessionId, connected ? "connected" : "disconnected");
 
-    WebrtcTransport * transport = GetTransport(sessionId);
-    if (transport == nullptr)
-    {
-        if (connected)
-        {
-            ChipLogError(Camera, "Transport not found for session %u during connection state change (connected)", sessionId);
-        }
-        else
-        {
-            ChipLogProgress(Camera, "Transport not found for session %u during disconnect; session may have already been cleaned up", sessionId);
-        }
-        return;
-    }
-
     if (connected)
     {
         RegisterWebrtcTransport(sessionId);
     }
     else
     {
+        WebrtcTransport * transport = GetTransport(sessionId);
+        if (transport == nullptr)
+        {
+
+            ChipLogProgress(Camera,
+                            "Transport not found for session %u during disconnect; session may have already been cleaned up",
+                            sessionId);
+            return;
+        }
+
         // Connection was closed/disconnected by the peer - clean up the session
         ChipLogProgress(Camera, "Peer connection closed for session %u, cleaning up resources", sessionId);
 

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -191,6 +191,27 @@ void WebRTCProviderManager::RegisterWebrtcTransport(uint16_t sessionId)
     mMediaController->RegisterTransport(transport, args.videoStreamId, args.audioStreamId);
 }
 
+void WebRTCProviderManager::UnregisterWebrtcTransport(uint16_t sessionId)
+{
+    ChipLogProgress(Camera, "UnregisterWebrtcTransport called for sessionId: %u", sessionId);
+
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
+    {
+        ChipLogProgress(Camera, "WebRTC Transport is null for sessionId %u. Already unregistered or not found", sessionId);
+        return;
+    }
+
+    if (mMediaController == nullptr)
+    {
+        ChipLogProgress(Camera, "mMediaController is null. Cannot unregister WebRTC Transport");
+        return;
+    }
+
+    mMediaController->UnregisterTransport(transport);
+    ChipLogProgress(Camera, "Successfully unregistered transport for sessionId: %u", sessionId);
+}
+
 std::string WebRTCProviderManager::ExtractMidFromSdp(const std::string & sdp, const std::string & mediaType)
 {
     if (sdp.empty() || mediaType.empty())
@@ -429,7 +450,7 @@ CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEnd
         // TODO: Lookup the sessionID to get the Video/Audio StreamID
         ReleaseAudioVideoStreams(sessionId);
 
-        mMediaController->UnregisterTransport(transport);
+        UnregisterWebrtcTransport(sessionId);
         mWebrtcTransportMap.erase(sessionId);
         WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
         mSessionIdMap.erase(ScopedNodeId(args.peerNodeId, args.fabricIndex));
@@ -713,7 +734,7 @@ void WebRTCProviderManager::OnDeviceConnected(void * context, Messaging::Exchang
         // Release the Video and Audio Streams from the CameraAVStreamManagement
         // cluster and update the reference counts.
         self->ReleaseAudioVideoStreams(sessionId);
-        self->mMediaController->UnregisterTransport(transport);
+        self->UnregisterWebrtcTransport(sessionId);
         WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
         self->mSessionIdMap.erase(ScopedNodeId(args.peerNodeId, args.fabricIndex));
 
@@ -849,10 +870,45 @@ void WebRTCProviderManager::OnLocalDescription(const std::string & sdp, SDPType 
 
 void WebRTCProviderManager::OnConnectionStateChanged(bool connected, const uint16_t sessionId)
 {
-    ChipLogProgress(Camera, "Connection state changed for session %u", sessionId);
+    ChipLogProgress(Camera, "Connection state changed for session %u: %s", sessionId, connected ? "connected" : "disconnected");
+
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
+    {
+        ChipLogError(Camera, "Transport not found for session %u during connection state change", sessionId);
+        return;
+    }
+
     if (connected)
     {
         RegisterWebrtcTransport(sessionId);
+    }
+    else
+    {
+        // Connection was closed/disconnected by the peer - clean up the session
+        ChipLogProgress(Camera, "Peer connection closed for session %u, cleaning up resources", sessionId);
+
+        // Release the Video and Audio Streams from the CameraAVStreamManagement
+        // cluster and update the reference counts.
+        ReleaseAudioVideoStreams(sessionId);
+
+        // Unregister the transport from the media controller
+        UnregisterWebrtcTransport(sessionId);
+
+        // Remove from session maps
+        WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
+        mSessionIdMap.erase(ScopedNodeId(args.peerNodeId, args.fabricIndex));
+
+        // Remove from current sessions list in the WebRTC Transport Provider
+        if (mWebRTCTransportProvider != nullptr)
+        {
+            mWebRTCTransportProvider->RemoveSession(sessionId);
+        }
+
+        // Finally, remove and destroy the transport
+        mWebrtcTransportMap.erase(sessionId);
+
+        ChipLogProgress(Camera, "Session %u cleanup completed", sessionId);
     }
 }
 

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -302,6 +302,11 @@ public:
             {
                 onConnectionState(true);
             }
+            else if (state == rtc::PeerConnection::State::Disconnected || state == rtc::PeerConnection::State::Failed ||
+                     state == rtc::PeerConnection::State::Closed)
+            {
+                onConnectionState(false);
+            }
         });
 
         mPeerConnection->onGatheringStateChange([](rtc::PeerConnection::GatheringState state) {

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -302,9 +302,11 @@ public:
             {
                 onConnectionState(true);
             }
-            else if (state == rtc::PeerConnection::State::Disconnected || state == rtc::PeerConnection::State::Failed ||
-                     state == rtc::PeerConnection::State::Closed)
+            else if (state == rtc::PeerConnection::State::Failed || state == rtc::PeerConnection::State::Closed)
             {
+                // rtc::PeerConnection::State::Disconnected as a terminal state will trigger teardown on transient ICE disconnects;
+                // per WebRTC semantics, Disconnected can recover to Connected. Limit the false signal to Failed and Closed only to
+                // avoid prematurely ending sessions.
                 onConnectionState(false);
             }
         });

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -298,10 +298,9 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
                 mSessionEstablishedCallback(mCurrentVideoStreamId);
             }
         }
-        else if (state == rtc::PeerConnection::State::Disconnected || state == rtc::PeerConnection::State::Failed ||
-                 state == rtc::PeerConnection::State::Closed)
+        else if (state == rtc::PeerConnection::State::Failed || state == rtc::PeerConnection::State::Closed)
         {
-            // Clean up resources when connection is lost
+            // Limit the clearup to Failed and Closed only to avoid prematurely ending sessions.
             Disconnect();
         }
     });

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -238,7 +238,7 @@ void WebRTCManager::Disconnect()
 
     // Reset track
     mTrack.reset();
-    audioTrack.reset();
+    mAudioTrack.reset();
 
     // Clear state
     mCurrentVideoStreamId = 0;
@@ -302,7 +302,7 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
                  state == rtc::PeerConnection::State::Closed)
         {
             // Clean up resources when connection is lost
-            CloseRTPSocket();
+            Disconnect();
         }
     });
 
@@ -355,12 +355,12 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
     rtc::Description::Audio audioMedia("audio", rtc::Description::Direction::RecvOnly);
     audioMedia.addOpusCodec(kOpusPayloadType);
     audioMedia.setBitrate(kAudioBitRate);
-    audioTrack = mPeerConnection->addTrack(audioMedia);
+    mAudioTrack = mPeerConnection->addTrack(audioMedia);
 
     auto audioSession = std::make_shared<rtc::RtcpReceivingSession>();
-    audioTrack->setMediaHandler(audioSession);
+    mAudioTrack->setMediaHandler(audioSession);
 
-    audioTrack->onMessage(
+    mAudioTrack->onMessage(
         [this, audioAddr](rtc::binary message) {
             // This is an RTP Audio packet
             sendto(mAudioRTPSocket, reinterpret_cast<const char *>(message.data()), static_cast<size_t>(message.size()), 0,

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -91,7 +91,7 @@ private:
     std::vector<std::string> mLocalCandidates;
 
     std::shared_ptr<rtc::Track> mTrack;
-    std::shared_ptr<rtc::Track> audioTrack;
+    std::shared_ptr<rtc::Track> mAudioTrack;
 
     // Callback to notify when session is established
     SessionEstablishedCallback mSessionEstablishedCallback;


### PR DESCRIPTION
#### Summary

When a peer connection is torn by the client, then camera app does become aware of the peer connection state (closed) through its webrtc stack, but it doesn't clear/end the session in its webrtc sessions table, unless the client's matter controller also explicitly sends an End command over matter means to the cluster.

#### Related issues

Fixes: #41471


#### Testing

Validate by CI