### PR TITLE
[TC_ZONEMGMT-2_4] Remove unnecessary user prompt during blind duration phase

### DIFF
--- a/src/python_testing/TC_ZONEMGMT_2_4.py
+++ b/src/python_testing/TC_ZONEMGMT_2_4.py
@@ -333,12 +333,12 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
         # Generate some activity triggers to facilitate advancing of triggerdetectedDuration
         # beyond maxduration
         if self.is_pics_sdk_ci_only:
-            for i in range(maxDuration):
+            for i in range(maxDuration+2):
                 self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
                 time.sleep(1)
         else:
             self.wait_for_user_input(
-                prompt_msg=f"Press enter and immediately start and keep generating motion activity from zone {zoneID1} for a period exceeding {maxDuration} seconds")
+                prompt_msg=f"Press enter and immediately start, and keep generating motion activity from zone {zoneID1} for a period exceeding {maxDuration} seconds. \n After {maxDuration}, keep generating some motion activity during the {blindDuration} seconds blind duration phase. DUT should not send any ZoneTriggered event during this phase.")
 
         event_delay_seconds = maxDuration
         event = event_listener.wait_for_event_report(
@@ -352,10 +352,9 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
 
         self.step("5c")
         event_delay_seconds = blindDuration + 1
-        await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1}. Stop after 2-3 seconds.")
 
         event = event_listener.wait_for_event_expect_no_report(timeout_sec=event_delay_seconds)
-        logger.info(f"Successfully timed out without receiving any ZoneTriggered event for zone: {zoneID1}")
+        logger.info(f"Successfully timed out without receiving any ZoneTriggered event during blind duration for zone: {zoneID1}")
 
         self.step("6")
 

--- a/src/python_testing/TC_ZONEMGMT_2_4.py
+++ b/src/python_testing/TC_ZONEMGMT_2_4.py
@@ -333,7 +333,7 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
         # Generate some activity triggers to facilitate advancing of triggerdetectedDuration
         # beyond maxduration
         if self.is_pics_sdk_ci_only:
-            for i in range(maxDuration+2):
+            for i in range(maxDuration + 2):
                 self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
                 time.sleep(1)
         else:

--- a/src/python_testing/TC_ZONEMGMT_2_4.py
+++ b/src/python_testing/TC_ZONEMGMT_2_4.py
@@ -338,7 +338,8 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
                 time.sleep(1)
         else:
             self.wait_for_user_input(
-                prompt_msg=f"Press enter and immediately start, and keep generating motion activity from zone {zoneID1} for a period exceeding {maxDuration} seconds. \n After {maxDuration}, keep generating some motion activity during the {blindDuration} seconds blind duration phase. DUT should not send any ZoneTriggered event during this phase.")
+                prompt_msg=f"""Press enter and immediately start, and keep generating motion activity from zone {zoneID1} for a period exceeding {maxDuration} seconds.
+After {maxDuration}, keep generating some motion activity during the {blindDuration} seconds blind duration phase. DUT should not send any ZoneTriggered event during this phase.""")
 
         event_delay_seconds = maxDuration
         event = event_listener.wait_for_event_report(

--- a/src/python_testing/TC_ZONEMGMT_2_4.py
+++ b/src/python_testing/TC_ZONEMGMT_2_4.py
@@ -333,7 +333,7 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
         # Generate some activity triggers to facilitate advancing of triggerdetectedDuration
         # beyond maxduration
         if self.is_pics_sdk_ci_only:
-            for i in range(maxDuration + 2):
+            for i in range(maxDuration):
                 self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
                 time.sleep(1)
         else:

--- a/src/python_testing/TC_ZONEMGMT_2_4.py
+++ b/src/python_testing/TC_ZONEMGMT_2_4.py
@@ -353,7 +353,8 @@ After {maxDuration}, keep generating some motion activity during the {blindDurat
 
         self.step("5c")
         event_delay_seconds = blindDuration + 1
-
+        if self.is_pics_sdk_ci_only:
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
         event = event_listener.wait_for_event_expect_no_report(timeout_sec=event_delay_seconds)
         logger.info(f"Successfully timed out without receiving any ZoneTriggered event during blind duration for zone: {zoneID1}")
 


### PR DESCRIPTION
#### Summary
 Remove unnecessary user prompt during blind duration phase after triggering zone events beyond max duration.
Also, slightly adjust prompt messages.

#### Testing
DUT: `./chip-camera-app --app-pipe /tmp/app_pipe_zonemgmt`
Controller: `python3 src/python_testing/TC_ZONEMGMT_2_4.py --endpoint 1 --app-pipe /tmp/app_pipe_zonemgmt --PICS src/app/tests/suites/certification/ci-pics-values`

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
