### PR TITLE
Add `print-tlv` dumper to `chip-cert` tool

### DIFF
--- a/src/tools/chip-cert/BUILD.gn
+++ b/src/tools/chip-cert/BUILD.gn
@@ -28,6 +28,7 @@ executable("chip-cert") {
     "Cmd_GenCert.cpp",
     "Cmd_PrintCD.cpp",
     "Cmd_PrintCert.cpp",
+    "Cmd_PrintTLV.cpp",
     "Cmd_ResignCert.cpp",
     "Cmd_ValidateAttCert.cpp",
     "Cmd_ValidateCert.cpp",

--- a/src/tools/chip-cert/Cmd_PrintCD.cpp
+++ b/src/tools/chip-cert/Cmd_PrintCD.cpp
@@ -238,7 +238,6 @@ bool PrintCD(ByteSpan cd)
     uint32_t signerKeyIdHexLen = 0;
 
     VerifyOrReturnError(!cd.empty(), false);
-    VerifyOrReturnError(OpenFile(gOutFileName, gOutFile, true), false);
     VerifyOrReturnError(CMS_ExtractKeyId(cd, signerKeyId) == CHIP_NO_ERROR, false);
     VerifyOrReturnError(CMS_ExtractCDContent(cd, cdContent) == CHIP_NO_ERROR, false);
 
@@ -272,5 +271,10 @@ bool Cmd_PrintCD(int argc, char * argv[])
     std::optional<std::vector<uint8_t>> cd = ReadCD(gInFileNameOrStr);
     VerifyOrReturnError(cd.has_value(), false);
 
-    return PrintCD(ByteSpan{ cd->data(), cd->size() });
+    bool isSuccess = false;
+    VerifyOrReturnError(OpenFile(gOutFileName, gOutFile, true), false);
+    isSuccess = PrintCD(ByteSpan{ cd->data(), cd->size() });
+    CloseFile(gOutFile);
+
+    return isSuccess;
 }

--- a/src/tools/chip-cert/Cmd_PrintCD.cpp
+++ b/src/tools/chip-cert/Cmd_PrintCD.cpp
@@ -272,5 +272,5 @@ bool Cmd_PrintCD(int argc, char * argv[])
     std::optional<std::vector<uint8_t>> cd = ReadCD(gInFileNameOrStr);
     VerifyOrReturnError(cd.has_value(), false);
 
-    return PrintCD(ByteSpan{cd->data(), cd->size()});
+    return PrintCD(ByteSpan{ cd->data(), cd->size() });
 }

--- a/src/tools/chip-cert/Cmd_PrintCD.cpp
+++ b/src/tools/chip-cert/Cmd_PrintCD.cpp
@@ -24,7 +24,9 @@
  */
 
 #include <memory>
+#include <optional>
 #include <utility>
+#include <vector>
 
 #include "chip-cert.h"
 
@@ -162,26 +164,25 @@ CDFormat DetectCDFormat(const uint8_t * cd, uint32_t cdLen)
     return kCDFormat_Unknown;
 }
 
