### PR TITLE
Add --app-filter and --override-binary-path to local.py

### DIFF
--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -802,7 +802,8 @@ def gen_coverage(flat):
     "--override-binary-path",
     default=None,
     nargs=2,
-    help="Defines an override binary path for a given app. E.g. --override-binary-path ALL_CLUSTERS_APP out/some/path/chip-all-clusters-app"
+    multiple=True,
+    help="Defines an override binary path for a given app. Can be used multiple times. E.g. --override-binary-path ALL_CLUSTERS_APP out/some/path/chip-all-clusters-app"
 )
 @click.option(
     "--app-filter",
@@ -846,9 +847,7 @@ def python_tests(
         return _maybe_with_runner(os.path.basename(path), path, runner)
 
     # create an env file
-    override_binaries = {}
-    if override_binary_path:
-        override_binaries[override_binary_path[0]] = override_binary_path[1]
+    override_binaries = dict(override_binary_path or [])
 
     with open("./out/test_env.yaml", "wt") as f:
         for target in _get_targets(coverage):

--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -22,7 +22,6 @@ import logging
 import multiprocessing
 import os
 import platform
-import re
 import shlex
 import stat
 import subprocess

--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -38,6 +38,7 @@ import colorama
 import coloredlogs
 import tabulate
 import yaml
+
 from matter.testing.metadata import extract_runs_args
 
 

--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -807,8 +807,8 @@ def gen_coverage(flat):
 )
 @click.option(
     "--app-filter",
-    default="*",
-    show_default=True,
+    default=None,
+    type=str,
     help="Run only tests that are for the given app. Comma separated list of apps. E.g. --app-filter ALL_CLUSTERS_APP,CHIP_TOOL",
 )
 def python_tests(
@@ -864,9 +864,9 @@ def python_tests(
         test_filter = "*"
     test_filter = _parse_filters(test_filter)
 
-    if not app_filter:
-        app_filter = "*"
-    app_filter_list = _parse_filters(app_filter)
+    app_filter_list = None
+    if app_filter:
+        app_filter_list = _parse_filters(app_filter)
 
     if skip:
         print("SKIP IS %r" % skip)
@@ -917,7 +917,7 @@ def python_tests(
     try:
         to_run = []
         for script in [t for t in test_scripts if test_filter.any_matches(t)]:
-            if app_filter != "*":
+            if app_filter_list:
                 required_apps = _get_apps_from_script(script)
                 if not any(app_filter_list.any_matches(app) for app in required_apps):
                     logging.info("Skipping %s due to app filter (requires %r)", script, required_apps)
@@ -950,7 +950,7 @@ def python_tests(
                     f"./scripts/tests/run_python_test.py --load-from-env out/test_env.yaml --script {script}",
                 ]
 
-                if app_filter != "*":
+                if app_filter_list:
                     cmd.extend(('--app-filter', app_filter))
 
                 if dry_run:

--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -951,7 +951,7 @@ def python_tests(
                 ]
 
                 if app_filter != "*":
-                    cmd.append(f'--app-filter "{app_filter}"')
+                    cmd.extend(('--app-filter', app_filter))
 
                 if dry_run:
                     print(shlex.join(cmd))

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -167,9 +167,10 @@ class AppProcessManager:
               help="Do not print output from passing tests. Use this flag in CI to keep GitHub log size manageable.")
 @click.option("--load-from-env", default=None, help="YAML file that contains values for environment variables.")
 @click.option("--run", type=str, multiple=True, help="Run only the specified test run(s).")
+@click.option("--app-filter", type=str, default=None, help="Run only for the specified app(s). Comma separated.")
 def main(app: str, factory_reset: bool, factory_reset_app_only: bool, app_args: str,
          app_ready_pattern: str, app_stdin_pipe: str, script: str, script_args: str,
-         script_gdb: bool, quiet: bool, load_from_env, run):
+         script_gdb: bool, quiet: bool, load_from_env, run, app_filter):
     if load_from_env:
         reader = MetadataReader(load_from_env)
         runs = reader.parse_script(script)
@@ -195,6 +196,12 @@ def main(app: str, factory_reset: bool, factory_reset_app_only: bool, app_args: 
     if run:
         # Filter runs based on the command line arguments
         runs = [r for r in runs if r.run in run]
+
+    if app_filter:
+        allowed_apps = [s.strip() for s in app_filter.split(',')]
+        # app name in metadata is like "${APP_NAME}"
+        allowed_apps_with_format = [f"${{{app}}}" for app in allowed_apps]
+        runs = [r for r in runs if r.app in allowed_apps_with_format]
 
     # Override runs Metadata with the command line options
     for run in runs:


### PR DESCRIPTION
#### Summary

This PR adds two new arguments to `local.py`:
* `--override-binary-path`
* `--app-filter`

These new arguments make it possible to override the binary path for a certain app and also filter tests for an specific app. This makes it easier to run tests locally for specific binaries.

Usage example: `./scripts/tests/local.py python-tests --app-filter AIR_PURIFIER_APP --override-binary-path AIR_PURIFIER_APP out/unified-build/standalone/chip-air-purifier-app`

#### Testing

Confirmed it skips tests based on `--app-filter` and also confirmed it successfully overrides the binary.
For example:
```
$ ./scripts/tests/local.py python-tests --app-filter AIR_PURIFIER_APP --override-binary-path AIR_PURIFIER_APP out/unified-build/standalone/chip-air-purifier-app
2025-10-23 18:57:05 INFO    Defaults read from 'out/local_py.ini'
2025-10-23 18:57:05 INFO    Skipping src/controller/python/tests/scripts/mobile-device-test.py due to app filter (requires ['ALL_CLUSTERS_APP'])
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TCP_Tests.py due to app filter (requires ['ALL_CLUSTERS_APP'])
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TC_ACE_1_2.py due to app filter (requires ['ALL_CLUSTERS_APP'])
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TC_ACE_1_3.py due to app filter (requires ['ALL_CLUSTERS_APP'])
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TC_ACE_1_4.py due to app filter (requires 
....
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TC_AVSM_2_1.py due to app filter (requires ['CAMERA_APP'])
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TC_AVSM_2_10.py due to app filter (requires ['CAMERA_APP'])
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TC_AVSM_2_11.py due to app filter (requires ['CAMERA_APP'])
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TC_AVSM_2_12.py due to app filter (requires ['CAMERA_APP'])
...
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TC_ZONEMGMT_2_2.py due to app filter (requires ['CAMERA_APP'])
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TC_ZONEMGMT_2_3.py due to app filter (requires ['CAMERA_APP'])
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TC_ZONEMGMT_2_4.py due to app filter (requires ['CAMERA_APP'])
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TestFrameworkArgParsing.py due to app filter (requires [])
2025-10-23 18:57:05 INFO    Skipping src/python_testing/TestReadSubscribeAceExistenceErrors.py due to app filter (requires ['ALL_CLUSTERS_APP'])
on 3: 2025-10-23 18:57:23 WARNING SLOW test 'TC_FAN_3_1.py' is executing (expect to take around 15 seconds). Be patient...
Running tests |████████████████████████████████████████| 6/6 [100%] in 52.5s (0.10/s) 
Script           Duration(sec)  Status
-------------  ---------------  --------
TC_FAN_2_1.py          5.90909  PASS
TC_FAN_2_4.py          6.02508  PASS
TC_FAN_2_3.py          6.10084  PASS
TC_FAN_3_2.py          7.11067  PASS
TC_FAN_3_1.py         13.3993   PASS
TC_FAN_4_1.py         13.7049   PASS
```

