### PR TITLE
Decouple Network commissioning and general commissioning via a breadcrumb tracker

### DIFF
--- a/src/app/clusters/general-commissioning-server/BUILD.gn
+++ b/src/app/clusters/general-commissioning-server/BUILD.gn
@@ -16,6 +16,10 @@ import("//build_overrides/chip.gni")
 
 import("${chip_root}/src/app/common_flags.gni")
 
+source_set("bread-crumb-tracker") {
+  sources = [ "BreadCrumbTracker.h" ]
+}
+
 source_set("general-commissioning-server") {
   sources = [
     "general-commissioning-cluster.cpp",
@@ -23,6 +27,7 @@ source_set("general-commissioning-server") {
   ]
 
   public_deps = [
+    ":bread-crumb-tracker",
     "${chip_root}/src/app:app_config",
     "${chip_root}/src/app/data-model-provider",
     "${chip_root}/src/app/server",

--- a/src/app/clusters/general-commissioning-server/BUILD.gn
+++ b/src/app/clusters/general-commissioning-server/BUILD.gn
@@ -18,6 +18,8 @@ import("${chip_root}/src/app/common_flags.gni")
 
 source_set("bread-crumb-tracker") {
   sources = [ "BreadCrumbTracker.h" ]
+
+  public_configs = [ "${chip_root}/src:includes" ]
 }
 
 source_set("general-commissioning-server") {

--- a/src/app/clusters/general-commissioning-server/BreadCrumbTracker.h
+++ b/src/app/clusters/general-commissioning-server/BreadCrumbTracker.h
@@ -19,6 +19,12 @@
 
 namespace chip::app::Clusters {
 
+/// Defines an interface for tracking a breadcrumb value.
+///
+/// The Breadcrumb attribute allows commissioners and administrators
+/// to save a small payload that can be subsequently read, to keep
+/// track of progress (see 11.10.6.1 of the Matter spec related
+/// to Breadcrumb Attribute in the General Commissioning Cluster).
 class BreadCrumbTracker
 {
 public:

--- a/src/app/clusters/general-commissioning-server/BreadCrumbTracker.h
+++ b/src/app/clusters/general-commissioning-server/BreadCrumbTracker.h
@@ -1,0 +1,29 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+#include <cstdint>
+
+namespace chip::app::Clusters {
+
+class BreadCrumbTracker
+{
+public:
+    virtual ~BreadCrumbTracker()               = default;
+    virtual void SetBreadCrumb(uint64_t value) = 0;
+};
+
+} // namespace chip::app::Clusters

--- a/src/app/clusters/general-commissioning-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-commissioning-server/CodegenIntegration.cpp
@@ -15,7 +15,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "CodegenIntegration.h"
+#include <app/clusters/general-commissioning-server/CodegenIntegration.h>
 
 #include <app/clusters/general-commissioning-server/general-commissioning-cluster.h>
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>

--- a/src/app/clusters/general-commissioning-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-commissioning-server/CodegenIntegration.cpp
@@ -62,7 +62,7 @@ public:
 
     ServerClusterInterface * FindRegistration(unsigned clusterInstanceIndex) override { return &gRegistration.Cluster(); }
 
-    // Nothing to destroy: separate singleton class without constructor/destructor is used
+    // Nothing to destroy: gRegistration is a global static that handles destruction
     void ReleaseRegistration(unsigned clusterInstanceIndex) override {}
 };
 

--- a/src/app/clusters/general-commissioning-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-commissioning-server/CodegenIntegration.cpp
@@ -18,15 +18,8 @@
 #include "CodegenIntegration.h"
 
 #include <app/clusters/general-commissioning-server/general-commissioning-cluster.h>
-#include <app/server-cluster/ServerClusterInterfaceRegistry.h>
-#include <app/server/Server.h>
 #include <app/static-cluster-config/GeneralCommissioning.h>
 #include <data-model-providers/codegen/ClusterIntegration.h>
-#include <lib/core/DataModelTypes.h>
-#include <lib/support/CodeUtils.h>
-#include <platform/ConfigurationManager.h>
-#include <platform/DeviceControlServer.h>
-#include <platform/PlatformManager.h>
 
 using namespace chip;
 using namespace chip::app;

--- a/src/app/clusters/general-commissioning-server/CodegenIntegration.h
+++ b/src/app/clusters/general-commissioning-server/CodegenIntegration.h
@@ -1,0 +1,34 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/clusters/general-commissioning-server/general-commissioning-cluster.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace GeneralCommissioning {
+
+/// Returns the singleton instance of the general commissioning cluster, if enabled.
+///
+/// This is a temporary integration point for ember-based apps.
+GeneralCommissioningCluster * Instance();
+
+} // namespace GeneralCommissioning
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/general-commissioning-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/general-commissioning-server/app_config_dependent_sources.gni
@@ -11,4 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-app_config_dependent_sources = [ "CodegenIntegration.cpp" ]
+app_config_dependent_sources = [
+  "CodegenIntegration.cpp",
+  "CodegenIntegration.h",
+]

--- a/src/app/clusters/general-commissioning-server/general-commissioning-cluster.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-cluster.cpp
@@ -404,7 +404,7 @@ CHIP_ERROR GeneralCommissioningCluster::Startup(ServerClusterContext & context)
 
 void GeneralCommissioningCluster::Shutdown()
 {
-    PlatformMgrImpl().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>());
+    PlatformMgrImpl().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
     Server::GetInstance().GetFabricTable().RemoveFabricDelegate(this);
     DefaultServerCluster::Shutdown();
 }

--- a/src/app/clusters/general-commissioning-server/general-commissioning-cluster.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-cluster.cpp
@@ -139,12 +139,12 @@ void NotifyTermsAndConditionsAttributeChangeIfRequired(const TermsAndConditionsS
 }
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
 
-void OnPlatformEventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t /* arg */)
+void OnPlatformEventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t self)
 {
     if (event->Type == DeviceLayer::DeviceEventType::kFailSafeTimerExpired)
     {
         // Spec says to reset Breadcrumb attribute to 0.
-        GeneralCommissioningCluster::Instance().SetBreadCrumb(0);
+        reinterpret_cast<GeneralCommissioningCluster *>(self)->SetBreadCrumb(0);
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         if (event->FailSafeTimerExpired.updateTermsAndConditionsHasBeenInvoked)
@@ -161,15 +161,9 @@ void OnPlatformEventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t
     }
 }
 
-GeneralCommissioningCluster gInstance;
 } // anonymous namespace
 
 namespace chip::app::Clusters {
-
-GeneralCommissioningCluster & GeneralCommissioningCluster::Instance()
-{
-    return gInstance;
-}
 
 DataModel::ActionReturnStatus GeneralCommissioningCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                                          AttributeValueEncoder & encoder)
@@ -403,14 +397,14 @@ void GeneralCommissioningCluster::SetBreadCrumb(uint64_t value)
 CHIP_ERROR GeneralCommissioningCluster::Startup(ServerClusterContext & context)
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
-    PlatformMgrImpl().AddEventHandler(OnPlatformEventHandler, 0);
+    PlatformMgrImpl().AddEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this));
     Server::GetInstance().GetFabricTable().AddFabricDelegate(this);
     return CHIP_NO_ERROR;
 }
 
 void GeneralCommissioningCluster::Shutdown()
 {
-    PlatformMgrImpl().RemoveEventHandler(OnPlatformEventHandler, 0);
+    PlatformMgrImpl().RemoveEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>());
     Server::GetInstance().GetFabricTable().RemoveFabricDelegate(this);
     DefaultServerCluster::Shutdown();
 }