-bool ReadCD(const char * fileNameOrStr, MutableByteSpan cd)
+std::optional<std::vector<uint8_t>> ReadCD(const char * fileNameOrStr)
 {
     CDFormat cdFmt = kCDFormat_Unknown;
     uint32_t cdLen = 0;
-    std::unique_ptr<uint8_t[]> cdBuf;
+    std::vector<uint8_t> cdBuf;
 
     // If fileNameOrStr is a file name
     if (access(fileNameOrStr, R_OK) == 0)
     {
-        VerifyOrReturnError(ReadFileIntoMem(fileNameOrStr, nullptr, cdLen), false);
+        VerifyOrReturnError(ReadFileIntoMem(fileNameOrStr, nullptr, cdLen), std::nullopt);
+        cdBuf.resize(cdLen);
 
-        cdBuf = std::make_unique<uint8_t[]>(cdLen);
+        VerifyOrReturnError(ReadFileIntoMem(fileNameOrStr, cdBuf.data(), cdLen), std::nullopt);
 
-        VerifyOrReturnError(ReadFileIntoMem(fileNameOrStr, cdBuf.get(), cdLen), false);
-
-        cdFmt = DetectCDFormat(cdBuf.get(), cdLen);
+        cdFmt = DetectCDFormat(cdBuf.data(), cdLen);
         if (cdFmt == kCDFormat_Unknown)
         {
             fprintf(stderr, "Unrecognized CD Format in File: %s\n", fileNameOrStr);
-            return false;
+            return std::nullopt;
         }
     }
     // Otherwise, treat fileNameOrStr as a pointer to the CD string (in hex or base64 encoded format)
@@ -193,31 +194,28 @@ bool ReadCD(const char * fileNameOrStr, MutableByteSpan cd)
         if (cdFmt == kCDFormat_Unknown)
         {
             fprintf(stderr, "Unrecognized CD Format in the Input Argument: %s\n", fileNameOrStr);
-            return false;
+            return std::nullopt;
         }
 
-        cdBuf = std::make_unique<uint8_t[]>(cdLen);
-        memcpy(cdBuf.get(), fileNameOrStr, cdLen);
+        cdBuf.resize(cdLen);
+        memcpy(cdBuf.data(), fileNameOrStr, cdLen);
     }
 
     if (cdFmt == kCDFormat_Hex)
     {
-        size_t len = chip::Encoding::HexToBytes(Uint8::to_char(cdBuf.get()), cdLen, cdBuf.get(), cdLen);
-        VerifyOrReturnError(CanCastTo<uint32_t>(2 * len), false);
-        VerifyOrReturnError(2 * len == cdLen, false);
+        size_t len = chip::Encoding::HexToBytes(Uint8::to_char(cdBuf.data()), cdLen, cdBuf.data(), cdLen);
+        VerifyOrReturnError(CanCastTo<uint32_t>(2 * len), std::nullopt);
+        VerifyOrReturnError(2 * len == cdLen, std::nullopt);
         cdLen = static_cast<uint32_t>(len);
     }
     else if (cdFmt == kCDFormat_Base64)
     {
-        VerifyOrReturnError(Base64Decode(cdBuf.get(), cdLen, cdBuf.get(), cdLen, cdLen), false);
+        VerifyOrReturnError(Base64Decode(cdBuf.data(), cdLen, cdBuf.data(), cdLen, cdLen), std::nullopt);
     }
 
-    VerifyOrReturnError(cdLen <= cd.size(), false);
-    memcpy(cd.data(), cdBuf.get(), cdLen);
+    cdBuf.resize(cdLen);
 
-    cd.reduce_size(cdLen);
-
-    return true;
+    return cdBuf;
 }
 
 void ENFORCE_FORMAT(1, 2) SimpleDumpWriter(const char * aFormat, ...)
@@ -263,9 +261,6 @@ bool PrintCD(ByteSpan cd)
 
 bool Cmd_PrintCD(int argc, char * argv[])
 {
-    uint8_t cdBuf[kCertificationElements_TLVEncodedMaxLength] = { 0 };
-    MutableByteSpan cd(cdBuf);
-
     if (argc == 1)
     {
         gHelpOptions.PrintBriefUsage(stderr);
@@ -274,7 +269,8 @@ bool Cmd_PrintCD(int argc, char * argv[])
 
     VerifyOrReturnError(ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs), false);
 
-    VerifyOrReturnError(ReadCD(gInFileNameOrStr, cd), false);
+    std::optional<std::vector<uint8_t>> cd = ReadCD(gInFileNameOrStr);
+    VerifyOrReturnError(cd.has_value(), false);
 
-    return PrintCD(cd);
+    return PrintCD(ByteSpan{cd->data(), cd->size()});
 }

--- a/src/tools/chip-cert/Cmd_PrintTLV.cpp
+++ b/src/tools/chip-cert/Cmd_PrintTLV.cpp
@@ -218,7 +218,6 @@ bool PrintTLV(ByteSpan tlv)
     chip::TLV::TLVReader reader;
 
     VerifyOrReturnError(!tlv.empty(), false);
