### PR TITLE
script for TC-CC-10.1 - changes for CCB4261

### DIFF
--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -261,7 +261,7 @@ class TC_CC_10_1(MatterBaseTest):
                                       "ColorTemperatureMireds is not less than or equal to %d" % CTmax)
             asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster][attributes.ColorTemperatureMireds], CTmin,
                                          "ColorTemperatureMireds is not greater than or equal to %d" % CTmin)
-        
+
         self.step("2h")
         if self.pics_guard(self.check_pics("CC.S.F01")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.EnhancedMoveToHueAndSaturation(20000, 50, 0, 1, 1))

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -253,9 +253,9 @@ class TC_CC_10_1(MatterBaseTest):
             await asyncio.sleep(1)
 
         self.step("2f")
-        CTmax = round(CTtarget * (1 + kTempTolerance))
-        CTmin = round(CTtarget * (1 - kTempTolerance))
         if self.pics_guard(self.check_pics("CC.S.F04")):
+            CTmax = round(CTtarget * (1 + kTempTolerance))
+            CTmin = round(CTtarget * (1 - kTempTolerance))
             result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.ColorTemperatureMireds)])
             asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster][attributes.ColorTemperatureMireds], CTmax,
                                       "ColorTemperatureMireds is not less than or equal to %d" % CTmax)

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -109,10 +109,9 @@ class TC_CC_10_1(MatterBaseTest):
             TestStep("2c", "TH sends _MoveToColor command_ to DUT, with: ColorX = 32768/0x8000 (x=0.5) (purple), ColorY = 19660/0x4CCC (y=0.3), TransitionTime = 0 (immediate)"),
             TestStep("2d", "TH reads _CurrentX and CurrentY attributes_ from DUT."),
             TestStep("2e", "TH sends _MoveToColorTemperature command_ to DUT with _ColorTemperatureMireds_=(_ColorTempPhysicalMinMireds_ + _ColorTempPhysicalMaxMireds_)/2"),
-            TestStep("2f", "TH sends _MoveColorTemperature command_ to DUT with _MoveMode_ = 0x01 (up), _Rate_ = (_ColorTempPhysicalMaxMireds_ - _ColorTempPhysicalMinMireds_)/40"),
-            TestStep("2g", "After 10 seconds, TH reads _ColorTemperatureMireds attribute_ from DUT."),
-            TestStep("2h", "TH sends _EnhancedMoveToHueAndSaturation command_ to DUT with _EnhancedHue_=20000, _Saturation_=50 and _TransitionTime_=0 (immediately)."),
-            TestStep("2i", "TH reads _EnhancedCurrentHue and CurrentSaturation attributes_ from DUT."),
+            TestStep("2f", "TH reads _ColorTemperatureMireds attribute_ from DUT."),
+            TestStep("2g", "TH sends _EnhancedMoveToHueAndSaturation command_ to DUT with _EnhancedHue_=20000, _Saturation_=50 and _TransitionTime_=0 (immediately)."),
+            TestStep("2h", "TH reads _EnhancedCurrentHue and CurrentSaturation attributes_ from DUT."),
             TestStep("3", "TH sends a _StoreScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
             TestStep("4", "TH sends a _ViewScene_ command to DUT with the _GroupID_ field set to _G~1~_ and the _SceneID_ field set to 0x01."),
             TestStep(
@@ -262,12 +261,12 @@ class TC_CC_10_1(MatterBaseTest):
             asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster][attributes.ColorTemperatureMireds], CTmin,
                                          "ColorTemperatureMireds is not greater than or equal to %d" % CTmin)
 
-        self.step("2h")
+        self.step("2g")
         if self.pics_guard(self.check_pics("CC.S.F01")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.EnhancedMoveToHueAndSaturation(20000, 50, 0, 1, 1))
             await asyncio.sleep(1)
 
