### PR TITLE
Fix CMAF clip duration calculation and recorded file cleanup

### DIFF
--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -164,6 +164,13 @@ private:
     CHIP_ERROR IsAnyPrivacyModeActive(bool & isActive);
 
     /**
+     * @brief Checks if the specified CMAF interface type is supported.
+     * @param cmafInterface The CMAF interface enum to validate.
+     * @return true if the interface is supported, false otherwise.
+     */
+    bool IsCMAFInterfaceSupported(CMAFInterfaceEnum cmafInterface) const;
+
+    /**
      * @brief Calculates the total bandwidth in bps for the given video and audio stream IDs.
      * @param videoStreamId Optional nullable video stream ID.
      * @param audioStreamId Optional nullable audio stream ID.

--- a/examples/camera-app/linux/include/pushav-clip-recorder.h
+++ b/examples/camera-app/linux/include/pushav-clip-recorder.h
@@ -90,7 +90,6 @@ public:
         uint16_t mElapsedTimeS;                               ///< Elapsed time since recording start in seconds
         std::string mOutputPath;                              ///< Base output directory path
         std::string mTrackName;                               ///< Track name for segmented files
-        AVRational mInputTimeBase;                            ///< Input time base
         std::string mUrl;                                     ///< URL for uploading clips;
         int mTriggerType;                                     ///< Recording trigger type
         std::chrono::steady_clock::time_point activationTime; ///< Time when the recording started

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -303,13 +303,16 @@ Protocols::InteractionModel::Status PushAvStreamTransportManager::ManuallyTrigge
 
 bool PushAvStreamTransportManager::IsCMAFInterfaceSupported(CMAFInterfaceEnum cmafInterface) const
 {
-    // Only CMAF interface 1 is supported in the current implementation
+    // CMAF interface 1 and DASH (interface 2) are supported in the current implementation
     switch (cmafInterface)
     {
     case CMAFInterfaceEnum::kInterface1:
         return true;
     case CMAFInterfaceEnum::kInterface2DASH:
-        return false;
+        ChipLogDetail(Camera,
+                      "DASH interface enabled - WARNING: This is still provisional and full compliance to CMAF ingest "
+                      "interface-2: DASH may not be available");
+        return true;
     case CMAFInterfaceEnum::kInterface2HLS:
         return false;
     case CMAFInterfaceEnum::kUnknownEnumValue:

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -119,7 +119,8 @@ bool PushAVClipRecorder::EnsureDirectoryExists(const std::string & path)
         {
             if (!std::filesystem::create_directories(p, ec))
             {
-                ChipLogError(Camera, "Failed to create directory: %s", p.c_str());
+                ChipLogError(Camera, "Failed to create directory: %s, error code: %d (%s)", p.c_str(), ec.value(),
+                             ec.message().c_str());
                 return false;
             }
             // Set permissions to file: (owner rwx, group rx)
@@ -130,23 +131,49 @@ bool PushAVClipRecorder::EnsureDirectoryExists(const std::string & path)
         }
         else if (!std::filesystem::is_directory(p, ec))
         {
-            ChipLogError(Camera, "Path is not a directory: %s", p.c_str());
+            ChipLogError(Camera, "Path is not a directory: %s, error code: %d (%s)", p.c_str(), ec.value(), ec.message().c_str());
             return false;
         }
 
         auto perms = std::filesystem::status(p, ec).permissions();
         if ((perms & std::filesystem::perms::owner_write) == std::filesystem::perms::none)
         {
-            ChipLogError(Camera, "Directory is not writable: %s", p.c_str());
+            ChipLogError(Camera, "Directory is not writable: %s, error code: %d (%s)", p.c_str(), ec.value(), ec.message().c_str());
             return false;
         }
         return true;
     };
 
     // Ensure base directory exists
-    if (!ensure(basePath))
+
+    std::string basePathStr = basePath.string();
+    std::string pathExists;
+    pathExists.reserve(basePathStr.length());
+
+    size_t startIndex = (basePathStr[0] == '/') ? 1 : 0;
+
+    for (size_t i = startIndex; i < basePathStr.length(); ++i)
     {
-        return false;
+        if (basePathStr[i] == '/' || i == basePathStr.length() - 1)
+        {
+            // Include the current character if it's the last character and not a slash
+            size_t endPos = (basePathStr[i] == '/' && i != basePathStr.length() - 1) ? i : i + 1;
+
+            // Build the path incrementally
+            pathExists = basePathStr.substr(0, endPos);
+
+            // Skip empty paths (can happen with consecutive slashes)
+            if (pathExists.empty() || pathExists.back() == '/')
+            {
+                continue;
+            }
+
+            if (!ensure(pathExists))
+            {
+                ChipLogError(Camera, "Failed to ensure directory exists: %s", pathExists.c_str());
+                return false;
+            }
+        }
     }
 
     // Clean up previous session directory if it exists

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -51,7 +51,8 @@ AVDictionary * options = NULL;
 
 PushAVClipRecorder::PushAVClipRecorder(ClipInfoStruct & aClipInfo, AudioInfoStruct & aAudioInfo, VideoInfoStruct & aVideoInfo,
                                        PushAVUploader * aUploader) :
-    mClipInfo(aClipInfo), mAudioInfo(aAudioInfo), mVideoInfo(aVideoInfo), mUploader(aUploader)
+    mClipInfo(aClipInfo),
+    mAudioInfo(aAudioInfo), mVideoInfo(aVideoInfo), mUploader(aUploader)
 {
     mFormatContext        = nullptr;
     mInputFormatContext   = nullptr;

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -16,19 +16,36 @@
  *    limitations under the License.
  */
 
