### PR TITLE
Enhance delete-cache action to accept GitHub token as input

### DIFF
--- a/.github/actions/delete-cache/action.yml
+++ b/.github/actions/delete-cache/action.yml
@@ -4,6 +4,9 @@ inputs:
   cache-key:
     required: true
     description: 'The cache key to delete'
+  github-token:
+    required: true
+    description: 'GitHub token for API authentication'
 runs:
   using: "composite"
   steps:
@@ -12,7 +15,7 @@ runs:
       env:
         CACHE_KEY: ${{ inputs.cache-key }}
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token }}
         script: |
           const owner = context.repo.owner;
           const repo = context.repo.repo;

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -447,6 +447,7 @@ jobs:
               uses: ./.github/actions/delete-cache
               with:
                   cache-key: ${{ env.CCACHE_KEY }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Save ccache
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: actions/cache/save@v4
@@ -937,6 +938,7 @@ jobs:
               uses: ./.github/actions/delete-cache
               with:
                   cache-key: ${{ env.CCACHE_KEY }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Save ccache
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: actions/cache/save@v4


### PR DESCRIPTION
- Added 'github-token' input to the delete-cache action for API authentication.
- Updated workflow files to pass the GitHub token when invoking the delete-cache action.

#### Summary

Composite actions cannot directly access secrets, they should be passed via action inputs

### Related issues

This should fix failure https://github.com/project-chip/connectedhomeip/actions/runs/18685359850/job/53276415371 


### Testing
