### PR TITLE
TC-EEVSE-2.3: Fix check when command returns success, but expects error

### DIFF
--- a/examples/energy-management-app/energy-management-common/energy-evse/src/ChargingTargetsMemMgr.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/ChargingTargetsMemMgr.cpp
@@ -93,7 +93,7 @@ CHIP_ERROR ChargingTargetsMemMgr::AllocAndCopy()
     // ChargingTargetsMemMgr.h before this method can be called.
 
     VerifyOrDie(mpListOfDays[mChargingTargetSchedulesIdx] == nullptr);
-    VerifyOrReturnError(mNumDailyChargingTargets <= 10, CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(mNumDailyChargingTargets <= kEvseTargetsMaxTargetsPerDay, CHIP_ERROR_NO_MEMORY);
 
     if (mNumDailyChargingTargets > 0)
     {
@@ -125,7 +125,7 @@ ChargingTargetsMemMgr::AllocAndCopy(const DataModel::List<const Structs::Chargin
     VerifyOrDie(mpListOfDays[mChargingTargetSchedulesIdx] == nullptr);
 
     mNumDailyChargingTargets = static_cast<uint16_t>(chargingTargets.size());
-    VerifyOrReturnError(mNumDailyChargingTargets <= 10, CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(mNumDailyChargingTargets <= kEvseTargetsMaxTargetsPerDay, CHIP_ERROR_NO_MEMORY);
 
     if (mNumDailyChargingTargets > 0)
     {
@@ -163,7 +163,7 @@ ChargingTargetsMemMgr::AllocAndCopy(const DataModel::DecodableList<Structs::Char
     ReturnErrorOnFailure(chargingTargets.ComputeSize(&numDailyChargingTargets));
 
     mNumDailyChargingTargets = static_cast<uint16_t>(numDailyChargingTargets);
-    VerifyOrReturnError(mNumDailyChargingTargets <= 10, CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(mNumDailyChargingTargets <= kEvseTargetsMaxTargetsPerDay, CHIP_ERROR_NO_MEMORY);
 
     if (mNumDailyChargingTargets > 0)
     {

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/ChargingTargetsMemMgr.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/ChargingTargetsMemMgr.cpp
@@ -93,6 +93,7 @@ CHIP_ERROR ChargingTargetsMemMgr::AllocAndCopy()
     // ChargingTargetsMemMgr.h before this method can be called.
 
     VerifyOrDie(mpListOfDays[mChargingTargetSchedulesIdx] == nullptr);
+    VerifyOrReturnError(mNumDailyChargingTargets <= 10, CHIP_ERROR_NO_MEMORY);
 
     if (mNumDailyChargingTargets > 0)
     {
@@ -124,6 +125,7 @@ ChargingTargetsMemMgr::AllocAndCopy(const DataModel::List<const Structs::Chargin
     VerifyOrDie(mpListOfDays[mChargingTargetSchedulesIdx] == nullptr);
 
     mNumDailyChargingTargets = static_cast<uint16_t>(chargingTargets.size());
+    VerifyOrReturnError(mNumDailyChargingTargets <= 10, CHIP_ERROR_NO_MEMORY);
 
     if (mNumDailyChargingTargets > 0)
     {
@@ -161,6 +163,7 @@ ChargingTargetsMemMgr::AllocAndCopy(const DataModel::DecodableList<Structs::Char
     ReturnErrorOnFailure(chargingTargets.ComputeSize(&numDailyChargingTargets));
 
     mNumDailyChargingTargets = static_cast<uint16_t>(numDailyChargingTargets);
+    VerifyOrReturnError(mNumDailyChargingTargets <= 10, CHIP_ERROR_NO_MEMORY);
 
     if (mNumDailyChargingTargets > 0)
     {

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
@@ -368,6 +368,10 @@ Status EnergyEvseDelegate::SetTargets(
     VerifyOrReturnError(targets != nullptr, Status::Failure);
 
     CHIP_ERROR err = targets->SetTargets(chargingTargetSchedules);
+    if (err == CHIP_ERROR_NO_MEMORY)
+    {
+        return Status::ResourceExhausted;
+    }
     VerifyOrReturnError(err == CHIP_NO_ERROR, StatusIB(err).mStatus);
 
     /* The Application needs to be told that the Targets have been updated

--- a/src/app/clusters/energy-evse-server/energy-evse-server.cpp
+++ b/src/app/clusters/energy-evse-server/energy-evse-server.cpp
@@ -449,6 +449,12 @@ Status Instance::ValidateTargets(
             innerIdx++;
         }
 
+        if (innerIdx > kEvseTargetsMaxTargetsPerDay)
+        {
+            ChipLogError(AppServer, "Too many targets in a single ChargingTargetScheduleStruct (%d)", innerIdx);
+            return Status::ResourceExhausted;
+        }
+
         if (iterInner.GetStatus() != CHIP_NO_ERROR)
         {
             return Status::InvalidCommand;

--- a/src/python_testing/TC_CNET_4_12.py
+++ b/src/python_testing/TC_CNET_4_12.py
@@ -60,7 +60,7 @@ class TC_CNET_4_12(MatterBaseTest):
         return instance_name
 
     async def wait_for_srp_update(self, timeout_seconds: int = 180):
-        instance_qname = f"{self.get_dut_instance_name()}.{MdnsServiceType.OPERATIONAL.value}"
+        instance_qname = f"{self.get_dut_instance_name}.{MdnsServiceType.OPERATIONAL.value}"
 
         mdns = MdnsDiscovery()
         srv_record = await mdns.get_srv_record(

--- a/src/python_testing/TC_CNET_4_12.py
+++ b/src/python_testing/TC_CNET_4_12.py
@@ -22,9 +22,11 @@
 import asyncio
 import logging
 
+from mdns_discovery.mdns_discovery import MdnsDiscovery, MdnsServiceType
 from mobly import asserts
 
 import matter.clusters as Clusters
+from matter.exceptions import ChipStackError
 from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
 
 logger = logging.getLogger(__name__)
@@ -49,6 +51,29 @@ class TC_CNET_4_12(MatterBaseTest):
     CLUSTER_DESC = Clusters.Descriptor
     CLUSTER_CGEN = Clusters.GeneralCommissioning
     failsafe_expiration_seconds = 900
+
+    def get_dut_instance_name(self) -> str:
+        # TODO: Consolidate this with other tests after SVE
+        node_id = self.dut_node_id
+        compressed_fabric_id = self.default_controller.GetCompressedFabricId()
+        instance_name = f'{compressed_fabric_id:016X}-{node_id:016X}'
+        return instance_name
+
+    async def wait_for_srp_update(self, timeout_seconds: int = 600):
+        instance_qname = f"{self.get_dut_instance_name}.{MdnsServiceType.OPERATIONAL.value}"
+
+        # *** STEP 6 ***
+        # TH performs a query for the SRV record against the qname instance_qname.
+        self.step(6)
+        mdns = MdnsDiscovery()
+        srv_record = await mdns.get_srv_record(
+            service_name=instance_qname,
+            service_type=MdnsServiceType.OPERATIONAL.value,
+            query_timeout_sec=timeout_seconds,
+            log_output=True
+        )
+        srv_record_returned = srv_record is not None and srv_record.service_name == instance_qname
+        asserts.assert_true(srv_record_returned, "Unable to find device")
 
     async def validate_thread_dataset(self, dataset_bytes, dataset_name):
         """
@@ -375,16 +400,12 @@ class TC_CNET_4_12(MatterBaseTest):
             # device on the second network and by the networks attribute.
             pass
 
-        logger.info(f'Step #7: ConnectNetwork resp for THREAD_2ND: ({vars(resp)})')
-        logger.info(f'Step #7: ConnectNetwork Status for THREAD_2ND is success: ({resp.networkingStatus})')
-        # Verify that the DUT responds with AddThreadNConnectNetworketwork with NetworkingStatus as 'Success'(0)
-        asserts.assert_equal(resp.networkingStatus, Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess,
-                             "Failure status returned from ConnectNetwork")
-
         # TODO: Consider replacing the sleep (connect_max_time + fudge_factor) with dns-sd adverts check as improvement.
         # Wait for the device to establish connection with the new Thread network
         # Includes a fudge factor for SRP record propagation.
-        await asyncio.sleep(connect_max_time_seconds + fudge_factor_seconds)
+        logger.info(f"Step #7: Awaiting device on SRP")
+        await self.wait_for_srp_update()
+        self.default_controller.ExpireSessions(self.dut_node_id)
         logger.info("Step #7: Sleep completed for Thread network connection and SRP record propagation")
 
         self.step(8)
@@ -398,7 +419,7 @@ class TC_CNET_4_12(MatterBaseTest):
         await self.verify_thread_network_connected(networks, thread_network_id_bytes_th2, "THREAD_2ND", "#8")
 
         self.step(9)
-        # Expired session is re-established the new session reading attribute (Breadcrum)
+        # Expired session is re-established the new session reading attribute (Breadcrumb)
         breadcrumb_info = await self.read_single_attribute_check_success(
             cluster=Clusters.GeneralCommissioning,
             attribute=Clusters.GeneralCommissioning.Attributes.Breadcrumb
@@ -408,16 +429,19 @@ class TC_CNET_4_12(MatterBaseTest):
                              "The Breadcrumb attribute is not 2")
 
         self.step(10)
-        cmd = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=0)
-        resp = await self.send_single_cmd(
-            dev_ctrl=self.default_controller,
-            node_id=self.dut_node_id,
-            cmd=cmd
-        )
-        # Verify that the DUT responds with ArmFailSafeResponse with ErrorCode as 'OK'(0)
-        logger.info(f'Step #10: ArmFailSafeResponse with ErrorCode as OK: ({resp.errorCode})')
-        asserts.assert_equal(resp.errorCode, Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk,
-                             "Failure status returned from arm failsafe")
+        try:
+            cmd = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=0)
+            resp = await self.send_single_cmd(
+                dev_ctrl=self.default_controller,
+                node_id=self.dut_node_id,
+                cmd=cmd
+            )
+            # Verify that the DUT responds with ArmFailSafeResponse with ErrorCode as 'OK'(0)
+            logger.info(f'Step #10: ArmFailSafeResponse with ErrorCode as OK: ({resp.errorCode})')
+            asserts.assert_equal(resp.errorCode, Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk,
+                                 "Failure status returned from arm failsafe")
+        except ChipStackError:
+            pass
 
         self.step(11)
         # Step 11: When the failsafe is disarmed, the device should automatically return to THREAD_1ST.
@@ -426,7 +450,9 @@ class TC_CNET_4_12(MatterBaseTest):
         logger.info('Step #11: DUT automatically return to THREAD_1ST')
 
         # Wait for reconnection.
-        await asyncio.sleep(connect_max_time_seconds + fudge_factor_seconds)
+        logger.info(f"Step #11: Awaiting device on SRP")
+        await self.wait_for_srp_update()
+        self.default_controller.ExpireSessions(self.dut_node_id)
 
         self.step(12)
         networks = await self.read_single_attribute_check_success(
@@ -435,20 +461,17 @@ class TC_CNET_4_12(MatterBaseTest):
         )
         logger.info(f'Step #12: Networks attribute: {networks}')
 
-        # Session expired and re-establish the new session reading attribute (Breadcrum)
-        await asyncio.sleep(connect_max_time_seconds + 5)
+        # Session expired and re-establish the new session reading attribute (Breadcrumb)
         breadcrumb_info = await self.read_single_attribute_check_success(
             cluster=Clusters.GeneralCommissioning,
             attribute=Clusters.GeneralCommissioning.Attributes.Breadcrumb
         )
         logger.info(f'Step #12: Breadcrumb attribute: {breadcrumb_info}')
-
-        await asyncio.sleep(connect_max_time_seconds + 5)
         networks = await self.read_single_attribute_check_success(
             cluster=Clusters.NetworkCommissioning,
             attribute=Clusters.NetworkCommissioning.Attributes.Networks
         )
-        logger.info(f'Step #12: Networks attribute after read atribute: {networks}')
+        logger.info(f'Step #12: Networks attribute after read attribute: {networks}')
         await self.verify_thread_network_connected(networks, thread_network_id_bytes_th1, "THREAD_1ST", "#12")
 
         self.step(13)
@@ -503,21 +526,22 @@ class TC_CNET_4_12(MatterBaseTest):
         )
         logger.info(f'Step #16: Networks attribute: {networks}')
 
-        cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=thread_network_id_bytes_th2, breadcrumb=3)
-        resp = await self.send_single_cmd(
-            dev_ctrl=self.default_controller,
-            node_id=self.dut_node_id,
-            cmd=cmd
-        )
-        logger.info(f'Step #16: ConnectNetwork resp for THREAD_2ND: ({vars(resp)})')
-        logger.info(f'Step #16: ConnectNetwork Status for THREAD_2ND is success ({resp.networkingStatus})')
-        # Verify that the DUT responds with AddThreadNConnectNetworketwork with NetworkingStatus as 'Success'(0)
-        asserts.assert_equal(resp.networkingStatus, Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess,
-                             "Failure status returned from ConnectNetwork")
+        try:
+            cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=thread_network_id_bytes_th2, breadcrumb=3)
+            resp = await self.send_single_cmd(
+                dev_ctrl=self.default_controller,
+                node_id=self.dut_node_id,
+                cmd=cmd
+            )
+        except ChipStackError:
+            pass
 
         # Wait for the device to establish connection with the new Thread network
         # Includes a fudge factor for SRP record propagation.
-        await asyncio.sleep(connect_max_time_seconds + fudge_factor_seconds)
+        logger.info(f"Step #16: Awaiting device on SRP")
+        await self.wait_for_srp_update()
+        self.default_controller.ExpireSessions(self.dut_node_id)
+
         logger.info("Step #16: Sleep completed for Thread network connection and SRP record propagation")
 
         self.step(17)
@@ -538,11 +562,6 @@ class TC_CNET_4_12(MatterBaseTest):
         logger.info(f'Step #18:  Breadcrumb attribute: {breadcrumb_info}')
         asserts.assert_equal(breadcrumb_info, 3,
                              "The Breadcrumb attribute is not 3")
-
-        # Wait for the device to establish connection with the new Thread network
-        # Includes a fudge factor for SRP record propagation.
-        await asyncio.sleep(connect_max_time_seconds + fudge_factor_seconds)
-        logger.info("Step #18: Sleep completed for Thread network connection and SRP record propagation")
 
         self.step(19)
         cmd = Clusters.GeneralCommissioning.Commands.CommissioningComplete()
@@ -613,20 +632,21 @@ class TC_CNET_4_12(MatterBaseTest):
             networkID=thread_network_id_bytes_th1
         )
 
-        resp = await self.send_single_cmd(
-            dev_ctrl=self.default_controller,
-            node_id=self.dut_node_id,
-            cmd=cmd
-        )
-        logger.info(f'Step #21: ConnectNetwork resp for for THREAD_1ST: ({vars(resp)})')
-        # Verify that the DUT responds with ConnectNetwork with NetworkingStatus as 'Success'(0)
-        asserts.assert_equal(resp.networkingStatus, Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess,
-                             "Failure status returned from ConnectNetwork")
+        try:
+            resp = await self.send_single_cmd(
+                dev_ctrl=self.default_controller,
+                node_id=self.dut_node_id,
+                cmd=cmd
+            )
+        except ChipStackError:
+            pass
 
         # TODO: Consider replacing the sleep (connect_max_time + fudge_factor) with dns-sd adverts check as improvement.
         # Wait for the device to establish connection with the new Thread network
         # Includes a fudge factor for SRP record propagation.
-        await asyncio.sleep(connect_max_time_seconds + fudge_factor_seconds)
+        logger.info(f"Step #21: Awaiting device on SRP")
+        await self.wait_for_srp_update()
+        self.default_controller.ExpireSessions(self.dut_node_id)
         logger.info("Step #21: Sleep completed for Thread network connection and SRP record propagation")
 
         # THREAD_1ST Successfully connects to the DUT from previous step

--- a/src/python_testing/TC_CNET_4_12.py
+++ b/src/python_testing/TC_CNET_4_12.py
@@ -361,20 +361,12 @@ class TC_CNET_4_12(MatterBaseTest):
         )
 
         self.step(7)
-        try:
-            cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=thread_network_id_bytes_th2, breadcrumb=2)
-            resp = await self.send_single_cmd(
-                dev_ctrl=self.default_controller,
-                node_id=self.dut_node_id,
-                cmd=cmd
-            )
-        except ChipStackError:
-            # This is OK - if the device does not send the response before swapping networks
-            # then we will not receive a response and that is fine.
-            # Will will be able to tell if this succeeded by whether we can reach the
-            # device on the second network and by the networks attribute.
-            pass
-
+        cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=thread_network_id_bytes_th2, breadcrumb=2)
+        resp = await self.send_single_cmd(
+            dev_ctrl=self.default_controller,
+            node_id=self.dut_node_id,
+            cmd=cmd
+        )
         logger.info(f'Step #7: ConnectNetwork resp for THREAD_2ND: ({vars(resp)})')
         logger.info(f'Step #7: ConnectNetwork Status for THREAD_2ND is success: ({resp.networkingStatus})')
         # Verify that the DUT responds with AddThreadNConnectNetworketwork with NetworkingStatus as 'Success'(0)
@@ -424,9 +416,6 @@ class TC_CNET_4_12(MatterBaseTest):
         # This means the THREAD_2ND network will be removed,
         # and the device will reconnect to Thread 1 without further intervention.
         logger.info('Step #11: DUT automatically return to THREAD_1ST')
-
-        # Wait for reconnection.
-        await asyncio.sleep(connect_max_time_seconds + fudge_factor_seconds)
 
         self.step(12)
         networks = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_CNET_4_12.py
+++ b/src/python_testing/TC_CNET_4_12.py
@@ -361,12 +361,20 @@ class TC_CNET_4_12(MatterBaseTest):
         )
 
         self.step(7)
-        cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=thread_network_id_bytes_th2, breadcrumb=2)
-        resp = await self.send_single_cmd(
-            dev_ctrl=self.default_controller,
-            node_id=self.dut_node_id,
-            cmd=cmd
-        )
+        try:
+            cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=thread_network_id_bytes_th2, breadcrumb=2)
+            resp = await self.send_single_cmd(
+                dev_ctrl=self.default_controller,
+                node_id=self.dut_node_id,
+                cmd=cmd
+            )
+        except ChipStackError:
+            # This is OK - if the device does not send the response before swapping networks
+            # then we will not receive a response and that is fine.
+            # Will will be able to tell if this succeeded by whether we can reach the
+            # device on the second network and by the networks attribute.
+            pass
+
         logger.info(f'Step #7: ConnectNetwork resp for THREAD_2ND: ({vars(resp)})')
         logger.info(f'Step #7: ConnectNetwork Status for THREAD_2ND is success: ({resp.networkingStatus})')
         # Verify that the DUT responds with AddThreadNConnectNetworketwork with NetworkingStatus as 'Success'(0)
@@ -416,6 +424,9 @@ class TC_CNET_4_12(MatterBaseTest):
         # This means the THREAD_2ND network will be removed,
         # and the device will reconnect to Thread 1 without further intervention.
         logger.info('Step #11: DUT automatically return to THREAD_1ST')
+
+        # Wait for reconnection.
+        await asyncio.sleep(connect_max_time_seconds + fudge_factor_seconds)
 
         self.step(12)
         networks = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_CNET_4_12.py
+++ b/src/python_testing/TC_CNET_4_12.py
@@ -59,12 +59,9 @@ class TC_CNET_4_12(MatterBaseTest):
         instance_name = f'{compressed_fabric_id:016X}-{node_id:016X}'
         return instance_name
 
-    async def wait_for_srp_update(self, timeout_seconds: int = 600):
+    async def wait_for_srp_update(self, timeout_seconds: int = 180):
         instance_qname = f"{self.get_dut_instance_name}.{MdnsServiceType.OPERATIONAL.value}"
 
-        # *** STEP 6 ***
-        # TH performs a query for the SRV record against the qname instance_qname.
-        self.step(6)
         mdns = MdnsDiscovery()
         srv_record = await mdns.get_srv_record(
             service_name=instance_qname,

--- a/src/python_testing/TC_CNET_4_12.py
+++ b/src/python_testing/TC_CNET_4_12.py
@@ -60,7 +60,7 @@ class TC_CNET_4_12(MatterBaseTest):
         return instance_name
 
     async def wait_for_srp_update(self, timeout_seconds: int = 180):
-        instance_qname = f"{self.get_dut_instance_name}.{MdnsServiceType.OPERATIONAL.value}"
+        instance_qname = f"{self.get_dut_instance_name()}.{MdnsServiceType.OPERATIONAL.value}"
 
         mdns = MdnsDiscovery()
         srv_record = await mdns.get_srv_record(

--- a/src/python_testing/TC_CNET_4_12.py
+++ b/src/python_testing/TC_CNET_4_12.py
@@ -59,9 +59,12 @@ class TC_CNET_4_12(MatterBaseTest):
         instance_name = f'{compressed_fabric_id:016X}-{node_id:016X}'
         return instance_name
 
-    async def wait_for_srp_update(self, timeout_seconds: int = 180):
+    async def wait_for_srp_update(self, timeout_seconds: int = 600):
         instance_qname = f"{self.get_dut_instance_name}.{MdnsServiceType.OPERATIONAL.value}"
 
+        # *** STEP 6 ***
+        # TH performs a query for the SRV record against the qname instance_qname.
+        self.step(6)
         mdns = MdnsDiscovery()
         srv_record = await mdns.get_srv_record(
             service_name=instance_qname,

--- a/src/python_testing/TC_EEVSE_Utils.py
+++ b/src/python_testing/TC_EEVSE_Utils.py
@@ -88,7 +88,7 @@ class EEVSEBaseTestHelper:
 
             # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
-                                 "Unexpected error returned")
+                                 f"Unexpected Success returned when expected {expected_status}")
 
         except InteractionModelError as e:
             # The command failed, which might be what we expected, check if it is the expected error
@@ -113,7 +113,7 @@ class EEVSEBaseTestHelper:
 
             # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
-                                 "Unexpected error returned")
+                                 f"Unexpected Success returned when expected {expected_status}")
 
         except InteractionModelError as e:
             # The command failed, which might be what we expected, check if it is the expected error
@@ -128,7 +128,7 @@ class EEVSEBaseTestHelper:
 
             # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
-                                 "Unexpected error returned")
+                                 f"Unexpected Success returned when expected {expected_status}")
 
         except InteractionModelError as e:
             # The command failed, which might be what we expected, check if it is the expected error
@@ -144,7 +144,7 @@ class EEVSEBaseTestHelper:
 
             # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
-                                 "Unexpected error returned")
+                                 f"Unexpected Success returned when expected {expected_status}")
 
         except InteractionModelError as e:
             # The command failed, which might be what we expected, check if it is the expected error
@@ -160,7 +160,7 @@ class EEVSEBaseTestHelper:
 
             # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
-                                 "Unexpected error returned")
+                                 f"Unexpected Success returned when expected {expected_status}")
 
         except InteractionModelError as e:
             # The command failed, which might be what we expected, check if it is the expected error
@@ -176,7 +176,7 @@ class EEVSEBaseTestHelper:
 
             # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
-                                 "Unexpected error returned")
+                                f"Unexpected Success returned when expected {expected_status}")
 
         except InteractionModelError as e:
             # The command failed, which might be what we expected, check if it is the expected error
@@ -197,7 +197,7 @@ class EEVSEBaseTestHelper:
 
             # If the command was expected to fail but it succeeded, check it wasn't meant to fail            
             asserts.assert_equal(expected_status, Status.Success,
-                                 "Unexpected error returned")
+                                 f"Unexpected Success returned when expected {expected_status}")
 
         except InteractionModelError as e:
             # The command failed, which might be what we expected, check if it is the expected error

--- a/src/python_testing/TC_EEVSE_Utils.py
+++ b/src/python_testing/TC_EEVSE_Utils.py
@@ -300,7 +300,7 @@ class EEVSEBaseTestHelper:
 
         logger.info(
             f"minutesPastMidnight = {minutes_past_midnight} => "
-            f"{int(minutes_past_midnight/60)}:{int(minutes_past_midnight%60)}"
+            f"{int(minutes_past_midnight/60)}:{int(minutes_past_midnight % 60)}"
             f" Expected target_time = {target_time}")
 
         # Matter Epoch is 1st Jan 2000

--- a/src/python_testing/TC_EEVSE_Utils.py
+++ b/src/python_testing/TC_EEVSE_Utils.py
@@ -176,7 +176,7 @@ class EEVSEBaseTestHelper:
 
             # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
-                                f"Unexpected Success returned when expected {expected_status}")
+                                 f"Unexpected Success returned when expected {expected_status}")
 
         except InteractionModelError as e:
             # The command failed, which might be what we expected, check if it is the expected error
@@ -195,7 +195,7 @@ class EEVSEBaseTestHelper:
                                        endpoint=endpoint,
                                        timedRequestTimeoutMs=timedRequestTimeoutMs)
 
-            # If the command was expected to fail but it succeeded, check it wasn't meant to fail            
+            # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
                                  f"Unexpected Success returned when expected {expected_status}")
 

--- a/src/python_testing/TC_EEVSE_Utils.py
+++ b/src/python_testing/TC_EEVSE_Utils.py
@@ -86,10 +86,12 @@ class EEVSEBaseTestHelper:
                     endpoint=endpoint,
                     timedRequestTimeoutMs=timedRequestTimeoutMs)
 
+            # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
                                  "Unexpected error returned")
 
         except InteractionModelError as e:
+            # The command failed, which might be what we expected, check if it is the expected error
             asserts.assert_equal(e.status, expected_status,
                                  "Unexpected error returned")
 
@@ -109,10 +111,12 @@ class EEVSEBaseTestHelper:
                     endpoint=endpoint,
                     timedRequestTimeoutMs=timedRequestTimeoutMs)
 
+            # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
                                  "Unexpected error returned")
 
         except InteractionModelError as e:
+            # The command failed, which might be what we expected, check if it is the expected error
             asserts.assert_equal(e.status, expected_status,
                                  "Unexpected error returned")
 
@@ -122,10 +126,12 @@ class EEVSEBaseTestHelper:
                                        endpoint=endpoint,
                                        timedRequestTimeoutMs=timedRequestTimeoutMs)
 
+            # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
                                  "Unexpected error returned")
 
         except InteractionModelError as e:
+            # The command failed, which might be what we expected, check if it is the expected error
             asserts.assert_equal(e.status, expected_status,
                                  "Unexpected error returned")
 
@@ -136,10 +142,12 @@ class EEVSEBaseTestHelper:
                                        endpoint=endpoint,
                                        timedRequestTimeoutMs=timedRequestTimeoutMs)
 
+            # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
                                  "Unexpected error returned")
 
         except InteractionModelError as e:
+            # The command failed, which might be what we expected, check if it is the expected error
             asserts.assert_equal(e.status, expected_status,
                                  "Unexpected error returned")
 
@@ -150,10 +158,12 @@ class EEVSEBaseTestHelper:
                                        endpoint=endpoint,
                                        timedRequestTimeoutMs=timedRequestTimeoutMs)
 
+            # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
                                  "Unexpected error returned")
 
         except InteractionModelError as e:
+            # The command failed, which might be what we expected, check if it is the expected error
             asserts.assert_equal(e.status, expected_status,
                                  "Unexpected error returned")
 
@@ -163,10 +173,13 @@ class EEVSEBaseTestHelper:
             get_targets_resp = await self.send_single_cmd(cmd=Clusters.EnergyEvse.Commands.GetTargets(),
                                                           endpoint=endpoint,
                                                           timedRequestTimeoutMs=timedRequestTimeoutMs)
+
+            # If the command was expected to fail but it succeeded, check it wasn't meant to fail
             asserts.assert_equal(expected_status, Status.Success,
                                  "Unexpected error returned")
 
         except InteractionModelError as e:
+            # The command failed, which might be what we expected, check if it is the expected error
             asserts.assert_equal(e.status, expected_status,
                                  "Unexpected error returned")
 
@@ -181,10 +194,13 @@ class EEVSEBaseTestHelper:
             await self.send_single_cmd(cmd=Clusters.EnergyEvse.Commands.SetTargets(chargingTargetSchedules),
                                        endpoint=endpoint,
                                        timedRequestTimeoutMs=timedRequestTimeoutMs)
+
+            # If the command was expected to fail but it succeeded, check it wasn't meant to fail            
             asserts.assert_equal(expected_status, Status.Success,
                                  "Unexpected error returned")
 
         except InteractionModelError as e:
+            # The command failed, which might be what we expected, check if it is the expected error
             asserts.assert_equal(e.status, expected_status,
                                  "Unexpected error returned")
 

--- a/src/python_testing/TC_EEVSE_Utils.py
+++ b/src/python_testing/TC_EEVSE_Utils.py
@@ -164,6 +164,8 @@ class EEVSEBaseTestHelper:
             await self.send_single_cmd(cmd=Clusters.EnergyEvse.Commands.SetTargets(chargingTargetSchedules),
                                        endpoint=endpoint,
                                        timedRequestTimeoutMs=timedRequestTimeoutMs)
+            asserts.assert_equal(expected_status, Status.Success,
+                                 "Unexpected error returned")
 
         except InteractionModelError as e:
             asserts.assert_equal(e.status, expected_status,

--- a/src/python_testing/TC_EEVSE_Utils.py
+++ b/src/python_testing/TC_EEVSE_Utils.py
@@ -86,6 +86,9 @@ class EEVSEBaseTestHelper:
                     endpoint=endpoint,
                     timedRequestTimeoutMs=timedRequestTimeoutMs)
 
+            asserts.assert_equal(expected_status, Status.Success,
+                                 "Unexpected error returned")
+
         except InteractionModelError as e:
             asserts.assert_equal(e.status, expected_status,
                                  "Unexpected error returned")
@@ -106,6 +109,9 @@ class EEVSEBaseTestHelper:
                     endpoint=endpoint,
                     timedRequestTimeoutMs=timedRequestTimeoutMs)
 
+            asserts.assert_equal(expected_status, Status.Success,
+                                 "Unexpected error returned")
+
         except InteractionModelError as e:
             asserts.assert_equal(e.status, expected_status,
                                  "Unexpected error returned")
@@ -115,6 +121,9 @@ class EEVSEBaseTestHelper:
             await self.send_single_cmd(cmd=Clusters.EnergyEvse.Commands.Disable(),
                                        endpoint=endpoint,
                                        timedRequestTimeoutMs=timedRequestTimeoutMs)
+
+            asserts.assert_equal(expected_status, Status.Success,
+                                 "Unexpected error returned")
 
         except InteractionModelError as e:
             asserts.assert_equal(e.status, expected_status,
@@ -127,6 +136,9 @@ class EEVSEBaseTestHelper:
                                        endpoint=endpoint,
                                        timedRequestTimeoutMs=timedRequestTimeoutMs)
 
+            asserts.assert_equal(expected_status, Status.Success,
+                                 "Unexpected error returned")
+
         except InteractionModelError as e:
             asserts.assert_equal(e.status, expected_status,
                                  "Unexpected error returned")
@@ -138,6 +150,9 @@ class EEVSEBaseTestHelper:
                                        endpoint=endpoint,
                                        timedRequestTimeoutMs=timedRequestTimeoutMs)
 
+            asserts.assert_equal(expected_status, Status.Success,
+                                 "Unexpected error returned")
+
         except InteractionModelError as e:
             asserts.assert_equal(e.status, expected_status,
                                  "Unexpected error returned")
@@ -148,6 +163,8 @@ class EEVSEBaseTestHelper:
             get_targets_resp = await self.send_single_cmd(cmd=Clusters.EnergyEvse.Commands.GetTargets(),
                                                           endpoint=endpoint,
                                                           timedRequestTimeoutMs=timedRequestTimeoutMs)
+            asserts.assert_equal(expected_status, Status.Success,
+                                 "Unexpected error returned")
 
         except InteractionModelError as e:
             asserts.assert_equal(e.status, expected_status,


### PR DESCRIPTION
#### Summary

The current logic is:
- send command
- if success return
- if error, make sure error is expected error

But if you're expecting an error, then a success return is also incorrect and there needs to be an additional assertion there. 

This is initially going to cause a failure in the CI and does locally. There are two problems here:
1) DUT is incorrectly returning success
2) Test is not catching that success response != RESOURCE_EXHAUSTED

First commit fixes the test so we can see the failure, next commit will fix the example

#### Related issues


#### Testing
Local and CI. Will show first run with failure. 

Ran all TC_EEVSE_2.x python scripts locally with these changes.
NOTE: only TC_EEVSE_2.3 & 2.5 should be impacted by the change to TC_EEVSE_Utils.py since none of the other scripts are looking for command failures.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
