### PR TITLE
[Camera] Fix crash when HandleProvideAnswer is called twice for the same session.

### DIFF
--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -383,6 +383,15 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideAnswer(uint16_t sessionId, const 
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
+    // Check if we already received an SDP answer (duplicate answer scenario)
+    // If we're already in SendingICECandidates or later state, we've already processed an answer
+    if (transport->GetState() != WebrtcTransport::State::SendingOffer && transport->GetState() != WebrtcTransport::State::Idle)
+    {
+        ChipLogProgress(Camera, "Ignoring duplicate SDP answer for session ID %u (current state: %s)", sessionId,
+                        transport->GetStateStr());
+        return CHIP_NO_ERROR;
+    }
+
     transport->GetPeerConnection()->SetRemoteDescription(sdpAnswer, SDPType::Answer);
 
     transport->MoveToState(WebrtcTransport::State::SendingICECandidates);


### PR DESCRIPTION
#### Summary

When [HandleProvideAnswer](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is called twice for the same session, the WebRTC library tries to set a remote description when the peer connection is already in a "stable" state (after the first answer was processed), which causes the std::logic_error exception.

The solution is to check the current state before calling SetRemoteDescription and handle the duplicate answer gracefully. 

#### Related issues

Fixes: #41465

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
