### PR TITLE
TC-CNET-4.10 and 4.16: Set endpoint to 0 for general commissioning cluster commands

### DIFF
--- a/src/python_testing/TC_CNET_4_10.py
+++ b/src/python_testing/TC_CNET_4_10.py
@@ -348,9 +348,9 @@ class TC_CNET_4_10(MatterBaseTest):
 
         # Step 17: Complete commissioning
         self.step(17)
-        await self.send_single_cmd(
-            cmd=gen_comm.Commands.CommissioningComplete()
-        )
+        await self.send_single_cmd(endpoint=0,
+                                   cmd=gen_comm.Commands.CommissioningComplete()
+                                   )
         # Successful command execution is implied if no exception is raised.
 
         # Step 18: Verify failsafe disabled
@@ -395,9 +395,9 @@ class TC_CNET_4_10(MatterBaseTest):
                              "Failed to add/update Thread network during cleanup")
 
         # Commit the change by completing commissioning
-        await self.send_single_cmd(
-            cmd=gen_comm.Commands.CommissioningComplete()
-        )
+        await self.send_single_cmd(endpoint=0,
+                                   cmd=gen_comm.Commands.CommissioningComplete()
+                                   )
 
         # Verify network added and is the one we intended to add
         networks_after_add = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_CNET_4_10.py
+++ b/src/python_testing/TC_CNET_4_10.py
@@ -280,6 +280,7 @@ class TC_CNET_4_10(MatterBaseTest):
         # Step 10: Verify breadcrumb
         self.step(10)
         breadcrumb = await self.read_single_attribute_check_success(
+            endpoint=0,
             cluster=gen_comm,
             attribute=gen_comm.Attributes.Breadcrumb
         )
@@ -299,6 +300,7 @@ class TC_CNET_4_10(MatterBaseTest):
         # Step 12: Verify breadcrumb unchanged
         self.step(12)
         breadcrumb = await self.read_single_attribute_check_success(
+            endpoint=0,
             cluster=gen_comm,
             attribute=gen_comm.Attributes.Breadcrumb
         )

--- a/src/python_testing/TC_CNET_4_10.py
+++ b/src/python_testing/TC_CNET_4_10.py
@@ -209,9 +209,9 @@ class TC_CNET_4_10(MatterBaseTest):
 
         # Step 4: Arm failsafe and verify response
         self.step(4)
-        await self.send_single_cmd(
-            cmd=gen_comm.Commands.ArmFailSafe(expiryLengthSeconds=900, breadcrumb=0)
-        )
+        await self.send_single_cmd(endpoint=0,
+                                   cmd=gen_comm.Commands.ArmFailSafe(expiryLengthSeconds=900, breadcrumb=0)
+                                   )
         # Successful command execution is implied if no exception is raised.
 
         # Step 5: Read Networks and verify thread network
@@ -306,9 +306,9 @@ class TC_CNET_4_10(MatterBaseTest):
 
         # Step 13: Disable failsafe
         self.step(13)
-        await self.send_single_cmd(
-            cmd=gen_comm.Commands.ArmFailSafe(expiryLengthSeconds=0, breadcrumb=0)
-        )
+        await self.send_single_cmd(endpoint=0,
+                                   cmd=gen_comm.Commands.ArmFailSafe(expiryLengthSeconds=0, breadcrumb=0)
+                                   )
         # Successful command execution is implied if no exception is raised.
 
         # Step 14: Verify network restored
@@ -329,9 +329,9 @@ class TC_CNET_4_10(MatterBaseTest):
 
         # Step 15: Re-arm failsafe
         self.step(15)
-        await self.send_single_cmd(
-            cmd=gen_comm.Commands.ArmFailSafe(expiryLengthSeconds=900, breadcrumb=0)
-        )
+        await self.send_single_cmd(endpoint=0,
+                                   cmd=gen_comm.Commands.ArmFailSafe(expiryLengthSeconds=900, breadcrumb=0)
+                                   )
         # Successful command execution is implied if no exception is raised.
 
         # Step 16: Remove network again
@@ -355,9 +355,9 @@ class TC_CNET_4_10(MatterBaseTest):
 
         # Step 18: Verify failsafe disabled
         self.step(18)
-        await self.send_single_cmd(
-            cmd=gen_comm.Commands.ArmFailSafe(expiryLengthSeconds=0, breadcrumb=0)
-        )
+        await self.send_single_cmd(endpoint=0,
+                                   cmd=gen_comm.Commands.ArmFailSafe(expiryLengthSeconds=0, breadcrumb=0)
+                                   )
         # Successful command execution is implied if no exception is raised.
 
         # Step 19: Verify network remains removed
@@ -380,9 +380,9 @@ class TC_CNET_4_10(MatterBaseTest):
         operational_dataset = self.matter_test_config.thread_operational_dataset
 
         # Need to re-arm failsafe to add network
-        await self.send_single_cmd(
-            cmd=gen_comm.Commands.ArmFailSafe(expiryLengthSeconds=900, breadcrumb=0)
-        )
+        await self.send_single_cmd(endpoint=0,
+                                   cmd=gen_comm.Commands.ArmFailSafe(expiryLengthSeconds=900, breadcrumb=0)
+                                   )
 
         # Use AddOrUpdateThreadNetwork with the dataset
         add_resp = await self.send_single_cmd(

--- a/src/python_testing/TC_CNET_4_16.py
+++ b/src/python_testing/TC_CNET_4_16.py
@@ -77,7 +77,7 @@ class TC_CNET_4_16(MatterBaseTest):
         self.step(1)
 
         cmd = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=900)
-        res = await self.send_single_cmd(cmd=cmd)
+        res = await self.send_single_cmd(endpoint=0, cmd=cmd)
         # Verify that DUT sends ArmFailSafeResponse command to the TH
         asserts.assert_equal(
             res.errorCode,


### PR DESCRIPTION
#### Summary

This is to support secondary network interfaces.

#### Related issues

https://github.com/project-chip/connectedhomeip/issues/41698

#### Testing

Tested by a device manufacturer at SVE. This cannot be tested by the CI since we only support on-network commissioning.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
