### PR TITLE
Disable ccache basedir rewrite in global configuration

### DIFF
--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -29,6 +29,7 @@ runs:
           mkdir -p .ccache
           echo "CCACHE_NOHASHDIR=1" >> $GITHUB_ENV
           echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "CCACHE_PREFIX_CPP=${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh" >> $GITHUB_ENV
           echo "CCACHE_SLOPPINESS=time_macros" >> $GITHUB_ENV
           echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
           echo "CCACHE_COMPILERCHECK=content" >> $GITHUB_ENV

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -28,6 +28,7 @@ concurrency:
 
 env:
     CCACHE_NOHASHDIR: 1
+    CCACHE_BASEDIR: ${{ github.workspace }}
     CHIP_NO_LOG_TIMESTAMPS: true
     CHIP_PW_COMMAND_LAUNCHER: ccache
 

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -29,6 +29,7 @@ concurrency:
 env:
     CCACHE_NOHASHDIR: 1
     CCACHE_BASEDIR: ${{ github.workspace }}
+    CCACHE_PREFIX_CPP: ${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh
     CHIP_NO_LOG_TIMESTAMPS: true
     CHIP_PW_COMMAND_LAUNCHER: ccache
 

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -28,6 +28,7 @@ concurrency:
 
 env:
     CCACHE_NOHASHDIR: 1
+    CCACHE_BASEDIR: ${{ github.workspace }}
     CHIP_NO_LOG_TIMESTAMPS: true
     CHIP_PW_COMMAND_LAUNCHER: ccache
 

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -29,6 +29,7 @@ concurrency:
 env:
     CCACHE_NOHASHDIR: 1
     CCACHE_BASEDIR: ${{ github.workspace }}
+    CCACHE_PREFIX_CPP: ${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh
     CHIP_NO_LOG_TIMESTAMPS: true
     CHIP_PW_COMMAND_LAUNCHER: ccache
 

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -211,8 +211,8 @@ fi
 #       to figure out why NRF builds do not work when sharing cache between
 #       applications.
 #export CCACHE_NOHASHDIR=1
+#export CCACHE_BASEDIR="$_CHIP_ROOT"
 export CCACHE_PREFIX_CPP="$_CHIP_ROOT/scripts/helpers/ccache-prefix-cpp.sh"
-export CCACHE_BASEDIR="$_CHIP_ROOT"
 
 unset -f _bootstrap_or_activate
 unset -f _install_additional_pip_requirements

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -205,14 +205,14 @@ if [ -n "$ZSH_VERSION" ]; then
 fi
 
 # Set ccache environment variables
-# TODO: For now, the no-hash-dir is not enabled globally, however, anyone can
+# TODO: For now, the ccache env is not enabled globally, however, anyone can
 #       enable it in the local environment, so apps build in different output
 #       directories can reuse cache. In order to enable it globally we need
 #       to figure out why NRF builds do not work when sharing cache between
 #       applications.
 #export CCACHE_NOHASHDIR=1
 #export CCACHE_BASEDIR="$_CHIP_ROOT"
-export CCACHE_PREFIX_CPP="$_CHIP_ROOT/scripts/helpers/ccache-prefix-cpp.sh"
+#export CCACHE_PREFIX_CPP="$_CHIP_ROOT/scripts/helpers/ccache-prefix-cpp.sh"
 
 unset -f _bootstrap_or_activate
 unset -f _install_additional_pip_requirements


### PR DESCRIPTION
#### Summary

This should fix NRF build fail on master after #41503 was merged.

#### Testing

CI should verify.
Verified locally that I can build NRF examples in nrf docker.