### PR TITLE
Remove PICs keys since every attribute is mandatory TC-GRPKEY-2.2

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_GRPKEY_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_GRPKEY_2_2.yaml
@@ -35,7 +35,6 @@ tests:
           "Step 1: TH reads MaxGroupKeysPerFabric attribute from
           GroupKeyManagement cluster on DUT using a fabric-filtered read. Save
           the value as Max_GrpKey for future use."
-      PICS: GRPKEY.S.A0003
       command: "readAttribute"
       attribute: "MaxGroupKeysPerFabric"
       fabricFiltered: true
@@ -50,7 +49,6 @@ tests:
           5)EpochKey1: d1d1d2d3d4d5d6d7d8d9dadbdcdddedf 6)EpochStartTime1:
           18446744073709551613 7)EpochKey2: d2d1d2d3d4d5d6d7d8d9dadbdcdddedf
           8)EpochStartTime2:18446744073709551614"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -70,7 +68,6 @@ tests:
     - label:
           "Step 3: TH sends KeySetRead command to GroupKeyManagement cluster
           with GroupKeySetID as 0x01a"
-      PICS: GRPKEY.S.C01.Rsp && GRPKEY.S.C02.Tx
       command: "KeySetRead"
       arguments:
           values:
@@ -98,7 +95,6 @@ tests:
           (0) 3)EpochKey0: d0d1d2d3d4d5d6d7d8d9dadbdcdddedf 4)EpochStartTime0: 1
           5)EpochKey1: null 6)EpochStartTime1:null 7)EpochKey2: null
           8)EpochStartTime2:null"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -123,7 +119,6 @@ tests:
           5)EpochKey1: d1d1d2d3d4d5d6d7d8d9dadbdcdddedf
           6)EpochStartTime1:18446744073709551613 7)EpochKey2: null
           8)EpochStartTime2:null"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -148,7 +143,6 @@ tests:
           6)EpochStartTime1:18446744073709551613 7)EpochKey2:
           d2d1d2d3d4d5d6d7d8d9dadbdcdddedf
           8)EpochStartTime2:18446744073709551614"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -175,7 +169,6 @@ tests:
           5)EpochKey1: d1d1d2d3d4d5d6d7d8d9dadbdcdddedf 6)EpochStartTime1:
           18446744073709551613 7)EpochKey2: d2d1d2d3d4d5d6d7d8d9dadbdcdddedf
           8)EpochStartTime2: 18446744073709551614"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -202,7 +195,6 @@ tests:
           5)EpochKey1: d1d1d2d3d4d5d6d7d8d9dadbdcdddedf 6)EpochStartTime1:
           18446744073709551613 7)EpochKey2: d2d1d2d3d4d5d6d7d8d9dadbdcdddedf
           8)EpochStartTime2:18446744073709551614"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -229,7 +221,6 @@ tests:
           5)EpochKey1: null 6)EpochStartTime1: 18446744073709551613 7)EpochKey2:
           d2d1d2d3d4d5d6d7d8d9dadbdcdddedf
           8)EpochStartTime2:18446744073709551614"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -256,7 +247,6 @@ tests:
           5)EpochKey1: d1d1d2d3d4d5d6d7d8d9dadbdcdddedf 6)EpochStartTime1: null
           7)EpochKey2: d2d1d2d3d4d5d6d7d8d9dadbdcdddedf
           8)EpochStartTime2:18446744073709551614"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -283,7 +273,6 @@ tests:
           18446744073709551613 5)EpochKey1: d1d1d2d3d4d5d6d7d8d9dadbdcdddedf
           6)EpochStartTime1: 1 7)EpochKey2: d2d1d2d3d4d5d6d7d8d9dadbdcdddedf
           8)EpochStartTime2: 18446744073709551614"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -311,7 +300,6 @@ tests:
           d2d1d2d3d4d5d6d7d8d9dadbdcdddedf 8)EpochStartTime2:
           18446744073709551614 Note: EpochKey1 and EpochStartTime1 are null when
           EpochKey2 and EpochStartTime2 are not null"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -339,7 +327,6 @@ tests:
           18446744073709551613 7)EpochKey2: null 8)EpochStartTime2:
           18446744073709551614 Note: EpochKey2 is set to null and
           EpochStartTime2 is not null"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -367,7 +354,6 @@ tests:
           18446744073709551613 7)EpochKey2: d2d1d2d3d4d5d6d7d8d9dadbdcdddedf
           8)EpochStartTime2: null Note: EpochKey2 is not null and
           EpochStartTime2 is null"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -395,7 +381,6 @@ tests:
           18446744073709551613 8)EpochKey2: d2d1d2d3d4d5d6d7d8d9dadbdcdddedf
           9)EpochStartTime2: 1 Note: EpochStartTime2 is earlier than
           EpochStartTime1"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -423,7 +408,6 @@ tests:
           18446744073709551613 7)EpochKey2: d2d1d2d3d4d5d6d7d8d9dadbdcdddedf
           8)EpochStartTime2: 1 Note1: Repeat the step by sending EpochKey1 and
           EpochKey2 with 1 byte value (< 16 bytes)"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -445,7 +429,6 @@ tests:
     - label:
           "Step 16: Repeat the step by sending EpochKey1 with 1 byte value (< 16
           bytes)"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -467,7 +450,6 @@ tests:
     - label:
           "Step 16: Note: Repeat the step by sending EpochKey2 with 1 byte value
           (< 16 bytes)"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -491,7 +473,6 @@ tests:
           cluster to DUT. Note: Repeat step 16 by sending KeySetWrite Command
           with EpochKey0, EpochKey1 and EpochKey2 having 15 bytes value (< 16
           byte)"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -513,7 +494,6 @@ tests:
     - label:
           "Step 16a: Repeat step 16a by sending KeySetWrite Command with
           EpochKey1 having 15 bytes value (< 16 byte)"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -535,7 +515,6 @@ tests:
     - label:
           "Step 16a: Repeat step 16a by sending KeySetWrite Command with
           EpochKey2 having 15 bytes value (< 16 byte)"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -559,7 +538,6 @@ tests:
           cluster to DUT. Note: Repeat step 16 by sending KeySetWrite Command
           with EpochKey0, EpochKey1 and EpochKey2 having 17 bytes value (> 16
           bytes)"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -581,7 +559,6 @@ tests:
     - label:
           "Step 16b: Repeat step 16 by sending KeySetWrite Command with
           EpochKey1 having 17 bytes value (> 16 bytes)"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -603,7 +580,6 @@ tests:
     - label:
           "Step 16b: Repeat step 16 by sending KeySetWrite Command with
           EpochKey2 having 17 bytes value (> 16 bytes)"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -632,7 +608,6 @@ tests:
           8)EpochStartTime2: 17446744073709551614 Note: KeySetWrite command is
           sent with different EpochKeys,EpochStartTime1 and EpochStartTime2
           values"
