### PR TITLE
Fix bootstrap for python3.13

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -60,7 +60,7 @@ jobs:
             - name: Install esp-idf-kconfig
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "pip install esp-idf-kconfig==2.5.0"
+                    "pip install -r ./scripts/setup/requirements.esp32.idfv5_5.txt"
 
             - name: Build example All Clusters App(Target:ESP32C3)
               run: |

--- a/docs/platforms/esp32/build_app_and_commission.md
+++ b/docs/platforms/esp32/build_app_and_commission.md
@@ -62,6 +62,14 @@ functionality can still work fine.
     $ source scripts/activate.sh
     ```
 
+-   Install IDF requirements for IDF v5.5.1
+
+    For IDF v5.5.1 you need to install esp-idf-kconfig and idf-component-manager for Matter environment.
+
+    ```
+    pip install -r ./scripts/setup/requirements.esp32.idfv5_5.txt
+    ```
+
 -   Ccache
 
     Enable Ccache for faster IDF builds. It is recommended to have Ccache

--- a/docs/platforms/esp32/build_app_and_commission.md
+++ b/docs/platforms/esp32/build_app_and_commission.md
@@ -64,7 +64,8 @@ functionality can still work fine.
 
 -   Install IDF requirements for IDF v5.5.1
 
-    For IDF v5.5.1 you need to install esp-idf-kconfig and idf-component-manager for Matter environment.
+    For IDF v5.5.1 you need to install esp-idf-kconfig and idf-component-manager
+    for Matter environment.
 
     ```
     pip install -r ./scripts/setup/requirements.esp32.idfv5_5.txt

--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -96,7 +96,7 @@ ghapi==1.0.3
     # via -r requirements.memory.txt
 humanfriendly==10.0
     # via coloredlogs
-idf-component-manager==2.4.1
+idf-component-manager==1.5.3
     # via -r requirements.esp32.txt
 idna==3.4
     # via requests

--- a/scripts/setup/requirements.esp32.idfv5_5.txt
+++ b/scripts/setup/requirements.esp32.idfv5_5.txt
@@ -1,0 +1,2 @@
+esp-idf-kconfig==2.5.0
+idf-component-manager==2.4.1


### PR DESCRIPTION
#### Summary

The bootstrap for python 3.13 was broken

#### Related issues

NA

#### Testing

- run bootstrap.sh with python3.13
- CI should pass
