### PR TITLE
Recovery for bad cached video players

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -178,9 +178,9 @@ public interface CastingPlayer {
    */
   String getConnectionStateNative();
 
-  /** 
-   * @brief Removes any fabric associated with this player in order to cause the UDC flow when 
-   * verifyOrEstablishConnection is called 
+  /**
+   * @brief Removes any fabric associated with this player in order to cause the UDC flow when
+   *     verifyOrEstablishConnection is called
    */
   void removeFabric();
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -177,4 +177,10 @@ public interface CastingPlayer {
    * @returns A String representation of the CastingPlayer's current connectation.
    */
   String getConnectionStateNative();
+
+  /** 
+   * @brief Removes any fabric associated with this player in order to cause the UDC flow when 
+   * verifyOrEstablishConnection is called 
+   */
+  void removeFabric();
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -269,6 +269,9 @@ public class MatterCastingPlayer implements CastingPlayer {
   @Override
   public native void disconnect();
 
+  @Override
+  public native void removeFabric();
+
   /**
    * @brief Get CastingPlayer's current ConnectionState.
    * @throws IllegalArgumentException or NullPointerException when native layer returns invalid

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -165,6 +165,19 @@ JNI_METHOD(void, disconnect)
     castingPlayer->Disconnect();
 }
 
+JNI_METHOD(void, removeFabric)
+(JNIEnv * env, jobject thiz)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::removeFabric()");
+
+    core::CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
+    VerifyOrReturn(castingPlayer != nullptr,
+                   ChipLogError(AppServer, "MatterCastingPlayer-JNI::removeFabric() castingPlayer == nullptr"));
+
+    castingPlayer->RemoveFabric();
+}
+
 JNI_METHOD(jstring, getConnectionStateNative)
 (JNIEnv * env, jobject thiz)
 {

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
@@ -159,6 +159,12 @@ typedef enum {
 - (void)disconnect;
 
 /**
+ * @brief Removes any fabric associated with this player in order to cause the UDC flow when
+ *     verifyOrEstablishConnection is called
+ */
+- (void)removeFabric;
+
+/**
  * @brief Get the CastingPlayer's connection state
  * @param state The current connection state that will be return.
  * @return nil if request submitted successfully, otherwise a NSError object corresponding to the error.

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
@@ -190,6 +190,17 @@ static const NSInteger kMinCommissioningWindowTimeoutSec = matter::casting::core
     });
 }
 
+- (void)removeFabric
+{
+    ChipLogProgress(AppServer, "MCCastingPlayer.removeFabric() called");
+    VerifyOrReturn([[MCCastingApp getSharedInstance] isRunning], ChipLogError(AppServer, "MCCastingPlayer.removeFabric() MCCastingApp NOT running"));
+
+    dispatch_queue_t workQueue = [[MCCastingApp getSharedInstance] getWorkQueue];
+    dispatch_sync(workQueue, ^{
+        _cppCastingPlayer->RemoveFabric();
+    });
+}
+
 - (NSError * _Nullable)getConnectionState:(MCCastingPlayerConnectionState * _Nonnull)state;
 {
     ChipLogProgress(AppServer, "MCCastingPlayer.getConnectionState() called");

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/compat-shim/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/compat-shim/CastingServerBridge.h
@@ -169,6 +169,15 @@ __attribute__((deprecated("Use the APIs described in /examples/tv-casting-app/AP
 - (void)disconnect:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler;
 
 /*!
+ @brief  Removes any fabric associated with this player in order to cause the UDC flow when verifyOrEstablishConnection is called.
+
+ @param clientQueue Queue to invoke callbacks on
+
+ @param requestSentHandler Called after the request has been sent
+ */
+- (void)removeFabric:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler;
+
+/*!
  @brief Purge data cached by the Matter casting library
 
  @param clientQueue Queue to invoke callbacks on

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/compat-shim/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/compat-shim/CastingServerBridge.mm
@@ -339,6 +339,18 @@ static const uint32_t kTargetPlayerDeviceType = 0x23;
     });
 }
 
+- (void)removeFabric:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler
+{
+    ChipLogProgress(AppServer, "CastingServerBridge().removeFabric() called");
+    MCCastingPlayer * castingPlayer = [MCCastingPlayer getTargetCastingPlayer];
+    if (castingPlayer != nil) {
+        [castingPlayer removeFabric];
+    }
+    dispatch_async(clientQueue, ^{
+        requestSentHandler();
+    });
+}
+
 - (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(void (^)(MatterError * _Nonnull))responseHandler
 {
     ChipLogProgress(AppServer, "CastingServerBridge().purgeCache() called");

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -182,7 +182,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                             CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(error, nullptr);
                             mTargetCastingPlayer.reset();
                         });
-                    return; // FindOrEstablishSession called. Return early.                  
+                    return; // FindOrEstablishSession called. Return early.
                 }
             }
         }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -153,21 +153,24 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                 {
                     FindOrEstablishSession(
                         nullptr,
-                        [](void * context, chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle) {
+                        [](void * context, chip::Messaging::ExchangeManager & exchangeMgr,
+                           const chip::SessionHandle & sessionHandle) {
                             ChipLogProgress(AppServer,
                                             "CastingPlayer::VerifyOrEstablishConnection() FindOrEstablishSession Connection to "
                                             "CastingPlayer successful");
                             CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_CONNECTED;
 
-                            // this async call will Load all the endpoints with their respective attributes into the TargetCastingPlayer
+                            // this async call will Load all the endpoints with their respective attributes into the
+                            // TargetCastingPlayer.
+                            //
                             // persist the TargetCastingPlayer information into the CastingStore and call mOnCompleted()
                             support::EndpointListLoader::GetInstance()->Initialize(&exchangeMgr, &sessionHandle);
                             support::EndpointListLoader::GetInstance()->Load();
                         },
                         [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
                             ChipLogError(AppServer,
-                                        "CastingPlayer::VerifyOrEstablishConnection() FindOrEstablishSession Connection to "
-                                        "CastingPlayer failed");
+                                         "CastingPlayer::VerifyOrEstablishConnection() FindOrEstablishSession Connection to "
+                                         "CastingPlayer failed");
                             CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
                             CHIP_ERROR e = support::CastingStore::GetInstance()->Delete(*CastingPlayer::GetTargetCastingPlayer());
                             if (e != CHIP_NO_ERROR)
@@ -179,7 +182,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                             CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(error, nullptr);
                             mTargetCastingPlayer.reset();
                         });
-                    return; // FindOrEstablishSession called. Return early.                    
+                    return; // FindOrEstablishSession called. Return early.                  
                 }
             }
         }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -120,27 +120,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                     AppServer,
                     "CastingPlayer::VerifyOrEstablishConnection() Attempting to Re-establish CASE with cached CastingPlayer");
 
-                // forcebypass flag
-                // Preserve the IP addresses from the discovered CastingPlayer before overwriting with cached data
-                unsigned int discoveredNumIPs = mAttributes.numIPs;
-                chip::Inet::IPAddress discoveredIpAddresses[chip::Dnssd::CommonResolutionData::kMaxIPAddresses];
-                for (unsigned int i = 0; i < discoveredNumIPs; i++)
-                {
-                    discoveredIpAddresses[i] = mAttributes.ipAddresses[i];
-                }
-                chip::Inet::InterfaceId discoveredInterfaceId = mAttributes.interfaceId;
-
                 *this                          = cachedCastingPlayers[index];
-
-                // Restore the IP addresses from the discovered CastingPlayer
-                mAttributes.numIPs = discoveredNumIPs;
-                for (unsigned int i = 0; i < discoveredNumIPs; i++)
-                {
-                    mAttributes.ipAddresses[i] = discoveredIpAddresses[i];
-                }
-                mAttributes.interfaceId = discoveredInterfaceId;
-                ChipLogProgress(AppServer, "Restored discovered CastingPlayer numIPs: %u", mAttributes.numIPs);
-
                 mConnectionState               = CASTING_PLAYER_CONNECTING;
                 mOnCompleted                   = connectionCallbacks.mOnConnectionComplete;
                 mCommissioningWindowTimeoutSec = commissioningWindowTimeoutSec;

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -327,6 +327,12 @@ void CastingPlayer::RemoveFabric()
     chip::Server::GetInstance().GetFabricTable().Delete(mAttributes.fabricIndex);
     mAttributes.fabricIndex = 0;
     mAttributes.nodeId      = 0;
+
+    CHIP_ERROR err = support::CastingStore::GetInstance()->AddOrUpdate(*this);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "CastingStore::AddOrUpdate() failed. Err: %" CHIP_ERROR_FORMAT, err.Format());
+    }
 }
 
 void CastingPlayer::RegisterEndpoint(const memory::Strong<Endpoint> endpoint)

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -143,6 +143,10 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                 mAttributes.interfaceId = discoveredInterfaceId;
                 ChipLogProgress(AppServer, "Restored discovered CastingPlayer numIPs: %u", mAttributes.numIPs);
 
+                // make sure to copy fields passed in which are needed for UDC
+                mIdOptions                                     = idOptions;
+                mClientProvidedCommissionerDeclarationCallback = connectionCallbacks.mCommissionerDeclarationCallback != nullptr;
+
                 // don't attempt to connect with the cached CastingPlayer if the nodeId is not set
                 // instead, fall through to trigger UDC
                 if (mAttributes.nodeId != 0)

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -222,6 +222,14 @@ public:
      */
     void Disconnect();
 
+    /** 
+     * @brief Removes any fabric associated with this player in order to cause the UDC flow when 
+     * verifyOrEstablishConnection is called 
+     *
+     * @note This method will set nodeId and fabricIndex to 0.
+     */
+    void RemoveFabric();
+
     /**
      * @brief Find an existing session for this CastingPlayer, or trigger a new session
      * request.

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -222,9 +222,9 @@ public:
      */
     void Disconnect();
 
-    /** 
-     * @brief Removes any fabric associated with this player in order to cause the UDC flow when 
-     * verifyOrEstablishConnection is called 
+    /**
+     * @brief Removes any fabric associated with this player in order to cause the UDC flow when
+     * verifyOrEstablishConnection is called
      *
      * @note This method will set nodeId and fabricIndex to 0.
      */

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -511,7 +511,7 @@ CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayer
         chip::TLV::TLVType endpointsContainerType;
         ReturnErrorOnFailure(tlvWriter.StartContainer(chip::TLV::ContextTag(kCastingPlayerEndpointsContainerTag),
                                                       chip::TLV::kTLVType_Array, endpointsContainerType));
-        std::vector<memory::Strong<core::Endpoint>> endpoints = core::CastingPlayer::GetTargetCastingPlayer()->GetEndpoints();
+        std::vector<memory::Strong<core::Endpoint>> endpoints = castingPlayer.GetEndpoints();
         for (auto & endpoint : endpoints)
         {
             ChipLogProgress(

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -114,11 +114,6 @@ void ChipDeviceEventHandler::HandleFailSafeTimerExpired()
     {
         ChipLogProgress(AppServer, "ChipDeviceEventHandler::HandleFailSafeTimerExpired() when sUdcInProgress: %d, returning early",
                         sUdcInProgress);
-        // sUdcInProgress                                            = false;
-        // CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
-        // CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(CHIP_ERROR_TIMEOUT, nullptr);
-        // CastingPlayer::GetTargetCastingPlayer()->mOnCompleted = nullptr;
-        // CastingPlayer::GetTargetCastingPlayer()->mTargetCastingPlayer.reset();
         return;
     }
 

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -114,11 +114,11 @@ void ChipDeviceEventHandler::HandleFailSafeTimerExpired()
     {
         ChipLogProgress(AppServer, "ChipDeviceEventHandler::HandleFailSafeTimerExpired() when sUdcInProgress: %d, returning early",
                         sUdcInProgress);
-        sUdcInProgress                                            = false;
-        CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
-        CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(CHIP_ERROR_TIMEOUT, nullptr);
-        CastingPlayer::GetTargetCastingPlayer()->mOnCompleted = nullptr;
-        CastingPlayer::GetTargetCastingPlayer()->mTargetCastingPlayer.reset();
+        // sUdcInProgress                                            = false;
+        // CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
+        // CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(CHIP_ERROR_TIMEOUT, nullptr);
+        // CastingPlayer::GetTargetCastingPlayer()->mOnCompleted = nullptr;
+        // CastingPlayer::GetTargetCastingPlayer()->mTargetCastingPlayer.reset();
         return;
     }
 


### PR DESCRIPTION
This addresses 2 problems seen in the field which relate to the video player cache.

1. When attempting to be commissioned by a TV and already on the fabric, some TVs will expire the FailSafeTimer, delete the fabric, and then retry.

3. When already on the fabric of the TV, if its ACL list is cleared there is no easy way to recover.

To address (1): 
- don't cancel commissioning (and alert UI) upon FailSafeTimerExpiry. Allow commissioning mode timeout to drive UI and keep targetVideoPlayer state so that subsequent PASE session can take place.

To address (2):
- provide removeFabric command which clears the fabric underlying the cached video player and ensures it attempts UDC upon next attempt to connect.

#### Testing

Tested with Android casting app