### PR TITLE
[Chef] Fix identify cluster initialisation

### DIFF
--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -75,8 +75,10 @@ void InitIdentifyCluster()
         if (epIndex >= kIdentifyTableSize)
             continue;
 
-        gIdentifyInstanceTable[epIndex] =
-            std::make_unique<struct Identify>(endpointId, nullptr, nullptr, chip::app::Clusters::Identify::IdentifyTypeEnum::kNone);
+        gIdentifyInstanceTable[epIndex] = std::make_unique<struct Identify>(
+            endpointId, [](struct Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
+            [](struct Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
+            chip::app::Clusters::Identify::IdentifyTypeEnum::kNone);
     }
 }
 } // namespace

--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -53,34 +53,12 @@ using namespace chip::app::Clusters;
 namespace {
 // TODO: Move this to a standalone cluster cpp file.
 
-constexpr size_t kIdentifyTableSize = MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT;
-static_assert(kIdentifyTableSize <= kEmberInvalidEndpointIndex, "Identify table size error");
-std::unique_ptr<struct Identify> gIdentifyInstanceTable[kIdentifyTableSize];
-
-void InitIdentifyCluster()
-{
-    const uint16_t endpointCount = emberAfEndpointCount();
-
-    for (uint16_t endpointIndex = 0; endpointIndex < endpointCount; endpointIndex++)
-    {
-        chip::EndpointId endpointId = emberAfEndpointFromIndex(endpointIndex);
-        if (endpointId == kInvalidEndpointId)
-        {
-            continue;
-        }
-
-        // Check if endpoint has Identify cluster enabled
-        uint16_t epIndex = emberAfGetClusterServerEndpointIndex(endpointId, chip::app::Clusters::Identify::Id,
-                                                                MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT);
-        if (epIndex >= kIdentifyTableSize)
-            continue;
-
-        gIdentifyInstanceTable[epIndex] = std::make_unique<struct Identify>(
-            endpointId, [](struct Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
-            [](struct Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
-            chip::app::Clusters::Identify::IdentifyTypeEnum::kNone);
-    }
-}
+struct Identify gIdentify1 = {
+    chip::EndpointId{ 1 },
+    [](struct Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
+    [](struct Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
+    chip::app::Clusters::Identify::IdentifyTypeEnum::kNone,
+};
 } // namespace
 #endif // MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT
 namespace {
@@ -578,10 +556,6 @@ void ApplicationInit()
     ChipLogProgress(NotSpecified, "Initializing MicrowaveOvenControl cluster.");
     InitChefMicrowaveOvenControlCluster();
 #endif // MATTER_DM_PLUGIN_MICROWAVE_OVEN_CONTROL_SERVER
-
-#if MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT > 0
-    InitIdentifyCluster();
-#endif // MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT
 }
 
 void ApplicationShutdown()


### PR DESCRIPTION
#### Summary

Recent failure in issuing identify command in chef devices. Logs show cluster was not initialised -

```
[1761857615.278] [2265348:2265348] [SVR] Failed to find Instance of Identify cluster for endpoint 1
```

Fix - Initialising the identify cluster object in global space.


Tested identify command works using chip tool.

Chef device - `./chef.py -br -d rootnode_airqualitysensor_e63187f6c9 -t linux`