-    VerifyOrReturnError(OpenFile(gOutFileName, gOutFile, true), false);
 
     reader.Init(tlv);
     reader.ImplicitProfileId = 0;
@@ -249,5 +248,10 @@ bool Cmd_PrintTLV(int argc, char * argv[])
     std::optional<std::vector<uint8_t>> tlv = ReadTLV(gInFileNameOrStr);
     VerifyOrReturnError(tlv.has_value(), false);
 
-    return PrintTLV(ByteSpan{ tlv->data(), tlv->size() });
+    bool isSuccess = false;
+    VerifyOrReturnError(OpenFile(gOutFileName, gOutFile, true), false);
+    isSuccess = PrintTLV(ByteSpan{ tlv->data(), tlv->size() });
+    CloseFile(gOutFile);
+
+    return isSuccess;
 }

--- a/src/tools/chip-cert/Cmd_PrintTLV.cpp
+++ b/src/tools/chip-cert/Cmd_PrintTLV.cpp
@@ -32,9 +32,6 @@ namespace {
 
 using namespace chip;
 using namespace chip::ArgParser;
-
-using namespace chip;
-using namespace chip::ArgParser;
 using namespace chip::Credentials;
 
 #define CMD_NAME "chip-cert print-tlv"
@@ -178,6 +175,11 @@ std::optional<std::vector<uint8_t>> ReadTLV(const char * fileNameOrStr)
 
     if (tlvFmt == TLVFormat::kTLVFormat_Hex)
     {
+        if (tlvLen % 2 != 0)
+        {
+            fprintf(stderr, "Invalid hex input string: length must be even, but got %zu\n", tlvLen);
+            return std::nullopt;
+        }
         size_t len = chip::Encoding::HexToBytes(Uint8::to_char(tlvBuf.data()), tlvLen, tlvBuf.data(), tlvLen);
         VerifyOrReturnError(CanCastTo<uint32_t>(2 * len), std::nullopt);
         VerifyOrReturnError(2 * len == tlvLen, std::nullopt);

--- a/src/tools/chip-cert/Cmd_PrintTLV.cpp
+++ b/src/tools/chip-cert/Cmd_PrintTLV.cpp
@@ -137,7 +137,7 @@ enum class TLVFormat
 std::optional<std::vector<uint8_t>> ReadTLV(const char * fileNameOrStr)
 {
     TLVFormat tlvFmt = TLVFormat::kTLVFormat_Unknown;
-    size_t tlvLen  = 0;
+    size_t tlvLen    = 0;
     std::vector<uint8_t> tlvBuf;
 
     // If fileNameOrStr is a file name

--- a/src/tools/chip-cert/Cmd_PrintTLV.cpp
+++ b/src/tools/chip-cert/Cmd_PrintTLV.cpp
@@ -1,0 +1,251 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "chip-cert.h"
+
+#include <lib/core/TLVDebug.h>
+#include <lib/support/Base64.h>
+#include <lib/support/BytesToHex.h>
+
+namespace {
+
+using namespace chip;
+using namespace chip::ArgParser;
+
+using namespace chip;
+using namespace chip::ArgParser;
+using namespace chip::Credentials;
+
+#define CMD_NAME "chip-cert print-tlv"
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[]);
+
+// clang-format off
+OptionDef gCmdOptionDefs[] =
+{
+    { "out",           kArgumentRequired, 'o' },
+    { }
+};
+
+const char * const gCmdOptionHelp =
+    "   -o, --out <file/stdout>\n"
+    "\n"
+    "       The output file name. If not specified or if specified as '-'\n"
+    "       then output is written to stdout.\n"
+    "\n"
+    ;
+
+OptionSet gCmdOptions =
+{
+    HandleOption,
+    gCmdOptionDefs,
+    "COMMAND OPTIONS",
+    gCmdOptionHelp
+};
+
+HelpOptions gHelpOptions(
+    CMD_NAME,
+    "Usage: " CMD_NAME " [<options...>] <file/str>\n",
+    CHIP_VERSION_STRING "\n" COPYRIGHT_STRING,
+    "Print a Matter TLV structure in human-readable format.\n"
+    "\n"
+    "ARGUMENTS\n"
+    "\n"
+    "  <file/str>\n"
+    "\n"
+    "       File or string containing a Matter TLV structure. The tool will attempt\n"
+    "       to auto-detect the encoding of the input string (filename, hex, or base64).\n"
+    "\n"
+);
+
+OptionSet *gCmdOptionSets[] =
+{
+    &gCmdOptions,
+    &gHelpOptions,
+    nullptr
+};
+// clang-format on
+
+const char * gInFileNameOrStr = nullptr;
+const char * gOutFileName     = "-";
+FILE * gOutFile               = nullptr;
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
+{
+    switch (id)
+    {
+    case 'o':
+        gOutFileName = arg;
+        break;
+    default:
+        PrintArgError("%s: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[])
+{
+    if (argc == 0)
+    {
+        PrintArgError("%s: Please specify the TLV data to be printed.\n", progName);
+        return false;
+    }
+
+    if (argc > 1)
+    {
+        PrintArgError("%s: Unexpected argument: %s\n", progName, argv[1]);
+        return false;
+    }
+
+    gInFileNameOrStr = argv[0];
+
+    return true;
+}
+
+enum class TLVFormat
+{
+    kTLVFormat_Unknown = 0,
+    kTLVFormat_Raw,
+    kTLVFormat_Hex,
+    kTLVFormat_Base64,
+};
+
+std::optional<std::vector<uint8_t>> ReadTLV(const char * fileNameOrStr)
+{
+    TLVFormat tlvFmt = TLVFormat::kTLVFormat_Unknown;
+    size_t tlvLen  = 0;
+    std::vector<uint8_t> tlvBuf;
+
+    // If fileNameOrStr is a file name
+    if (access(fileNameOrStr, R_OK) == 0)
+    {
+        uint32_t computedSize = 0;
+        VerifyOrReturnError(ReadFileIntoMem(fileNameOrStr, nullptr, computedSize), std::nullopt);
+
+        tlvLen = computedSize;
+        tlvBuf.resize(tlvLen);
+
+        VerifyOrReturnError(ReadFileIntoMem(fileNameOrStr, tlvBuf.data(), computedSize), std::nullopt);
+        tlvFmt = TLVFormat::kTLVFormat_Raw;
+    }
+    // Otherwise, treat fileNameOrStr as a pointer to the TLV string (in hex or base64 encoded format)
+    else
+    {
+        tlvLen = strlen(fileNameOrStr);
+        tlvBuf.resize(tlvLen);
+        memcpy(tlvBuf.data(), fileNameOrStr, tlvLen);
+
+        // Check hex first since hex characters are a full subset of base64, and it's unlikely a
+        // large base64 payload would only have the hex space in it.
+        if (IsHexString(tlvBuf.data(), tlvLen))
+        {
+            tlvFmt = TLVFormat::kTLVFormat_Hex;
+        }
+        else if (IsBase64String(reinterpret_cast<const char *>(tlvBuf.data()), tlvLen))
+        {
+            tlvFmt = TLVFormat::kTLVFormat_Base64;
+        }
+        else
+        {
+            fprintf(stderr, "Invalid input string: neither hex nor base64 encoded!\n");
+            return std::nullopt;
+        }
+    }
+
+    if (tlvFmt == TLVFormat::kTLVFormat_Hex)
+    {
+        size_t len = chip::Encoding::HexToBytes(Uint8::to_char(tlvBuf.data()), tlvLen, tlvBuf.data(), tlvLen);
+        VerifyOrReturnError(CanCastTo<uint32_t>(2 * len), std::nullopt);
+        VerifyOrReturnError(2 * len == tlvLen, std::nullopt);
+        tlvLen = len;
+    }
+    else if (tlvFmt == TLVFormat::kTLVFormat_Base64)
+    {
+        VerifyOrReturnError(CanCastTo<uint16_t>(tlvLen), std::nullopt);
+        uint16_t decodedLen = chip::Base64Decode(Uint8::to_char(tlvBuf.data()), static_cast<uint16_t>(tlvLen), tlvBuf.data());
+        if (decodedLen == UINT16_MAX)
+        {
+            fprintf(stderr, "Invalid Base64 input string\n");
+            return std::nullopt;
+        }
+        tlvLen = decodedLen;
+    }
+
+    tlvBuf.resize(tlvLen);
+
+    return tlvBuf;
+}
+
+void ENFORCE_FORMAT(1, 2) SimpleDumpWriter(const char * aFormat, ...)
+{
+    va_list args;
+
+    va_start(args, aFormat);
+
+    vfprintf(gOutFile, aFormat, args);
+
+    va_end(args);
+}
+
+bool PrintTLV(ByteSpan tlv)
+{
+    chip::TLV::TLVReader reader;
+
+    VerifyOrReturnError(!tlv.empty(), false);
+    VerifyOrReturnError(OpenFile(gOutFileName, gOutFile, true), false);
+
+    reader.Init(tlv);
+    reader.ImplicitProfileId = 0;
+
+    CHIP_ERROR err = chip::TLV::Debug::Dump(reader, SimpleDumpWriter);
+
+    if ((err != CHIP_NO_ERROR) && (err != CHIP_ERROR_END_OF_TLV))
+    {
+        fprintf(stderr, "Error during parsing: %" CHIP_ERROR_FORMAT "\n", err.Format());
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+bool Cmd_PrintTLV(int argc, char * argv[])
+{
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        return true;
+    }
+
+    VerifyOrReturnError(ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs), false);
+
+    std::optional<std::vector<uint8_t>> tlv = ReadTLV(gInFileNameOrStr);
+    VerifyOrReturnError(tlv.has_value(), false);
+
+    return PrintTLV(ByteSpan{ tlv->data(), tlv->size() });
+}

--- a/src/tools/chip-cert/Cmd_PrintTLV.cpp
+++ b/src/tools/chip-cert/Cmd_PrintTLV.cpp
@@ -177,7 +177,7 @@ std::optional<std::vector<uint8_t>> ReadTLV(const char * fileNameOrStr)
     {
         if (tlvLen % 2 != 0)
         {
-            fprintf(stderr, "Invalid hex input string: length must be even, but got %zu\n", tlvLen);
+            fprintf(stderr, "Invalid hex input string: length must be even, but got %u\n", static_cast<unsigned>(tlvLen));
             return std::nullopt;
         }
         size_t len = chip::Encoding::HexToBytes(Uint8::to_char(tlvBuf.data()), tlvLen, tlvBuf.data(), tlvLen);

--- a/src/tools/chip-cert/GeneralUtils.cpp
+++ b/src/tools/chip-cert/GeneralUtils.cpp
@@ -204,7 +204,7 @@ bool IsBase64String(const char * str, size_t strLen)
 
 bool IsHexString(const uint8_t * s, size_t len)
 {
-    for (uint32_t i = 0; i < len; i++)
+    for (size_t i = 0; i < len; i++)
     {
         if (!isxdigit(s[i]))
         {

--- a/src/tools/chip-cert/GeneralUtils.cpp
+++ b/src/tools/chip-cert/GeneralUtils.cpp
@@ -31,6 +31,7 @@
 #include <utility>
 
 #include <errno.h>
+#include <stddef.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/SafeInt.h>
@@ -189,11 +190,23 @@ exit:
     return res;
 }
 
-bool IsBase64String(const char * str, uint32_t strLen)
+bool IsBase64String(const char * str, size_t strLen)
 {
     for (; strLen > 0; strLen--, str++)
     {
         if (!isalnum(*str) && *str != '+' && *str != '/' && *str != '=' && !isspace(*str))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool IsHexString(const uint8_t * s, size_t len)
+{
+    for (uint32_t i = 0; i < len; i++)
+    {
+        if (!isxdigit(s[i]))
         {
             return false;
         }

--- a/src/tools/chip-cert/GeneralUtils.cpp
+++ b/src/tools/chip-cert/GeneralUtils.cpp
@@ -31,10 +31,10 @@
 #include <utility>
 
 #include <errno.h>
-#include <stddef.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/SafeInt.h>
+#include <stddef.h>
 
 using namespace chip;
 using namespace chip::Credentials;

--- a/src/tools/chip-cert/chip-cert.cpp
+++ b/src/tools/chip-cert/chip-cert.cpp
@@ -32,7 +32,7 @@ namespace {
 
 // clang-format off
 const char * const sHelp =
-    "Usage: chip <command> [ <args...> ]\n"
+    "Usage: chip-cert <command> [ <args...> ]\n"
     "\n"
     "Commands:\n"
     "\n"
@@ -55,6 +55,8 @@ const char * const sHelp =
     "    gen-cd -- Generate a CHIP certification declaration signed message.\n"
     "\n"
     "    print-cd -- Print a CHIP certification declaration (CD) content.\n"
+    "\n"
+    "    print-tlv -- Print a CHIP TLV structure.\n"
     "\n"
     "    version -- Print the program version and exit.\n"
     "\n";
@@ -132,6 +134,10 @@ int main(int argc, char * argv[])
     else if (strcasecmp(argv[1], "print-cd") == 0 || strcasecmp(argv[1], "printcd") == 0)
     {
         res = Cmd_PrintCD(argc - 1, argv + 1);
+    }
+    else if (strcasecmp(argv[1], "print-tlv") == 0 || strcasecmp(argv[1], "printtlv") == 0)
+    {
+        res = Cmd_PrintTLV(argc - 1, argv + 1);
     }
     else
     {

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -35,6 +35,7 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <memory>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -76,7 +77,7 @@ using chip::ASN1::OID;
 #endif
 
 #define COPYRIGHT_STRING                                                                                                           \
-    "Copyright (c) 2021-2022 Project CHIP Authors. "                                                                               \
+    "Copyright (c) 2021-2025 Project CHIP Authors. "                                                                               \
     "Copyright (c) 2019 Google LLC. "                                                                                              \
     "Copyright (c) 2013-2017 Nest Labs, Inc. "                                                                                     \
     "All rights reserved.\n"
@@ -429,6 +430,7 @@ extern bool Cmd_ValidateAttCert(int argc, char * argv[]);
 extern bool Cmd_ValidateCert(int argc, char * argv[]);
 extern bool Cmd_PrintCert(int argc, char * argv[]);
 extern bool Cmd_PrintCD(int argc, char * argv[]);
+extern bool Cmd_PrintTLV(int argc, char * argv[]);
 extern bool Cmd_GenAttCert(int argc, char * argv[]);
 
 extern bool ReadCert(const char * fileNameOrStr, std::unique_ptr<X509, void (*)(X509 *)> & cert);
@@ -464,7 +466,8 @@ extern bool X509ToChipCert(X509 * cert, chip::MutableByteSpan & chipCert);
 extern bool InitOpenSSL();
 extern bool Base64Encode(const uint8_t * inData, uint32_t inDataLen, uint8_t * outBuf, uint32_t outBufSize, uint32_t & outDataLen);
 extern bool Base64Decode(const uint8_t * inData, uint32_t inDataLen, uint8_t * outBuf, uint32_t outBufSize, uint32_t & outDataLen);
-extern bool IsBase64String(const char * str, uint32_t strLen);
+extern bool IsBase64String(const char * str, size_t strLen);
+extern bool IsHexString(const uint8_t * s, size_t strLen);
 extern bool ContainsPEMMarker(const char * marker, const uint8_t * data, uint32_t dataLen);
 extern bool ParseDateTime(const char * str, struct tm & date);
 extern bool ReadFileIntoMem(const char * fileName, uint8_t * data, uint32_t & dataLen);


### PR DESCRIPTION
#### Summary
- Add a `chip-cert print-tlv` command to help dump raw TLV
- Fix long-standing use-after free bugs in print-cd command

#### Testing

- Manually tested valid and invalid input with the tool. Unfortunately the chip-cert tool never got unit tests.
- Ran valgrind against the tool in both print-cd and print-tlv, showing no longer having use-after-free.
