### PR TITLE
Add support for minRevision/maxRevision to YAML test framework

### DIFF
--- a/docs/testing/yaml.md
+++ b/docs/testing/yaml.md
@@ -287,15 +287,15 @@ Here is an example of only checking for the value of a given attribute if
 `ClusterRevision` >= 3 using `minRevision`.
 
 ```yaml
-    - label: "Verify the minimum-to-support Max Paths Per Invoke value"
-      command: "readAttribute"
-      attribute: "MaxPathsPerInvoke"
-      minRevision: 3  # Attribute was added in revision 3, so this step applies
-                      # to revision >= 3.
-      response:
-          constraints:
-              minValue: 1
-
+- label: "Verify the minimum-to-support Max Paths Per Invoke value"
+  command: "readAttribute"
+  attribute: "MaxPathsPerInvoke"
+  minRevision:
+      3 # Attribute was added in revision 3, so this step applies
+      # to revision >= 3.
+  response:
+      constraints:
+          minValue: 1
 ```
 
 #### Setting step timeouts

--- a/docs/testing/yaml.md
+++ b/docs/testing/yaml.md
@@ -271,11 +271,32 @@ the test harness. Note that full-test gating is not currently implemented in the
 local runner or in the CI.
 
 Some test steps need to be gated on values from earlier in the test. In these
