### PR TITLE
[Scenes] Fix the PICS guard around CTarget calculation in CC_10_1

### DIFF
--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -246,8 +246,8 @@ class TC_CC_10_1(MatterBaseTest):
                                          "CurrentY is not greater than or equal to 17000")
 
         self.step("2e")
-        CTtarget = round((ColorTempPhysicalMinMiredsValue + ColorTempPhysicalMaxMiredsValue) / 2)
         if self.pics_guard(self.check_pics("CC.S.F04")):
+            CTtarget = round((ColorTempPhysicalMinMiredsValue + ColorTempPhysicalMaxMiredsValue) / 2)
             await self.TH1.SendCommand(self.dut_node_id, self.matter_test_config.endpoint, cluster.Commands.MoveToColorTemperature(CTtarget, 0, 1, 1))
             await asyncio.sleep(1)
 


### PR DESCRIPTION
#### Summary

Fix the PICS guard around CTarget calculation in CC_10_1 introduced https://github.com/project-chip/connectedhomeip/pull/41561.

#### Related issues

test plan issue https://github.com/CHIP-Specifications/chip-test-plans/issues/5629 and CCB: [4261](https://zigbeecertifiedproducts.knack.com/zigbee-alliance-ccb-tool#home/ccbs4/ccb-details16/68f257b298880a0308124a5d)

#### Testing

Ran the tests locally with and without the PICS

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
