### PR TITLE
[WEBRTCP] Use correct user input method

### DIFF
--- a/src/python_testing/TC_WEBRTCP_2_13.py
+++ b/src/python_testing/TC_WEBRTCP_2_13.py
@@ -112,7 +112,7 @@ class TC_WEBRTCP_2_13(MatterBaseTest, WEBRTCPTestBase):
         if self.is_pics_sdk_ci_only:
             self.write_to_app_pipe({"Name": "SetHardPrivacyModeOn", "Value": True})
         else:
-            input("Please turn ON the physical privacy switch on the device, then press Enter to continue...")
+            self.wait_for_user_input("Please turn ON the physical privacy switch on the device, then press Enter to continue...")
 
         # Verify the attribute reflects the privacy switch state
         hard_privacy_mode = await self.read_single_attribute_check_success(
@@ -163,7 +163,7 @@ class TC_WEBRTCP_2_13(MatterBaseTest, WEBRTCPTestBase):
         if self.is_pics_sdk_ci_only:
             self.write_to_app_pipe({"Name": "SetHardPrivacyModeOn", "Value": False})
         else:
-            input("Please turn OFF the physical privacy switch on the device, then press Enter to continue...")
+            self.wait_for_user_input("Please turn OFF the physical privacy switch on the device, then press Enter to continue...")
 
         # Verify the attribute reflects the privacy switch state
         hard_privacy_mode = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_WEBRTCP_2_7.py
+++ b/src/python_testing/TC_WEBRTCP_2_7.py
@@ -110,7 +110,7 @@ class TC_WebRTCP_2_7(MatterBaseTest, WEBRTCPTestBase):
         if self.is_pics_sdk_ci_only:
             self.write_to_app_pipe({"Name": "SetHardPrivacyModeOn", "Value": True})
         else:
-            input("Please turn ON the physical privacy switch on the device, then press Enter to continue...")
+            self.wait_for_user_input("Please turn ON the physical privacy switch on the device, then press Enter to continue...")
 
         # Verify the attribute was set successfully
         hard_privacy_mode = await self.read_single_attribute_check_success(
@@ -141,7 +141,7 @@ class TC_WebRTCP_2_7(MatterBaseTest, WEBRTCPTestBase):
         if self.is_pics_sdk_ci_only:
             self.write_to_app_pipe({"Name": "SetHardPrivacyModeOn", "Value": False})
         else:
-            input("Please turn OFF the physical privacy switch on the device, then press Enter to continue...")
+            self.wait_for_user_input("Please turn OFF the physical privacy switch on the device, then press Enter to continue...")
 
         # Verify the attribute was set successfully
         hard_privacy_mode = await self.read_single_attribute_check_success(


### PR DESCRIPTION
#### Summary

WEBRTCP 2.7 and 2.13 are hanging in the TH UI due to the incorrect method being used to prompt for user input.  This corrects that.

#### Related issues

Fixes https://github.com/project-chip/certification-tool/issues/773

#### Testing

Run WEBRTCP 2.7 and 2.13

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
