### PR TITLE
[SETRF] Add missing await in TC 3.1

### DIFF
--- a/src/python_testing/TC_SETRF_3_1.py
+++ b/src/python_testing/TC_SETRF_3_1.py
@@ -724,7 +724,7 @@ class TC_SETRF_3_1(CommodityTariffTestBaseHelper):
 
         self.step("44")
         # TH removes the subscription to Commodity Tariff cluster attributes
-        subscription_handler.cancel()
+        await subscription_handler.cancel()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Summary

This PR adds missing await instruction in TC_SETRF_3_1.py

#### Testing

How to test:
Start energy-gateway-app:
```
rm -f /tmp/chip_*;  ./chip-energy-gateway-app --enable-key 000102030405060708090a0b0c0d0e0f
```

Run test:
```
python src/python_testing/TC_SETRF_3_1.py --endpoint 1 -m on-network -n 1234 -p 20202021 -d 3840 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --PICS src/app/tests/suites/certification/ci-pics-values
```

