### PR TITLE
Delete-before-save cache rotation on master

### DIFF
--- a/.github/actions/delete-cache/action.yml
+++ b/.github/actions/delete-cache/action.yml
@@ -1,0 +1,38 @@
+name: 'Delete Cache'
+description: 'Deletes a GitHub Actions cache by key using the GitHub API'
+inputs:
+  cache-key:
+    required: true
+    description: 'The cache key to delete'
+runs:
+  using: "composite"
+  steps:
+    - name: Delete cache
+      uses: actions/github-script@v7
+      env:
+        CACHE_KEY: ${{ inputs.cache-key }}
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const key = process.env.CACHE_KEY;
+          const ref = context.ref;
+          
+          core.info(`Attempting to delete cache: ${key}`);
+          
+          try {
+            await github.rest.actions.deleteActionsCacheByKey({
+              owner: owner,
+              repo: repo,
+              key: key,
+              ref: ref
+            });
+            core.info(`Successfully deleted cache`);
+          } catch (e) {
+            if (e.status === 404) {
+              core.info(`Cache not found (first run or already deleted)`);
+            } else {
+              core.warning(`Failed to delete cache: ${e.message}`);
+            }
+          }

--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -42,14 +42,11 @@ runs:
       id: cache-vars
       shell: bash
       run: |
-        CACHE_WEEK=$(date +%G-%V)
-        echo "CACHE_WEEK=${CACHE_WEEK}" >> "$GITHUB_ENV"
-
         CACHE_SUFFIX="${{ inputs.cache-suffix }}"
         if [ -n "$CACHE_SUFFIX" ]; then
-          CCACHE_KEY="ccache-${{ runner.os }}-${{ inputs.build-variant }}-w${CACHE_WEEK}-${CACHE_SUFFIX}"
+          CCACHE_KEY="ccache-${{ runner.os }}-${{ inputs.build-variant }}-${CACHE_SUFFIX}"
         else
-          CCACHE_KEY="ccache-${{ runner.os }}-${{ inputs.build-variant }}-w${CACHE_WEEK}"
+          CCACHE_KEY="ccache-${{ runner.os }}-${{ inputs.build-variant }}"
         fi
         echo "CCACHE_KEY=${CCACHE_KEY}" >> "$GITHUB_ENV"
         echo "cache_key=${CCACHE_KEY}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -447,34 +447,9 @@ jobs:
                   retention-days: 5
             - name: Delete existing ccache before save
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
-              uses: actions/github-script@v7
-              env:
-                  CACHE_KEY: ${{ env.CCACHE_KEY }}
+              uses: ./.github/actions/delete-cache
               with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  script: |
-                      const owner = context.repo.owner;
-                      const repo = context.repo.repo;
-                      const key = process.env.CACHE_KEY;
-                      const ref = context.ref;
-                      
-                      core.info(`Attempting to delete cache: ${key}`);
-                      
-                      try {
-                        await github.rest.actions.deleteActionsCacheByKey({
-                          owner: owner,
-                          repo: repo,
-                          key: key,
-                          ref: ref
-                        });
-                        core.info(`Successfully deleted cache`);
-                      } catch (e) {
-                        if (e.status === 404) {
-                          core.info(`Cache not found (first run or already deleted)`);
-                        } else {
-                          core.warning(`Failed to delete cache: ${e.message}`);
-                        }
-                      }
+                  cache-key: ${{ env.CCACHE_KEY }}
             - name: Save ccache
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: actions/cache/save@v4
@@ -965,34 +940,9 @@ jobs:
                   retention-days: 5
             - name: Delete existing ccache before save
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
-              uses: actions/github-script@v7
-              env:
-                  CACHE_KEY: ${{ env.CCACHE_KEY }}
+              uses: ./.github/actions/delete-cache
               with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  script: |
-                      const owner = context.repo.owner;
-                      const repo = context.repo.repo;
-                      const key = process.env.CACHE_KEY;
-                      const ref = context.ref;
-                      
-                      core.info(`Attempting to delete cache: ${key}`);
-                      
-                      try {
-                        await github.rest.actions.deleteActionsCacheByKey({
-                          owner: owner,
-                          repo: repo,
-                          key: key,
-                          ref: ref
-                        });
-                        core.info(`Successfully deleted cache`);
-                      } catch (e) {
-                        if (e.status === 404) {
-                          core.info(`Cache not found (first run or already deleted)`);
-                        } else {
-                          core.warning(`Failed to delete cache: ${e.message}`);
-                        }
-                      }
+                  cache-key: ${{ env.CCACHE_KEY }}
             - name: Save ccache
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: actions/cache/save@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -467,7 +467,7 @@ jobs:
                           key: key,
                           ref: ref
                         });
-                        core.info(`✅ Successfully deleted cache`);
+                        core.info(`Successfully deleted cache`);
                       } catch (e) {
                         if (e.status === 404) {
                           core.info(`Cache not found (first run or already deleted)`);
@@ -985,7 +985,7 @@ jobs:
                           key: key,
                           ref: ref
                         });