-cases, PICS cannot be used. Instead, the runIf: tag can be used. This tag
+cases, PICS cannot be used. Instead, the `runIf` tag can be used. This tag
 requires a boolean value. To convert values to booleans, the TestEqualities
 function can be use. See
 [TestEqualities](https://github.com/project-chip/connectedhomeip/blob/master/src/app/tests/suites/TestEqualities.yaml)
 for an example of how to use this pseudo-cluster.
+
+In addition to the `PICS` and `runIf` tags, there are the `minRevision` and
+`maxRevision` tags which use the step's `cluster`'s `ClusterRevision` attribute
+to determine if a step should be skipped because it only applies to older or
+newer versions. A step will be skipped if the cluster's `ClusterRevision`
+attribute is < `minRevision` (if present), or > `maxRevision` (if present).
+
+Here is an example of only checking for the value of a given attribute if
+`ClusterRevision` >= 3 using `minRevision`.
+
+```yaml
+    - label: "Verify the minimum-to-support Max Paths Per Invoke value"
+      command: "readAttribute"
+      attribute: "MaxPathsPerInvoke"
+      minRevision: 3  # Attribute was added in revision 3, so this step applies
+                      # to revision >= 3.
+      response:
+          constraints:
+              minValue: 1
+
+```
 
 #### Setting step timeouts
 

--- a/docs/testing/yaml_schema.md
+++ b/docs/testing/yaml_schema.md
@@ -76,3 +76,5 @@ YAML schema
 |&emsp; dataVersion |list,int|Y|
 |&emsp; busyWaitMs |int||
 |&emsp; wait |str||
+|&emsp; minRevision |int|Y|
+|&emsp; maxRevision |int|Y|

--- a/scripts/py_matter_yamltests/matter/yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/parser.py
@@ -895,7 +895,7 @@ class TestStep:
         # `YamlTests` class).
         var_name = build_revision_var_name(endpoint, cluster)
 
-        cluster_revision = self._runtime_config_variable_storage.get(var_name)
+        cluster_revision = self.get_runtime_variable(var_name)
 
         if cluster_revision is None:
             LOGGER.warning(
@@ -951,6 +951,10 @@ class TestStep:
                 event_number = received_event_number
 
         return event_number
+
+    def get_runtime_variable(self, name: str) -> Any:
+        """Gets a runtime variable from the test context, or None if missing."""
+        return self._runtime_config_variable_storage.get(name)
 
     def post_process_response(self, received_responses):
         result = PostProcessResponseResult()

--- a/scripts/py_matter_yamltests/matter/yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/parser.py
@@ -18,7 +18,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Optional
+from typing import Any, Optional
 
 from . import fixes
 from .constraints import get_constraints, is_typed_constraint, is_variable_aware_constraint
@@ -45,6 +45,10 @@ ANY_COMMANDS_LIST = [
 # If True, enum values should use a valid name instead of a raw value
 STRICT_ENUM_VALUE_CHECK = False
 
+
+def build_revision_var_name(endpoint, cluster) -> str:
+    """Helper to create a unique variable name for the cluster revision read-out."""
+    return f'__cluster_revision_read_EP_{endpoint}_CL_{cluster}'
 
 class UnknownPathQualifierError(TestStepError):
     """Raise when an attribute/command/event name is not found in the definitions."""
@@ -301,6 +305,8 @@ class _TestStepWithPlaceholders:
 
         self.identity = _value_or_none(test, 'identity')
         self.fabric_filtered = _value_or_none(test, 'fabricFiltered')
+        self.min_revision = _value_or_none(test, 'minRevision')
+        self.max_revision = _value_or_none(test, 'maxRevision')
         self.min_interval = _value_or_none(test, 'minInterval')
         self.max_interval = _value_or_none(test, 'maxInterval')
         self.keep_subscriptions = _value_or_none(test, 'keepSubscriptions')
@@ -748,6 +754,10 @@ class TestStep:
                 self._test.group_id)
             self._test.node_id = self._config_variable_substitution(
                 self._test.node_id)
+            self._test.min_revision = self._config_variable_substitution(
+                self._test.min_revision)
+            self._test.max_revision = self._config_variable_substitution(
+                self._test.max_revision)
             test.update_arguments(self.arguments)
             test.update_responses(self.responses)
 
@@ -854,6 +864,70 @@ class TestStep:
     @property
     def pics(self):
         return self._test.pics
+
+    @property
+    def min_revision(self):
+        return self._test.min_revision
+
+    @property
+    def max_revision(self):
+        return self._test.max_revision
+
+    @property
+    def is_revision_condition_passed(self) -> Optional[bool]:
+        """Checks if the revision conditions passed properly based on min/maxRevision.
+
+        This is evaluated at runtime by the runner.
+
+        Returns True if step can be run, False if it cannot be run, or None if there
+        was an error processing revision (i.e. internal error).
+        """
+        # If no revision checks are defined, the step is OK to run.
+        if self.min_revision is None and self.max_revision is None:
+            return True
+
+        endpoint = self.endpoint
+        cluster = self.cluster
+
+        # The runner will have executed a prior step to read the revision, based
+        # on the parser having injected that step (search for minRevision in
+        # `YamlTests` class).
+        var_name = build_revision_var_name(endpoint, cluster)
+
+        cluster_revision = self._runtime_config_variable_storage.get(var_name)
+
+        if cluster_revision is None:
+            LOGGER.warning(
+                f"Step '{self.label}': Cannot check min/maxRevision. "
+                f"ClusterRevision variable '{var_name}' is not set (read step may have been skipped or failed)."
+            )
+            return None
+
+        # Perform the checks
+        try:
+            # Ensure values are integers for comparison
+            cluster_revision = int(cluster_revision)
+
+            min_ok = True
+            if self.min_revision is not None:
+                min_revision_val = int(self.min_revision)
+                min_ok = (cluster_revision >= min_revision_val)
+
+            max_ok = True
+            if self.max_revision is not None:
+                max_revision_val = int(self.max_revision)
+                max_ok = (cluster_revision <= max_revision_val)
+
+            return min_ok and max_ok
+
+        except (ValueError, TypeError) as e:
+            # Failed to convert revision to int, or comparison failed.
+            LOGGER.error(
+                f"Step '{self.label}': Error checking min/maxRevision. "
+                f"cluster_revision='{cluster_revision}', min='{self.min_revision}', max='{self.max_revision}'. "
+                f"Error: {e}."
+            )
+            return None
 
     def _get_last_event_number(self, responses) -> Optional[int]:
         if not self.is_event:
@@ -1265,9 +1339,18 @@ class YamlTests:
 
     def __init__(self, parsing_config_variable_storage: dict, definitions: SpecDefinitions, pics_checker: PICSChecker, tests: dict):
         self._parsing_config_variable_storage = parsing_config_variable_storage
+        self._runtime_config_variable_storage = copy.deepcopy(
+            parsing_config_variable_storage)
+        self._definitions = definitions
+        self._pics_checker = pics_checker
+
+        tests_with_cluster_revision_injections = self._tests_with_cluster_revision_checks(tests)
+
+        # Build list of enabled tests from the starting point where pseudo steps are added/injected for
+        # things like min/maxRevision tests.
         enabled_tests = []
         try:
-            for step_index, step in enumerate(tests):
+            for step_index, step in enumerate(tests_with_cluster_revision_injections):
                 test_with_placeholders = _TestStepWithPlaceholders(
                     step, self._parsing_config_variable_storage, definitions, pics_checker)
                 if test_with_placeholders.is_enabled:
@@ -1278,11 +1361,93 @@ class YamlTests:
 
         fixes.try_update_yaml_node_id_test_runner_state(
             enabled_tests, self._parsing_config_variable_storage)
-        self._runtime_config_variable_storage = copy.deepcopy(
-            parsing_config_variable_storage)
+
         self._tests = enabled_tests
         self._index = 0
         self.count = len(self._tests)
+
+
+    def _tests_with_cluster_revision_checks(self, tests: dict) -> list[TestStep]:
+        """Injection Logic for synthetic steps needed to process cluster revision checks."""
+
+        # Pre-pass: Find all (endpoint, cluster) pairs that *need* a revision check.
+        default_endpoint = self._get_config_value(
+            self._parsing_config_variable_storage, 'endpoint')
+        default_cluster = self._get_config_value(
+            self._parsing_config_variable_storage, 'cluster')
+
+        needed_revisions = set()  # Set of (endpoint, cluster) tuples
+        for step in tests:
+            # A step needs a revision check if it has min/maxRevision and is not disabled.
+            if 'disabled' in step and step['disabled']:
+                continue
+
+            if 'minRevision' in step or 'maxRevision' in step:
+                endpoint = step.get('endpoint', default_endpoint)
+                cluster = step.get('cluster', default_cluster)
+
+                if endpoint is not None and cluster is not None:
+                    needed_revisions.add((endpoint, cluster))
+
+        # Main pass: Inject steps
+        injected_tests = []
+        seen_injections = set()  # Set of (endpoint, cluster) tuples
+
+        for step in tests:
+            endpoint = step.get('endpoint', default_endpoint)
+            cluster = step.get('cluster', default_cluster)
+            key = (endpoint, cluster)
+            is_disabled = 'disabled' in step and step['disabled']
+            step_has_revision_condition = 'minRevision' in step or 'maxRevision' in step
+
+            # Determine if an enabled step is the first that would need a cluster revision not yet read.
+            # Prepend the read to such steps.
+            if step_has_revision_condition and (key in needed_revisions) and (key not in seen_injections) and (not is_disabled):
+                # Inject the step *before* the current step.
+                revision_var_name = build_revision_var_name(endpoint, cluster)
+
+                # Add to config storage so it's a known variable
+                if revision_var_name not in self._parsing_config_variable_storage:
+                    self._parsing_config_variable_storage[revision_var_name] = None
+
+                # Also update the runtime storage, since it was already copied.
+                if revision_var_name not in self._runtime_config_variable_storage:
+                    self._runtime_config_variable_storage[revision_var_name] = None
+
+                injected_step = {
+                    'label': f'Read ClusterRevision for conditions (EP: {endpoint}, CL: {cluster})',
+                    'cluster': cluster,
+                    'endpoint': endpoint,
+                    'command': 'readAttribute',
+                    'attribute': 'ClusterRevision',
+                    'response': {
+                        'saveAs': revision_var_name,
+                        'constraints': {
+                            'type': 'int16u'
+                        }
+                    }
+                }
+
+                injected_tests.append(injected_step)
+                seen_injections.add(key)
+
+            injected_tests.append(step)
+
+        return injected_tests
+
+    def _get_config_value(self, config_storage, key):
+        value = config_storage.get(key)
+        if isinstance(value, dict) and 'defaultValue' in value:
+            return value['defaultValue']
+        return value
+
+    def set_runtime_variable(self, name: str, value: Any) -> None:
+        """Sets a runtime variable in the test context."""
+        self._runtime_config_variable_storage[name] = value
+
+    def get_runtime_variable(self, name: str) -> Any:
+        """Gets a runtime variable from the test context, or None if missing."""
+        self._runtime_config_variable_storage.get(name)
 
     def __iter__(self):
         return self

--- a/scripts/py_matter_yamltests/matter/yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/parser.py
@@ -50,6 +50,7 @@ def build_revision_var_name(endpoint, cluster) -> str:
     """Helper to create a unique variable name for the cluster revision read-out."""
     return f'__cluster_revision_read_EP_{endpoint}_CL_{cluster}'
 
+
 class UnknownPathQualifierError(TestStepError):
     """Raise when an attribute/command/event name is not found in the definitions."""
 
@@ -1233,7 +1234,8 @@ class TestStep:
 
             for constraint in constraints:
                 try:
-                    constraint.validate(received_value, response_type_name, self._runtime_config_variable_storage)
+                    constraint.validate(
+                        received_value, response_type_name, self._runtime_config_variable_storage)
                     result.success(check_type, error_success)
                 except TestStepError as e:
                     e.update_context(expected_response, self.step_index)
@@ -1344,7 +1346,8 @@ class YamlTests:
         self._definitions = definitions
         self._pics_checker = pics_checker
 
-        tests_with_cluster_revision_injections = self._tests_with_cluster_revision_checks(tests)
+        tests_with_cluster_revision_injections = self._tests_with_cluster_revision_checks(
+            tests)
 
         # Build list of enabled tests from the starting point where pseudo steps are added/injected for
         # things like min/maxRevision tests.
@@ -1365,7 +1368,6 @@ class YamlTests:
         self._tests = enabled_tests
         self._index = 0
         self.count = len(self._tests)
-
 
     def _tests_with_cluster_revision_checks(self, tests: dict) -> list[TestStep]:
         """Injection Logic for synthetic steps needed to process cluster revision checks."""

--- a/scripts/py_matter_yamltests/matter/yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/parser.py
@@ -1449,7 +1449,7 @@ class YamlTests:
 
     def get_runtime_variable(self, name: str) -> Any:
         """Gets a runtime variable from the test context, or None if missing."""
-        self._runtime_config_variable_storage.get(name)
+        return self._runtime_config_variable_storage.get(name)
 
     def __iter__(self):
         return self

--- a/scripts/py_matter_yamltests/matter/yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/parser.py
@@ -909,8 +909,8 @@ class TestStep:
             cluster_revision = int(cluster_revision)
 
             return all([
-              (self.min_revision is None) or (cluster_revision >= int(self.min_revision)),
-              (self.max_revision is None) or (cluster_revision <= int(self.max_revision)),
+                (self.min_revision is None) or (cluster_revision >= int(self.min_revision)),
+                (self.max_revision is None) or (cluster_revision <= int(self.max_revision)),
             ])
         except (ValueError, TypeError) as e:
             # Failed to convert revision to int. This can happen with malformed YAML.

--- a/scripts/py_matter_yamltests/matter/yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/runner.py
@@ -194,20 +194,7 @@ class TestRunner(TestRunnerBase):
                     continue
 
                 # Handle skipping steps where ClusterRevision does not apply.
-                fail_msg = ""
-                try:
-                    is_revision_condition_passed = request.is_revision_condition_passed
-                    if is_revision_condition_passed is None:
-                        fail_msg = f"Failed to compute ClusterRevision constraints for step '{request.label}'!"
-                except Exception as e:
-                    fail_msg = f"Error during ClusterRevision check for step '{request.label}': {e}"
-                    is_revision_condition_passed = None
-
-                if is_revision_condition_passed is None:
-                    # This should never happen.
-                    raise ValueError(fail_msg)
-
-                if not is_revision_condition_passed:
+                if not request.is_revision_condition_passed:
                     # Try to get the var name and value for a more informative message
                     try:
                         var_name = build_revision_var_name(

--- a/scripts/py_matter_yamltests/matter/yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/runner.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 
 from .adapter import TestAdapter
 from .hooks import TestRunnerHooks
-from .parser import build_revision_var_name, TestParser
+from .parser import TestParser, build_revision_var_name
 from .parser_builder import TestParserBuilder, TestParserBuilderConfig
 from .pseudo_clusters.pseudo_clusters import PseudoClusters
 

--- a/scripts/py_matter_yamltests/matter/yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/runner.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 
 from .adapter import TestAdapter
 from .hooks import TestRunnerHooks
-from .parser import TestParser
+from .parser import build_revision_var_name, TestParser
 from .parser_builder import TestParserBuilder, TestParserBuilderConfig
 from .pseudo_clusters.pseudo_clusters import PseudoClusters
 
@@ -188,10 +188,41 @@ class TestRunner(TestRunnerBase):
 
             test_duration = 0
             for idx, request in enumerate(parser.tests):
+                # Handle skipping tests where PICS do not apply.
                 if not request.is_pics_enabled:
                     hooks.step_skipped(request.label, request.pics)
                     continue
-                elif not config.adapter:
+
+                # Handle skipping steps where ClusterRevision does not apply.
+                fail_msg = ""
+                try:
+                    is_revision_condition_passed = request.is_revision_condition_passed
+                    if is_revision_condition_passed is None:
+                        fail_msg = f"Failed to compute ClusterRevision constraints for step '{request.label}'!"
+                except Exception as e:
+                    fail_msg = f"Error during ClusterRevision check for step '{request.label}': {e}"
+                    is_revision_condition_passed = None
+
+                if is_revision_condition_passed is None:
+                    # This should never happen.
+                    raise ValueError(fail_msg)
+
+                if not is_revision_condition_passed:
+                    # Try to get the var name and value for a more informative message
+                    try:
+                        var_name = build_revision_var_name(request.endpoint, request.cluster)
+                        current_val = request.get_runtime_variable(var_name)
+                    except (ValueError, IndexError, KeyError) as e:
+                        current_val = "unknown"
+
+                    reason = (f"Step skipped due to ClusterRevision range not matching (val={current_val}, "
+                              f"min={request.min_revision}, "
+                              f"max={request.max_revision})")
+                    hooks.step_skipped(request.label, reason)
+                    continue
+
+                # Handle normal flows of execution after condition skipping above.
+                if not config.adapter:
                     hooks.step_start(request)
                     hooks.step_unknown()
                     continue

--- a/scripts/py_matter_yamltests/matter/yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/runner.py
@@ -213,7 +213,7 @@ class TestRunner(TestRunnerBase):
                         var_name = build_revision_var_name(
                             request.endpoint, request.cluster)
                         current_val = request.get_runtime_variable(var_name)
-                    except (ValueError, IndexError, KeyError) as e:
+                    except (ValueError, IndexError, KeyError):
                         current_val = "unknown"
 
                     reason = (f"Step skipped due to ClusterRevision range not matching (val={current_val}, "

--- a/scripts/py_matter_yamltests/matter/yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/runner.py
@@ -210,7 +210,8 @@ class TestRunner(TestRunnerBase):
                 if not is_revision_condition_passed:
                     # Try to get the var name and value for a more informative message
                     try:
-                        var_name = build_revision_var_name(request.endpoint, request.cluster)
+                        var_name = build_revision_var_name(
+                            request.endpoint, request.cluster)
                         current_val = request.get_runtime_variable(var_name)
                     except (ValueError, IndexError, KeyError) as e:
                         current_val = "unknown"

--- a/scripts/py_matter_yamltests/matter/yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/yaml_loader.py
@@ -56,16 +56,18 @@ _TEST_STEP_SCHEMA = {
     'verification': str,
     'PICS': str,
     'arguments': dict,
-    'response': (dict, list, str),  # Can be a variable
+    'response': (dict, list, str),  # Can be a variable.
     'saveResponseAs': str,
     'minInterval': int,
     'maxInterval': int,
     'keepSubscriptions': bool,
     'timeout': int,
     'timedInteractionTimeoutMs': int,
-    'dataVersion': (list, int, str),  # Can be a variable
+    'dataVersion': (list, int, str),  # Can be a variable.
     'busyWaitMs': int,
     'wait': str,
+    'minRevision': (int, str),  # Can be a variable.
+    'maxRevision': (int, str),  # Can be a variable.
 }
 
 _TEST_STEP_ARGUMENTS_SCHEMA = {

--- a/scripts/py_matter_yamltests/test_yaml_parser.py
+++ b/scripts/py_matter_yamltests/test_yaml_parser.py
@@ -552,10 +552,11 @@ class TestYamlParser(unittest.TestCase):
         self.assertFalse(test_step.is_revision_condition_passed)
 
     def test_revision_check_variable_not_set(self):
-        # Variable is not set (simulated by passing None)
+        # Variable is not set (simulated by passing None): this is illegal and raises
         test_step = self._get_revision_check_between_5_and_10_test_step(
             revision_value=None)
-        self.assertFalse(test_step.is_revision_condition_passed)
+        with self.assertRaises(KeyError):
+            test_step.is_revision_condition_passed
 
     def test_revision_check_only_min(self):
         # This test needs a slightly different YAML

--- a/scripts/py_matter_yamltests/test_yaml_parser.py
+++ b/scripts/py_matter_yamltests/test_yaml_parser.py
@@ -364,7 +364,8 @@ class TestYamlParser(unittest.TestCase):
             self.assertEqual(len(values), 1)
             value = values[0]
             self.assertEqual(value['name'], 'arg')
-            self.assertEqual(value['value'], _BASIC_ARITHMETIC_ARG_RESULTS[idx])
+            self.assertEqual(
+                value['value'], _BASIC_ARITHMETIC_ARG_RESULTS[idx])
 
     def test_config_override(self):
         config_override = {'nodeId': 12345,
@@ -424,10 +425,10 @@ class TestYamlParser(unittest.TestCase):
         self.assertEqual(steps[1].label, "Step 2 - No revision check")
         self.assertEqual(steps[2].label, "Step 3 - No revision check")
 
-
     def test_revision_step_injection(self):
         parser_config = TestParserConfig(None, self._definitions)
-        yaml_parser = TestParser(min_max_revision_injection_yaml, parser_config)
+        yaml_parser = TestParser(
+            min_max_revision_injection_yaml, parser_config)
 
         # The parser's YAML had 3 steps. The injection logic should add one
         # `readAttribute` step before step 2 (which is index 1).
@@ -505,8 +506,10 @@ class TestYamlParser(unittest.TestCase):
         # The injected step (list(yaml_parser.tests)[0]) set this variable
         # during a read that the runner would do for real.
         # We are checking the step that *uses* it (list(yaml_parser.tests)[1]).
-        cluster_rev_var_name = build_revision_var_name(endpoint=1, cluster="Test")
-        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=revision_value)
+        cluster_rev_var_name = build_revision_var_name(
+            endpoint=1, cluster="Test")
+        yaml_parser.tests.set_runtime_variable(
+            name=cluster_rev_var_name, value=revision_value)
 
         # Get the step that has the min/max check.
         # This is the 2nd step (index 1) after the injected step (index 0).
@@ -520,32 +523,38 @@ class TestYamlParser(unittest.TestCase):
 
     def test_revision_check_in_range(self):
         # 7 is between 5 and 10
-        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=7)
+        test_step = self._get_revision_check_between_5_and_10_test_step(
+            revision_value=7)
         self.assertTrue(test_step.is_revision_condition_passed)
 
     def test_revision_check_in_range_min_boundary(self):
         # 5 is between 5 and 10 (inclusive)
-        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=5)
+        test_step = self._get_revision_check_between_5_and_10_test_step(
+            revision_value=5)
         self.assertTrue(test_step.is_revision_condition_passed)
 
     def test_revision_check_in_range_max_boundary(self):
         # 10 is between 5 and 10 (inclusive)
-        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=10)
+        test_step = self._get_revision_check_between_5_and_10_test_step(
+            revision_value=10)
         self.assertTrue(test_step.is_revision_condition_passed)
 
     def test_revision_check_out_of_range_min(self):
         # 4 is less than 5
-        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=4)
+        test_step = self._get_revision_check_between_5_and_10_test_step(
+            revision_value=4)
         self.assertFalse(test_step.is_revision_condition_passed)
 
     def test_revision_check_out_of_range_max(self):
         # 11 is greater than 10
-        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=11)
+        test_step = self._get_revision_check_between_5_and_10_test_step(
+            revision_value=11)
         self.assertFalse(test_step.is_revision_condition_passed)
 
     def test_revision_check_variable_not_set(self):
         # Variable is not set (simulated by passing None)
