### PR TITLE
Make TestBdxTransferServer::Shutdown() restore the default UnsolicitedMessageHandler

### DIFF
--- a/src/controller/python/matter/ChipStack.py
+++ b/src/controller/python/matter/ChipStack.py
@@ -193,6 +193,9 @@ class ChipStack(object):
         for subscription in tuple(self._subscriptions.values()):
             subscription.Shutdown()
 
+        # Shut down the BDX server.
+        Bdx.Shutdown()
+
         # Terminate Matter thread and shutdown the stack.
         self._ChipStackLib.pychip_DeviceController_StackShutdown()
 

--- a/src/controller/python/matter/bdx/Bdx.py
+++ b/src/controller/python/matter/bdx/Bdx.py
@@ -236,6 +236,15 @@ def Init():
         setter.Set('pychip_Bdx_InitCallbacks', None, [
                    _OnTransferObtainedCallbackFunct, _OnFailedToObtainTransferCallbackFunct, _OnDataReceivedCallbackFunct,
                    _OnTransferCompletedCallbackFunct])
+        setter.Set('pychip_Bdx_Shutdown',
+                   None, [])
 
     handle.pychip_Bdx_InitCallbacks(
         _OnTransferObtainedCallback, _OnFailedToObtainTransferCallback, _OnDataReceivedCallback, _OnTransferCompletedCallback)
+
+def Shutdown():
+    '''
+    Shut down the BDX server.
+    '''
+    handle = GetLibraryHandle()
+    handle.pychip_Bdx_Shutdown()

--- a/src/controller/python/matter/bdx/Bdx.py
+++ b/src/controller/python/matter/bdx/Bdx.py
@@ -242,6 +242,7 @@ def Init():
     handle.pychip_Bdx_InitCallbacks(
         _OnTransferObtainedCallback, _OnFailedToObtainTransferCallback, _OnDataReceivedCallback, _OnTransferCompletedCallback)
 
