### PR TITLE
[Fix] Adding run_if_endpoint_matches marker to check for extension attr before running ACL_2_3 and ACL_2_7 test modules

### DIFF
--- a/src/python_testing/TC_ACL_2_10.py
+++ b/src/python_testing/TC_ACL_2_10.py
@@ -57,6 +57,9 @@ class TC_ACL_2_10(MatterBaseTest):
     def desc_TC_ACL_2_10(self) -> str:
         return "[TC-ACL-2.10] Persistence"
 
+    def pics_TC_ACL_2_10(self) -> list[str]:
+        return ['ACL.S.A0001']
+
     def steps_TC_ACL_2_10(self) -> list[TestStep]:
         steps = [
             TestStep(1, "TH1 commissions DUT using admin node ID",

--- a/src/python_testing/TC_ACL_2_2.py
+++ b/src/python_testing/TC_ACL_2_2.py
@@ -42,6 +42,9 @@ class TC_ACL_2_2(MatterBaseTest):
     def desc_TC_ACL_2_2(self) -> str:
         return "[TC-ACL-2.2] Cluster endpoint"
 
+    def pics_TC_ACL_2_2(self) -> list[str]:
+        return ['ACL.S']
+
     def steps_TC_ACL_2_2(self) -> list[TestStep]:
         steps = [
             TestStep(1, "Commissioning, already done", is_commissioning=True),

--- a/src/python_testing/TC_ACL_2_3.py
+++ b/src/python_testing/TC_ACL_2_3.py
@@ -327,6 +327,9 @@ class TC_ACL_2_3(MatterBaseTest):
     def desc_TC_ACL_2_3(self) -> str:
         return "[TC-ACL-2.3] Multiple fabrics test"
 
+    def pics_TC_ACL_2_3(self) -> list[str]:
+        return ['ACL.S.A0001']
+
     def steps_TC_ACL_2_3(self) -> list[TestStep]:
         steps = [
             TestStep(1, "TH1 commissions DUT using admin node ID",

--- a/src/python_testing/TC_ACL_2_3.py
+++ b/src/python_testing/TC_ACL_2_3.py
@@ -39,7 +39,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.interaction_model import Status
-from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_attribute,
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, default_matter_test_main, has_attribute,
                                            run_if_endpoint_matches)
 
 # These below variables are used to test the AccessControl clusters Extension attribute and come from the test plan here:

--- a/src/python_testing/TC_ACL_2_3.py
+++ b/src/python_testing/TC_ACL_2_3.py
@@ -39,7 +39,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, run_if_endpoint_matches, has_attribute
 
 # These below variables are used to test the AccessControl clusters Extension attribute and come from the test plan here:
 # https://github.com/CHIP-Specifications/chip-test-plans/blob/59e8c45b8e7c24d5ce130b166520ff4f7bd935b6/src/cluster/AccessControl.adoc#tc-acl-2-6-accesscontrolentrychanged-event:~:text=D_OK_EMPTY%3A%20%221718%22%20which%20is%20an%20octstr%20of%20length%202%20containing%20valid%20TLV%3A

--- a/src/python_testing/TC_ACL_2_3.py
+++ b/src/python_testing/TC_ACL_2_3.py
@@ -374,7 +374,7 @@ class TC_ACL_2_3(MatterBaseTest):
         ]
         return steps
 
-    @async_test_body
+    @run_if_endpoint_matches(has_attribute(Clusters.AccessControl.Attributes.Extension))
     async def test_TC_ACL_2_3(self):
         await self.internal_test_TC_ACL_2_3(force_legacy_encoding=False)
         self.current_step_index = 0

--- a/src/python_testing/TC_ACL_2_3.py
+++ b/src/python_testing/TC_ACL_2_3.py
@@ -28,7 +28,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#       --endpoint 1
+#       --endpoint 0
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/TC_ACL_2_3.py
+++ b/src/python_testing/TC_ACL_2_3.py
@@ -39,7 +39,8 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, run_if_endpoint_matches, has_attribute
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_attribute,
+                                           run_if_endpoint_matches)
 
 # These below variables are used to test the AccessControl clusters Extension attribute and come from the test plan here:
 # https://github.com/CHIP-Specifications/chip-test-plans/blob/59e8c45b8e7c24d5ce130b166520ff4f7bd935b6/src/cluster/AccessControl.adoc#tc-acl-2-6-accesscontrolentrychanged-event:~:text=D_OK_EMPTY%3A%20%221718%22%20which%20is%20an%20octstr%20of%20length%202%20containing%20valid%20TLV%3A

--- a/src/python_testing/TC_ACL_2_3.py
+++ b/src/python_testing/TC_ACL_2_3.py
@@ -39,8 +39,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.interaction_model import Status
-from matter.testing.matter_testing import (MatterBaseTest, TestStep, default_matter_test_main, has_attribute,
-                                           run_if_endpoint_matches)
+from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_attribute, run_if_endpoint_matches
 
 # These below variables are used to test the AccessControl clusters Extension attribute and come from the test plan here:
 # https://github.com/CHIP-Specifications/chip-test-plans/blob/59e8c45b8e7c24d5ce130b166520ff4f7bd935b6/src/cluster/AccessControl.adoc#tc-acl-2-6-accesscontrolentrychanged-event:~:text=D_OK_EMPTY%3A%20%221718%22%20which%20is%20an%20octstr%20of%20length%202%20containing%20valid%20TLV%3A

--- a/src/python_testing/TC_ACL_2_4.py
+++ b/src/python_testing/TC_ACL_2_4.py
@@ -44,7 +44,10 @@ from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_b
 
 class TC_ACL_2_4(MatterBaseTest):
     def desc_TC_ACL_2_4(self) -> str:
-        return "[TC-ACL-2.4] ACL "
+        return "[TC-ACL-2.4] ACL Attribute"
+
+    def pics_TC_ACL_2_4(self) -> list[str]:
+        return ['ACL.S']
 
     def steps_TC_ACL_2_4(self) -> list[TestStep]:
         steps = [

--- a/src/python_testing/TC_ACL_2_6.py
+++ b/src/python_testing/TC_ACL_2_6.py
@@ -79,6 +79,9 @@ class TC_ACL_2_6(MatterBaseTest):
     def desc_TC_ACL_2_6(self) -> str:
         return "[TC-ACL-2.6] AccessControlEntryChanged event"
 
+    def pics_TC_ACL_2_6(self) -> list[str]:
+        return ['ACL.S']
+
     async def internal_test_TC_ACL_2_6(self, force_legacy_encoding: bool):
         self.step(1)
         # Initialize TH1 controller

--- a/src/python_testing/TC_ACL_2_7.py
+++ b/src/python_testing/TC_ACL_2_7.py
@@ -123,7 +123,7 @@ class TC_ACL_2_7(MatterBaseTest):
         ]
         return steps
 
-    @async_test_body
+    @run_if_endpoint_matches(has_attribute(Clusters.AccessControl.Attributes.Extension))
     async def test_TC_ACL_2_7(self):
         self.step(1)
         self.th1 = self.default_controller

--- a/src/python_testing/TC_ACL_2_7.py
+++ b/src/python_testing/TC_ACL_2_7.py
@@ -41,7 +41,8 @@ import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.clusters.Types import Nullable
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, run_if_endpoint_matches, has_attribute
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_attribute,
+                                           run_if_endpoint_matches)
 
 # These below variables are used to test the AccessControl cluster Extension attribute and come from the test plan here: https://github.com/CHIP-Specifications/chip-test-plans/blob/59e8c45b8e7c24d5ce130b166520ff4f7bd935b6/src/cluster/AccessControl.adoc#tc-acl-2-6-accesscontrolentrychanged-event:~:text=D_OK_EMPTY%3A%20%221718%22%20which%20is%20an%20octstr%20of%20length%202%20containing%20valid%20TLV%3A
 D_OK_EMPTY = bytes.fromhex('1718')

--- a/src/python_testing/TC_ACL_2_7.py
+++ b/src/python_testing/TC_ACL_2_7.py
@@ -41,7 +41,7 @@ import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.clusters.Types import Nullable
 from matter.interaction_model import Status
-from matter.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_attribute,
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, default_matter_test_main, has_attribute,
                                            run_if_endpoint_matches)
 
 # These below variables are used to test the AccessControl cluster Extension attribute and come from the test plan here: https://github.com/CHIP-Specifications/chip-test-plans/blob/59e8c45b8e7c24d5ce130b166520ff4f7bd935b6/src/cluster/AccessControl.adoc#tc-acl-2-6-accesscontrolentrychanged-event:~:text=D_OK_EMPTY%3A%20%221718%22%20which%20is%20an%20octstr%20of%20length%202%20containing%20valid%20TLV%3A

