### PR TITLE
[Silabs] Fix unit test builds following cherry-pick update merge

### DIFF
--- a/examples/platform/silabs/wifi/wfx_notify.cpp
+++ b/examples/platform/silabs/wifi/wfx_notify.cpp
@@ -219,7 +219,7 @@ void wfx_retry_connection(uint16_t retryAttempt)
             return;
         }
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI91X_MCU_INTERFACE
-        wfx_rsi_power_save(RSI_SLEEP_MODE_8, STANDBY_POWER_SAVE_WITH_RAM_RETENTION);
+        wfx_rsi_power_save(RSI_SLEEP_MODE_8, ASSOCIATED_POWER_SAVE);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI91X_MCU_INTERFACE
         ChipLogProgress(DeviceLayer, "wfx_retry_connection : Next attempt after %d Seconds", retryInterval);
         retryInterval += retryInterval;

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -114,6 +114,7 @@ source_set("efr32_test_main") {
   ]
 
   include_dirs = [ "${chip_root}/examples/common/pigweed/efr32" ]
+  public_configs = [ ":efr32_ldflags" ]
 }
 
 # This target is referred to by BuildRoot in scripts/build/builders/efr32.py, as well as the example in README.md.

--- a/src/test_driver/efr32/args.gni
+++ b/src/test_driver/efr32/args.gni
@@ -15,9 +15,7 @@
 import("//build_overrides/chip.gni")
 import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/efr32/lib/pw_rpc/pw_rpc.gni")
-import("${chip_root}/examples/platform/silabs/args.gni")
 import("${chip_root}/src/platform/silabs/efr32/args.gni")
-import("${chip_root}/third_party/silabs/silabs_board.gni")  # silabs_family
 
 silabs_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
@@ -46,9 +44,3 @@ pw_unit_test_MAIN = "//:efr32_test_main"
 # Additional variables needed by silabs_executable that must be passed in to pw_test.
 test_executable_output_name = "matter-silabs-device_tests-"
 test_executable_output_name_suffix = ".out"
-_ldscript =
-    "${chip_root}/examples/platform/silabs/ldscripts/${silabs_family}.ld"
-test_executable_ldflags = [
-  "-T" + rebase_path(_ldscript, root_build_dir),
-  "-Wl,--no-warn-rwx-segment",
-]


### PR DESCRIPTION
#### Summary
PR fixes the unit tests builds following #41143 merge into the release branch.
Configuration changes were missing to be able to build the unit tests.

#### Related issues

Fixes CI failure from #41143 

#### Testing
CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
