### PR TITLE
Move Terms&Conditions instance to be a reference not a pointer

### DIFF
--- a/examples/air-purifier-app/ameba/main/chipinterface.cpp
+++ b/examples/air-purifier-app/ameba/main/chipinterface.cpp
@@ -154,7 +154,7 @@ static void InitServer(intptr_t context)
     const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
         app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
     PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
-    chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
+    chip::app::TermsAndConditionsManager::GetInstance().Init(&persistentStorageDelegate, termsAndConditions);
 #endif
 
     if (RTW_SUCCESS != wifi_is_connected_to_ap())

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -160,7 +160,7 @@ static void InitServer(intptr_t context)
     const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
         app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
     PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
-    chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
+    chip::app::TermsAndConditionsManager::GetInstance().Init(&persistentStorageDelegate, termsAndConditions);
 #endif
 
     NetWorkCommissioningInstInit();

--- a/examples/light-switch-app/ameba/main/chipinterface.cpp
+++ b/examples/light-switch-app/ameba/main/chipinterface.cpp
@@ -119,7 +119,7 @@ static void InitServer(intptr_t context)
     const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
         app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
     PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
-    chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
+    chip::app::TermsAndConditionsManager::GetInstance().Init(&persistentStorageDelegate, termsAndConditions);
 #endif
 
     if (RTW_SUCCESS != wifi_is_connected_to_ap())

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -144,7 +144,7 @@ static void InitServer(intptr_t context)
     const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
         app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
     PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
-    chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
+    chip::app::TermsAndConditionsManager::GetInstance().Init(&persistentStorageDelegate, termsAndConditions);
 #endif
 
     NetWorkCommissioningInstInit();

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -789,7 +789,7 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
         uint16_t version  = LinuxDeviceOptions::GetInstance().tcVersion.Value();
         uint16_t required = LinuxDeviceOptions::GetInstance().tcRequired.Value();
         Optional<app::TermsAndConditions> requiredAcknowledgements(app::TermsAndConditions(required, version));
-        app::TermsAndConditionsManager::GetInstance()->Init(initParams.persistentStorageDelegate, requiredAcknowledgements);
+        app::TermsAndConditionsManager::GetInstance().Init(initParams.persistentStorageDelegate, requiredAcknowledgements);
     }
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
 

--- a/examples/platform/nxp/se05x/linux/AppMain.cpp
+++ b/examples/platform/nxp/se05x/linux/AppMain.cpp
@@ -653,7 +653,7 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
         uint16_t version  = LinuxDeviceOptions::GetInstance().tcVersion.Value();
         uint16_t required = LinuxDeviceOptions::GetInstance().tcRequired.Value();
         Optional<app::TermsAndConditions> requiredAcknowledgements(app::TermsAndConditions(required, version));
-        app::TermsAndConditionsManager::GetInstance()->Init(initParams.persistentStorageDelegate, requiredAcknowledgements);
+        app::TermsAndConditionsManager::GetInstance().Init(initParams.persistentStorageDelegate, requiredAcknowledgements);
     }
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
 

--- a/examples/terms-and-conditions-app/linux/main.cpp
+++ b/examples/terms-and-conditions-app/linux/main.cpp
@@ -65,7 +65,7 @@ void ApplicationInit()
 {
     const app::TermsAndConditions termsAndConditions = app::TermsAndConditions(sTcRequiredAcknowledgements, sTcMinRequiredVersion);
     PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
-    app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, MakeOptional(termsAndConditions));
+    app::TermsAndConditionsManager::GetInstance().Init(&persistentStorageDelegate, MakeOptional(termsAndConditions));
 }
 
 void ApplicationShutdown() {}

--- a/src/app/clusters/general-commissioning-server/general-commissioning-cluster.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-cluster.cpp
@@ -81,15 +81,15 @@ typedef struct sTermsAndConditionsState
     Optional<uint32_t> updateAcceptanceDeadline;
 } TermsAndConditionsState;
 
