### PR TITLE
Always use preprocessor mode when calculating ccache cache key

### DIFF
--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -24,15 +24,13 @@ runs:
   steps:
     - name: Configure ccache
       uses: pyTooling/Actions/with-post-step@v0.4.5
-      # NOTE: the following was REMOVED because it causes invalid cache re-uses.
-      #       We observed changed headers not being detected in cpp file rebuilds and
-      #       caches being re-used when they should not be.
-      # echo "CCACHE_PREFIX_CPP=${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh" >> $GITHUB_ENV
       with:
         main: |
           mkdir -p .ccache
           echo "CCACHE_NOHASHDIR=1" >> $GITHUB_ENV
           echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "CCACHE_NODIRECT=1" >> $GITHUB_ENV
+          echo "CCACHE_PREFIX_CPP=${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh" >> $GITHUB_ENV
           echo "CCACHE_SLOPPINESS=time_macros" >> $GITHUB_ENV
           echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
           echo "CCACHE_COMPILERCHECK=content" >> $GITHUB_ENV

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -27,10 +27,6 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    CCACHE_NOHASHDIR: 1
-    CCACHE_BASEDIR: ${{ github.workspace }}
-    # Disabled as this seems to cause invalid cache re-uses
-    # CCACHE_PREFIX_CPP: ${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh
     CHIP_NO_LOG_TIMESTAMPS: true
     CHIP_PW_COMMAND_LAUNCHER: ccache
 

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -27,10 +27,6 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    CCACHE_NOHASHDIR: 1
-    CCACHE_BASEDIR: ${{ github.workspace }}
-    # Disabled as this seems to cause invalid cache re-uses
-    # CCACHE_PREFIX_CPP: ${{ github.workspace }}/scripts/helpers/ccache-prefix-cpp.sh
     CHIP_NO_LOG_TIMESTAMPS: true
     CHIP_PW_COMMAND_LAUNCHER: ccache
 

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -207,7 +207,7 @@ fi
 # Set ccache environment variables
 #
 # Rewrite includes to use relative paths within BASEDIR and do not add PWD to
-# the hash key, so we can share cached objects even thought apps are built in
+# the hash key, so we can share cached objects even though apps are built in
 # different output directories.
 export CCACHE_BASEDIR="$_CHIP_ROOT" CCACHE_NOHASHDIR=1
 # Always create cache key based on preprocessed source. It is important, because

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -205,14 +205,16 @@ if [ -n "$ZSH_VERSION" ]; then
 fi
 
 # Set ccache environment variables
-# TODO: For now, the ccache env is not enabled globally, however, anyone can
-#       enable it in the local environment, so apps build in different output
-#       directories can reuse cache. In order to enable it globally we need
-#       to figure out why NRF builds do not work when sharing cache between
-#       applications.
-#export CCACHE_NOHASHDIR=1
-#export CCACHE_BASEDIR="$_CHIP_ROOT"
-#export CCACHE_PREFIX_CPP="$_CHIP_ROOT/scripts/helpers/ccache-prefix-cpp.sh"
+#
+# Rewrite includes to use relative paths within BASEDIR and do not add PWD to
+# the hash key, so we can share cached objects even thought apps are built in
+# different output directories.
+export CCACHE_BASEDIR="$_CHIP_ROOT" CCACHE_NOHASHDIR=1
+# Always create cache key based on preprocessed source. It is important, because
+# we want to reuse cached objects across different apps and configurations.
+export CCACHE_NODIRECT=1
+# Wrap preprocessor with our script to allow some tweaking.
+export CCACHE_PREFIX_CPP="$_CHIP_ROOT/scripts/helpers/ccache-prefix-cpp.sh"
 
 unset -f _bootstrap_or_activate
 unset -f _install_additional_pip_requirements


### PR DESCRIPTION
#### Summary

Direct mode (default in a default ccahce setup) can reuse compile object with different configuration especially when configuration is done by a configuration include file. Key change here is `export CCACHE_NODIRECT=1`.

#### Related issues

Fixes #40910

#### Testing

Tested locally that we can build NRF examples run on CI. Also, verified that error seen here https://github.com/project-chip/connectedhomeip/actions/runs/18605407997/job/53180697671?pr=41518 does not longer occurs.