+#include <ctime>
+#include <filesystem>
 #include <push-av-stream-manager.h>
 #include <pushav-transport.h>
+#include <time.h>
 
 using namespace chip::app::Clusters::PushAvStreamTransport;
 
 PushAVTransport::PushAVTransport(const TransportOptionsStruct & transportOptions, const uint16_t connectionID,
                                  AudioStreamStruct & audioStreamParams, VideoStreamStruct & videoStreamParams) :
-    mAudioStreamParams(audioStreamParams),
-    mVideoStreamParams(videoStreamParams)
+    mAudioStreamParams(audioStreamParams), mVideoStreamParams(videoStreamParams)
 {
     ConfigureRecorderSettings(transportOptions, audioStreamParams, videoStreamParams);
     mConnectionID    = connectionID;
     mTransportStatus = TransportStatusEnum::kInactive;
+
+    auto now               = std::chrono::system_clock::now();
+    std::time_t time_t_now = std::chrono::system_clock::to_time_t(now);
+    std::tm tm_now;
+    localtime_r(&time_t_now, &tm_now);
+
+    char datetime_str[32];
+    std::strftime(datetime_str, sizeof(datetime_str), "%Y%m%d_%H%M%S", &tm_now);
+
+    // Example folder name: FabricIdx1_ConnectionId2_20251103_225428
+    std::string uniqueDirName =
+        "FabricIdx" + std::to_string(mFabricIndex) + "_ConnectionId" + std::to_string(connectionID) + "_" + datetime_str;
+
+    std::filesystem::path outputPath = std::filesystem::path("/tmp") / uniqueDirName / "";
+    mClipInfo.mOutputPath            = outputPath.string();
 }
 
 const char * GetAudioCodecName(int codecId)