+
 def Shutdown():
     '''
     Shut down the BDX server.

--- a/src/controller/python/matter/bdx/bdx.cpp
+++ b/src/controller/python/matter/bdx/bdx.cpp
@@ -215,6 +215,12 @@ void pychip_Bdx_InitCallbacks(OnTransferObtainedCallback onTransferObtainedCallb
     gBdxTransferServer.Init(systemLayer, factory.GetSystemState()->ExchangeMgr());
 }
 
+void pychip_Bdx_Shutdown()
+{
+    // Shut down and clean up resources associated with the TestBdxTransferServer instance.
+    gBdxTransferServer.Shutdown();
+}
+
 // Prepares the BDX system to expect a new transfer.
 PyChipError pychip_Bdx_ExpectBdxTransfer(PyObject transferObtainedContext)
 {

--- a/src/controller/python/matter/bdx/test-bdx-transfer-server.cpp
+++ b/src/controller/python/matter/bdx/test-bdx-transfer-server.cpp
@@ -15,8 +15,8 @@
  *    limitations under the License.
  */
 
-#include <controller/python/matter/bdx/test-bdx-transfer-server.h>
 #include <controller/CHIPDeviceControllerFactory.h>
+#include <controller/python/matter/bdx/test-bdx-transfer-server.h>
 
 namespace chip {
 namespace bdx {

--- a/src/controller/python/matter/bdx/test-bdx-transfer-server.cpp
+++ b/src/controller/python/matter/bdx/test-bdx-transfer-server.cpp
@@ -49,7 +49,9 @@ void TestBdxTransferServer::Shutdown()
     // Re-register the BdxTransferServer that was registered as part of CHIPDeviceControllerFactory.
     // Otherwise when BdxTransferServer::Shutdown() attempts to unregister this, it causes an error.
     if (mPrevSendInitHandler != nullptr)
+    {
         LogErrorOnFailure(mExchangeManager->RegisterUnsolicitedMessageHandlerForType(MessageType::SendInit, mPrevSendInitHandler));
+    }
 
     mExchangeManager = nullptr;
 }

--- a/src/controller/python/matter/bdx/test-bdx-transfer-server.cpp
+++ b/src/controller/python/matter/bdx/test-bdx-transfer-server.cpp
@@ -36,7 +36,7 @@ CHIP_ERROR TestBdxTransferServer::Init(System::Layer * systemLayer, Messaging::E
     mSystemLayer     = systemLayer;
     mExchangeManager = exchangeManager;
     // This removes the BdxTransferServer registered as part of CHIPDeviceControllerFactory.
-    // Capture the handler that was previously registered for SendInit so we can restore it on shutdown.
+    // Store the handler that was previously registered for SendInit so we can restore it on shutdown.
     mExchangeManager->UnregisterUnsolicitedMessageHandlerForType(MessageType::SendInit, &mPrevSendInitHandler);
     return mExchangeManager->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::BDX::Id, this);
 }

--- a/src/controller/python/matter/bdx/test-bdx-transfer-server.h
+++ b/src/controller/python/matter/bdx/test-bdx-transfer-server.h
@@ -59,10 +59,11 @@ private:
     static constexpr size_t kTransferPoolSize = 2;
 
     ObjectPool<BdxTransfer, kTransferPoolSize> mTransferPool;
-    System::Layer * mSystemLayer                  = nullptr;
-    Messaging::ExchangeManager * mExchangeManager = nullptr;
-    BdxTransfer::Delegate * mBdxTransferDelegate  = nullptr;
-    size_t mExpectedTransfers                     = 0;
+    System::Layer * mSystemLayer                                = nullptr;
+    Messaging::ExchangeManager * mExchangeManager               = nullptr;
+    BdxTransfer::Delegate * mBdxTransferDelegate                = nullptr;
+    size_t mExpectedTransfers                                   = 0;
+    Messaging::UnsolicitedMessageHandler * mPrevSendInitHandler = nullptr;
 };
 
 } // namespace bdx

--- a/src/controller/python/matter/bdx/test-bdx-transfer-server.h
+++ b/src/controller/python/matter/bdx/test-bdx-transfer-server.h
@@ -63,6 +63,10 @@ private:
     Messaging::ExchangeManager * mExchangeManager = nullptr;
     BdxTransfer::Delegate * mBdxTransferDelegate  = nullptr;
     size_t mExpectedTransfers                     = 0;
+
+    // Saved unsolicited handler for BDX SendInit that was registered before this server took over.
+    // This is typically the BDXTransferServer installed by CHIPDeviceControllerFactory.
+    Messaging::UnsolicitedMessageHandler * mPrevSendInitHandler = nullptr;
 };
 
 } // namespace bdx

--- a/src/controller/python/matter/bdx/test-bdx-transfer-server.h
+++ b/src/controller/python/matter/bdx/test-bdx-transfer-server.h
@@ -63,10 +63,6 @@ private:
     Messaging::ExchangeManager * mExchangeManager = nullptr;
     BdxTransfer::Delegate * mBdxTransferDelegate  = nullptr;
     size_t mExpectedTransfers                     = 0;
-
-    // Saved unsolicited handler for BDX SendInit that was registered before this server took over.
-    // This is typically the BDXTransferServer installed by CHIPDeviceControllerFactory.
-    Messaging::UnsolicitedMessageHandler * mPrevSendInitHandler = nullptr;
 };
 
 } // namespace bdx

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -178,9 +178,11 @@ CHIP_ERROR ExchangeManager::UnregisterUMH(Protocols::Id protocolId, int16_t msgT
     {
         if (umh.IsInUse() && umh.Matches(protocolId, msgType))
         {
-            // Capture the handler before resetting the slot.
+            // Capture the handler before unregistering.
             if (outHandler != nullptr)
+            {
                 *outHandler = umh.Handler;
+            }
             umh.Reset();
             SYSTEM_STATS_DECREMENT(chip::System::Stats::kExchangeMgr_NumUMHandlers);
             return CHIP_NO_ERROR;
@@ -188,7 +190,9 @@ CHIP_ERROR ExchangeManager::UnregisterUMH(Protocols::Id protocolId, int16_t msgT
     }
 
     if (outHandler != nullptr)
+    {
         *outHandler = nullptr;
+    }
 
     return CHIP_ERROR_NO_UNSOLICITED_MESSAGE_HANDLER;
 }

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -178,7 +178,7 @@ CHIP_ERROR ExchangeManager::UnregisterUMH(Protocols::Id protocolId, int16_t msgT
     {
         if (umh.IsInUse() && umh.Matches(protocolId, msgType))
         {
-            // Capture the handler before unregistering.
+            // Store the handler before unregistering.
             if (outHandler != nullptr)
             {
                 *outHandler = umh.Handler;

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -135,9 +135,10 @@ CHIP_ERROR ExchangeManager::UnregisterUnsolicitedMessageHandlerForProtocol(Proto
     return UnregisterUMH(protocolId, kAnyMessageType);
 }
 
-CHIP_ERROR ExchangeManager::UnregisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType)
+CHIP_ERROR ExchangeManager::UnregisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType,
+                                                                       Messaging::UnsolicitedMessageHandler ** outHandler)
 {
-    return UnregisterUMH(protocolId, static_cast<int16_t>(msgType));
+    return UnregisterUMH(protocolId, static_cast<int16_t>(msgType), outHandler);
 }
 
 CHIP_ERROR ExchangeManager::RegisterUMH(Protocols::Id protocolId, int16_t msgType, UnsolicitedMessageHandler * handler)
@@ -170,17 +171,24 @@ CHIP_ERROR ExchangeManager::RegisterUMH(Protocols::Id protocolId, int16_t msgTyp
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ExchangeManager::UnregisterUMH(Protocols::Id protocolId, int16_t msgType)
+CHIP_ERROR ExchangeManager::UnregisterUMH(Protocols::Id protocolId, int16_t msgType,
+                                          Messaging::UnsolicitedMessageHandler ** outHandler)
 {
     for (auto & umh : UMHandlerPool)
     {
         if (umh.IsInUse() && umh.Matches(protocolId, msgType))
         {
+            // Capture the handler before resetting the slot.
+            if (outHandler != nullptr)
+                *outHandler = umh.Handler;
             umh.Reset();
             SYSTEM_STATS_DECREMENT(chip::System::Stats::kExchangeMgr_NumUMHandlers);
             return CHIP_NO_ERROR;
         }
     }
+
+    if (outHandler != nullptr)
+        *outHandler = nullptr;
 
     return CHIP_ERROR_NO_UNSOLICITED_MESSAGE_HANDLER;
 }

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -168,10 +168,9 @@ public:
      *
      *  @param[in]    msgType       The message type of the corresponding protocol.
      *
-     *  @param[out]   outHandler   If non-null, receives the handler that was removed from the
-     *                             unsolicited message handler pool. If no handler matched, *outHandler
-     *                             will be set to nullptr. Callers may pass nullptr if they do not
-     *                             need this information.
+     *  @param[out]   outHandler   If non-null, receives the handler that was unregistered. If no
+     *                             handler matched, *outHandler is set to nullptr. Callers may pass
+     *                             nullptr if they do not need this information.
      *
      *  @retval #CHIP_ERROR_NO_UNSOLICITED_MESSAGE_HANDLER  If the matching unsolicited message handler
      *                                                       is not found.

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -168,20 +168,27 @@ public:
      *
      *  @param[in]    msgType       The message type of the corresponding protocol.
      *
+     *  @param[out]   outHandler   If non-null, receives the handler that was removed from the
+     *                             unsolicited message handler pool. If no handler matched, *outHandler
+     *                             will be set to nullptr. Callers may pass nullptr if they do not
+     *                             need this information.
+     *
      *  @retval #CHIP_ERROR_NO_UNSOLICITED_MESSAGE_HANDLER  If the matching unsolicited message handler
      *                                                       is not found.
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR UnregisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType);
+    CHIP_ERROR UnregisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType,
+                                                          Messaging::UnsolicitedMessageHandler ** outHandler = nullptr);
 
     /**
      * A strongly-message-typed version of UnregisterUnsolicitedMessageHandlerForType.
      */
     template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
-    CHIP_ERROR UnregisterUnsolicitedMessageHandlerForType(MessageType msgType)
+    CHIP_ERROR UnregisterUnsolicitedMessageHandlerForType(MessageType msgType,
+                                                          Messaging::UnsolicitedMessageHandler ** outHandler = nullptr)
     {
         return UnregisterUnsolicitedMessageHandlerForType(Protocols::MessageTypeTraits<MessageType>::ProtocolId(),
-                                                          to_underlying(msgType));
+                                                          to_underlying(msgType), outHandler);
     }
 
     /**
@@ -244,7 +251,8 @@ private:
     UnsolicitedMessageHandlerSlot UMHandlerPool[CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS];
 
     CHIP_ERROR RegisterUMH(Protocols::Id protocolId, int16_t msgType, UnsolicitedMessageHandler * handler);
-    CHIP_ERROR UnregisterUMH(Protocols::Id protocolId, int16_t msgType);
+    CHIP_ERROR UnregisterUMH(Protocols::Id protocolId, int16_t msgType,
+                             Messaging::UnsolicitedMessageHandler ** outHandler = nullptr);
 
     void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, const SessionHandle & session,
                            DuplicateMessage isDuplicate, System::PacketBufferHandle && msgBuf) override;

--- a/src/messaging/tests/TestExchange.cpp
+++ b/src/messaging/tests/TestExchange.cpp
@@ -151,8 +151,11 @@ void TestExchange::DoRoundTripTest(MockExchangeDelegate & delegate1, MockExchang
     ec1->Close();
     ec2->Close();
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::Id, kMsgType_TEST1);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::Id, kMsgType_TEST1,
+                                                                          &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &delegate2);
 }
 
 TEST_F(TestExchange, CheckBasicMessageRoundTrip)

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -149,8 +149,10 @@ TEST_F(TestExchangeMgr, CheckSessionExpirationBasics)
     EXPECT_FALSE(receiveDelegate.IsOnMessageReceivedCalled);
     ec1->Close();
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &receiveDelegate);
 
     // recreate closed session.
     EXPECT_EQ(CreateSessionAliceToBob(), CHIP_NO_ERROR);
@@ -219,11 +221,15 @@ TEST_F(TestExchangeMgr, CheckUmhRegistrationTest)
     err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForProtocol(Protocols::Echo::Id);
     EXPECT_NE(err, CHIP_NO_ERROR);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::Echo::Id, kMsgType_TEST1);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::Echo::Id, kMsgType_TEST1, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockAppDelegate);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::Echo::Id, kMsgType_TEST2);
+    removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::Echo::Id, kMsgType_TEST2, &removedHandler);
     EXPECT_NE(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, nullptr);
 }
 
 TEST_F(TestExchangeMgr, CheckExchangeMessages)
@@ -256,8 +262,10 @@ TEST_F(TestExchangeMgr, CheckExchangeMessages)
     DrainAndServiceIO();
     EXPECT_TRUE(mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::BDX::Id, kMsgType_TEST1, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockUnsolicitedAppDelegate);
 }
 
 } // namespace

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -704,8 +704,10 @@ TEST_F(TestReliableMessageProtocol, CheckResendApplicationMessageWithPeerExchang
     EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
     EXPECT_TRUE(mockReceiver.IsOnMessageReceivedCalled);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockReceiver);
 }
 
 TEST_F(TestReliableMessageProtocol, CheckDuplicateMessageClosedExchange)
@@ -757,8 +759,10 @@ TEST_F(TestReliableMessageProtocol, CheckDuplicateMessageClosedExchange)
     // Let's not drop the duplicate message
     mockReceiver.SetDropAckResponse(false);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockReceiver);
 
     // Wait for the first re-transmit and ack (should take 64ms)
     GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 3; });
@@ -849,8 +853,10 @@ TEST_F(TestReliableMessageProtocol, CheckDuplicateOldMessageClosedExchange)
     // Let's not drop the duplicate message's ack.
     mockReceiver.SetDropAckResponse(false);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockReceiver);
 
     // Wait for the first re-transmit and ack (should take 64ms)
     rm->StartTimer();
@@ -914,8 +920,10 @@ TEST_F(TestReliableMessageProtocol, CheckResendSessionEstablishmentMessageWithPe
     EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
     EXPECT_TRUE(mockReceiver.IsOnMessageReceivedCalled);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockReceiver);
 }
 
 TEST_F(TestReliableMessageProtocol, CheckDuplicateMessage)
@@ -964,8 +972,10 @@ TEST_F(TestReliableMessageProtocol, CheckDuplicateMessage)
     EXPECT_EQ(loopback.mDroppedMessageCount, 0u);
     EXPECT_EQ(rm->TestGetCountRetransTable(), 1);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockReceiver);
 
     // Let's not drop the duplicate message
     mockReceiver.SetDropAckResponse(false);
@@ -1062,8 +1072,10 @@ TEST_F(TestReliableMessageProtocol, CheckReceiveAfterStandaloneAck)
     // Ensure that we have received that response.
     EXPECT_TRUE(mockSender.IsOnMessageReceivedCalled);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockReceiver);
 
     EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
 }
@@ -1187,8 +1199,10 @@ TEST_F(TestReliableMessageProtocol, CheckPiggybackAfterPiggyback)
     EXPECT_TRUE(mockSender.IsOnMessageReceivedCalled);
     EXPECT_TRUE(mockSender.mReceivedPiggybackAck);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockReceiver);
 
     EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
 }
@@ -1371,8 +1385,10 @@ TEST_F(TestReliableMessageProtocol, CheckMessageAfterClosed)
     // immediately on the receiver, due to the exchange being closed.
     EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockReceiver);
 
     EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
 }
@@ -1926,8 +1942,10 @@ TEST_F(TestReliableMessageProtocol, CheckApplicationResponseDelayed)
     err = CreateSessionAliceToBob();
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockReceiver);
 }
 
 TEST_F(TestReliableMessageProtocol, CheckApplicationResponseNeverComes)
@@ -2048,8 +2066,10 @@ TEST_F(TestReliableMessageProtocol, CheckApplicationResponseNeverComes)
     err = CreateSessionAliceToBob();
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
+    Messaging::UnsolicitedMessageHandler * removedHandler = nullptr;
+    err = GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest, &removedHandler);
     EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(removedHandler, &mockReceiver);
 }
 
 #if CHIP_CONFIG_MRP_ANALYTICS_ENABLED


### PR DESCRIPTION
#### Summary

When using the python controller, the following error message occurs during shutdown
ERROR:matter.native.-:src/messaging/ExchangeMgr.cpp:192: CHIP Error 0x00000007: No unsolicited message handler at src/protocols/bdx/BdxTransferServer.cpp:55

This happens because the python controller's TestBdxTransferServer overrides the default BdxTransferServer (that which would be used by non-Python implementations), and during initialization it unregisters the unsolicited message handler for SendInit that had been registered by the default BdxTransferServer so that it can register its own protocol-wide handler instead. However when it tears down it never puts the old handler back in place, so then when the default BdxTransferServer shuts down it tries to unregister its SendInit handler but finds that there is no such handler registered anymore, so it throws an error.

This PR:

- Creates `Bdx.Shutdown()` and calls it from `ChipStack.Shutdown()` (before the call to `pychip_DeviceController_StackShutdown` thus ensuring that the Python controller's BDX server is shut down before the default matter BDX server).
- Creates `pychip_Bdx_Shutdown()`, registers it, and calls it from `Bdx.Shutdown()`.  This method calls `TestBdxTransferServer::Shutdown()`, which previously existed but was never called by anything.
- Adds to `TestBdxTransferServer::Shutdown()` a call to `RegisterUnsolicitedMessageHandlerForType()` which re-registers the default BdxTransferServer that had previously been unregistered by `TestBdxTransferServer::Init()`.
- During `TestBdxTransferServer::Init`, to store the handler that had previously been registered it was necessary to modify `UnregisterUnsolicitedMessageHandlerForType` so that it can return the handler that gets unregistered, which is then stored in a private member variable in TestBdxTransferServer.
- `UnregisterUnsolicitedMessageHandlerForType` takes an additional optional parameter `outHandler` which, if non-null, is assigned the handler that is being unregistered.  If `outHandler`is nullptr or is not provided at all, then it does not do this, so existing code does not have to change.
- Unit tests were updated so that all uses of `UnregisterUnsolicitedMessageHandlerForType` will also check that the handler being unregistered matches the one that was originally registered.

#### Related issues

Fixes: #41464

#### Testing

The python integration tests are sufficient to test this change.  I used `src/python_testing/TestBdxTransfer.py`, but any of them would do.  While the bug had not been causing these tests to fail, it was causing an error message during shutdown.  I've confirmed that this error message is now gone.

The change that was made to `UnregisterUnsolicitedMessageHandlerForType` (adding the optional `outHandler` parameter) is tested by the unit tests `TestExhange.cpp`, `TestExchangeMgr.cpp`, and `TestReliableMessageProtocol.cpp`, all of which use that function.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