-        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=None)
+        test_step = self._get_revision_check_between_5_and_10_test_step(
+            revision_value=None)
         self.assertFalse(test_step.is_revision_condition_passed)
 
     def test_revision_check_only_min(self):
@@ -560,19 +569,23 @@ tests:
 '''
         parser_config = TestParserConfig(None, self._definitions)
         yaml_parser = TestParser(yaml_content, parser_config)
-        cluster_rev_var_name = build_revision_var_name(endpoint=1, cluster="Test")
+        cluster_rev_var_name = build_revision_var_name(
+            endpoint=1, cluster="Test")
 
-        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=4)
+        yaml_parser.tests.set_runtime_variable(
+            name=cluster_rev_var_name, value=4)
         test_step_fail = list(yaml_parser.tests)[1]
         self.assertFalse(test_step_fail.is_revision_condition_passed)
 
         yaml_parser = TestParser(yaml_content, parser_config)
-        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=5)
+        yaml_parser.tests.set_runtime_variable(
+            name=cluster_rev_var_name, value=5)
         test_step_pass = list(yaml_parser.tests)[1]
         self.assertTrue(test_step_pass.is_revision_condition_passed)
 
         yaml_parser = TestParser(yaml_content, parser_config)
-        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=100)
+        yaml_parser.tests.set_runtime_variable(
+            name=cluster_rev_var_name, value=100)
         test_step_pass_high = list(yaml_parser.tests)[1]
         self.assertTrue(test_step_pass_high.is_revision_condition_passed)
 
@@ -588,19 +601,23 @@ tests:
 '''
         parser_config = TestParserConfig(None, self._definitions)
         yaml_parser = TestParser(yaml_content, parser_config)