-CHIP_ERROR GetTermsAndConditionsAttributeState(TermsAndConditionsProvider * tcProvider,
+CHIP_ERROR GetTermsAndConditionsAttributeState(TermsAndConditionsProvider & tcProvider,
                                                TermsAndConditionsState & outTermsAndConditionsState)
 {
     TermsAndConditionsState termsAndConditionsState;
 
-    ReturnErrorOnFailure(tcProvider->GetAcceptance(termsAndConditionsState.acceptance));
-    ReturnErrorOnFailure(tcProvider->GetAcknowledgementsRequired(termsAndConditionsState.acknowledgementsRequired));
-    ReturnErrorOnFailure(tcProvider->GetRequirements(termsAndConditionsState.requirements));
-    ReturnErrorOnFailure(tcProvider->GetUpdateAcceptanceDeadline(termsAndConditionsState.updateAcceptanceDeadline));
+    ReturnErrorOnFailure(tcProvider.GetAcceptance(termsAndConditionsState.acceptance));
+    ReturnErrorOnFailure(tcProvider.GetAcknowledgementsRequired(termsAndConditionsState.acknowledgementsRequired));
+    ReturnErrorOnFailure(tcProvider.GetRequirements(termsAndConditionsState.requirements));
+    ReturnErrorOnFailure(tcProvider.GetUpdateAcceptanceDeadline(termsAndConditionsState.updateAcceptanceDeadline));
 
     outTermsAndConditionsState = termsAndConditionsState;
     return CHIP_NO_ERROR;
@@ -150,11 +150,10 @@ void OnPlatformEventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t
         if (event->FailSafeTimerExpired.updateTermsAndConditionsHasBeenInvoked)
         {
             // Clear terms and conditions acceptance on failsafe timer expiration
-            TermsAndConditionsProvider * tcProvider = TermsAndConditionsManager::GetInstance();
+            TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
             TermsAndConditionsState initialState, updatedState;
-            VerifyOrReturn(nullptr != tcProvider);
             VerifyOrReturn(CHIP_NO_ERROR == GetTermsAndConditionsAttributeState(tcProvider, initialState));
-            VerifyOrReturn(CHIP_NO_ERROR == tcProvider->RevertAcceptance());
+            VerifyOrReturn(CHIP_NO_ERROR == tcProvider.RevertAcceptance());
             VerifyOrReturn(CHIP_NO_ERROR == GetTermsAndConditionsAttributeState(tcProvider, updatedState));
             NotifyTermsAndConditionsAttributeChangeIfRequired(initialState, updatedState);
         }
@@ -205,47 +204,42 @@ DataModel::ActionReturnStatus GeneralCommissioningCluster::ReadAttribute(const D
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
     case TCAcceptedVersion::Id: {
-        TermsAndConditionsProvider * tcProvider = TermsAndConditionsManager::GetInstance();
+        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
         Optional<TermsAndConditions> outTermsAndConditions;
 
-        VerifyOrReturnError(nullptr != tcProvider, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
-        ReturnErrorOnFailure(tcProvider->GetAcceptance(outTermsAndConditions));
+        ReturnErrorOnFailure(tcProvider.GetAcceptance(outTermsAndConditions));
 
         return encoder.Encode(outTermsAndConditions.ValueOr(TermsAndConditions(0, 0)).GetVersion());
     }
     case TCMinRequiredVersion::Id: {
-        TermsAndConditionsProvider * tcProvider = TermsAndConditionsManager::GetInstance();
+        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
         Optional<TermsAndConditions> outTermsAndConditions;
 
-        VerifyOrReturnError(nullptr != tcProvider, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
-        ReturnErrorOnFailure(tcProvider->GetRequirements(outTermsAndConditions));
+        ReturnErrorOnFailure(tcProvider.GetRequirements(outTermsAndConditions));
 
         return encoder.Encode(outTermsAndConditions.ValueOr(TermsAndConditions(0, 0)).GetVersion());
     }
     case TCAcknowledgements::Id: {
-        TermsAndConditionsProvider * tcProvider = TermsAndConditionsManager::GetInstance();
+        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
         Optional<TermsAndConditions> outTermsAndConditions;
 
-        VerifyOrReturnError(nullptr != tcProvider, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
-        ReturnErrorOnFailure(tcProvider->GetAcceptance(outTermsAndConditions));
+        ReturnErrorOnFailure(tcProvider.GetAcceptance(outTermsAndConditions));
 
         return encoder.Encode(outTermsAndConditions.ValueOr(TermsAndConditions(0, 0)).GetValue());
     }
     case TCAcknowledgementsRequired::Id: {
-        TermsAndConditionsProvider * tcProvider = TermsAndConditionsManager::GetInstance();
+        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
         bool acknowledgementsRequired;
 
-        VerifyOrReturnError(nullptr != tcProvider, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
-        ReturnErrorOnFailure(tcProvider->GetAcknowledgementsRequired(acknowledgementsRequired));
+        ReturnErrorOnFailure(tcProvider.GetAcknowledgementsRequired(acknowledgementsRequired));
 
         return encoder.Encode(acknowledgementsRequired);
     }
     case TCUpdateDeadline::Id: {
-        TermsAndConditionsProvider * tcProvider = TermsAndConditionsManager::GetInstance();
+        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
         Optional<uint32_t> outUpdateAcceptanceDeadline;
 
-        VerifyOrReturnError(nullptr != tcProvider, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
-        ReturnErrorOnFailure(tcProvider->GetUpdateAcceptanceDeadline(outUpdateAcceptanceDeadline));
+        ReturnErrorOnFailure(tcProvider.GetUpdateAcceptanceDeadline(outUpdateAcceptanceDeadline));
 
         if (!outUpdateAcceptanceDeadline.HasValue())
         {
@@ -389,11 +383,10 @@ void GeneralCommissioningCluster::OnFabricRemoved(const FabricTable & fabricTabl
         ChipLogProgress(Zcl, "general-commissioning-server: Last Fabric index 0x%x was removed",
                         static_cast<unsigned>(fabricIndex));
 
-        TermsAndConditionsProvider * tcProvider = TermsAndConditionsManager::GetInstance();
+        TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
         TermsAndConditionsState initialState, updatedState;
-        VerifyOrReturn(nullptr != tcProvider);
         VerifyOrReturn(CHIP_NO_ERROR == GetTermsAndConditionsAttributeState(tcProvider, initialState));
-        VerifyOrReturn(CHIP_NO_ERROR == tcProvider->ResetAcceptance());
+        VerifyOrReturn(CHIP_NO_ERROR == tcProvider.ResetAcceptance());
         VerifyOrReturn(CHIP_NO_ERROR == GetTermsAndConditionsAttributeState(tcProvider, updatedState));
         NotifyTermsAndConditionsAttributeChangeIfRequired(initialState, updatedState);
     }
@@ -503,59 +496,56 @@ GeneralCommissioningCluster::HandleCommissioningComplete(const DataModel::Invoke
     }
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-    TermsAndConditionsProvider * tcProvider = TermsAndConditionsManager::GetInstance();
+    TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
 
     // Ensure required terms and conditions have been accepted, then attempt to commit
-    if (nullptr != tcProvider)
+    Optional<TermsAndConditions> requiredTermsAndConditionsMaybe;
+    Optional<TermsAndConditions> acceptedTermsAndConditionsMaybe;
+
+    CheckSuccess(tcProvider.GetRequirements(requiredTermsAndConditionsMaybe), Failure);
+    CheckSuccess(tcProvider.GetAcceptance(acceptedTermsAndConditionsMaybe), Failure);
+
+    if (requiredTermsAndConditionsMaybe.HasValue() && !acceptedTermsAndConditionsMaybe.HasValue())
     {
-        Optional<TermsAndConditions> requiredTermsAndConditionsMaybe;
-        Optional<TermsAndConditions> acceptedTermsAndConditionsMaybe;
+        response.errorCode = CommissioningErrorEnum::kTCAcknowledgementsNotReceived;
+        handler->AddResponse(request.path, response);
+        return std::nullopt;
+    }
 
-        CheckSuccess(tcProvider->GetRequirements(requiredTermsAndConditionsMaybe), Failure);
-        CheckSuccess(tcProvider->GetAcceptance(acceptedTermsAndConditionsMaybe), Failure);
+    if (requiredTermsAndConditionsMaybe.HasValue() && acceptedTermsAndConditionsMaybe.HasValue())
+    {
+        TermsAndConditions requiredTermsAndConditions = requiredTermsAndConditionsMaybe.Value();
+        TermsAndConditions acceptedTermsAndConditions = acceptedTermsAndConditionsMaybe.Value();
 
-        if (requiredTermsAndConditionsMaybe.HasValue() && !acceptedTermsAndConditionsMaybe.HasValue())
+        if (!requiredTermsAndConditions.ValidateVersion(acceptedTermsAndConditions))
         {
-            response.errorCode = CommissioningErrorEnum::kTCAcknowledgementsNotReceived;
+            response.errorCode = CommissioningErrorEnum::kTCMinVersionNotMet;
             handler->AddResponse(request.path, response);
             return std::nullopt;
         }
 
-        if (requiredTermsAndConditionsMaybe.HasValue() && acceptedTermsAndConditionsMaybe.HasValue())
+        if (!requiredTermsAndConditions.ValidateValue(acceptedTermsAndConditions))
         {
-            TermsAndConditions requiredTermsAndConditions = requiredTermsAndConditionsMaybe.Value();
-            TermsAndConditions acceptedTermsAndConditions = acceptedTermsAndConditionsMaybe.Value();
-
-            if (!requiredTermsAndConditions.ValidateVersion(acceptedTermsAndConditions))
-            {
-                response.errorCode = CommissioningErrorEnum::kTCMinVersionNotMet;
-                handler->AddResponse(request.path, response);
-                return std::nullopt;
-            }
-
-            if (!requiredTermsAndConditions.ValidateValue(acceptedTermsAndConditions))
-            {
-                response.errorCode = CommissioningErrorEnum::kRequiredTCNotAccepted;
-                handler->AddResponse(request.path, response);
-                return std::nullopt;
-            }
+            response.errorCode = CommissioningErrorEnum::kRequiredTCNotAccepted;
+            handler->AddResponse(request.path, response);
+            return std::nullopt;
         }
+    }
 
-        if (failSafe.UpdateTermsAndConditionsHasBeenInvoked())
+    if (failSafe.UpdateTermsAndConditionsHasBeenInvoked())
+    {
+        // Commit terms and conditions acceptance on commissioning complete
+        err = tcProvider.CommitAcceptance();
+        if (err != CHIP_NO_ERROR)
         {
-            // Commit terms and conditions acceptance on commissioning complete
-            err = tcProvider->CommitAcceptance();
-            if (err != CHIP_NO_ERROR)
-            {
-                ChipLogError(FailSafe, "GeneralCommissioning: Failed to commit terms and conditions: %" CHIP_ERROR_FORMAT,
-                             err.Format());
-            }
-            else
-            {
-                ChipLogProgress(FailSafe, "GeneralCommissioning: Successfully committed terms and conditions");
-            }
-            CheckSuccess(err, Failure);
+            ChipLogError(FailSafe, "GeneralCommissioning: Failed to commit terms and conditions: %" CHIP_ERROR_FORMAT,
+                         err.Format());
         }
+        else
+        {
+            ChipLogProgress(FailSafe, "GeneralCommissioning: Successfully committed terms and conditions");
+        }
+        CheckSuccess(err, Failure);
     }
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
 
@@ -653,17 +643,12 @@ GeneralCommissioningCluster::HandleSetTCAcknowledgements(const DataModel::Invoke
     MATTER_TRACE_SCOPE("SetTCAcknowledgements", "GeneralCommissioning");
 
     auto & failSafeContext                  = Server::GetInstance().GetFailSafeContext();
-    TermsAndConditionsProvider * tcProvider = TermsAndConditionsManager::GetInstance();
-
-    if (nullptr == tcProvider)
-    {
-        return Protocols::InteractionModel::Status::Failure;
-    }
+    TermsAndConditionsProvider & tcProvider = TermsAndConditionsManager::GetInstance();
 
     Optional<TermsAndConditions> requiredTermsAndConditionsMaybe;
     Optional<TermsAndConditions> previousAcceptedTermsAndConditionsMaybe;
-    CheckSuccess(tcProvider->GetRequirements(requiredTermsAndConditionsMaybe), Failure);
-    CheckSuccess(tcProvider->GetAcceptance(previousAcceptedTermsAndConditionsMaybe), Failure);
+    CheckSuccess(tcProvider.GetRequirements(requiredTermsAndConditionsMaybe), Failure);
+    CheckSuccess(tcProvider.GetAcceptance(previousAcceptedTermsAndConditionsMaybe), Failure);
     TermsAndConditions acceptedTermsAndConditions = TermsAndConditions(commandData.TCUserResponse, commandData.TCVersion);
     Optional<TermsAndConditions> acceptedTermsAndConditionsPresent = Optional<TermsAndConditions>(acceptedTermsAndConditions);
 
@@ -692,14 +677,14 @@ GeneralCommissioningCluster::HandleSetTCAcknowledgements(const DataModel::Invoke
     {
         TermsAndConditionsState initialState, updatedState;
         CheckSuccess(GetTermsAndConditionsAttributeState(tcProvider, initialState), Failure);
-        CheckSuccess(tcProvider->SetAcceptance(acceptedTermsAndConditionsPresent), Failure);
+        CheckSuccess(tcProvider.SetAcceptance(acceptedTermsAndConditionsPresent), Failure);
         CheckSuccess(GetTermsAndConditionsAttributeState(tcProvider, updatedState), Failure);
         NotifyTermsAndConditionsAttributeChangeIfRequired(initialState, updatedState);
 
         // Commit or defer based on fail-safe state
         if (!failSafeContext.IsFailSafeArmed())
         {
-            CheckSuccess(tcProvider->CommitAcceptance(), Failure);
+            CheckSuccess(tcProvider.CommitAcceptance(), Failure);
         }
         else
         {

--- a/src/app/server/TermsAndConditionsManager.cpp
+++ b/src/app/server/TermsAndConditionsManager.cpp
@@ -24,9 +24,9 @@ static chip::app::TermsAndConditionsManager sTermsAndConditionsManager;
 static chip::app::DefaultTermsAndConditionsProvider sTermsAndConditionsProviderInstance;
 static chip::app::DefaultTermsAndConditionsStorageDelegate sTermsAndConditionsStorageDelegateInstance;
 
-chip::app::TermsAndConditionsManager * chip::app::TermsAndConditionsManager::GetInstance()
+chip::app::TermsAndConditionsManager & chip::app::TermsAndConditionsManager::GetInstance()
 {
-    return &sTermsAndConditionsManager;
+    return sTermsAndConditionsManager;
 }
 
 CHIP_ERROR chip::app::TermsAndConditionsManager::Init(chip::PersistentStorageDelegate * inPersistentStorageDelegate,

--- a/src/app/server/TermsAndConditionsManager.h
+++ b/src/app/server/TermsAndConditionsManager.h
@@ -28,7 +28,7 @@ namespace app {
 class TermsAndConditionsManager : public TermsAndConditionsProvider
 {
 public:
-    static TermsAndConditionsManager * GetInstance();
+    static TermsAndConditionsManager & GetInstance();
     CHIP_ERROR Init(PersistentStorageDelegate * inPersistentStorageDelegate,
                     const Optional<TermsAndConditions> & inRequiredTermsAndConditions);
     CHIP_ERROR CommitAcceptance();


### PR DESCRIPTION
#### Summary

The value can never be null and the extra checks for null add more code and also make the code harder to reason about (this was pulled out of #41689).

Using references makes it clear that the object can never be null. Since this is controlled by a feature flag, we use the flag to decide if the feature is enabled or not and there is no need to support both at this time in the same device build.

I expect this to provide minute flash savings and some maintainability/readability clarity.

#### Testing

Existing CI still applies