### PR TITLE
Fix Late Instantiation Bug on Identify Cluster

### DIFF
--- a/src/app/clusters/identify-server/CodegenIntegration.cpp
+++ b/src/app/clusters/identify-server/CodegenIntegration.cpp
@@ -175,7 +175,8 @@ void MatterIdentifyClusterInitCallback(EndpointId endpointId)
     if (GetLegacyIdentifyInstance(endpointId) != nullptr &&
         CodegenDataModelProvider::Instance().Registry().Get({ endpointId, Clusters::Identify::Id }) == nullptr)
     {
-        ChipLogError(AppServer, "Init error: failed to find Identify cluster registration for endpoint %u", endpointId);
+        ChipLogError(AppServer, "Warning: unexpected state. Failed to find Identify cluster registration for endpoint %u",
+                     endpointId);
     }
 #endif // CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
 }

--- a/src/app/clusters/identify-server/CodegenIntegration.cpp
+++ b/src/app/clusters/identify-server/CodegenIntegration.cpp
@@ -176,16 +176,7 @@ void MatterIdentifyClusterInitCallback(EndpointId endpointId)
 #endif // CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
 }
 
-void MatterIdentifyClusterShutdownCallback(EndpointId endpointId)
-{
-#if CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
-    if (GetLegacyIdentifyInstance(endpointId) != nullptr &&
-        CodegenDataModelProvider::Instance().Registry().Get({ endpointId, Clusters::Identify::Id }) == nullptr)
-    {
-        ChipLogError(AppServer, "Shutdown error: failed to find Identify cluster registration for endpoint %u", endpointId);
-    }
-#endif // CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
-}
+void MatterIdentifyClusterShutdownCallback(EndpointId endpointId) {}
 
 // Legacy PluginServer callback stubs
 void MatterIdentifyPluginServerInitCallback() {}

--- a/src/app/clusters/identify-server/CodegenIntegration.cpp
+++ b/src/app/clusters/identify-server/CodegenIntegration.cpp
@@ -156,12 +156,12 @@ Identify::Identify(EndpointId endpoint, onIdentifyStartCb onIdentifyStart, onIde
                  .WithEffectVariant(effectVariant))
 {
     RegisterLegacyIdentify(this);
-    (void) CodegenDataModelProvider::Instance().Registry().Register(mCluster.Registration());
+    RETURN_SAFELY_IGNORED CodegenDataModelProvider::Instance().Registry().Register(mCluster.Registration());
 };
 
 Identify::~Identify()
 {
-    (void) CodegenDataModelProvider::Instance().Registry().Unregister(&(mCluster.Cluster()));
+    RETURN_SAFELY_IGNORED CodegenDataModelProvider::Instance().Registry().Unregister(&(mCluster.Cluster()));
     UnregisterLegacyIdentify(this);
 }
 

--- a/src/app/clusters/identify-server/CodegenIntegration.cpp
+++ b/src/app/clusters/identify-server/CodegenIntegration.cpp
@@ -156,51 +156,35 @@ Identify::Identify(EndpointId endpoint, onIdentifyStartCb onIdentifyStart, onIde
                  .WithEffectVariant(effectVariant))
 {
     RegisterLegacyIdentify(this);
+    (void) CodegenDataModelProvider::Instance().Registry().Register(mCluster.Registration());
 };
 
 Identify::~Identify()
 {
+    (void) CodegenDataModelProvider::Instance().Registry().Unregister(&(mCluster.Cluster()));
     UnregisterLegacyIdentify(this);
 }
 
 void MatterIdentifyClusterInitCallback(EndpointId endpointId)
 {
-    Identify * identify = GetLegacyIdentifyInstance(endpointId);
-    if (identify != nullptr)
-    {
-        CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Register(identify->mCluster.Registration());
-
-        if (err != CHIP_NO_ERROR)
-        {
 #if CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
-            ChipLogError(AppServer, "Failed to register cluster %u/" ChipLogFormatMEI ":   %" CHIP_ERROR_FORMAT, endpointId,
-                         ChipLogValueMEI(Clusters::Identify::Id), err.Format());
-#endif // CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
-        }
-    }
-#if CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
-    else
+    if (GetLegacyIdentifyInstance(endpointId) != nullptr &&
+        CodegenDataModelProvider::Instance().Registry().Get({ endpointId, Clusters::Identify::Id }) == nullptr)
     {
-        ChipLogError(AppServer, "Failed to find Instance of Identify cluster for endpoint %u", endpointId);
+        ChipLogError(AppServer, "Init error: failed to find Identify cluster registration for endpoint %u", endpointId);
     }
 #endif // CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
 }
 
 void MatterIdentifyClusterShutdownCallback(EndpointId endpointId)
 {
-    Identify * identify = GetLegacyIdentifyInstance(endpointId);
-    if (identify != nullptr)
-    {
-        CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&(identify->mCluster.Cluster()));
-
-        if (err != CHIP_NO_ERROR)
-        {
 #if CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
-            ChipLogError(AppServer, "Failed to unregister cluster %u/" ChipLogFormatMEI ": %" CHIP_ERROR_FORMAT, endpointId,
-                         ChipLogValueMEI(Clusters::Identify::Id), err.Format());
-#endif // CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
-        }
+    if (GetLegacyIdentifyInstance(endpointId) != nullptr &&
+        CodegenDataModelProvider::Instance().Registry().Get({ endpointId, Clusters::Identify::Id }) == nullptr)
+    {
+        ChipLogError(AppServer, "Shutdown error: failed to find Identify cluster registration for endpoint %u", endpointId);
     }
+#endif // CHIP_CODEGEN_CONFIG_ENABLE_CODEGEN_INTEGRATION_LOOKUP_ERRORS
 }
 
 // Legacy PluginServer callback stubs