-        cluster_rev_var_name = build_revision_var_name(endpoint=1, cluster="Test")
+        cluster_rev_var_name = build_revision_var_name(
+            endpoint=1, cluster="Test")
 
-        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=11)
+        yaml_parser.tests.set_runtime_variable(
+            name=cluster_rev_var_name, value=11)
         test_step_fail = list(yaml_parser.tests)[1]
         self.assertFalse(test_step_fail.is_revision_condition_passed)
 
         yaml_parser = TestParser(yaml_content, parser_config)
-        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=10)
+        yaml_parser.tests.set_runtime_variable(
+            name=cluster_rev_var_name, value=10)
         test_step_pass = list(yaml_parser.tests)[1]
         self.assertTrue(test_step_pass.is_revision_condition_passed)
 
         yaml_parser = TestParser(yaml_content, parser_config)
-        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=2)
+        yaml_parser.tests.set_runtime_variable(
+            name=cluster_rev_var_name, value=2)
         test_step_pass_low = list(yaml_parser.tests)[1]
         self.assertTrue(test_step_pass_low.is_revision_condition_passed)
 

--- a/scripts/py_matter_yamltests/test_yaml_parser.py
+++ b/scripts/py_matter_yamltests/test_yaml_parser.py
@@ -25,7 +25,7 @@ from unittest.mock import mock_open, patch
 
 from matter.yamltests.definitions import ParseSource, SpecDefinitions
 from matter.yamltests.errors import TestStepEnumError, TestStepEnumSpecifierNotUnknownError, TestStepEnumSpecifierWrongError
