### PR TITLE
[NXP] add wifi FW recovery mechanism

### DIFF
--- a/examples/thermostat/nxp/rt/rw61x/BUILD.gn
+++ b/examples/thermostat/nxp/rt/rw61x/BUILD.gn
@@ -89,12 +89,21 @@ rt_sdk("sdk") {
   # Indicate the default path to OpenThreadConfig.h
   include_dirs += [ "${example_platform_dir}/app/project_include/openthread" ]
 
+  # Indicate the default path to WiFiUserConfig.h
+  include_dirs += [ "${example_platform_dir}/app/project_include/WiFi" ]
+
   # For matter with BR feature, increase FreeRTOS heap size and enable TBR cluster
   # Additionally in the context of OTBR support the freeRTOS heap should be big enough to allow to handle a large number of mDNS packets
   if (chip_enable_wifi && chip_enable_openthread) {
     defines += [
       "configTOTAL_HEAP_SIZE=(size_t)(250 * 1024)",
       "CHIP_DEVICE_CONFIG_ENABLE_TBR=1",
+    ]
+  }
+
+  if(chip_enable_wifi) {
+    defines += [
+      "WIFI_USER_CONFIG_FILE=<WiFiUserConfig.h>",
     ]
   }
 

--- a/examples/thermostat/nxp/rt/rw61x/BUILD.gn
+++ b/examples/thermostat/nxp/rt/rw61x/BUILD.gn
@@ -101,10 +101,8 @@ rt_sdk("sdk") {
     ]
   }
 
-  if(chip_enable_wifi) {
-    defines += [
-      "WIFI_USER_CONFIG_FILE=<WiFiUserConfig.h>",
-    ]
+  if (chip_enable_wifi) {
+    defines += [ "WIFI_USER_CONFIG_FILE=<WiFiUserConfig.h>" ]
   }
 
   defines += [

--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -486,13 +486,13 @@ void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
     case WLAN_REASON_INITIALIZED:
         sInstance._SetWiFiStationState(kWiFiStationState_NotConnected);
         sInstance._SetWiFiStationMode(kWiFiStationMode_Enabled);
-        if (IsWifiRecovering)
+        if (mIsWifiRecovering)
         {
             /*
-            Wifi recovery mechanism (due to firmware hang) is finish, we will attempt to reconnect to the previously staged network
+            Wifi recovery mechanism (due to firmware hang) is finished, we will attempt to reconnect to the previously staged network
             */
-            IsWifiRecovering = false;
-            err = NetworkCommissioning::NXPWiFiDriver::GetInstance().ConnectWifiStagedNetwork();
+            mIsWifiRecovering = false;
+            err = NetworkCommissioning::NXPWiFiDriver::GetInstance().ConnectWiFiStagedNetwork();
             if(err == CHIP_ERROR_KEY_NOT_FOUND)
             {
                 /* if no SSID is staged, notify the network commissioning module to clean environnement for next commissioning  */
@@ -504,13 +504,13 @@ void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
 
     case WLAN_REASON_FW_HANG:
         /* 
-         If Wifi driver is hang, recovery mechanism has be triggered, this mechanism will be ended by re-initializing the wifi driver.
-         If wifi state is different to kWiFiStationState_NotConnected and kWiFiStationState_Disconnecting, 
-         we want to retry the wifi connection once the driver will be re-initialized.
+         If the Wifi driver hangs, a recovery mechanism has been triggered. This mechanism will end with re-initializing the wifi driver.
+         If the wifi state is different from kWiFiStationState_NotConnected and kWiFiStationState_Disconnecting, 
+         we want to retry the wifi connection once the driver is re-initialized.
         */
         if(mWiFiStationState != kWiFiStationState_NotConnected && mWiFiStationState != kWiFiStationState_Disconnecting)
         {
-            IsWifiRecovering = true;
+            mIsWifiRecovering = true;
         }
         break;
 

--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -502,7 +502,8 @@ void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
             }
             else if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "Failed to reconnect to staged network after WiFi FW recovery: %" CHIP_ERROR_FORMAT, err.Format());
+                ChipLogError(DeviceLayer, "Failed to reconnect to staged network after WiFi FW recovery: %" CHIP_ERROR_FORMAT,
+                             err.Format());
             }
         }
         break;

--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -503,9 +503,9 @@ void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
         break;
 
     case WLAN_REASON_FW_HANG:
-        /* 
+        /*
          If the Wifi driver hangs, a recovery mechanism has been triggered. This mechanism will end with re-initializing the wifi driver.
-         If the wifi state is different from kWiFiStationState_NotConnected and kWiFiStationState_Disconnecting, 
+         If the wifi state is different from kWiFiStationState_NotConnected and kWiFiStationState_Disconnecting,
          we want to retry the wifi connection once the driver is re-initialized.
         */
         if(mWiFiStationState != kWiFiStationState_NotConnected && mWiFiStationState != kWiFiStationState_Disconnecting)

--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -371,7 +371,6 @@ bool ConnectivityManagerImpl::_IsWiFiStationApplicationControlled()
 
 void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
 {
-    CHIP_ERROR err                     = CHIP_NO_ERROR;
     WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
     uint8_t associationFailureCause =
         chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCauseEnum::kUnknown);
@@ -493,7 +492,7 @@ void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
             network
             */
             mIsWifiRecovering = false;
-            err               = NetworkCommissioning::NXPWiFiDriver::GetInstance().ConnectWiFiStagedNetwork();
+            CHIP_ERROR err    = NetworkCommissioning::NXPWiFiDriver::GetInstance().ConnectWiFiStagedNetwork();
             if (err == CHIP_ERROR_KEY_NOT_FOUND)
             {
                 /* if no SSID is staged, notify the network commissioning module to clean environnement for next commissioning  */

--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -500,6 +500,10 @@ void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
                 NetworkCommissioning::NXPWiFiDriver::GetInstance().OnConnectWiFiNetwork(
                     NetworkCommissioning::Status::kNetworkIDNotFound, CharSpan(), wlanEvent);
             }
+            else if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(DeviceLayer, "Failed to reconnect to staged network after WiFi FW recovery: %" CHIP_ERROR_FORMAT, err.Format());
+            }
         }
         break;
 

--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -371,7 +371,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationApplicationControlled()
 
 void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err                     = CHIP_NO_ERROR;
     WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
     uint8_t associationFailureCause =
         chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCauseEnum::kUnknown);
@@ -489,26 +489,27 @@ void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
         if (mIsWifiRecovering)
         {
             /*
-            Wifi recovery mechanism (due to firmware hang) is finished, we will attempt to reconnect to the previously staged network
+            Wifi recovery mechanism (due to firmware hang) is finished, we will attempt to reconnect to the previously staged
+            network
             */
             mIsWifiRecovering = false;
-            err = NetworkCommissioning::NXPWiFiDriver::GetInstance().ConnectWiFiStagedNetwork();
-            if(err == CHIP_ERROR_KEY_NOT_FOUND)
+            err               = NetworkCommissioning::NXPWiFiDriver::GetInstance().ConnectWiFiStagedNetwork();
+            if (err == CHIP_ERROR_KEY_NOT_FOUND)
             {
                 /* if no SSID is staged, notify the network commissioning module to clean environnement for next commissioning  */
-                NetworkCommissioning::NXPWiFiDriver::GetInstance().OnConnectWiFiNetwork(NetworkCommissioning::Status::kNetworkIDNotFound,
-                                                                                CharSpan(), wlanEvent);
+                NetworkCommissioning::NXPWiFiDriver::GetInstance().OnConnectWiFiNetwork(
+                    NetworkCommissioning::Status::kNetworkIDNotFound, CharSpan(), wlanEvent);
             }
         }
         break;
 
     case WLAN_REASON_FW_HANG:
         /*
-         If the Wifi driver hangs, a recovery mechanism has been triggered. This mechanism will end with re-initializing the wifi driver.
-         If the wifi state is different from kWiFiStationState_NotConnected and kWiFiStationState_Disconnecting,
-         we want to retry the wifi connection once the driver is re-initialized.
+         If the Wifi driver hangs, a recovery mechanism has been triggered. This mechanism will end with re-initializing the wifi
+         driver. If the wifi state is different from kWiFiStationState_NotConnected and kWiFiStationState_Disconnecting, we want to
+         retry the wifi connection once the driver is re-initialized.
         */
-        if(mWiFiStationState != kWiFiStationState_NotConnected && mWiFiStationState != kWiFiStationState_Disconnecting)
+        if (mWiFiStationState != kWiFiStationState_NotConnected && mWiFiStationState != kWiFiStationState_Disconnecting)
         {
             mIsWifiRecovering = true;
         }