--- a/src/app/clusters/identify-server/CodegenIntegration.cpp
+++ b/src/app/clusters/identify-server/CodegenIntegration.cpp
@@ -156,6 +156,10 @@ Identify::Identify(EndpointId endpoint, onIdentifyStartCb onIdentifyStart, onIde
                  .WithEffectVariant(effectVariant))
 {
     RegisterLegacyIdentify(this);
+
+    // CodegenDataModelProvider::Instance() is a Meyer’s singleton so it's safe to call this here without worrying about
+    // intialization order. It's also OK to Register() the cluster in the provider even if the endpoint is not yet started up. It
+    // will be started up when the endpoint is started and a context is set.
     RETURN_SAFELY_IGNORED CodegenDataModelProvider::Instance().Registry().Register(mCluster.Registration());
 };
 

--- a/src/app/clusters/identify-server/tests/TestIdentifyClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/identify-server/tests/TestIdentifyClusterBackwardsCompatibility.cpp
@@ -174,8 +174,7 @@ TEST_F(TestIdentifyClusterBackwardsCompatibility, TestLateLegacyInstantiation)
     // Instantiate legacy Identify late (after the callback/ember init)
     struct Identify identify(endpointId, nullptr, nullptr, chip::app::Clusters::Identify::IdentifyTypeEnum::kNone);
 
-    // Check that the cluster is NOT properly registered in the CodegenDMP Registry
-    // because there's a bug where we don't register properly if instantiated late
+    // Check the cluster is properly registered in the CodegenDMP Registry
     EXPECT_TRUE(CodegenDataModelProvider::Instance().Registry().Get(ConcreteClusterPath(endpointId, Clusters::Identify::Id)) !=
                 nullptr);
 }

--- a/src/app/clusters/identify-server/tests/TestIdentifyClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/identify-server/tests/TestIdentifyClusterBackwardsCompatibility.cpp
@@ -17,8 +17,10 @@
 
 #include "ClusterActions.h"
 #include "TestTimerDelegate.h"
+#include <app/ConcreteClusterPath.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <gtest/gtest.h>
 
 using namespace chip;
@@ -26,6 +28,11 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::Identify;
 using namespace chip::app::Clusters::Identify::Attributes;
+
+// Forward declaration of the callback to emulate ember initialization
+void MatterIdentifyClusterInitCallback(chip::EndpointId endpointId);
+// Stub for DataModelHandler init function
+void InitDataModelHandler() {}
 
 namespace {
 
@@ -155,6 +162,22 @@ TEST_F(TestIdentifyClusterBackwardsCompatibility, TestMActive)
     // Test that mActive is false after writing 0 to IdentifyTime.
     EXPECT_EQ(WriteAttribute(identify.mCluster.Cluster(), IdentifyTime::Id, 0u), CHIP_NO_ERROR);
     EXPECT_FALSE(identify.mActive);
+}
+
+TEST_F(TestIdentifyClusterBackwardsCompatibility, TestLateLegacyInstantiation)
+{
+    EndpointId endpointId = 1;
+
+    // Call MatterIdentifyClusterInitCallback(enpointId) to emulate ember initialization
+    MatterIdentifyClusterInitCallback(endpointId);
+
+    // Instantiate legacy Identify late (after the callback/ember init)
+    struct Identify identify(endpointId, nullptr, nullptr, chip::app::Clusters::Identify::IdentifyTypeEnum::kNone);
+
+    // Check that the cluster is NOT properly registered in the CodegenDMP Registry
+    // because there's a bug where we don't register properly if instantiated late
+    EXPECT_TRUE(CodegenDataModelProvider::Instance().Registry().Get(ConcreteClusterPath(endpointId, Clusters::Identify::Id)) !=
+                nullptr);
 }
 
 } // namespace


### PR DESCRIPTION
#### Summary

This PR fixes a bug where the Identify Cluster will not get properly registered in the Codegen Data Model provider if it is instantiated late (after ember).

#### Testing

Added unit test