### PR TITLE
[Camera] Call RemoveSession method from Matter context

### DIFF
--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -887,7 +887,9 @@ void WebRTCProviderManager::OnConnectionStateChanged(bool connected, const uint1
     }
     else
     {
-        // Schedule cleanup on Matter thread to ensure proper locking when calling RemoveSession
+        // Schedule cleanup on Matter thread to ensure proper locking when calling RemoveSession.
+        // Safe to capture 'this' by value: WebRTCProviderManager is a member of the global CameraDevice
+        // object which has static storage duration and lives for the entire program lifetime.
         DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() {
             WebrtcTransport * transport = GetTransport(sessionId);
             if (transport == nullptr)

--- a/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.cpp
+++ b/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.cpp
@@ -160,6 +160,8 @@ WebRTCSessionStruct * WebRTCTransportProviderServer::FindSession(uint16_t sessio
 
 WebRTCTransportProviderServer::UpsertResultEnum WebRTCTransportProviderServer::UpsertSession(const WebRTCSessionStruct & session)
 {
+    assertChipStackLockedByCurrentThread();
+
     UpsertResultEnum result;
     auto it = std::find_if(mCurrentSessions.begin(), mCurrentSessions.end(),
                            [id = session.id](const auto & existing) { return existing.id == id; });
@@ -183,6 +185,8 @@ WebRTCTransportProviderServer::UpsertResultEnum WebRTCTransportProviderServer::U
 
 void WebRTCTransportProviderServer::RemoveSession(uint16_t sessionId)
 {
+    assertChipStackLockedByCurrentThread();
+
     size_t originalSize = mCurrentSessions.size();
 
     // Erase-Remove idiom


### PR DESCRIPTION
#### Summary

The crash is happening because MatterReportingAttributeChangeCallback is being called from a WebRTC worker thread (the libdatachannel "RTC worker" thread) without holding the Matter stack lock. This violates Matter's threading requirements.

Looking at the stack trace:

WebRTC connection closes on an RTC worker thread

1. Callback chain leads to WebRTCProviderManager::OnConnectionStateChanged
2. Which calls RemoveSession
3. Which calls MatterReportingAttributeChangeCallback without the Matter lock

The RemoveSession method needs to ensure it's called on the Matter thread with the stack lock held. 

#### Related issues

Fixes: #41538

#### Testing

Establish a webrtc connection in normal flow:

- Client/Controller -> Server/Device: SDP offer
- Client <- Server: SDP answer
- Client <-> Server: ICE exchange

End the webrtc connection:

- Client -> Server: End

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
