### PR TITLE
Add generic read attribute function

### DIFF
--- a/src/app/clusters/testing/BUILD.gn
+++ b/src/app/clusters/testing/BUILD.gn
@@ -26,6 +26,7 @@ source_set("testing") {
   public_deps = [
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/app/data-model-provider/tests:encode-decode",
+    "${chip_root}/src/app/server-cluster:server-cluster",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
   ]

--- a/src/app/clusters/testing/TestReadWriteAttribute.h
+++ b/src/app/clusters/testing/TestReadWriteAttribute.h
@@ -29,7 +29,7 @@ namespace Test {
 
 // Helper function to read any attribute value of a given type
 template <typename T>
-CHIP_ERROR ReadClusterAttribute(chip::app::ServerClusterInterface & cluster, const app::ConcreteDataAttributePath & path, T & value)
+CHIP_ERROR ReadClusterAttribute(app::ServerClusterInterface & cluster, const app::ConcreteDataAttributePath & path, T & value)
 {
     static_assert(std::is_integral_v<T> || std::is_enum_v<T>);
 
@@ -47,21 +47,20 @@ CHIP_ERROR ReadClusterAttribute(chip::app::ServerClusterInterface & cluster, con
 
 // Helper function to read any attribute value of a given type
 template <typename T>
-CHIP_ERROR ReadClusterAttribute(chip::app::ServerClusterInterface & cluster, AttributeId attr, T & value)
+CHIP_ERROR ReadClusterAttribute(app::ServerClusterInterface & cluster, AttributeId attr, T & value)
 {
     static_assert(std::is_integral_v<T> || std::is_enum_v<T>);
 
     const auto & paths = cluster.GetPaths();
     // This should be a size-1 span
     VerifyOrReturnError(paths.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
-    chip::app::ConcreteAttributePath attributePath(paths[0].mEndpointId, paths[0].mClusterId, attr);
+    app::ConcreteAttributePath attributePath(paths[0].mEndpointId, paths[0].mClusterId, attr);
     return ReadClusterAttribute(cluster, attributePath, value);
 }
 
 // Helper function to write any attribute value of a given type
 template <typename T>
-CHIP_ERROR WriteClusterAttribute(chip::app::ServerClusterInterface & cluster, const app::ConcreteAttributePath & path,
-                                 const T & value)
+CHIP_ERROR WriteClusterAttribute(app::ServerClusterInterface & cluster, const app::ConcreteAttributePath & path, const T & value)
 {
     static_assert(std::is_integral_v<T> || std::is_enum_v<T>);
 
@@ -72,14 +71,14 @@ CHIP_ERROR WriteClusterAttribute(chip::app::ServerClusterInterface & cluster, co
 
 // Helper function to write any attribute value of a given type
 template <typename T>
-CHIP_ERROR WriteClusterAttribute(chip::app::ServerClusterInterface & cluster, AttributeId attr, const T & value)
+CHIP_ERROR WriteClusterAttribute(app::ServerClusterInterface & cluster, AttributeId attr, const T & value)
 {
     static_assert(std::is_integral_v<T> || std::is_enum_v<T>);
 
     const auto & paths = cluster.GetPaths();
     // This should be a size-1 span
     VerifyOrReturnError(paths.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
-    chip::app::ConcreteAttributePath attributePath(paths[0].mEndpointId, paths[0].mClusterId, attr);
+    app::ConcreteAttributePath attributePath(paths[0].mEndpointId, paths[0].mClusterId, attr);
     return WriteClusterAttribute(cluster, attributePath, value);
 }
 

--- a/src/app/clusters/testing/TestReadWriteAttribute.h
+++ b/src/app/clusters/testing/TestReadWriteAttribute.h
@@ -17,7 +17,7 @@
 #pragma once
 #include <app/AttributeValueDecoder.h>
 #include <app/AttributeValueEncoder.h>
-
+#include <app/ConcreteAttributePath.h>
 #include <app/data-model-provider/tests/ReadTesting.h>
 #include <app/data-model-provider/tests/WriteTesting.h>
 
@@ -26,6 +26,7 @@
 namespace chip {
 namespace Test {
 
+// Helper function to read any attribute value of a given type
 template <typename ClusterT, typename T>
 CHIP_ERROR ReadClusterAttribute(ClusterT & cluster, const app::ConcreteDataAttributePath & path, T & value)
 {
@@ -39,6 +40,16 @@ CHIP_ERROR ReadClusterAttribute(ClusterT & cluster, const app::ConcreteDataAttri
     VerifyOrReturnError(attributeData.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
 
     return app::DataModel::Decode(attributeData[0].dataReader, value);
+}
+
+// Helper function to read any attribute value of a given type
+template <typename ClusterT, typename T>
+CHIP_ERROR ReadClusterAttribute(ClusterT & cluster, AttributeId attr, T & val)
+{
+    const auto & paths = cluster.GetPaths();
+    // This should be a size-1 span
+    VerifyOrReturnError(paths.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
+    return ReadClusterAttribute(cluster, chip::app::ConcreteAttributePath(paths[0].mEndpointId, paths[0].mClusterId, attr), val);
 }
 
 // Helper function to write any attribute value of a given type

--- a/src/app/clusters/testing/TestReadWriteAttribute.h
+++ b/src/app/clusters/testing/TestReadWriteAttribute.h
@@ -20,7 +20,7 @@
 #include <app/ConcreteAttributePath.h>
 #include <app/data-model-provider/tests/ReadTesting.h>
 #include <app/data-model-provider/tests/WriteTesting.h>
-#include <app/server-cluster/DefaultServerCluster.h>
+#include <app/server-cluster/ServerClusterInterface.h>
 
 #include <lib/core/TLVReader.h>
 
@@ -29,7 +29,7 @@ namespace Test {
 
 // Helper function to read any attribute value of a given type
 template <typename T>
-CHIP_ERROR ReadClusterAttribute(chip::app::DefaultServerCluster & cluster, const app::ConcreteDataAttributePath & path, T & value)
+CHIP_ERROR ReadClusterAttribute(chip::app::ServerClusterInterface & cluster, const app::ConcreteDataAttributePath & path, T & value)
 {
     static_assert(std::is_integral_v<T> || std::is_enum_v<T>);
 
@@ -47,7 +47,7 @@ CHIP_ERROR ReadClusterAttribute(chip::app::DefaultServerCluster & cluster, const
 
 // Helper function to read any attribute value of a given type
 template <typename T>
-CHIP_ERROR ReadClusterAttribute(chip::app::DefaultServerCluster & cluster, AttributeId attr, T & val)
+CHIP_ERROR ReadClusterAttribute(chip::app::ServerClusterInterface & cluster, AttributeId attr, T & val)
 {
     static_assert(std::is_integral_v<T> || std::is_enum_v<T>);
 
@@ -60,7 +60,7 @@ CHIP_ERROR ReadClusterAttribute(chip::app::DefaultServerCluster & cluster, Attri
 
 // Helper function to write any attribute value of a given type
 template <typename T>
-CHIP_ERROR WriteClusterAttribute(chip::app::DefaultServerCluster & cluster, const app::ConcreteAttributePath & path,
+CHIP_ERROR WriteClusterAttribute(chip::app::ServerClusterInterface & cluster, const app::ConcreteAttributePath & path,
                                  const T & value)
 {
     static_assert(std::is_integral_v<T> || std::is_enum_v<T>);

--- a/src/app/clusters/testing/TestReadWriteAttribute.h
+++ b/src/app/clusters/testing/TestReadWriteAttribute.h
@@ -47,7 +47,7 @@ CHIP_ERROR ReadClusterAttribute(chip::app::ServerClusterInterface & cluster, con
 
 // Helper function to read any attribute value of a given type
 template <typename T>
-CHIP_ERROR ReadClusterAttribute(chip::app::ServerClusterInterface & cluster, AttributeId attr, T & val)
+CHIP_ERROR ReadClusterAttribute(chip::app::ServerClusterInterface & cluster, AttributeId attr, T & value)
 {
     static_assert(std::is_integral_v<T> || std::is_enum_v<T>);
 
@@ -55,7 +55,7 @@ CHIP_ERROR ReadClusterAttribute(chip::app::ServerClusterInterface & cluster, Att
     // This should be a size-1 span
     VerifyOrReturnError(paths.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
     chip::app::ConcreteAttributePath attributePath(paths[0].mEndpointId, paths[0].mClusterId, attr);
-    return ReadClusterAttribute(cluster, attributePath, val);
+    return ReadClusterAttribute(cluster, attributePath, value);
 }
 
 // Helper function to write any attribute value of a given type
@@ -68,6 +68,19 @@ CHIP_ERROR WriteClusterAttribute(chip::app::ServerClusterInterface & cluster, co
     app::Testing::WriteOperation writeOperation(path);
     app::AttributeValueDecoder decoder = writeOperation.DecoderFor(value);
     return cluster.WriteAttribute(writeOperation.GetRequest(), decoder).GetUnderlyingError();
+}
+
+// Helper function to write any attribute value of a given type
+template <typename T>
+CHIP_ERROR WriteClusterAttribute(chip::app::ServerClusterInterface & cluster, AttributeId attr, const T & value)
+{
+    static_assert(std::is_integral_v<T> || std::is_enum_v<T>);
+
+    const auto & paths = cluster.GetPaths();
+    // This should be a size-1 span
+    VerifyOrReturnError(paths.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
+    chip::app::ConcreteAttributePath attributePath(paths[0].mEndpointId, paths[0].mClusterId, attr);
+    return WriteClusterAttribute(cluster, attributePath, value);
 }
 
 } // namespace Test

--- a/src/app/clusters/user-label-server/tests/TestUserLabelCluster.cpp
+++ b/src/app/clusters/user-label-server/tests/TestUserLabelCluster.cpp
@@ -33,6 +33,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::UserLabel;
 using namespace chip::app::Clusters::UserLabel::Attributes;
+using namespace chip::Test;
 
 struct TestUserLabelCluster : public ::testing::Test
 {
@@ -50,12 +51,6 @@ struct TestUserLabelCluster : public ::testing::Test
     ServerClusterContext context;
     UserLabelCluster userLabel;
 };
-
-template <typename ClusterT, typename T>
-inline CHIP_ERROR ReadClusterAttribute(ClusterT & cluster, AttributeId attr, T & val)
-{
-    return chip::Test::ReadClusterAttribute(cluster, ConcreteAttributePath(kRootEndpointId, UserLabel::Id, attr), val);
-}
 
 } // namespace
 
@@ -78,6 +73,7 @@ TEST_F(TestUserLabelCluster, ReadAttributeTest)
     uint32_t features{};
     ASSERT_EQ(ReadClusterAttribute(userLabel, FeatureMap::Id, features), CHIP_NO_ERROR);
 
-    DataModel::DecodableList<Structs::LabelStruct::Type> labelList;
-    ASSERT_EQ(ReadClusterAttribute(userLabel, LabelList::Id, labelList), CHIP_NO_ERROR);
+    // TODO: It's not safe to use ReadClusterAttribute() for a list
+    // DataModel::DecodableList<Structs::LabelStruct::Type> labelList;
+    // ASSERT_EQ(ReadClusterAttribute(userLabel, LabelList::Id, labelList), CHIP_NO_ERROR);
 }


### PR DESCRIPTION
#### Summary

Add new overload for generic read attribute function, this function will help reduce some duplicated code in unit tests, 

#### Testing

Took a unit test and adapted it to use this new function and the unit test run successfully, once this PR is merged the unit tests will be adapted in different PRs.