@@ -67,7 +84,6 @@ void PrintTransportSettings(PushAVClipRecorder::ClipInfoStruct clipInfo, PushAVC
     ChipLogProgress(Camera, "Trigger Type: %d", clipInfo.mTriggerType);
     ChipLogProgress(Camera, "Output Path: %s", clipInfo.mOutputPath.c_str());
     ChipLogProgress(Camera, "Track Name: %s", clipInfo.mTrackName.c_str());
-    ChipLogProgress(Camera, "Input Time Base: %d/%d", clipInfo.mInputTimeBase.num, clipInfo.mInputTimeBase.den);
     // Time control parameters are only passed during transport allocation for motion triggers.
     if (clipInfo.mTriggerType == 1)
     {
@@ -146,8 +162,6 @@ void PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStruct & t
     }
 
     mTransportTriggerType = transportOptions.triggerOptions.triggerType;
-    mClipInfo.mOutputPath = "/tmp/"; // CAUTION: If path is not accessible to executable, the program may fail to write and crash.
-    mClipInfo.mInputTimeBase = { 1, 1000000 };
 
     uint8_t audioCodec = static_cast<uint8_t>(audioStreamParams.audioCodec);
     if (audioStreamParams.channelCount == 0)
@@ -161,6 +175,7 @@ void PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStruct & t
     {
         if (audioStreamParams.sampleRate == 0)
         {
+            ChipLogError(Camera, "Invalid sample rate: 0. Using fallback 48000 Hz.");
             audioStreamParams.sampleRate = 48000; // Fallback value for invalid sample rate
         }
         mAudioInfo.mAudioCodecId       = AV_CODEC_ID_OPUS;
@@ -176,11 +191,6 @@ void PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStruct & t
         ChipLogError(Camera, "Unsupported Audio codec");
     }
 
-    if (audioStreamParams.sampleRate == 0)
-    {
-        ChipLogError(Camera, "Invalid sample rate: 0. Using fallback 48000 Hz.");
-        audioStreamParams.sampleRate = 48000; // Fallback value for invalid sample rate
-    }
     mAudioInfo.mSampleRate = audioStreamParams.sampleRate;
     if (audioStreamParams.bitRate == 0)
     {
@@ -222,7 +232,7 @@ void PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStruct & t
     }
     mVideoInfo.mFrameRate = videoStreamParams.minFrameRate;
 
-    mVideoInfo.mVideoFrameDuration = 900000 / mVideoInfo.mFrameRate;
+    mVideoInfo.mVideoFrameDuration = mVideoInfo.mVideoTimeBase.den / (mVideoInfo.mFrameRate * mVideoInfo.mVideoTimeBase.num);
     mVideoInfo.mVideoStreamIndex   = -1;
     mVideoInfo.mBitRate            = videoStreamParams.minBitRate;
 
@@ -249,11 +259,31 @@ void PushAVTransport::InitializeRecorder()
 
 PushAVTransport::~PushAVTransport()
 {
-    // TODO: cleanup the existing recorded files here.
     mCanSendVideo = false;
     mCanSendAudio = false;
+
     mRecorder.reset();
     mUploader.reset();
+
+    std::filesystem::path uniqueDirPath(mClipInfo.mOutputPath);
+
+    if (std::filesystem::exists(uniqueDirPath) && std::filesystem::is_directory(uniqueDirPath))
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(uniqueDirPath, ec);
+        if (ec)
+        {
+            ChipLogError(Camera, "Failed to remove directory %s: %s", uniqueDirPath.c_str(), ec.message().c_str());
+        }
+        else
+        {
+            ChipLogProgress(Camera, "Successfully removed directory: %s", uniqueDirPath.c_str());
+        }
+    }
+    else
+    {
+        ChipLogDetail(Camera, "Directory does not exist: %s", uniqueDirPath.c_str());
+    }
 }
 
 bool InBlindPeriod(std::chrono::steady_clock::time_point blindStartTime, uint16_t blindDuration)

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -26,7 +26,8 @@ using namespace chip::app::Clusters::PushAvStreamTransport;
 
 PushAVTransport::PushAVTransport(const TransportOptionsStruct & transportOptions, const uint16_t connectionID,
                                  AudioStreamStruct & audioStreamParams, VideoStreamStruct & videoStreamParams) :
