### PR TITLE
[ESP32]: update the default values of MRP parameters (v1.3-cherrypick)

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -1266,7 +1266,7 @@ menu "CHIP Device Layer"
             int "MRP local active retry interval for Thread network in milliseconds"
             depends on ENABLE_MATTER_OVER_THREAD
             range 0 3600000
-            default 800
+            default 2000
             help
                 Base retry interval of the present Thread node when it is in the active state.
 
@@ -1282,7 +1282,7 @@ menu "CHIP Device Layer"
             int "MRP local idle retry interval for Thread network in milliseconds"
             depends on ENABLE_MATTER_OVER_THREAD
             range 0 3600000
-            default 800
+            default 2000
             help
                 Base retry interval of the present Thread node when it is in the idle state.
 
@@ -1298,7 +1298,7 @@ menu "CHIP Device Layer"
             int "MRP retransmission delta timeout for Thread network in milliseconds"
             depends on ENABLE_MATTER_OVER_THREAD
             range 0 3600000
-            default 500
+            default 1500
             help
                 A constant value added to the calculated retransmission timeout.
 


### PR DESCRIPTION
#### Summary
Cherrypick https://github.com/project-chip/connectedhomeip/pull/41576 to v1.3.