-      PICS: GRPKEY.S.C00.Rsp
       command: "KeySetWrite"
       arguments:
           values:
@@ -652,7 +627,6 @@ tests:
     - label:
           "Step 18: TH sends KeySetRead command to GroupKeyManagement cluster
           with GroupKeySetID as 0x01a"
-      PICS: GRPKEY.S.C01.Rsp && GRPKEY.S.C02.Tx
       command: "KeySetRead"
       arguments:
           values:
@@ -677,7 +651,6 @@ tests:
           "Step 19: TH sends KeySetRead command to GroupKeyManagement cluster
           with GroupKeySetID as 0x01b that does not exist in the GroupKeyMap
           attribute list."
-      PICS: GRPKEY.S.C01.Rsp
       command: "KeySetRead"
       arguments:
           values:
@@ -690,7 +663,6 @@ tests:
           "Step 20: TH removes the Group key set that was added by sending a
           KeySetRemove command to the GroupKeyManagement cluster with the
           GroupKeySetID field set to 0x01a."
-      PICS: GRPKEY.S.C03.Rsp
       command: "KeySetRemove"
       arguments:
           values:
@@ -769,7 +741,7 @@ tests:
           [1692341838.536348][8091:8094] CHIP:DMG:
           [1692341838.536353][8091:8094] CHIP:DMG:         InteractionModelRevision = 1
           [1692341838.536359][8091:8094] CHIP:DMG: }
-      PICS: GRPKEY.S.C00.Rsp && PICS_SKIP_SAMPLE_APP
+      PICS: PICS_SKIP_SAMPLE_APP
       cluster: "LogCommands"
       command: "UserPrompt"
       arguments:
@@ -782,7 +754,7 @@ tests:
     - label:
           "Step 22: TH again sends KeySetWrite command to DUT with any other
           GroupKeySetID not used yet."
-      PICS: GRPKEY.S.C00.Rsp && PICS_SKIP_SAMPLE_APP
+      PICS: PICS_SKIP_SAMPLE_APP
       command: "KeySetWrite"
       arguments:
           values:
@@ -813,7 +785,7 @@ tests:
           [1692342735.277550][8297:8300] CHIP:TOO:       [2]: 1
           [1692342735.277554][8297:8300] CHIP:TOO:       [3]: 0
           [1692342735.277557][8297:8300] CHIP:TOO:    }
-      PICS: GRPKEY.S.C04.Rsp && GRPKEY.S.C05.Tx && PICS_SKIP_SAMPLE_APP
+      PICS: PICS_SKIP_SAMPLE_APP
       cluster: "LogCommands"
       command: "UserPrompt"
       arguments:
@@ -827,7 +799,6 @@ tests:
           "Step 24: TH removes the Group key set that was added by sending a
           KeySetRemove command to the GroupKeyManagement cluster with the
           GroupKeySetID field set to 0x0"
-      PICS: GRPKEY.S.C03.Rsp
       command: "KeySetRemove"
       arguments:
           values:
@@ -841,7 +812,6 @@ tests:
           KeySetRemove command to the GroupKeyManagement cluster with the
           GroupKeySetID field set to 0x01b that does not exist in the
           GroupKeyMap attribute list."
-      PICS: GRPKEY.S.C03.Rsp
       command: "KeySetRemove"
       arguments:
           values:


### PR DESCRIPTION
#### Summary
This change removes all mandatory PICs for the GroupKeyManagement cluster.

#### Related issues
N/A

#### Testing
I ran the tests against the following applications:
- darwin-x64-lighting-app
- darwin-x64-all-clusters-app

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
