### PR TITLE
Dependency injection decoupling - General Commissioning Cluster

### DIFF
--- a/src/app/clusters/general-commissioning-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-commissioning-server/CodegenIntegration.cpp
@@ -60,20 +60,19 @@ public:
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
 
-        gServer.Create(GeneralCommissioningCluster::Context {
-            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
-                .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
-                .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-                .fabricTable            = Server::GetInstance().GetFabricTable(),                //
-                .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
-                .platformManager        = DeviceLayer::PlatformMgr(),                            //
+        gServer.Create(
+            GeneralCommissioningCluster::Context {
+                .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
+                    .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
+                    .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                    .fabricTable            = Server::GetInstance().GetFabricTable(),                //
+                    .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
+                    .platformManager        = DeviceLayer::PlatformMgr(),                            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+                    .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-        });
-
-        // Configure optional attributes based on fetched bits
-        gServer.Cluster().GetOptionalAttributes() = GeneralCommissioningCluster::OptionalAttributes(optionalAttributeBits);
+            },
+            GeneralCommissioningCluster::OptionalAttributes(optionalAttributeBits));
 
         return gServer.Registration();
     }

--- a/src/app/clusters/general-commissioning-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/general-commissioning-server/app_config_dependent_sources.cmake
@@ -18,6 +18,7 @@ TARGET_SOURCES(
   ${APP_TARGET}
   PRIVATE
     "${CLUSTER_DIR}/CodegenIntegration.cpp"
+    "${CLUSTER_DIR}/CodegenIntegration.h"
 )
 
 # These are the things that BUILD.gn dependencies would pull

--- a/src/app/clusters/general-commissioning-server/general-commissioning-cluster.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-cluster.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "general-commissioning-cluster.h"
+#include "platform/ConfigurationManager.h"
 
 #include <app/AppConfig.h>
 #include <app/reporting/reporting.h>
@@ -32,9 +33,8 @@
 #include <transport/SecureSession.h>
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-#include <app/server/TermsAndConditionsManager.h>  //nogncheck
-#include <app/server/TermsAndConditionsProvider.h> //nogncheck
-#endif
+#include <app/server/TermsAndConditionsManager.h> //nogncheck
+#endif                                            // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
 
 using namespace chip;
 using namespace chip::app;
@@ -57,10 +57,11 @@ namespace {
         }                                                                                                                          \
     } while (false)
 
