### PR TITLE
ACL cluster: make sure std::nullopt is returned if a response is added

### DIFF
--- a/src/app/clusters/access-control-server/access-control-cluster.cpp
+++ b/src/app/clusters/access-control-server/access-control-cluster.cpp
@@ -639,19 +639,16 @@ std::optional<DataModel::ActionReturnStatus> AccessControlCluster::HandleReviewF
     CHIP_ERROR err = GetAccessControl().GetAccessRestrictionProvider()->RequestFabricRestrictionReview(
         commandObj->GetAccessingFabricIndex(), entries, token);
 
-    if (err == CHIP_NO_ERROR)
-    {
-        Clusters::AccessControl::Commands::ReviewFabricRestrictionsResponse::Type response;
-        response.token = token;
-        commandObj->AddResponse(commandPath, response);
-    }
-    else
+    if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DataManagement, "AccessControlCluster: restriction review failed: %" CHIP_ERROR_FORMAT, err.Format());
         return Protocols::InteractionModel::ClusterStatusCode(err);
     }
 
-    return Protocols::InteractionModel::Status::Success;
+    Clusters::AccessControl::Commands::ReviewFabricRestrictionsResponse::Type response;
+    response.token = token;
+    commandObj->AddResponse(commandPath, response);
+    return std::nullopt;
 }
 
 void AccessControlCluster::MarkCommissioningRestrictionListChanged()


### PR DESCRIPTION
#### Summary

Invariant of responses is that if a response is added (or a status is set) we MUST return std::nullopt.

Code likely works by chance since we send to status IBs but the first one is the "correct one". However over the wire we should not double-return.

#### Testing

CI should still handle this.