### PR TITLE
[ICD][Controller]Get additional lit backoff interval

### DIFF
--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -303,6 +303,12 @@ void OperationalSessionSetup::SetAdditionalLitBackoffInterval(const Optional<Sys
         additionalTime.ValueOr(System::Clock::Milliseconds32(CHIP_CONFIG_ADDITIONAL_LIT_BACKOFF_INTERVAL));
 }
 
+System::Clock::Milliseconds32 OperationalSessionSetup::GetAdditionalLitBackoffInterval()
+{
+    assertChipStackLockedByCurrentThread();
+    return sAdditionalLitBackoffInterval;
+}
+
 CHIP_ERROR OperationalSessionSetup::EstablishConnection(const ResolveResult & result)
 {
     auto config = result.mrpRemoteConfig;

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -277,6 +277,7 @@ public:
     void OnNodeAddressResolutionFailed(const PeerId & peerId, CHIP_ERROR reason) override;
 
     static void SetAdditionalLitBackoffInterval(const Optional<System::Clock::Milliseconds32> & additionalTime);
+    static System::Clock::Milliseconds32 GetAdditionalLitBackoffInterval();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
     // Update our remaining attempt count to be at least the given value.


### PR DESCRIPTION
#### Summary
(https://github.com/project-chip/connectedhomeip/pull/41350) missing OperationalSessionSetup::GetAdditionalLitBackoffInterval(), this PR add this API in.
#### Related issues
N/A
#### Testing

local testing.

#### Readability checklist