--- a/src/python_testing/TC_ACL_2_7.py
+++ b/src/python_testing/TC_ACL_2_7.py
@@ -41,7 +41,7 @@ import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.clusters.Types import Nullable
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, run_if_endpoint_matches, has_attribute
 
 # These below variables are used to test the AccessControl cluster Extension attribute and come from the test plan here: https://github.com/CHIP-Specifications/chip-test-plans/blob/59e8c45b8e7c24d5ce130b166520ff4f7bd935b6/src/cluster/AccessControl.adoc#tc-acl-2-6-accesscontrolentrychanged-event:~:text=D_OK_EMPTY%3A%20%221718%22%20which%20is%20an%20octstr%20of%20length%202%20containing%20valid%20TLV%3A
 D_OK_EMPTY = bytes.fromhex('1718')

--- a/src/python_testing/TC_ACL_2_7.py
+++ b/src/python_testing/TC_ACL_2_7.py
@@ -41,8 +41,7 @@ import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.clusters.Types import Nullable
 from matter.interaction_model import Status
-from matter.testing.matter_testing import (MatterBaseTest, TestStep, default_matter_test_main, has_attribute,
-                                           run_if_endpoint_matches)
+from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_attribute, run_if_endpoint_matches
 
 # These below variables are used to test the AccessControl cluster Extension attribute and come from the test plan here: https://github.com/CHIP-Specifications/chip-test-plans/blob/59e8c45b8e7c24d5ce130b166520ff4f7bd935b6/src/cluster/AccessControl.adoc#tc-acl-2-6-accesscontrolentrychanged-event:~:text=D_OK_EMPTY%3A%20%221718%22%20which%20is%20an%20octstr%20of%20length%202%20containing%20valid%20TLV%3A
 D_OK_EMPTY = bytes.fromhex('1718')

