### PR TITLE
Remove CCACHE_PREFIX_CPP

### DIFF
--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -24,12 +24,15 @@ runs:
   steps:
     - name: Configure ccache
       uses: pyTooling/Actions/with-post-step@v0.4.5
+      # NOTE: the following was REMOVED because it causes invalid cache re-uses.
+      #       We observed changed headers not being detected in cpp file rebuilds and
+      #       caches being re-used when they should not be.
+      # echo "CCACHE_PREFIX_CPP=${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh" >> $GITHUB_ENV
       with:
         main: |
           mkdir -p .ccache
           echo "CCACHE_NOHASHDIR=1" >> $GITHUB_ENV
           echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
-          echo "CCACHE_PREFIX_CPP=${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh" >> $GITHUB_ENV
           echo "CCACHE_SLOPPINESS=time_macros" >> $GITHUB_ENV
           echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
           echo "CCACHE_COMPILERCHECK=content" >> $GITHUB_ENV

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -29,7 +29,8 @@ concurrency:
 env:
     CCACHE_NOHASHDIR: 1
     CCACHE_BASEDIR: ${{ github.workspace }}
-    CCACHE_PREFIX_CPP: ${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh
+    # Disabled as this seems to cause invalid cache re-uses
+    # CCACHE_PREFIX_CPP: ${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh
     CHIP_NO_LOG_TIMESTAMPS: true
     CHIP_PW_COMMAND_LAUNCHER: ccache
 

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -29,7 +29,8 @@ concurrency:
 env:
     CCACHE_NOHASHDIR: 1
     CCACHE_BASEDIR: ${{ github.workspace }}
-    CCACHE_PREFIX_CPP: ${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh
+    # Disabled as this seems to cause invalid cache re-uses
+    # CCACHE_PREFIX_CPP: ${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh
     CHIP_NO_LOG_TIMESTAMPS: true
     CHIP_PW_COMMAND_LAUNCHER: ccache
 


### PR DESCRIPTION
This causes bad builds: cpp compilation reuses object files when headers change, which results in wrong code compiled.

#### Testing

This is based on checks from @arkq locally - apparently this was the cause of bad cache usage. Temporary fix until we find a better solution (if one exists). I expect this change will affect cache hits.