### PR TITLE
[Groupcast ]Expand TestGroupcastCluster with skeleton to test Commands

### DIFF
--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -20,7 +20,9 @@ constexpr DataModel::AcceptedCommandEntry kAcceptedCommands[] = {
 };
 } // namespace
 
-GroupcastCluster::GroupcastCluster() : DefaultServerCluster({ kRootEndpointId, Groupcast::Id }) {}
+GroupcastCluster::GroupcastCluster(BitFlags<Groupcast::Feature> features) :
+    DefaultServerCluster({ kRootEndpointId, Groupcast::Id }), mLogic(features)
+{}
 
 DataModel::ActionReturnStatus GroupcastCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                               AttributeValueEncoder & encoder)

--- a/src/app/clusters/groupcast/GroupcastCluster.h
+++ b/src/app/clusters/groupcast/GroupcastCluster.h
@@ -31,7 +31,7 @@ namespace Clusters {
 class GroupcastCluster : public DefaultServerCluster
 {
 public:
-    GroupcastCluster();
+    GroupcastCluster(BitFlags<Groupcast::Feature> features);
     virtual ~GroupcastCluster() {}
 
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,

--- a/src/app/clusters/groupcast/GroupcastLogic.h
+++ b/src/app/clusters/groupcast/GroupcastLogic.h
@@ -37,7 +37,7 @@ namespace Clusters {
 class GroupcastLogic
 {
 public:
-    GroupcastLogic() : mFeatures(0) {}
+    GroupcastLogic(BitFlags<Groupcast::Feature> features) : mFeatures(features) {}
     const BitFlags<Groupcast::Feature> & Features() const { return mFeatures; }
 
     CHIP_ERROR ReadMembership(EndpointId endpoint, AttributeValueEncoder & aEncoder);

--- a/src/app/clusters/groupcast/tests/BUILD.gn
+++ b/src/app/clusters/groupcast/tests/BUILD.gn
@@ -27,6 +27,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/app/clusters/groupcast",
     "${chip_root}/src/app/clusters/testing",
+    "${chip_root}/src/app/server-cluster/testing:testing",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
   ]

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -15,10 +15,13 @@
  */
 #include <pw_unit_test/framework.h>
 
+#include <app/MessageDef/CommandDataIB.h>
 #include <app/clusters/groupcast/GroupcastCluster.h>
 #include <app/clusters/testing/AttributeTesting.h>
+#include <app/clusters/testing/ClusterTester.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/server-cluster/DefaultServerCluster.h>
+#include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <clusters/Groupcast/Enums.h>
 #include <clusters/Groupcast/Metadata.h>
 #include <lib/core/CHIPError.h>
@@ -35,6 +38,75 @@ using namespace chip::app::Clusters::Groupcast;
 using chip::app::DataModel::AcceptedCommandEntry;
 using chip::app::DataModel::AttributeEntry;
 
+class MockCommandHandler : public app::CommandHandler
+{
+public:
+    ~MockCommandHandler() override {}
+
+    struct ResponseRecord
+    {
+        app::ConcreteCommandPath path;
+        CommandId commandId;
+        System::PacketBufferHandle encodedData;
+    };
+
+    CHIP_ERROR FallibleAddStatus(const app::ConcreteCommandPath & aRequestCommandPath,
+                                 const Protocols::InteractionModel::ClusterStatusCode & aStatus,
+                                 const char * context = nullptr) override
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    void AddStatus(const app::ConcreteCommandPath & aRequestCommandPath,
+                   const Protocols::InteractionModel::ClusterStatusCode & aStatus, const char * context = nullptr) override
+    {
+        CHIP_ERROR err = FallibleAddStatus(aRequestCommandPath, aStatus, context);
+        VerifyOrDie(err == CHIP_NO_ERROR);
+    }
+
+    FabricIndex GetAccessingFabricIndex() const override { return mFabricIndex; }
+
+    CHIP_ERROR AddResponseData(const app::ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
+                               const app::DataModel::EncodableToTLV & aEncodable) override
+    {
+        System::PacketBufferHandle handle = MessagePacketBuffer::New(1024);
+        VerifyOrReturnError(!handle.IsNull(), CHIP_ERROR_NO_MEMORY);
+        TLV::TLVWriter baseWriter;
+        baseWriter.Init(handle->Start(), handle->MaxDataLength());
+        app::DataModel::FabricAwareTLVWriter writer(baseWriter, mFabricIndex);
+        TLV::TLVType ct;
+        ReturnErrorOnFailure(
+            static_cast<TLV::TLVWriter &>(writer).StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, ct));
+        ReturnErrorOnFailure(aEncodable.EncodeTo(writer, TLV::ContextTag(app::CommandDataIB::Tag::kFields)));
+        ReturnErrorOnFailure(static_cast<TLV::TLVWriter &>(writer).EndContainer(ct));
+        handle->SetDataLength(static_cast<TLV::TLVWriter &>(writer).GetLengthWritten());
+        mResponse.path        = aRequestCommandPath;
+        mResponse.commandId   = aResponseCommandId;
+        mResponse.encodedData = std::move(handle);
+        return CHIP_NO_ERROR;
+    }
+
+    void AddResponse(const app::ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
+                     const app::DataModel::EncodableToTLV & aEncodable) override
+    {
+        (void) AddResponseData(aRequestCommandPath, aResponseCommandId, aEncodable);
+    }
+
+    bool IsTimedInvoke() const override { return false; }
+    void FlushAcksRightAwayOnSlowCommand() override {}
+    Access::SubjectDescriptor GetSubjectDescriptor() const override { return Access::SubjectDescriptor{}; }
+    Messaging::ExchangeContext * GetExchangeContext() const override { return nullptr; }
+
+    const ResponseRecord & GetResponse() const { return mResponse; }
+
+    // Optional for test configuration
+    void SetFabricIndex(FabricIndex index) { mFabricIndex = index; }
+
+private:
+    ResponseRecord mResponse;
+    FabricIndex mFabricIndex = 0;
+};
+
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestGroupcastCluster : public ::testing::Test
 {
@@ -44,12 +116,11 @@ struct TestGroupcastCluster : public ::testing::Test
 
 TEST_F(TestGroupcastCluster, TestAttributes)
 {
-    app::Clusters::GroupcastCluster cluster;
-
+    app::Clusters::GroupcastCluster cluster(BitFlags<Feature>{ Feature::kSender });
     // Attributes
     {
         ReadOnlyBufferBuilder<AttributeEntry> builder;
-        ASSERT_EQ(cluster.Attributes({ kRootEndpointId, chip::app::Clusters::Groupcast::Id }, builder), CHIP_NO_ERROR);
+        ASSERT_EQ(cluster.Attributes({ kRootEndpointId, app::Clusters::Groupcast::Id }, builder), CHIP_NO_ERROR);
 
         ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
         ASSERT_EQ(expectedBuilder.AppendElements({
@@ -60,6 +131,61 @@ TEST_F(TestGroupcastCluster, TestAttributes)
         ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
         ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
     }
+
+    // Read attributes for expected values
+    {
+        chip::Test::ClusterTester tester(cluster);
+        uint16_t revision{};
+        ASSERT_EQ(tester.ReadAttribute(Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
+        ASSERT_EQ(revision, app::Clusters::Groupcast::kRevision);
+
+        // Validate Constructor sets features correctly and is readable from attribute
+        uint32_t features{};
+        ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, features), CHIP_NO_ERROR);
+        ASSERT_EQ(features, to_underlying(Feature::kSender));
+    }
 }
 
+TEST_F(TestGroupcastCluster, TestAcceptedCommands)
+{
+    app::Clusters::GroupcastCluster cluster(BitFlags<Feature>{ Feature::kListener });
+    ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
+    ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, app::Clusters::Groupcast::Id }, builder), CHIP_NO_ERROR);
+
+    ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
+    ASSERT_EQ(expectedBuilder.AppendElements({
+                  Commands::JoinGroup::kMetadataEntry,
+                  Commands::LeaveGroup::kMetadataEntry,
+                  Commands::UpdateGroupKey::kMetadataEntry,
+                  Commands::ExpireGracePeriod::kMetadataEntry,
+                  Commands::ConfigureAuxiliaryACL::kMetadataEntry,
+              }),
+              CHIP_NO_ERROR);
+    ASSERT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+}
+
+TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
+{
+    chip::Test::TestServerClusterContext context;
+    app::Clusters::GroupcastCluster cluster(BitFlags<Feature>{ Feature::kListener });
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    // Form a valid JoinGroup command
+    Commands::JoinGroup::Type cmdData;
+    cmdData.groupID         = 1;
+    cmdData.endpoints       = { 1 };
+    cmdData.keyID           = 0xAABBCCDD;
+    const uint8_t keyData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+    cmdData.key             = MakeOptional(Span<const uint8_t>(keyData, sizeof(keyData)));
+    cmdData.gracePeriod     = MakeOptional(0U);
+    cmdData.useAuxiliaryACL = MakeOptional(true);
+
+    MockCommandHandler cmdHandler;
+    chip::Test::ClusterTester tester(cluster);
+    auto result = tester.InvokeCommand(Commands::JoinGroup::Id, cmdData, &cmdHandler);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().GetStatusCode().GetStatus(),    // NOLINT(bugprone-unchecked-optional-access)
+              Protocols::InteractionModel::Status::Failure); // Currently expect Failure as JoinGroup command returns
+                                                             // CHIP_ERROR_NOT_IMPLEMENTED
+}
 } // namespace

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -176,7 +176,7 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
     cmdData.endpoints       = { 1 };
     cmdData.keyID           = 0xAABBCCDD;
     const uint8_t keyData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
-    cmdData.key             = MakeOptional(Span<const uint8_t>(keyData, sizeof(keyData)));
+    cmdData.key             = MakeOptional(ByteSpan(keyData));
     cmdData.gracePeriod     = MakeOptional(0U);
     cmdData.useAuxiliaryACL = MakeOptional(true);
 

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -27,6 +27,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/BitFlags.h>
+#include <lib/support/CodeUtils.h>
 #include <lib/support/ReadOnlyBuffer.h>
 #include <platform/NetworkCommissioning.h>
 
@@ -171,11 +172,13 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
     // Form a valid JoinGroup command
+    const uint8_t keyData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+    const EndpointId kEndpoints[] = { 1 };
+
     Commands::JoinGroup::Type cmdData;
     cmdData.groupID         = 1;
-    cmdData.endpoints       = { 1 };
+    cmdData.endpoints       = chip::app::DataModel::List<const EndpointId>(kEndpoints, MATTER_ARRAY_SIZE(kEndpoints));
     cmdData.keyID           = 0xAABBCCDD;
-    const uint8_t keyData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
     cmdData.key             = MakeOptional(ByteSpan(keyData));
     cmdData.gracePeriod     = MakeOptional(0U);
     cmdData.useAuxiliaryACL = MakeOptional(true);

--- a/src/app/clusters/testing/ClusterTester.h
+++ b/src/app/clusters/testing/ClusterTester.h
@@ -105,7 +105,9 @@ public:
         VerifyOrReturnError(paths.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
         const chip::app::DataModel::InvokeRequest request = { .path = { paths[0].mEndpointId, paths[0].mClusterId, commandId } };
 
-        uint8_t buffer[128];
+        constexpr size_t kTlvBufferSize = 128; // Typically CommanderSender will use a TLV of size kMaxSecureSduLengthBytes. For
+                                               // now, just use 128 for the unit test.
+        uint8_t buffer[kTlvBufferSize];
         chip::TLV::TLVWriter tlvWriter;
         tlvWriter.Init(buffer);
         ReturnErrorOnFailure(data.Encode(tlvWriter, chip::TLV::AnonymousTag()));


### PR DESCRIPTION
#### Summary
1) Expand TestGroupcastCluster with a skeleton to test Commands through InvokeCommands. Add Featuremap configuration in the Groupcast constructor.
- This will allow us to test Groupcast command argument parsing/check, return conditions and error codes and eventually command behaviours.

2) Add a featuremap field in the Groupcast Cluster constructor so a user can correctly configure the cluster feature at instantiation.
- Add a step in unittest to read the cluster Featuremap attribute to ensure it is properly propagated to the class and datamodel.
- Add a step in unittest to read the cluster Revision for good measure.


#### Related issues
n/a

#### Testing
Build/run TestGroupCast unit test:

```
[==========] Running all tests.
[ RUN      ] TestGroupcastCluster.TestAttributes
[       OK ] TestGroupcastCluster.TestAttributes
[ RUN      ] TestGroupcastCluster.TestAcceptedCommands
[       OK ] TestGroupcastCluster.TestAcceptedCommands
[ RUN      ] TestGroupcastCluster.TestJoinGroupCommand
[       OK ] TestGroupcastCluster.TestJoinGroupCommand
[==========] Done running all tests.
[  PASSED  ] 3 test(s).
```