--- a/src/platform/nxp/common/ConnectivityManagerImpl.h
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.h
@@ -88,6 +88,7 @@ public:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     void StartWiFiManagement();
+    static int _WlanEventCallback(enum wlan_event_reason event, void * data);
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -149,11 +150,12 @@ private:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     ConnectivityManager::WiFiStationMode mWiFiStationMode;
-    ConnectivityManager::WiFiStationState mWiFiStationState;
+    ConnectivityManager::WiFiStationState mWiFiStationState = kWiFiStationState_NotConnected;
     ConnectivityManager::WiFiAPMode mWiFiAPMode;
     uint32_t mWiFiStationReconnectIntervalMS;
     bool mWifiManagerInit   = false;
     bool mWifiIsProvisioned = false;
+    bool IsWifiRecovering = false;
 
     enum WiFiEventGroup{
         kWiFiEventGroup_WiFiStationModeBit = (1 << 0),
@@ -170,7 +172,6 @@ private:
     char mHostname[chip::Dnssd::kHostNameMaxLength + 1] = "";
 #endif
 
-    static int _WlanEventCallback(enum wlan_event_reason event, void * data);
     static void _NetifExtCallback(struct netif * netif, netif_nsc_reason_t reason, const netif_ext_callback_args_t * args);
 
     void OnStationConnected(void);

--- a/src/platform/nxp/common/ConnectivityManagerImpl.h
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.h
@@ -155,7 +155,7 @@ private:
     uint32_t mWiFiStationReconnectIntervalMS;
     bool mWifiManagerInit   = false;
     bool mWifiIsProvisioned = false;
-    bool mIsWifiRecovering = false;
+    bool mIsWifiRecovering  = false;
 
     enum WiFiEventGroup{
         kWiFiEventGroup_WiFiStationModeBit = (1 << 0),

--- a/src/platform/nxp/common/ConnectivityManagerImpl.h
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.h
@@ -155,7 +155,7 @@ private:
     uint32_t mWiFiStationReconnectIntervalMS;
     bool mWifiManagerInit   = false;
     bool mWifiIsProvisioned = false;
-    bool IsWifiRecovering = false;
+    bool mIsWifiRecovering = false;
 
     enum WiFiEventGroup{
         kWiFiEventGroup_WiFiStationModeBit = (1 << 0),

--- a/src/platform/nxp/common/NetworkCommissioningDriver.h
+++ b/src/platform/nxp/common/NetworkCommissioningDriver.h
@@ -71,7 +71,7 @@ public:
     Status RemoveNetwork(ByteSpan networkId, MutableCharSpan & outDebugText, uint8_t & outNetworkIndex) override;
     Status ReorderNetwork(ByteSpan networkId, uint8_t index, MutableCharSpan & outDebugText) override;
     void ConnectNetwork(ByteSpan networkId, ConnectCallback * callback) override;
-    CHIP_ERROR ConnectWifiStagedNetwork();
+    CHIP_ERROR ConnectWiFiStagedNetwork();
 
     /* Returns the network SSID. User needs to allocate a buffer of size >= DeviceLayer::Internal::kMaxWiFiSSIDLength.
      * ssid - pointer to the returned SSID

--- a/src/platform/nxp/common/NetworkCommissioningDriver.h
+++ b/src/platform/nxp/common/NetworkCommissioningDriver.h
@@ -71,6 +71,7 @@ public:
     Status RemoveNetwork(ByteSpan networkId, MutableCharSpan & outDebugText, uint8_t & outNetworkIndex) override;
     Status ReorderNetwork(ByteSpan networkId, uint8_t index, MutableCharSpan & outDebugText) override;
     void ConnectNetwork(ByteSpan networkId, ConnectCallback * callback) override;
+    CHIP_ERROR ConnectWifiStagedNetwork();
 
     /* Returns the network SSID. User needs to allocate a buffer of size >= DeviceLayer::Internal::kMaxWiFiSSIDLength.
      * ssid - pointer to the returned SSID

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -107,8 +107,7 @@ CHIP_ERROR NXPWiFiDriver::ConnectWiFiStagedNetwork()
     VerifyOrReturnError(mSavedNetwork.ssidLen != 0, CHIP_ERROR_KEY_NOT_FOUND);
 
     // Connect to saved network
-    return ConnectWiFiNetwork(mSavedNetwork.ssid, mSavedNetwork.ssidLen, mSavedNetwork.credentials,
-                              mSavedNetwork.credentialsLen);
+    return ConnectWiFiNetwork(mSavedNetwork.ssid, mSavedNetwork.ssidLen, mSavedNetwork.credentials, mSavedNetwork.credentialsLen);
 }
 
 void NXPWiFiDriver::Shutdown()

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -103,17 +103,12 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
 
 CHIP_ERROR NXPWiFiDriver::ConnectWiFiStagedNetwork()
 {
-    if (mSavedNetwork.ssidLen != 0)
-    {
-        // Connect to saved network
-        return ConnectWiFiNetwork(mSavedNetwork.ssid, mSavedNetwork.ssidLen, mSavedNetwork.credentials,
-                                  mSavedNetwork.credentialsLen);
-    }
-    else
-    {
-        // no needed to connect to the staged network if commissioning failed
-        return CHIP_ERROR_KEY_NOT_FOUND;
-    }
+    // no needed to connect to the staged network if commissioning failed
+    VerifyOrReturnError(mSavedNetwork.ssidLen != 0, CHIP_ERROR_KEY_NOT_FOUND);
+
+    // Connect to saved network
+    return ConnectWiFiNetwork(mSavedNetwork.ssid, mSavedNetwork.ssidLen, mSavedNetwork.credentials,
+                              mSavedNetwork.credentialsLen);
 }
 
 void NXPWiFiDriver::Shutdown()

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -101,6 +101,22 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     return err;
 }
 
+CHIP_ERROR NXPWiFiDriver::ConnectWifiStagedNetwork()
+{
+    if(mSavedNetwork.ssidLen !=0)
+    {
+        // Connect to saved network
+        return ConnectWiFiNetwork(mSavedNetwork.ssid, mSavedNetwork.ssidLen, mSavedNetwork.credentials, mSavedNetwork.credentialsLen);
+    }
+    else
+    {
+        // no needed to connect to the staged network if commissioning failed
+        return CHIP_ERROR_KEY_NOT_FOUND;
+    }
+    
+}
+
+
 void NXPWiFiDriver::Shutdown()
 {
     mpStatusChangeCallback = nullptr;

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -113,7 +113,7 @@ CHIP_ERROR NXPWiFiDriver::ConnectWiFiStagedNetwork()
         // no needed to connect to the staged network if commissioning failed
         return CHIP_ERROR_KEY_NOT_FOUND;
     }
-    
+
 }
 
 

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -101,7 +101,7 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     return err;
 }
 
-CHIP_ERROR NXPWiFiDriver::ConnectWifiStagedNetwork()
+CHIP_ERROR NXPWiFiDriver::ConnectWiFiStagedNetwork()
 {
     if(mSavedNetwork.ssidLen !=0)
     {

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -103,19 +103,18 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
 
 CHIP_ERROR NXPWiFiDriver::ConnectWiFiStagedNetwork()
 {
-    if(mSavedNetwork.ssidLen !=0)
+    if (mSavedNetwork.ssidLen != 0)
     {
         // Connect to saved network
-        return ConnectWiFiNetwork(mSavedNetwork.ssid, mSavedNetwork.ssidLen, mSavedNetwork.credentials, mSavedNetwork.credentialsLen);
+        return ConnectWiFiNetwork(mSavedNetwork.ssid, mSavedNetwork.ssidLen, mSavedNetwork.credentials,
+                                  mSavedNetwork.credentialsLen);
     }
     else
     {
         // no needed to connect to the staged network if commissioning failed
         return CHIP_ERROR_KEY_NOT_FOUND;
     }
-
 }
-
 
 void NXPWiFiDriver::Shutdown()
 {

--- a/src/platform/nxp/rt/rw61x/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/rt/rw61x/PlatformManagerImpl.cpp
@@ -90,7 +90,7 @@ extern "C" void __wrap_exit(int __status)
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 extern "C" int wlan_event_callback(enum wlan_event_reason reason, void * data)
 {
-    /* Could be called by wifi driver for specific event scenarios like when driver is hang */
+    /* Could be called by wifi driver for specific event scenarios like when the driver hangs */
     return chip::DeviceLayer::ConnectivityMgrImpl()._WlanEventCallback(reason, data);
 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_WPA */

--- a/src/platform/nxp/rt/rw61x/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/rt/rw61x/PlatformManagerImpl.cpp
@@ -90,7 +90,8 @@ extern "C" void __wrap_exit(int __status)
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 extern "C" int wlan_event_callback(enum wlan_event_reason reason, void * data)
 {
-    return 0;
+    /* Could be called by wifi driver for specific event scenarios like when driver is hang */
+    return chip::DeviceLayer::ConnectivityMgrImpl()._WlanEventCallback(reason, data);
 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_WPA */
 


### PR DESCRIPTION
#### Summary

Enable wifi recovery mechanism when wifi driver is hang

#### Testing

Performed internal validation by simulating a Wi-Fi driver hang. Verified that the device successfully recovered and remained reachable after the recovery mechanism was triggered.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
