### PR TITLE
Enhance MinSetpointDeadBand range to 0..127

### DIFF
--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -1070,7 +1070,7 @@ Status MatterThermostatClusterServerPreAttributeChangedCallback(const app::Concr
         requested = *value;
         if (!AutoSupported)
             return Status::UnsupportedAttribute;
-        if (requested < 0 || requested > 25)
+        if (requested < 0 || requested > 127)
             return Status::InvalidValue;
         return Status::Success;
     }

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
@@ -435,7 +435,7 @@ tests:
           constraints:
               type: int8s
               minValue: 0
-              maxValue: 25
+              maxValue: 127
 
     - label: "Step 21: TH reads the RemoteSensing attribute from the DUT"
       PICS: TSTAT.S.A001a

--- a/src/python_testing/TC_TSTAT_2_2.py
+++ b/src/python_testing/TC_TSTAT_2_2.py
@@ -593,7 +593,7 @@ class TC_TSTAT_2_2(MatterBaseTest):
         # Test Harness Reads MinSetpointDeadBand attribute from Server DUT and verifies that the value is within range
         if self.pics_guard(hasAutoModeFeature):
             val = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.MinSetpointDeadBand)
-            asserts.assert_less_equal(val, 25)
+            asserts.assert_less_equal(val, 127)
 
             if self.pics_guard(self.check_pics("TSTAT.S.M.MinSetpointDeadBandWritable")):
                 # Test Harness Writes a value back that is different but valid for MinSetpointDeadBand attribute
@@ -611,7 +611,7 @@ class TC_TSTAT_2_2(MatterBaseTest):
             asserts.assert_equal(status, Status.ConstraintError)
 
             # Test Harness Writes the value above MinSetpointDeadBand
-            status = await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(30), endpoint_id=endpoint, expect_success=False)
+            status = await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(128), endpoint_id=endpoint, expect_success=False)
             asserts.assert_equal(status, Status.ConstraintError)
 
         self.step("11c")
@@ -621,7 +621,7 @@ class TC_TSTAT_2_2(MatterBaseTest):
             await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(0), endpoint_id=endpoint)
 
             # Test Harness Writes the max limit of MinSetpointDeadBand
-            await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(25), endpoint_id=endpoint)
+            await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(127), endpoint_id=endpoint)
 
         self.step("12")
 


### PR DESCRIPTION
#### Summary

In Matter 1.4.0 the allowed range for MinSetpointDeadband was adjusted from 0..25 to 0..127 but SDK and tests were not updated to reflect this.

Formally also the default value changed in Spec from 25 to 20 and this default is spread over many files in the repo here. I decided for now to leave that because it does not hurt to much

This PR shall be considered for backport into 1.4.0, 1.4.1 and 1.4.2 SDK branches

I do not know if more places (like XMLs or such) are also needed to be adjusted, so please provide guidance.

#### Related issues

fixes #41638

#### Testing

test cases Test_TC_TSTAT_2_1.yaml and TC_TSTAT_2_2.py are also adjusted