-        self.step("2i")
+        self.step("2h")
         if self.pics_guard(self.check_pics("CC.S.F01")):
             result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.EnhancedCurrentHue), (self.matter_test_config.endpoint, attributes.CurrentSaturation)])
             asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster][attributes.EnhancedCurrentHue], 21800,

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -46,6 +46,7 @@ from matter.interaction_model import Status
 from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 kCCAttributeValueIDs = [0x0001, 0x0003, 0x0004, 0x0007, 0x4000, 0x4001, 0x4002, 0x4003, 0x4004]
+kTempTolerance = 0.15
 
 
 class TC_CC_10_1(MatterBaseTest):

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -253,15 +253,14 @@ class TC_CC_10_1(MatterBaseTest):
             await asyncio.sleep(1)
 
         self.step("2f")
-        CTmax = round (CTtarget * (1 + kTempTolerance))
-        CTmin = round (CTtarget * (1 - kTempTolerance))
+        CTmax = round(CTtarget * (1 + kTempTolerance))
+        CTmin = round(CTtarget * (1 - kTempTolerance))
         if self.pics_guard(self.check_pics("CC.S.F04")):
             result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.ColorTemperatureMireds)])
             asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster][attributes.ColorTemperatureMireds], CTmax,
-                                         "ColorTemperatureMireds is not less than or equal to %d" % CTmax)
+                                      "ColorTemperatureMireds is not less than or equal to %d" % CTmax)
             asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster][attributes.ColorTemperatureMireds], CTmin,
                                          "ColorTemperatureMireds is not greater than or equal to %d" % CTmin)
-
         
         self.step("2h")
         if self.pics_guard(self.check_pics("CC.S.F01")):

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -261,7 +261,6 @@ class TC_CC_10_1(MatterBaseTest):
             asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster][attributes.ColorTemperatureMireds], CTmin,
                                          "ColorTemperatureMireds is not greater than or equal to %d" % CTmin)
 
-        // step 2g no longer exists
         
         self.step("2h")
         if self.pics_guard(self.check_pics("CC.S.F01")):

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -253,8 +253,8 @@ class TC_CC_10_1(MatterBaseTest):
             await asyncio.sleep(1)
 
         self.step("2f")
-        CTmax = round (CTtarget * 1.15)
-        CTmin = round (CTtarget * 0.85)
+        CTmax = round (CTtarget * (1 + kTempTolerance))
+        CTmin = round (CTtarget * (1 - kTempTolerance))
         if self.pics_guard(self.check_pics("CC.S.F04")):
             result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.ColorTemperatureMireds)])
             asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster][attributes.ColorTemperatureMireds], CTmax,

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -225,9 +225,9 @@ class TC_CC_10_1(MatterBaseTest):
             asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster][attributes.CurrentHue], 170,
                                          "CurrentHue is not greater than or equal to 170")
             asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster]
-                                      [attributes.CurrentSaturation], 58, "CurrentSaturation is not 58")
+                                      [attributes.CurrentSaturation], 58, "CurrentSaturation is not less than or equal 58")
             asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster]
-                                         [attributes.CurrentSaturation], 42, "CurrentSaturation is not 42")
+                                         [attributes.CurrentSaturation], 42, "CurrentSaturation is not greater than or equal 42")
 
         self.step("2c")
         if self.pics_guard(self.check_pics("CC.S.F03")):

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -214,6 +214,7 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("2a")
         if self.pics_guard(self.check_pics("CC.S.F00")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.MoveToHueAndSaturation(200, 50, 0, 1, 1))
+            await asyncio.sleep(1)
 
         self.step("2b")
         if self.pics_guard(self.check_pics("CC.S.F00")):
@@ -230,6 +231,7 @@ class TC_CC_10_1(MatterBaseTest):
         self.step("2c")
         if self.pics_guard(self.check_pics("CC.S.F03")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.MoveToColor(32768, 19660, 0, 1, 1))
+            await asyncio.sleep(1)
 
         self.step("2d")
         if self.pics_guard(self.check_pics("CC.S.F03")):
@@ -244,26 +246,27 @@ class TC_CC_10_1(MatterBaseTest):
                                          "CurrentY is not greater than or equal to 17000")
 
         self.step("2e")
