### PR TITLE
Endpoint interface remove semantic tags

### DIFF
--- a/src/data-model-providers/codedriven/endpoint/EndpointInterface.h
+++ b/src/data-model-providers/codedriven/endpoint/EndpointInterface.h
@@ -41,8 +41,6 @@ public:
 
     using SemanticTag = Clusters::Globals::Structs::SemanticTagStruct::Type;
 
-    virtual CHIP_ERROR SemanticTags(ReadOnlyBufferBuilder<SemanticTag> & out) const = 0;
-
     virtual CHIP_ERROR DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const = 0;
 
     virtual CHIP_ERROR ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const = 0;

--- a/src/data-model-providers/codedriven/endpoint/SpanEndpoint.cpp
+++ b/src/data-model-providers/codedriven/endpoint/SpanEndpoint.cpp
@@ -75,14 +75,16 @@ CharSpan SpanEndpoint::EndpointUniqueId() const
 
 // Private constructor for Builder
 #if CHIP_CONFIG_USE_ENDPOINT_UNIQUE_ID
-SpanEndpoint::SpanEndpoint(const Span<const ClusterId> & clientClusters,
-                           const Span<const DataModel::DeviceTypeEntry> & deviceTypes, const CharSpan & uniqueEndpointId) :
-    mDeviceTypes(deviceTypes), mClientClusters(clientClusters), mEndpointUniqueId(uniqueEndpointId)
+SpanEndpoint::SpanEndpoint(const Span<const ClusterId> & clientClusters, const Span<const DataModel::DeviceTypeEntry> & deviceTypes,
+                           const CharSpan & uniqueEndpointId) :
+    mDeviceTypes(deviceTypes),
+    mClientClusters(clientClusters), mEndpointUniqueId(uniqueEndpointId)
 {}
 #else
 SpanEndpoint::SpanEndpoint(const Span<const ClusterId> & clientClusters,
                            const Span<const DataModel::DeviceTypeEntry> & deviceTypes) :
-    mDeviceTypes(deviceTypes), mClientClusters(clientClusters)
+    mDeviceTypes(deviceTypes),
+    mClientClusters(clientClusters)
 {}
 #endif
 

--- a/src/data-model-providers/codedriven/endpoint/SpanEndpoint.cpp
+++ b/src/data-model-providers/codedriven/endpoint/SpanEndpoint.cpp
@@ -33,12 +33,6 @@ SpanEndpoint::Builder & SpanEndpoint::Builder::SetClientClusters(Span<const Clus
     return *this;
 }
 