-    mAudioStreamParams(audioStreamParams), mVideoStreamParams(videoStreamParams)
+    mAudioStreamParams(audioStreamParams),
+    mVideoStreamParams(videoStreamParams)
 {
     ConfigureRecorderSettings(transportOptions, audioStreamParams, videoStreamParams);
     mConnectionID    = connectionID;

--- a/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
+++ b/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
@@ -291,7 +291,8 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
     std::string contentType = "application/*"; // Default fallback
 
     // Extract file extension from full path using std::filesystem
-    std::filesystem::path extension = data.first.extension();
+    std::filesystem::path filePath(data.first);
+    std::filesystem::path extension = filePath.extension();
     if (extension == ".mpd")
     {
         contentType = "application/dash+xml"; // Manifest file
@@ -318,7 +319,6 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
     std::string rootCertPEM;
     std::string clientCertPEM;
     std::string derKeyToPemstr;
-    bool isMPDFile;
     std::error_code ec;
     size_t sessionPos;
     CURLcode res;

--- a/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
+++ b/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
@@ -19,8 +19,8 @@
 #include "pushav-uploader.h"
 #include <algorithm>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
-#include <iomanip>
 #include <iostream>
 #include <lib/support/logging/CHIPLogging.h>
 #include <openssl/bio.h>
@@ -41,6 +41,22 @@ PushAVUploader::~PushAVUploader()
     }
 
     Stop();
+
+    while (!mAvData.empty())
+    {
+        std::pair<std::string, std::string> uploadJob = std::move(mAvData.front());
+        mAvData.pop();
+
+        std::error_code ec;
+        if (!std::filesystem::remove(uploadJob.first, ec))
+        {
+            ChipLogError(Camera, "Failed to delete file: %s, error: %s", uploadJob.first.c_str(), ec.message().c_str());
+        }
+        else
+        {
+            ChipLogDetail(Camera, "Successfully deleted file: %s", uploadJob.first.c_str());
+        }
+    }
 }
 
 // Helper function to convert certificate from DER format to PEM format
@@ -78,25 +94,6 @@ std::string DerCertToPem(const std::vector<uint8_t> & derData)
     X509_free(cert);
 
     return pem;
-}
-
-// Helper function to convert vector of bytes to hex string representation
-std::string vectorToHexString(const std::vector<uint8_t> & vec)
-{
-    std::ostringstream oss;
-    for (size_t i = 0; i < vec.size(); ++i)
-    {
-        oss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(vec[i]);
-        if ((i + 1) % 16 == 0)
-        {
-            oss << "\n";
-        }
-        else if (i != vec.size() - 1)
-        {
-            oss << " ";
-        }
-    }
-    return oss.str();
 }
 
 // Helper function to convert ECDSA private key from DER format to PEM format
@@ -293,23 +290,19 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
     // Determine content type based on file extension
     std::string contentType = "application/*"; // Default fallback
 
-    // Extract file extension from full path
-    size_t dotPos = data.first.find_last_of('.');
-    if (dotPos != std::string::npos)
+    // Extract file extension from full path using std::filesystem
+    std::filesystem::path extension = data.first.extension();
+    if (extension == ".mpd")
     {
-        std::string extension = data.first.substr(dotPos);
-        if (extension == ".mpd")
-        {
-            contentType = "application/dash+xml"; // Manifest file
-        }
-        else if (extension == ".m4s")
-        {
-            contentType = "video/iso.segment"; // Media segment
-        }
-        else if (extension == ".init")
-        {
-            contentType = "video/mp4"; // Initialization segment
-        }
+        contentType = "application/dash+xml"; // Manifest file
+    }
+    else if (extension == ".m4s")
+    {
+        contentType = "video/iso.segment"; // Media segment
+    }
+    else if (extension == ".init")
+    {
+        contentType = "video/mp4"; // Initialization segment
     }
 
     std::string contentTypeHeader = "Content-Type: " + contentType;
@@ -317,21 +310,37 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
 
     // Extract the filename from the full path
     std::string fullPath = data.first;
