### PR TITLE
 [Engine] Add a hook to store a customized ProviderChangeListener

### DIFF
--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -26,6 +26,7 @@
 
 #include <DeviceInfoProviderImpl.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/InteractionModelEngine.h>
 #include <app/TestEventTriggerDelegate.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
@@ -37,6 +38,7 @@
 #include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <crypto/RandUtils.h>
 #include <data-model-providers/codegen/Instance.h>
 #include <lib/core/ErrorStr.h>
 #include <lib/support/CHIPMem.h>
@@ -77,12 +79,14 @@ using namespace ::chip::DeviceLayer;
 
 namespace {
 
-constexpr int kFactoryResetTriggerTimeout      = 3000;
-constexpr int kFactoryResetCancelWindowTimeout = 3000;
-constexpr int kAppEventQueueSize               = 10;
-constexpr EndpointId kLightEndpointId          = 1;
-constexpr uint8_t kDefaultMinLevel             = 0;
-constexpr uint8_t kDefaultMaxLevel             = 254;
+constexpr int kFactoryResetTriggerTimeout        = 3000;
+constexpr int kFactoryResetCancelWindowTimeout   = 3000;
+constexpr int kUpdateClusterStateBaseTimeoutMs   = 1000;
+constexpr int kUpdateClusterStateJitterTimeoutMs = 1000;
+constexpr int kAppEventQueueSize                 = 10;
+constexpr EndpointId kLightEndpointId            = 1;
+constexpr uint8_t kDefaultMinLevel               = 0;
+constexpr uint8_t kDefaultMaxLevel               = 254;
 #if NUMBER_OF_BUTTONS == 2
 constexpr uint32_t kAdvertisingTriggerTimeout = 3000;
 #endif
@@ -155,6 +159,23 @@ constexpr uint32_t kOff_ms{ 950 };
 #ifdef CONFIG_CHIP_WIFI
 app::Clusters::NetworkCommissioning::Instance sWiFiCommissioningInstance(0, &(NetworkCommissioning::NrfWiFiDriver::Instance()));
 #endif
+
+void MarkDirtyInterpreter::MarkDirty(const chip::app::AttributePathParams & path)
+{
+    AppTask::MarkDirty(path);
+}
+
+void AppTask::MarkDirty(const chip::app::AttributePathParams & path)
+{
+    Instance().mAttributePaths.push_back(path);
+    // Batch all changes that happen within the timer window.
+    if (!Instance().mFunctionTimerActive)
+    {
+        uint32_t jitter = chip::Crypto::GetRandU16() % kUpdateClusterStateJitterTimeoutMs;
+        Instance().StartTimer(kUpdateClusterStateBaseTimeoutMs + jitter);
+    }
+    Instance().mFunction = FunctionEvent::UpdateClusterState;
+};
 
 CHIP_ERROR AppTask::Init()
 {
@@ -288,6 +309,10 @@ CHIP_ERROR AppTask::Init()
     initParams.testEventTriggerDelegate = &sTestEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
     AppFabricTableDelegate::Init();
+
+    // Register customized MarkDirtyInterpreter.
+    chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetMarkDirtyInterceptor(
+        std::move(mMarkDirtyInterpreter));
 
 #ifdef CONFIG_CHIP_MIGRATE_OPERATIONAL_KEYS_TO_ITS
     err = MoveOperationalKeysFromKvsToIts(sLocalInitData.mServerInitParams->persistentStorageDelegate,
@@ -502,6 +527,20 @@ void AppTask::FunctionTimerEventHandler(const AppEvent & event)
         StartBLEAdvertisementHandler(event);
         Instance().mFunction = FunctionEvent::NoneSelected;
 #endif
+    }
+    else if (Instance().mFunction == FunctionEvent::UpdateClusterState)
+    {
+        for (const auto & path : Instance().mAttributePaths)
+        {
+            CHIP_ERROR err = chip::app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(path);
+            if (err != CHIP_NO_ERROR)
+            {
+                LOG_ERR("Failed to set path dirty with error %" CHIP_ERROR_FORMAT, err.Format());
+            }
+        }
+        Instance().mAttributePaths.clear();
+        Instance().mFunction = FunctionEvent::NoneSelected;
+        Instance().CancelTimer();
     }
 }
 

--- a/examples/lighting-app/nrfconnect/main/include/AppEvent.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppEvent.h
@@ -42,7 +42,8 @@ enum class FunctionEvent : uint8_t
     NoneSelected   = 0,
     SoftwareUpdate = 0,
     FactoryReset,
-    AdvertisingStart
+    AdvertisingStart,
+    UpdateClusterState
 };
 
 struct AppEvent