-CHIP_ERROR ReadIfSupported(CHIP_ERROR (ConfigurationManager::*getter)(uint8_t &), AttributeValueEncoder & aEncoder)
+CHIP_ERROR ReadIfSupported(ConfigurationManager & mgr, CHIP_ERROR (ConfigurationManager::*getter)(uint8_t &),
+                           AttributeValueEncoder & aEncoder)
 {
     uint8_t data   = 0;
-    CHIP_ERROR err = (DeviceLayer::ConfigurationMgr().*getter)(data);
+    CHIP_ERROR err = (mgr.*getter)(data);
     if (err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
     {
         data = 0;
@@ -139,18 +140,20 @@ void NotifyTermsAndConditionsAttributeChangeIfRequired(const TermsAndConditionsS
 }
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
 
-void OnPlatformEventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t self)
+void OnPlatformEventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
     if (event->Type == DeviceLayer::DeviceEventType::kFailSafeTimerExpired)
     {
+        auto self = reinterpret_cast<GeneralCommissioningCluster *>(arg);
+
         // Spec says to reset Breadcrumb attribute to 0.
-        reinterpret_cast<GeneralCommissioningCluster *>(self)->SetBreadCrumb(0);
+        self->SetBreadCrumb(0);
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         if (event->FailSafeTimerExpired.updateTermsAndConditionsHasBeenInvoked)
         {
             // Clear terms and conditions acceptance on failsafe timer expiration
-            TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
+            TermsAndConditionsProvider & tcProvider = self->ClusterContext().termsAndConditionsProvider;
             TermsAndConditionsState initialState, updatedState;
             VerifyOrReturn(CHIP_NO_ERROR == GetTermsAndConditionsAttributeState(tcProvider, initialState));
             VerifyOrReturn(CHIP_NO_ERROR == tcProvider.RevertAcceptance());
@@ -190,56 +193,44 @@ DataModel::ActionReturnStatus GeneralCommissioningCluster::ReadAttribute(const D
         return encoder.Encode(info);
     }
     case RegulatoryConfig::Id:
-        return ReadIfSupported(&ConfigurationManager::GetRegulatoryLocation, encoder);
+        return ReadIfSupported(mClusterContext.configurationManager, &ConfigurationManager::GetRegulatoryLocation, encoder);
     case LocationCapability::Id:
-        return ReadIfSupported(&ConfigurationManager::GetLocationCapability, encoder);
+        return ReadIfSupported(mClusterContext.configurationManager, &ConfigurationManager::GetLocationCapability, encoder);
     case SupportsConcurrentConnection::Id:
         return encoder.Encode(CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION != 0);
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
     case TCAcceptedVersion::Id: {
-        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
         Optional<TermsAndConditions> outTermsAndConditions;
-
-        ReturnErrorOnFailure(tcProvider.GetAcceptance(outTermsAndConditions));
-
+        ReturnErrorOnFailure(mClusterContext.termsAndConditionsProvider.GetAcceptance(outTermsAndConditions));
         return encoder.Encode(outTermsAndConditions.ValueOr(TermsAndConditions(0, 0)).GetVersion());
     }
     case TCMinRequiredVersion::Id: {
-        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
         Optional<TermsAndConditions> outTermsAndConditions;
 
-        ReturnErrorOnFailure(tcProvider.GetRequirements(outTermsAndConditions));
-
+        ReturnErrorOnFailure(mClusterContext.termsAndConditionsProvider.GetRequirements(outTermsAndConditions));
         return encoder.Encode(outTermsAndConditions.ValueOr(TermsAndConditions(0, 0)).GetVersion());
     }
     case TCAcknowledgements::Id: {
-        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
         Optional<TermsAndConditions> outTermsAndConditions;
 
-        ReturnErrorOnFailure(tcProvider.GetAcceptance(outTermsAndConditions));
-
+        ReturnErrorOnFailure(mClusterContext.termsAndConditionsProvider.GetAcceptance(outTermsAndConditions));
         return encoder.Encode(outTermsAndConditions.ValueOr(TermsAndConditions(0, 0)).GetValue());
     }
     case TCAcknowledgementsRequired::Id: {
-        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
         bool acknowledgementsRequired;
-
-        ReturnErrorOnFailure(tcProvider.GetAcknowledgementsRequired(acknowledgementsRequired));
-
+        ReturnErrorOnFailure(mClusterContext.termsAndConditionsProvider.GetAcknowledgementsRequired(acknowledgementsRequired));
         return encoder.Encode(acknowledgementsRequired);
     }
     case TCUpdateDeadline::Id: {
-        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
         Optional<uint32_t> outUpdateAcceptanceDeadline;
+        ReturnErrorOnFailure(mClusterContext.termsAndConditionsProvider.GetUpdateAcceptanceDeadline(outUpdateAcceptanceDeadline));
 
-        ReturnErrorOnFailure(tcProvider.GetUpdateAcceptanceDeadline(outUpdateAcceptanceDeadline));
-
+        // NOTE: encoding an optional as a Nullable (they are not fully compatible)
         if (!outUpdateAcceptanceDeadline.HasValue())
         {
             return encoder.EncodeNull();
         }
-
         return encoder.Encode(outUpdateAcceptanceDeadline.Value());
     }
 #endif
@@ -372,12 +363,12 @@ void GeneralCommissioningCluster::OnFabricRemoved(const FabricTable & fabricTabl
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
     // If the FabricIndex matches the last remaining entry in the Fabrics list, then the device SHALL delete all Matter
     // related data on the node which was created since it was commissioned.
-    if (Server::GetInstance().GetFabricTable().FabricCount() == 0)
+    if (fabricTable.FabricCount() == 0)
     {
         ChipLogProgress(Zcl, "general-commissioning-server: Last Fabric index 0x%x was removed",
                         static_cast<unsigned>(fabricIndex));
 
-        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
+        TermsAndConditionsProvider & tcProvider = mClusterContext.termsAndConditionsProvider;
         TermsAndConditionsState initialState, updatedState;
         VerifyOrReturn(CHIP_NO_ERROR == GetTermsAndConditionsAttributeState(tcProvider, initialState));
         VerifyOrReturn(CHIP_NO_ERROR == tcProvider.ResetAcceptance());
@@ -397,15 +388,15 @@ void GeneralCommissioningCluster::SetBreadCrumb(uint64_t value)
 CHIP_ERROR GeneralCommissioningCluster::Startup(ServerClusterContext & context)
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
-    PlatformMgrImpl().AddEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
-    Server::GetInstance().GetFabricTable().AddFabricDelegate(this);
+    mClusterContext.platformManager.AddEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
+    mClusterContext.fabricTable.AddFabricDelegate(this);
     return CHIP_NO_ERROR;
 }
 
 void GeneralCommissioningCluster::Shutdown()
 {
-    PlatformMgrImpl().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
-    Server::GetInstance().GetFabricTable().RemoveFabricDelegate(this);
+    mClusterContext.platformManager.RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
+    mClusterContext.fabricTable.RemoveFabricDelegate(this);
     DefaultServerCluster::Shutdown();
 }
 
@@ -414,7 +405,7 @@ GeneralCommissioningCluster::HandleArmFailSafe(const DataModel::InvokeRequest & 
                                                const GeneralCommissioning::Commands::ArmFailSafe::DecodableType & commandData)
 {
     MATTER_TRACE_SCOPE("ArmFailSafe", "GeneralCommissioning");
-    auto & failSafeContext = Server::GetInstance().GetFailSafeContext();
+    auto & failSafeContext = mClusterContext.failsafeContext;
     Commands::ArmFailSafeResponse::Type response;
 
     ChipLogProgress(FailSafe, "GeneralCommissioning: Received ArmFailSafe (%us)",
@@ -435,8 +426,7 @@ GeneralCommissioningCluster::HandleArmFailSafe(const DataModel::InvokeRequest & 
     {
         // We do not allow CASE connections to arm the failsafe for the first time while the commissioning window is open in order
         // to allow commissioners the opportunity to obtain this failsafe for the purpose of commissioning
-        if (!failSafeContext.IsFailSafeArmed() &&
-            Server::GetInstance().GetCommissioningWindowManager().IsCommissioningWindowOpen() &&
+        if (!failSafeContext.IsFailSafeArmed() && mClusterContext.commissioningWindowManager.IsCommissioningWindowOpen() &&
             request.subjectDescriptor->authMode == Access::AuthMode::kCase)
         {
             response.errorCode = CommissioningErrorEnum::kBusyWithOtherAdmin;
@@ -472,9 +462,7 @@ GeneralCommissioningCluster::HandleCommissioningComplete(const DataModel::Invoke
 {
     MATTER_TRACE_SCOPE("CommissioningComplete", "GeneralCommissioning");
 
-    DeviceControlServer * devCtrl = &DeviceLayer::DeviceControlServer::DeviceControlSvr();
-    auto & failSafe               = Server::GetInstance().GetFailSafeContext();
-    auto & fabricTable            = Server::GetInstance().GetFabricTable();
+    auto & failSafe = mClusterContext.failsafeContext;
 
     ChipLogProgress(FailSafe, "GeneralCommissioning: Received CommissioningComplete");
 
@@ -490,7 +478,7 @@ GeneralCommissioningCluster::HandleCommissioningComplete(const DataModel::Invoke
     }
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-    TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
+    TermsAndConditionsProvider & tcProvider = mClusterContext.termsAndConditionsProvider;
 
     // Ensure required terms and conditions have been accepted, then attempt to commit
     Optional<TermsAndConditions> requiredTermsAndConditionsMaybe;
@@ -559,7 +547,7 @@ GeneralCommissioningCluster::HandleCommissioningComplete(const DataModel::Invoke
     // Handle NOC commands
     if (failSafe.NocCommandHasBeenInvoked())
     {
-        err = fabricTable.CommitPendingFabricData();
+        err = mClusterContext.fabricTable.CommitPendingFabricData();
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(FailSafe, "GeneralCommissioning: Failed to commit pending fabric data: %" CHIP_ERROR_FORMAT, err.Format());
@@ -574,7 +562,8 @@ GeneralCommissioningCluster::HandleCommissioningComplete(const DataModel::Invoke
 
     // Disarm the fail-safe and notify the DeviceControlServer
     failSafe.DisarmFailSafe();
-    err = devCtrl->PostCommissioningCompleteEvent(handle->AsSecureSession()->GetPeerNodeId(), handle->GetFabricIndex());
+    err = mClusterContext.deviceControlServer.PostCommissioningCompleteEvent(handle->AsSecureSession()->GetPeerNodeId(),
+                                                                             handle->GetFabricIndex());
     CheckSuccess(err, Failure);
 
     SetBreadCrumb(0);
@@ -588,7 +577,6 @@ GeneralCommissioningCluster::HandleSetRegulatoryConfig(const DataModel::InvokeRe
                                                        const Commands::SetRegulatoryConfig::DecodableType & commandData)
 {
     MATTER_TRACE_SCOPE("SetRegulatoryConfig", "GeneralCommissioning");
-    DeviceControlServer * server = &DeviceLayer::DeviceControlServer::DeviceControlSvr();
     Commands::SetRegulatoryConfigResponse::Type response;
     auto & countryCode = commandData.countryCode;
 
@@ -606,7 +594,7 @@ GeneralCommissioningCluster::HandleSetRegulatoryConfig(const DataModel::InvokeRe
     }
 
     uint8_t locationCapability;
-    if (ConfigurationMgr().GetLocationCapability(locationCapability) != CHIP_NO_ERROR)
+    if (mClusterContext.configurationManager.GetLocationCapability(locationCapability) != CHIP_NO_ERROR)
     {
         return Protocols::InteractionModel::Status::Failure;
     }
@@ -622,7 +610,7 @@ GeneralCommissioningCluster::HandleSetRegulatoryConfig(const DataModel::InvokeRe
         return std::nullopt;
     }
 
-    CheckSuccess(server->SetRegulatoryConfig(location, countryCode), Failure);
+    CheckSuccess(mClusterContext.deviceControlServer.SetRegulatoryConfig(location, countryCode), Failure);
     SetBreadCrumb(commandData.breadcrumb);
     response.errorCode = CommissioningErrorEnum::kOk;
     handler->AddResponse(request.path, response);
@@ -636,8 +624,8 @@ GeneralCommissioningCluster::HandleSetTCAcknowledgements(const DataModel::Invoke
 {
     MATTER_TRACE_SCOPE("SetTCAcknowledgements", "GeneralCommissioning");
 
-    auto & failSafeContext                  = Server::GetInstance().GetFailSafeContext();
-    TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
+    auto & failSafeContext                  = mClusterContext.failsafeContext;
+    TermsAndConditionsProvider & tcProvider = mClusterContext.termsAndConditionsProvider;
 
     Optional<TermsAndConditions> requiredTermsAndConditionsMaybe;
     Optional<TermsAndConditions> previousAcceptedTermsAndConditionsMaybe;

--- a/src/app/clusters/general-commissioning-server/general-commissioning-cluster.h
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-cluster.h
@@ -60,12 +60,11 @@ public:
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
     };
 
-    GeneralCommissioningCluster(Context && context) :
+    GeneralCommissioningCluster(Context && context, const OptionalAttributes & attrs) :
         DefaultServerCluster({ kRootEndpointId, GeneralCommissioning::Id }), mClusterContext(std::move(context)),
-        mOptionalAttributes(0)
+        mOptionalAttributes(attrs)
     {}
 
-    OptionalAttributes & GetOptionalAttributes() { return mOptionalAttributes; }
     Context & ClusterContext() { return mClusterContext; }
 
     void SetBreadCrumb(uint64_t value) final;
@@ -99,7 +98,7 @@ public:
 
 private:
     Context mClusterContext;
-    OptionalAttributes mOptionalAttributes;
+    const OptionalAttributes mOptionalAttributes;
     uint64_t mBreadCrumb = 0;
 
     std::optional<DataModel::ActionReturnStatus>

--- a/src/app/clusters/general-commissioning-server/tests/TestGeneralCommissioningCluster.cpp
+++ b/src/app/clusters/general-commissioning-server/tests/TestGeneralCommissioningCluster.cpp
@@ -53,19 +53,19 @@ TEST_F(TestGeneralCommissioningCluster, TestAttributes)
 {
     // test without optional attributes
     {
-        GeneralCommissioningCluster cluster(GeneralCommissioningCluster::Context {
-            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
-                .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
-                .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-                .fabricTable            = Server::GetInstance().GetFabricTable(),                //
-                .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
-                .platformManager        = DeviceLayer::PlatformMgr(),                            //
+        GeneralCommissioningCluster cluster(
+            GeneralCommissioningCluster::Context {
+                .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
+                    .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
+                    .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                    .fabricTable            = Server::GetInstance().GetFabricTable(),                //
+                    .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
+                    .platformManager        = DeviceLayer::PlatformMgr(),                            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+                    .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-        });
-        auto & optionalAttributes = cluster.GetOptionalAttributes();
-        optionalAttributes        = GeneralCommissioningCluster::OptionalAttributes(0);
+            },
+            GeneralCommissioningCluster::OptionalAttributes(0));
 
         ReadOnlyBufferBuilder<AttributeEntry> builder;
         ASSERT_EQ(cluster.Attributes({ kRootEndpointId, GeneralCommissioning::Id }, builder), CHIP_NO_ERROR);
@@ -99,19 +99,19 @@ TEST_F(TestGeneralCommissioningCluster, TestAttributes)
 
     // test with optional attributes
     {
-        GeneralCommissioningCluster cluster(GeneralCommissioningCluster::Context {
-            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
-                .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
-                .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-                .fabricTable            = Server::GetInstance().GetFabricTable(),                //
-                .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
-                .platformManager        = DeviceLayer::PlatformMgr(),                            //
+        GeneralCommissioningCluster cluster(
+            GeneralCommissioningCluster::Context {
+                .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
+                    .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
+                    .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                    .fabricTable            = Server::GetInstance().GetFabricTable(),                //
+                    .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
+                    .platformManager        = DeviceLayer::PlatformMgr(),                            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+                    .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-        });
-        auto & optionalAttributes = cluster.GetOptionalAttributes();
-        optionalAttributes.Set<IsCommissioningWithoutPower::Id>();
+            },
+            GeneralCommissioningCluster::OptionalAttributes().Set<IsCommissioningWithoutPower::Id>());
 
         ReadOnlyBufferBuilder<AttributeEntry> builder;
         ASSERT_EQ(cluster.Attributes({ kRootEndpointId, GeneralCommissioning::Id }, builder), CHIP_NO_ERROR);
@@ -152,17 +152,19 @@ TEST_F(TestGeneralCommissioningCluster, TestAttributes)
 
 TEST_F(TestGeneralCommissioningCluster, TestAcceptedCommands)
 {
-    GeneralCommissioningCluster cluster(GeneralCommissioningCluster::Context {
-        .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
-            .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
-            .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-            .fabricTable            = Server::GetInstance().GetFabricTable(),                //
-            .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
-            .platformManager        = DeviceLayer::PlatformMgr(),                            //
+    GeneralCommissioningCluster cluster(
+        GeneralCommissioningCluster::Context {
+            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
+                .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
+                .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                .fabricTable            = Server::GetInstance().GetFabricTable(),                //
+                .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
+                .platformManager        = DeviceLayer::PlatformMgr(),                            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-    });
+        },
+        GeneralCommissioningCluster::OptionalAttributes());
 
     {
         ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;

--- a/src/app/clusters/general-commissioning-server/tests/TestGeneralCommissioningCluster.cpp
+++ b/src/app/clusters/general-commissioning-server/tests/TestGeneralCommissioningCluster.cpp
@@ -21,12 +21,14 @@
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <app/server-cluster/DefaultServerCluster.h>
+#include <app/server/Server.h>
 #include <clusters/GeneralCommissioning/Enums.h>
 #include <clusters/GeneralCommissioning/Metadata.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/ReadOnlyBuffer.h>
 #include <lib/support/Span.h>
+#include <platform/DeviceControlServer.h>
 #include <platform/NetworkCommissioning.h>
 
 namespace {
@@ -51,7 +53,17 @@ TEST_F(TestGeneralCommissioningCluster, TestAttributes)
 {
     // test without optional attributes
     {
-        GeneralCommissioningCluster cluster;
+        GeneralCommissioningCluster cluster(GeneralCommissioningCluster::Context {
+            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
+                .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
+                .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                .fabricTable            = Server::GetInstance().GetFabricTable(),                //
+                .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
+                .platformManager        = DeviceLayer::PlatformMgr(),                            //
+#if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
+                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+#endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
+        });
         auto & optionalAttributes = cluster.GetOptionalAttributes();
         optionalAttributes        = GeneralCommissioningCluster::OptionalAttributes(0);
 
@@ -87,7 +99,17 @@ TEST_F(TestGeneralCommissioningCluster, TestAttributes)
 
     // test with optional attributes
     {
-        GeneralCommissioningCluster cluster;
+        GeneralCommissioningCluster cluster(GeneralCommissioningCluster::Context {
+            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
+                .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
+                .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                .fabricTable            = Server::GetInstance().GetFabricTable(),                //
+                .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
+                .platformManager        = DeviceLayer::PlatformMgr(),                            //
+#if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
+                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+#endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
+        });
         auto & optionalAttributes = cluster.GetOptionalAttributes();
         optionalAttributes.Set<IsCommissioningWithoutPower::Id>();
 
@@ -130,9 +152,20 @@ TEST_F(TestGeneralCommissioningCluster, TestAttributes)
 
 TEST_F(TestGeneralCommissioningCluster, TestAcceptedCommands)
 {
+    GeneralCommissioningCluster cluster(GeneralCommissioningCluster::Context {
+        .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
+            .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
+            .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+            .fabricTable            = Server::GetInstance().GetFabricTable(),                //
+            .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
+            .platformManager        = DeviceLayer::PlatformMgr(),                            //
+#if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
+            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+#endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
+    });
+
     {
         ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
-        GeneralCommissioningCluster cluster;
         ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, GeneralCommissioning::Id }, builder), CHIP_NO_ERROR);
 
         ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <cstdint>
 #include <pw_unit_test/framework.h>
 
 #include <app/AttributePathParams.h>
@@ -25,6 +26,7 @@
 #include <app/data-model-provider/tests/WriteTesting.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
+#include <app/server/Server.h>
 #include <clusters/GeneralCommissioning/Attributes.h>
 #include <clusters/NetworkCommissioning/Commands.h>
 #include <clusters/NetworkCommissioning/Enums.h>
@@ -34,6 +36,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/ReadOnlyBuffer.h>
+#include <platform/DeviceControlServer.h>
 #include <platform/NetworkCommissioning.h>
 
 #include "FakeWifiDriver.h"
@@ -54,6 +57,7 @@ class NoopBreadcrumbTracker : public BreadCrumbTracker
 public:
     void SetBreadCrumb(uint64_t v) override {}
 };
+
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestNetworkCommissioningCluster : public ::testing::Test
 {
@@ -66,7 +70,6 @@ TEST_F(TestNetworkCommissioningCluster, TestAttributes)
     NoopBreadcrumbTracker tracker;
     {
         Testing::FakeWiFiDriver fakeWifiDriver;
-
         NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, tracker);
 
         ReadOnlyBufferBuilder<AttributeEntry> builder;

--- a/src/app/clusters/thread-border-router-management-server/thread-border-router-management-server.cpp
+++ b/src/app/clusters/thread-border-router-management-server/thread-border-router-management-server.cpp
@@ -29,6 +29,7 @@
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/StatusIB.h>
 #include <app/clusters/general-commissioning-server/CodegenIntegration.h>
+#include <app/clusters/general-commissioning-server/general-commissioning-cluster.h>
 #include <app/data-model/Nullable.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/Optional.h>


### PR DESCRIPTION
#### Summary

Perform a global instance decoupling for the general commissioning cluster.

Picked this cluster since it has the most external dependencies, looked to see impact (flash and RAM) for a full decoupling of this.

#### Testing

No functional changes and general commissioning is heavily exercised in CI. Existing CI tests are expected to check that no functional changes were made.