### PR TITLE
Fix comparison operator for active preset handle

### DIFF
--- a/src/python_testing/TC_TSTAT_4_2.py
+++ b/src/python_testing/TC_TSTAT_4_2.py
@@ -463,7 +463,7 @@ class TC_TSTAT_4_2(MatterBaseTest):
                 await self.send_atomic_request_begin_command()
 
                 # Write to the presets attribute after removing the preset that was set as the active preset handle.
-                test_presets = list(preset for preset in current_presets if preset.presetHandle is not activePresetHandle)
+                test_presets = list(preset for preset in current_presets if preset.presetHandle != activePresetHandle)
                 logger.info(f"Sending Presets: {test_presets}")
                 await self.write_presets(endpoint=endpoint, presets=test_presets)
 


### PR DESCRIPTION
#### Summary

This code bug was preventing the test step from doing what it wanted to do. it would be good to equip the All clusters app at least with also a Builtin preset as default in order for this test part to be executed.

The bug was introduced in https://github.com/project-chip/connectedhomeip/commit/1a892ed56ccce68d3f4fd4471f53fc521b42af23 as it seems and so exists since 1.4.0 ... In my eyes so this change should be backported into all test harness down to 1.4.0

#### Testing

tested manually with matter.js and a defined builtIn preset which was configured as default.

fixes #41637 