### PR TITLE
[NXP][wifi] Switching kPlatformNxpWlanEvent to public event to allow application to be informed on Wlan event

### DIFF
--- a/examples/thermostat/nxp/common/main/DeviceCallbacks.cpp
+++ b/examples/thermostat/nxp/common/main/DeviceCallbacks.cpp
@@ -70,6 +70,24 @@ using namespace ::chip::System;
 using namespace ::chip::DeviceLayer;
 using namespace chip::app::Clusters;
 
+void ThermostatApp::DeviceCallbacks::DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
+{
+    // First call the parent implementation to maintain existing functionality
+    chip::NXP::App::CommonDeviceCallbacks::DeviceEventCallback(event, arg);
+
+// Example of how to process WLAN events from the application layer
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+    if (event != nullptr)
+    {
+        if (event->Type == chip::DeviceLayer::DeviceEventType::kPlatformNxpWlanEvent &&
+            event->Platform.WlanEventReason == WLAN_REASON_CONNECT_FAILED)
+        {
+            ChipLogError(DeviceLayer, "WLAN connection failed");
+        }
+    }
+#endif
+}
+
 void ThermostatApp::DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId,
                                                                  AttributeId attributeId, uint8_t type, uint16_t size,
                                                                  uint8_t * value)

--- a/examples/thermostat/nxp/common/main/DeviceCallbacks.cpp
+++ b/examples/thermostat/nxp/common/main/DeviceCallbacks.cpp
@@ -76,14 +76,12 @@ void ThermostatApp::DeviceCallbacks::DeviceEventCallback(const chip::DeviceLayer
     chip::NXP::App::CommonDeviceCallbacks::DeviceEventCallback(event, arg);
 
 // Example of how to process WLAN events from the application layer
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    if (event != nullptr)
+// Such event is visible only on WPA enabled builds with FreeRTOS OS
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA && CONFIG_APP_FREERTOS_OS
+    if (event != nullptr && event->Type == chip::DeviceLayer::DeviceEventType::kPlatformNxpWlanEvent &&
+        event->Platform.WlanEventReason == WLAN_REASON_CONNECT_FAILED)
     {
-        if (event->Type == chip::DeviceLayer::DeviceEventType::kPlatformNxpWlanEvent &&
-            event->Platform.WlanEventReason == WLAN_REASON_CONNECT_FAILED)
-        {
-            ChipLogError(DeviceLayer, "WLAN connection failed");
-        }
+        ChipLogError(DeviceLayer, "WLAN connection failed");
     }
 #endif
 }

--- a/examples/thermostat/nxp/common/main/include/DeviceCallbacks.h
+++ b/examples/thermostat/nxp/common/main/include/DeviceCallbacks.h
@@ -35,6 +35,9 @@ public:
     // This returns an instance of this class.
     static DeviceCallbacks & GetDefaultInstance();
 
+    // Override DeviceEventCallback from parent class
+    void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg) override;
+
     void PostAttributeChangeCallback(chip::EndpointId endpointId, chip::ClusterId clusterId, chip::AttributeId attributeId,
                                      uint8_t type, uint16_t size, uint8_t * value);
 

--- a/src/platform/nxp/common/CHIPDevicePlatformEvent.h
+++ b/src/platform/nxp/common/CHIPDevicePlatformEvent.h
@@ -51,7 +51,7 @@ namespace DeviceEventType {
  */
 enum PublicPlatformSpecificEventTypes
 {
-    /* None currently defined */
+    kPlatformNxpWlanEvent = kRange_PublicPlatformSpecific,
 };
 
 /**
@@ -66,7 +66,6 @@ enum InternalPlatformSpecificEventTypes
     kPlatformZephyrBleC1WriteEvent,
     kPlatformZephyrBleC2IndDoneEvent,
     kPlatformZephyrBleOutOfBuffersEvent,
-    kPlatformNxpWlanEvent,
     kPlatformNxpIpChangeEvent,
     kPlatformNxpStartWlanConnectEvent,
     kPlatformNxpScanWiFiNetworkDoneEvent,


### PR DESCRIPTION
#### Summary

This PR makes the kPlatformNxpWlanEvent a public event to allow applications to be informed of WLAN events, and demonstrates this functionality in the NXP thermostat app.

#### Testing

A test has been done on NXP RW platform to validate that the event is correctly received by the application.