--- a/src/python_testing/TC_ACL_2_7.py
+++ b/src/python_testing/TC_ACL_2_7.py
@@ -96,7 +96,10 @@ class TC_ACL_2_7(MatterBaseTest):
                 found_other_event, f"{controller_name} should not see any events from {other_controller}'s fabric when fabric filtered")
 
     def desc_TC_ACL_2_7(self) -> str:
-        return "[TC-ACL-2.7] Multiple fabrics test"
+        return "[TC-ACL-2.7] Extension multi-fabric"
+
+    def pics_TC_ACL_2_7(self) -> list[str]:
+        return ['ACL.S.A0001']
 
     def steps_TC_ACL_2_7(self) -> list[TestStep]:
         steps = [

--- a/src/python_testing/TC_ACL_2_7.py
+++ b/src/python_testing/TC_ACL_2_7.py
@@ -28,7 +28,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#       --endpoint 1
+#       --endpoint 0
 # === END CI TEST ARGUMENTS ===
 
 

--- a/src/python_testing/TC_ACL_2_8.py
+++ b/src/python_testing/TC_ACL_2_8.py
@@ -517,6 +517,9 @@ class TC_ACL_2_8(MatterBaseTest):
     def desc_TC_ACL_2_8(self) -> str:
         return "[TC-ACL-2.8] ACL multi-fabric"
 
+    def pics_TC_ACL_2_8(self) -> list[str]:
+        return ['ACL.S']
+
     def steps_TC_ACL_2_8(self) -> list[TestStep]:
         steps = [
             TestStep(1, "TH1 commissions DUT using admin node ID N1",

--- a/src/python_testing/TC_ACL_2_9.py
+++ b/src/python_testing/TC_ACL_2_9.py
@@ -61,6 +61,9 @@ class TC_ACL_2_9(MatterBaseTest):
     def desc_TC_ACL_2_9(self) -> str:
         return "[TC-ACL-2.9] Cluster access"
 
+    def pics_TC_ACL_2_9(self) -> list[str]:
+        return ['ACL.S.A0001']
+
     def steps_TC_ACL_2_9(self) -> list[TestStep]:
         steps = [
             TestStep(


### PR DESCRIPTION
#### Summary

- Fix here is to add the run_if_endpoint_matches marker to check if the endpoint contains the extension attribute before running TC_ACL_2_3 or TC_ACL_2_7 python3 test modules.
- Same fix as done with ACL_2_5 applied here to ACL_2_3 and ACL_2_7 as a majority of the test steps in both of these test modules rely on the extension attribute being supported on the endpoint being tested in order to pass.

#### Related issues

Fixes issue [41139](https://github.com/project-chip/connectedhomeip/issues/41139)

#### Testing

Tested TC_ACL_2_3 and TC_ACL_2_7 in WSL with both the all-clusters-chip-app and the rvc-app

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
