### PR TITLE
[NXP] Fix TC-CNET-4.9 and add wifi reconnection in revert configuration

### DIFF
--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -127,7 +127,7 @@ CHIP_ERROR NXPWiFiDriver::CommitConfiguration()
 
 CHIP_ERROR NXPWiFiDriver::RevertConfiguration()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err                      = CHIP_NO_ERROR;
     struct wlan_network searchedNetwork = { 0 };
 
     /* If network was added we have to remove it (only if device is not connected to a wifi network) from wifi driver to be able
@@ -144,11 +144,11 @@ CHIP_ERROR NXPWiFiDriver::RevertConfiguration()
     }
 
     mStagingNetwork = mSavedNetwork;
-    if(mStagingNetwork.ssidLen > 0)
+    if (mStagingNetwork.ssidLen > 0)
     {
         // Connect to saved network
-        err = ConnectWiFiNetwork(mSavedNetwork.ssid, mSavedNetwork.ssidLen, mSavedNetwork.credentials, mSavedNetwork.credentialsLen);
-
+        err =
+            ConnectWiFiNetwork(mSavedNetwork.ssid, mSavedNetwork.ssidLen, mSavedNetwork.credentials, mSavedNetwork.credentialsLen);
     }
 
     return err;

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -127,7 +127,6 @@ CHIP_ERROR NXPWiFiDriver::CommitConfiguration()
 
 CHIP_ERROR NXPWiFiDriver::RevertConfiguration()
 {
-    CHIP_ERROR err                      = CHIP_NO_ERROR;
     struct wlan_network searchedNetwork = { 0 };
 
     /* If network was added we have to remove it (only if device is not connected to a wifi network) from wifi driver to be able
@@ -143,15 +142,13 @@ CHIP_ERROR NXPWiFiDriver::RevertConfiguration()
         }
     }
 
+    /* Reset mStagingNetwork as it may have been updated during add/update network operation */
     mStagingNetwork = mSavedNetwork;
-    if (mStagingNetwork.ssidLen > 0)
-    {
-        // Connect to saved network
-        err =
-            ConnectWiFiNetwork(mSavedNetwork.ssid, mSavedNetwork.ssidLen, mSavedNetwork.credentials, mSavedNetwork.credentialsLen);
-    }
 
-    return err;
+    // succeed right away if no saved network
+    VerifyOrReturnError(mStagingNetwork.ssidLen > 0, CHIPO_NO_ERROR);
+    // Connect to saved network
+    return ConnectWiFiNetwork(mStagingNetwork.ssid, mStagingNetwork.ssidLen, mStagingNetwork.credentials, mStagingNetwork.credentialsLen);
 }
 
 bool NXPWiFiDriver::NetworkMatch(const WiFiNetwork & network, ByteSpan networkId)

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -146,7 +146,7 @@ CHIP_ERROR NXPWiFiDriver::RevertConfiguration()
     mStagingNetwork = mSavedNetwork;
 
     // succeed right away if no saved network
-    VerifyOrReturnError(mStagingNetwork.ssidLen > 0, CHIPO_NO_ERROR);
+    VerifyOrReturnError(mStagingNetwork.ssidLen > 0, CHIP_NO_ERROR);
     // Connect to saved network
     return ConnectWiFiNetwork(mStagingNetwork.ssid, mStagingNetwork.ssidLen, mStagingNetwork.credentials,
                               mStagingNetwork.credentialsLen);

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -148,7 +148,8 @@ CHIP_ERROR NXPWiFiDriver::RevertConfiguration()
     // succeed right away if no saved network
     VerifyOrReturnError(mStagingNetwork.ssidLen > 0, CHIPO_NO_ERROR);
     // Connect to saved network
-    return ConnectWiFiNetwork(mStagingNetwork.ssid, mStagingNetwork.ssidLen, mStagingNetwork.credentials, mStagingNetwork.credentialsLen);
+    return ConnectWiFiNetwork(mStagingNetwork.ssid, mStagingNetwork.ssidLen, mStagingNetwork.credentials,
+                              mStagingNetwork.credentialsLen);
 }
 
 bool NXPWiFiDriver::NetworkMatch(const WiFiNetwork & network, ByteSpan networkId)


### PR DESCRIPTION
#### Summary

Fix TC-CNET-4.9: Preserve network connection when self-safe timer expires
Prevent removal of the current network if the self-safe timer expires and the device is still connected to a Wi-Fi network.
Enhance the revert configuration logic to include Wi-Fi reconnection. This allows the device to automatically reconnect to the last known network if a credentials update fails during the connection process.

#### Testing
rw61x thermosat wifi application

- TC-CNET-4.9 test pass
- change the DUT network to a non-existing one to force fail safe timer expired for revert configuration and check the DUT is reconnecting to the last network and respond to chip-tool command

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
