### PR TITLE
[Silabs] Refactor WiFi scanning logic to avoid double async operation in scan API

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -907,7 +907,7 @@ CHIP_ERROR WifiInterfaceImpl::StartNetworkScan(chip::ByteSpan ssid, ::ScanCallba
     {
         // Copy the requested SSID to the sl_wifi_ssid_t structure
         chip::MutableByteSpan requestedSsidSpan(requested_ssid.value, sizeof(requested_ssid.value));
-        chip::CopySpanToMutableSpan(ssid, requestedSsidSpan);
+        ReturnOnFailure(chip::CopySpanToMutableSpan(ssid, requestedSsidSpan));
         // Copy the length of the requested SSID to the sl_wifi_ssid_t structure
         requested_ssid.length = static_cast<uint8_t>(ssid.size());
         requested_ssid_ptr    = &requested_ssid;

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -232,12 +232,12 @@ sl_status_t BackgroundScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t 
 
         // Copy the scanned SSID to the current scan ssid buffer that will be forwarded to the callback
         chip::MutableByteSpan currentScanSsid(currentScanResult.ssid, WFX_MAX_SSID_LENGTH);
-        chip::CopySpanToMutableSpan(scannedSsidSpan, currentScanSsid);
+        ReturnOnFailure(chip::CopySpanToMutableSpan(scannedSsidSpan, currentScanSsid));
         currentScanResult.ssid_length = currentScanSsid.size();
 
         chip::ByteSpan inBssid(result->scan_info[i].bssid, kWifiMacAddressLength);
         chip::MutableByteSpan outBssid(currentScanResult.bssid, kWifiMacAddressLength);
-        chip::CopySpanToMutableSpan(inBssid, outBssid);
+        ReturnOnFailure(chip::CopySpanToMutableSpan(inBssid, outBssid));
 
         // TODO: We should revisit this to make sure we are setting the correct values
         currentScanResult.security = static_cast<wfx_sec_t>(result->scan_info[i].security_mode);

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -899,7 +899,7 @@ CHIP_ERROR WifiInterfaceImpl::StartNetworkScan(chip::ByteSpan ssid, ::ScanCallba
         return CHIP_ERROR_INTERNAL;
     }
 
-    // If an ssid was not provided, we need to call the scan API with nullptr to scan all Wi-Fi networks
+    // If an ssid was not provided, we need to call sl_wifi_start_scan with nullptr to scan all Wi-Fi networks
     sl_wifi_ssid_t requested_ssid       = { 0 };
     sl_wifi_ssid_t * requested_ssid_ptr = nullptr;
 
@@ -921,6 +921,7 @@ CHIP_ERROR WifiInterfaceImpl::StartNetworkScan(chip::ByteSpan ssid, ::ScanCallba
 
     if (SL_STATUS_IN_PROGRESS == status)
     {
+        // NOTE: Intentional to wait for timeout here as the scan completion is indicated by the callback
         osSemaphoreAcquire(sScanCompleteSemaphore, kWifiScanTimeoutTicks);
     }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -929,6 +929,8 @@ CHIP_ERROR WifiInterfaceImpl::StartNetworkScan(chip::ByteSpan ssid, ::ScanCallba
     if (status != SL_STATUS_OK)
     {
         ChipLogError(DeviceLayer, "sl_wifi_start_scan failed: 0x%lx", status);
+        // Map the sl_wifi error to a CHIP_ERROR; use CHIP_ERROR_INTERNAL as a generic fallback
+        return CHIP_ERROR_INTERNAL;
     }
     return CHIP_NO_ERROR;
 }

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -566,7 +566,7 @@ CHIP_ERROR WifiInterfaceImpl::InitWiFiStack(void)
 
     // Create Semaphore for scan in-progress protection
     sScanInProgressSemaphore = osSemaphoreNew(1, 1, nullptr);
-    VerifyOrReturnError(sScanCompleteSemaphore != nullptr, CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(sScanInProgressSemaphore != nullptr, CHIP_ERROR_NO_MEMORY);
 
     // Create the message queue
     sWifiEventQueue = osMessageQueueNew(kWfxQueueSize, sizeof(WifiPlatformEvent), nullptr);

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -232,12 +232,14 @@ sl_status_t BackgroundScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t 
 
         // Copy the scanned SSID to the current scan ssid buffer that will be forwarded to the callback
         chip::MutableByteSpan currentScanSsid(currentScanResult.ssid, WFX_MAX_SSID_LENGTH);
-        ReturnOnFailure(chip::CopySpanToMutableSpan(scannedSsidSpan, currentScanSsid));
+        VerifyOrReturnError(chip::CopySpanToMutableSpan(scannedSsidSpan, currentScanSsid) == CHIP_NO_ERROR,
+                            SL_STATUS_SI91X_MEMORY_IS_NOT_SUFFICIENT);
         currentScanResult.ssid_length = currentScanSsid.size();
 
         chip::ByteSpan inBssid(result->scan_info[i].bssid, kWifiMacAddressLength);
         chip::MutableByteSpan outBssid(currentScanResult.bssid, kWifiMacAddressLength);
-        ReturnOnFailure(chip::CopySpanToMutableSpan(inBssid, outBssid));
+        VerifyOrReturnError(chip::CopySpanToMutableSpan(inBssid, outBssid) == CHIP_NO_ERROR,
+                            SL_STATUS_SI91X_MEMORY_IS_NOT_SUFFICIENT);
 
         // TODO: We should revisit this to make sure we are setting the correct values
         currentScanResult.security = static_cast<wfx_sec_t>(result->scan_info[i].security_mode);
@@ -907,7 +909,7 @@ CHIP_ERROR WifiInterfaceImpl::StartNetworkScan(chip::ByteSpan ssid, ::ScanCallba
     {
         // Copy the requested SSID to the sl_wifi_ssid_t structure
         chip::MutableByteSpan requestedSsidSpan(requested_ssid.value, sizeof(requested_ssid.value));
-        ReturnOnFailure(chip::CopySpanToMutableSpan(ssid, requestedSsidSpan));
+        ReturnErrorOnFailure(chip::CopySpanToMutableSpan(ssid, requestedSsidSpan));
         // Copy the length of the requested SSID to the sl_wifi_ssid_t structure
         requested_ssid.length = static_cast<uint8_t>(ssid.size());
         requested_ssid_ptr    = &requested_ssid;

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -911,10 +911,10 @@ CHIP_ERROR WifiInterfaceImpl::StartNetworkScan(chip::ByteSpan ssid, ::ScanCallba
     if (wfx_rsi.scan_ssid != nullptr)
     {
         chip::ByteSpan requestedSsid(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length);
-        chip::MutableByteSpan ouputSsid(_ssid.value, sizeof(_ssid.value));
-        chip::CopySpanToMutableSpan(requestedSsid, ouputSsid);
+        chip::MutableByteSpan outputSsid(_ssid.value, sizeof(_ssid.value));
+        chip::CopySpanToMutableSpan(requestedSsid, outputSsid);
 
-        _ssid.length = ouputSsid.size();
+        _ssid.length = outputSsid.size();
         ssidPtr      = &_ssid;
     }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -212,13 +212,13 @@ sl_status_t BackgroundScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t 
     VerifyOrReturnError(result != nullptr, SL_STATUS_NULL_POINTER);
     VerifyOrReturnError(wfx_rsi.scan_cb != nullptr, SL_STATUS_INVALID_HANDLE);
 
-    sl_wifi_ssid_t * requested_ssid_ptr = nullptr;
+    sl_wifi_ssid_t * requestedSsidPtr = nullptr;
     chip::ByteSpan requestedSsidSpan;
     // arg is the requested SSID pointer passed during sl_wifi_set_scan_callback
     if (arg != nullptr)
     {
-        requested_ssid_ptr = reinterpret_cast<sl_wifi_ssid_t *>(arg);
-        requestedSsidSpan  = chip::ByteSpan(requested_ssid_ptr->value, requested_ssid_ptr->length);
+        requestedSsidPtr  = reinterpret_cast<sl_wifi_ssid_t *>(arg);
+        requestedSsidSpan = chip::ByteSpan(requestedSsidPtr->value, requestedSsidPtr->length);
     }
 
     uint32_t nbreResults = result->scan_count;
@@ -902,24 +902,24 @@ CHIP_ERROR WifiInterfaceImpl::StartNetworkScan(chip::ByteSpan ssid, ::ScanCallba
     }
 
     // If an ssid was not provided, we need to call sl_wifi_start_scan with nullptr to scan all Wi-Fi networks
-    sl_wifi_ssid_t requested_ssid       = { 0 };
-    sl_wifi_ssid_t * requested_ssid_ptr = nullptr;
+    sl_wifi_ssid_t requestedSsid      = { 0 };
+    sl_wifi_ssid_t * requestedSsidPtr = nullptr;
 
     if (!ssid.empty())
     {
         // Copy the requested SSID to the sl_wifi_ssid_t structure
-        chip::MutableByteSpan requestedSsidSpan(requested_ssid.value, sizeof(requested_ssid.value));
+        chip::MutableByteSpan requestedSsidSpan(requestedSsid.value, sizeof(requestedSsid.value));
         ReturnErrorOnFailure(chip::CopySpanToMutableSpan(ssid, requestedSsidSpan));
         // Copy the length of the requested SSID to the sl_wifi_ssid_t structure
-        requested_ssid.length = static_cast<uint8_t>(ssid.size());
-        requested_ssid_ptr    = &requested_ssid;
+        requestedSsid.length = static_cast<uint8_t>(ssid.size());
+        requestedSsidPtr     = &requestedSsid;
     }
 
     osSemaphoreAcquire(sScanInProgressSemaphore, osWaitForever);
 
-    // NOTE: sending requested_ssid_ptr as background scan does not filter for SSID
-    sl_wifi_set_scan_callback(BackgroundScanCallback, requested_ssid_ptr);
-    status = sl_wifi_start_scan(SL_WIFI_CLIENT_2_4GHZ_INTERFACE, requested_ssid_ptr, &wifi_scan_configuration);
+    // NOTE: sending requestedSsidPtr as background scan does not filter for SSID
+    sl_wifi_set_scan_callback(BackgroundScanCallback, requestedSsidPtr);
+    status = sl_wifi_start_scan(SL_WIFI_CLIENT_2_4GHZ_INTERFACE, requestedSsidPtr, &wifi_scan_configuration);
 
     if (SL_STATUS_IN_PROGRESS == status)
     {

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -896,7 +896,7 @@ CHIP_ERROR WifiInterfaceImpl::StartNetworkScan(chip::ByteSpan ssid, ::ScanCallba
 
     status = sl_wifi_set_advanced_scan_configuration(&advanced_scan_configuration);
 
-    // TODO: Seems like Chipdie should be called here, the device should be initialized here
+    // TODO: Seems like ChipDie should be called here, the device should be initialized here
     VerifyOrReturnError(
         status == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
         ChipLogError(DeviceLayer, "sl_wifi_set_advanced_scan_configuration failed: 0x%lx", static_cast<uint32_t>(status)));

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.h
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.h
@@ -34,7 +34,6 @@ public:
         kStationDisconnect  = 1,
         kAPStart            = 2,
         kAPStop             = 3,
-        kScan               = 4, /* This combines the scan start and scan result events  */
         kStationStartJoin   = 5,
         kConnectionComplete = 6, /* This combines the DHCP and Notify */
         kStationDhcpDone    = 7,

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -438,8 +438,6 @@ typedef struct wfx_rsi_s
     uint16_t ap_chan; /* The chan our STA is using	*/
     chip::DeviceLayer::Silabs::WifiInterface::WifiCredentials credentials;
     ScanCallback scan_cb;
-    uint8_t * scan_ssid; /* Which one are we scanning for */
-    size_t scan_ssid_length;
 #ifdef SL_WFX_CONFIG_SOFTAP
     chip::DeviceLayer::Silabs::WifiInterface::MacAddress softap_mac;
 #endif


### PR DESCRIPTION
#### Summary
The WiFi scan logic was a double async operation in the SiWx917, using the `WifiPlatformEvent::kScan`, a `WifiPlatformEvent` was posted in order to start a scan, even when an API existed in the `WiFiInterface` layer.


#### Related issues
N/A

### Testing
Manually tested after commissioning using the following command
`chip-tool networkcommissioning scan-networks <node-id> 0`
`chip-tool networkcommissioning scan-networks <node-id> 0 --Ssid <requested-ssid>`

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