-from matter.yamltests.parser import TestParser, TestParserConfig
+from matter.yamltests.parser import build_revision_var_name, TestParser, TestParserConfig
 
 simple_test_description = '''<?xml version="1.0"?>
   <configurator>
@@ -46,6 +46,7 @@ simple_test_description = '''<?xml version="1.0"?>
       <code>0x1234</code>
 
       <attribute side="server" code="0x0024" type="TestEnum" writable="true" optional="false">test_enum</attribute>
+      <attribute side="server" code="0xFFFD" type="int16u" writable="false" optional="false">ClusterRevision</attribute>
 
       <command source="client" code="1" name="test"></command>
       <command source="client" code="2" name="IntTest">
@@ -253,6 +254,75 @@ tests:
                 value: (myVariable +3)/7
 '''
 
+no_revision_check_yaml = '''
+name: Test without any min/maxRevision applied
+config:
+    nodeId: 0x12344321
+    cluster: "Test"
+    endpoint: 1
+tests:
+    - label: "Step 1 - No revision check"
+      command: "test"
+    - label: "Step 2 - No revision check"
+      command: "test"
+    - label: "Step 3 - No revision check"
+      command: "test"
+'''
+
+min_max_revision_injection_yaml = '''
+name: Test Min/Max Revision Injection
+config:
+    nodeId: 0x12344321
+    cluster: "Test"
+    endpoint: 1
+tests:
+    - label: "Step 1 - No revision check"
+      command: "test"
+    - label: "Step 2 - With revision check"
+      command: "test"
+      minRevision: 5
+    - label: "Step 3 - Also with revision check"
+      command: "test"
+      maxRevision: 10
+'''
+
+min_max_revision_check_yaml = '''
+name: Test Min/Max Revision Check
+config:
+    nodeId: 0x12344321
+    cluster: "Test"
+    endpoint: 1
+tests:
+    - label: "Step 1 - The revision check"
+      command: "test"
+      minRevision: 5
+      maxRevision: 10
+'''
+
+# A YAML to test ClusterRevision check injection on two different endpoints
+min_max_revision_multi_injection_yaml = '''
+name: Test Min/Max Revision Multi Injection
+config:
+    nodeId: 0x12344321
+    cluster: "Test"
+    endpoint: 1
+tests:
+    - label: "Step 1 - EP 1"
+      command: "test"
+      minRevision: 5
+    - label: "Step 2 - EP 2"
+      endpoint: 2
+      command: "test"
+      maxRevision: 10
+    - label: "Step 3 - EP 1 again"
+      command: "test"
+      maxRevision: 10
+    - label: "Step 4 - EP 2 again"
+      endpoint: 2
+      command: "test"
+      minRevision: 5
+'''
+
 
 def mock_open_with_parameter_content(content):
     file_object = mock_open(read_data=content).return_value
@@ -342,6 +412,204 @@ class TestYamlParser(unittest.TestCase):
         parser_config = TestParserConfig(None, self._definitions)
         self.assertRaises(TestStepEnumSpecifierNotUnknownError, TestParser,
                           enum_value_read_response_not_unknown_code_specified_yaml, parser_config)
+
+    def test_revision_no_injection_when_not_needed(self):
+        parser_config = TestParserConfig(None, self._definitions)
+        yaml_parser = TestParser(no_revision_check_yaml, parser_config)
+
+        steps = list(yaml_parser.tests)
+        # Original YAML has 3 tests. It should remain untouched.
+        self.assertEqual(len(steps), 3)
+        self.assertEqual(steps[0].label, "Step 1 - No revision check")
+        self.assertEqual(steps[1].label, "Step 2 - No revision check")
+        self.assertEqual(steps[2].label, "Step 3 - No revision check")
+
+
+    def test_revision_step_injection(self):
+        parser_config = TestParserConfig(None, self._definitions)
+        yaml_parser = TestParser(min_max_revision_injection_yaml, parser_config)
+
+        # The parser's YAML had 3 steps. The injection logic should add one
+        # `readAttribute` step before step 2 (which is index 1).
+        # The parser filters disabled steps, but here we have none.
+        # The injection happens in YamlTests.__init__
+        steps = list(yaml_parser.tests)
+
+        # Original YAML has 3 tests. We should have 1 read operation injection.
+        self.assertEqual(len(steps), 4)
+
+        # Step index 0 should be the original "Step 1 - No revision check"
+        self.assertEqual(steps[0].label, "Step 1 - No revision check")
+
+        # Step index 1 should be the *injected* step
+        self.assertEqual(
+            steps[1].label, "Read ClusterRevision for conditions (EP: 1, CL: Test)")
+        self.assertEqual(steps[1].command, "readAttribute")
+        self.assertEqual(steps[1].attribute, "ClusterRevision")
+        self.assertEqual(
+            steps[1].responses[0]['values'][0]['saveAs'], build_revision_var_name(endpoint=1, cluster="Test"))
+
+        # Step index 2 should be the original "Step 2 - With revision check"
+        self.assertEqual(steps[2].label, "Step 2 - With revision check")
+        self.assertEqual(steps[2].min_revision, 5)
+
+        # Step index 3 should be the original "Step 3 - Also with revision check"
+        self.assertEqual(steps[3].label, "Step 3 - Also with revision check")
+        self.assertEqual(steps[3].max_revision, 10)
+
+    def test_revision_step_multi_injection(self):
+        parser_config = TestParserConfig(None, self._definitions)
+        yaml_parser = TestParser(
+            min_max_revision_multi_injection_yaml, parser_config)
+
+        steps = list(yaml_parser.tests)
+
+        # Original YAML has 4 tests. We should have 2 injections (one for EP1, one for EP2).
+        self.assertEqual(len(steps), 6)
+
+        # Step index 0: Injected for (EP: 1, CL: Test)
+        self.assertEqual(
+            steps[0].label, "Read ClusterRevision for conditions (EP: 1, CL: Test)")
+        self.assertEqual(steps[0].endpoint, 1)
+        self.assertEqual(
+            steps[0].responses[0]['values'][0]['saveAs'], build_revision_var_name(endpoint=1, cluster="Test"))
+
+        # Step index 1: Original "Step 1 - EP 1"
+        self.assertEqual(steps[1].label, "Step 1 - EP 1")
+        self.assertEqual(steps[1].endpoint, 1)
+
+        # Step index 2: Injected for (EP: 2, CL: Test)
+        self.assertEqual(
+            steps[2].label, "Read ClusterRevision for conditions (EP: 2, CL: Test)")
+        self.assertEqual(steps[2].endpoint, 2)
+        self.assertEqual(
+            steps[2].responses[0]['values'][0]['saveAs'], build_revision_var_name(endpoint=2, cluster="Test"))
+
+        # Step index 3: Original "Step 2 - EP 2"
+        self.assertEqual(steps[3].label, "Step 2 - EP 2")
+        self.assertEqual(steps[3].endpoint, 2)
+
+        # Step index 4: Original "Step 3 - EP 1 again" (no new injection)
+        self.assertEqual(steps[4].label, "Step 3 - EP 1 again")
+        self.assertEqual(steps[4].endpoint, 1)
+
+        # Step index 5: Original "Step 4 - EP 2 again" (no new injection)
+        self.assertEqual(steps[5].label, "Step 4 - EP 2 again")
+        self.assertEqual(steps[5].endpoint, 2)
+
+    def _get_revision_check_between_5_and_10_test_step(self, revision_value):
+        parser_config = TestParserConfig(None, self._definitions)
+        yaml_parser = TestParser(min_max_revision_check_yaml, parser_config)
+
+        # Manually set the runtime variable to simulate the read step.
+        # The injected step (list(yaml_parser.tests)[0]) set this variable
+        # during a read that the runner would do for real.
+        # We are checking the step that *uses* it (list(yaml_parser.tests)[1]).
+        cluster_rev_var_name = build_revision_var_name(endpoint=1, cluster="Test")
+        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=revision_value)
+
+        # Get the step that has the min/max check.
+        # This is the 2nd step (index 1) after the injected step (index 0).
+        test_step = list(yaml_parser.tests)[1]
+
+        # The step from the YAML has min: 5, max: 10
+        self.assertEqual(test_step.min_revision, 5)
+        self.assertEqual(test_step.max_revision, 10)
+
+        return test_step
+
+    def test_revision_check_in_range(self):
+        # 7 is between 5 and 10
+        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=7)
+        self.assertTrue(test_step.is_revision_condition_passed)
+
+    def test_revision_check_in_range_min_boundary(self):
+        # 5 is between 5 and 10 (inclusive)
+        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=5)
+        self.assertTrue(test_step.is_revision_condition_passed)
+
+    def test_revision_check_in_range_max_boundary(self):
+        # 10 is between 5 and 10 (inclusive)
+        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=10)
+        self.assertTrue(test_step.is_revision_condition_passed)
+
+    def test_revision_check_out_of_range_min(self):
+        # 4 is less than 5
+        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=4)
+        self.assertFalse(test_step.is_revision_condition_passed)
+
+    def test_revision_check_out_of_range_max(self):
+        # 11 is greater than 10
+        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=11)
+        self.assertFalse(test_step.is_revision_condition_passed)
+
+    def test_revision_check_variable_not_set(self):
+        # Variable is not set (simulated by passing None)
+        test_step = self._get_revision_check_between_5_and_10_test_step(revision_value=None)
+        self.assertFalse(test_step.is_revision_condition_passed)
+
+    def test_revision_check_only_min(self):
+        # This test needs a slightly different YAML
+        yaml_content = '''
+name: Test Min/Max Revision Check
+config: { cluster: "Test", endpoint: 1 }
+tests:
+    - label: "Step 1"
+      command: "test"
+      minRevision: 5
+'''
+        parser_config = TestParserConfig(None, self._definitions)
+        yaml_parser = TestParser(yaml_content, parser_config)
+        cluster_rev_var_name = build_revision_var_name(endpoint=1, cluster="Test")
+
+        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=4)
+        test_step_fail = list(yaml_parser.tests)[1]
+        self.assertFalse(test_step_fail.is_revision_condition_passed)
+
+        yaml_parser = TestParser(yaml_content, parser_config)
+        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=5)
+        test_step_pass = list(yaml_parser.tests)[1]
+        self.assertTrue(test_step_pass.is_revision_condition_passed)
+
+        yaml_parser = TestParser(yaml_content, parser_config)
+        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=100)
+        test_step_pass_high = list(yaml_parser.tests)[1]
+        self.assertTrue(test_step_pass_high.is_revision_condition_passed)
+
+    def test_revision_check_only_max(self):
+        # This test needs a slightly different YAML
+        yaml_content = '''
+name: Test Min/Max Revision Check
+config: { cluster: "Test", endpoint: 1 }
+tests:
+    - label: "Step 1"
+      command: "test"
+      maxRevision: 10
+'''
+        parser_config = TestParserConfig(None, self._definitions)
+        yaml_parser = TestParser(yaml_content, parser_config)
+        cluster_rev_var_name = build_revision_var_name(endpoint=1, cluster="Test")
+
+        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=11)
+        test_step_fail = list(yaml_parser.tests)[1]
+        self.assertFalse(test_step_fail.is_revision_condition_passed)
+
+        yaml_parser = TestParser(yaml_content, parser_config)
+        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=10)
+        test_step_pass = list(yaml_parser.tests)[1]
+        self.assertTrue(test_step_pass.is_revision_condition_passed)
+
+        yaml_parser = TestParser(yaml_content, parser_config)
+        yaml_parser.tests.set_runtime_variable(name=cluster_rev_var_name, value=2)
+        test_step_pass_low = list(yaml_parser.tests)[1]
+        self.assertTrue(test_step_pass_low.is_revision_condition_passed)
+
+    def test_revision_check_no_revision_at_all(self):
+        parser_config = TestParserConfig(None, self._definitions)
+        yaml_parser = TestParser(no_revision_check_yaml, parser_config)
+
+        test_step_fail = list(yaml_parser.tests)[0]
+        self.assertTrue(test_step_fail.is_revision_condition_passed)
 
 
 def main():

--- a/scripts/py_matter_yamltests/test_yaml_parser.py
+++ b/scripts/py_matter_yamltests/test_yaml_parser.py
@@ -25,7 +25,7 @@ from unittest.mock import mock_open, patch
 
 from matter.yamltests.definitions import ParseSource, SpecDefinitions
 from matter.yamltests.errors import TestStepEnumError, TestStepEnumSpecifierNotUnknownError, TestStepEnumSpecifierWrongError
-from matter.yamltests.parser import build_revision_var_name, TestParser, TestParserConfig
+from matter.yamltests.parser import TestParser, TestParserConfig, build_revision_var_name
 
 simple_test_description = '''<?xml version="1.0"?>
   <configurator>

