### PR TITLE
Suppress non-literal build error in camera-app

### DIFF
--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -891,6 +891,8 @@ void PushAVClipRecorder::FinalizeCurrentClip(int reason)
     // Helper function for safe path formatting
     char path_buffer[512];
     auto make_path = [&](const char * format, int number = -1) -> std::string {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
         if (number >= 0)
         {
             snprintf(path_buffer, sizeof(path_buffer), format, basePath.c_str(), number);
@@ -899,6 +901,7 @@ void PushAVClipRecorder::FinalizeCurrentClip(int reason)
         {
             snprintf(path_buffer, sizeof(path_buffer), format, basePath.c_str());
         }
+#pragma GCC diagnostic pop
         return std::string(path_buffer);
     };
 


### PR DESCRIPTION

#### Summary
There is warning about the format string is not using literal. This commit adds pragma to suppress the warning.
#### Related issues
```
../../examples/camera-app/linux/src/pushav-clip-recorder.cpp: In lambda function:
../../examples/camera-app/linux/src/pushav-clip-recorder.cpp:896:21: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
  896 |             snprintf(path_buffer, sizeof(path_buffer), format, basePath.c_str(), number);
      |             ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../examples/camera-app/linux/src/pushav-clip-recorder.cpp:900:21: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
  900 |             snprintf(path_buffer, sizeof(path_buffer), format, basePath.c_str());
      |             ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
#### Testing

local build