### PR TITLE
[NXP] Rework common & mcxw71 ConfigurationManagerImpl.cpp

### DIFF
--- a/src/platform/nxp/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.cpp
@@ -66,7 +66,7 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
     return sInstance;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint8_t rebootCause)
+CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint32_t rebootCause)
 {
 #if CONFIG_BOOT_REASON_SDK_SUPPORT
     /*
@@ -114,7 +114,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     uint32_t rebootCount = 0;
 
 #if CONFIG_BOOT_REASON_SDK_SUPPORT
-    uint8_t rebootCause = POWER_GetResetCause();
+    uint32_t rebootCause = POWER_GetResetCause();
     POWER_ClearResetCause(rebootCause);
 #endif
 

--- a/src/platform/nxp/common/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020, 2025 Project CHIP Authors
  *    Copyright (c) 2020 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -83,7 +83,7 @@ private:
 
     static void DoFactoryReset(intptr_t arg);
 
-    CHIP_ERROR DetermineBootReason(uint8_t rebootCause);
+    CHIP_ERROR DetermineBootReason(uint32_t rebootCause);
 };
 
 /**

--- a/src/platform/nxp/mcxw71/BUILD.gn
+++ b/src/platform/nxp/mcxw71/BUILD.gn
@@ -76,6 +76,7 @@ config("nxp_platform_config") {
 
 static_library("nxp_platform") {
   defines = [
+    "CONFIG_CHIP_NXP_PLATFORM_MCXW71=1",
     "NXP_DEVICE_MCXW7X=1",
     "NXP_USE_MML=1",
   ]

--- a/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020, 2025 Project CHIP Authors
  *    Copyright (c) 2020 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -20,7 +20,7 @@
 /**
  *    @file
  *          Provides the implementation of the Device Layer ConfigurationManager object
- *          for K32W platforms using the NXP SDK.
+ *          for NXP MCXW7X platforms using the NXP SDK.
  */
 
 /* this file behaves like a config.h, comes first */
@@ -33,16 +33,17 @@
 #include <src/platform/nxp/mcxw71/SMU2Manager.h>
 #endif
 
-// #include <openthread/platform/misc.h>
 #include "fsl_cmc.h"
 #include "fsl_device_registers.h"
+
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+#include "OtaSupport.h"
+#endif
 
 namespace chip {
 namespace DeviceLayer {
 
 using namespace ::chip::DeviceLayer::Internal;
-
-// TODO: Define a Singleton instance of CHIP Group Key Store here
 
 ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 {
@@ -50,10 +51,51 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
     return sInstance;
 }
 
+CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint32_t reason)
+{
+    BootReasonType bootReason = BootReasonType::kUnspecified;
+
+    if ((reason & CMC_SRS_POR_MASK) || (reason & CMC_SRS_PIN_MASK))
+    {
+        bootReason = BootReasonType::kPowerOnReboot;
+    }
+    else if (reason & CMC_SRS_SW_MASK)
+    {
+        bootReason = BootReasonType::kSoftwareReset;
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+        OtaImgState_t img_state = OTA_GetImgState();
+        if (img_state == OtaImgState_RunCandidate)
+        {
+            bootReason = BootReasonType::kSoftwareUpdateCompleted;
+        }
+#endif
+    }
+    else if ((reason & CMC_SRS_WDOG0_MASK) || (reason & CMC_SRS_WDOG1_MASK))
+    {
+        bootReason = BootReasonType::kSoftwareWatchdogReset;
+    }
+    else
+    {
+        bootReason = BootReasonType::kUnspecified;
+    }
+
+    return StoreBootReason(to_underlying(bootReason));
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreSoftwareUpdateCompleted()
+{
+    /* Empty implementation*/
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
     uint32_t rebootCount = 0;
+
+    // Initialize the generic implementation base class.
+    err = Internal::GenericConfigurationManagerImpl<NXPConfig>::Init();
+    SuccessOrExit(err);
 
     if (NXPConfig::ConfigValueExists(NXPConfig::kCounterKey_RebootCount))
     {
@@ -66,7 +108,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     else
     {
         // The first boot after factory reset of the Node.
-        err = StoreRebootCount(0);
+        err = StoreRebootCount(1);
         SuccessOrExit(err);
     }
 
@@ -76,15 +118,13 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
+    SuccessOrExit(err = DetermineBootReason(CMC_GetSystemResetStatus(CMC0)));
+
     if (!NXPConfig::ConfigValueExists(NXPConfig::kCounterKey_BootReason))
     {
         err = StoreBootReason(to_underlying(BootReasonType::kUnspecified));
         SuccessOrExit(err);
     }
-
-    // Initialize the generic implementation base class.
-    err = Internal::GenericConfigurationManagerImpl<NXPConfig>::Init();
-    SuccessOrExit(err);
 
     // TODO: Initialize the global GroupKeyStore object here
 
@@ -94,61 +134,34 @@ exit:
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::StoreSoftwareUpdateCompleted()
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
-    /* Empty implementation*/
-    return CHIP_NO_ERROR;
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
+CHIP_ERROR ConfigurationManagerImpl::GetUniqueId(char * buf, size_t bufSize)
 {
-    return ReadConfigValue(NXPConfig::kCounterKey_RebootCount, rebootCount);
+    CHIP_ERROR err;
+    size_t uniqueIdLen = 0; // without counting null-terminator
+    err                = ReadConfigValueStr(NXPConfig::kConfigKey_UniqueId, buf, bufSize, uniqueIdLen);
+
+    ReturnErrorOnFailure(err);
+
+    VerifyOrReturnError(uniqueIdLen < bufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(buf[uniqueIdLen] == 0, CHIP_ERROR_INVALID_STRING_LENGTH);
+
+    return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::StoreRebootCount(uint32_t rebootCount)
+CHIP_ERROR ConfigurationManagerImpl::StoreUniqueId(const char * uniqueId, size_t uniqueIdLen)
 {
-    return WriteConfigValue(NXPConfig::kCounterKey_RebootCount, rebootCount);
+    return WriteConfigValueStr(NXPConfig::kConfigKey_UniqueId, uniqueId, uniqueIdLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
+CHIP_ERROR ConfigurationManagerImpl::GenerateUniqueId(char * buf, size_t bufSize)
 {
-    return ReadConfigValue(NXPConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
-}
-
-CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
-{
-    return WriteConfigValue(NXPConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
-}
-
-CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
-{
-    bootReason = to_underlying(BootReasonType::kUnspecified);
-
-    uint32_t reason = CMC_GetSystemResetStatus(CMC0);
-
-    if ((reason & CMC_SRS_POR_MASK) || (reason & CMC_SRS_PIN_MASK))
-    {
-        bootReason = to_underlying(BootReasonType::kPowerOnReboot);
-    }
-    else if (reason & CMC_SRS_SW_MASK)
-    {
-        bootReason = to_underlying(BootReasonType::kSoftwareReset);
-    }
-    else if ((reason & CMC_SRS_WDOG0_MASK) || (reason & CMC_SRS_WDOG1_MASK))
-    {
-        bootReason = to_underlying(BootReasonType::kSoftwareWatchdogReset);
-    }
-    else
-    {
-        bootReason = to_underlying(BootReasonType::kUnspecified);
-    }
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR ConfigurationManagerImpl::StoreBootReason(uint32_t bootReason)
-{
-    return WriteConfigValue(NXPConfig::kCounterKey_BootReason, bootReason);
+    uint64_t randomUniqueId = Crypto::GetRandU64();
+    return Encoding::BytesToUppercaseHexString(reinterpret_cast<uint8_t *>(&randomUniqueId), sizeof(uint64_t), buf, bufSize);
 }
 
 bool ConfigurationManagerImpl::CanFactoryReset()
@@ -280,11 +293,41 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     // Restart the system.
     ChipLogProgress(DeviceLayer, "System restarting");
 
-    NVIC_SystemReset();
+#if CONFIG_CHIP_NXP_PLATFORM_MCXW71
+    PlatformMgrImpl().Reset();
+#else
+    PlatformMgrImpl().ScheduleResetInIdle();
+#endif
+}
 
-    while (1)
-    {
-    }
+CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
+{
+    return ReadConfigValue(NXPConfig::kCounterKey_RebootCount, rebootCount);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreRebootCount(uint32_t rebootCount)
+{
+    return WriteConfigValue(NXPConfig::kCounterKey_RebootCount, rebootCount);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
+{
+    return ReadConfigValue(NXPConfig::kCounterKey_BootReason, bootReason);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreBootReason(uint32_t bootReason)
+{
+    return WriteConfigValue(NXPConfig::kCounterKey_BootReason, bootReason);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
+{
+    return ReadConfigValue(NXPConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
+{
+    return WriteConfigValue(NXPConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
 }
 
 ConfigurationManager & ConfigurationMgrImpl()

--- a/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
@@ -108,7 +108,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     else
     {
         // The first boot after factory reset of the Node.
-        err = StoreRebootCount(1);
+        err = StoreRebootCount(0);
         SuccessOrExit(err);
     }
 
@@ -118,7 +118,8 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
-    SuccessOrExit(err = DetermineBootReason(CMC_GetSystemResetStatus(CMC0)));
+    err = DetermineBootReason(CMC_GetSystemResetStatus(CMC0));
+    SuccessOrExit(err);
 
     if (!NXPConfig::ConfigValueExists(NXPConfig::kCounterKey_BootReason))
     {

--- a/src/platform/nxp/mcxw71/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/mcxw71/ConfigurationManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020, 2025 Project CHIP Authors
  *    Copyright (c) 2020 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -20,7 +20,7 @@
 /**
  *    @file
  *          Provides an implementation of the ConfigurationManager object
- *          for K32W platforms using the NXP SDK.
+ *          for NXP MCXW7X platforms using the NXP SDK.
  */
 
 #pragma once
@@ -36,7 +36,7 @@ namespace chip {
 namespace DeviceLayer {
 
 /**
- * Concrete implementation of the ConfigurationManager singleton object for the K32W platform.
+ * Concrete implementation of the ConfigurationManager singleton object for the NXP MCXW7X platform.
  */
 class ConfigurationManagerImpl final : public Internal::GenericConfigurationManagerImpl<Internal::NXPConfig>
 {
@@ -54,6 +54,9 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
+    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
+    CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override;
+    CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override;
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;
     CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
@@ -80,12 +83,9 @@ private:
     // ===== Private members reserved for use by this class only.
 
     static void DoFactoryReset(intptr_t arg);
-};
 
-inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
+    CHIP_ERROR DetermineBootReason(uint32_t reason);
+};
 
 /**
  * Returns the platform-specific implementation of the ConfigurationManager object.

--- a/src/platform/nxp/mcxw72/BUILD.gn
+++ b/src/platform/nxp/mcxw72/BUILD.gn
@@ -81,7 +81,6 @@ static_library("nxp_platform") {
     "../../FreeRTOS/SystemTimeSupport.cpp",
     "../../SingletonConfigurationManager.cpp",
     "../common/CHIPDevicePlatformEvent.h",
-    "../mcxw71/ConfigurationManagerImpl.cpp",
     "../common/ConfigurationManagerImpl.h",
     "../common/ConnectivityManagerImpl.cpp",
     "../common/ConnectivityManagerImpl.h",
@@ -94,6 +93,7 @@ static_library("nxp_platform") {
     "../common/NetworkProvisioningServerImpl.h",
     "../common/PlatformManagerImpl.h",
     "../common/SoftwareUpdateManagerImpl.h",
+    "../mcxw71/ConfigurationManagerImpl.cpp",
     "CHIPDevicePlatformConfig.h",
     "PlatformManagerImpl.cpp",
   ]

--- a/src/platform/nxp/mcxw72/BUILD.gn
+++ b/src/platform/nxp/mcxw72/BUILD.gn
@@ -81,7 +81,7 @@ static_library("nxp_platform") {
     "../../FreeRTOS/SystemTimeSupport.cpp",
     "../../SingletonConfigurationManager.cpp",
     "../common/CHIPDevicePlatformEvent.h",
-    "../common/ConfigurationManagerImpl.cpp",
+    "../mcxw71/ConfigurationManagerImpl.cpp",
     "../common/ConfigurationManagerImpl.h",
     "../common/ConnectivityManagerImpl.cpp",
     "../common/ConnectivityManagerImpl.h",


### PR DESCRIPTION
#### Summary

This PR updates the platform specific nxp/common and nxp/mcxw71 ConfigurationManagerImpl.cpp files.

- common: Update DetermineBootReason signature, parameter type
- mcxw71: Move/Update GetBootReason to DetermineBootReason
- mcxw71: Add nxp/common missing functions
- mcxw71: Add CONFIG_CHIP_NXP_PLATFORM_MCXW71 macro
- mcxw72: Switch to mcxw ConfigurationManagerImpl
- Align nxp/common and nxp/mcxw71 ConfigurationManagerImpl.cpp files
- Update copyright, description


#### Testing

Compilation and functional tests have been conducted internally (e.g commissioning, factory reset)