-SpanEndpoint::Builder & SpanEndpoint::Builder::SetSemanticTags(Span<const SemanticTag> semanticTags)
-{
-    mSemanticTags = semanticTags;
-    return *this;
-}
-
 SpanEndpoint::Builder & SpanEndpoint::Builder::SetDeviceTypes(Span<const DataModel::DeviceTypeEntry> deviceTypes)
 {
     mDeviceTypes = deviceTypes;
@@ -56,16 +50,10 @@ SpanEndpoint::Builder & SpanEndpoint::Builder::SetEndpointUniqueId(CharSpan endp
 SpanEndpoint SpanEndpoint::Builder::Build()
 {
 #if CHIP_CONFIG_USE_ENDPOINT_UNIQUE_ID
-    return SpanEndpoint(mClientClusters, mSemanticTags, mDeviceTypes, mEndpointUniqueId);
+    return SpanEndpoint(mClientClusters, mDeviceTypes, mEndpointUniqueId);
 #else
-    return SpanEndpoint(mClientClusters, mSemanticTags, mDeviceTypes);
+    return SpanEndpoint(mClientClusters, mDeviceTypes);
 #endif
-}
-
-CHIP_ERROR
-SpanEndpoint::SemanticTags(ReadOnlyBufferBuilder<SemanticTag> & out) const
-{
-    return out.ReferenceExisting(mSemanticTags);
 }
 
 CHIP_ERROR SpanEndpoint::DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const
@@ -87,16 +75,14 @@ CharSpan SpanEndpoint::EndpointUniqueId() const
 
 // Private constructor for Builder
 #if CHIP_CONFIG_USE_ENDPOINT_UNIQUE_ID
-SpanEndpoint::SpanEndpoint(const Span<const ClusterId> & clientClusters, const Span<const SemanticTag> & semanticTags,
+SpanEndpoint::SpanEndpoint(const Span<const ClusterId> & clientClusters,
                            const Span<const DataModel::DeviceTypeEntry> & deviceTypes, const CharSpan & uniqueEndpointId) :
-    mDeviceTypes(deviceTypes),
-    mSemanticTags(semanticTags), mClientClusters(clientClusters), mEndpointUniqueId(uniqueEndpointId)
+    mDeviceTypes(deviceTypes), mClientClusters(clientClusters), mEndpointUniqueId(uniqueEndpointId)
 {}
 #else
-SpanEndpoint::SpanEndpoint(const Span<const ClusterId> & clientClusters, const Span<const SemanticTag> & semanticTags,
+SpanEndpoint::SpanEndpoint(const Span<const ClusterId> & clientClusters,
                            const Span<const DataModel::DeviceTypeEntry> & deviceTypes) :
-    mDeviceTypes(deviceTypes),
-    mSemanticTags(semanticTags), mClientClusters(clientClusters)
+    mDeviceTypes(deviceTypes), mClientClusters(clientClusters)
 {}
 #endif
 

--- a/src/data-model-providers/codedriven/endpoint/SpanEndpoint.h
+++ b/src/data-model-providers/codedriven/endpoint/SpanEndpoint.h
@@ -28,8 +28,7 @@ namespace app {
  * @brief An implementation of EndpointInterface that uses `chip::Span` to refer to its data.
  *
  * This provider is constructed using its `Builder` class. It stores `chip::Span` members that
- * point to externally managed arrays for its configuration (device types, server/client clusters,
- * semantic tags, etc.).
+ * point to externally managed arrays for its configuration (device types, server/client clusters, etc.).
  *
  * @warning Lifetime of Span-Referenced Data:
  * `SpanEndpoint` does NOT take ownership of the data arrays referenced by its
@@ -58,7 +57,6 @@ public:
         explicit Builder() = default;
 
         Builder & SetClientClusters(Span<const ClusterId> clientClusters);
-        Builder & SetSemanticTags(Span<const SemanticTag> semanticTags);
         Builder & SetDeviceTypes(Span<const DataModel::DeviceTypeEntry> deviceTypes);
 
 #if CHIP_CONFIG_USE_ENDPOINT_UNIQUE_ID
@@ -68,7 +66,6 @@ public:
 
     private:
         Span<const ClusterId> mClientClusters;
-        Span<const SemanticTag> mSemanticTags;
         Span<const DataModel::DeviceTypeEntry> mDeviceTypes;
 
 #if CHIP_CONFIG_USE_ENDPOINT_UNIQUE_ID
@@ -88,7 +85,6 @@ public:
     SpanEndpoint & operator=(SpanEndpoint &&) = default;
 
     // Iteration methods
-    CHIP_ERROR SemanticTags(ReadOnlyBufferBuilder<SemanticTag> & out) const override;
     CHIP_ERROR DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const override;
     CHIP_ERROR ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const override;
 
@@ -99,16 +95,15 @@ public:
 private:
     // Private constructor for Builder
 #if CHIP_CONFIG_USE_ENDPOINT_UNIQUE_ID
-    SpanEndpoint(const Span<const ClusterId> & clientClusters, const Span<const SemanticTag> & semanticTags,
+    SpanEndpoint(const Span<const ClusterId> & clientClusters,
                  const Span<const DataModel::DeviceTypeEntry> & deviceTypes, const CharSpan & uniqueEndpointId);
 #else
-    SpanEndpoint(const Span<const ClusterId> & clientClusters, const Span<const SemanticTag> & semanticTags,
+    SpanEndpoint(const Span<const ClusterId> & clientClusters,
                  const Span<const DataModel::DeviceTypeEntry> & deviceTypes);
 #endif
 
     // Iteration methods
     Span<const DataModel::DeviceTypeEntry> mDeviceTypes;
-    Span<const SemanticTag> mSemanticTags;
     Span<const ClusterId> mClientClusters;
 
 #if CHIP_CONFIG_USE_ENDPOINT_UNIQUE_ID

--- a/src/data-model-providers/codedriven/endpoint/SpanEndpoint.h
+++ b/src/data-model-providers/codedriven/endpoint/SpanEndpoint.h
@@ -95,11 +95,10 @@ public:
 private:
     // Private constructor for Builder
 #if CHIP_CONFIG_USE_ENDPOINT_UNIQUE_ID
-    SpanEndpoint(const Span<const ClusterId> & clientClusters,
-                 const Span<const DataModel::DeviceTypeEntry> & deviceTypes, const CharSpan & uniqueEndpointId);
+    SpanEndpoint(const Span<const ClusterId> & clientClusters, const Span<const DataModel::DeviceTypeEntry> & deviceTypes,
+                 const CharSpan & uniqueEndpointId);
 #else
-    SpanEndpoint(const Span<const ClusterId> & clientClusters,
-                 const Span<const DataModel::DeviceTypeEntry> & deviceTypes);
+    SpanEndpoint(const Span<const ClusterId> & clientClusters, const Span<const DataModel::DeviceTypeEntry> & deviceTypes);
 #endif
 
     // Iteration methods

--- a/src/data-model-providers/codedriven/endpoint/tests/TestSpanEndpoint.cpp
+++ b/src/data-model-providers/codedriven/endpoint/tests/TestSpanEndpoint.cpp
@@ -12,30 +12,22 @@
 using namespace chip;
 using namespace chip::app;
 using chip::app::DataModel::DeviceTypeEntry;
-using SemanticTag = chip::app::Clusters::Globals::Structs::SemanticTagStruct::Type;
 
 using namespace chip::app;
 
 TEST(TestSpanEndpoint, InstantiateWithAllParameters)
 {
     const chip::ClusterId clientClusters[] = { 10, 20 };
-    const SemanticTag semanticTags[]       = { { .mfgCode = chip::VendorId::TestVendor1, .namespaceID = 1, .tag = 1 },
-                                               { .mfgCode = chip::VendorId::TestVendor2, .namespaceID = 2, .tag = 2 } };
     const DeviceTypeEntry deviceTypes[]    = { Device::Type::kDoorLock, Device::Type::kSpeaker };
 
     auto endpoint = SpanEndpoint::Builder()
                         .SetClientClusters(Span<const chip::ClusterId>(clientClusters))
-                        .SetSemanticTags(Span<const SemanticTag>(semanticTags))
                         .SetDeviceTypes(Span<const DeviceTypeEntry>(deviceTypes))
                         .Build();
 
     ReadOnlyBufferBuilder<chip::ClusterId> clientBuilder;
     ASSERT_EQ(endpoint.ClientClusters(clientBuilder), CHIP_NO_ERROR);
     ASSERT_EQ(clientBuilder.Size(), std::size(clientClusters));
-
-    ReadOnlyBufferBuilder<SemanticTag> tagBuilder;
-    ASSERT_EQ(endpoint.SemanticTags(tagBuilder), CHIP_NO_ERROR);
-    ASSERT_EQ(tagBuilder.Size(), std::size(semanticTags));
 
     ReadOnlyBufferBuilder<DeviceTypeEntry> deviceTypeBuilder;
     ASSERT_EQ(endpoint.DeviceTypes(deviceTypeBuilder), CHIP_NO_ERROR);
@@ -64,20 +56,6 @@ TEST(TestSpanEndpoint, SetAndGetClientClusters)
     EXPECT_TRUE(retrievedClusters.data_equal(Span<const chip::ClusterId>(clientClusters, std::size(clientClusters))));
 }
 
-TEST(TestSpanEndpoint, SetAndGetSemanticTags)
-{
-    const SemanticTag semanticTags[] = { { .mfgCode = chip::VendorId::TestVendor1, .namespaceID = 1, .tag = 1 },
-                                         { .mfgCode = chip::VendorId::TestVendor2, .namespaceID = 2, .tag = 2 } };
-    auto endpoint                    = SpanEndpoint::Builder().SetSemanticTags(Span<const SemanticTag>(semanticTags)).Build();
-    ReadOnlyBufferBuilder<SemanticTag> builder;
-    ASSERT_EQ(endpoint.SemanticTags(builder), CHIP_NO_ERROR);
-    auto retrievedTags = builder.TakeBuffer();
-    ASSERT_EQ(retrievedTags.size(), std::size(semanticTags));
-    // SemanticTagStruct does not have operator== by default, manual check or compare members if needed
-    EXPECT_EQ(retrievedTags[0].mfgCode, semanticTags[0].mfgCode);
-    EXPECT_EQ(retrievedTags[1].namespaceID, semanticTags[1].namespaceID);
-}
-
 TEST(TestSpanEndpoint, SetAndGetDeviceTypes)
 {
     const DeviceTypeEntry deviceTypes[] = { Device::Type::kAirPurifier, Device::Type::kClosure };
@@ -95,7 +73,6 @@ TEST(TestSpanEndpoint, BuildWithEmptySpans)
 {
     auto endpoint = SpanEndpoint::Builder()
                         .SetClientClusters(Span<const chip::ClusterId>())
-                        .SetSemanticTags(Span<const SemanticTag>())
                         .SetDeviceTypes(Span<const DataModel::DeviceTypeEntry>())
                         .Build();
 
@@ -103,11 +80,6 @@ TEST(TestSpanEndpoint, BuildWithEmptySpans)
     ReadOnlyBufferBuilder<chip::ClusterId> clientBuilder;
     ASSERT_EQ(endpoint.ClientClusters(clientBuilder), CHIP_NO_ERROR);
     ASSERT_EQ(clientBuilder.Size(), 0u);
-
-    // Test SetSemanticTags with an empty span
-    ReadOnlyBufferBuilder<SemanticTag> tagBuilder;
-    ASSERT_EQ(endpoint.SemanticTags(tagBuilder), CHIP_NO_ERROR);
-    ASSERT_EQ(tagBuilder.Size(), 0u);
 
     // Test SetDeviceTypes with an empty span
     ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> deviceTypeBuilder;

--- a/src/data-model-providers/codedriven/tests/TestCodeDrivenDataModelProvider.cpp
+++ b/src/data-model-providers/codedriven/tests/TestCodeDrivenDataModelProvider.cpp
@@ -39,7 +39,6 @@
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Testing;
-using SemanticTag = chip::app::Clusters::Globals::Structs::SemanticTagStruct::Type;
 
 class TestProviderChangeListener : public DataModel::ProviderChangeListener
 {
@@ -267,17 +266,6 @@ constexpr DataModel::EndpointEntry endpointEntry4 = { .id                 = 4,
                                                       .parentId           = kInvalidEndpointId,
                                                       .compositionPattern = DataModel::EndpointCompositionPattern::kFullFamily };
 
-SemanticTag semanticTag1 = { .mfgCode     = VendorId::Google,
-                             .namespaceID = 1,
-                             .tag         = 1,
-                             .label       = chip::Optional<chip::app::DataModel::Nullable<chip::CharSpan>>(
-                                 { chip::app::DataModel::MakeNullable(chip::CharSpan("label1", 6)) }) };
-SemanticTag semanticTag2 = { .mfgCode     = VendorId::Google,
-                             .namespaceID = 2,
-                             .tag         = 2,
-                             .label       = chip::Optional<chip::app::DataModel::Nullable<chip::CharSpan>>(
-                                 { chip::app::DataModel::MakeNullable(chip::CharSpan("label1", 6)) }) };
-
 constexpr chip::EndpointId clientClusterId1 = 1;
 constexpr chip::EndpointId clientClusterId2 = 2;
 
@@ -467,14 +455,11 @@ TEST_F(TestCodeDrivenDataModelProvider, EndpointWithStaticData)
     ASSERT_EQ(localProvider.Startup(mContext), CHIP_NO_ERROR);
 
     static const ClusterId clientClustersArray[]               = { 0xD001, 0xD002 };
-    static const SemanticTag semanticTagsArray[]               = { { .mfgCode = VendorId::Google, .namespaceID = 10, .tag = 100 },
-                                                                   { .mfgCode = VendorId::Google, .namespaceID = 11, .tag = 101 } };
     static const DataModel::DeviceTypeEntry deviceTypesArray[] = { { .deviceTypeId = 0x7001, .deviceTypeRevision = 1 },
                                                                    { .deviceTypeId = 0x7002, .deviceTypeRevision = 2 } };
 
     SpanEndpoint ep = SpanEndpoint::Builder()
                           .SetClientClusters(chip::Span<const ClusterId>(clientClustersArray))
-                          .SetSemanticTags(chip::Span<const SemanticTag>(semanticTagsArray))
                           .SetDeviceTypes(chip::Span<const DataModel::DeviceTypeEntry>(deviceTypesArray))
                           .Build();
 
@@ -494,7 +479,6 @@ TEST_F(TestCodeDrivenDataModelProvider, EndpointWithEmptyStaticData)
 {
     auto endpoint = std::make_unique<SpanEndpoint>(SpanEndpoint::Builder()
                                                        .SetClientClusters(Span<const ClusterId>())
-                                                       .SetSemanticTags(Span<const SemanticTag>())
                                                        .SetDeviceTypes(Span<const DataModel::DeviceTypeEntry>())
                                                        .Build());
     mEndpointStorage.push_back(std::move(endpoint));


### PR DESCRIPTION
#### Summary
This is a follow-up from [this comment](https://github.com/project-chip/connectedhomeip/pull/40935#discussion_r2417779628). Removing the `SemanticTags()` function from the endpoint interface as this information is now passed into the descriptor cluster constructor, and can be read through the `ReadAttribute()` function.

#### Testing

- Removed semantic tag tests from the endpoint interface tests
- CI should still pass
