### PR TITLE
Undo PR 41559 changes for chef cloudbuilder

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:174"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:174"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -23,7 +23,7 @@ steps:
           - name: pwenv
             path: /pwenv
       timeout: 900s
-    - name: "ghcr.io/project-chip/chip-build-vscode:174"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -38,7 +38,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:174"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       # ICD device is currently not supported for ESP32 and NRF targets. New rule to compile only ICD
       # linux binary.
       env:
@@ -53,7 +53,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:174"
+    - name: "ghcr.io/project-chip/chip-build-vscode:169"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:


### PR DESCRIPTION
#### Summary

Adding this change to undo cloubuild/chef.yaml changes made in this [PR](https://github.com/project-chip/connectedhomeip/pull/41559/files#diff-34e79a51a6b4df9e196b38317d9cfed549bf11a010dfa83464f41fb1fffef0b4).

Unable to build chef ESP32 variants in docker image `ghcr.io/project-chip/chip-build-vscode:174`. Build fails with the error -
```
Step #2 - "CompileAll": AttributeError: 'MenuNode' object has no attribute 'help'
Step #2 - "CompileAll": CMake Error at /opt/espressif/esp-idf/tools/cmake/kconfig.cmake:237 (message):
Step #2 - "CompileAll":   Failed to run kconfgen
Step #2 - "CompileAll":   (/pwenv/pigweed-venv/bin/python;-m;kconfgen;--list-separator=semicolon;--kconfig;/opt/espressif/esp-idf/Kconfig;--sdkconfig-rename;/opt/espressif/esp-idf/sdkconfig.rename;--config;/workspace/examples/chef/esp32/sdkconfig;--defaults;/workspace/examples/chef/esp32/sdkconfig_rpc.defaults;--env;IDF_MINIMAL_BUILD=n;--env-file;/workspace/examples/chef/esp32/build/config.env).
Step #2 - "CompileAll":   Error 1
Step #2 - "CompileAll": Call Stack (most recent call first):
Step #2 - "CompileAll":   /opt/espressif/esp-idf/tools/cmake/build.cmake:704 (__kconfig_generate_config)
Step #2 - "CompileAll":   /opt/espressif/esp-idf/tools/cmake/project.cmake:740 (idf_build_process)
Step #2 - "CompileAll":   CMakeLists.txt:60 (project)
```

So changing docker image back to ghcr.io/project-chip/chip-build-vscode:169

#### Testing

Cloud build trigger passed on this commit.