### PR TITLE
[chip-tool] make `discover commissionables` return a list of all discovered devices instead of only one

### DIFF
--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -33,7 +33,7 @@ void DiscoverCommissionablesCommandBase::OnDiscoveredDevice(const Dnssd::Commiss
     nodeData.LogDetail();
     LogErrorOnFailure(RemoteDataModelLogger::LogDiscoveredNodeData(nodeData));
 
-    if (mDiscoverOnce.ValueOr(true))
+    if (mDiscoverOnce.ValueOr(false))
     {
         mCommissioner->RegisterDeviceDiscoveryDelegate(nullptr);
         auto err = mCommissioner->StopCommissionableDiscovery();

--- a/src/controller/AbstractDnssdDiscoveryController.cpp
+++ b/src/controller/AbstractDnssdDiscoveryController.cpp
@@ -71,10 +71,6 @@ void AbstractDnssdDiscoveryController::OnNodeDiscovered(const chip::Dnssd::Disco
             SameExceptOrder(discoveredNodeIPAddressSpan, nodeDataIPAddressSpan))
         {
             discoveredNode = nodeData;
-            if (mDeviceDiscoveryDelegate != nullptr)
-            {
-                mDeviceDiscoveryDelegate->OnDiscoveredDevice(nodeData);
-            }
             return;
         }
     }


### PR DESCRIPTION
#### Summary

- Calling `discover commissionables` command only diplays one discovery result and then exits
- Documentation of chip-tool mentions that it should mention all discovered commissionables.


#### Testing

CI Testing