-                        core.info(`✅ Successfully deleted cache`);
+                        core.info(`Successfully deleted cache`);
                       } catch (e) {
                         if (e.status === 404) {
                           core.info(`Cache not found (first run or already deleted)`);

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -293,6 +293,7 @@ jobs:
                   CCACHE_DIR: "${{ github.workspace }}/.ccache"
               run: |
                   echo "CCACHE_DISABLE=1" >> $GITHUB_ENV
+                  echo "DISABLE_CCACHE=true" >> $GITHUB_ENV
                   rm -rf "${{ github.workspace }}/.ccache" || true
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build_python.sh \
@@ -444,8 +445,38 @@ jobs:
                   path: objdir-clone/
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
+            - name: Delete existing ccache before save
+              if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
+              uses: actions/github-script@v7
+              env:
+                  CACHE_KEY: ${{ env.CCACHE_KEY }}
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const owner = context.repo.owner;
+                      const repo = context.repo.repo;
+                      const key = process.env.CACHE_KEY;
+                      const ref = context.ref;
+                      
+                      core.info(`Attempting to delete cache: ${key}`);
+                      
+                      try {
+                        await github.rest.actions.deleteActionsCacheByKey({
+                          owner: owner,
+                          repo: repo,
+                          key: key,
+                          ref: ref
+                        });
+                        core.info(`✅ Successfully deleted cache`);
+                      } catch (e) {
+                        if (e.status === 404) {
+                          core.info(`Cache not found (first run or already deleted)`);
+                        } else {
+                          core.warning(`Failed to delete cache: ${e.message}`);
+                        }
+                      }
             - name: Save ccache
-              if: github.ref == 'refs/heads/master' && steps.ccache.outputs.cache-hit != 'true' && env.DISABLE_CCACHE != 'true' && env.CCACHE_DISABLE != '1'
+              if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: actions/cache/save@v4
               with:
                   path: .ccache
@@ -586,6 +617,8 @@ jobs:
         env:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
             BUILD_VARIANT: ${{matrix.build_variant}}
+            DISABLE_CCACHE: ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_ccache == 'true') && 'true' || (contains(github.event.head_commit.message, '[no-ccache]') && 'true') || 'false' }}
+            CCACHE_KEY_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && inputs.cache_suffix || '' }}
 
         runs-on: ubuntu-latest
 
@@ -620,9 +653,11 @@ jobs:
               uses: ./.github/actions/setup-ccache
               with:
                 build-variant: ${{ matrix.build_variant }}
+                disable: ${{ env.DISABLE_CCACHE }}
+                cache-suffix: ${{ env.CCACHE_KEY_SUFFIX }}
 
             - name: Build python env
-              run: scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv --enable-ccache'
+              run: scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv $([ "${DISABLE_CCACHE}" != "true" ] && echo --enable-ccache)'
 
             - name: Build linux-x64-all-clusters
               env:
@@ -928,8 +963,38 @@ jobs:
                   path: objdir-clone/
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
+            - name: Delete existing ccache before save
+              if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
+              uses: actions/github-script@v7
+              env:
+                  CACHE_KEY: ${{ env.CCACHE_KEY }}
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const owner = context.repo.owner;
+                      const repo = context.repo.repo;
+                      const key = process.env.CACHE_KEY;
+                      const ref = context.ref;
+                      
+                      core.info(`Attempting to delete cache: ${key}`);
+                      
+                      try {
+                        await github.rest.actions.deleteActionsCacheByKey({
+                          owner: owner,
+                          repo: repo,
+                          key: key,
+                          ref: ref
+                        });
+                        core.info(`✅ Successfully deleted cache`);
+                      } catch (e) {
+                        if (e.status === 404) {
+                          core.info(`Cache not found (first run or already deleted)`);
+                        } else {
+                          core.warning(`Failed to delete cache: ${e.message}`);
+                        }
+                      }
             - name: Save ccache
-              if: github.ref == 'refs/heads/master' && steps.ccache.outputs.cache-hit != 'true'
+              if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: actions/cache/save@v4
               with:
                   path: .ccache


### PR DESCRIPTION
### Summary

#### 1. **Delete-Before-Save Cache Rotation on Master**
- Implemented automatic cache deletion before saving on master builds
- Cache is now refreshed on every master build instead of accumulating stale data
- Uses GitHub Actions API to delete existing cache by key before creating a new one

#### 2. **Removed Weekly Time-Based Rotation**
- Removed `CACHE_WEEK=$(date +%G-%V)` from cache key generation
- Simplified cache keys: `ccache-{OS}-{variant}-w{WEEK}` → `ccache-{OS}-{variant}`
- Weekly rotation unnecessary with delete-before-save approach

#### 3. **Manual Cache Control**
- Added `disable_ccache` workflow_dispatch input to disable ccache (`CCACHE_DISABLE=1`)
- Added `cache_suffix` workflow_dispatch input for manual cache rotation
- Support for `[no-ccache]` flag in commit messages
- Applied to both `test_suites_linux` and `repl_tests_linux` jobs
- Unified `DISABLE_CCACHE` environment variable across jobs
- Conditional `--enable-ccache` flag in build commands
- Fixed retry build step to set both flags consistently

### Benefits
- **Always fresh cache** from latest master build will increase cache hit ratio and decrease build times
- **Simpler cache keys** without time-based suffixes  
- **Manual control** for testing and debugging
---

### Related issues

Fixes: https://github.com/project-chip/matter-test-scripts/issues/717

### Testing

CI testing