### PR TITLE
[ESP32]: update the default values of MRP parameters

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -1161,7 +1161,7 @@ menu "CHIP Device Layer"
             int "MRP local active retry interval for Thread network in milliseconds"
             depends on ENABLE_MATTER_OVER_THREAD
             range 0 3600000
-            default 800
+            default 2000
             help
                 Base retry interval of the present Thread node when it is in the active state.
 
@@ -1177,7 +1177,7 @@ menu "CHIP Device Layer"
             int "MRP local idle retry interval for Thread network in milliseconds"
             depends on ENABLE_MATTER_OVER_THREAD
             range 0 3600000
-            default 800
+            default 2000
             help
                 Base retry interval of the present Thread node when it is in the idle state.
 
@@ -1193,7 +1193,7 @@ menu "CHIP Device Layer"
             int "MRP retransmission delta timeout for Thread network in milliseconds"
             depends on ENABLE_MATTER_OVER_THREAD
             range 0 3600000
-            default 500
+            default 1500
             help
                 A constant value added to the calculated retransmission timeout.
 


### PR DESCRIPTION
#### Summary
Update the default values of MRP parameters on ESP platform  to be consistent with the [SDK](https://github.com/project-chip/connectedhomeip/blob/c6194cab96fecce722ceae06ebcce19adfcb2770/src/messaging/ReliableMessageProtocolConfig.h#L55).

#### Testing
Manually tested lighting-app on ESP32H2 with MRP retransmiting.