--- a/src/app/clusters/general-commissioning-server/general-commissioning-cluster.h
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-cluster.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <app/AppConfig.h>
+#include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/OptionalAttributeSet.h>
 #include <clusters/GeneralCommissioning/AttributeIds.h>
@@ -28,7 +29,7 @@
 
 namespace chip::app::Clusters {
 
-class GeneralCommissioningCluster : public DefaultServerCluster, chip::FabricTable::Delegate
+class GeneralCommissioningCluster : public DefaultServerCluster, chip::FabricTable::Delegate, public BreadCrumbTracker
 {
 public:
     using OptionalAttributes = OptionalAttributeSet<GeneralCommissioning::Attributes::IsCommissioningWithoutPower::Id>;
@@ -37,7 +38,7 @@ public:
 
     OptionalAttributes & GetOptionalAttributes() { return mOptionalAttributes; }
 
-    void SetBreadCrumb(uint64_t value);
+    void SetBreadCrumb(uint64_t value) override;
 
     // Server cluster implementation
     CHIP_ERROR Startup(ServerClusterContext & context) override;

--- a/src/app/clusters/general-commissioning-server/general-commissioning-cluster.h
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-cluster.h
@@ -58,9 +58,6 @@ public:
     // Fabric delegate
     void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override;
 
-    // GeneralCommissioning is a singleton cluster that exists only on the root endpoint.
-    static GeneralCommissioningCluster & Instance();
-
     // Feature map constant based on compile-time defines. This ensures feature map
     // is in sync with the actual supported features determined at build time.
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED

--- a/src/app/clusters/general-commissioning-server/general-commissioning-cluster.h
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-cluster.h
@@ -38,7 +38,7 @@ public:
 
     OptionalAttributes & GetOptionalAttributes() { return mOptionalAttributes; }
 
-    void SetBreadCrumb(uint64_t value) override;
+    void SetBreadCrumb(uint64_t value) final;
 
     // Server cluster implementation
     CHIP_ERROR Startup(ServerClusterContext & context) override;
@@ -56,7 +56,7 @@ public:
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
     // Fabric delegate
-    void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override;
+    void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) final;
 
     // Feature map constant based on compile-time defines. This ensures feature map
     // is in sync with the actual supported features determined at build time.

--- a/src/app/clusters/general-commissioning-server/tests/TestGeneralCommissioningCluster.cpp
+++ b/src/app/clusters/general-commissioning-server/tests/TestGeneralCommissioningCluster.cpp
@@ -51,7 +51,7 @@ TEST_F(TestGeneralCommissioningCluster, TestAttributes)
 {
     // test without optional attributes
     {
-        auto & cluster            = GeneralCommissioningCluster::Instance();
+        GeneralCommissioningCluster cluster;
         auto & optionalAttributes = cluster.GetOptionalAttributes();
         optionalAttributes        = GeneralCommissioningCluster::OptionalAttributes(0);
 
@@ -87,7 +87,7 @@ TEST_F(TestGeneralCommissioningCluster, TestAttributes)
 
     // test with optional attributes
     {
-        auto & cluster            = GeneralCommissioningCluster::Instance();
+        GeneralCommissioningCluster cluster;
         auto & optionalAttributes = cluster.GetOptionalAttributes();
         optionalAttributes.Set<IsCommissioningWithoutPower::Id>();
 
@@ -132,8 +132,8 @@ TEST_F(TestGeneralCommissioningCluster, TestAcceptedCommands)
 {
     {
         ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
-        ASSERT_EQ(GeneralCommissioningCluster::Instance().AcceptedCommands({ kRootEndpointId, GeneralCommissioning::Id }, builder),
-                  CHIP_NO_ERROR);
+        GeneralCommissioningCluster cluster;
+        ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, GeneralCommissioning::Id }, builder), CHIP_NO_ERROR);
 
         ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
         ASSERT_EQ(expectedBuilder.AppendElements({

--- a/src/app/clusters/network-commissioning/BUILD.gn
+++ b/src/app/clusters/network-commissioning/BUILD.gn
@@ -59,7 +59,7 @@ source_set("network-commissioning") {
     ":thread-response-encoding",
     ":wifi-response-encoding",
     "${chip_root}/src/app:interaction-model",
-    "${chip_root}/src/app/clusters/general-commissioning-server:general-commissioning-server",
+    "${chip_root}/src/app/clusters/general-commissioning-server:bread-crumb-tracker",
     "${chip_root}/src/app/data-model-provider",
     "${chip_root}/src/app/server",
     "${chip_root}/src/app/server-cluster",

--- a/src/app/clusters/network-commissioning/CodegenInstance.cpp
+++ b/src/app/clusters/network-commissioning/CodegenInstance.cpp
@@ -29,10 +29,12 @@ namespace NetworkCommissioning {
 void Instance::CodegenGeneralCommissioningBreadcrumbTracker::SetBreadCrumb(uint64_t value)
 {
     GeneralCommissioningCluster * cluster = GeneralCommissioning::Instance();
-    if (cluster != nullptr)
+    if (cluster == nullptr)
     {
-        cluster->SetBreadCrumb(value);
+        ChipLogError(Zcl, "General commissioning cluster not available. Failed to set breadcrumb.");
+        return;
     }
+    cluster->SetBreadCrumb(value);
 }
 
 CHIP_ERROR Instance::Init()

--- a/src/app/clusters/network-commissioning/CodegenInstance.cpp
+++ b/src/app/clusters/network-commissioning/CodegenInstance.cpp
@@ -16,12 +16,24 @@
  */
 #include "CodegenInstance.h"
 
+#include <app/clusters/general-commissioning-server/CodegenIntegration.h>
+#include <app/clusters/general-commissioning-server/general-commissioning-cluster.h>
+#include <app/clusters/network-commissioning/NetworkCommissioningCluster.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 
 namespace chip {
 namespace app {
 namespace Clusters {
 namespace NetworkCommissioning {
+
+void Instance::CodegenGeneralCommissioningBreadcrumbTracker::SetBreadCrumb(uint64_t value)
+{
+    GeneralCommissioningCluster * cluster = GeneralCommissioning::Instance();
+    if (cluster != nullptr)
+    {
+        cluster->SetBreadCrumb(value);
+    }
+}
 
 CHIP_ERROR Instance::Init()
 {

--- a/src/app/clusters/network-commissioning/CodegenInstance.h
+++ b/src/app/clusters/network-commissioning/CodegenInstance.h
@@ -18,6 +18,7 @@
 
 #include "NetworkCommissioningCluster.h"
 
+#include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 
@@ -44,11 +45,19 @@ public:
     /// Calls Shutdown on the cluster and unregisters the cluster from the CodegenDataModelProvider Registry
     void Shutdown();
 
-    Instance(EndpointId aEndpointId, WiFiDriver * apDelegate) : mCluster(aEndpointId, apDelegate) {}
-    Instance(EndpointId aEndpointId, ThreadDriver * apDelegate) : mCluster(aEndpointId, apDelegate) {}
-    Instance(EndpointId aEndpointId, EthernetDriver * apDelegate) : mCluster(aEndpointId, apDelegate) {}
+    Instance(EndpointId aEndpointId, WiFiDriver * apDelegate) : mCluster(aEndpointId, apDelegate, &mTracker) {}
+    Instance(EndpointId aEndpointId, ThreadDriver * apDelegate) : mCluster(aEndpointId, apDelegate, &mTracker) {}
+    Instance(EndpointId aEndpointId, EthernetDriver * apDelegate) : mCluster(aEndpointId, apDelegate, &mTracker) {}
 
 private:
+    // does the tracking via the public general commissioning cluster (if available)
+    class CodegenGeneralCommissioningBreadcrumbTracker : public BreadCrumbTracker
+    {
+    public:
+        void SetBreadCrumb(uint64_t value) override;
+    };
+
+    CodegenGeneralCommissioningBreadcrumbTracker mTracker;
     RegisteredServerCluster<NetworkCommissioningCluster> mCluster;
 };
 

--- a/src/app/clusters/network-commissioning/CodegenInstance.h
+++ b/src/app/clusters/network-commissioning/CodegenInstance.h
@@ -50,7 +50,7 @@ public:
     Instance(EndpointId aEndpointId, EthernetDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker) {}
 
 private:
-    // does the tracking via the public general commissioning cluster (if available)
+    // Does the tracking via the public general commissioning cluster (if available)
     class CodegenGeneralCommissioningBreadcrumbTracker : public BreadCrumbTracker
     {
     public:

--- a/src/app/clusters/network-commissioning/CodegenInstance.h
+++ b/src/app/clusters/network-commissioning/CodegenInstance.h
@@ -45,9 +45,9 @@ public:
     /// Calls Shutdown on the cluster and unregisters the cluster from the CodegenDataModelProvider Registry
     void Shutdown();
 
-    Instance(EndpointId aEndpointId, WiFiDriver * apDelegate) : mCluster(aEndpointId, apDelegate, &mTracker) {}
-    Instance(EndpointId aEndpointId, ThreadDriver * apDelegate) : mCluster(aEndpointId, apDelegate, &mTracker) {}
-    Instance(EndpointId aEndpointId, EthernetDriver * apDelegate) : mCluster(aEndpointId, apDelegate, &mTracker) {}
+    Instance(EndpointId aEndpointId, WiFiDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker) {}
+    Instance(EndpointId aEndpointId, ThreadDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker) {}
+    Instance(EndpointId aEndpointId, EthernetDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker) {}
 
 private:
     // does the tracking via the public general commissioning cluster (if available)

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
 #include <app/clusters/network-commissioning/NetworkCommissioningLogic.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 
@@ -33,14 +34,20 @@ namespace Clusters {
 class NetworkCommissioningCluster : public DefaultServerCluster
 {
 public:
-    NetworkCommissioningCluster(EndpointId endpointId, DeviceLayer::NetworkCommissioning::WiFiDriver * driver) :
-        DefaultServerCluster({ endpointId, NetworkCommissioning::Id }), mLogic(endpointId, driver)
+    NetworkCommissioningCluster(EndpointId endpointId, DeviceLayer::NetworkCommissioning::WiFiDriver * driver,
+                                BreadCrumbTracker * tracker) :
+        DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
+        mLogic(endpointId, driver, tracker)
     {}
-    NetworkCommissioningCluster(EndpointId endpointId, DeviceLayer::NetworkCommissioning::ThreadDriver * driver) :
-        DefaultServerCluster({ endpointId, NetworkCommissioning::Id }), mLogic(endpointId, driver)
+    NetworkCommissioningCluster(EndpointId endpointId, DeviceLayer::NetworkCommissioning::ThreadDriver * driver,
+                                BreadCrumbTracker * tracker) :
+        DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
+        mLogic(endpointId, driver, tracker)
     {}
-    NetworkCommissioningCluster(EndpointId endpointId, DeviceLayer::NetworkCommissioning::EthernetDriver * driver) :
-        DefaultServerCluster({ endpointId, NetworkCommissioning::Id }), mLogic(endpointId, driver)
+    NetworkCommissioningCluster(EndpointId endpointId, DeviceLayer::NetworkCommissioning::EthernetDriver * driver,
+                                BreadCrumbTracker * tracker) :
+        DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
+        mLogic(endpointId, driver, tracker)
     {}
 
     CHIP_ERROR Init() { return mLogic.Init(); }

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
@@ -35,17 +35,17 @@ class NetworkCommissioningCluster : public DefaultServerCluster
 {
 public:
     NetworkCommissioningCluster(EndpointId endpointId, DeviceLayer::NetworkCommissioning::WiFiDriver * driver,
-                                BreadCrumbTracker * tracker) :
+                                BreadCrumbTracker & tracker) :
         DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
         mLogic(endpointId, driver, tracker)
     {}
     NetworkCommissioningCluster(EndpointId endpointId, DeviceLayer::NetworkCommissioning::ThreadDriver * driver,
-                                BreadCrumbTracker * tracker) :
+                                BreadCrumbTracker & tracker) :
         DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
         mLogic(endpointId, driver, tracker)
     {}
     NetworkCommissioningCluster(EndpointId endpointId, DeviceLayer::NetworkCommissioning::EthernetDriver * driver,
-                                BreadCrumbTracker * tracker) :
+                                BreadCrumbTracker & tracker) :
         DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
         mLogic(endpointId, driver, tracker)
     {}

--- a/src/app/clusters/network-commissioning/NetworkCommissioningLogic.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningLogic.cpp
@@ -134,7 +134,7 @@ NetworkCommissioningLogic::NetworkInstanceList NetworkCommissioningLogic::sInsta
 #endif
 
 NetworkCommissioningLogic::NetworkCommissioningLogic(EndpointId aEndpointId, WiFiDriver * apDelegate,
-                                                     BreadCrumbTracker * aTracker) :
+                                                     BreadCrumbTracker & aTracker) :
     mEndpointId(aEndpointId),
     mFeatureFlags(WiFiFeatures(apDelegate)), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate), mBreadcrumbTracker(aTracker)
 {
@@ -142,7 +142,7 @@ NetworkCommissioningLogic::NetworkCommissioningLogic(EndpointId aEndpointId, WiF
 }
 
 NetworkCommissioningLogic::NetworkCommissioningLogic(EndpointId aEndpointId, ThreadDriver * apDelegate,
-                                                     BreadCrumbTracker * aTracker) :
+                                                     BreadCrumbTracker & aTracker) :
     mEndpointId(aEndpointId),
     mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate),
     mBreadcrumbTracker(aTracker)
@@ -151,7 +151,7 @@ NetworkCommissioningLogic::NetworkCommissioningLogic(EndpointId aEndpointId, Thr
 }
 
 NetworkCommissioningLogic::NetworkCommissioningLogic(EndpointId aEndpointId, EthernetDriver * apDelegate,
-                                                     BreadCrumbTracker * aTracker) :
+                                                     BreadCrumbTracker & aTracker) :
     mEndpointId(aEndpointId),
     mFeatureFlags(Feature::kEthernetNetworkInterface), mpWirelessDriver(nullptr), mpBaseDriver(apDelegate),
     mBreadcrumbTracker(aTracker)
@@ -588,7 +588,7 @@ NetworkCommissioningLogic::HandleAddOrUpdateThreadNetwork(CommandHandler & handl
 void NetworkCommissioningLogic::UpdateBreadcrumb(const Optional<uint64_t> & breadcrumb)
 {
     VerifyOrReturn(breadcrumb.HasValue());
-    mBreadcrumbTracker->SetBreadCrumb(breadcrumb.Value());
+    mBreadcrumbTracker.SetBreadCrumb(breadcrumb.Value());
 }
 
 void NetworkCommissioningLogic::CommitSavedBreadcrumb()

--- a/src/app/clusters/network-commissioning/NetworkCommissioningLogic.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningLogic.cpp
@@ -22,7 +22,7 @@
 #include <app/CommandHandlerInterface.h>
 #include <app/CommandHandlerInterfaceRegistry.h>
 #include <app/ConcreteCommandPath.h>
-#include <app/clusters/general-commissioning-server/general-commissioning-cluster.h>
+
 #include <app/clusters/network-commissioning/ThreadScanResponse.h>
 #include <app/clusters/network-commissioning/WifiScanResponse.h>
 #include <app/data-model/Nullable.h>
@@ -133,21 +133,28 @@ private:
 NetworkCommissioningLogic::NetworkInstanceList NetworkCommissioningLogic::sInstances;
 #endif
 
-NetworkCommissioningLogic::NetworkCommissioningLogic(EndpointId aEndpointId, WiFiDriver * apDelegate) :
-    mEndpointId(aEndpointId), mFeatureFlags(WiFiFeatures(apDelegate)), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate)
+NetworkCommissioningLogic::NetworkCommissioningLogic(EndpointId aEndpointId, WiFiDriver * apDelegate,
+                                                     BreadCrumbTracker * aTracker) :
+    mEndpointId(aEndpointId),
+    mFeatureFlags(WiFiFeatures(apDelegate)), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate), mBreadcrumbTracker(aTracker)
 {
     mpDriver.Set<WiFiDriver *>(apDelegate);
 }
 
-NetworkCommissioningLogic::NetworkCommissioningLogic(EndpointId aEndpointId, ThreadDriver * apDelegate) :
-    mEndpointId(aEndpointId), mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(apDelegate),
-    mpBaseDriver(apDelegate)
+NetworkCommissioningLogic::NetworkCommissioningLogic(EndpointId aEndpointId, ThreadDriver * apDelegate,
+                                                     BreadCrumbTracker * aTracker) :
+    mEndpointId(aEndpointId),
+    mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate),
+    mBreadcrumbTracker(aTracker)
 {
     mpDriver.Set<ThreadDriver *>(apDelegate);
 }
 
-NetworkCommissioningLogic::NetworkCommissioningLogic(EndpointId aEndpointId, EthernetDriver * apDelegate) :
-    mEndpointId(aEndpointId), mFeatureFlags(Feature::kEthernetNetworkInterface), mpWirelessDriver(nullptr), mpBaseDriver(apDelegate)
+NetworkCommissioningLogic::NetworkCommissioningLogic(EndpointId aEndpointId, EthernetDriver * apDelegate,
+                                                     BreadCrumbTracker * aTracker) :
+    mEndpointId(aEndpointId),
+    mFeatureFlags(Feature::kEthernetNetworkInterface), mpWirelessDriver(nullptr), mpBaseDriver(apDelegate),
+    mBreadcrumbTracker(aTracker)
 {}
 
 CHIP_ERROR NetworkCommissioningLogic::Init()
@@ -581,7 +588,7 @@ NetworkCommissioningLogic::HandleAddOrUpdateThreadNetwork(CommandHandler & handl
 void NetworkCommissioningLogic::UpdateBreadcrumb(const Optional<uint64_t> & breadcrumb)
 {
     VerifyOrReturn(breadcrumb.HasValue());
-    GeneralCommissioningCluster::Instance().SetBreadCrumb(breadcrumb.Value());
+    mBreadcrumbTracker->SetBreadCrumb(breadcrumb.Value());
 }
 
 void NetworkCommissioningLogic::CommitSavedBreadcrumb()

--- a/src/app/clusters/network-commissioning/NetworkCommissioningLogic.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningLogic.h
@@ -19,6 +19,7 @@
 #include <app/AttributeValueEncoder.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
 #include <app/data-model/Nullable.h>
 #include <clusters/NetworkCommissioning/Attributes.h>
@@ -208,6 +209,7 @@ private:
     uint8_t mLastNetworkIDLen = 0;
     Optional<uint64_t> mCurrentOperationBreadcrumb;
     bool mScanningWasDirected = false;
+    BreadCrumbTracker * mBreadcrumbTracker;
 
     void SetLastNetworkingStatusValue(NetworkCommissioning::Attributes::LastNetworkingStatus::TypeInfo::Type networkingStatusValue);
     void SetLastConnectErrorValue(NetworkCommissioning::Attributes::LastConnectErrorValue::TypeInfo::Type connectErrorValue);
@@ -227,9 +229,9 @@ private:
     void UpdateBreadcrumb(const Optional<uint64_t> & breadcrumbValue);
 
 public:
-    NetworkCommissioningLogic(EndpointId aEndpointId, WiFiDriver * apDelegate);
-    NetworkCommissioningLogic(EndpointId aEndpointId, ThreadDriver * apDelegate);
-    NetworkCommissioningLogic(EndpointId aEndpointId, EthernetDriver * apDelegate);
+    NetworkCommissioningLogic(EndpointId aEndpointId, WiFiDriver * apDelegate, BreadCrumbTracker * tracker);
+    NetworkCommissioningLogic(EndpointId aEndpointId, ThreadDriver * apDelegate, BreadCrumbTracker * tracker);
+    NetworkCommissioningLogic(EndpointId aEndpointId, EthernetDriver * apDelegate, BreadCrumbTracker * tracker);
     virtual ~NetworkCommissioningLogic()
     {
 #if CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION

--- a/src/app/clusters/network-commissioning/NetworkCommissioningLogic.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningLogic.h
@@ -209,7 +209,7 @@ private:
     uint8_t mLastNetworkIDLen = 0;
     Optional<uint64_t> mCurrentOperationBreadcrumb;
     bool mScanningWasDirected = false;
-    BreadCrumbTracker * mBreadcrumbTracker;
+    BreadCrumbTracker & mBreadcrumbTracker;
 
     void SetLastNetworkingStatusValue(NetworkCommissioning::Attributes::LastNetworkingStatus::TypeInfo::Type networkingStatusValue);
     void SetLastConnectErrorValue(NetworkCommissioning::Attributes::LastConnectErrorValue::TypeInfo::Type connectErrorValue);
@@ -229,9 +229,9 @@ private:
     void UpdateBreadcrumb(const Optional<uint64_t> & breadcrumbValue);
 
 public:
-    NetworkCommissioningLogic(EndpointId aEndpointId, WiFiDriver * apDelegate, BreadCrumbTracker * tracker);
-    NetworkCommissioningLogic(EndpointId aEndpointId, ThreadDriver * apDelegate, BreadCrumbTracker * tracker);
-    NetworkCommissioningLogic(EndpointId aEndpointId, EthernetDriver * apDelegate, BreadCrumbTracker * tracker);
+    NetworkCommissioningLogic(EndpointId aEndpointId, WiFiDriver * apDelegate, BreadCrumbTracker & tracker);
+    NetworkCommissioningLogic(EndpointId aEndpointId, ThreadDriver * apDelegate, BreadCrumbTracker & tracker);
+    NetworkCommissioningLogic(EndpointId aEndpointId, EthernetDriver * apDelegate, BreadCrumbTracker & tracker);
     virtual ~NetworkCommissioningLogic()
     {
 #if CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <cstdint>
 #include <pw_unit_test/framework.h>
 
 #include <app/AttributePathParams.h>

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -67,7 +67,7 @@ TEST_F(TestNetworkCommissioningCluster, TestAttributes)
     {
         Testing::FakeWiFiDriver fakeWifiDriver;
 
-        NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, &tracker);
+        NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, tracker);
 
         ReadOnlyBufferBuilder<AttributeEntry> builder;
         ASSERT_EQ(cluster.Attributes({ kRootEndpointId, NetworkCommissioning::Id }, builder), CHIP_NO_ERROR);
@@ -106,7 +106,7 @@ TEST_F(TestNetworkCommissioningCluster, TestNotifyOnEnableInterface)
 {
     Testing::FakeWiFiDriver fakeWifiDriver;
     NoopBreadcrumbTracker tracker;
-    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, &tracker);
+    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, tracker);
 
     chip::Test::TestServerClusterContext context;
     ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -13,10 +13,12 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <cstdint>
 #include <pw_unit_test/framework.h>
 
 #include <app/AttributePathParams.h>
 #include <app/AttributeValueDecoder.h>
+#include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
 #include <app/clusters/network-commissioning/NetworkCommissioningCluster.h>
 #include <app/clusters/testing/AttributeTesting.h>
 #include <app/data-model-provider/MetadataTypes.h>
@@ -48,6 +50,11 @@ using chip::app::DataModel::AttributeEntry;
 using chip::app::Testing::kAdminSubjectDescriptor;
 using chip::app::Testing::WriteOperation;
 
+class NoopBreadcrumbTracker : public BreadCrumbTracker
+{
+public:
+    void SetBreadCrumb(uint64_t v) override {}
+};
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestNetworkCommissioningCluster : public ::testing::Test
 {
@@ -57,9 +64,11 @@ struct TestNetworkCommissioningCluster : public ::testing::Test
 
 TEST_F(TestNetworkCommissioningCluster, TestAttributes)
 {
+    NoopBreadcrumbTracker tracker;
     {
         Testing::FakeWiFiDriver fakeWifiDriver;
-        NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver);
+
+        NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, &tracker);
 
         ReadOnlyBufferBuilder<AttributeEntry> builder;
         ASSERT_EQ(cluster.Attributes({ kRootEndpointId, NetworkCommissioning::Id }, builder), CHIP_NO_ERROR);
@@ -97,7 +106,8 @@ TEST_F(TestNetworkCommissioningCluster, TestAttributes)
 TEST_F(TestNetworkCommissioningCluster, TestNotifyOnEnableInterface)
 {
     Testing::FakeWiFiDriver fakeWifiDriver;
-    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver);
+    NoopBreadcrumbTracker tracker;
+    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, &tracker);
 
     chip::Test::TestServerClusterContext context;
     ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningLogic.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningLogic.cpp
@@ -51,7 +51,7 @@ TEST_F(TestNetworkCommissioningLogic, TestFeatures)
 {
     Testing::FakeWiFiDriver fakeWifiDriver;
     NoopBreadcrumbTracker tracker;
-    NetworkCommissioningLogic logic(kRootEndpointId, &fakeWifiDriver, &tracker);
+    NetworkCommissioningLogic logic(kRootEndpointId, &fakeWifiDriver, tracker);
     ASSERT_EQ(logic.Features(), BitFlags<NetworkCommissioning::Feature>(NetworkCommissioning::Feature::kWiFiNetworkInterface));
 }
 

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningLogic.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningLogic.cpp
@@ -34,6 +34,12 @@ namespace {
 using namespace chip;
 using namespace chip::app::Clusters;
 
+class NoopBreadcrumbTracker : public BreadCrumbTracker
+{
+public:
+    void SetBreadCrumb(uint64_t v) override {}
+};
+
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestNetworkCommissioningLogic : public ::testing::Test
 {
@@ -44,7 +50,8 @@ struct TestNetworkCommissioningLogic : public ::testing::Test
 TEST_F(TestNetworkCommissioningLogic, TestFeatures)
 {
     Testing::FakeWiFiDriver fakeWifiDriver;
-    NetworkCommissioningLogic logic(kRootEndpointId, &fakeWifiDriver);
+    NoopBreadcrumbTracker tracker;
+    NetworkCommissioningLogic logic(kRootEndpointId, &fakeWifiDriver, &tracker);
     ASSERT_EQ(logic.Features(), BitFlags<NetworkCommissioning::Feature>(NetworkCommissioning::Feature::kWiFiNetworkInterface));
 }
 

--- a/src/app/clusters/thread-border-router-management-server/thread-border-router-management-server.cpp
+++ b/src/app/clusters/thread-border-router-management-server/thread-border-router-management-server.cpp
@@ -17,27 +17,28 @@
 
 #include "thread-border-router-management-server.h"
 
-#include "app-common/zap-generated/cluster-objects.h"
-#include "app-common/zap-generated/ids/Attributes.h"
-#include "app-common/zap-generated/ids/Clusters.h"
-#include "app-common/zap-generated/ids/Commands.h"
-#include "app/AttributeAccessInterfaceRegistry.h"
-#include "app/AttributeValueEncoder.h"
-#include "app/CommandHandler.h"
-#include "app/CommandHandlerInterface.h"
-#include "app/CommandHandlerInterfaceRegistry.h"
-#include "app/InteractionModelEngine.h"
-#include "app/MessageDef/StatusIB.h"
-#include "app/clusters/general-commissioning-server/general-commissioning-cluster.h"
-#include "app/data-model/Nullable.h"
-#include "lib/core/CHIPError.h"
-#include "lib/core/Optional.h"
-#include "lib/support/CodeUtils.h"
-#include "lib/support/Span.h"
-#include "lib/support/ThreadOperationalDataset.h"
-#include "platform/CHIPDeviceEvent.h"
-#include "platform/PlatformManager.h"
-#include "protocols/interaction_model/StatusCode.h"
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app-common/zap-generated/ids/Commands.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
+#include <app/AttributeValueEncoder.h>
+#include <app/CommandHandler.h>
+#include <app/CommandHandlerInterface.h>
+#include <app/CommandHandlerInterfaceRegistry.h>
+#include <app/InteractionModelEngine.h>
+#include <app/MessageDef/StatusIB.h>
+#include <app/clusters/general-commissioning-server/CodegenIntegration.h>
+#include <app/data-model/Nullable.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/Optional.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+#include <lib/support/ThreadOperationalDataset.h>
+#include <platform/CHIPDeviceEvent.h>
+#include <platform/PlatformManager.h>
+#include <protocols/interaction_model/StatusCode.h>
+
 #include <optional>
 
 namespace chip {

--- a/src/app/clusters/thread-border-router-management-server/thread-border-router-management-server.cpp
+++ b/src/app/clusters/thread-border-router-management-server/thread-border-router-management-server.cpp
@@ -300,7 +300,11 @@ void ServerInstance::CommitSavedBreadcrumb()
 {
     if (mBreadcrumb.HasValue())
     {
-        GeneralCommissioningCluster::Instance().SetBreadCrumb(mBreadcrumb.Value());
+        GeneralCommissioningCluster * cluster = GeneralCommissioning::Instance();
+        if (cluster != nullptr)
+        {
+            cluster->SetBreadCrumb(mBreadcrumb.Value());
+        }
     }
     mBreadcrumb.ClearValue();
 }

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -142,12 +142,17 @@ source_set("thread-border-router-management-test-srcs") {
     "${chip_root}/src/app/clusters/thread-border-router-management-server/thread-border-router-management-server.cpp",
     "${chip_root}/src/app/clusters/thread-border-router-management-server/thread-border-router-management-server.h",
     "${chip_root}/src/app/clusters/thread-border-router-management-server/thread-br-delegate.h",
+
+    # Sources needed because codegen integration of general commissioning provides general commissioning instance
+    "${chip_root}/src/app/clusters/general-commissioning-server/CodegenIntegration.cpp",
+    "${chip_root}/src/app/clusters/general-commissioning-server/CodegenIntegration.h",
   ]
 
   public_deps = [
     "${chip_root}/src/app",
     "${chip_root}/src/app/clusters/general-commissioning-server:general-commissioning-server",
     "${chip_root}/src/app/common:cluster-objects",
+    "${chip_root}/src/app/util/mock:mock_codegen_data_model",
     "${chip_root}/src/app/util/mock:mock_ember",
     "${chip_root}/src/lib/core",
   ]

--- a/src/app/util/mock/include/app/static-cluster-config/GeneralCommissioning.h
+++ b/src/app/util/mock/include/app/static-cluster-config/GeneralCommissioning.h
@@ -1,0 +1,103 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/// NOTE: this is a MOCK for testing purposes only.
+#pragma once
+
+#include <app/util/cluster-config.h>
+#include <clusters/GeneralCommissioning/AttributeIds.h>
+#include <clusters/GeneralCommissioning/CommandIds.h>
+#include <clusters/GeneralCommissioning/Enums.h>
+
+#include <array>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace GeneralCommissioning {
+namespace StaticApplicationConfig {
+namespace detail {
+inline constexpr AttributeId kEndpoint0EnabledAttributes[] = {
+    Attributes::AcceptedCommandList::Id,    Attributes::AttributeList::Id,
+    Attributes::BasicCommissioningInfo::Id, Attributes::Breadcrumb::Id,
+    Attributes::ClusterRevision::Id,        Attributes::FeatureMap::Id,
+    Attributes::GeneratedCommandList::Id,   Attributes::LocationCapability::Id,
+    Attributes::RegulatoryConfig::Id,       Attributes::SupportsConcurrentConnection::Id,
+};
+
+inline constexpr CommandId kEndpoint0EnabledCommands[] = {
+    Commands::ArmFailSafe::Id,           Commands::ArmFailSafeResponse::Id,
+    Commands::CommissioningComplete::Id, Commands::CommissioningCompleteResponse::Id,
+    Commands::SetRegulatoryConfig::Id,   Commands::SetRegulatoryConfigResponse::Id,
+};
+
+} // namespace detail
+
+using FeatureBitmapType = Feature;
+
+inline constexpr std::array<Clusters::StaticApplicationConfig::ClusterConfiguration<FeatureBitmapType>, 1> kFixedClusterConfig = { {
+    {
+        .endpointNumber    = 0,
+        .featureMap        = BitFlags<FeatureBitmapType>{},
+        .enabledAttributes = Span<const AttributeId>(detail::kEndpoint0EnabledAttributes),
+        .enabledCommands   = Span<const CommandId>(detail::kEndpoint0EnabledCommands),
+    },
+} };
+
+// If a specific attribute is supported at all across all endpoint static instantiations
+inline constexpr bool IsAttributeEnabledOnSomeEndpoint(AttributeId attributeId)
+{
+    switch (attributeId)
+    {
+    case Attributes::AcceptedCommandList::Id:
+    case Attributes::AttributeList::Id:
+    case Attributes::BasicCommissioningInfo::Id:
+    case Attributes::Breadcrumb::Id:
+    case Attributes::ClusterRevision::Id:
+    case Attributes::FeatureMap::Id:
+    case Attributes::GeneratedCommandList::Id:
+    case Attributes::LocationCapability::Id:
+    case Attributes::RegulatoryConfig::Id:
+    case Attributes::SupportsConcurrentConnection::Id:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// If a specific command is supported at all across all endpoint static instantiations
+inline constexpr bool IsCommandEnabledOnSomeEndpoint(CommandId commandId)
+{
+    switch (commandId)
+    {
+    case Commands::ArmFailSafe::Id:
+    case Commands::ArmFailSafeResponse::Id:
+    case Commands::CommissioningComplete::Id:
+    case Commands::CommissioningCompleteResponse::Id:
+    case Commands::SetRegulatoryConfig::Id:
+    case Commands::SetRegulatoryConfigResponse::Id:
+        return true;
+    default:
+        return false;
+    }
+}
+
+} // namespace StaticApplicationConfig
+} // namespace GeneralCommissioning
+} // namespace Clusters
+} // namespace app
+} // namespace chip


### PR DESCRIPTION
#### Summary

Make the "set the breadcrumb" a separatable interface. This simplifies testing (less coupling between one cluster and another directly).

This is a split out of #41689 and this change makes using a cluster context a lot easier due to much reduced coupling.

#### Testing

Breadcrumbs should still work. Existing CI applies.