### PR TITLE
[NXP][CI] Limiting FreeRTOS build instances to improve CI build efficiency

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -74,9 +74,6 @@ jobs:
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
                       --target nxp-mcxw71-freertos-contact-sensor-thread-mtd-low-power-cmake-frdm \
-                      --target nxp-mcxw71-freertos-lighting-thread-cmake-frdm \
-                      --target nxp-mcxw71-freertos-lock-app-thread-mtd-low-power-cmake-frdm \
-                      --target nxp-mcxw71-freertos-contact-sensor-low-power \
                       build \
                   "
             - name: Get MCXW71 contact sensor size stats
@@ -85,42 +82,18 @@ jobs:
                     nxp mcxw71+release contact \
                     out/nxp-mcxw71-freertos-contact-sensor-thread-mtd-low-power-cmake-frdm/app.elf \
                     /tmp/bloat_reports/
-            - name: Get MCXW71 lighting app size stats
-              run: |
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    nxp mcxw71+release lighting \
-                    out/nxp-mcxw71-freertos-lighting-thread-cmake-frdm/app.elf \
-                    /tmp/bloat_reports/
-            - name: Get MCXW71 lock app size stats
-              run: |
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    nxp mcxw71+release lock \
-                    out/nxp-mcxw71-freertos-lock-app-thread-mtd-low-power-cmake-frdm/app.elf \
-                    /tmp/bloat_reports/
 
             - name: Build MCXW72 examples
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
                       --target nxp-mcxw72-freertos-contact-sensor-thread-mtd-low-power-cmake-frdm \
-                      --target nxp-mcxw72-freertos-lighting-thread-cmake-frdm \
-                      --target nxp-mcxw72-freertos-lock-app-thread-mtd-low-power-cmake-frdm \
-                      --target nxp-mcxw72-freertos-contact-sensor-ota-low-power \
                       build \
                   "
 
             - name: clean build
               run: rm -rf ./out
 
-            - name: Build RT1060 all clusters example app
-              run: |
-                  scripts/run_in_build_env.sh "\
-                      ./scripts/build/build_examples.py \
-                      --target nxp-rt1060-freertos-all-clusters-wifi-iw416-cmake \
-                      --target nxp-rt1060-freertos-all-clusters-wifi-w8801-no-ble-cmake \
-                      --target nxp-rt1060-freertos-all-clusters-wifi-ota-evkc-iwx12-cmake \
-                      build \
-                  "
             - name: Build RT1060 thermostat example app
               if:
                   github.event_name == 'push' || steps.changed_paths.outputs.nxp
@@ -128,7 +101,6 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
-                      --target nxp-rt1060-freertos-thermostat-wifi-evkc-iw610-cmake \
                       --target nxp-rt1060-freertos-thermostat-thread-wifi-ota-evkc-iwx12-cmake \
                       build \
                   "
@@ -136,18 +108,10 @@ jobs:
             - name: clean build
               run: rm -rf ./out
 
-            - name: Build RT1170 all clusters example app
+            - name: Build RT1170 thermostat example app
               if:
                   github.event_name == 'push' || steps.changed_paths.outputs.nxp
                   == 'true' || steps.changed_paths.outputs.pigweed == 'true'
-              run: |
-                  scripts/run_in_build_env.sh "\
-                      ./scripts/build/build_examples.py \
-                      --target nxp-rt1170-freertos-all-clusters-wifi-iwx12-cmake \
-                      --target nxp-rt1170-freertos-all-clusters-wifi-ota-iwx12-cmake \
-                      build \
-                  "
-            - name: Build RT1170 thermostat example app
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
@@ -158,18 +122,12 @@ jobs:
             - name: clean build
               run: rm -rf ./out
 
-            - name: Build RW61X all clusters example app
-              run: |
-                  scripts/run_in_build_env.sh "\
-                      ./scripts/build/build_examples.py \
-                      --target nxp-rw61x-freertos-all-clusters-wifi-ota-se05x-cmake \
-                      build \
-                  "
             - name: Build RW61X thermostat OTBR example app
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
                       --target nxp-rw61x-freertos-thermostat-thread-wifi-ota-factory-cmake \
+                      --target nxp-rw61x-freertos-thermostat-wifi-se05x-cmake \
                       build \
                   "
             - name: Build RW61X thermostat ethernet example app
@@ -177,13 +135,6 @@ jobs:
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
                       --target nxp-rw61x-freertos-thermostat-ethernet-cmake-frdm \
-                      build \
-                  "
-            - name: Build RW61X unit test example app
-              run: |
-                  scripts/run_in_build_env.sh "\
-                      ./scripts/build/build_examples.py \
-                      --target nxp-rw61x-freertos-unit-test-cmake-frdm \
                       build \
                   "
 


### PR DESCRIPTION
#### Summary

This PR aims to reduce the NXP FreeRTOS build time to under one hour by keeping only 1 application build per platform.

### Testing

No manual tests were performed; CI results from the PR will be used to validate the reduction in build time.