--- a/scripts/tests/chiptest/yamltest_with_matter_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_matter_repl_tester.py
@@ -39,7 +39,7 @@ from matter.ChipStack import ChipStack
 from matter.storage import PersistentStorageJSON
 from matter.yaml.runner import ReplTestRunner
 from matter.yamltests.definitions import SpecDefinitionsFromPaths
-from matter.yamltests.parser import build_revision_var_name, PostProcessCheckStatus, TestParser, TestParserConfig
+from matter.yamltests.parser import PostProcessCheckStatus, TestParser, TestParserConfig, build_revision_var_name
 
 _DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", ".."))

--- a/scripts/tests/chiptest/yamltest_with_matter_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_matter_repl_tester.py
@@ -65,8 +65,8 @@ async def execute_test(yaml, runner):
                 current_val = "unknown"
 
             logging.warning(f"Step {test_step.label} skipped due to ClusterRevision range not matching (val={current_val}, "
-                      f"min={test_step.min_revision}, "
-                      f"max={test_step.max_revision})")
+                            f"min={test_step.min_revision}, "
+                            f"max={test_step.max_revision})")
             continue
 
         test_action = runner.encode(test_step)

--- a/scripts/tests/chiptest/yamltest_with_matter_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_matter_repl_tester.py
@@ -39,7 +39,7 @@ from matter.ChipStack import ChipStack
 from matter.storage import PersistentStorageJSON
 from matter.yaml.runner import ReplTestRunner
 from matter.yamltests.definitions import SpecDefinitionsFromPaths
