### PR TITLE
[Scenes] Fixed EFS in TC_CC_10_1

### DIFF
--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -64,19 +64,6 @@ class TC_CC_10_1(MatterBaseTest):
                     found = True
                     break
 
-            if not found:
-                if attribute_id == 0x0001 or attribute_id == 0x4001 or attribute_id == 0x4002 or attribute_id == 0x4003:
-                    empty_attribute_value = Clusters.ScenesManagement.Structs.AttributeValuePairStruct(
-                        attributeID=attribute_id,
-                        valueUnsigned8=0x00,
-                    )
-                elif attribute_id == 0x0003 or attribute_id == 0x0004 or attribute_id == 0x0007 or attribute_id == 0x4004:
-                    empty_attribute_value = Clusters.ScenesManagement.Structs.AttributeValuePairStruct(
-                        attributeID=attribute_id,
-                        valueUnsigned16=0x0000,
-                    )
-                efs_attribute_value_list.append(empty_attribute_value)
-
         extension_field_set = Clusters.ScenesManagement.Structs.ExtensionFieldSetStruct(
             clusterID=Clusters.Objects.ColorControl.id,
             attributeValueList=efs_attribute_value_list

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -56,12 +56,9 @@ class TC_CC_10_1(MatterBaseTest):
     def _prepare_cc_extension_field_set(self, attribute_value_list: List[Clusters.ScenesManagement.Structs.AttributeValuePairStruct]) -> Clusters.ScenesManagement.Structs.ExtensionFieldSetStruct:
         efs_attribute_value_list: List[Clusters.ScenesManagement.Structs.AttributeValuePairStruct] = []
         for attribute_id in kCCAttributeValueIDs:
-            # Attempt to find the attribute in the input list
-            found = False
             for pair in attribute_value_list:
                 if pair.attributeID == attribute_id:
                     efs_attribute_value_list.append(pair)
-                    found = True
                     break
 
         extension_field_set = Clusters.ScenesManagement.Structs.ExtensionFieldSetStruct(


### PR DESCRIPTION
#### Summary

Removed the part of TC-CC-10.1 that would "padd" the missing fields in extension field sets when they were used for add scenes.

#### Related issues

https://github.com/project-chip/connectedhomeip/issues/41694

#### Testing

Ran TC_CC_10_1.py locally with different PICS sets to confirm a device could pass test without supporting all features.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
