### PR TITLE
[CLOSURE] PICS guard for selective test execution

### DIFF
--- a/src/python_testing/TC_CLCTRL_3_1.py
+++ b/src/python_testing/TC_CLCTRL_3_1.py
@@ -115,7 +115,7 @@ class TC_CLCTRL_3_1(MatterBaseTest):
 
     def pics_TC_CLCTRL_3_1(self) -> list[str]:
         pics = [
-            "CLCTRL.S"
+            "CLCTRL.S", "CLCTRL.S.F06"
         ]
         return pics
 

--- a/src/python_testing/TC_CLCTRL_4_1.py
+++ b/src/python_testing/TC_CLCTRL_4_1.py
@@ -195,7 +195,7 @@ class TC_CLCTRL_4_1(MatterBaseTest):
 
     def pics_TC_CLCTRL_4_1(self) -> list[str]:
         pics = [
-            "CLCTRL.S"
+            "CLCTRL.S", "CLCTRL.S.F00"
         ]
         return pics
 

--- a/src/python_testing/TC_CLCTRL_4_2.py
+++ b/src/python_testing/TC_CLCTRL_4_2.py
@@ -156,7 +156,7 @@ class TC_CLCTRL_4_2(MatterBaseTest):
 
     def pics_TC_CLCTRL_4_2(self) -> list[str]:
         pics = [
-            "CLCTRL.S",
+            "CLCTRL.S", "CLCTRL.S.F01"
         ]
         return pics
 

--- a/src/python_testing/TC_CLCTRL_4_4.py
+++ b/src/python_testing/TC_CLCTRL_4_4.py
@@ -132,7 +132,7 @@ class TC_CLCTRL_4_4(MatterBaseTest):
 
     def pics_TC_CLCTRL_4_4(self) -> list[str]:
         pics = [
-            "CLCTRL.S",
+            "CLCTRL.S", "CLCTRL.S.A0000"
         ]
         return pics
 

--- a/src/python_testing/TC_CLCTRL_5_1.py
+++ b/src/python_testing/TC_CLCTRL_5_1.py
@@ -149,7 +149,7 @@ class TC_CLCTRL_5_1(MatterBaseTest):
 
     def pics_TC_CLCTRL_5_1(self) -> list[str]:
         pics = [
-            "CLCTRL.S", "CLTRL.S.C00"
+            "CLCTRL.S", "CLCTRL.S.C00"
         ]
         return pics
 

--- a/src/python_testing/TC_CLCTRL_5_1.py
+++ b/src/python_testing/TC_CLCTRL_5_1.py
@@ -149,7 +149,7 @@ class TC_CLCTRL_5_1(MatterBaseTest):
 
     def pics_TC_CLCTRL_5_1(self) -> list[str]:
         pics = [
-            "CLCTRL.S"
+            "CLCTRL.S", "CLTRL.S.C00"
         ]
         return pics
 

--- a/src/python_testing/TC_CLDIM_3_1.py
+++ b/src/python_testing/TC_CLDIM_3_1.py
@@ -134,7 +134,7 @@ class TC_CLDIM_3_1(MatterBaseTest):
 
     def pics_TC_CLDIM_3_1(self) -> list[str]:
         pics = [
-            "CLDIM.S",
+            "CLDIM.S", "CLDIM.S.F00"
         ]
         return pics
 

--- a/src/python_testing/TC_CLDIM_3_2.py
+++ b/src/python_testing/TC_CLDIM_3_2.py
@@ -99,7 +99,7 @@ class TC_CLDIM_3_2(MatterBaseTest):
 
     def pics_TC_CLDIM_3_2(self) -> list[str]:
         pics = [
-            "CLDIM.S",
+            "CLDIM.S", "CLDIM.S.F01"
         ]
         return pics
 

--- a/src/python_testing/TC_CLDIM_4_1.py
+++ b/src/python_testing/TC_CLDIM_4_1.py
@@ -132,7 +132,7 @@ class TC_CLDIM_4_1(MatterBaseTest):
 
     def pics_TC_CLDIM_4_1(self) -> list[str]:
         pics = [
-            "CLDIM.S",
+            "CLDIM.S", "CLDIM.S.F00"
         ]
         return pics
 

--- a/src/python_testing/TC_CLDIM_4_2.py
+++ b/src/python_testing/TC_CLDIM_4_2.py
@@ -88,7 +88,7 @@ class TC_CLDIM_4_2(MatterBaseTest):
 
     def pics_TC_CLDIM_4_2(self) -> list[str]:
         pics = [
-            "CLDIM.S",
+            "CLDIM.S", "CLDIM.S.F00"
         ]
         return pics
 


### PR DESCRIPTION
#### Summary

All closure test are run and some stop early due to not supporting a specific feature.

We added PICS guard to skip those test instead.

#### Related PR

- https://github.com/CHIP-Specifications/chip-test-plans/pull/5654

#### Testing