-    std::string filename;
-    if (fullPath.substr(0, 5) == "/tmp/")
+    std::string filename = "";
+    std::string baseUrl  = data.second;
+    std::string fullUrl;
+
+    // Declare all variables that are used after goto cleanup
+    std::string rootCertPEM;
+    std::string clientCertPEM;
+    std::string derKeyToPemstr;
+    bool isMPDFile;
+    std::error_code ec;
+    size_t sessionPos;
+    CURLcode res;
+
+    sessionPos = fullPath.find("/session_");
+    if (sessionPos != std::string::npos)
     {
-        filename = fullPath.substr(5);
+        filename = fullPath.substr(sessionPos + 1);
     }
     else
     {
-        filename = fullPath;
+        ChipLogError(Camera,
+                     "Invalid file path: %s. Expected to contain "
+                     "'session_<SessionNumber>/<TrackName>/segment_<SegmentNumber>.<SegmentExtension>' pattern. Skipping upload.",
+                     fullPath.c_str());
+        goto cleanup;
     }
-    std::string baseUrl = data.second;
     if (baseUrl.back() != '/')
     {
         baseUrl += "/";
     }
-    std::string fullUrl = baseUrl + filename;
+    fullUrl = baseUrl + filename;
 
     ChipLogProgress(Camera, "Uploading file: %s to URL: %s", filename.c_str(), fullUrl.c_str());
 
@@ -347,8 +356,8 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
     // TODO: The logic to provide DER-formatted certificates and keys in memory (blob) format to curl is currently unstable. As a
     // temporary workaround, PEM-format files are being provided as input to curl.
 