+        CTtarget = round((ColorTempPhysicalMinMiredsValue + ColorTempPhysicalMaxMiredsValue) / 2)
         if self.pics_guard(self.check_pics("CC.S.F04")):
-            await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.MoveToColorTemperature((ColorTempPhysicalMinMiredsValue + ColorTempPhysicalMaxMiredsValue) / 2, 0, 1, 1))
+            await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.MoveToColorTemperature(CTtarget, 0, 1, 1))
             await asyncio.sleep(1)
 
         self.step("2f")
+        CTmax = round (CTtarget * 1.15)
+        CTmin = round (CTtarget * 0.85)
         if self.pics_guard(self.check_pics("CC.S.F04")):
-            await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.MoveColorTemperature(self.matter_test_config.endpoint, (ColorTempPhysicalMaxMiredsValue - ColorTempPhysicalMinMiredsValue) / 40, 1, 1))
-            await asyncio.sleep(10)
+            result = await self.TH1.ReadAttribute(self.dut_node_id, [(self.matter_test_config.endpoint, attributes.ColorTemperatureMireds)])
+            asserts.assert_less_equal(result[self.matter_test_config.endpoint][cluster][attributes.ColorTemperatureMireds], CTmax,
+                                         "ColorTemperatureMireds is not less than or equal to %d" % CTmax)
+            asserts.assert_greater_equal(result[self.matter_test_config.endpoint][cluster][attributes.ColorTemperatureMireds], CTmin,
+                                         "ColorTemperatureMireds is not greater than or equal to %d" % CTmin)
 
-        self.step("2g")
-        if self.pics_guard(self.check_pics("CC.S.F04")):
-            ColorTemperatureMireds = await self.read_single_attribute_check_success(cluster, attributes.ColorTemperatureMireds)
-            asserts.assert_less_equal(ColorTemperatureMireds, ColorTempPhysicalMaxMiredsValue,
-                                      "ColorTemperatureMireds is not less than or equal to ColorTempPhysicalMaxMireds")
-            asserts.assert_greater_equal(ColorTemperatureMireds, ColorTempPhysicalMinMiredsValue,
-                                         "ColorTemperatureMireds is not greater than or equal to ColorTempPhysicalMinMireds")
-
+        // step 2g no longer exists
+        
         self.step("2h")
         if self.pics_guard(self.check_pics("CC.S.F01")):
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.EnhancedMoveToHueAndSaturation(20000, 50, 0, 1, 1))
+            await asyncio.sleep(1)
 
         self.step("2i")
         if self.pics_guard(self.check_pics("CC.S.F01")):


### PR DESCRIPTION
#### Summary and related issues
test plan issue [5629](https://github.com/CHIP-Specifications/chip-test-plans/issues/5629) and CCB: [4261](https://zigbeecertifiedproducts.knack.com/zigbee-alliance-ccb-tool#home/ccbs4/ccb-details16/68f257b298880a0308124a5d) identified some flaws in the test plan for TC-CC-10.1, i.e.

- Step 2a sends a command to set hue and saturation, step 2b then reads the values to confirm. In the script, a delay should be added in step 2b since without delay the reading happens before the command has been processed.
  - proposed resolution: add a "sleep(1)" like already present in the script on steps 2e,2f
 
- Same for step 2c-2d, and 2h-2i
 
- Steps 2f,2g are redundant (testing MoveColorTemperature which is redundant since already tested in TC-CC-6.2) ;
  - these steps should be removed, and we need to add a step with check on the value (like in 2b/2d/2i)
 
- Step 2e calculates a target value of ColorTemperatureMireds which can be fractional depending on the min/max values reported by the DUT
  - need to add a "round" or "trunc"

Test plan PR [5634](https://github.com/CHIP-Specifications/chip-test-plans/pull/5634/files) and this PR for the python script address the changes.

#### Testing

These changes were tested by @suneelsignify using the updated script and a product DUT supporting Matter 1.4.2

#### Readability checklist

-   [x] PR title is [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html) rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase
