### PR TITLE
[Silabs] Clean up anonymous enum constants to use constant expressions

### DIFF
--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -146,12 +146,9 @@ private:
         kExtAdvertisingEnabled    = 0x0040,
     };
 
-    enum
-    {
-        kMaxConnections      = BLE_LAYER_NUM_BLE_ENDPOINTS,
-        kMaxDeviceNameLength = 21,
-        kUnusedIndex         = 0xFF,
-    };
+    static constexpr uint8_t kMaxConnections      = BLE_LAYER_NUM_BLE_ENDPOINTS,
+    static constexpr uint8_t kMaxDeviceNameLength = 21,
+    static constexpr uint8_t kUnusedIndex         = 0xFF,
 
     static constexpr uint8_t kFlagTlvSize       = 3; // 1 byte for length, 1b for type and 1b for the Flag value
     static constexpr uint8_t kUUIDTlvSize       = 4; // 1 byte for length, 1b for type and 2b for the UUID value

--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -146,9 +146,9 @@ private:
         kExtAdvertisingEnabled    = 0x0040,
     };
 
-    static constexpr uint8_t kMaxConnections      = BLE_LAYER_NUM_BLE_ENDPOINTS,
-    static constexpr uint8_t kMaxDeviceNameLength = 21,
-    static constexpr uint8_t kUnusedIndex         = 0xFF,
+    static constexpr uint8_t kMaxConnections      = BLE_LAYER_NUM_BLE_ENDPOINTS;
+    static constexpr uint8_t kMaxDeviceNameLength = 21;
+    static constexpr uint8_t kUnusedIndex         = 0xFF;
 
     static constexpr uint8_t kFlagTlvSize       = 3; // 1 byte for length, 1b for type and 1b for the Flag value
     static constexpr uint8_t kUUIDTlvSize       = 4; // 1 byte for length, 1b for type and 2b for the UUID value


### PR DESCRIPTION
#### Summary
Cleaned up anonymous enum constants to use constant expressions in the BleManagerAbstraction.

#### Related issues
N/A

#### Testing
Tested local build and ble-wifi pairing for commissioning for light and lock app on 917SOC. Both are successful.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
