### PR TITLE
Update Silabs Documentation Links 

### DIFF
--- a/docs/platforms/silabs/silabs_cli_guide.md
+++ b/docs/platforms/silabs/silabs_cli_guide.md
@@ -9,10 +9,10 @@ with or without the Matter CLI. For Wi-Fi devices, only the Matter CLI is
 available.
 
 -   [Introduction](#introduction)
--   [Enable the CLI interfaces](#enable-the-cli-interfaces)
+-   [Enable the CLI Interfaces](#enable-the-cli-interfaces)
     -   [Matter CLI](#matter-cli)
     -   [OpenThread CLI](#openthread-cli)
--   [Connecting to the device](#connecting-to-the-device)
+-   [Connecting to the Device](#connecting-to-the-device)
     -   [Screen Utility](#screen-utility)
     -   [Tera Term](#tera-term)
 -   [Command List](#command-list)
@@ -70,7 +70,7 @@ screen /dev/cu.usbmodem0004403048491 115200 8-N-1
 ### Tera Term
 
 See the
-[Tera Term guide](https://siliconlabs.github.io/matter/latest/wifi/MATTER_SHELL.html)
+[Tera Term guide](https://docs.silabs.com/matter/latest/matter-overview-guides/serial-port-communications)
 on how to connect to the device on Windows.
 
 ## Command List
@@ -88,7 +88,6 @@ When the prompt `matterCli>` is printed, the device is ready for a command.
 -   [config](#config)
 -   [device](#device)
 -   [onboardingcodes](#onboardingcodes)
--   [dns](#dns)
 -   [dns](#dns)
 -   [ota](#ota)
 -   [stat](#stat)

--- a/docs/platforms/silabs/silabs_cli_guide.md
+++ b/docs/platforms/silabs/silabs_cli_guide.md
@@ -8,15 +8,15 @@ line interface (CLI). For OpenThread devices, the OpenThread CLI can be used
 with or without the Matter CLI. For Wi-Fi devices, only the Matter CLI is
 available.
 
-- [Introduction](#introduction)
-- [Enable the CLI Interfaces](#enable-the-cli-interfaces)
-    - [Matter CLI](#matter-cli)
-    - [OpenThread CLI](#openthread-cli)
-- [Connecting to the Device](#connecting-to-the-device)
-    - [Screen Utility](#screen-utility)
-    - [Tera Term](#tera-term)
-- [Command List](#command-list)
-- [Application Specific Commands](#application-specific-commands)
+-   [Introduction](#introduction)
+-   [Enable the CLI Interfaces](#enable-the-cli-interfaces)
+    -   [Matter CLI](#matter-cli)
+    -   [OpenThread CLI](#openthread-cli)
+-   [Connecting to the Device](#connecting-to-the-device)
+    -   [Screen Utility](#screen-utility)
+    -   [Tera Term](#tera-term)
+-   [Command List](#command-list)
+-   [Application Specific Commands](#application-specific-commands)
 
 ## Enable the CLI Interfaces
 
@@ -80,21 +80,21 @@ When the prompt `matterCli>` is printed, the device is ready for a command.
 > **Note**: When the OpenThread CLI is used without the Matter CLI, the prompt
 > is `>`.
 
-- [help](#help)
-- [base64](#base64)
-- [exit](#exit)
-- [version](#version)
-- [ble](#ble)
-- [config](#config)
-- [device](#device)
-- [onboardingcodes](#onboardingcodes)
-- [dns](#dns)
-- [ota](#ota)
-- [stat](#stat)
-- [echo](#echo)
-- [log](#log)
-- [rand](#rand)
-- [otcli](#otcli)
+-   [help](#help)
+-   [base64](#base64)
+-   [exit](#exit)
+-   [version](#version)
+-   [ble](#ble)
+-   [config](#config)
+-   [device](#device)
+-   [onboardingcodes](#onboardingcodes)
+-   [dns](#dns)
+-   [ota](#ota)
+-   [stat](#stat)
+-   [echo](#echo)
+-   [log](#log)
+-   [rand](#rand)
+-   [otcli](#otcli)
 
 ### help
 

--- a/docs/platforms/silabs/silabs_cli_guide.md
+++ b/docs/platforms/silabs/silabs_cli_guide.md
@@ -8,15 +8,15 @@ line interface (CLI). For OpenThread devices, the OpenThread CLI can be used
 with or without the Matter CLI. For Wi-Fi devices, only the Matter CLI is
 available.
 
--   [Introduction](#introduction)
--   [Enable the CLI Interfaces](#enable-the-cli-interfaces)
-    -   [Matter CLI](#matter-cli)
-    -   [OpenThread CLI](#openthread-cli)
--   [Connecting to the Device](#connecting-to-the-device)
-    -   [Screen Utility](#screen-utility)
-    -   [Tera Term](#tera-term)
--   [Command List](#command-list)
--   [Application Specific Commands](#application-specific-commands)
+- [Introduction](#introduction)
+- [Enable the CLI Interfaces](#enable-the-cli-interfaces)
+    - [Matter CLI](#matter-cli)
+    - [OpenThread CLI](#openthread-cli)
+- [Connecting to the Device](#connecting-to-the-device)
+    - [Screen Utility](#screen-utility)
+    - [Tera Term](#tera-term)
+- [Command List](#command-list)
+- [Application Specific Commands](#application-specific-commands)
 
 ## Enable the CLI Interfaces
 
@@ -80,21 +80,21 @@ When the prompt `matterCli>` is printed, the device is ready for a command.
 > **Note**: When the OpenThread CLI is used without the Matter CLI, the prompt
 > is `>`.
 
--   [help](#help)
--   [base64](#base64)
--   [exit](#exit)
--   [version](#version)
--   [ble](#ble)
--   [config](#config)
--   [device](#device)
--   [onboardingcodes](#onboardingcodes)
--   [dns](#dns)
--   [ota](#ota)
--   [stat](#stat)
--   [echo](#echo)
--   [log](#log)
--   [rand](#rand)
--   [otcli](#otcli)
+- [help](#help)
+- [base64](#base64)
+- [exit](#exit)
+- [version](#version)
+- [ble](#ble)
+- [config](#config)
+- [device](#device)
+- [onboardingcodes](#onboardingcodes)
+- [dns](#dns)
+- [ota](#ota)
+- [stat](#stat)
+- [echo](#echo)
+- [log](#log)
+- [rand](#rand)
+- [otcli](#otcli)
 
 ### help
 

--- a/docs/platforms/silabs/silabs_getting_started.md
+++ b/docs/platforms/silabs/silabs_getting_started.md
@@ -12,7 +12,7 @@ sample app.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 >
 > Developers can find more resources on the
 > [Silicon Labs Matter Community Page](https://community.silabs.com/s/article/connected-home-over-ip-chip-faq?language=en_US).

--- a/docs/platforms/silabs/silabs_getting_started.md
+++ b/docs/platforms/silabs/silabs_getting_started.md
@@ -17,18 +17,18 @@ sample app.
 > Developers can find more resources on the
 > [Silicon Labs Matter Community Page](https://community.silabs.com/s/article/connected-home-over-ip-chip-faq?language=en_US).
 
--   [Introduction](#introduction)
--   [Requirements](#requirements)
-    -   [Hardware Requirements](#hardware-requirements)
-    -   [Software Requirements](#software-requirements)
-    -   [Software Artifacts](#software-artifacts)
--   [Building](#building)
-    -   [Build Script](#build-script)
-    -   [Build Arguments](#build-arguments)
--   [Flashing](#flashing)
-    -   [Flasher Arguments](#flasher-arguments)
--   [Standard Application Behavior](#standard-application-behavior)
--   [Silabs CLI](#silabs-cli)
+- [Introduction](#introduction)
+- [Requirements](#requirements)
+    - [Hardware Requirements](#hardware-requirements)
+    - [Software Requirements](#software-requirements)
+    - [Software Artifacts](#software-artifacts)
+- [Building](#building)
+    - [Build Script](#build-script)
+    - [Build Arguments](#build-arguments)
+- [Flashing](#flashing)
+    - [Flasher Arguments](#flasher-arguments)
+- [Standard Application Behavior](#standard-application-behavior)
+- [Silabs CLI](#silabs-cli)
 
 ## Requirements
 

--- a/docs/platforms/silabs/silabs_getting_started.md
+++ b/docs/platforms/silabs/silabs_getting_started.md
@@ -12,7 +12,7 @@ sample app.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 >
 > Developers can find more resources on the
 > [Silicon Labs Matter Community Page](https://community.silabs.com/s/article/connected-home-over-ip-chip-faq?language=en_US).
@@ -35,20 +35,20 @@ sample app.
 ### Hardware Requirements
 
 For the list of hardware requirements, see the official
-[Silicon Labs Matter HW requirements](https://siliconlabs.github.io/matter/latest/general/HARDWARE_REQUIREMENTS.html)
+[Silicon Labs Matter HW requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
 documentation.
 
 ### Software Requirements
 
 For the list of software requirements, see the official
-[Silicon Labs Matter Software requirements](https://siliconlabs.github.io/matter/latest/general/SOFTWARE_REQUIREMENTS.html)
+[Silicon Labs Matter Software requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/software-requirements)
 documentation.
 
 #### Software Artifacts
 
 For pre-built binaries for the latest Silicon Labs Matter release, see the
 official
-[Silicon Labs Matter Software Artifacts](https://siliconlabs.github.io/matter/latest/general/ARTIFACTS.html#matter-software-artifacts).
+[Silicon Labs Matter Software Artifacts](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts).
 This includes all necessary binaries to run a Silicon Labs sample app.
 
 ## Building
@@ -57,32 +57,40 @@ Silicon Labs currently supports the following list of sample apps in the main
 Matter SDK. Every sample has its own documentation explaining its unique
 features and functionalities. The examples in the `CSA Matter Repository` column
 are supported in the main Matter SDK. Additionally, the
-[Silabs Matter Repository](https://github.com/SiliconLabs/matter) offers extra
-sample applications for different device-types
+[Silabs Matter Repository](https://github.com/SiliconLabsSoftware/matter_sdk)
+offers extra sample applications for different device-types
 
 <table>
     <tbody>
         <tr>
             <th>CSA Matter Repository</th>
-            <th> <a href="https://github.com/SiliconLabs/matter">Silabs Matter Repository</a></th>
+            <th> <a href="https://github.com/SiliconLabsSoftware/matter_sdk">Silabs matter_sdk Repository</a></th>
         </tr>
         <tr>
           <td>
             <ul>
-                <li> <a href="../../lighting-app/silabs/README.md">Lighting App</a></li>
-                <li> <a href="../../light-switch-app/silabs/README.md)">Light-Switch App</a></li>
-                <li> <a href="../../chef/README.md">Chef App</a></li>
-                <li> <a href="../../lock-app/silabs/README.md">Lock App</a></li>
-                <li> <a href="../../pump-app/silabs/README.md">Pump App</a></li>
-                <li> <a href="../../smoke-co-alarm-app/silabs/README.md">Smoke & CO Alarm App</a></li>
-                <li> <a href="../../thermostat/silabs/README.md">Thermostat App</a></li>
+                <li> <a href="../../../examples/lighting-app/silabs/README.md">Lighting App</a></li>
+                <li> <a href="../../../examples/light-switch-app/silabs/README.md">Light-Switch App</a></li>
+                <li> <a href="../../../examples/chef/README.md">Chef App</a></li>
+                <li> <a href="../../../examples/lock-app/silabs/README.md">Lock App</a></li>
+                <li> <a href="../../../examples/pump-app/silabs/README.md">Pump App</a></li>
+                <li> <a href="../../../examples/smoke-co-alarm-app/silabs/README.md">Smoke & CO Alarm App</a></li>
+                <li> <a href="../../../examples/thermostat/silabs/README.md">Thermostat App</a></li>
+                <li> <a href="../../../examples/air-quality-sensor-app/silabs/README.md">Air Quality Sensor App</a></li>
+                <li> <a href="../../../examples/closure-app/silabs/README.md">Closure App</a></li>
+                <li> <a href="../../../examples/dishwasher-app/silabs/README.md">Dishwasher App</a></li>
+                <li> <a href="../../../examples/energy-management-app/silabs/README.md">Energy Management App</a></li>
+                <li> <a href="../../../examples/lit-icd-app/silabs/README.md">LIT ICD App</a></li>
+                <li> <a href="../../../examples/refrigerator-app/silabs/README.md">Refrigerator App</a></li>
+                <li> <a href="../../../examples/window-app/silabs/README.md">Window App</a></li>
             </ul>
           </td>
           <td>
             <ul>
-                <li><a href="https://github.com/SiliconLabs/matter/blob/release_2.2.0-1.2/silabs_examples/dishwasher-app/silabs/README.md">Dishwasher App</a></li>
-                <li><a href="https://github.com/SiliconLabs/matter/blob/release_2.2.0-1.2/silabs_examples/onoff-plug-app/README.md">On-Off Plug App</a></li>
-                <li><a href="https://github.com/SiliconLabs/matter/blob/release_2.2.0-1.2/silabs_examples/silabs-sensors/README.md">Multi Sensor App</a></li>
+                <li><a href="https://github.com/SiliconLabsSoftware/matter_sdk/blob/main/examples/base-platform-app/silabs/README.md">Platform App</a></li>
+                <li><a href="https://github.com/SiliconLabsSoftware/matter_sdk/blob/main/examples/onoff-plug-app/silabs/README.md">On-Off Plug App</a></li>
+                <li><a href="https://github.com/SiliconLabsSoftware/matter_sdk/blob/main/examples/multi-sensor-app/silabs">Multi Sensor App</a></li>
+                <li><a href="https://github.com/SiliconLabsSoftware/matter_sdk/blob/main/examples/template/silabs/README.md">Template App</a></li>
             </ul>
           </td>
         </tr>

--- a/docs/platforms/silabs/silabs_getting_started.md
+++ b/docs/platforms/silabs/silabs_getting_started.md
@@ -17,18 +17,18 @@ sample app.
 > Developers can find more resources on the
 > [Silicon Labs Matter Community Page](https://community.silabs.com/s/article/connected-home-over-ip-chip-faq?language=en_US).
 
-- [Introduction](#introduction)
-- [Requirements](#requirements)
-    - [Hardware Requirements](#hardware-requirements)
-    - [Software Requirements](#software-requirements)
-    - [Software Artifacts](#software-artifacts)
-- [Building](#building)
-    - [Build Script](#build-script)
-    - [Build Arguments](#build-arguments)
-- [Flashing](#flashing)
-    - [Flasher Arguments](#flasher-arguments)
-- [Standard Application Behavior](#standard-application-behavior)
-- [Silabs CLI](#silabs-cli)
+-   [Introduction](#introduction)
+-   [Requirements](#requirements)
+    -   [Hardware Requirements](#hardware-requirements)
+    -   [Software Requirements](#software-requirements)
+    -   [Software Artifacts](#software-artifacts)
+-   [Building](#building)
+    -   [Build Script](#build-script)
+    -   [Build Arguments](#build-arguments)
+-   [Flashing](#flashing)
+    -   [Flasher Arguments](#flasher-arguments)
+-   [Standard Application Behavior](#standard-application-behavior)
+-   [Silabs CLI](#silabs-cli)
 
 ## Requirements
 

--- a/examples/air-quality-sensor-app/silabs/README.md
+++ b/examples/air-quality-sensor-app/silabs/README.md
@@ -5,28 +5,28 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 <hr>
 
 - [Matter Air Quality Sensor Example](#matter-air-quality-sensor-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-      - [Linux](#linux)
-      - [Mac OS X](#mac-os-x)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Notes](#notes)
-      - [On Border Router:](#on-border-router)
-      - [On PC(Linux):](#on-pclinux)
-  - [Running RPC console](#running-rpc-console)
-  - [Memory settings](#memory-settings)
-  - [OTA Software Update](#ota-software-update)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Introduction](#introduction)
+    - [Building](#building)
+        - [Linux](#linux)
+        - [Mac OS X](#mac-os-x)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT](#segger-rtt)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Notes](#notes)
+            - [On Border Router:](#on-border-router)
+            - [On PC(Linux):](#on-pclinux)
+    - [Running RPC console](#running-rpc-console)
+    - [Memory settings](#memory-settings)
+    - [OTA Software Update](#ota-software-update)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling LCD](#disabling-lcd)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -57,17 +57,16 @@ the Silicon Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain (For most Host, the
-    bootstrap already installs the toolchain):
-    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+- Download and install a suitable ARM gcc tool chain (For most Host, the
+  bootstrap already installs the toolchain):
+  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
--   Install some additional tools(likely already present for CHIP developers):
+- Install some additional tools(likely already present for CHIP developers):
 
 #### Linux
 
@@ -77,38 +76,34 @@ the Silicon Labs platform.
 
     $ brew install ninja
 
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     MG21 boards: Currently not supported due to RAM limitation.
-
-    -   BRD4180A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4180A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
     MG24 boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+* Region code Setting (917 WiFi projects)
+    - In Wifi configurations, the region code can be set in this
+      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+      The available region codes can be found
+      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-*   Region code Setting (917 WiFi projects)
-
-    -   In Wifi configurations, the region code can be set in this
-        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-        The available region codes can be found
-        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
-
-*   Build the example application:
+* Build the example application:
 
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/air-quality-sensor-app/silabs/ ./out/air-quality-sensor-app BRD4187C
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
@@ -122,16 +117,16 @@ the Silicon Labs platform.
           $ gn gen out/debug
           $ ninja -C out/debug
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip/examples/air-quality-sensor-app/silabs
           $ rm -rf out/
 
-*   Build the example with Matter shell
+* Build the example with Matter shell
 
           ./scripts/examples/gn_silabs_example.sh examples/air-quality-sensor-app/silabs/ out/air-quality-sensor-app-app BRD4187C chip_build_libshell=true
 
-*   Build the example as Intermittently Connected Device (ICD)
+* Build the example as Intermittently Connected Device (ICD)
 
           $ ./scripts/examples/gn_silabs_example.sh ./examples/air-quality-sensor-app/silabs/ ./out/air-quality-sensor-app-app_ICD BRD4187C --icd
 
@@ -139,7 +134,7 @@ the Silicon Labs platform.
 
           $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
 
-*   Build the example with pigweed RCP
+* Build the example with pigweed RCP
 
           $ ./scripts/examples/gn_silabs_example.sh examples/air-quality-sensor-app/silabs/ out/air-quality-sensor-app-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
@@ -159,12 +154,12 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           $ cd ~/connectedhomeip/examples/air-quality-sensor-app/silabs
           $ python3 out/debug/matter-silabs-air-quality-sensor-app-switch-example.flash.py
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -186,27 +181,27 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG12 use:
 
@@ -216,7 +211,7 @@ combination with JLinkRTTClient as follows:
 
           $ JLinkExe -device EFR32MG21AXXXF1024 -if SWD -speed 4000 -autoconnect 1
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
 
@@ -233,9 +228,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -246,23 +241,22 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   For this example to work, it is necessary to have a second efr32 device
-    running the
-    [air quality sensor app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/air-quality-sensor-app/silabs/README.md)
-    commissioned on the same openthread network
+- For this example to work, it is necessary to have a second efr32 device
+  running the
+  [air quality sensor app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/air-quality-sensor-app/silabs/README.md)
+  commissioned on the same openthread network
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.
@@ -300,9 +294,9 @@ With any serial terminal application such as screen, putty, minicom etc.
             procedure. **LEDs** blink in unison when the factory reset procedure is
             initiated.
 
-*   You can provision and control the Chip device using the python controller,
-    [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
-    standalone, Android or iOS app
+* You can provision and control the Chip device using the python controller,
+  [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
+  standalone, Android or iOS app
 
     Here is an example with the CHIPTool:
 
@@ -312,10 +306,10 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
--   Depending on your network settings your router might not provide native ipv6
-    addresses to your devices (Border router / PC). If this is the case, you
-    need to add a static ipv6 addresses on both device and then an ipv6 route to
-    the border router on your PC
+- Depending on your network settings your router might not provide native ipv6
+  addresses to your devices (Border router / PC). If this is the case, you need
+  to add a static ipv6 addresses on both device and then an ipv6 route to the
+  border router on your PC
 
 #### On Border Router:
 
@@ -330,20 +324,20 @@ via 2002::2
 
 ## Running RPC console
 
--   As part of building the example with RPCs enabled the chip_rpc python
-    interactive console is installed into your venv. The python wheel files are
-    also created in the output folder: out/debug/chip_rpc_console_wheels. To
-    install the wheel files without rebuilding:
+- As part of building the example with RPCs enabled the chip_rpc python
+  interactive console is installed into your venv. The python wheel files are
+  also created in the output folder: out/debug/chip_rpc_console_wheels. To
+  install the wheel files without rebuilding:
 
     `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
--   To use the chip-rpc console after it has been installed run:
+- To use the chip-rpc console after it has been installed run:
 
     `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
--   Then you can simulate a button press or release using the following command
-    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-    RELEASE Test toggling the LED with
+- Then you can simulate a button press or release using the following command
+  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+  RELEASE Test toggling the LED with
 
     `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 

--- a/examples/air-quality-sensor-app/silabs/README.md
+++ b/examples/air-quality-sensor-app/silabs/README.md
@@ -34,7 +34,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/air-quality-sensor-app/silabs/README.md
+++ b/examples/air-quality-sensor-app/silabs/README.md
@@ -4,29 +4,29 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 
 <hr>
 
-- [Matter Air Quality Sensor Example](#matter-air-quality-sensor-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-        - [Linux](#linux)
-        - [Mac OS X](#mac-os-x)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT](#segger-rtt)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Notes](#notes)
-            - [On Border Router:](#on-border-router)
-            - [On PC(Linux):](#on-pclinux)
-    - [Running RPC console](#running-rpc-console)
-    - [Memory settings](#memory-settings)
-    - [OTA Software Update](#ota-software-update)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling LCD](#disabling-lcd)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter Air Quality Sensor Example](#matter-air-quality-sensor-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+        -   [Linux](#linux)
+        -   [Mac OS X](#mac-os-x)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Notes](#notes)
+            -   [On Border Router:](#on-border-router)
+            -   [On PC(Linux):](#on-pclinux)
+    -   [Running RPC console](#running-rpc-console)
+    -   [Memory settings](#memory-settings)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -57,16 +57,17 @@ the Silicon Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain (For most Host, the
-  bootstrap already installs the toolchain):
-  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+-   Download and install a suitable ARM gcc tool chain (For most Host, the
+    bootstrap already installs the toolchain):
+    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
-- Install some additional tools(likely already present for CHIP developers):
+-   Install some additional tools(likely already present for CHIP developers):
 
 #### Linux
 
@@ -76,76 +77,80 @@ the Silicon Labs platform.
 
     $ brew install ninja
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG21 boards: Currently not supported due to RAM limitation.
-    - BRD4180A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+
+    -   BRD4180A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
     MG24 boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Region code Setting (917 WiFi projects)
-    - In Wifi configurations, the region code can be set in this
-      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-      The available region codes can be found
-      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Build the example application:
+*   Region code Setting (917 WiFi projects)
 
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/air-quality-sensor-app/silabs/ ./out/air-quality-sensor-app BRD4187C
+    -   In Wifi configurations, the region code can be set in this
+        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+        The available region codes can be found
+        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-- To delete generated executable, libraries and object files use:
+*   Build the example application:
 
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/air-quality-sensor-app/silabs/ ./out/air-quality-sensor-app BRD4187C
+
+-   To delete generated executable, libraries and object files use:
+
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/air-quality-sensor-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/air-quality-sensor-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug
+            $ ninja -C out/debug
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/air-quality-sensor-app/silabs
-          $ rm -rf out/
+            $ cd ~/connectedhomeip/examples/air-quality-sensor-app/silabs
+            $ rm -rf out/
 
-* Build the example with Matter shell
+*   Build the example with Matter shell
 
-          ./scripts/examples/gn_silabs_example.sh examples/air-quality-sensor-app/silabs/ out/air-quality-sensor-app-app BRD4187C chip_build_libshell=true
+            ./scripts/examples/gn_silabs_example.sh examples/air-quality-sensor-app/silabs/ out/air-quality-sensor-app-app BRD4187C chip_build_libshell=true
 
-* Build the example as Intermittently Connected Device (ICD)
+*   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/air-quality-sensor-app/silabs/ ./out/air-quality-sensor-app-app_ICD BRD4187C --icd
+            $ ./scripts/examples/gn_silabs_example.sh ./examples/air-quality-sensor-app/silabs/ ./out/air-quality-sensor-app-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
+            $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
 
-* Build the example with pigweed RCP
+*   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/air-quality-sensor-app/silabs/ out/air-quality-sensor-app-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+            $ ./scripts/examples/gn_silabs_example.sh examples/air-quality-sensor-app/silabs/ out/air-quality-sensor-app-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/air-quality-sensor-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/air-quality-sensor-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+            $ ninja -C out/debug
 
 For more build options, help is provided when running the build script without
 arguments
@@ -154,12 +159,12 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          $ cd ~/connectedhomeip/examples/air-quality-sensor-app/silabs
-          $ python3 out/debug/matter-silabs-air-quality-sensor-app-switch-example.flash.py
+            $ cd ~/connectedhomeip/examples/air-quality-sensor-app/silabs
+            $ python3 out/debug/matter-silabs-air-quality-sensor-app-switch-example.flash.py
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -181,39 +186,39 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          $ sudo usermod -a -G dialout ${USER}
+            $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG12 use:
 
-          $ JLinkExe -device EFR32MG12PXXXF1024 -if JTAG -speed 4000 -autoconnect 1
+            $ JLinkExe -device EFR32MG12PXXXF1024 -if JTAG -speed 4000 -autoconnect 1
 
     For MG21 use:
 
-          $ JLinkExe -device EFR32MG21AXXXF1024 -if SWD -speed 4000 -autoconnect 1
+            $ JLinkExe -device EFR32MG21AXXXF1024 -if SWD -speed 4000 -autoconnect 1
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          $ JLinkRTTClient
+            $ JLinkRTTClient
 
 ### Console Log
 
@@ -228,9 +233,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -241,62 +246,63 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- For this example to work, it is necessary to have a second efr32 device
-  running the
-  [air quality sensor app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/air-quality-sensor-app/silabs/README.md)
-  commissioned on the same openthread network
+-   For this example to work, it is necessary to have a second efr32 device
+    running the
+    [air quality sensor app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/air-quality-sensor-app/silabs/README.md)
+    commissioned on the same openthread network
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0** shows the overall state of the device and its connectivity. The
     following states are possible:
 
-        -   Short Flash On (50 ms on/950 ms off): The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+          -   Short Flash On (50 ms on/950 ms off): The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-        -   Rapid Even Flashing (100 ms on/100 ms off): The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+          -   Rapid Even Flashing (100 ms on/100 ms off): The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-        -   Short Flash Off (950ms on/50ms off): The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+          -   Short Flash Off (950ms on/50ms off): The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-        -   Solid On: The device is fully provisioned and has full Thread
-            network and service connectivity.
+          -   Solid On: The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **Push Button 0**
 
-        -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
-            for 30 seconds. The device will then switch to a slower interval advertisement.
-            After 15 minutes, the advertisement stops.
-            Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
+          -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
+              for 30 seconds. The device will then switch to a slower interval advertisement.
+              After 15 minutes, the advertisement stops.
+              Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
 
-        -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
-* You can provision and control the Chip device using the python controller,
-  [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
-  standalone, Android or iOS app
+*   You can provision and control the Chip device using the python controller,
+    [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
+    standalone, Android or iOS app
 
     Here is an example with the CHIPTool:
 
@@ -306,10 +312,10 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
-- Depending on your network settings your router might not provide native ipv6
-  addresses to your devices (Border router / PC). If this is the case, you need
-  to add a static ipv6 addresses on both device and then an ipv6 route to the
-  border router on your PC
+-   Depending on your network settings your router might not provide native ipv6
+    addresses to your devices (Border router / PC). If this is the case, you
+    need to add a static ipv6 addresses on both device and then an ipv6 route to
+    the border router on your PC
 
 #### On Border Router:
 
@@ -324,20 +330,20 @@ via 2002::2
 
 ## Running RPC console
 
-- As part of building the example with RPCs enabled the chip_rpc python
-  interactive console is installed into your venv. The python wheel files are
-  also created in the output folder: out/debug/chip_rpc_console_wheels. To
-  install the wheel files without rebuilding:
+-   As part of building the example with RPCs enabled the chip_rpc python
+    interactive console is installed into your venv. The python wheel files are
+    also created in the output folder: out/debug/chip_rpc_console_wheels. To
+    install the wheel files without rebuilding:
 
     `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
-- To use the chip-rpc console after it has been installed run:
+-   To use the chip-rpc console after it has been installed run:
 
     `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
-- Then you can simulate a button press or release using the following command
-  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-  RELEASE Test toggling the LED with
+-   Then you can simulate a button press or release using the following command
+    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+    RELEASE Test toggling the LED with
 
     `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 

--- a/examples/air-quality-sensor-app/silabs/README.md
+++ b/examples/air-quality-sensor-app/silabs/README.md
@@ -4,27 +4,29 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 
 <hr>
 
--   [Matter Air Quality Sensor Example](#matter-air-quality-sensor-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-        -   [Linux](#linux)
-        -   [Mac OS X](#mac-os-x)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-            -   [On Border Router:](#on-border-router)
-            -   [On PC(Linux):](#on-pclinux)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Memory settings](#memory-settings)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter Air Quality Sensor Example](#matter-air-quality-sensor-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+      - [Linux](#linux)
+      - [Mac OS X](#mac-os-x)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Notes](#notes)
+      - [On Border Router:](#on-border-router)
+      - [On PC(Linux):](#on-pclinux)
+  - [Running RPC console](#running-rpc-console)
+  - [Memory settings](#memory-settings)
+  - [OTA Software Update](#ota-software-update)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -32,7 +34,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -78,8 +80,8 @@ the Silicon Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG21 boards: Currently not supported due to RAM limitation.
 
@@ -165,9 +167,8 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 ## Viewing Logging Output
 

--- a/examples/closure-app/silabs/README.md
+++ b/examples/closure-app/silabs/README.md
@@ -4,17 +4,17 @@ An example showing the use of CHIP on the Silicon Labs SiWx917
 
 <hr>
 
--   [Matter SiWx917 Closure Example](#matter-siwx917-closure-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Running the Complete Example](#running-the-complete-example)
-    -   [Group Communication (Multicast)](#group-communication-multicast)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling QR CODE](#disabling-qr-code)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter SiWx917 Closure Example](#matter-siwx917-closure-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+  - [Flashing the Application](#flashing-the-application)
+  - [Running the Complete Example](#running-the-complete-example)
+  - [Group Communication (Multicast)](#group-communication-multicast)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling QR CODE](#disabling-qr-code)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -22,7 +22,7 @@ An example showing the use of CHIP on the Silicon Labs SiWx917
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -58,8 +58,8 @@ based on the Silicon Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     917SoC boards :
 
@@ -105,9 +105,9 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All SiWx917 boards require a connectivity firmware, see Silicon Labs
-documentation for more info. Pre-built bootloader binaries are available in the
-Assets section of the Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+documentation for more info. Pre-built firmware binaries are available are
+available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#siwx917-firmware-for-siwn917-ncp-and-siwg917-soc).
 
 ## Running the Complete Example
 

--- a/examples/closure-app/silabs/README.md
+++ b/examples/closure-app/silabs/README.md
@@ -22,7 +22,7 @@ An example showing the use of CHIP on the Silicon Labs SiWx917
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/closure-app/silabs/README.md
+++ b/examples/closure-app/silabs/README.md
@@ -5,16 +5,16 @@ An example showing the use of CHIP on the Silicon Labs SiWx917
 <hr>
 
 - [Matter SiWx917 Closure Example](#matter-siwx917-closure-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-  - [Flashing the Application](#flashing-the-application)
-  - [Running the Complete Example](#running-the-complete-example)
-  - [Group Communication (Multicast)](#group-communication-multicast)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling QR CODE](#disabling-qr-code)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Introduction](#introduction)
+    - [Building](#building)
+    - [Flashing the Application](#flashing-the-application)
+    - [Running the Complete Example](#running-the-complete-example)
+    - [Group Communication (Multicast)](#group-communication-multicast)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling QR CODE](#disabling-qr-code)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -40,37 +40,33 @@ based on the Silicon Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain:
-    [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
+- Download and install a suitable ARM gcc tool chain:
+  [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
 
--   Install some additional tools (likely already present for CHIP developers):
+- Install some additional tools (likely already present for CHIP developers):
+    - Linux: `sudo apt-get install git ninja-build`
 
-    -   Linux: `sudo apt-get install git ninja-build`
+    - Mac OS X: `brew install ninja`
 
-    -   Mac OS X: `brew install ninja`
-
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     917SoC boards :
+    - BRD4338A
 
-    -   BRD4338A
-
-*   Build the example application:
+* Build the example application:
 
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/closure-app/silabs/ ./out/closure-app BRD4338A
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
@@ -87,7 +83,7 @@ based on the Silicon Labs platform.
           $ gn gen out/debug
           $ ninja -C out/debug
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip/examples/closure-app/silabs
           $ rm -rf out/
@@ -99,10 +95,10 @@ arguments
 
 ## Flashing the Application
 
--   SiWx917 SoC device support is available in the latest Simplicity Commander.
-    The SiWx917 SOC board will support .rps as the only file to flash.
+- SiWx917 SoC device support is available in the latest Simplicity Commander.
+  The SiWx917 SOC board will support .rps as the only file to flash.
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All SiWx917 boards require a connectivity firmware, see Silicon Labs
 documentation for more info. Pre-built firmware binaries are available on the
@@ -110,9 +106,8 @@ documentation for more info. Pre-built firmware binaries are available on the
 
 ## Running the Complete Example
 
--   To run a Matter over Wi-Fi application, you must first create a Matter
-    network using the chip-tool, and then control the Matter device from the
-    chip-tool.
+- To run a Matter over Wi-Fi application, you must first create a Matter network
+  using the chip-tool, and then control the Matter device from the chip-tool.
 
 **Creating the Matter Network**
 
@@ -123,8 +118,8 @@ documentation for more info. Pre-built firmware binaries are available on the
      - The Silicon Labs device will join the Wi-Fi network and get an IP address. It then starts providing mDNS records on IPv4 and IPv6.
      - Future communications (tests) will then happen over Wi-Fi.
 
--   You can provision and control the Chip device using the python controller,
-    Chip tool standalone, Android or iOS app
+- You can provision and control the Chip device using the python controller,
+  Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
@@ -132,7 +127,7 @@ documentation for more info. Pre-built firmware binaries are available on the
 
           $ chip-tool pairing ble-wifi 1 <SSID> <Password> 20202021 3840
 
-*   User interface :
+* User interface :
 
     **Push Button 0**
 

--- a/examples/closure-app/silabs/README.md
+++ b/examples/closure-app/silabs/README.md
@@ -4,17 +4,17 @@ An example showing the use of CHIP on the Silicon Labs SiWx917
 
 <hr>
 
-- [Matter SiWx917 Closure Example](#matter-siwx917-closure-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-    - [Flashing the Application](#flashing-the-application)
-    - [Running the Complete Example](#running-the-complete-example)
-    - [Group Communication (Multicast)](#group-communication-multicast)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling QR CODE](#disabling-qr-code)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter SiWx917 Closure Example](#matter-siwx917-closure-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Running the Complete Example](#running-the-complete-example)
+    -   [Group Communication (Multicast)](#group-communication-multicast)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling QR CODE](#disabling-qr-code)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -40,53 +40,57 @@ based on the Silicon Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain:
-  [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
+-   Download and install a suitable ARM gcc tool chain:
+    [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
 
-- Install some additional tools (likely already present for CHIP developers):
-    - Linux: `sudo apt-get install git ninja-build`
+-   Install some additional tools (likely already present for CHIP developers):
 
-    - Mac OS X: `brew install ninja`
+    -   Linux: `sudo apt-get install git ninja-build`
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+    -   Mac OS X: `brew install ninja`
+
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     917SoC boards :
-    - BRD4338A
 
-* Build the example application:
+    -   BRD4338A
 
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/closure-app/silabs/ ./out/closure-app BRD4338A
+*   Build the example application:
 
-- To delete generated executable, libraries and object files use:
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/closure-app/silabs/ ./out/closure-app BRD4338A
 
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
+-   To delete generated executable, libraries and object files use:
+
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/closure-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4338A
+            $ cd ~/connectedhomeip/examples/closure-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4338A
 
     To build the Closure example
 
-          $ gn gen out/debug
-          $ ninja -C out/debug
+            $ gn gen out/debug
+            $ ninja -C out/debug
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/closure-app/silabs
-          $ rm -rf out/
+            $ cd ~/connectedhomeip/examples/closure-app/silabs
+            $ rm -rf out/
 
 For more build options, help is provided when running the build script without
 arguments
@@ -95,10 +99,10 @@ arguments
 
 ## Flashing the Application
 
-- SiWx917 SoC device support is available in the latest Simplicity Commander.
-  The SiWx917 SOC board will support .rps as the only file to flash.
+-   SiWx917 SoC device support is available in the latest Simplicity Commander.
+    The SiWx917 SOC board will support .rps as the only file to flash.
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All SiWx917 boards require a connectivity firmware, see Silicon Labs
 documentation for more info. Pre-built firmware binaries are available on the
@@ -106,8 +110,9 @@ documentation for more info. Pre-built firmware binaries are available on the
 
 ## Running the Complete Example
 
-- To run a Matter over Wi-Fi application, you must first create a Matter network
-  using the chip-tool, and then control the Matter device from the chip-tool.
+-   To run a Matter over Wi-Fi application, you must first create a Matter
+    network using the chip-tool, and then control the Matter device from the
+    chip-tool.
 
 **Creating the Matter Network**
 
@@ -118,28 +123,28 @@ documentation for more info. Pre-built firmware binaries are available on the
      - The Silicon Labs device will join the Wi-Fi network and get an IP address. It then starts providing mDNS records on IPv4 and IPv6.
      - Future communications (tests) will then happen over Wi-Fi.
 
-- You can provision and control the Chip device using the python controller,
-  Chip tool standalone, Android or iOS app
+-   You can provision and control the Chip device using the python controller,
+    Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
     Here is an example with the chip-tool:
 
-          $ chip-tool pairing ble-wifi 1 <SSID> <Password> 20202021 3840
+            $ chip-tool pairing ble-wifi 1 <SSID> <Password> 20202021 3840
 
-* User interface :
+*   User interface :
 
     **Push Button 0**
 
-        -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
-            for 30 seconds. The device will then switch to a slower interval advertisement.
-            After 15 minutes, the advertisement stops.
-            Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
+          -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
+              for 30 seconds. The device will then switch to a slower interval advertisement.
+              After 15 minutes, the advertisement stops.
+              Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
 
-        -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
 ## Group Communication (Multicast)
 

--- a/examples/closure-app/silabs/README.md
+++ b/examples/closure-app/silabs/README.md
@@ -105,8 +105,7 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All SiWx917 boards require a connectivity firmware, see Silicon Labs
-documentation for more info. Pre-built firmware binaries are available are
-available on the
+documentation for more info. Pre-built firmware binaries are available on the
 [Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#siwx917-firmware-for-siwn917-ncp-and-siwg917-soc).
 
 ## Running the Complete Example

--- a/examples/dishwasher-app/silabs/README.md
+++ b/examples/dishwasher-app/silabs/README.md
@@ -4,17 +4,17 @@ An example showing the use of Matter on the Silicon Labs EFR32 MG24 boards.
 
 <hr>
 
-- [Matter Silabs dishwasher Example](#matter-silabs-dishwasher-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT](#segger-rtt)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Commissioning](#commissioning)
+-   [Matter Silabs dishwasher Example](#matter-silabs-dishwasher-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Commissioning](#commissioning)
 
 <hr>
 
@@ -45,64 +45,69 @@ Silicon Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain:
-  [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
+-   Download and install a suitable ARM gcc tool chain:
+    [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
 
-- Install some additional tools (likely already present for CHIP developers):
-    - Linux: `sudo apt-get install git ninja-build`
+-   Install some additional tools (likely already present for CHIP developers):
 
-    - Mac OS X: `brew install ninja`
+    -   Linux: `sudo apt-get install git ninja-build`
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+    -   Mac OS X: `brew install ninja`
+
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG21 boards: Currently not supported due to RAM limitation.
-    - BRD4180A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+
+    -   BRD4180A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
     MG24 boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD2703A / MG24 Explorer Kit
-    - BRD2704A / SparkFun Thing Plus MGM240P board
 
-* Region code Setting (917 WiFi projects)
-    - In Wifi configurations, the region code can be set in this
-      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-      The available region codes can be found
-      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD2703A / MG24 Explorer Kit
+    -   BRD2704A / SparkFun Thing Plus MGM240P board
 
-- Build the example application:
+*   Region code Setting (917 WiFi projects)
+    -   In Wifi configurations, the region code can be set in this
+        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+        The available region codes can be found
+        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./silabs_examples/dishwasher-app/silabs/ ./out/dishwasher-app BRD4187C
+-   Build the example application:
 
-* To delete generated executable, libraries and object files use:
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./silabs_examples/dishwasher-app/silabs/ ./out/dishwasher-app BRD4187C
 
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
+*   To delete generated executable, libraries and object files use:
+
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/silabs_examples/dishwasher-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/dishwasher-app
-          $ ninja -C out/dishwasher-app
+            $ cd ~/connectedhomeip/silabs_examples/dishwasher-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/dishwasher-app
+            $ ninja -C out/dishwasher-app
 
-* To delete generated executable, libraries and object files use:
+*   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/silabs_examples/dishwasher-app/silabs
-          $ rm -rf out/
+            $ cd ~/connectedhomeip/silabs_examples/dishwasher-app/silabs
+            $ rm -rf out/
 
 For more build options, help is provided when running the build script without
 arguments
@@ -111,11 +116,11 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          $ python3 out/dishwasher-app/matter-silabs-dishwasher-example.flash.py
+            $ python3 out/dishwasher-app/matter-silabs-dishwasher-example.flash.py
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -137,35 +142,35 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          $ sudo usermod -a -G dialout ${USER}
+            $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
-          $ JLinkExe -device EFR32MG24AXXXF1024 -if SWD -speed 4000 -autoconnect 1
+            $ JLinkExe -device EFR32MG24AXXXF1024 -if SWD -speed 4000 -autoconnect 1
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          $ JLinkRTTClient
+            $ JLinkRTTClient
 
 ### Console Log
 
@@ -180,9 +185,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -193,60 +198,61 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0** shows the overall state of the device and its connectivity. The
     following states are possible:
 
-        -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+          -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-        -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+          -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-        -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+          -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-        -   _Solid On_ ; The device is fully provisioned and has full Thread
-            network and service connectivity.
+          -   _Solid On_ ; The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **LED 1** Shows the dishwasher working state following states are possible:
 
-        -   _Solid On_ ; dishwasher is running
-        -   _Slow_Blink_ ; dishwasher is paused
-        -   _Off_ ; dishwasher is stopped
-        -   _Fast_Blink_ ; dishwasher has encountered an error
+          -   _Solid On_ ; dishwasher is running
+          -   _Slow_Blink_ ; dishwasher is paused
+          -   _Off_ ; dishwasher is stopped
+          -   _Fast_Blink_ ; dishwasher has encountered an error
 
     **Push Button 0**
 
-        -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
-            for 30 seconds. The device will then switch to a slower interval advertisement.
-            After 15 minutes, the advertisement stops.
-            Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
+          -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
+              for 30 seconds. The device will then switch to a slower interval advertisement.
+              After 15 minutes, the advertisement stops.
+              Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
 
-        -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
     **Push Button 1** Cycle the dishwasher operational states
     Running/Paused/Stopped

--- a/examples/dishwasher-app/silabs/README.md
+++ b/examples/dishwasher-app/silabs/README.md
@@ -4,15 +4,17 @@ An example showing the use of Matter on the Silicon Labs EFR32 MG24 boards.
 
 <hr>
 
--   [Matter Silabs dishwasher Example](#matter-silabs-dishwasher-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Commissioning](#commissioning)
+- [Matter Silabs dishwasher Example](#matter-silabs-dishwasher-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Commissioning](#commissioning)
 
 <hr>
 
@@ -20,7 +22,7 @@ An example showing the use of Matter on the Silicon Labs EFR32 MG24 boards.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -61,8 +63,8 @@ Silicon Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG21 boards: Currently not supported due to RAM limitation.
 
@@ -121,10 +123,9 @@ arguments
 
 -   Or with the Ozone debugger, just load the .out file.
 
-All Silabs boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+All EFR32 boards require a bootloader, see Silicon Labs documentation for more
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 ## Viewing Logging Output
 

--- a/examples/dishwasher-app/silabs/README.md
+++ b/examples/dishwasher-app/silabs/README.md
@@ -22,7 +22,7 @@ An example showing the use of Matter on the Silicon Labs EFR32 MG24 boards.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/dishwasher-app/silabs/README.md
+++ b/examples/dishwasher-app/silabs/README.md
@@ -5,16 +5,16 @@ An example showing the use of Matter on the Silicon Labs EFR32 MG24 boards.
 <hr>
 
 - [Matter Silabs dishwasher Example](#matter-silabs-dishwasher-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Commissioning](#commissioning)
+    - [Introduction](#introduction)
+    - [Building](#building)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT](#segger-rtt)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Commissioning](#commissioning)
 
 <hr>
 
@@ -45,53 +45,47 @@ Silicon Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain:
-    [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
+- Download and install a suitable ARM gcc tool chain:
+  [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
 
--   Install some additional tools (likely already present for CHIP developers):
+- Install some additional tools (likely already present for CHIP developers):
+    - Linux: `sudo apt-get install git ninja-build`
 
-    -   Linux: `sudo apt-get install git ninja-build`
+    - Mac OS X: `brew install ninja`
 
-    -   Mac OS X: `brew install ninja`
-
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     MG21 boards: Currently not supported due to RAM limitation.
-
-    -   BRD4180A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4180A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
     MG24 boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD2703A / MG24 Explorer Kit
+    - BRD2704A / SparkFun Thing Plus MGM240P board
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD2703A / MG24 Explorer Kit
-    -   BRD2704A / SparkFun Thing Plus MGM240P board
+* Region code Setting (917 WiFi projects)
+    - In Wifi configurations, the region code can be set in this
+      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+      The available region codes can be found
+      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-*   Region code Setting (917 WiFi projects)
-
-    -   In Wifi configurations, the region code can be set in this
-        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-        The available region codes can be found
-        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
-
--   Build the example application:
+- Build the example application:
 
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./silabs_examples/dishwasher-app/silabs/ ./out/dishwasher-app BRD4187C
 
-*   To delete generated executable, libraries and object files use:
+* To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
@@ -105,7 +99,7 @@ Silicon Labs platform.
           $ gn gen out/dishwasher-app
           $ ninja -C out/dishwasher-app
 
-*   To delete generated executable, libraries and object files use:
+* To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip/silabs_examples/dishwasher-app/silabs
           $ rm -rf out/
@@ -117,11 +111,11 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           $ python3 out/dishwasher-app/matter-silabs-dishwasher-example.flash.py
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -143,33 +137,33 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
           $ JLinkExe -device EFR32MG24AXXXF1024 -if SWD -speed 4000 -autoconnect 1
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
 
@@ -186,9 +180,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -199,18 +193,17 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.

--- a/examples/energy-management-app/silabs/README.md
+++ b/examples/energy-management-app/silabs/README.md
@@ -32,7 +32,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/energy-management-app/silabs/README.md
+++ b/examples/energy-management-app/silabs/README.md
@@ -4,27 +4,27 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 
 <hr>
 
-- [Matter EFR32 Energy Management Example](#matter-efr32-energy-management-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT](#segger-rtt)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Notes](#notes)
-    - [Running RPC console](#running-rpc-console)
-    - [Device Tracing](#device-tracing)
-    - [Memory settings](#memory-settings)
-    - [OTA Software Update](#ota-software-update)
-    - [Group Communication (Multicast)](#group-communication-multicast)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling LCD](#disabling-lcd)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter EFR32 Energy Management Example](#matter-efr32-energy-management-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Notes](#notes)
+    -   [Running RPC console](#running-rpc-console)
+    -   [Device Tracing](#device-tracing)
+    -   [Memory settings](#memory-settings)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Group Communication (Multicast)](#group-communication-multicast)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -55,90 +55,94 @@ creating real products based on the Silicon Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain:
-  [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
+-   Download and install a suitable ARM gcc tool chain:
+    [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
 
-- Install some additional tools (likely already present for CHIP developers):
-    - Linux: `sudo apt-get install git ninja-build`
+-   Install some additional tools (likely already present for CHIP developers):
 
-    - Mac OS X: `brew install ninja`
+    -   Linux: `sudo apt-get install git ninja-build`
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+    -   Mac OS X: `brew install ninja`
+
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD2703A / MG24 Explorer Kit
-    - BRD2704A / SparkFun Thing Plus MGM240P board
 
-* Build the example application:
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD2703A / MG24 Explorer Kit
+    -   BRD2704A / SparkFun Thing Plus MGM240P board
 
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/energy-management-app/silabs/ ./out/energy-management-app BRD4187C
+*   Build the example application:
 
-- To delete generated executable, libraries and object files use:
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/energy-management-app/silabs/ ./out/energy-management-app BRD4187C
 
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
+-   To delete generated executable, libraries and object files use:
+
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/energy-management-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
+            $ cd ~/connectedhomeip/examples/energy-management-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
 
     To build the EVSE example
 
-          $ gn gen out/debug
-          $ ninja -C out/debug
+            $ gn gen out/debug
+            $ ninja -C out/debug
 
     To build the Water Heater example you can change the args to gn gen (see
     BUILD.gn for arg options)
 
-          $ gn gen out/debug --args='sl_enable_example_evse_device=false sl_enable_example_water_heater_device=true'
-          $ ninja -C out/debug
+            $ gn gen out/debug --args='sl_enable_example_evse_device=false sl_enable_example_water_heater_device=true'
+            $ ninja -C out/debug
 
     To change Device Energy Management feature support (e.g. Power forecast or
     State forecast reporting), you can change the args to gn gen (see BUILD.gn
     for arg options)
 
-          $ gn gen out/debug --args='sl_dem_support_state_forecast_reporting=true sl_dem_support_power_forecast_reporting=false'
-          $ ninja -C out/debug
+            $ gn gen out/debug --args='sl_dem_support_state_forecast_reporting=true sl_dem_support_power_forecast_reporting=false'
+            $ ninja -C out/debug
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/energy-management-app/silabs
-          $ rm -rf out/
+            $ cd ~/connectedhomeip/examples/energy-management-app/silabs
+            $ rm -rf out/
 
-* Build the example as Intermittently Connected Device (ICD)
+*   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/energy-management-app/silabs/ ./out/energy-management-app_ICD BRD4187C --icd
+            $ ./scripts/examples/gn_silabs_example.sh ./examples/energy-management-app/silabs/ ./out/energy-management-app_ICD BRD4187C --icd
 
-* Build the example with pigweed RPC
+*   Build the example with pigweed RPC
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/energy-management-app/silabs/ out/energy_management_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+            $ ./scripts/examples/gn_silabs_example.sh examples/energy-management-app/silabs/ out/energy_management_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/energy-management-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/energy-management-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+            $ ninja -C out/debug
 
     [Running Pigweed RPC console](#running-rpc-console)
 
@@ -149,12 +153,12 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          $ cd ~/connectedhomeip/examples/energy-management-app/silabs
-          $ python3 out/debug/matter-silabs-energy-management-example.flash.py
+            $ cd ~/connectedhomeip/examples/energy-management-app/silabs
+            $ python3 out/debug/matter-silabs-energy-management-example.flash.py
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -176,39 +180,39 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          $ sudo usermod -a -G dialout ${USER}
+            $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG12 use:
 
-          $ JLinkExe -device EFR32MG12PXXXF1024 -if JTAG -speed 4000 -autoconnect 1
+            $ JLinkExe -device EFR32MG12PXXXF1024 -if JTAG -speed 4000 -autoconnect 1
 
     For MG21 use:
 
-          $ JLinkExe -device EFR32MG21AXXXF1024 -if SWD -speed 4000 -autoconnect 1
+            $ JLinkExe -device EFR32MG21AXXXF1024 -if SWD -speed 4000 -autoconnect 1
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          $ JLinkRTTClient
+            $ JLinkRTTClient
 
 ### Console Log
 
@@ -223,9 +227,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -236,94 +240,96 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0** shows the overall state of the device and its connectivity. The
     following states are possible:
 
-        -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+          -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-        -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+          -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-        -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+          -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-        -   _Solid On_ ; The device is fully provisioned and has full Thread
-            network and service connectivity.
+          -   _Solid On_ ; The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **Push Button 0**
 
-        -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
-            for 30 seconds. The device will then switch to a slower interval advertisement.
-            After 15 minutes, the advertisement stops.
-            Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
+          -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
+              for 30 seconds. The device will then switch to a slower interval advertisement.
+              After 15 minutes, the advertisement stops.
+              Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
 
-        -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
-* You can provision and control the Chip device using the python controller,
-  Chip tool standalone, Android or iOS app
+*   You can provision and control the Chip device using the python controller,
+    Chip tool standalone, Android or iOS app
 
-* You can provision and control the Chip device using the python controller,
-  Chip tool standalone, Android or iOS app
+*   You can provision and control the Chip device using the python controller,
+    Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
     Here is an example with the chip-tool:
 
-          $ chip-tool pairing ble-thread 1 hex:<operationalDataset> 20202021 3840
+            $ chip-tool pairing ble-thread 1 hex:<operationalDataset> 20202021 3840
 
 ### Notes
 
-- Depending on your network settings your router might not provide native ipv6
-  addresses to your devices (Border router / PC). If this is the case, you need
-  to add a static ipv6 addresses on both device and then an ipv6 route to the
-  border router on your PC
-    - On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
+-   Depending on your network settings your router might not provide native ipv6
+    addresses to your devices (Border router / PC). If this is the case, you
+    need to add a static ipv6 addresses on both device and then an ipv6 route to
+    the border router on your PC
 
-    - On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
+    -   On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
 
-    - Add Ipv6 route on PC(Linux)
-      `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
+    -   On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
+
+    -   Add Ipv6 route on PC(Linux)
+        `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
 
 ## Running RPC console
 
-- As part of building the example with RPCs enabled the chip_rpc python
-  interactive console is installed into your venv. The python wheel files are
-  also created in the output folder: out/debug/chip_rpc_console_wheels. To
-  install the wheel files without rebuilding:
-  `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
+-   As part of building the example with RPCs enabled the chip_rpc python
+    interactive console is installed into your venv. The python wheel files are
+    also created in the output folder: out/debug/chip_rpc_console_wheels. To
+    install the wheel files without rebuilding:
+    `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
-- To use the chip-rpc console after it has been installed run:
-  `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
+-   To use the chip-rpc console after it has been installed run:
+    `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
-- Then you can simulate a button press or release using the following command
-  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-  RELEASE Test toggling the LED with
-  `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
+-   Then you can simulate a button press or release using the following command
+    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+    RELEASE Test toggling the LED with
+    `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 
 ## Device Tracing
 

--- a/examples/energy-management-app/silabs/README.md
+++ b/examples/energy-management-app/silabs/README.md
@@ -4,25 +4,27 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 
 <hr>
 
--   [Matter EFR32 Energy Management Example](#matter-efr32-energy-management-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Device Tracing](#device-tracing)
-    -   [Memory settings](#memory-settings)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Group Communication (Multicast)](#group-communication-multicast)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter EFR32 Energy Management Example](#matter-efr32-energy-management-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Notes](#notes)
+  - [Running RPC console](#running-rpc-console)
+  - [Device Tracing](#device-tracing)
+  - [Memory settings](#memory-settings)
+  - [OTA Software Update](#ota-software-update)
+  - [Group Communication (Multicast)](#group-communication-multicast)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -30,7 +32,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -71,8 +73,8 @@ creating real products based on the Silicon Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
 
@@ -159,9 +161,8 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 ## Viewing Logging Output
 

--- a/examples/energy-management-app/silabs/README.md
+++ b/examples/energy-management-app/silabs/README.md
@@ -5,26 +5,26 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
 <hr>
 
 - [Matter EFR32 Energy Management Example](#matter-efr32-energy-management-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Notes](#notes)
-  - [Running RPC console](#running-rpc-console)
-  - [Device Tracing](#device-tracing)
-  - [Memory settings](#memory-settings)
-  - [OTA Software Update](#ota-software-update)
-  - [Group Communication (Multicast)](#group-communication-multicast)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Introduction](#introduction)
+    - [Building](#building)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT](#segger-rtt)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Notes](#notes)
+    - [Running RPC console](#running-rpc-console)
+    - [Device Tracing](#device-tracing)
+    - [Memory settings](#memory-settings)
+    - [OTA Software Update](#ota-software-update)
+    - [Group Communication (Multicast)](#group-communication-multicast)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling LCD](#disabling-lcd)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -55,44 +55,40 @@ creating real products based on the Silicon Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain:
-    [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
+- Download and install a suitable ARM gcc tool chain:
+  [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
 
--   Install some additional tools (likely already present for CHIP developers):
+- Install some additional tools (likely already present for CHIP developers):
+    - Linux: `sudo apt-get install git ninja-build`
 
-    -   Linux: `sudo apt-get install git ninja-build`
+    - Mac OS X: `brew install ninja`
 
-    -   Mac OS X: `brew install ninja`
-
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     MG24 boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD2703A / MG24 Explorer Kit
+    - BRD2704A / SparkFun Thing Plus MGM240P board
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD2703A / MG24 Explorer Kit
-    -   BRD2704A / SparkFun Thing Plus MGM240P board
-
-*   Build the example application:
+* Build the example application:
 
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/energy-management-app/silabs/ ./out/energy-management-app BRD4187C
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
@@ -122,16 +118,16 @@ creating real products based on the Silicon Labs platform.
           $ gn gen out/debug --args='sl_dem_support_state_forecast_reporting=true sl_dem_support_power_forecast_reporting=false'
           $ ninja -C out/debug
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip/examples/energy-management-app/silabs
           $ rm -rf out/
 
-*   Build the example as Intermittently Connected Device (ICD)
+* Build the example as Intermittently Connected Device (ICD)
 
           $ ./scripts/examples/gn_silabs_example.sh ./examples/energy-management-app/silabs/ ./out/energy-management-app_ICD BRD4187C --icd
 
-*   Build the example with pigweed RPC
+* Build the example with pigweed RPC
 
           $ ./scripts/examples/gn_silabs_example.sh examples/energy-management-app/silabs/ out/energy_management_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
@@ -153,12 +149,12 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           $ cd ~/connectedhomeip/examples/energy-management-app/silabs
           $ python3 out/debug/matter-silabs-energy-management-example.flash.py
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -180,27 +176,27 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG12 use:
 
@@ -210,7 +206,7 @@ combination with JLinkRTTClient as follows:
 
           $ JLinkExe -device EFR32MG21AXXXF1024 -if SWD -speed 4000 -autoconnect 1
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
 
@@ -227,9 +223,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -240,18 +236,17 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.
@@ -289,11 +284,11 @@ With any serial terminal application such as screen, putty, minicom etc.
             procedure. **LEDs** blink in unison when the factory reset procedure is
             initiated.
 
-*   You can provision and control the Chip device using the python controller,
-    Chip tool standalone, Android or iOS app
+* You can provision and control the Chip device using the python controller,
+  Chip tool standalone, Android or iOS app
 
-*   You can provision and control the Chip device using the python controller,
-    Chip tool standalone, Android or iOS app
+* You can provision and control the Chip device using the python controller,
+  Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
@@ -303,33 +298,32 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
--   Depending on your network settings your router might not provide native ipv6
-    addresses to your devices (Border router / PC). If this is the case, you
-    need to add a static ipv6 addresses on both device and then an ipv6 route to
-    the border router on your PC
+- Depending on your network settings your router might not provide native ipv6
+  addresses to your devices (Border router / PC). If this is the case, you need
+  to add a static ipv6 addresses on both device and then an ipv6 route to the
+  border router on your PC
+    - On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
 
-    -   On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
+    - On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
 
-    -   On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
-
-    -   Add Ipv6 route on PC(Linux)
-        `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
+    - Add Ipv6 route on PC(Linux)
+      `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
 
 ## Running RPC console
 
--   As part of building the example with RPCs enabled the chip_rpc python
-    interactive console is installed into your venv. The python wheel files are
-    also created in the output folder: out/debug/chip_rpc_console_wheels. To
-    install the wheel files without rebuilding:
-    `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
+- As part of building the example with RPCs enabled the chip_rpc python
+  interactive console is installed into your venv. The python wheel files are
+  also created in the output folder: out/debug/chip_rpc_console_wheels. To
+  install the wheel files without rebuilding:
+  `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
--   To use the chip-rpc console after it has been installed run:
-    `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
+- To use the chip-rpc console after it has been installed run:
+  `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
--   Then you can simulate a button press or release using the following command
-    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-    RELEASE Test toggling the LED with
-    `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
+- Then you can simulate a button press or release using the following command
+  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+  RELEASE Test toggling the LED with
+  `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 
 ## Device Tracing
 

--- a/examples/light-switch-app/silabs/README.md
+++ b/examples/light-switch-app/silabs/README.md
@@ -4,27 +4,29 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
--   [Matter EFR32 Light Switch Example](#matter-efr32-light-switch-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-        -   [Linux](#linux)
-        -   [Mac OS X](#mac-os-x)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-            -   [On Border Router:](#on-border-router)
-            -   [On PC(Linux):](#on-pclinux)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Memory settings](#memory-settings)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter EFR32 Light Switch Example](#matter-efr32-light-switch-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+      - [Linux](#linux)
+      - [Mac OS X](#mac-os-x)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Notes](#notes)
+      - [On Border Router:](#on-border-router)
+      - [On PC(Linux):](#on-pclinux)
+  - [Running RPC console](#running-rpc-console)
+  - [Memory settings](#memory-settings)
+  - [OTA Software Update](#ota-software-update)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -32,7 +34,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -78,8 +80,8 @@ Silicon Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
 
@@ -161,9 +163,8 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases).
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 -   On the command line:
 

--- a/examples/light-switch-app/silabs/README.md
+++ b/examples/light-switch-app/silabs/README.md
@@ -34,7 +34,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/light-switch-app/silabs/README.md
+++ b/examples/light-switch-app/silabs/README.md
@@ -5,28 +5,28 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 <hr>
 
 - [Matter EFR32 Light Switch Example](#matter-efr32-light-switch-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-      - [Linux](#linux)
-      - [Mac OS X](#mac-os-x)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Notes](#notes)
-      - [On Border Router:](#on-border-router)
-      - [On PC(Linux):](#on-pclinux)
-  - [Running RPC console](#running-rpc-console)
-  - [Memory settings](#memory-settings)
-  - [OTA Software Update](#ota-software-update)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Introduction](#introduction)
+    - [Building](#building)
+        - [Linux](#linux)
+        - [Mac OS X](#mac-os-x)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT](#segger-rtt)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Notes](#notes)
+            - [On Border Router:](#on-border-router)
+            - [On PC(Linux):](#on-pclinux)
+    - [Running RPC console](#running-rpc-console)
+    - [Memory settings](#memory-settings)
+    - [OTA Software Update](#ota-software-update)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling LCD](#disabling-lcd)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -57,17 +57,16 @@ Silicon Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain (For most Host, the
-    bootstrap already installs the toolchain):
-    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+- Download and install a suitable ARM gcc tool chain (For most Host, the
+  bootstrap already installs the toolchain):
+  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
--   Install some additional tools(likely already present for CHIP developers):
+- Install some additional tools(likely already present for CHIP developers):
 
 #### Linux
 
@@ -77,34 +76,31 @@ Silicon Labs platform.
 
     $ brew install ninja
 
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     MG24 boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+* Region code Setting (917 WiFi projects)
+    - In Wifi configurations, the region code can be set in this
+      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+      The available region codes can be found
+      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-*   Region code Setting (917 WiFi projects)
-
-    -   In Wifi configurations, the region code can be set in this
-        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-        The available region codes can be found
-        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
-
-*   Build the example application:
+* Build the example application:
 
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/ ./out/light-switch-app BRD4187C
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
@@ -118,16 +114,16 @@ Silicon Labs platform.
           $ gn gen out/debug
           $ ninja -C out/debug
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip/examples/light-switch-app/silabs
           $ rm -rf out/
 
-*   Build the example with Matter shell
+* Build the example with Matter shell
 
           ./scripts/examples/gn_silabs_example.sh examples/light-switch-app/silabs/ out/light-switch-app BRD4187C chip_build_libshell=true
 
-*   Build the example as Intermittently Connected Device (ICD)
+* Build the example as Intermittently Connected Device (ICD)
 
           $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/ ./out/light-switch-app_ICD BRD4187C --icd
 
@@ -135,7 +131,7 @@ Silicon Labs platform.
 
           $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
 
-*   Build the example with pigweed RCP
+* Build the example with pigweed RCP
 
           $ ./scripts/examples/gn_silabs_example.sh examples/light-switch-app/silabs/ out/light-switch-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
@@ -155,18 +151,18 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           $ cd ~/connectedhomeip/examples/light-switch-app/silabs
           $ python3 out/debug/matter-silabs-light-switch-example.flash.py
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
 [Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
--   On the command line:
+- On the command line:
 
           $ commander flash bootloader_binaries/bootloader-storage-internal-single-512k-BRD4187C-gsdk4.1.s37
 
@@ -186,27 +182,27 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
@@ -214,7 +210,7 @@ combination with JLinkRTTClient as follows:
           $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
           ```
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
 
@@ -231,9 +227,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -244,23 +240,22 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   For this example to work, it is necessary to have a second efr32 device
-    running the
-    [lighting app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/lighting-app/silabs/README.md)
-    commissioned on the same openthread network
+- For this example to work, it is necessary to have a second efr32 device
+  running the
+  [lighting app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/lighting-app/silabs/README.md)
+  commissioned on the same openthread network
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.
@@ -327,9 +322,9 @@ With any serial terminal application such as screen, putty, minicom etc.
         - 'switch binding unicast  <fabric index> <node id> <endpoint>' : Creates a unicast binding
         - 'switch binding group <fabric index> <group id>'              : Creates a group binding
 
-*   You can provision and control the Chip device using the python controller,
-    [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
-    standalone, Android or iOS app
+* You can provision and control the Chip device using the python controller,
+  [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
+  standalone, Android or iOS app
 
     Here is an example with the CHIPTool for unicast commands only:
 
@@ -369,10 +364,10 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
--   Depending on your network settings your router might not provide native ipv6
-    addresses to your devices (Border router / PC). If this is the case, you
-    need to add a static ipv6 addresses on both device and then an ipv6 route to
-    the border router on your PC
+- Depending on your network settings your router might not provide native ipv6
+  addresses to your devices (Border router / PC). If this is the case, you need
+  to add a static ipv6 addresses on both device and then an ipv6 route to the
+  border router on your PC
 
 #### On Border Router:
 
@@ -387,24 +382,24 @@ via 2002::2
 
 ## Running RPC console
 
--   As part of building the example with RPCs enabled the chip_rpc python
-    interactive console is installed into your venv. The python wheel files are
-    also created in the output folder: out/debug/chip_rpc_console_wheels. To
-    install the wheel files without rebuilding:
+- As part of building the example with RPCs enabled the chip_rpc python
+  interactive console is installed into your venv. The python wheel files are
+  also created in the output folder: out/debug/chip_rpc_console_wheels. To
+  install the wheel files without rebuilding:
 
     `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
--   To use the chip-rpc console after it has been installed run:
+- To use the chip-rpc console after it has been installed run:
 
     `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
--   Then you can simulate a button press or release using the following command
-    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-    RELEASE Test toggling the LED with
+- Then you can simulate a button press or release using the following command
+  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+  RELEASE Test toggling the LED with
 
     `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 
--   You can also Get and Set the light directly using the RPCs:
+- You can also Get and Set the light directly using the RPCs:
 
     `rpcs.chip.rpc.Lighting.Get()`
 

--- a/examples/light-switch-app/silabs/README.md
+++ b/examples/light-switch-app/silabs/README.md
@@ -4,29 +4,29 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
-- [Matter EFR32 Light Switch Example](#matter-efr32-light-switch-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-        - [Linux](#linux)
-        - [Mac OS X](#mac-os-x)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT](#segger-rtt)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Notes](#notes)
-            - [On Border Router:](#on-border-router)
-            - [On PC(Linux):](#on-pclinux)
-    - [Running RPC console](#running-rpc-console)
-    - [Memory settings](#memory-settings)
-    - [OTA Software Update](#ota-software-update)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling LCD](#disabling-lcd)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter EFR32 Light Switch Example](#matter-efr32-light-switch-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+        -   [Linux](#linux)
+        -   [Mac OS X](#mac-os-x)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Notes](#notes)
+            -   [On Border Router:](#on-border-router)
+            -   [On PC(Linux):](#on-pclinux)
+    -   [Running RPC console](#running-rpc-console)
+    -   [Memory settings](#memory-settings)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -57,16 +57,17 @@ Silicon Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain (For most Host, the
-  bootstrap already installs the toolchain):
-  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+-   Download and install a suitable ARM gcc tool chain (For most Host, the
+    bootstrap already installs the toolchain):
+    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
-- Install some additional tools(likely already present for CHIP developers):
+-   Install some additional tools(likely already present for CHIP developers):
 
 #### Linux
 
@@ -76,73 +77,76 @@ Silicon Labs platform.
 
     $ brew install ninja
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Region code Setting (917 WiFi projects)
-    - In Wifi configurations, the region code can be set in this
-      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-      The available region codes can be found
-      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Build the example application:
+*   Region code Setting (917 WiFi projects)
 
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/ ./out/light-switch-app BRD4187C
+    -   In Wifi configurations, the region code can be set in this
+        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+        The available region codes can be found
+        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-- To delete generated executable, libraries and object files use:
+*   Build the example application:
 
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/ ./out/light-switch-app BRD4187C
+
+-   To delete generated executable, libraries and object files use:
+
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/light-switch-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/light-switch-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug
+            $ ninja -C out/debug
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/light-switch-app/silabs
-          $ rm -rf out/
+            $ cd ~/connectedhomeip/examples/light-switch-app/silabs
+            $ rm -rf out/
 
-* Build the example with Matter shell
+*   Build the example with Matter shell
 
-          ./scripts/examples/gn_silabs_example.sh examples/light-switch-app/silabs/ out/light-switch-app BRD4187C chip_build_libshell=true
+            ./scripts/examples/gn_silabs_example.sh examples/light-switch-app/silabs/ out/light-switch-app BRD4187C chip_build_libshell=true
 
-* Build the example as Intermittently Connected Device (ICD)
+*   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/ ./out/light-switch-app_ICD BRD4187C --icd
+            $ ./scripts/examples/gn_silabs_example.sh ./examples/light-switch-app/silabs/ ./out/light-switch-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
+            $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
 
-* Build the example with pigweed RCP
+*   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/light-switch-app/silabs/ out/light-switch-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+            $ ./scripts/examples/gn_silabs_example.sh examples/light-switch-app/silabs/ out/light-switch-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/light-switch-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/light-switch-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+            $ ninja -C out/debug
 
 For more build options, help is provided when running the build script without
 arguments
@@ -151,20 +155,20 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          $ cd ~/connectedhomeip/examples/light-switch-app/silabs
-          $ python3 out/debug/matter-silabs-light-switch-example.flash.py
+            $ cd ~/connectedhomeip/examples/light-switch-app/silabs
+            $ python3 out/debug/matter-silabs-light-switch-example.flash.py
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
 [Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
-- On the command line:
+-   On the command line:
 
-          $ commander flash bootloader_binaries/bootloader-storage-internal-single-512k-BRD4187C-gsdk4.1.s37
+            $ commander flash bootloader_binaries/bootloader-storage-internal-single-512k-BRD4187C-gsdk4.1.s37
 
 ## Viewing Logging Output
 
@@ -182,37 +186,37 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          $ sudo usermod -a -G dialout ${USER}
+            $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
-          ```
-          $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
-          ```
+            ```
+            $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
+            ```
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          $ JLinkRTTClient
+            $ JLinkRTTClient
 
 ### Console Log
 
@@ -227,9 +231,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -240,91 +244,92 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- For this example to work, it is necessary to have a second efr32 device
-  running the
-  [lighting app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/lighting-app/silabs/README.md)
-  commissioned on the same openthread network
+-   For this example to work, it is necessary to have a second efr32 device
+    running the
+    [lighting app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/lighting-app/silabs/README.md)
+    commissioned on the same openthread network
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0**
 
-        -   ICD Configuration (Default) - LED is only active under two circumstances:
+          -   ICD Configuration (Default) - LED is only active under two circumstances:
 
-            1. Factory reset sequence - LED will blink when initiated upon press and hold of
-            Button 0 after 3 seconds
-            2. An Identify command was received
+              1. Factory reset sequence - LED will blink when initiated upon press and hold of
+              Button 0 after 3 seconds
+              2. An Identify command was received
 
-        -   Non-ICD Configuration - shows the overall state of the device and its connectivity. The
-            following states are possible:
+          -   Non-ICD Configuration - shows the overall state of the device and its connectivity. The
+              following states are possible:
 
-            Short Flash On (50 ms on/950 ms off): The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+              Short Flash On (50 ms on/950 ms off): The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-            Rapid Even Flashing (100 ms on/100 ms off): The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+              Rapid Even Flashing (100 ms on/100 ms off): The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-            Short Flash Off (950ms on/50ms off): The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+              Short Flash Off (950ms on/50ms off): The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-            Solid On: The device is fully provisioned and has full Thread
-            network and service connectivity.
+              Solid On: The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **Push Button 0**
 
-        -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
-            for 30 seconds. The device will then switch to a slower interval advertisement.
-            After 15 minutes, the advertisement stops.
-            Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
+          -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
+              for 30 seconds. The device will then switch to a slower interval advertisement.
+              After 15 minutes, the advertisement stops.
+              Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
 
-        -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
     **Push Button 1**
 
-        -   Sends a Toggle command to bound light app
+          -   Sends a Toggle command to bound light app
 
     **Matter shell**
 
     **_OnOff Cluster_**
 
-        -  'switch onoff on'            : Sends unicast On command to bound device
-        -  'switch onoff off'           : Sends unicast Off command to bound device
-        -  'switch onoff toggle'        : Sends unicast Toggle command to bound device
+          -  'switch onoff on'            : Sends unicast On command to bound device
+          -  'switch onoff off'           : Sends unicast Off command to bound device
+          -  'switch onoff toggle'        : Sends unicast Toggle command to bound device
 
-        -  'switch groups onoff on'     : Sends On group command to bound group
-        -  'switch groups onoff off'    : Sends On group command to bound group
-        -  'switch groups onoff toggle' : Sends On group command to bound group
+          -  'switch groups onoff on'     : Sends On group command to bound group
+          -  'switch groups onoff off'    : Sends On group command to bound group
+          -  'switch groups onoff toggle' : Sends On group command to bound group
 
     **_Binding Cluster_**
 
-        - 'switch binding unicast  <fabric index> <node id> <endpoint>' : Creates a unicast binding
-        - 'switch binding group <fabric index> <group id>'              : Creates a group binding
+          - 'switch binding unicast  <fabric index> <node id> <endpoint>' : Creates a unicast binding
+          - 'switch binding group <fabric index> <group id>'              : Creates a group binding
 
-* You can provision and control the Chip device using the python controller,
-  [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
-  standalone, Android or iOS app
+*   You can provision and control the Chip device using the python controller,
+    [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
+    standalone, Android or iOS app
 
     Here is an example with the CHIPTool for unicast commands only:
 
@@ -364,10 +369,10 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
-- Depending on your network settings your router might not provide native ipv6
-  addresses to your devices (Border router / PC). If this is the case, you need
-  to add a static ipv6 addresses on both device and then an ipv6 route to the
-  border router on your PC
+-   Depending on your network settings your router might not provide native ipv6
+    addresses to your devices (Border router / PC). If this is the case, you
+    need to add a static ipv6 addresses on both device and then an ipv6 route to
+    the border router on your PC
 
 #### On Border Router:
 
@@ -382,24 +387,24 @@ via 2002::2
 
 ## Running RPC console
 
-- As part of building the example with RPCs enabled the chip_rpc python
-  interactive console is installed into your venv. The python wheel files are
-  also created in the output folder: out/debug/chip_rpc_console_wheels. To
-  install the wheel files without rebuilding:
+-   As part of building the example with RPCs enabled the chip_rpc python
+    interactive console is installed into your venv. The python wheel files are
+    also created in the output folder: out/debug/chip_rpc_console_wheels. To
+    install the wheel files without rebuilding:
 
     `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
-- To use the chip-rpc console after it has been installed run:
+-   To use the chip-rpc console after it has been installed run:
 
     `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
-- Then you can simulate a button press or release using the following command
-  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-  RELEASE Test toggling the LED with
+-   Then you can simulate a button press or release using the following command
+    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+    RELEASE Test toggling the LED with
 
     `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 
-- You can also Get and Set the light directly using the RPCs:
+-   You can also Get and Set the light directly using the RPCs:
 
     `rpcs.chip.rpc.Lighting.Get()`
 

--- a/examples/lighting-app/silabs/README.md
+++ b/examples/lighting-app/silabs/README.md
@@ -4,25 +4,27 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
--   [Matter EFR32 Lighting Example](#matter-efr32-lighting-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt-recommended)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Device Tracing](#device-tracing)
-    -   [Memory settings](#memory-settings)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Group Communication (Multicast)](#group-communication-multicast)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter EFR32 Lighting Example](#matter-efr32-lighting-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT (recommended)](#segger-rtt-recommended)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Notes](#notes)
+  - [Running RPC console](#running-rpc-console)
+  - [Device Tracing](#device-tracing)
+  - [Memory settings](#memory-settings)
+  - [OTA Software Update](#ota-software-update)
+  - [Group Communication (Multicast)](#group-communication-multicast)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -30,7 +32,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -72,8 +74,8 @@ Silicon Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
 
@@ -155,9 +157,8 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 ## Viewing Logging Output
 

--- a/examples/lighting-app/silabs/README.md
+++ b/examples/lighting-app/silabs/README.md
@@ -32,7 +32,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/lighting-app/silabs/README.md
+++ b/examples/lighting-app/silabs/README.md
@@ -4,27 +4,27 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
-- [Matter EFR32 Lighting Example](#matter-efr32-lighting-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT (recommended)](#segger-rtt-recommended)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Notes](#notes)
-    - [Running RPC console](#running-rpc-console)
-    - [Device Tracing](#device-tracing)
-    - [Memory settings](#memory-settings)
-    - [OTA Software Update](#ota-software-update)
-    - [Group Communication (Multicast)](#group-communication-multicast)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling LCD](#disabling-lcd)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter EFR32 Lighting Example](#matter-efr32-lighting-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT (recommended)](#segger-rtt-recommended)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Notes](#notes)
+    -   [Running RPC console](#running-rpc-console)
+    -   [Device Tracing](#device-tracing)
+    -   [Memory settings](#memory-settings)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Group Communication (Multicast)](#group-communication-multicast)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -55,85 +55,90 @@ Silicon Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain (For most Host, the
-  bootstrap already installs the toolchain):
-  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+-   Download and install a suitable ARM gcc tool chain (For most Host, the
+    bootstrap already installs the toolchain):
+    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
-- Install some additional tools (likely already present for CHIP developers):
-    - Linux: `sudo apt-get install git ninja-build`
+-   Install some additional tools (likely already present for CHIP developers):
 
-    - Mac OS X: `brew install ninja`
+    -   Linux: `sudo apt-get install git ninja-build`
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+    -   Mac OS X: `brew install ninja`
+
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD2703A / MG24 Explorer Kit
-    - BRD2704A / SparkFun Thing Plus MGM240P board
 
-* Region code Setting (917 WiFi projects)
-    - In Wifi configurations, the region code can be set in this
-      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-      The available region codes can be found
-      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD2703A / MG24 Explorer Kit
+    -   BRD2704A / SparkFun Thing Plus MGM240P board
 
-* Build the example application:
+*   Region code Setting (917 WiFi projects)
 
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/ ./out/lighting-app BRD4187C
+    -   In Wifi configurations, the region code can be set in this
+        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+        The available region codes can be found
+        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-- To delete generated executable, libraries and object files use:
+*   Build the example application:
 
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/ ./out/lighting-app BRD4187C
+
+-   To delete generated executable, libraries and object files use:
+
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/lighting-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/lighting-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug
+            $ ninja -C out/debug
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/lighting-app/silabs
-          $ rm -rf out/
+            $ cd ~/connectedhomeip/examples/lighting-app/silabs
+            $ rm -rf out/
 
-* Build the example as Intermittently Connected Device (ICD)
+*   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/ ./out/lighting-app_ICD BRD4187C --icd
+            $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/ ./out/lighting-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
+            $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
-* Build the example with pigweed RPC
+*   Build the example with pigweed RPC
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs/ out/lighting_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+            $ ./scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs/ out/lighting_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/lighting-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/lighting-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+            $ ninja -C out/debug
 
     [Running Pigweed RPC console](#running-rpc-console)
 
@@ -144,12 +149,12 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          $ cd ~/connectedhomeip/examples/lighting-app/silabs
-          $ python3 out/debug/matter-silabs-lighting-example.flash.py
+            $ cd ~/connectedhomeip/examples/lighting-app/silabs
+            $ python3 out/debug/matter-silabs-lighting-example.flash.py
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -171,37 +176,37 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          $ sudo usermod -a -G dialout ${USER}
+            $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
-          ```
-          $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
-          ```
+            ```
+            $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
+            ```
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          $ JLinkRTTClient
+            $ JLinkRTTClient
 
 ### Console Log
 
@@ -216,9 +221,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -229,105 +234,107 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0** shows the overall state of the device and its connectivity. The
     following states are possible:
 
-        -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+          -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-        -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+          -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-        -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+          -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-        -   _Solid On_ ; The device is fully provisioned and has full Thread
-            network and service connectivity.
+          -   _Solid On_ ; The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **LED 1** Simulates the Light The following states are possible:
 
-        -   _Solid On_ ; Light is on
-        -   _Off_ ; Light is off
+          -   _Solid On_ ; Light is on
+          -   _Off_ ; Light is off
 
     **Push Button 0**
 
-        -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
-            for 30 seconds. The device will then switch to a slower interval advertisement.
-            After 15 minutes, the advertisement stops.
-            Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
+          -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
+              for 30 seconds. The device will then switch to a slower interval advertisement.
+              After 15 minutes, the advertisement stops.
+              Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
 
-        -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
     **Push Button 1** Toggles the light state On/Off
 
-* You can provision and control the Chip device using the python controller,
-  Chip tool standalone, Android or iOS app
+*   You can provision and control the Chip device using the python controller,
+    Chip tool standalone, Android or iOS app
 
-* You can provision and control the Chip device using the python controller,
-  Chip tool standalone, Android or iOS app
+*   You can provision and control the Chip device using the python controller,
+    Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
     Here is an example with the chip-tool:
 
-          $ chip-tool pairing ble-thread 1 hex:<operationalDataset> 20202021 3840
-          $ chip-tool onoff on 1 1
+            $ chip-tool pairing ble-thread 1 hex:<operationalDataset> 20202021 3840
+            $ chip-tool onoff on 1 1
 
 ### Notes
 
-- Depending on your network settings your router might not provide native ipv6
-  addresses to your devices (Border router / PC). If this is the case, you need
-  to add a static ipv6 addresses on both device and then an ipv6 route to the
-  border router on your PC
-    - On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
+-   Depending on your network settings your router might not provide native ipv6
+    addresses to your devices (Border router / PC). If this is the case, you
+    need to add a static ipv6 addresses on both device and then an ipv6 route to
+    the border router on your PC
 
-    - On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
+    -   On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
 
-    - Add Ipv6 route on PC(Linux)
-      `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
+    -   On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
+
+    -   Add Ipv6 route on PC(Linux)
+        `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
 
 ## Running RPC console
 
-- As part of building the example with RPCs enabled the chip_rpc python
-  interactive console is installed into your venv. The python wheel files are
-  also created in the output folder: out/debug/chip_rpc_console_wheels. To
-  install the wheel files without rebuilding:
-  `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
+-   As part of building the example with RPCs enabled the chip_rpc python
+    interactive console is installed into your venv. The python wheel files are
+    also created in the output folder: out/debug/chip_rpc_console_wheels. To
+    install the wheel files without rebuilding:
+    `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
-- To use the chip-rpc console after it has been installed run:
-  `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
+-   To use the chip-rpc console after it has been installed run:
+    `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
-- Then you can simulate a button press or release using the following command
-  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-  RELEASE Test toggling the LED with
-  `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
+-   Then you can simulate a button press or release using the following command
+    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+    RELEASE Test toggling the LED with
+    `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 
-- You can also Get and Set the light directly using the RPCs:
-  `rpcs.chip.rpc.Lighting.Get()`
+-   You can also Get and Set the light directly using the RPCs:
+    `rpcs.chip.rpc.Lighting.Get()`
 
     `rpcs.chip.rpc.Lighting.Set(on=True, level=128, color=protos.chip.rpc.LightingColor(hue=5, saturation=5))`
 

--- a/examples/lighting-app/silabs/README.md
+++ b/examples/lighting-app/silabs/README.md
@@ -5,26 +5,26 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 <hr>
 
 - [Matter EFR32 Lighting Example](#matter-efr32-lighting-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT (recommended)](#segger-rtt-recommended)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Notes](#notes)
-  - [Running RPC console](#running-rpc-console)
-  - [Device Tracing](#device-tracing)
-  - [Memory settings](#memory-settings)
-  - [OTA Software Update](#ota-software-update)
-  - [Group Communication (Multicast)](#group-communication-multicast)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Introduction](#introduction)
+    - [Building](#building)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT (recommended)](#segger-rtt-recommended)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Notes](#notes)
+    - [Running RPC console](#running-rpc-console)
+    - [Device Tracing](#device-tracing)
+    - [Memory settings](#memory-settings)
+    - [OTA Software Update](#ota-software-update)
+    - [Group Communication (Multicast)](#group-communication-multicast)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling LCD](#disabling-lcd)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -55,52 +55,47 @@ Silicon Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain (For most Host, the
-    bootstrap already installs the toolchain):
-    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+- Download and install a suitable ARM gcc tool chain (For most Host, the
+  bootstrap already installs the toolchain):
+  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
--   Install some additional tools (likely already present for CHIP developers):
+- Install some additional tools (likely already present for CHIP developers):
+    - Linux: `sudo apt-get install git ninja-build`
 
-    -   Linux: `sudo apt-get install git ninja-build`
+    - Mac OS X: `brew install ninja`
 
-    -   Mac OS X: `brew install ninja`
-
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     MG24 boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD2703A / MG24 Explorer Kit
+    - BRD2704A / SparkFun Thing Plus MGM240P board
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD2703A / MG24 Explorer Kit
-    -   BRD2704A / SparkFun Thing Plus MGM240P board
+* Region code Setting (917 WiFi projects)
+    - In Wifi configurations, the region code can be set in this
+      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+      The available region codes can be found
+      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-*   Region code Setting (917 WiFi projects)
-
-    -   In Wifi configurations, the region code can be set in this
-        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-        The available region codes can be found
-        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
-
-*   Build the example application:
+* Build the example application:
 
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/ ./out/lighting-app BRD4187C
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
@@ -114,12 +109,12 @@ Silicon Labs platform.
           $ gn gen out/debug
           $ ninja -C out/debug
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip/examples/lighting-app/silabs
           $ rm -rf out/
 
-*   Build the example as Intermittently Connected Device (ICD)
+* Build the example as Intermittently Connected Device (ICD)
 
           $ ./scripts/examples/gn_silabs_example.sh ./examples/lighting-app/silabs/ ./out/lighting-app_ICD BRD4187C --icd
 
@@ -127,7 +122,7 @@ Silicon Labs platform.
 
           $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
-*   Build the example with pigweed RPC
+* Build the example with pigweed RPC
 
           $ ./scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs/ out/lighting_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
@@ -149,12 +144,12 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           $ cd ~/connectedhomeip/examples/lighting-app/silabs
           $ python3 out/debug/matter-silabs-lighting-example.flash.py
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -176,27 +171,27 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
@@ -204,7 +199,7 @@ combination with JLinkRTTClient as follows:
           $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
           ```
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
 
@@ -221,9 +216,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -234,18 +229,17 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.
@@ -290,11 +284,11 @@ With any serial terminal application such as screen, putty, minicom etc.
 
     **Push Button 1** Toggles the light state On/Off
 
-*   You can provision and control the Chip device using the python controller,
-    Chip tool standalone, Android or iOS app
+* You can provision and control the Chip device using the python controller,
+  Chip tool standalone, Android or iOS app
 
-*   You can provision and control the Chip device using the python controller,
-    Chip tool standalone, Android or iOS app
+* You can provision and control the Chip device using the python controller,
+  Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
@@ -305,36 +299,35 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
--   Depending on your network settings your router might not provide native ipv6
-    addresses to your devices (Border router / PC). If this is the case, you
-    need to add a static ipv6 addresses on both device and then an ipv6 route to
-    the border router on your PC
+- Depending on your network settings your router might not provide native ipv6
+  addresses to your devices (Border router / PC). If this is the case, you need
+  to add a static ipv6 addresses on both device and then an ipv6 route to the
+  border router on your PC
+    - On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
 
-    -   On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
+    - On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
 
-    -   On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
-
-    -   Add Ipv6 route on PC(Linux)
-        `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
+    - Add Ipv6 route on PC(Linux)
+      `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
 
 ## Running RPC console
 
--   As part of building the example with RPCs enabled the chip_rpc python
-    interactive console is installed into your venv. The python wheel files are
-    also created in the output folder: out/debug/chip_rpc_console_wheels. To
-    install the wheel files without rebuilding:
-    `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
+- As part of building the example with RPCs enabled the chip_rpc python
+  interactive console is installed into your venv. The python wheel files are
+  also created in the output folder: out/debug/chip_rpc_console_wheels. To
+  install the wheel files without rebuilding:
+  `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
--   To use the chip-rpc console after it has been installed run:
-    `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
+- To use the chip-rpc console after it has been installed run:
+  `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
--   Then you can simulate a button press or release using the following command
-    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-    RELEASE Test toggling the LED with
-    `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
+- Then you can simulate a button press or release using the following command
+  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+  RELEASE Test toggling the LED with
+  `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 
--   You can also Get and Set the light directly using the RPCs:
-    `rpcs.chip.rpc.Lighting.Get()`
+- You can also Get and Set the light directly using the RPCs:
+  `rpcs.chip.rpc.Lighting.Get()`
 
     `rpcs.chip.rpc.Lighting.Set(on=True, level=128, color=protos.chip.rpc.LightingColor(hue=5, saturation=5))`
 

--- a/examples/lighting-app/silabs/zephyr/README.md
+++ b/examples/lighting-app/silabs/zephyr/README.md
@@ -257,7 +257,7 @@ platform with the standard Silicon Labs lighting example.
 
 ### Additional Resources:
 
--   [Silicon Labs Matter Documentation](https://github.com/SiliconLabs/matter)
+-   [Silicon Labs Matter Documentation](https://github.com/SiliconLabsSoftware/matter_sdk)
 -   [SiWx917 Development Kit User Guide](https://www.silabs.com/development-tools/wireless/wi-fi/siwx917-development-kit)
 -   [Matter Specification](https://csa-iot.org/all-solutions/matter/)
 -   [Zephyr RTOS Documentation](https://docs.zephyrproject.org/)

--- a/examples/lighting-app/silabs/zephyr/README.md
+++ b/examples/lighting-app/silabs/zephyr/README.md
@@ -5,19 +5,19 @@ Zephyr RTOS.
 
 <hr>
 
--   [Matter SiWx917 Lighting Example](#matter-siwx917-lighting-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Commissioning over BLE](#commissioning-over-ble)
-        -   [Testing with chip-tool](#testing-with-chip-tool)
-    -   [Building Options](#building-options)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling logging](#disabling-logging)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Limitations](#limitations)
+- [Matter SiWx917 Lighting Example](#matter-siwx917-lighting-example)
+    - [Introduction](#introduction)
+    - [Building](#building)
+    - [Flashing the Application](#flashing-the-application)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Commissioning over BLE](#commissioning-over-ble)
+        - [Testing with chip-tool](#testing-with-chip-tool)
+    - [Building Options](#building-options)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling logging](#disabling-logging)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [OTA Software Update](#ota-software-update)
+    - [Limitations](#limitations)
 
 <hr>
 
@@ -56,34 +56,31 @@ settings. Changes are automatically saved to the build configuration.
 
 ## Building
 
--   Install the required dependencies for Matter development:
+- Install the required dependencies for Matter development:
+    - [Matter Prerequisites](../../../../docs/guides/BUILDING.md)
 
-    -   [Matter Prerequisites](../../../../docs/guides/BUILDING.md)
+- Install the Silicon Labs Zephyr SDK and tools:
+    - Follow the
+      [Silicon Labs Zephyr Repo](https://github.com/SiliconLabsSoftware/zephyr-silabs)
 
--   Install the Silicon Labs Zephyr SDK and tools:
+- Supported hardware:
+    - **SiWx917 SoC boards:**
+        - BRD4338A (SiWx917 Radio Board with 2.4GHz WiFi)
 
-    -   Follow the
-        [Silicon Labs Zephyr Repo](https://github.com/SiliconLabsSoftware/zephyr-silabs)
-
--   Supported hardware:
-
-    -   **SiWx917 SoC boards:**
-        -   BRD4338A (SiWx917 Radio Board with 2.4GHz WiFi)
-
--   Build the example application:
+- Build the example application:
 
     ```bash
     cd silabs_zephyr
     west build -b siwx917_rb4338a connectedhomeip/examples/lighting-app/silabs/zephyr
     ```
 
--   To clean the build:
+- To clean the build:
 
     ```bash
     west build -t clean
     ```
 
--   For a pristine build (removes all build artifacts):
+- For a pristine build (removes all build artifacts):
 
     ```bash
     rm -rf build
@@ -97,26 +94,26 @@ settings. Changes are automatically saved to the build configuration.
 
 ## Flashing the Application
 
--   **SiWx917 SoC device support is available in the latest Simplicity
-    Commander.** The SiWx917 SOC board will support `.hex` files for flashing.
+- **SiWx917 SoC device support is available in the latest Simplicity
+  Commander.** The SiWx917 SOC board will support `.hex` files for flashing.
 
--   Flash using west:
+- Flash using west:
 
     ```bash
     west flash
     ```
 
--   Or flash using Simplicity Commander:
+- Or flash using Simplicity Commander:
 
     ```bash
     commander flash build/zephyr/zephyr.hex
     ```
 
--   **Bootloader and Connectivity Firmware:** All SiWx917 boards require
-    connectivity firmware. See Silicon Labs documentation for more info.
-    Pre-built bootloader binaries are available in the Assets section of the
-    Releases page on
-    [Wiseconnect](https://github.com/SiliconLabs/wiseconnect/tree/v3.5.0/connectivity_firmware/standard).
+- **Bootloader and Connectivity Firmware:** All SiWx917 boards require
+  connectivity firmware. See Silicon Labs documentation for more info. Pre-built
+  bootloader binaries are available in the Assets section of the Releases page
+  on
+  [Wiseconnect](https://github.com/SiliconLabs/wiseconnect/tree/v3.5.0/connectivity_firmware/standard).
 
 ## Running the Complete Example
 
@@ -130,13 +127,13 @@ using a Matter controller over BLE, then provide WiFi credentials.
 This procedure uses the chip-tool installed on the Matter Hub. The commissioning
 procedure does the following:
 
--   Chip-tool scans BLE and locates the Silicon Labs device that uses the
-    specified discriminator
--   Establishes operational certificates
--   Sends the WiFi SSID and Passkey
--   The Silicon Labs device will join the WiFi network and get an IP address
--   It then starts providing mDNS records on IPv4 and IPv6
--   Future communications (tests) will then happen over WiFi
+- Chip-tool scans BLE and locates the Silicon Labs device that uses the
+  specified discriminator
+- Establishes operational certificates
+- Sends the WiFi SSID and Passkey
+- The Silicon Labs device will join the WiFi network and get an IP address
+- It then starts providing mDNS records on IPv4 and IPv6
+- Future communications (tests) will then happen over WiFi
 
 ### Testing with chip-tool
 
@@ -178,10 +175,10 @@ Here is an example with the chip-tool:
 
 Where:
 
--   `${NODE_ID}` is the node ID assigned to the device
--   `20202021` is the setup PIN code
--   `3840` is the discriminator
--   `${SSID}` and `${PASSWORD}` are your WiFi network credentials
+- `${NODE_ID}` is the node ID assigned to the device
+- `20202021` is the setup PIN code
+- `3840` is the discriminator
+- `${SSID}` and `${PASSWORD}` are your WiFi network credentials
 
 ## Building Options
 
@@ -257,7 +254,7 @@ platform with the standard Silicon Labs lighting example.
 
 ### Additional Resources:
 
--   [Silicon Labs Matter Documentation](https://github.com/SiliconLabsSoftware/matter_sdk)
--   [SiWx917 Development Kit User Guide](https://www.silabs.com/development-tools/wireless/wi-fi/siwx917-development-kit)
--   [Matter Specification](https://csa-iot.org/all-solutions/matter/)
--   [Zephyr RTOS Documentation](https://docs.zephyrproject.org/)
+- [Silicon Labs Matter Documentation](https://github.com/SiliconLabsSoftware/matter_sdk)
+- [SiWx917 Development Kit User Guide](https://www.silabs.com/development-tools/wireless/wi-fi/siwx917-development-kit)
+- [Matter Specification](https://csa-iot.org/all-solutions/matter/)
+- [Zephyr RTOS Documentation](https://docs.zephyrproject.org/)

--- a/examples/lighting-app/silabs/zephyr/README.md
+++ b/examples/lighting-app/silabs/zephyr/README.md
@@ -5,19 +5,19 @@ Zephyr RTOS.
 
 <hr>
 
-- [Matter SiWx917 Lighting Example](#matter-siwx917-lighting-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-    - [Flashing the Application](#flashing-the-application)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Commissioning over BLE](#commissioning-over-ble)
-        - [Testing with chip-tool](#testing-with-chip-tool)
-    - [Building Options](#building-options)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling logging](#disabling-logging)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
-    - [OTA Software Update](#ota-software-update)
-    - [Limitations](#limitations)
+-   [Matter SiWx917 Lighting Example](#matter-siwx917-lighting-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Commissioning over BLE](#commissioning-over-ble)
+        -   [Testing with chip-tool](#testing-with-chip-tool)
+    -   [Building Options](#building-options)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling logging](#disabling-logging)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Limitations](#limitations)
 
 <hr>
 
@@ -56,31 +56,34 @@ settings. Changes are automatically saved to the build configuration.
 
 ## Building
 
-- Install the required dependencies for Matter development:
-    - [Matter Prerequisites](../../../../docs/guides/BUILDING.md)
+-   Install the required dependencies for Matter development:
 
-- Install the Silicon Labs Zephyr SDK and tools:
-    - Follow the
-      [Silicon Labs Zephyr Repo](https://github.com/SiliconLabsSoftware/zephyr-silabs)
+    -   [Matter Prerequisites](../../../../docs/guides/BUILDING.md)
 
-- Supported hardware:
-    - **SiWx917 SoC boards:**
-        - BRD4338A (SiWx917 Radio Board with 2.4GHz WiFi)
+-   Install the Silicon Labs Zephyr SDK and tools:
 
-- Build the example application:
+    -   Follow the
+        [Silicon Labs Zephyr Repo](https://github.com/SiliconLabsSoftware/zephyr-silabs)
+
+-   Supported hardware:
+
+    -   **SiWx917 SoC boards:**
+        -   BRD4338A (SiWx917 Radio Board with 2.4GHz WiFi)
+
+-   Build the example application:
 
     ```bash
     cd silabs_zephyr
     west build -b siwx917_rb4338a connectedhomeip/examples/lighting-app/silabs/zephyr
     ```
 
-- To clean the build:
+-   To clean the build:
 
     ```bash
     west build -t clean
     ```
 
-- For a pristine build (removes all build artifacts):
+-   For a pristine build (removes all build artifacts):
 
     ```bash
     rm -rf build
@@ -94,26 +97,26 @@ settings. Changes are automatically saved to the build configuration.
 
 ## Flashing the Application
 
-- **SiWx917 SoC device support is available in the latest Simplicity
-  Commander.** The SiWx917 SOC board will support `.hex` files for flashing.
+-   **SiWx917 SoC device support is available in the latest Simplicity
+    Commander.** The SiWx917 SOC board will support `.hex` files for flashing.
 
-- Flash using west:
+-   Flash using west:
 
     ```bash
     west flash
     ```
 
-- Or flash using Simplicity Commander:
+-   Or flash using Simplicity Commander:
 
     ```bash
     commander flash build/zephyr/zephyr.hex
     ```
 
-- **Bootloader and Connectivity Firmware:** All SiWx917 boards require
-  connectivity firmware. See Silicon Labs documentation for more info. Pre-built
-  bootloader binaries are available in the Assets section of the Releases page
-  on
-  [Wiseconnect](https://github.com/SiliconLabs/wiseconnect/tree/v3.5.0/connectivity_firmware/standard).
+-   **Bootloader and Connectivity Firmware:** All SiWx917 boards require
+    connectivity firmware. See Silicon Labs documentation for more info.
+    Pre-built bootloader binaries are available in the Assets section of the
+    Releases page on
+    [Wiseconnect](https://github.com/SiliconLabs/wiseconnect/tree/v3.5.0/connectivity_firmware/standard).
 
 ## Running the Complete Example
 
@@ -127,13 +130,13 @@ using a Matter controller over BLE, then provide WiFi credentials.
 This procedure uses the chip-tool installed on the Matter Hub. The commissioning
 procedure does the following:
 
-- Chip-tool scans BLE and locates the Silicon Labs device that uses the
-  specified discriminator
-- Establishes operational certificates
-- Sends the WiFi SSID and Passkey
-- The Silicon Labs device will join the WiFi network and get an IP address
-- It then starts providing mDNS records on IPv4 and IPv6
-- Future communications (tests) will then happen over WiFi
+-   Chip-tool scans BLE and locates the Silicon Labs device that uses the
+    specified discriminator
+-   Establishes operational certificates
+-   Sends the WiFi SSID and Passkey
+-   The Silicon Labs device will join the WiFi network and get an IP address
+-   It then starts providing mDNS records on IPv4 and IPv6
+-   Future communications (tests) will then happen over WiFi
 
 ### Testing with chip-tool
 
@@ -175,10 +178,10 @@ Here is an example with the chip-tool:
 
 Where:
 
-- `${NODE_ID}` is the node ID assigned to the device
-- `20202021` is the setup PIN code
-- `3840` is the discriminator
-- `${SSID}` and `${PASSWORD}` are your WiFi network credentials
+-   `${NODE_ID}` is the node ID assigned to the device
+-   `20202021` is the setup PIN code
+-   `3840` is the discriminator
+-   `${SSID}` and `${PASSWORD}` are your WiFi network credentials
 
 ## Building Options
 
@@ -254,7 +257,7 @@ platform with the standard Silicon Labs lighting example.
 
 ### Additional Resources:
 
-- [Silicon Labs Matter Documentation](https://github.com/SiliconLabsSoftware/matter_sdk)
-- [SiWx917 Development Kit User Guide](https://www.silabs.com/development-tools/wireless/wi-fi/siwx917-development-kit)
-- [Matter Specification](https://csa-iot.org/all-solutions/matter/)
-- [Zephyr RTOS Documentation](https://docs.zephyrproject.org/)
+-   [Silicon Labs Matter Documentation](https://github.com/SiliconLabsSoftware/matter_sdk)
+-   [SiWx917 Development Kit User Guide](https://www.silabs.com/development-tools/wireless/wi-fi/siwx917-development-kit)
+-   [Matter Specification](https://csa-iot.org/all-solutions/matter/)
+-   [Zephyr RTOS Documentation](https://docs.zephyrproject.org/)

--- a/examples/lit-icd-app/silabs/README.md
+++ b/examples/lit-icd-app/silabs/README.md
@@ -4,27 +4,29 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
--   [Matter EFR32 Lit ICD Example](#matter-efr32-lit-icd-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-        -   [Linux](#linux)
-        -   [Mac OS X](#mac-os-x)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-            -   [On Border Router:](#on-border-router)
-            -   [On PC(Linux):](#on-pclinux)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Memory settings](#memory-settings)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter EFR32 Lit ICD Example](#matter-efr32-lit-icd-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+      - [Linux](#linux)
+      - [Mac OS X](#mac-os-x)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Notes](#notes)
+      - [On Border Router:](#on-border-router)
+      - [On PC(Linux):](#on-pclinux)
+  - [Running RPC console](#running-rpc-console)
+  - [Memory settings](#memory-settings)
+  - [OTA Software Update](#ota-software-update)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -32,7 +34,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -78,8 +80,8 @@ Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
 
@@ -146,9 +148,8 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases).
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 -   On the command line:
 

--- a/examples/lit-icd-app/silabs/README.md
+++ b/examples/lit-icd-app/silabs/README.md
@@ -4,29 +4,29 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
-- [Matter EFR32 Lit ICD Example](#matter-efr32-lit-icd-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-        - [Linux](#linux)
-        - [Mac OS X](#mac-os-x)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT](#segger-rtt)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Notes](#notes)
-            - [On Border Router:](#on-border-router)
-            - [On PC(Linux):](#on-pclinux)
-    - [Running RPC console](#running-rpc-console)
-    - [Memory settings](#memory-settings)
-    - [OTA Software Update](#ota-software-update)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling LCD](#disabling-lcd)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter EFR32 Lit ICD Example](#matter-efr32-lit-icd-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+        -   [Linux](#linux)
+        -   [Mac OS X](#mac-os-x)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Notes](#notes)
+            -   [On Border Router:](#on-border-router)
+            -   [On PC(Linux):](#on-pclinux)
+    -   [Running RPC console](#running-rpc-console)
+    -   [Memory settings](#memory-settings)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -57,16 +57,17 @@ Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain (For most Host, the
-  bootstrap already installs the toolchain):
-  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+-   Download and install a suitable ARM gcc tool chain (For most Host, the
+    bootstrap already installs the toolchain):
+    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
-- Install some additional tools(likely already present for CHIP developers):
+-   Install some additional tools(likely already present for CHIP developers):
 
 #### Linux
 
@@ -76,59 +77,61 @@ Labs platform.
 
     $ brew install ninja
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Build the example application:
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/lit-icd-app/silabs/ ./out/lit-icd-app BRD4187C
+*   Build the example application:
 
-- To delete generated executable, libraries and object files use:
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/lit-icd-app/silabs/ ./out/lit-icd-app BRD4187C
 
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
+-   To delete generated executable, libraries and object files use:
+
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/lit-icd-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/lit-icd-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug
+            $ ninja -C out/debug
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/lit-icd-app/silabs
-          $ rm -rf out/
+            $ cd ~/connectedhomeip/examples/lit-icd-app/silabs
+            $ rm -rf out/
 
-* Build the example with Matter shell
+*   Build the example with Matter shell
 
-          ./scripts/examples/gn_silabs_example.sh examples/lit-icd-app/silabs/ out/lit-icd-app BRD4187C chip_build_libshell=true
+            ./scripts/examples/gn_silabs_example.sh examples/lit-icd-app/silabs/ out/lit-icd-app BRD4187C chip_build_libshell=true
 
-* Build the example with pigweed RCP
+*   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/lit-icd-app/silabs/ out/lit-icd-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+            $ ./scripts/examples/gn_silabs_example.sh examples/lit-icd-app/silabs/ out/lit-icd-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/lit-icd-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/lit-icd-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+            $ ninja -C out/debug
 
 For more build options, help is provided when running the build script without
 arguments
@@ -137,20 +140,20 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          $ cd ~/connectedhomeip/examples/lit-icd-app/silabs
-          $ python3 out/debug/matter-silabs-lit-icd-example.flash.py
+            $ cd ~/connectedhomeip/examples/lit-icd-app/silabs
+            $ python3 out/debug/matter-silabs-lit-icd-example.flash.py
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
 [Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
-- On the command line:
+-   On the command line:
 
-          $ commander flash bootloader_binaries/bootloader-storage-internal-single-512k-BRD4187C-gsdk4.1.s37
+            $ commander flash bootloader_binaries/bootloader-storage-internal-single-512k-BRD4187C-gsdk4.1.s37
 
 ## Viewing Logging Output
 
@@ -168,37 +171,37 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          $ sudo usermod -a -G dialout ${USER}
+            $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
-          ```
-          $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
-          ```
+            ```
+            $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
+            ```
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          $ JLinkRTTClient
+            $ JLinkRTTClient
 
 ### Console Log
 
@@ -213,9 +216,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -226,72 +229,73 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0**
 
-        -   ICD Configuration (Default) - LED is only active under two circumstances:
+          -   ICD Configuration (Default) - LED is only active under two circumstances:
 
-            1. Factory reset sequence - LED will blink when initiated upon press and hold of
-            Button 0 after 3 seconds
-            2. An Identify command was received
+              1. Factory reset sequence - LED will blink when initiated upon press and hold of
+              Button 0 after 3 seconds
+              2. An Identify command was received
 
-        -   Non-ICD Configuration - shows the overall state of the device and its connectivity. The
-            following states are possible:
+          -   Non-ICD Configuration - shows the overall state of the device and its connectivity. The
+              following states are possible:
 
-            Short Flash On (50 ms on/950 ms off): The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+              Short Flash On (50 ms on/950 ms off): The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-            Rapid Even Flashing (100 ms on/100 ms off): The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+              Rapid Even Flashing (100 ms on/100 ms off): The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-            Short Flash Off (950ms on/50ms off): The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+              Short Flash Off (950ms on/50ms off): The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-            Solid On: The device is fully provisioned and has full Thread
-            network and service connectivity.
+              Solid On: The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **Push Button 0**
 
-        -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
-            for 30 seconds. The device will then switch to a slower interval advertisement.
-            After 15 minutes, the advertisement stops.
-            Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
+          -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
+              for 30 seconds. The device will then switch to a slower interval advertisement.
+              After 15 minutes, the advertisement stops.
+              Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
 
-        -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
     **Push Button 1**
 
-        -   Triggers a User action event to transition the ICD to Active mode.
+          -   Triggers a User action event to transition the ICD to Active mode.
 
 ### Notes
 
-- Depending on your network settings your router might not provide native ipv6
-  addresses to your devices (Border router / PC). If this is the case, you need
-  to add a static ipv6 addresses on both device and then an ipv6 route to the
-  border router on your PC
+-   Depending on your network settings your router might not provide native ipv6
+    addresses to your devices (Border router / PC). If this is the case, you
+    need to add a static ipv6 addresses on both device and then an ipv6 route to
+    the border router on your PC
 
 #### On Border Router:
 
@@ -306,20 +310,20 @@ via 2002::2
 
 ## Running RPC console
 
-- As part of building the example with RPCs enabled the chip_rpc python
-  interactive console is installed into your venv. The python wheel files are
-  also created in the output folder: out/debug/chip_rpc_console_wheels. To
-  install the wheel files without rebuilding:
+-   As part of building the example with RPCs enabled the chip_rpc python
+    interactive console is installed into your venv. The python wheel files are
+    also created in the output folder: out/debug/chip_rpc_console_wheels. To
+    install the wheel files without rebuilding:
 
     `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
-- To use the chip-rpc console after it has been installed run:
+-   To use the chip-rpc console after it has been installed run:
 
     `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
-- Then you can simulate a button press or release using the following command
-  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-  RELEASE Test toggling the LED with
+-   Then you can simulate a button press or release using the following command
+    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+    RELEASE Test toggling the LED with
 
     `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 

--- a/examples/lit-icd-app/silabs/README.md
+++ b/examples/lit-icd-app/silabs/README.md
@@ -34,7 +34,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/lit-icd-app/silabs/README.md
+++ b/examples/lit-icd-app/silabs/README.md
@@ -5,28 +5,28 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 <hr>
 
 - [Matter EFR32 Lit ICD Example](#matter-efr32-lit-icd-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-      - [Linux](#linux)
-      - [Mac OS X](#mac-os-x)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Notes](#notes)
-      - [On Border Router:](#on-border-router)
-      - [On PC(Linux):](#on-pclinux)
-  - [Running RPC console](#running-rpc-console)
-  - [Memory settings](#memory-settings)
-  - [OTA Software Update](#ota-software-update)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Introduction](#introduction)
+    - [Building](#building)
+        - [Linux](#linux)
+        - [Mac OS X](#mac-os-x)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT](#segger-rtt)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Notes](#notes)
+            - [On Border Router:](#on-border-router)
+            - [On PC(Linux):](#on-pclinux)
+    - [Running RPC console](#running-rpc-console)
+    - [Memory settings](#memory-settings)
+    - [OTA Software Update](#ota-software-update)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling LCD](#disabling-lcd)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -57,17 +57,16 @@ Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain (For most Host, the
-    bootstrap already installs the toolchain):
-    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+- Download and install a suitable ARM gcc tool chain (For most Host, the
+  bootstrap already installs the toolchain):
+  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
--   Install some additional tools(likely already present for CHIP developers):
+- Install some additional tools(likely already present for CHIP developers):
 
 #### Linux
 
@@ -77,27 +76,25 @@ Labs platform.
 
     $ brew install ninja
 
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     MG24 boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-
-*   Build the example application:
+* Build the example application:
 
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/lit-icd-app/silabs/ ./out/lit-icd-app BRD4187C
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
@@ -111,16 +108,16 @@ Labs platform.
           $ gn gen out/debug
           $ ninja -C out/debug
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip/examples/lit-icd-app/silabs
           $ rm -rf out/
 
-*   Build the example with Matter shell
+* Build the example with Matter shell
 
           ./scripts/examples/gn_silabs_example.sh examples/lit-icd-app/silabs/ out/lit-icd-app BRD4187C chip_build_libshell=true
 
-*   Build the example with pigweed RCP
+* Build the example with pigweed RCP
 
           $ ./scripts/examples/gn_silabs_example.sh examples/lit-icd-app/silabs/ out/lit-icd-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
@@ -140,18 +137,18 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           $ cd ~/connectedhomeip/examples/lit-icd-app/silabs
           $ python3 out/debug/matter-silabs-lit-icd-example.flash.py
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
 [Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
--   On the command line:
+- On the command line:
 
           $ commander flash bootloader_binaries/bootloader-storage-internal-single-512k-BRD4187C-gsdk4.1.s37
 
@@ -171,27 +168,27 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
@@ -199,7 +196,7 @@ combination with JLinkRTTClient as follows:
           $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
           ```
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
 
@@ -216,9 +213,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -229,18 +226,17 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.
@@ -292,10 +288,10 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
--   Depending on your network settings your router might not provide native ipv6
-    addresses to your devices (Border router / PC). If this is the case, you
-    need to add a static ipv6 addresses on both device and then an ipv6 route to
-    the border router on your PC
+- Depending on your network settings your router might not provide native ipv6
+  addresses to your devices (Border router / PC). If this is the case, you need
+  to add a static ipv6 addresses on both device and then an ipv6 route to the
+  border router on your PC
 
 #### On Border Router:
 
@@ -310,20 +306,20 @@ via 2002::2
 
 ## Running RPC console
 
--   As part of building the example with RPCs enabled the chip_rpc python
-    interactive console is installed into your venv. The python wheel files are
-    also created in the output folder: out/debug/chip_rpc_console_wheels. To
-    install the wheel files without rebuilding:
+- As part of building the example with RPCs enabled the chip_rpc python
+  interactive console is installed into your venv. The python wheel files are
+  also created in the output folder: out/debug/chip_rpc_console_wheels. To
+  install the wheel files without rebuilding:
 
     `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
--   To use the chip-rpc console after it has been installed run:
+- To use the chip-rpc console after it has been installed run:
 
     `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
--   Then you can simulate a button press or release using the following command
-    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-    RELEASE Test toggling the LED with
+- Then you can simulate a button press or release using the following command
+  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+  RELEASE Test toggling the LED with
 
     `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 

--- a/examples/lock-app/silabs/README.md
+++ b/examples/lock-app/silabs/README.md
@@ -5,23 +5,23 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 <hr>
 
 - [Matter EFR32 Lock Example](#matter-efr32-lock-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Notes](#notes)
-  - [Memory settings](#memory-settings)
-  - [OTA Software Update](#ota-software-update)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Introduction](#introduction)
+    - [Building](#building)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT](#segger-rtt)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Notes](#notes)
+    - [Memory settings](#memory-settings)
+    - [OTA Software Update](#ota-software-update)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling LCD](#disabling-lcd)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -52,17 +52,16 @@ Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain (For most Host, the
-    bootstrap already installs the toolchain):
-    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+- Download and install a suitable ARM gcc tool chain (For most Host, the
+  bootstrap already installs the toolchain):
+  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
--   Install some additional tools(likely already present for CHIP developers):
+- Install some additional tools(likely already present for CHIP developers):
 
 Linux
 
@@ -72,36 +71,33 @@ Mac OS X
 
     brew install ninja
 
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     MG24 boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+* Region code Setting (917 WiFi projects)
+    - In Wifi configurations, the region code can be set in this
+      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+      The available region codes can be found
+      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-*   Region code Setting (917 WiFi projects)
-
-    -   In Wifi configurations, the region code can be set in this
-        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-        The available region codes can be found
-        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
-
-*   Build the example application:
+* Build the example application:
 
           ```
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/ ./out/lock_app BRD4187C
           ```
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           ```
           $ cd ~/connectedhomeip
@@ -119,14 +115,14 @@ Mac OS X
           $ ninja -C out/debug
           ```
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           ```
           $ cd ~/connectedhomeip/examples/lock-app/silabs
           $ rm -rf out/
           ```
 
-*   Build the example as Intermittently Connected Device (ICD)
+* Build the example as Intermittently Connected Device (ICD)
 
           ```
           $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/ ./out/lock-app_ICD BRD4187C --icd
@@ -138,7 +134,7 @@ Mac OS X
           $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
           ```
 
-*   Build the example with pigweed RCP
+* Build the example with pigweed RCP
 
           ```
           $ ./scripts/examples/gn_silabs_example.sh examples/lock-app/silabs/ out/lock_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
@@ -164,14 +160,14 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           ```
           $ cd ~/connectedhomeip/examples/lock-app/silabs
           $ python3 out/debug/matter-silabs-lock-example.flash.py
           ```
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -193,22 +189,22 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           ```
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
           ```
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           ```
           $ sudo usermod -a -G dialout ${USER}
@@ -217,7 +213,7 @@ after flashing the .out file.
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
@@ -225,7 +221,7 @@ combination with JLinkRTTClient as follows:
           $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
           ```
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           ```
           $ JLinkRTTClient
@@ -244,9 +240,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -257,18 +253,17 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.
@@ -322,8 +317,8 @@ With any serial terminal application such as screen, putty, minicom etc.
 
     **Push Button 1** Toggles the bolt state On/Off
 
--   You can provision and control the Chip device using the python controller,
-    Chip tool standalone, Android or iOS app
+- You can provision and control the Chip device using the python controller,
+  Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
@@ -372,10 +367,10 @@ Here is some CHIPTool examples:
 
 ### Notes
 
--   Depending on your network settings your router might not provide native ipv6
-    addresses to your devices (Border router / PC). If this is the case, you
-    need to add a static ipv6 addresses on both device and then an ipv6 route to
-    the border router on your PC
+- Depending on your network settings your router might not provide native ipv6
+  addresses to your devices (Border router / PC). If this is the case, you need
+  to add a static ipv6 addresses on both device and then an ipv6 route to the
+  border router on your PC
 
 #On Border Router: \$ sudo ip addr add dev <Network interface> 2002::2/64
 

--- a/examples/lock-app/silabs/README.md
+++ b/examples/lock-app/silabs/README.md
@@ -4,24 +4,24 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
-- [Matter EFR32 Lock Example](#matter-efr32-lock-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT](#segger-rtt)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Notes](#notes)
-    - [Memory settings](#memory-settings)
-    - [OTA Software Update](#ota-software-update)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling LCD](#disabling-lcd)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter EFR32 Lock Example](#matter-efr32-lock-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Notes](#notes)
+    -   [Memory settings](#memory-settings)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -52,16 +52,17 @@ Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain (For most Host, the
-  bootstrap already installs the toolchain):
-  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+-   Download and install a suitable ARM gcc tool chain (For most Host, the
+    bootstrap already installs the toolchain):
+    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
-- Install some additional tools(likely already present for CHIP developers):
+-   Install some additional tools(likely already present for CHIP developers):
 
 Linux
 
@@ -71,85 +72,88 @@ Mac OS X
 
     brew install ninja
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Region code Setting (917 WiFi projects)
-    - In Wifi configurations, the region code can be set in this
-      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-      The available region codes can be found
-      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Build the example application:
+*   Region code Setting (917 WiFi projects)
 
-          ```
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/ ./out/lock_app BRD4187C
-          ```
+    -   In Wifi configurations, the region code can be set in this
+        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+        The available region codes can be found
+        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-- To delete generated executable, libraries and object files use:
+*   Build the example application:
 
-          ```
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
-          ```
+            ```
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/ ./out/lock_app BRD4187C
+            ```
+
+-   To delete generated executable, libraries and object files use:
+
+            ```
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
+            ```
 
     OR use GN/Ninja directly
 
-          ```
-          $ cd ~/connectedhomeip/examples/lock-app/silabs/
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args="efr32_sdk_root=\"${EFR32_SDK_ROOT}\" SILABS_BOARD=\"${SILABS_BOARD}\""
-          $ ninja -C out/debug
-          ```
+            ```
+            $ cd ~/connectedhomeip/examples/lock-app/silabs/
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args="efr32_sdk_root=\"${EFR32_SDK_ROOT}\" SILABS_BOARD=\"${SILABS_BOARD}\""
+            $ ninja -C out/debug
+            ```
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          ```
-          $ cd ~/connectedhomeip/examples/lock-app/silabs
-          $ rm -rf out/
-          ```
+            ```
+            $ cd ~/connectedhomeip/examples/lock-app/silabs
+            $ rm -rf out/
+            ```
 
-* Build the example as Intermittently Connected Device (ICD)
+*   Build the example as Intermittently Connected Device (ICD)
 
-          ```
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/ ./out/lock-app_ICD BRD4187C --icd
-          ```
+            ```
+            $ ./scripts/examples/gn_silabs_example.sh ./examples/lock-app/silabs/ ./out/lock-app_ICD BRD4187C --icd
+            ```
 
     or use gn as previously mentioned but adding the following arguments:
 
-          ```
-          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
-          ```
+            ```
+            $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
+            ```
 
-* Build the example with pigweed RCP
+*   Build the example with pigweed RCP
 
-          ```
-          $ ./scripts/examples/gn_silabs_example.sh examples/lock-app/silabs/ out/lock_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
-          ```
+            ```
+            $ ./scripts/examples/gn_silabs_example.sh examples/lock-app/silabs/ out/lock_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+            ```
 
     or use GN/Ninja Directly
 
-          ```
-          $ cd ~/connectedhomeip/examples/lock-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-          $ ninja -C out/debug
-          ```
+            ```
+            $ cd ~/connectedhomeip/examples/lock-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+            $ ninja -C out/debug
+            ```
 
 For more build options, help is provided when running the build script without
 arguments
@@ -160,14 +164,14 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          ```
-          $ cd ~/connectedhomeip/examples/lock-app/silabs
-          $ python3 out/debug/matter-silabs-lock-example.flash.py
-          ```
+            ```
+            $ cd ~/connectedhomeip/examples/lock-app/silabs
+            $ python3 out/debug/matter-silabs-lock-example.flash.py
+            ```
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -189,43 +193,43 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          ```
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
-          ```
+            ```
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            ```
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          ```
-          $ sudo usermod -a -G dialout ${USER}
-          ```
+            ```
+            $ sudo usermod -a -G dialout ${USER}
+            ```
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
-          ```
-          $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
-          ```
+            ```
+            $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
+            ```
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          ```
-          $ JLinkRTTClient
-          ```
+            ```
+            $ JLinkRTTClient
+            ```
 
 ### Console Log
 
@@ -240,9 +244,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -253,72 +257,73 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0**
 
-        -   ICD Configuration (Default) - LED is only active under two circumstances:
+          -   ICD Configuration (Default) - LED is only active under two circumstances:
 
-            1. Factory reset sequence - LED will blink when initiated upon press and hold of
-            Button 0 after 3 seconds
-            2. An Identify command was received
+              1. Factory reset sequence - LED will blink when initiated upon press and hold of
+              Button 0 after 3 seconds
+              2. An Identify command was received
 
-        -   Non-ICD Configuration - shows the overall state of the device and its connectivity. The
-            following states are possible:
+          -   Non-ICD Configuration - shows the overall state of the device and its connectivity. The
+              following states are possible:
 
-            Short Flash On (50 ms on/950 ms off): The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+              Short Flash On (50 ms on/950 ms off): The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-            Rapid Even Flashing (100 ms on/100 ms off): The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+              Rapid Even Flashing (100 ms on/100 ms off): The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-            Short Flash Off (950ms on/50ms off): The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+              Short Flash Off (950ms on/50ms off): The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-            Solid On: The device is fully provisioned and has full Thread
-            network and service connectivity.
+              Solid On: The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **LED 1** Simulates the Lock The following states are possible:
 
-        -   _Solid On_ ; Bolt is unlocked
-        -   _Blinking_ ; Bolt is moving to the desired state
-        -   _Off_ ; Bolt is locked
+          -   _Solid On_ ; Bolt is unlocked
+          -   _Blinking_ ; Bolt is moving to the desired state
+          -   _Off_ ; Bolt is locked
 
     **Push Button 0**
 
-        -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
-            for 30 seconds. The device will then switch to a slower interval advertisement.
-            After 15 minutes, the advertisement stops.
-            Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
+          -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
+              for 30 seconds. The device will then switch to a slower interval advertisement.
+              After 15 minutes, the advertisement stops.
+              Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
 
-        -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
     **Push Button 1** Toggles the bolt state On/Off
 
-- You can provision and control the Chip device using the python controller,
-  Chip tool standalone, Android or iOS app
+-   You can provision and control the Chip device using the python controller,
+    Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
@@ -367,10 +372,10 @@ Here is some CHIPTool examples:
 
 ### Notes
 
-- Depending on your network settings your router might not provide native ipv6
-  addresses to your devices (Border router / PC). If this is the case, you need
-  to add a static ipv6 addresses on both device and then an ipv6 route to the
-  border router on your PC
+-   Depending on your network settings your router might not provide native ipv6
+    addresses to your devices (Border router / PC). If this is the case, you
+    need to add a static ipv6 addresses on both device and then an ipv6 route to
+    the border router on your PC
 
 #On Border Router: \$ sudo ip addr add dev <Network interface> 2002::2/64
 

--- a/examples/lock-app/silabs/README.md
+++ b/examples/lock-app/silabs/README.md
@@ -4,22 +4,24 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
--   [Matter EFR32 Lock Example](#matter-efr32-lock-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-    -   [Memory settings](#memory-settings)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter EFR32 Lock Example](#matter-efr32-lock-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Notes](#notes)
+  - [Memory settings](#memory-settings)
+  - [OTA Software Update](#ota-software-update)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -27,7 +29,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -73,8 +75,8 @@ Mac OS X
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
 
@@ -172,9 +174,8 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 ## Viewing Logging Output
 

--- a/examples/lock-app/silabs/README.md
+++ b/examples/lock-app/silabs/README.md
@@ -29,7 +29,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/pump-app/silabs/README.md
+++ b/examples/pump-app/silabs/README.md
@@ -4,26 +4,26 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
-- [Matter EFR32 Pump Example](#matter-efr32-pump-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT](#segger-rtt)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Notes](#notes)
-    - [Device Tracing](#device-tracing)
-    - [Memory settings](#memory-settings)
-    - [OTA Software Update](#ota-software-update)
-    - [Group Communication (Multicast)](#group-communication-multicast)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling LCD](#disabling-lcd)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter EFR32 Pump Example](#matter-efr32-pump-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Notes](#notes)
+    -   [Device Tracing](#device-tracing)
+    -   [Memory settings](#memory-settings)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Group Communication (Multicast)](#group-communication-multicast)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -54,79 +54,83 @@ Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain (For most Host, the
-  bootstrap already installs the toolchain):
-  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+-   Download and install a suitable ARM gcc tool chain (For most Host, the
+    bootstrap already installs the toolchain):
+    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
-- Install some additional tools (likely already present for CHIP developers):
-    - Linux: `sudo apt-get install git ninja-build`
+-   Install some additional tools (likely already present for CHIP developers):
 
-    - Mac OS X: `brew install ninja`
+    -   Linux: `sudo apt-get install git ninja-build`
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+    -   Mac OS X: `brew install ninja`
+
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD2703A / MG24 Explorer Kit
-    - BRD2704A / SparkFun Thing Plus MGM240P board
 
-* Build the example application:
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD2703A / MG24 Explorer Kit
+    -   BRD2704A / SparkFun Thing Plus MGM240P board
 
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/ ./out/pump-app BRD4187C
+*   Build the example application:
 
-- To delete generated executable, libraries and object files use:
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/ ./out/pump-app BRD4187C
 
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
+-   To delete generated executable, libraries and object files use:
+
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/pump-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/pump-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug
+            $ ninja -C out/debug
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/pump-app/silabs
-          $ rm -rf out/
+            $ cd ~/connectedhomeip/examples/pump-app/silabs
+            $ rm -rf out/
 
-* Build the example as Intermittently Connected Device (ICD)
+*   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/ ./out/pump-app_ICD BRD4187C --icd
+            $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/ ./out/pump-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
+            $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
-* Build the example with pigweed RPC
+*   Build the example with pigweed RPC
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/pump-app/silabs/ out/pump_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+            $ ./scripts/examples/gn_silabs_example.sh examples/pump-app/silabs/ out/pump_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/pump-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/pump-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+            $ ninja -C out/debug
 
 For more build options, help is provided when running the build script without
 arguments
@@ -135,12 +139,12 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          $ cd ~/connectedhomeip/examples/pump-app/silabs
-          $ python3 out/debug/matter-silabs-pump-example.flash.py
+            $ cd ~/connectedhomeip/examples/pump-app/silabs
+            $ python3 out/debug/matter-silabs-pump-example.flash.py
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -162,37 +166,37 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          $ sudo usermod -a -G dialout ${USER}
+            $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
-          ```
-          $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
-          ```
+            ```
+            $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
+            ```
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          $ JLinkRTTClient
+            $ JLinkRTTClient
 
 ### Console Log
 
@@ -207,9 +211,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -220,86 +224,88 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0** shows the overall state of the device and its connectivity. The
     following states are possible:
 
-        -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+          -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-        -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+          -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-        -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+          -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-        -   _Solid On_ ; The device is fully provisioned and has full Thread
-            network and service connectivity.
+          -   _Solid On_ ; The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **LED 1** Simulates the Light The following states are possible:
 
-        -   _Solid On_ ; Light is on
-        -   _Off_ ; Light is off
+          -   _Solid On_ ; Light is on
+          -   _Off_ ; Light is off
 
     **Push Button 0**
 
-        -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
-            for 30 seconds. The device will then switch to a slower interval advertisement.
-            After 15 minutes, the advertisement stops.
-            Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
+          -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
+              for 30 seconds. The device will then switch to a slower interval advertisement.
+              After 15 minutes, the advertisement stops.
+              Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
 
-        -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
     **Push Button 1** Toggles the light state On/Off
 
-* You can provision and control the Chip device using the python controller,
-  Chip tool standalone, Android or iOS app
+*   You can provision and control the Chip device using the python controller,
+    Chip tool standalone, Android or iOS app
 
-* You can provision and control the Chip device using the python controller,
-  Chip tool standalone, Android or iOS app
+*   You can provision and control the Chip device using the python controller,
+    Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
     Here is an example with the chip-tool:
 
-          $ chip-tool pairing ble-thread 1 hex:<operationalDataset> 20202021 3840
-          $ chip-tool onoff on 1 1
+            $ chip-tool pairing ble-thread 1 hex:<operationalDataset> 20202021 3840
+            $ chip-tool onoff on 1 1
 
 ### Notes
 
-- Depending on your network settings your router might not provide native ipv6
-  addresses to your devices (Border router / PC). If this is the case, you need
-  to add a static ipv6 addresses on both device and then an ipv6 route to the
-  border router on your PC
-    - On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
+-   Depending on your network settings your router might not provide native ipv6
+    addresses to your devices (Border router / PC). If this is the case, you
+    need to add a static ipv6 addresses on both device and then an ipv6 route to
+    the border router on your PC
 
-    - On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
+    -   On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
 
-    - Add Ipv6 route on PC(Linux)
-      `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
+    -   On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
+
+    -   Add Ipv6 route on PC(Linux)
+        `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
 
 ## Device Tracing
 

--- a/examples/pump-app/silabs/README.md
+++ b/examples/pump-app/silabs/README.md
@@ -31,7 +31,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/pump-app/silabs/README.md
+++ b/examples/pump-app/silabs/README.md
@@ -5,25 +5,25 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 <hr>
 
 - [Matter EFR32 Pump Example](#matter-efr32-pump-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Notes](#notes)
-  - [Device Tracing](#device-tracing)
-  - [Memory settings](#memory-settings)
-  - [OTA Software Update](#ota-software-update)
-  - [Group Communication (Multicast)](#group-communication-multicast)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Introduction](#introduction)
+    - [Building](#building)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT](#segger-rtt)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Notes](#notes)
+    - [Device Tracing](#device-tracing)
+    - [Memory settings](#memory-settings)
+    - [OTA Software Update](#ota-software-update)
+    - [Group Communication (Multicast)](#group-communication-multicast)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling LCD](#disabling-lcd)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -54,45 +54,41 @@ Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain (For most Host, the
-    bootstrap already installs the toolchain):
-    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+- Download and install a suitable ARM gcc tool chain (For most Host, the
+  bootstrap already installs the toolchain):
+  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
--   Install some additional tools (likely already present for CHIP developers):
+- Install some additional tools (likely already present for CHIP developers):
+    - Linux: `sudo apt-get install git ninja-build`
 
-    -   Linux: `sudo apt-get install git ninja-build`
+    - Mac OS X: `brew install ninja`
 
-    -   Mac OS X: `brew install ninja`
-
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     MG24 boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD2703A / MG24 Explorer Kit
+    - BRD2704A / SparkFun Thing Plus MGM240P board
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD2703A / MG24 Explorer Kit
-    -   BRD2704A / SparkFun Thing Plus MGM240P board
-
-*   Build the example application:
+* Build the example application:
 
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/ ./out/pump-app BRD4187C
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
@@ -106,12 +102,12 @@ Labs platform.
           $ gn gen out/debug
           $ ninja -C out/debug
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip/examples/pump-app/silabs
           $ rm -rf out/
 
-*   Build the example as Intermittently Connected Device (ICD)
+* Build the example as Intermittently Connected Device (ICD)
 
           $ ./scripts/examples/gn_silabs_example.sh ./examples/pump-app/silabs/ ./out/pump-app_ICD BRD4187C --icd
 
@@ -119,7 +115,7 @@ Labs platform.
 
           $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
-*   Build the example with pigweed RPC
+* Build the example with pigweed RPC
 
           $ ./scripts/examples/gn_silabs_example.sh examples/pump-app/silabs/ out/pump_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
@@ -139,12 +135,12 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           $ cd ~/connectedhomeip/examples/pump-app/silabs
           $ python3 out/debug/matter-silabs-pump-example.flash.py
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -166,27 +162,27 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
@@ -194,7 +190,7 @@ combination with JLinkRTTClient as follows:
           $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
           ```
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
 
@@ -211,9 +207,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -224,18 +220,17 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.
@@ -280,11 +275,11 @@ With any serial terminal application such as screen, putty, minicom etc.
 
     **Push Button 1** Toggles the light state On/Off
 
-*   You can provision and control the Chip device using the python controller,
-    Chip tool standalone, Android or iOS app
+* You can provision and control the Chip device using the python controller,
+  Chip tool standalone, Android or iOS app
 
-*   You can provision and control the Chip device using the python controller,
-    Chip tool standalone, Android or iOS app
+* You can provision and control the Chip device using the python controller,
+  Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
@@ -295,17 +290,16 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
--   Depending on your network settings your router might not provide native ipv6
-    addresses to your devices (Border router / PC). If this is the case, you
-    need to add a static ipv6 addresses on both device and then an ipv6 route to
-    the border router on your PC
+- Depending on your network settings your router might not provide native ipv6
+  addresses to your devices (Border router / PC). If this is the case, you need
+  to add a static ipv6 addresses on both device and then an ipv6 route to the
+  border router on your PC
+    - On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
 
-    -   On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
+    - On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
 
-    -   On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
-
-    -   Add Ipv6 route on PC(Linux)
-        `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
+    - Add Ipv6 route on PC(Linux)
+      `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
 
 ## Device Tracing
 

--- a/examples/pump-app/silabs/README.md
+++ b/examples/pump-app/silabs/README.md
@@ -4,24 +4,26 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
--   [Matter EFR32 Pump Example](#matter-efr32-pump-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-    -   [Device Tracing](#device-tracing)
-    -   [Memory settings](#memory-settings)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Group Communication (Multicast)](#group-communication-multicast)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter EFR32 Pump Example](#matter-efr32-pump-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Notes](#notes)
+  - [Device Tracing](#device-tracing)
+  - [Memory settings](#memory-settings)
+  - [OTA Software Update](#ota-software-update)
+  - [Group Communication (Multicast)](#group-communication-multicast)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -29,7 +31,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -71,8 +73,8 @@ Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
 
@@ -145,9 +147,8 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 ## Viewing Logging Output
 

--- a/examples/refrigerator-app/silabs/README.md
+++ b/examples/refrigerator-app/silabs/README.md
@@ -6,23 +6,23 @@ Wi-Fi Boards.
 <hr>
 
 - [Matter Refrigerator and Temperature Controlled Example](#matter-refrigerator-and-temperature-controlled-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-  - [Trigger events from Matter CLI](#trigger-events-from-matter-cli)
-    - [Notes](#notes)
-  - [OTA Software Update](#ota-software-update)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Introduction](#introduction)
+    - [Building](#building)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT](#segger-rtt)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+    - [Trigger events from Matter CLI](#trigger-events-from-matter-cli)
+        - [Notes](#notes)
+    - [OTA Software Update](#ota-software-update)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling LCD](#disabling-lcd)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -55,17 +55,16 @@ real products based on the Silicon Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain (For most Host, the
-    bootstrap already installs the toolchain):
-    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+- Download and install a suitable ARM gcc tool chain (For most Host, the
+  bootstrap already installs the toolchain):
+  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
--   Install some additional tools(likely already present for CHIP developers):
+- Install some additional tools(likely already present for CHIP developers):
 
            # Linux
            $ sudo apt-get install git ninja-build
@@ -73,36 +72,33 @@ real products based on the Silicon Labs platform.
            # Mac OS X
            $ brew install ninja
 
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     Silabs boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4338A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4346A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4338A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4346A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+* Region code Setting (917 WiFi projects)
+    - In Wifi configurations, the region code can be set in this
+      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+      The available region codes can be found
+      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-*   Region code Setting (917 WiFi projects)
-
-    -   In Wifi configurations, the region code can be set in this
-        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-        The available region codes can be found
-        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
-
-*   Build the example application:
+* Build the example application:
 
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/refrigerator-app/silabs/ ./out/refrigerator-app BRD4187C
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
@@ -116,12 +112,12 @@ real products based on the Silicon Labs platform.
           $ gn gen out/debug
           $ ninja -C out/debug
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip/examples/refrigerator-app/silabs
           $ rm -rf out/
 
-*   Build the example as Intermittently Connected Device (ICD)
+* Build the example as Intermittently Connected Device (ICD)
 
           $ ./scripts/examples/gn_silabs_example.sh ./examples/refrigerator-app/silabs/ ./out/refrigerator-app_ICD BRD4187C --icd
 
@@ -129,7 +125,7 @@ real products based on the Silicon Labs platform.
 
           $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
-*   Build the example with pigweed RCP
+* Build the example with pigweed RCP
 
           $ ./scripts/examples/gn_silabs_example.sh examples/refrigerator-app/silabs/ out/refrigerator_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
@@ -149,12 +145,12 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           $ cd ~/connectedhomeip/examples/refrigerator-app/silabs
           $ python3 out/debug/matter-silabs-refrigerator-example.flash.py
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -176,27 +172,27 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
@@ -204,7 +200,7 @@ combination with JLinkRTTClient as follows:
           $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
           ```
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
 
@@ -221,9 +217,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -234,18 +230,17 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](../../../docs/platforms/openthread/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](../../../docs/platforms/openthread/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.
@@ -294,8 +289,8 @@ With any serial terminal application such as screen, putty, minicom etc.
 
         -   Press and hold for 3 s: No implementation is present. this feature will be available in a future update.
 
-*   Once the device is provisioned, it will join the Thread network is
-    established, look for the RTT log
+* Once the device is provisioned, it will join the Thread network is
+  established, look for the RTT log
 
     ```
         [DL] Device Role: CHILD
@@ -363,7 +358,7 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 **door-state-change**
 
--   Trigger refrigeratoralarm door-state-change event:
+- Trigger refrigeratoralarm door-state-change event:
 
     ```
     -> matterCli> refrigeratoralarm event door-state-change open
@@ -372,10 +367,10 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
--   Depending on your network settings your router might not provide native ipv6
-    addresses to your devices (Border router / PC). If this is the case, you
-    need to add a static ipv6 addresses on both device and then an ipv6 route to
-    the border router on your PC
+- Depending on your network settings your router might not provide native ipv6
+  addresses to your devices (Border router / PC). If this is the case, you need
+  to add a static ipv6 addresses on both device and then an ipv6 route to the
+  border router on your PC
 
           # On Border Router :
           $ sudo ip addr add dev <Network interface> 2002::2/64

--- a/examples/refrigerator-app/silabs/README.md
+++ b/examples/refrigerator-app/silabs/README.md
@@ -5,21 +5,24 @@ Wi-Fi Boards.
 
 <hr>
 
--   [Matter Refrigerator and Temperature Controlled Example](#matter-refrigerator-and-temperature-controlled-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter Refrigerator and Temperature Controlled Example](#matter-refrigerator-and-temperature-controlled-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+  - [Trigger events from Matter CLI](#trigger-events-from-matter-cli)
+    - [Notes](#notes)
+  - [OTA Software Update](#ota-software-update)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -27,7 +30,7 @@ Wi-Fi Boards.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -73,8 +76,8 @@ real products based on the Silicon Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     Silabs boards :
 
@@ -154,9 +157,8 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 ## Viewing Logging Output
 

--- a/examples/refrigerator-app/silabs/README.md
+++ b/examples/refrigerator-app/silabs/README.md
@@ -5,24 +5,24 @@ Wi-Fi Boards.
 
 <hr>
 
-- [Matter Refrigerator and Temperature Controlled Example](#matter-refrigerator-and-temperature-controlled-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT](#segger-rtt)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-    - [Trigger events from Matter CLI](#trigger-events-from-matter-cli)
-        - [Notes](#notes)
-    - [OTA Software Update](#ota-software-update)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling LCD](#disabling-lcd)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter Refrigerator and Temperature Controlled Example](#matter-refrigerator-and-temperature-controlled-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+    -   [Trigger events from Matter CLI](#trigger-events-from-matter-cli)
+        -   [Notes](#notes)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -55,88 +55,92 @@ real products based on the Silicon Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain (For most Host, the
-  bootstrap already installs the toolchain):
-  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+-   Download and install a suitable ARM gcc tool chain (For most Host, the
+    bootstrap already installs the toolchain):
+    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
-- Install some additional tools(likely already present for CHIP developers):
+-   Install some additional tools(likely already present for CHIP developers):
 
-           # Linux
-           $ sudo apt-get install git ninja-build
+             # Linux
+             $ sudo apt-get install git ninja-build
 
-           # Mac OS X
-           $ brew install ninja
+             # Mac OS X
+             $ brew install ninja
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     Silabs boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4338A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4346A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Region code Setting (917 WiFi projects)
-    - In Wifi configurations, the region code can be set in this
-      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-      The available region codes can be found
-      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4338A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4346A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Build the example application:
+*   Region code Setting (917 WiFi projects)
 
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/refrigerator-app/silabs/ ./out/refrigerator-app BRD4187C
+    -   In Wifi configurations, the region code can be set in this
+        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+        The available region codes can be found
+        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-- To delete generated executable, libraries and object files use:
+*   Build the example application:
 
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/refrigerator-app/silabs/ ./out/refrigerator-app BRD4187C
+
+-   To delete generated executable, libraries and object files use:
+
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/refrigerator-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/refrigerator-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug
+            $ ninja -C out/debug
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/refrigerator-app/silabs
-          $ rm -rf out/
+            $ cd ~/connectedhomeip/examples/refrigerator-app/silabs
+            $ rm -rf out/
 
-* Build the example as Intermittently Connected Device (ICD)
+*   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/refrigerator-app/silabs/ ./out/refrigerator-app_ICD BRD4187C --icd
+            $ ./scripts/examples/gn_silabs_example.sh ./examples/refrigerator-app/silabs/ ./out/refrigerator-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
+            $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
-* Build the example with pigweed RCP
+*   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/refrigerator-app/silabs/ out/refrigerator_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+            $ ./scripts/examples/gn_silabs_example.sh examples/refrigerator-app/silabs/ out/refrigerator_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/refrigerator-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/refrigerator-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+            $ ninja -C out/debug
 
 For more build options, help is provided when running the build script without
 arguments
@@ -145,12 +149,12 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          $ cd ~/connectedhomeip/examples/refrigerator-app/silabs
-          $ python3 out/debug/matter-silabs-refrigerator-example.flash.py
+            $ cd ~/connectedhomeip/examples/refrigerator-app/silabs
+            $ python3 out/debug/matter-silabs-refrigerator-example.flash.py
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -172,37 +176,37 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          $ sudo usermod -a -G dialout ${USER}
+            $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
-          ```
-          $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
-          ```
+            ```
+            $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
+            ```
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          $ JLinkRTTClient
+            $ JLinkRTTClient
 
 ### Console Log
 
@@ -217,9 +221,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -230,67 +234,68 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](../../../docs/platforms/openthread/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](../../../docs/platforms/openthread/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0** shows the overall state of the device and its connectivity. The
     following states are possible:
 
-        -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+          -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-        -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+          -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-        -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+          -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-        -   _Solid On_ ; The device is fully provisioned and has full Thread
-            network and service connectivity.
+          -   _Solid On_ ; The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **LED 1** Shows the state of the refrigerator and temperature controlled
     cabinet
 
-        -   temperature ; No implementation is present. this feature will be available in a future update.
-        -   _Off_ ; No implementation is present. this feature will be available in a future update.
-        -   _Blinking slowly_ ; No implementation is present. this feature will be available in a future update.
-        -   _Blinking quickly_ ; No implementation is present. this feature will be available in a future update.
+          -   temperature ; No implementation is present. this feature will be available in a future update.
+          -   _Off_ ; No implementation is present. this feature will be available in a future update.
+          -   _Blinking slowly_ ; No implementation is present. this feature will be available in a future update.
+          -   _Blinking quickly_ ; No implementation is present. this feature will be available in a future update.
 
     **Push Button 0** Function button and factory reset
 
-        -   Pressed and release: No implementation is present. this feature will be available in a future update.
+          -   Pressed and release: No implementation is present. this feature will be available in a future update.
 
-        -   Pressed and hold for 6 s: Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   Pressed and hold for 6 s: Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
     **Push Button 1** Application button
 
-        -   Pressed and release: No implementation is present. this feature will be available in a future update.
+          -   Pressed and release: No implementation is present. this feature will be available in a future update.
 
-        -   Press and hold for 3 s: No implementation is present. this feature will be available in a future update.
+          -   Press and hold for 3 s: No implementation is present. this feature will be available in a future update.
 
-* Once the device is provisioned, it will join the Thread network is
-  established, look for the RTT log
+*   Once the device is provisioned, it will join the Thread network is
+    established, look for the RTT log
 
     ```
         [DL] Device Role: CHILD
@@ -358,7 +363,7 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 **door-state-change**
 
-- Trigger refrigeratoralarm door-state-change event:
+-   Trigger refrigeratoralarm door-state-change event:
 
     ```
     -> matterCli> refrigeratoralarm event door-state-change open
@@ -367,19 +372,19 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
-- Depending on your network settings your router might not provide native ipv6
-  addresses to your devices (Border router / PC). If this is the case, you need
-  to add a static ipv6 addresses on both device and then an ipv6 route to the
-  border router on your PC
+-   Depending on your network settings your router might not provide native ipv6
+    addresses to your devices (Border router / PC). If this is the case, you
+    need to add a static ipv6 addresses on both device and then an ipv6 route to
+    the border router on your PC
 
-          # On Border Router :
-          $ sudo ip addr add dev <Network interface> 2002::2/64
+            # On Border Router :
+            $ sudo ip addr add dev <Network interface> 2002::2/64
 
-          # On PC (Linux) :
-          $ sudo ip addr add dev <Network interface> 2002::1/64
+            # On PC (Linux) :
+            $ sudo ip addr add dev <Network interface> 2002::1/64
 
-          # Add Ipv6 route on PC (Linux)
-          $ sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2
+            # Add Ipv6 route on PC (Linux)
+            $ sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2
 
 ## OTA Software Update
 

--- a/examples/refrigerator-app/silabs/README.md
+++ b/examples/refrigerator-app/silabs/README.md
@@ -30,7 +30,7 @@ Wi-Fi Boards.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/smoke-co-alarm-app/silabs/README.md
+++ b/examples/smoke-co-alarm-app/silabs/README.md
@@ -5,24 +5,24 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 <hr>
 
 - [Matter EFR32 Smoke CO Alarm Example](#matter-efr32-smoke-co-alarm-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Notes](#notes)
-  - [Memory settings](#memory-settings)
-  - [OTA Software Update](#ota-software-update)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
-    - [Enabling test event trigger](#enabling-test-event-trigger)
+    - [Introduction](#introduction)
+    - [Building](#building)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT](#segger-rtt)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Notes](#notes)
+    - [Memory settings](#memory-settings)
+    - [OTA Software Update](#ota-software-update)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling LCD](#disabling-lcd)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
+        - [Enabling test event trigger](#enabling-test-event-trigger)
 
 <hr>
 
@@ -53,45 +53,41 @@ Silicon Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain (For most Host, the
-    bootstrap already installs the toolchain):
-    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+- Download and install a suitable ARM gcc tool chain (For most Host, the
+  bootstrap already installs the toolchain):
+  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
--   Install some additional tools(likely already present for CHIP developers):
+- Install some additional tools(likely already present for CHIP developers):
+    - Linux: `sudo apt-get install git ninja-build`
 
-    -   Linux: `sudo apt-get install git ninja-build`
+    - Mac OS X: `brew install ninja`
 
-    -   Mac OS X: `brew install ninja`
-
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     MG24 boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-
-*   Build the example application:
+* Build the example application:
 
           ```
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/smoke-co-alarm-app/silabs ./out/smoke-co-alarm-app BRD4187C
           ```
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           ```
           $ cd ~/connectedhomeip
@@ -109,14 +105,14 @@ Silicon Labs platform.
           $ ninja -C out/debug
           ```
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           ```
           $ cd ~/connectedhomeip/examples/smoke-co-alarm-app/silabs
           $ rm -rf out/
           ```
 
-*   Build the example as Intermittently Connected Device (ICD)
+* Build the example as Intermittently Connected Device (ICD)
 
           ```
           $ ./scripts/examples/gn_silabs_example.sh ./examples/smoke-co-alarm-app/silabs ./out/smoke-co-alarm-app_ICD BRD4187C --icd
@@ -128,7 +124,7 @@ Silicon Labs platform.
           $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
           ```
 
-*   Build the example with pigweed RPC
+* Build the example with pigweed RPC
 
           ```
           $ ./scripts/examples/gn_silabs_example.sh examples/smoke-co-alarm-app/silabs out/smoke_co_alarm_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
@@ -154,14 +150,14 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           ```
           $ cd ~/connectedhomeip/examples/smoke-co-alarm-app/silabs
           $ python3 out/debug/matter-silabs-smoke-co-alarm-example.flash.py
           ```
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -183,22 +179,22 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           ```
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
           ```
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           ```
           $ sudo usermod -a -G dialout ${USER}
@@ -207,7 +203,7 @@ after flashing the .out file.
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
@@ -215,7 +211,7 @@ combination with JLinkRTTClient as follows:
           $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
           ```
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           ```
           $ JLinkRTTClient
@@ -234,9 +230,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -247,18 +243,17 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.
@@ -296,8 +291,8 @@ With any serial terminal application such as screen, putty, minicom etc.
             procedure. **LEDs** blink in unison when the factory reset procedure is
             initiated.
 
-*   You can provision and control the Chip device using the python controller,
-    Chip tool standalone, Android or iOS app
+* You can provision and control the Chip device using the python controller,
+  Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
@@ -315,17 +310,16 @@ Here is some CHIPTool examples:
 
 ### Notes
 
--   Depending on your network settings your router might not provide native ipv6
-    addresses to your devices (Border router / PC). If this is the case, you
-    need to add a static ipv6 addresses on both device and then an ipv6 route to
-    the border router on your PC
+- Depending on your network settings your router might not provide native ipv6
+  addresses to your devices (Border router / PC). If this is the case, you need
+  to add a static ipv6 addresses on both device and then an ipv6 route to the
+  border router on your PC
+    - On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
 
-    -   On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
+    - On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
 
-    -   On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
-
-    -   Add Ipv6 route on PC(Linux)
-        `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
+    - Add Ipv6 route on PC(Linux)
+      `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
 
 ## Memory settings
 

--- a/examples/smoke-co-alarm-app/silabs/README.md
+++ b/examples/smoke-co-alarm-app/silabs/README.md
@@ -4,23 +4,25 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
--   [Matter EFR32 Smoke CO Alarm Example](#matter-efr32-smoke-co-alarm-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-    -   [Memory settings](#memory-settings)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
-        -   [Enabling test event trigger](#enabling-test-event-trigger)
+- [Matter EFR32 Smoke CO Alarm Example](#matter-efr32-smoke-co-alarm-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Notes](#notes)
+  - [Memory settings](#memory-settings)
+  - [OTA Software Update](#ota-software-update)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Enabling test event trigger](#enabling-test-event-trigger)
 
 <hr>
 
@@ -28,7 +30,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -70,8 +72,8 @@ Silicon Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
 
@@ -162,9 +164,8 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 ## Viewing Logging Output
 

--- a/examples/smoke-co-alarm-app/silabs/README.md
+++ b/examples/smoke-co-alarm-app/silabs/README.md
@@ -4,25 +4,25 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
-- [Matter EFR32 Smoke CO Alarm Example](#matter-efr32-smoke-co-alarm-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT](#segger-rtt)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Notes](#notes)
-    - [Memory settings](#memory-settings)
-    - [OTA Software Update](#ota-software-update)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling LCD](#disabling-lcd)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
-        - [Enabling test event trigger](#enabling-test-event-trigger)
+-   [Matter EFR32 Smoke CO Alarm Example](#matter-efr32-smoke-co-alarm-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Notes](#notes)
+    -   [Memory settings](#memory-settings)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+        -   [Enabling test event trigger](#enabling-test-event-trigger)
 
 <hr>
 
@@ -53,93 +53,97 @@ Silicon Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain (For most Host, the
-  bootstrap already installs the toolchain):
-  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+-   Download and install a suitable ARM gcc tool chain (For most Host, the
+    bootstrap already installs the toolchain):
+    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
-- Install some additional tools(likely already present for CHIP developers):
-    - Linux: `sudo apt-get install git ninja-build`
+-   Install some additional tools(likely already present for CHIP developers):
 
-    - Mac OS X: `brew install ninja`
+    -   Linux: `sudo apt-get install git ninja-build`
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+    -   Mac OS X: `brew install ninja`
+
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Build the example application:
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-          ```
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/smoke-co-alarm-app/silabs ./out/smoke-co-alarm-app BRD4187C
-          ```
+*   Build the example application:
 
-- To delete generated executable, libraries and object files use:
+            ```
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/smoke-co-alarm-app/silabs ./out/smoke-co-alarm-app BRD4187C
+            ```
 
-          ```
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
-          ```
+-   To delete generated executable, libraries and object files use:
+
+            ```
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
+            ```
 
     OR use GN/Ninja directly
 
-          ```
-          $ cd ~/connectedhomeip/examples/smoke-co-alarm-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug
-          $ ninja -C out/debug
-          ```
+            ```
+            $ cd ~/connectedhomeip/examples/smoke-co-alarm-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug
+            $ ninja -C out/debug
+            ```
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          ```
-          $ cd ~/connectedhomeip/examples/smoke-co-alarm-app/silabs
-          $ rm -rf out/
-          ```
+            ```
+            $ cd ~/connectedhomeip/examples/smoke-co-alarm-app/silabs
+            $ rm -rf out/
+            ```
 
-* Build the example as Intermittently Connected Device (ICD)
+*   Build the example as Intermittently Connected Device (ICD)
 
-          ```
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/smoke-co-alarm-app/silabs ./out/smoke-co-alarm-app_ICD BRD4187C --icd
-          ```
+            ```
+            $ ./scripts/examples/gn_silabs_example.sh ./examples/smoke-co-alarm-app/silabs ./out/smoke-co-alarm-app_ICD BRD4187C --icd
+            ```
 
     or use gn as previously mentioned but adding the following arguments:
 
-          ```
-          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
-          ```
+            ```
+            $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
+            ```
 
-* Build the example with pigweed RPC
+*   Build the example with pigweed RPC
 
-          ```
-          $ ./scripts/examples/gn_silabs_example.sh examples/smoke-co-alarm-app/silabs out/smoke_co_alarm_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
-          ```
+            ```
+            $ ./scripts/examples/gn_silabs_example.sh examples/smoke-co-alarm-app/silabs out/smoke_co_alarm_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+            ```
 
     or use GN/Ninja Directly
 
-          ```
-          $ cd ~/connectedhomeip/examples/smoke-co-alarm-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-          $ ninja -C out/debug
-          ```
+            ```
+            $ cd ~/connectedhomeip/examples/smoke-co-alarm-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+            $ ninja -C out/debug
+            ```
 
 For more build options, help is provided when running the build script without
 arguments
@@ -150,14 +154,14 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          ```
-          $ cd ~/connectedhomeip/examples/smoke-co-alarm-app/silabs
-          $ python3 out/debug/matter-silabs-smoke-co-alarm-example.flash.py
-          ```
+            ```
+            $ cd ~/connectedhomeip/examples/smoke-co-alarm-app/silabs
+            $ python3 out/debug/matter-silabs-smoke-co-alarm-example.flash.py
+            ```
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -179,43 +183,43 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          ```
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
-          ```
+            ```
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            ```
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          ```
-          $ sudo usermod -a -G dialout ${USER}
-          ```
+            ```
+            $ sudo usermod -a -G dialout ${USER}
+            ```
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
-          ```
-          $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
-          ```
+            ```
+            $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
+            ```
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          ```
-          $ JLinkRTTClient
-          ```
+            ```
+            $ JLinkRTTClient
+            ```
 
 ### Console Log
 
@@ -230,9 +234,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -243,56 +247,57 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0** shows the overall state of the device and its connectivity. The
     following states are possible:
 
-        -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+          -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-        -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+          -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-        -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+          -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-        -   _Solid On_ ; The device is fully provisioned and has full Thread
-            network and service connectivity.
+          -   _Solid On_ ; The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **Push Button 0**
 
-        -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
-            for 30 seconds. The device will then switch to a slower interval advertisement.
-            After 15 minutes, the advertisement stops.
-            Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
+          -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
+              for 30 seconds. The device will then switch to a slower interval advertisement.
+              After 15 minutes, the advertisement stops.
+              Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
 
-        -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
-* You can provision and control the Chip device using the python controller,
-  Chip tool standalone, Android or iOS app
+*   You can provision and control the Chip device using the python controller,
+    Chip tool standalone, Android or iOS app
 
     [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
 
@@ -310,16 +315,17 @@ Here is some CHIPTool examples:
 
 ### Notes
 
-- Depending on your network settings your router might not provide native ipv6
-  addresses to your devices (Border router / PC). If this is the case, you need
-  to add a static ipv6 addresses on both device and then an ipv6 route to the
-  border router on your PC
-    - On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
+-   Depending on your network settings your router might not provide native ipv6
+    addresses to your devices (Border router / PC). If this is the case, you
+    need to add a static ipv6 addresses on both device and then an ipv6 route to
+    the border router on your PC
 
-    - On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
+    -   On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
 
-    - Add Ipv6 route on PC(Linux)
-      `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
+    -   On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
+
+    -   Add Ipv6 route on PC(Linux)
+        `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
 
 ## Memory settings
 

--- a/examples/smoke-co-alarm-app/silabs/README.md
+++ b/examples/smoke-co-alarm-app/silabs/README.md
@@ -30,7 +30,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/thermostat/silabs/README.md
+++ b/examples/thermostat/silabs/README.md
@@ -5,28 +5,28 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 <hr>
 
 - [Matter EFR32 Thermostat Example](#matter-efr32-thermostat-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-      - [Linux](#linux)
-      - [Mac OS X](#mac-os-x)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Notes](#notes)
-      - [On Border Router:](#on-border-router)
-      - [On PC(Linux):](#on-pclinux)
-  - [Running RPC console](#running-rpc-console)
-  - [Memory settings](#memory-settings)
-  - [OTA Software Update](#ota-software-update)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Introduction](#introduction)
+    - [Building](#building)
+        - [Linux](#linux)
+        - [Mac OS X](#mac-os-x)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT](#segger-rtt)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Notes](#notes)
+            - [On Border Router:](#on-border-router)
+            - [On PC(Linux):](#on-pclinux)
+    - [Running RPC console](#running-rpc-console)
+    - [Memory settings](#memory-settings)
+    - [OTA Software Update](#ota-software-update)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling LCD](#disabling-lcd)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -57,17 +57,16 @@ Silicon Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain (For most Host, the
-    bootstrap already installs the toolchain):
-    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+- Download and install a suitable ARM gcc tool chain (For most Host, the
+  bootstrap already installs the toolchain):
+  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
--   Install some additional tools(likely already present for CHIP developers):
+- Install some additional tools(likely already present for CHIP developers):
 
 #### Linux
 
@@ -77,34 +76,31 @@ Silicon Labs platform.
 
     $ brew install ninja
 
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     MG24 boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+* Region code Setting (917 WiFi projects)
+    - In Wifi configurations, the region code can be set in this
+      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+      The available region codes can be found
+      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-*   Region code Setting (917 WiFi projects)
-
-    -   In Wifi configurations, the region code can be set in this
-        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-        The available region codes can be found
-        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
-
-*   Build the example application:
+* Build the example application:
 
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/ ./out/thermostat-app BRD4187C
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
@@ -118,16 +114,16 @@ Silicon Labs platform.
           $ gn gen out/debug
           $ ninja -C out/debug
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip/examples/thermostat/silabs
           $ rm -rf out/
 
-*   Build the example with Matter shell
+* Build the example with Matter shell
 
           ./scripts/examples/gn_silabs_example.sh examples/thermostat/silabs/ out/thermostat-app BRD4187C chip_build_libshell=true
 
-*   Build the example as Intermittently Connected Device (ICD)
+* Build the example as Intermittently Connected Device (ICD)
 
           $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/ ./out/thermostat-app_ICD BRD4187C --icd
 
@@ -135,7 +131,7 @@ Silicon Labs platform.
 
           $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
 
-*   Build the example with pigweed RCP
+* Build the example with pigweed RCP
 
           $ ./scripts/examples/gn_silabs_example.sh examples/thermostat/silabs/ out/thermostat-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
@@ -155,12 +151,12 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           $ cd ~/connectedhomeip/examples/thermostat/silabs
           $ python3 out/debug/matter-silabs-thermostat-switch-example.flash.py
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -182,27 +178,27 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
@@ -210,7 +206,7 @@ combination with JLinkRTTClient as follows:
           $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
           ```
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
 
@@ -227,9 +223,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -240,23 +236,22 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   For this example to work, it is necessary to have a second efr32 device
-    running the
-    [thermostat app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/thermostat/silabs/README.md)
-    commissioned on the same openthread network
+- For this example to work, it is necessary to have a second efr32 device
+  running the
+  [thermostat app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/thermostat/silabs/README.md)
+  commissioned on the same openthread network
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.
@@ -294,9 +289,9 @@ With any serial terminal application such as screen, putty, minicom etc.
             procedure. **LEDs** blink in unison when the factory reset procedure is
             initiated.
 
-*   You can provision and control the Chip device using the python controller,
-    [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
-    standalone, Android or iOS app
+* You can provision and control the Chip device using the python controller,
+  [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
+  standalone, Android or iOS app
 
     Here is an example with the CHIPTool:
 
@@ -306,10 +301,10 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
--   Depending on your network settings your router might not provide native ipv6
-    addresses to your devices (Border router / PC). If this is the case, you
-    need to add a static ipv6 addresses on both device and then an ipv6 route to
-    the border router on your PC
+- Depending on your network settings your router might not provide native ipv6
+  addresses to your devices (Border router / PC). If this is the case, you need
+  to add a static ipv6 addresses on both device and then an ipv6 route to the
+  border router on your PC
 
 #### On Border Router:
 
@@ -324,20 +319,20 @@ via 2002::2
 
 ## Running RPC console
 
--   As part of building the example with RPCs enabled the chip_rpc python
-    interactive console is installed into your venv. The python wheel files are
-    also created in the output folder: out/debug/chip_rpc_console_wheels. To
-    install the wheel files without rebuilding:
+- As part of building the example with RPCs enabled the chip_rpc python
+  interactive console is installed into your venv. The python wheel files are
+  also created in the output folder: out/debug/chip_rpc_console_wheels. To
+  install the wheel files without rebuilding:
 
     `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
--   To use the chip-rpc console after it has been installed run:
+- To use the chip-rpc console after it has been installed run:
 
     `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
--   Then you can simulate a button press or release using the following command
-    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-    RELEASE Test toggling the LED with
+- Then you can simulate a button press or release using the following command
+  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+  RELEASE Test toggling the LED with
 
     `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 

--- a/examples/thermostat/silabs/README.md
+++ b/examples/thermostat/silabs/README.md
@@ -4,29 +4,29 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
-- [Matter EFR32 Thermostat Example](#matter-efr32-thermostat-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-        - [Linux](#linux)
-        - [Mac OS X](#mac-os-x)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT](#segger-rtt)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Notes](#notes)
-            - [On Border Router:](#on-border-router)
-            - [On PC(Linux):](#on-pclinux)
-    - [Running RPC console](#running-rpc-console)
-    - [Memory settings](#memory-settings)
-    - [OTA Software Update](#ota-software-update)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling LCD](#disabling-lcd)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter EFR32 Thermostat Example](#matter-efr32-thermostat-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+        -   [Linux](#linux)
+        -   [Mac OS X](#mac-os-x)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Notes](#notes)
+            -   [On Border Router:](#on-border-router)
+            -   [On PC(Linux):](#on-pclinux)
+    -   [Running RPC console](#running-rpc-console)
+    -   [Memory settings](#memory-settings)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -57,16 +57,17 @@ Silicon Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain (For most Host, the
-  bootstrap already installs the toolchain):
-  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+-   Download and install a suitable ARM gcc tool chain (For most Host, the
+    bootstrap already installs the toolchain):
+    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
-- Install some additional tools(likely already present for CHIP developers):
+-   Install some additional tools(likely already present for CHIP developers):
 
 #### Linux
 
@@ -76,73 +77,76 @@ Silicon Labs platform.
 
     $ brew install ninja
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Region code Setting (917 WiFi projects)
-    - In Wifi configurations, the region code can be set in this
-      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-      The available region codes can be found
-      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Build the example application:
+*   Region code Setting (917 WiFi projects)
 
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/ ./out/thermostat-app BRD4187C
+    -   In Wifi configurations, the region code can be set in this
+        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+        The available region codes can be found
+        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-- To delete generated executable, libraries and object files use:
+*   Build the example application:
 
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/ ./out/thermostat-app BRD4187C
+
+-   To delete generated executable, libraries and object files use:
+
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/thermostat/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/thermostat/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug
+            $ ninja -C out/debug
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/thermostat/silabs
-          $ rm -rf out/
+            $ cd ~/connectedhomeip/examples/thermostat/silabs
+            $ rm -rf out/
 
-* Build the example with Matter shell
+*   Build the example with Matter shell
 
-          ./scripts/examples/gn_silabs_example.sh examples/thermostat/silabs/ out/thermostat-app BRD4187C chip_build_libshell=true
+            ./scripts/examples/gn_silabs_example.sh examples/thermostat/silabs/ out/thermostat-app BRD4187C chip_build_libshell=true
 
-* Build the example as Intermittently Connected Device (ICD)
+*   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/ ./out/thermostat-app_ICD BRD4187C --icd
+            $ ./scripts/examples/gn_silabs_example.sh ./examples/thermostat/silabs/ ./out/thermostat-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
+            $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false chip_build_libshell=true'
 
-* Build the example with pigweed RCP
+*   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/thermostat/silabs/ out/thermostat-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+            $ ./scripts/examples/gn_silabs_example.sh examples/thermostat/silabs/ out/thermostat-app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/thermostat/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/thermostat/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+            $ ninja -C out/debug
 
 For more build options, help is provided when running the build script without
 arguments
@@ -151,12 +155,12 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          $ cd ~/connectedhomeip/examples/thermostat/silabs
-          $ python3 out/debug/matter-silabs-thermostat-switch-example.flash.py
+            $ cd ~/connectedhomeip/examples/thermostat/silabs
+            $ python3 out/debug/matter-silabs-thermostat-switch-example.flash.py
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -178,37 +182,37 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          $ sudo usermod -a -G dialout ${USER}
+            $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
-          ```
-          $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
-          ```
+            ```
+            $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
+            ```
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          $ JLinkRTTClient
+            $ JLinkRTTClient
 
 ### Console Log
 
@@ -223,9 +227,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -236,62 +240,63 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- For this example to work, it is necessary to have a second efr32 device
-  running the
-  [thermostat app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/thermostat/silabs/README.md)
-  commissioned on the same openthread network
+-   For this example to work, it is necessary to have a second efr32 device
+    running the
+    [thermostat app example](https://github.com/project-chip/connectedhomeip/blob/master/examples/thermostat/silabs/README.md)
+    commissioned on the same openthread network
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0** shows the overall state of the device and its connectivity. The
     following states are possible:
 
-        -   Short Flash On (50 ms on/950 ms off): The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+          -   Short Flash On (50 ms on/950 ms off): The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-        -   Rapid Even Flashing (100 ms on/100 ms off): The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+          -   Rapid Even Flashing (100 ms on/100 ms off): The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-        -   Short Flash Off (950ms on/50ms off): The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+          -   Short Flash Off (950ms on/50ms off): The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-        -   Solid On: The device is fully provisioned and has full Thread
-            network and service connectivity.
+          -   Solid On: The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **Push Button 0**
 
-        -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
-            for 30 seconds. The device will then switch to a slower interval advertisement.
-            After 15 minutes, the advertisement stops.
-            Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
+          -   _Press and Release_ : Start, or restart, BLE advertisement in fast mode. It will advertise in this mode
+              for 30 seconds. The device will then switch to a slower interval advertisement.
+              After 15 minutes, the advertisement stops.
+              Additionally, it will cycle through the QR code, application status screen and device status screen, respectively.
 
-        -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   _Pressed and hold for 6 s_ : Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
-* You can provision and control the Chip device using the python controller,
-  [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
-  standalone, Android or iOS app
+*   You can provision and control the Chip device using the python controller,
+    [CHIPTool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/README.md)
+    standalone, Android or iOS app
 
     Here is an example with the CHIPTool:
 
@@ -301,10 +306,10 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
-- Depending on your network settings your router might not provide native ipv6
-  addresses to your devices (Border router / PC). If this is the case, you need
-  to add a static ipv6 addresses on both device and then an ipv6 route to the
-  border router on your PC
+-   Depending on your network settings your router might not provide native ipv6
+    addresses to your devices (Border router / PC). If this is the case, you
+    need to add a static ipv6 addresses on both device and then an ipv6 route to
+    the border router on your PC
 
 #### On Border Router:
 
@@ -319,20 +324,20 @@ via 2002::2
 
 ## Running RPC console
 
-- As part of building the example with RPCs enabled the chip_rpc python
-  interactive console is installed into your venv. The python wheel files are
-  also created in the output folder: out/debug/chip_rpc_console_wheels. To
-  install the wheel files without rebuilding:
+-   As part of building the example with RPCs enabled the chip_rpc python
+    interactive console is installed into your venv. The python wheel files are
+    also created in the output folder: out/debug/chip_rpc_console_wheels. To
+    install the wheel files without rebuilding:
 
     `pip3 install out/debug/chip_rpc_console_wheels/*.whl`
 
-- To use the chip-rpc console after it has been installed run:
+-   To use the chip-rpc console after it has been installed run:
 
     `chip-console --device /dev/tty.<SERIALDEVICE> -b 115200 -o /<YourFolder>/pw_log.out`
 
-- Then you can simulate a button press or release using the following command
-  where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
-  RELEASE Test toggling the LED with
+-   Then you can simulate a button press or release using the following command
+    where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for
+    RELEASE Test toggling the LED with
 
     `rpcs.chip.rpc.Button.Event(idx=1, pushed=True)`
 

--- a/examples/thermostat/silabs/README.md
+++ b/examples/thermostat/silabs/README.md
@@ -34,7 +34,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/thermostat/silabs/README.md
+++ b/examples/thermostat/silabs/README.md
@@ -80,7 +80,7 @@ Silicon Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-overview/#hardware-requirements)
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
         > in the Silicon Labs Matter Documentation
 
     MG24 boards :

--- a/examples/thermostat/silabs/README.md
+++ b/examples/thermostat/silabs/README.md
@@ -34,7 +34,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/thermostat/silabs/README.md
+++ b/examples/thermostat/silabs/README.md
@@ -4,27 +4,29 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
--   [Matter EFR32 Thermostat Example](#matter-efr32-thermostat-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-        -   [Linux](#linux)
-        -   [Mac OS X](#mac-os-x)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-            -   [On Border Router:](#on-border-router)
-            -   [On PC(Linux):](#on-pclinux)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Memory settings](#memory-settings)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter EFR32 Thermostat Example](#matter-efr32-thermostat-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+      - [Linux](#linux)
+      - [Mac OS X](#mac-os-x)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Notes](#notes)
+      - [On Border Router:](#on-border-router)
+      - [On PC(Linux):](#on-pclinux)
+  - [Running RPC console](#running-rpc-console)
+  - [Memory settings](#memory-settings)
+  - [OTA Software Update](#ota-software-update)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -32,7 +34,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
 
 ## Introduction
 
@@ -78,8 +80,8 @@ Silicon Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-overview/#hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
 
@@ -161,9 +163,8 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 ## Viewing Logging Output
 

--- a/examples/window-app/silabs/README.md
+++ b/examples/window-app/silabs/README.md
@@ -5,22 +5,22 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 <hr>
 
 - [Matter EFR32 Window Covering Example](#matter-efr32-window-covering-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-    - [SEGGER RTT](#segger-rtt)
-    - [Console Log](#console-log)
-      - [Configuring the VCOM](#configuring-the-vcom)
-    - [Using the console](#using-the-console)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Notes](#notes)
-  - [OTA Software Update](#ota-software-update)
-  - [Building options](#building-options)
-    - [Disabling logging](#disabling-logging)
-    - [Debug build / release build](#debug-build--release-build)
-    - [Disabling LCD](#disabling-lcd)
-    - [KVS maximum entry count](#kvs-maximum-entry-count)
+    - [Introduction](#introduction)
+    - [Building](#building)
+    - [Flashing the Application](#flashing-the-application)
+    - [Viewing Logging Output](#viewing-logging-output)
+        - [SEGGER RTT](#segger-rtt)
+        - [Console Log](#console-log)
+            - [Configuring the VCOM](#configuring-the-vcom)
+        - [Using the console](#using-the-console)
+    - [Running the Complete Example](#running-the-complete-example)
+        - [Notes](#notes)
+    - [OTA Software Update](#ota-software-update)
+    - [Building options](#building-options)
+        - [Disabling logging](#disabling-logging)
+        - [Debug build / release build](#debug-build--release-build)
+        - [Disabling LCD](#disabling-lcd)
+        - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -52,17 +52,16 @@ Silicon Labs platform.
 
 ## Building
 
--   Download the
-    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
-    (For Mac OS X, `commander` is located inside
-    `Commander.app/Contents/MacOS/`.)
+- Download the
+  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
+  line tool, and ensure that `commander` is your shell search path. (For Mac OS
+  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
 
--   Download and install a suitable ARM gcc tool chain (For most Host, the
-    bootstrap already installs the toolchain):
-    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+- Download and install a suitable ARM gcc tool chain (For most Host, the
+  bootstrap already installs the toolchain):
+  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
--   Install some additional tools(likely already present for CHIP developers):
+- Install some additional tools(likely already present for CHIP developers):
 
            # Linux
            $ sudo apt-get install git ninja-build
@@ -70,34 +69,31 @@ Silicon Labs platform.
            # Mac OS X
            $ brew install ninja
 
--   Supported hardware:
-
-    -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-        > in the Silicon Labs Matter Documentation
+- Supported hardware:
+    - > For the latest supported hardware please refer to the
+      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+      > in the Silicon Labs Matter Documentation
 
     MG24 boards :
+    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+* Region code Setting (917 WiFi projects)
+    - In Wifi configurations, the region code can be set in this
+      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+      The available region codes can be found
+      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-*   Region code Setting (917 WiFi projects)
-
-    -   In Wifi configurations, the region code can be set in this
-        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-        The available region codes can be found
-        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
-
-*   Build the example application:
+* Build the example application:
 
           cd ~/connectedhomeip
           ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/ ./out/window-app BRD4187C
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
@@ -111,12 +107,12 @@ Silicon Labs platform.
           $ gn gen out/debug
           $ ninja -C out/debug
 
--   To delete generated executable, libraries and object files use:
+- To delete generated executable, libraries and object files use:
 
           $ cd ~/connectedhomeip/examples/window-app/silabs
           $ rm -rf out/
 
-*   Build the example as Intermittently Connected Device (ICD)
+* Build the example as Intermittently Connected Device (ICD)
 
           $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/ ./out/window-app_ICD BRD4187C --icd
 
@@ -124,7 +120,7 @@ Silicon Labs platform.
 
           $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
-*   Build the example with pigweed RCP
+* Build the example with pigweed RCP
 
           $ ./scripts/examples/gn_silabs_example.sh examples/window-app/silabs/ out/window_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
@@ -144,12 +140,12 @@ arguments
 
 ## Flashing the Application
 
--   On the command line:
+- On the command line:
 
           $ cd ~/connectedhomeip/examples/window-app/silabs
           $ python3 out/debug/matter-silabs-window-example.flash.py
 
--   Or with the Ozone debugger, just load the .out file.
+- Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -171,27 +167,27 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
--   Download the J-Link installer by navigating to the appropriate URL and
-    agreeing to the license agreement.
+- Download the J-Link installer by navigating to the appropriate URL and
+  agreeing to the license agreement.
 
--   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
--   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-*   Install the J-Link software
+* Install the J-Link software
 
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-*   In Linux, grant the logged in user the ability to talk to the development
-    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
-    dialout group.
+* In Linux, grant the logged in user the ability to talk to the development
+  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
+  group.
 
           $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
--   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
@@ -199,7 +195,7 @@ combination with JLinkRTTClient as follows:
           $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
           ```
 
--   In a second terminal, run the JLinkRTTClient to view logs:
+- In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
 
@@ -216,9 +212,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
--   Using (Simplicity
-    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
--   Using commander-cli
+- Using (Simplicity
+  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+- Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -229,18 +225,17 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
--   It is assumed here that you already have an OpenThread border router
-    configured and running. If not see the following guide
-    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-    for more information on how to setup a border router on a raspberryPi.
+- It is assumed here that you already have an OpenThread border router
+  configured and running. If not see the following guide
+  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+  for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
--   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
-    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
-    BLE
+- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
+  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
 
         * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
           a URL can be found in the RTT logs.
@@ -294,8 +289,8 @@ With any serial terminal application such as screen, putty, minicom etc.
 
         - Pressing and hold both buttons at the same time: Cycles between window covering 1, and window covering 2.
 
-*   Once the device is provisioned, it will join the Thread network is
-    established, look for the RTT log
+* Once the device is provisioned, it will join the Thread network is
+  established, look for the RTT log
 
     ```
         [DL] Device Role: CHILD
@@ -342,10 +337,10 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
--   Depending on your network settings your router might not provide native ipv6
-    addresses to your devices (Border router / PC). If this is the case, you
-    need to add a static ipv6 addresses on both device and then an ipv6 route to
-    the border router on your PC
+- Depending on your network settings your router might not provide native ipv6
+  addresses to your devices (Border router / PC). If this is the case, you need
+  to add a static ipv6 addresses on both device and then an ipv6 route to the
+  border router on your PC
 
           # On Border Router :
           $ sudo ip addr add dev <Network interface> 2002::2/64

--- a/examples/window-app/silabs/README.md
+++ b/examples/window-app/silabs/README.md
@@ -28,7 +28,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
+> [Silabs matter_sdk Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 

--- a/examples/window-app/silabs/README.md
+++ b/examples/window-app/silabs/README.md
@@ -4,21 +4,23 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
--   [Matter EFR32 Window Covering Example](#matter-efr32-window-covering-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-        -   [SeggerRTT](#segger-rtt)
-        -   [Serial Console](#console-log)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Notes](#notes)
-    -   [OTA Software Update](#ota-software-update)
-    -   [Building options](#building-options)
-        -   [Disabling logging](#disabling-logging)
-        -   [Debug build / release build](#debug-build--release-build)
-        -   [Disabling LCD](#disabling-lcd)
-        -   [KVS maximum entry count](#kvs-maximum-entry-count)
+- [Matter EFR32 Window Covering Example](#matter-efr32-window-covering-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+    - [SEGGER RTT](#segger-rtt)
+    - [Console Log](#console-log)
+      - [Configuring the VCOM](#configuring-the-vcom)
+    - [Using the console](#using-the-console)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Notes](#notes)
+  - [OTA Software Update](#ota-software-update)
+  - [Building options](#building-options)
+    - [Disabling logging](#disabling-logging)
+    - [Debug build / release build](#debug-build--release-build)
+    - [Disabling LCD](#disabling-lcd)
+    - [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -26,7 +28,7 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 > frequent releases thoroughly tested and validated. Developers looking to
 > develop matter products with silabs hardware are encouraged to use our latest
 > release with added tools and documentation.
-> [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
+> [Silabs `matter_sdk` Github](https://github.com/SiliconLabsSoftware/matter_sdk/tags)
 
 ## Introduction
 
@@ -71,8 +73,8 @@ Silicon Labs platform.
 -   Supported hardware:
 
     -   > For the latest supported hardware please refer to the
-        > [Hardware Requirements](https://github.com/SiliconLabs/matter/blob/latest/docs/silabs/general/HARDWARE_REQUIREMENTS.md)
-        > in the Silicon Labs Matter Github Repo
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
 
@@ -150,9 +152,8 @@ arguments
 -   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
-info. Pre-built bootloader binaries are available in the Assets section of the
-Releases page on
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases) .
+info. Pre-built bootloader binaries are available on the
+[Matter Software Artifacts page](https://docs.silabs.com/matter/latest/matter-prerequisites/matter-artifacts#matter-bootloader-binaries).
 
 ## Viewing Logging Output
 

--- a/examples/window-app/silabs/README.md
+++ b/examples/window-app/silabs/README.md
@@ -4,23 +4,23 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
 
 <hr>
 
-- [Matter EFR32 Window Covering Example](#matter-efr32-window-covering-example)
-    - [Introduction](#introduction)
-    - [Building](#building)
-    - [Flashing the Application](#flashing-the-application)
-    - [Viewing Logging Output](#viewing-logging-output)
-        - [SEGGER RTT](#segger-rtt)
-        - [Console Log](#console-log)
-            - [Configuring the VCOM](#configuring-the-vcom)
-        - [Using the console](#using-the-console)
-    - [Running the Complete Example](#running-the-complete-example)
-        - [Notes](#notes)
-    - [OTA Software Update](#ota-software-update)
-    - [Building options](#building-options)
-        - [Disabling logging](#disabling-logging)
-        - [Debug build / release build](#debug-build--release-build)
-        - [Disabling LCD](#disabling-lcd)
-        - [KVS maximum entry count](#kvs-maximum-entry-count)
+-   [Matter EFR32 Window Covering Example](#matter-efr32-window-covering-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SEGGER RTT](#segger-rtt)
+        -   [Console Log](#console-log)
+            -   [Configuring the VCOM](#configuring-the-vcom)
+        -   [Using the console](#using-the-console)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Notes](#notes)
+    -   [OTA Software Update](#ota-software-update)
+    -   [Building options](#building-options)
+        -   [Disabling logging](#disabling-logging)
+        -   [Debug build / release build](#debug-build--release-build)
+        -   [Disabling LCD](#disabling-lcd)
+        -   [KVS maximum entry count](#kvs-maximum-entry-count)
 
 <hr>
 
@@ -52,86 +52,90 @@ Silicon Labs platform.
 
 ## Building
 
-- Download the
-  [Simplicity Commander](https://www.silabs.com/mcu/programming-options) command
-  line tool, and ensure that `commander` is your shell search path. (For Mac OS
-  X, `commander` is located inside `Commander.app/Contents/MacOS/`.)
+-   Download the
+    [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
+    command line tool, and ensure that `commander` is your shell search path.
+    (For Mac OS X, `commander` is located inside
+    `Commander.app/Contents/MacOS/`.)
 
-- Download and install a suitable ARM gcc tool chain (For most Host, the
-  bootstrap already installs the toolchain):
-  [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+-   Download and install a suitable ARM gcc tool chain (For most Host, the
+    bootstrap already installs the toolchain):
+    [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
-- Install some additional tools(likely already present for CHIP developers):
+-   Install some additional tools(likely already present for CHIP developers):
 
-           # Linux
-           $ sudo apt-get install git ninja-build
+             # Linux
+             $ sudo apt-get install git ninja-build
 
-           # Mac OS X
-           $ brew install ninja
+             # Mac OS X
+             $ brew install ninja
 
-- Supported hardware:
-    - > For the latest supported hardware please refer to the
-      > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
-      > in the Silicon Labs Matter Documentation
+-   Supported hardware:
+
+    -   > For the latest supported hardware please refer to the
+        > [Hardware Requirements](https://docs.silabs.com/matter/latest/matter-prerequisites/hardware-requirements)
+        > in the Silicon Labs Matter Documentation
 
     MG24 boards :
-    - BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
-    - BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
-    - BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Region code Setting (917 WiFi projects)
-    - In Wifi configurations, the region code can be set in this
-      [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
-      The available region codes can be found
-      [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
+    -   BRD2601B / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD2703A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4186C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@10dBm
+    -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
+    -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-* Build the example application:
+*   Region code Setting (917 WiFi projects)
 
-          cd ~/connectedhomeip
-          ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/ ./out/window-app BRD4187C
+    -   In Wifi configurations, the region code can be set in this
+        [file](https://github.com/project-chip/connectedhomeip/blob/85e9d5fd42071d52fa3940238739544fd2a3f717/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp#L104).
+        The available region codes can be found
+        [here](https://github.com/SiliconLabs/wiseconnect/blob/f675628eefa1ac4990e94146abb75dd08b522571/components/device/silabs/si91x/wireless/inc/sl_si91x_types.h#L71)
 
-- To delete generated executable, libraries and object files use:
+*   Build the example application:
 
-          $ cd ~/connectedhomeip
-          $ rm -rf ./out/
+            cd ~/connectedhomeip
+            ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/ ./out/window-app BRD4187C
+
+-   To delete generated executable, libraries and object files use:
+
+            $ cd ~/connectedhomeip
+            $ rm -rf ./out/
 
     OR use GN/Ninja directly
 
-          $ cd ~/connectedhomeip/examples/window-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/window-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug
+            $ ninja -C out/debug
 
-- To delete generated executable, libraries and object files use:
+-   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/window-app/silabs
-          $ rm -rf out/
+            $ cd ~/connectedhomeip/examples/window-app/silabs
+            $ rm -rf out/
 
-* Build the example as Intermittently Connected Device (ICD)
+*   Build the example as Intermittently Connected Device (ICD)
 
-          $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/ ./out/window-app_ICD BRD4187C --icd
+            $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs/ ./out/window-app_ICD BRD4187C --icd
 
     or use gn as previously mentioned but adding the following arguments:
 
-          $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
+            $ gn gen out/debug '--args=SILABS_BOARD="BRD4187C" enable_sleepy_device=true chip_openthread_ftd=false'
 
-* Build the example with pigweed RCP
+*   Build the example with pigweed RCP
 
-          $ ./scripts/examples/gn_silabs_example.sh examples/window-app/silabs/ out/window_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
+            $ ./scripts/examples/gn_silabs_example.sh examples/window-app/silabs/ out/window_app_rpc BRD4187C 'import("//with_pw_rpc.gni")'
 
     or use GN/Ninja Directly
 
-          $ cd ~/connectedhomeip/examples/window-app/silabs
-          $ git submodule update --init
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export SILABS_BOARD=BRD4187C
-          $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
-          $ ninja -C out/debug
+            $ cd ~/connectedhomeip/examples/window-app/silabs
+            $ git submodule update --init
+            $ source third_party/connectedhomeip/scripts/activate.sh
+            $ export SILABS_BOARD=BRD4187C
+            $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
+            $ ninja -C out/debug
 
 For more build options, help is provided when running the build script without
 arguments
@@ -140,12 +144,12 @@ arguments
 
 ## Flashing the Application
 
-- On the command line:
+-   On the command line:
 
-          $ cd ~/connectedhomeip/examples/window-app/silabs
-          $ python3 out/debug/matter-silabs-window-example.flash.py
+            $ cd ~/connectedhomeip/examples/window-app/silabs
+            $ python3 out/debug/matter-silabs-window-example.flash.py
 
-- Or with the Ozone debugger, just load the .out file.
+-   Or with the Ozone debugger, just load the .out file.
 
 All EFR32 boards require a bootloader, see Silicon Labs documentation for more
 info. Pre-built bootloader binaries are available on the
@@ -167,37 +171,37 @@ Software and Documentation Pack_
 Alternatively, SEGGER Ozone J-Link debugger can be used to view RTT logs too
 after flashing the .out file.
 
-- Download the J-Link installer by navigating to the appropriate URL and
-  agreeing to the license agreement.
+-   Download the J-Link installer by navigating to the appropriate URL and
+    agreeing to the license agreement.
 
-- [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
-- [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
+-   [JLink_Linux_x86_64.deb](https://www.segger.com/downloads/jlink/JLink_Linux_x86_64.deb)
+-   [JLink_MacOSX.pkg](https://www.segger.com/downloads/jlink/JLink_MacOSX.pkg)
 
-* Install the J-Link software
+*   Install the J-Link software
 
-          $ cd ~/Downloads
-          $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
+            $ cd ~/Downloads
+            $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
 
-* In Linux, grant the logged in user the ability to talk to the development
-  hardware via the linux tty device (/dev/ttyACMx) by adding them to the dialout
-  group.
+*   In Linux, grant the logged in user the ability to talk to the development
+    hardware via the linux tty device (/dev/ttyACMx) by adding them to the
+    dialout group.
 
-          $ sudo usermod -a -G dialout ${USER}
+            $ sudo usermod -a -G dialout ${USER}
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
 
-- Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
+-   Run the JLinkExe tool with arguments to autoconnect to the WSTK board:
 
     For MG24 use:
 
-          ```
-          $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
-          ```
+            ```
+            $ JLinkExe -device EFR32MG24AXXXF1536 -if SWD -speed 4000 -autoconnect 1
+            ```
 
-- In a second terminal, run the JLinkRTTClient to view logs:
+-   In a second terminal, run the JLinkRTTClient to view logs:
 
-          $ JLinkRTTClient
+            $ JLinkRTTClient
 
 ### Console Log
 
@@ -212,9 +216,9 @@ the verbose mode is selected (--verbose)
 
 #### Configuring the VCOM
 
-- Using (Simplicity
-  Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
-- Using commander-cli
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
     ```
     commander vcom config --baudrate 921600 --handshake rtscts
     ```
@@ -225,72 +229,73 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 
-- It is assumed here that you already have an OpenThread border router
-  configured and running. If not see the following guide
-  [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
-  for more information on how to setup a border router on a raspberryPi.
+-   It is assumed here that you already have an OpenThread border router
+    configured and running. If not see the following guide
+    [Openthread_border_router](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/openthread/openthread_border_router_pi.md)
+    for more information on how to setup a border router on a raspberryPi.
 
     Take note that the RCP code is available directly through
     [Simplicity Studio 5](https://www.silabs.com/products/development-tools/software/simplicity-studio/simplicity-studio-5)
     under File->New->Project Wizard->Examples->Thread : ot-rcp
 
-- User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR Code
-  is be scanned by the CHIP Tool app For the Rendez-vous procedure over BLE
+-   User interface : **LCD** The LCD on Silabs WSTK shows a QR Code. This QR
+    Code is be scanned by the CHIP Tool app For the Rendez-vous procedure over
+    BLE
 
-        * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
-          a URL can be found in the RTT logs.
+          * On devices that do not have or support the LCD Display like the BRD4166A Thunderboard Sense 2,
+            a URL can be found in the RTT logs.
 
-          <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
-          <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
+            <info  > [SVR] Copy/paste the below URL in a browser to see the QR Code:
+            <info  > [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34NM%20-00%200C9SS0
 
     **LED 0** shows the overall state of the device and its connectivity. The
     following states are possible:
 
-        -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
-            unprovisioned (unpaired) state and is waiting for a commissioning
-            application to connect.
+          -   _Short Flash On (50 ms on/950 ms off)_ ; The device is in the
+              unprovisioned (unpaired) state and is waiting for a commissioning
+              application to connect.
 
-        -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
-            unprovisioned state and a commissioning application is connected through
-            Bluetooth LE.
+          -   _Rapid Even Flashing_ ; (100 ms on/100 ms off)_ &mdash; The device is in the
+              unprovisioned state and a commissioning application is connected through
+              Bluetooth LE.
 
-        -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
-            provisioned, but does not yet have full Thread network or service
-            connectivity.
+          -   _Short Flash Off_ ; (950ms on/50ms off)_ &mdash; The device is fully
+              provisioned, but does not yet have full Thread network or service
+              connectivity.
 
-        -   _Solid On_ ; The device is fully provisioned and has full Thread
-            network and service connectivity.
+          -   _Solid On_ ; The device is fully provisioned and has full Thread
+              network and service connectivity.
 
     **LED 1** Shows the state of the window covering
 
-        -   _Solid On_ ; The window cover if fully open
-        -   _Off_ ; The window cover if fully closed
-        -   _Blinking slowly_ ; The window cover is half-open, either by tilt, or lift
-        -   _Blinking quickly_ ; The window cover is being automatically open or closed
+          -   _Solid On_ ; The window cover if fully open
+          -   _Off_ ; The window cover if fully closed
+          -   _Blinking slowly_ ; The window cover is half-open, either by tilt, or lift
+          -   _Blinking quickly_ ; The window cover is being automatically open or closed
 
     **Push Button 0** Increase either tilt or lift, and factory reset
 
-        -   Pressed and release: The lift/tilt increases by 10%
+          -   Pressed and release: The lift/tilt increases by 10%
 
-        -   Pressed and hold for 6 s: Initiates the factory reset of the device.
-            Releasing the button within the 6-second window cancels the factory reset
-            procedure. **LEDs** blink in unison when the factory reset procedure is
-            initiated.
+          -   Pressed and hold for 6 s: Initiates the factory reset of the device.
+              Releasing the button within the 6-second window cancels the factory reset
+              procedure. **LEDs** blink in unison when the factory reset procedure is
+              initiated.
 
     **Push Button 1** Decreases either tilt or lift, or switch the cover type
 
-        -   Pressed and release: The lift/tilt decreases by 10%
+          -   Pressed and release: The lift/tilt decreases by 10%
 
-        -   Press and hold for 3 s: Cycle between window covering type (Rollershade, Drapery, Tilt Blind - Lift and Tilt).
+          -   Press and hold for 3 s: Cycle between window covering type (Rollershade, Drapery, Tilt Blind - Lift and Tilt).
 
     **Push Button0 and Button1** Switch between lift and tilt
 
-        - Pressing and release both buttons at the same time: switches between lift and tilt modes. Most window covering types support either lift only, or tilt only, but type 0x08 support both (default)
+          - Pressing and release both buttons at the same time: switches between lift and tilt modes. Most window covering types support either lift only, or tilt only, but type 0x08 support both (default)
 
-        - Pressing and hold both buttons at the same time: Cycles between window covering 1, and window covering 2.
+          - Pressing and hold both buttons at the same time: Cycles between window covering 1, and window covering 2.
 
-* Once the device is provisioned, it will join the Thread network is
-  established, look for the RTT log
+*   Once the device is provisioned, it will join the Thread network is
+    established, look for the RTT log
 
     ```
         [DL] Device Role: CHILD
@@ -337,19 +342,19 @@ With any serial terminal application such as screen, putty, minicom etc.
 
 ### Notes
 
-- Depending on your network settings your router might not provide native ipv6
-  addresses to your devices (Border router / PC). If this is the case, you need
-  to add a static ipv6 addresses on both device and then an ipv6 route to the
-  border router on your PC
+-   Depending on your network settings your router might not provide native ipv6
+    addresses to your devices (Border router / PC). If this is the case, you
+    need to add a static ipv6 addresses on both device and then an ipv6 route to
+    the border router on your PC
 
-          # On Border Router :
-          $ sudo ip addr add dev <Network interface> 2002::2/64
+            # On Border Router :
+            $ sudo ip addr add dev <Network interface> 2002::2/64
 
-          # On PC (Linux) :
-          $ sudo ip addr add dev <Network interface> 2002::1/64
+            # On PC (Linux) :
+            $ sudo ip addr add dev <Network interface> 2002::1/64
 
-          # Add Ipv6 route on PC (Linux)
-          $ sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2
+            # Add Ipv6 route on PC (Linux)
+            $ sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2
 
 ## OTA Software Update
 


### PR DESCRIPTION
#### Summary
In current state, silabs documentation points to outdated links including:
- References to SMG repo: https://github.com/SiliconLabs/matter
- siliconlabs.github.io (no longer maintained) rather than docs.silabs.com

Updated these links to point to maintained resources, including:
- Silabs `matter_sdk` repo: https://github.com/SiliconLabsSoftware/matter_sdk
- Documentation in docs.silabs.com

Automatically update TOC in README files as well 

#### Testing
Verified links locally

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