--- a/examples/lighting-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppTask.h
@@ -103,6 +103,7 @@ private:
     PWMDevice mPWMDevice;
     std::unique_ptr<MarkDirtyInterpreter> mMarkDirtyInterpreter = std::make_unique<MarkDirtyInterpreter>();
     std::vector<chip::app::AttributePathParams> mAttributePaths;
+    struct k_mutex mMutex;
 
 #if CONFIG_CHIP_FACTORY_DATA
     chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData> mFactoryDataProvider;

--- a/examples/lighting-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppTask.h
@@ -22,7 +22,10 @@
 #include "LEDWidget.h"
 #include "PWMDevice.h"
 
+#include <app/AttributePathParams.h>
+#include <app/data-model-provider/ProviderChangeListener.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <vector>
 
 #if CONFIG_CHIP_FACTORY_DATA
 #include <platform/nrfconnect/FactoryDataProvider.h>
@@ -43,6 +46,12 @@
 struct k_timer;
 struct Identify;
 
+class MarkDirtyInterpreter : public chip::app::DataModel::ProviderChangeListener
+{
+public:
+    void MarkDirty(const chip::app::AttributePathParams & path) override;
+};
+
 class AppTask
 {
 public:
@@ -59,6 +68,7 @@ public:
 
     static void IdentifyStartHandler(Identify *);
     static void IdentifyStopHandler(Identify *);
+    static void MarkDirty(const chip::app::AttributePathParams & path);
 
 private:
 #ifdef CONFIG_CHIP_PW_RPC
@@ -91,6 +101,8 @@ private:
     FunctionEvent mFunction   = FunctionEvent::NoneSelected;
     bool mFunctionTimerActive = false;
     PWMDevice mPWMDevice;
+    std::unique_ptr<MarkDirtyInterpreter> mMarkDirtyInterpreter = std::make_unique<MarkDirtyInterpreter>();
+    std::vector<chip::app::AttributePathParams> mAttributePaths;
 
 #if CONFIG_CHIP_FACTORY_DATA
     chip::DeviceLayer::FactoryDataProvider<chip::DeviceLayer::InternalFlashFactoryData> mFactoryDataProvider;

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -1259,10 +1259,17 @@ void Engine::ScheduleUrgentEventDeliverySync(Optional<FabricIndex> fabricIndex)
 
 void Engine::MarkDirty(const AttributePathParams & path)
 {
-    CHIP_ERROR err = SetDirty(path);
-    if (err != CHIP_NO_ERROR)
+    if (mMarkDirtyInterceptor)
     {
-        ChipLogError(DataManagement, "Failed to set path dirty: %" CHIP_ERROR_FORMAT, err.Format());
+        mMarkDirtyInterceptor->MarkDirty(path);
+    }
+    else
+    {
+        CHIP_ERROR err = SetDirty(path);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(DataManagement, "Failed to set path dirty: %" CHIP_ERROR_FORMAT, err.Format());
+        }
     }
 }
 

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -132,6 +132,11 @@ public:
     /* ProviderChangeListener implementation */
     void MarkDirty(const AttributePathParams & path) override;
 
+    void SetMarkDirtyInterceptor(std::unique_ptr<DataModel::ProviderChangeListener> aMarkDirtyInterceptor)
+    {
+        mMarkDirtyInterceptor = std::move(aMarkDirtyInterceptor);
+    }
+
 private:
     /**
      * Main work-horse function that executes the run-loop.
@@ -292,6 +297,8 @@ private:
     InteractionModelEngine * mpImEngine = nullptr;
 
     EventManagement * mpEventManagement = nullptr;
+
+    std::unique_ptr<DataModel::ProviderChangeListener> mMarkDirtyInterceptor;
 };
 
 }; // namespace reporting


### PR DESCRIPTION
#### Summary

This change proposes to install a customized ProviderChangeListener in Engine. Products could choose to create a customized change listener and pass to Engine to override the default MarkDirty function.

#### Testing
Tested with a customized mark dirty interpreter in nrfconnect lighting-app. 
The attribute path marking dirty is delayed by 1s base +  1s jitter and DataReport is delayed correspondingly.