-    auto rootCertPEM   = DerCertToPem(mCertBuffer.mRootCertBuffer);
-    auto clientCertPEM = DerCertToPem(mCertBuffer.mClientCertBuffer);
+    rootCertPEM   = DerCertToPem(mCertBuffer.mRootCertBuffer);
+    clientCertPEM = DerCertToPem(mCertBuffer.mClientCertBuffer);
     if (!mCertBuffer.mIntermediateCertBuffer.empty())
     {
         clientCertPEM.append("\n"); // Add newline separator between certs in PEM format
@@ -357,7 +366,7 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
     {
         clientCertPEM.append(DerCertToPem(mCertBuffer.mIntermediateCertBuffer[i]) + "\n");
     }
-    std::string derKeyToPemstr = ConvertECDSAPrivateKey_DER_to_PEM(mCertBuffer.mClientKeyBuffer);
+    derKeyToPemstr = ConvertECDSAPrivateKey_DER_to_PEM(mCertBuffer.mClientKeyBuffer);
 
     SaveCertToFile(rootCertPEM, "/tmp/root.pem");
     SaveCertToFile(clientCertPEM, "/tmp/dev.pem");
@@ -386,7 +395,7 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
     curl_easy_setopt(curl, CURLOPT_READFUNCTION, PushAvUploadCb);
     curl_easy_setopt(curl, CURLOPT_READDATA, &upload);
 
-    CURLcode res = curl_easy_perform(curl);
+    res = curl_easy_perform(curl);
 
     if (res != CURLE_OK)
     {
@@ -396,6 +405,20 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
     {
         ChipLogDetail(Camera, "CURL uploaded file  %s size: %ld", data.first.c_str(), size);
     }
+
+    if (extension != ".mpd")
+    {
+        if (!std::filesystem::remove(data.first, ec))
+        {
+            ChipLogError(Camera, "Failed to delete file: %s, error: %s", data.first.c_str(), ec.message().c_str());
+        }
+        else
+        {
+            ChipLogDetail(Camera, "Successfully deleted file: %s", data.first.c_str());
+        }
+    }
+
+cleanup:
     if (upload.mData)
     {
         std::free(upload.mData);

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -51,7 +51,7 @@ public:
      *
      * @param transportOptions The configuration options of the transport to be allocated
      * @param connectionID The connectionID to allocate
-     * @param AccessingFabricIndex The FrabricIndex of the assosciated Fabric
+     * @param AccessingFabricIndex The FabricIndex of the associated Fabric
      * @return Success if allocation is successful and a PushTransportConnectionID was produced;
      *         otherwise, the command is rejected with Failure
      *
@@ -84,7 +84,7 @@ public:
      *         Failure if modification fails
      *
      * @note The buffers storing URL, Trigger Options, Motion Zones, Container Options are owned by
-     * the PushAVStreamTransport Server. The allocated buffers are cleared and reassigned to modified
+     * the PushAvStreamTransport Server. The allocated buffers are cleared and reassigned to modified
      * transportOptions on success of ModifyPushTransport and deallocated on success of DeallocatePushTransport.
      */
     virtual Protocols::InteractionModel::Status
@@ -142,7 +142,7 @@ public:
      * @brief Validates the provided Segment Duration.
      *
      * @param segmentDuration The Segment Duration to validate
-     * @param videoStreamId   The video stream to eb validated against
+     * @param videoStreamId   The video stream to be validated against
      * @return true if Segment Duration is multiple of KeyFrameInterval for the provided videoStreamId, false otherwise
      */
     virtual bool ValidateSegmentDuration(uint16_t segmentDuration,
@@ -275,7 +275,7 @@ public:
     /**
      * @brief Verifies whether Hard privacy mode is active on the device as set against the stream management instance
      *
-     * @param isActive boolean that is set by the delgate indicating privacy status, True is active
+     * @param isActive boolean that is set by the delegate indicating privacy status, True is active
      * @return CHIP_ERROR indicating success or failure
      */
     virtual CHIP_ERROR IsHardPrivacyModeActive(bool & isActive) = 0;
@@ -283,7 +283,7 @@ public:
     /**
      * @brief Verifies whether Soft Recording privacy mode is active on the device as set against the stream management instance
      *
-     * @param isActive boolean that is set by the delgate indicating privacy status, True is active
+     * @param isActive boolean that is set by the delegate indicating privacy status, True is active
      * @return CHIP_ERROR indicating success or failure
      */
     virtual CHIP_ERROR IsSoftRecordingPrivacyModeActive(bool & isActive) = 0;
@@ -291,7 +291,7 @@ public:
     /**
      * @brief Verifies whether Soft Livestream privacy mode is active on the device as set against the stream management instance
      *
-     * @param isActive boolean that is set by the delgate indicating privacy status, True is active
+     * @param isActive boolean that is set by the delegate indicating privacy status, True is active
      * @return CHIP_ERROR indicating success or failure
      */
     virtual CHIP_ERROR IsSoftLivestreamPrivacyModeActive(bool & isActive) = 0;

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -84,7 +84,7 @@ public:
      *         Failure if modification fails
      *
      * @note The buffers storing URL, Trigger Options, Motion Zones, Container Options are owned by
-     * the PushAvStreamTransport Server. The allocated buffers are cleared and reassigned to modified
+     * the Push AV Stream Transport server. The allocated buffers are cleared and reassigned to modified
      * transportOptions on success of ModifyPushTransport and deallocated on success of DeallocatePushTransport.
      */
     virtual Protocols::InteractionModel::Status


### PR DESCRIPTION
#### Summary

This PR addresses the following changes  & issues:

1.  Unique clip recorder path in the filesystem per each Push AV Transport

Old path: `/tmp/session_<N>/...`
New path: `/tmp/FabricIdx<M>_ConnectionId<O>_<YYYYMMDD>_<HHMMSS>/session_<N>/...`\
Example: `/tmp/FabricIdx0_ConnectionId2_20251113_230921/session_2/...`

2.  Remove recorded files from the filesystem after the upload and Push AV Termination

3. Fix Typos in the API documentation

4. Fix for incorrect video frame duration handling, replacing hardcoded values for `timebase`

5. Add Interface compatibility check ` i.e; IsCMAFInterfaceSupported()`validation.

#### Testing
```
# Build and run camera application
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debug/chip-camera-app

# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run Push AV TC
Example:
python3 src/python_testing/TC_PAVSTI_1_1.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1 --string-arg host_ip:localhost
```