### PR TITLE
[TC_ZONEMGMT-2_4] Remove unnecessary user prompt during blind duration phase (#41692)

### DIFF
--- a/src/python_testing/TC_ZONEMGMT_2_4.py
+++ b/src/python_testing/TC_ZONEMGMT_2_4.py
@@ -338,7 +338,8 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
                 time.sleep(1)
         else:
             self.wait_for_user_input(
-                prompt_msg=f"Press enter and immediately start and keep generating motion activity from zone {zoneID1} for a period exceeding {maxDuration} seconds")
+                prompt_msg=f"""Press enter and immediately start, and keep generating motion activity from zone {zoneID1} for a period exceeding {maxDuration} seconds.
+After {maxDuration}, keep generating some motion activity during the {blindDuration} seconds blind duration phase. DUT should not send any ZoneTriggered event during this phase.""")
 
         event_delay_seconds = maxDuration
         event = event_listener.wait_for_event_report(
@@ -352,10 +353,10 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
 
         self.step("5c")
         event_delay_seconds = blindDuration + 1
-        await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1}. Stop after 2-3 seconds.")
-
+        if self.is_pics_sdk_ci_only:
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
         event = event_listener.wait_for_event_expect_no_report(timeout_sec=event_delay_seconds)
-        logger.info(f"Successfully timed out without receiving any ZoneTriggered event for zone: {zoneID1}")
+        logger.info(f"Successfully timed out without receiving any ZoneTriggered event during blind duration for zone: {zoneID1}")
 
         self.step("6")
 


### PR DESCRIPTION
#### Summary

Cherry-pick PR #41692 
Fixes : https://github.com/project-chip/connectedhomeip/issues/41661

* [TC_ZONEMGMT-2_4] Remove unnecessary user prompt during blind duration phase after triggering zone events beyond max duration.

* Update src/python_testing/TC_ZONEMGMT_2_4.py



* Apply suggestion from @Copilot



* Apply suggestion from @gemini-code-assist[bot]



* Remove the extra triggers beyond maxDuration, since we are triggering after the ZoneStopped event in CI.

---------

#### Testing

CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
