### PR TITLE
Remove client-cluster entries from JF.

### DIFF
--- a/src/app/zap_cluster_list.json
+++ b/src/app/zap_cluster_list.json
@@ -66,10 +66,8 @@
         "ICD_MANAGEMENT_CLUSTER": [],
         "IDENTIFY_CLUSTER": [],
         "ILLUMINANCE_MEASUREMENT_CLUSTER": [],
-        "JOINT_FABRIC_DATASTORE_CLUSTER": ["joint-fabric-datastore-server"],
-        "JOINT_FABRIC_ADMINISTRATOR_CLUSTER": [
-            "joint-fabric-administrator-server"
-        ],
+        "JOINT_FABRIC_DATASTORE_CLUSTER": [],
+        "JOINT_FABRIC_ADMINISTRATOR_CLUSTER": [],
         "KEYPAD_INPUT_CLUSTER": [],
         "LAUNDRY_WASHER_MODE_CLUSTER": [],
         "LEVEL_CONTROL_CLUSTER": [],


### PR DESCRIPTION
#### Summary

Adding these folders as client clusters is likely a misunderstanding: the folders are the `-server` entries that are identical to the server side.

#### Testing

CI will validate - expect no changes.