-from matter.yamltests.parser import PostProcessCheckStatus, TestParser, TestParserConfig
+from matter.yamltests.parser import build_revision_var_name, PostProcessCheckStatus, TestParser, TestParserConfig
 
 _DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", ".."))
@@ -54,6 +54,21 @@ async def execute_test(yaml, runner):
     for test_step in yaml.tests:
         if not test_step.is_pics_enabled:
             continue
+
+        if not test_step.is_revision_condition_passed:
+            # Try to get the var name and value for a more informative message
+            try:
+                var_name = build_revision_var_name(
+                    test_step.endpoint, test_step.cluster)
+                current_val = test_step.get_runtime_variable(var_name)
+            except (ValueError, IndexError, KeyError):
+                current_val = "unknown"
+
+            logging.warning(f"Step {test_step.label} skipped due to ClusterRevision range not matching (val={current_val}, "
+                      f"min={test_step.min_revision}, "
+                      f"max={test_step.max_revision})")
+            continue
+
         test_action = runner.encode(test_step)
         if test_action is None:
             raise Exception(

--- a/src/app/tests/suites/TestBasicInformation.yaml
+++ b/src/app/tests/suites/TestBasicInformation.yaml
@@ -189,7 +189,7 @@ tests:
           by minRevision). Used to test YAML minRevision support."
       command: "readAttribute"
       attribute: "MaxPathsPerInvoke"
