### PR TITLE
[Camera] Include commissioning params in the prompt msg for TC_WEBRTCR_2_x

### DIFF
--- a/src/python_testing/TC_WEBRTCR_2_1.py
+++ b/src/python_testing/TC_WEBRTCR_2_1.py
@@ -146,7 +146,7 @@ class TC_WebRTCR_2_1(WEBRTCRTestBase):
         self.step(3)
         # Prompt user with instructions
         prompt_msg = (
-            "\nPlease commission the server app from DUT:\n"
+            f"\nPlease commission the server app with {params} from DUT:\n"
             f"  pairing onnetwork 1 {passcode}\n"
             "Input 'Y' if DUT successfully commissions without any warnings\n"
             "Input 'N' if commissioner warns about commissioning the non-genuine device, "

--- a/src/python_testing/TC_WEBRTCR_2_1.py
+++ b/src/python_testing/TC_WEBRTCR_2_1.py
@@ -146,7 +146,7 @@ class TC_WebRTCR_2_1(WEBRTCRTestBase):
         self.step(3)
         # Prompt user with instructions
         prompt_msg = (
-            f"\nPlease commission the server app with {params} from DUT:\n"
+            f"\nPlease commission the server app from DUT: manual code='{params.setupManualCode}' QR code='{params.setupQRCode}' :\n"
             f"  pairing onnetwork 1 {passcode}\n"
             "Input 'Y' if DUT successfully commissions without any warnings\n"
             "Input 'N' if commissioner warns about commissioning the non-genuine device, "

--- a/src/python_testing/TC_WEBRTCR_2_2.py
+++ b/src/python_testing/TC_WEBRTCR_2_2.py
@@ -146,7 +146,7 @@ class TC_WebRTCR_2_2(WEBRTCRTestBase):
         self.step(3)
         # Prompt user with instructions
         prompt_msg = (
-            f"\nPlease commission the server app with {params} from DUT:\n"
+            f"\nPlease commission the server app from DUT: manual code='{params.setupManualCode}' QR code='{params.setupQRCode}' :\n"
             f"  pairing onnetwork 1 {passcode}\n"
             "Input 'Y' if DUT successfully commissions without any warnings\n"
             "Input 'N' if commissioner warns about commissioning the non-genuine device, "

--- a/src/python_testing/TC_WEBRTCR_2_2.py
+++ b/src/python_testing/TC_WEBRTCR_2_2.py
@@ -146,7 +146,7 @@ class TC_WebRTCR_2_2(WEBRTCRTestBase):
         self.step(3)
         # Prompt user with instructions
         prompt_msg = (
-            "\nPlease commission the server app from DUT:\n"
+            f"\nPlease commission the server app with {params} from DUT:\n"
             f"  pairing onnetwork 1 {passcode}\n"
             "Input 'Y' if DUT successfully commissions without any warnings\n"
             "Input 'N' if commissioner warns about commissioning the non-genuine device, "

--- a/src/python_testing/TC_WEBRTCR_2_5.py
+++ b/src/python_testing/TC_WEBRTCR_2_5.py
@@ -150,7 +150,7 @@ class TC_WebRTCR_2_5(WEBRTCRTestBase):
         self.step(3)
         # Prompt user with instructions
         prompt_msg = (
-            f"\nPlease commission the server app with {params} from DUT:\n"
+            f"\nPlease commission the server app from DUT: manual code='{params.setupManualCode}' QR code='{params.setupQRCode}' :\n"
             f"  pairing onnetwork 1 {passcode}\n"
             "Input 'Y' if DUT successfully commissions without any warnings\n"
             "Input 'N' if commissioner warns about commissioning the non-genuine device, "

--- a/src/python_testing/TC_WEBRTCR_2_5.py
+++ b/src/python_testing/TC_WEBRTCR_2_5.py
@@ -150,7 +150,7 @@ class TC_WebRTCR_2_5(WEBRTCRTestBase):
         self.step(3)
         # Prompt user with instructions
         prompt_msg = (
-            "\nPlease commission the server app from DUT:\n"
+            f"\nPlease commission the server app with {params} from DUT:\n"
             f"  pairing onnetwork 1 {passcode}\n"
             "Input 'Y' if DUT successfully commissions without any warnings\n"
             "Input 'N' if commissioner warns about commissioning the non-genuine device, "

--- a/src/python_testing/TC_WEBRTCR_2_6.py
+++ b/src/python_testing/TC_WEBRTCR_2_6.py
@@ -147,7 +147,7 @@ class TC_WebRTCR_2_6(WEBRTCRTestBase):
         self.step(3)
         # Prompt user with instructions
         prompt_msg = (
-            "\nPlease commission the server app from DUT:\n"
+            f"\nPlease commission the server app with {params} from DUT:\n"
             f"  pairing onnetwork 1 {passcode}\n"
             "Input 'Y' if DUT successfully commissions without any warnings\n"
             "Input 'N' if commissioner warns about commissioning the non-genuine device, "

--- a/src/python_testing/TC_WEBRTCR_2_6.py
+++ b/src/python_testing/TC_WEBRTCR_2_6.py
@@ -147,7 +147,7 @@ class TC_WebRTCR_2_6(WEBRTCRTestBase):
         self.step(3)
         # Prompt user with instructions
         prompt_msg = (
-            f"\nPlease commission the server app with {params} from DUT:\n"
+            f"\nPlease commission the server app from DUT: manual code='{params.setupManualCode}' QR code='{params.setupQRCode}' :\n"
             f"  pairing onnetwork 1 {passcode}\n"
             "Input 'Y' if DUT successfully commissions without any warnings\n"
             "Input 'N' if commissioner warns about commissioning the non-genuine device, "

--- a/src/python_testing/TC_WEBRTCR_2_7.py
+++ b/src/python_testing/TC_WEBRTCR_2_7.py
@@ -147,7 +147,7 @@ class TC_WebRTCR_2_7(WEBRTCRTestBase):
         self.step(3)
         # Prompt user with instructions
         prompt_msg = (
-            "\nPlease commission the server app from DUT:\n"
+            f"\nPlease commission the server app with {params} from DUT:\n"
             f"  pairing onnetwork 1 {passcode}\n"
             "Input 'Y' if DUT successfully commissions without any warnings\n"
             "Input 'N' if commissioner warns about commissioning the non-genuine device, "

--- a/src/python_testing/TC_WEBRTCR_2_7.py
+++ b/src/python_testing/TC_WEBRTCR_2_7.py
@@ -147,7 +147,7 @@ class TC_WebRTCR_2_7(WEBRTCRTestBase):
         self.step(3)
         # Prompt user with instructions
         prompt_msg = (
-            f"\nPlease commission the server app with {params} from DUT:\n"
+            f"\nPlease commission the server app from DUT: manual code='{params.setupManualCode}' QR code='{params.setupQRCode}' :\n"
             f"  pairing onnetwork 1 {passcode}\n"
             "Input 'Y' if DUT successfully commissions without any warnings\n"
             "Input 'N' if commissioner warns about commissioning the non-genuine device, "


### PR DESCRIPTION
Print commissioning params with the prompt msg for TC_WEBRTCR_2_x so that controller / commissioner DUTs can onboard the TH server in their preferred method.

### Testing
Manual Verification