-      minRevision: 100
+      minRevision: 1000
       response:
           constraints:
               maxValue: 0
@@ -199,7 +199,7 @@ tests:
           by maxRevision). Used to test YAML maxRevision support."
       command: "readAttribute"
       attribute: "MaxPathsPerInvoke"
-      maxRevision: 1
+      maxRevision: 0
       response:
           constraints:
               maxValue: 0

--- a/src/app/tests/suites/TestBasicInformation.yaml
+++ b/src/app/tests/suites/TestBasicInformation.yaml
@@ -184,7 +184,9 @@ tests:
           constraints:
               minValue: 1
 
-    - label: "Force-fail if minRevision is not handled properly (should be skipped by minRevision). Used to test YAML minRevision support."
+    - label:
+          "Force-fail if minRevision is not handled properly (should be skipped
+          by minRevision). Used to test YAML minRevision support."
       command: "readAttribute"
       attribute: "MaxPathsPerInvoke"
       minRevision: 100
@@ -192,7 +194,9 @@ tests:
           constraints:
               maxValue: 0
 
-    - label: "Force-fail if maxRevision is not handled properly (should be skipped by maxRevision). Used to test YAML maxRevision support."
+    - label:
+          "Force-fail if maxRevision is not handled properly (should be skipped
+          by maxRevision). Used to test YAML maxRevision support."
       command: "readAttribute"
       attribute: "MaxPathsPerInvoke"
       maxRevision: 1

--- a/src/app/tests/suites/TestBasicInformation.yaml
+++ b/src/app/tests/suites/TestBasicInformation.yaml
@@ -171,6 +171,7 @@ tests:
     - label: "Read the Specification Version value"
       command: "readAttribute"
       attribute: "SpecificationVersion"
+      minRevision: 3
       response:
           # For now all-clusters-app has a version 1.5
           value: 0x01050000
@@ -178,9 +179,26 @@ tests:
     - label: "Read the Max Paths Per Invoke value"
       command: "readAttribute"
       attribute: "MaxPathsPerInvoke"
+      minRevision: 3
       response:
           constraints:
               minValue: 1
+
+    - label: "Force-fail if minRevision is not handled properly (should be skipped by minRevision). Used to test YAML minRevision support."
+      command: "readAttribute"
+      attribute: "MaxPathsPerInvoke"
+      minRevision: 100
+      response:
+          constraints:
+              maxValue: 0
+
+    - label: "Force-fail if maxRevision is not handled properly (should be skipped by maxRevision). Used to test YAML maxRevision support."
+      command: "readAttribute"
+      attribute: "MaxPathsPerInvoke"
+      maxRevision: 1
+      response:
+          constraints:
+              maxValue: 0
 
     - label: "Write global ClusterRevision attribute"
       command: "writeAttribute"


### PR DESCRIPTION
#### Summary

- Add minRevision and maxRevision fields to YAML tests processing
- Add code to auto-augment the ClusterRevision reading in the test execution set of steps if any other steps have minRevision, maxRevision.
- Update runner to honor skipping on min/maxRevision
- Update docs to show usage.

#### Testing

- Added necessary unit tests to existing test_yaml_parser.py
- Added an integration test in TestBasicInformation.yaml
- All other unit and integration tests pass
