### PR TITLE
Add ContinueCommissioningAfterConnectNetworkRequest to CHIPDeviceController's JNI.

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1387,7 +1387,8 @@ JNI_METHOD(void, continueCommissioningAfterConnectNetworkRequest)(JNIEnv * env, 
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Failed to continue Commissioning after Connect Network Request. : %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogError(Controller, "Failed to continue Commissioning after Connect Network Request. : %" CHIP_ERROR_FORMAT,
+                     err.Format());
         JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
     }
 }

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1382,12 +1382,13 @@ JNI_METHOD(void, continueCommissioningAfterConnectNetworkRequest)(JNIEnv * env, 
     wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
     VerifyOrExit(wrapper != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    wrapper->Controller()->ContinueCommissioningAfterConnectNetworkRequest(static_cast<NodeId>(remoteDeviceId));
+    err = wrapper->Controller()->ContinueCommissioningAfterConnectNetworkRequest(static_cast<NodeId>(remoteDeviceId));
+    SuccessOrExit(err);
 
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Failed to continue Commissioning after Connect Network Request. : %" CHIP_ERROR_FORMAT,
+        ChipLogError(Controller, "Failed to continue Commissioning after Connect Network Request: %" CHIP_ERROR_FORMAT,
                      err.Format());
         JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
     }

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1367,6 +1367,31 @@ JNI_METHOD(void, unpairDeviceCallback)(JNIEnv * env, jobject self, jlong handle,
     }
 }
 
+// Method used in case of NFC-based Commissioning without power.
+// At end of 1st commissioning phase, the user is asked to install and power ON the device.
+// Present function is used to confirm that this action has been done.
+// The 2nd commissioning phase, on the Operational network, will then start.
+JNI_METHOD(void, continueCommissioningAfterConnectNetworkRequest)(JNIEnv * env, jobject self, jlong handle, jlong remoteDeviceId)
+{
+    chip::DeviceLayer::StackLock lock;
+    AndroidDeviceControllerWrapper * wrapper = nullptr;
+    CHIP_ERROR err                           = CHIP_NO_ERROR;
+
+    VerifyOrExit(env != nullptr, err = CHIP_ERROR_BAD_REQUEST);
+
+    wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+    VerifyOrExit(wrapper != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    wrapper->Controller()->ContinueCommissioningAfterConnectNetworkRequest(static_cast<NodeId>(remoteDeviceId));
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to continue Commissioning after Connect Network Request. : %" CHIP_ERROR_FORMAT, err.Format());
+        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
+    }
+}
+
 JNI_METHOD(void, stopDevicePairing)(JNIEnv * env, jobject self, jlong handle, jlong deviceId)
 {
     chip::DeviceLayer::StackLock lock;

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -1722,7 +1722,8 @@ public class ChipDeviceController {
   private native void unpairDeviceCallback(
       long deviceControllerPtr, long deviceId, UnpairDeviceCallback callback);
 
-  private native void continueCommissioningAfterConnectNetworkRequest(long deviceControllerPtr, long remoteDeviceId);
+  private native void continueCommissioningAfterConnectNetworkRequest(
+      long deviceControllerPtr, long remoteDeviceId);
 
   private native void stopDevicePairing(long deviceControllerPtr, long deviceId);
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -636,6 +636,10 @@ public class ChipDeviceController {
     unpairDeviceCallback(deviceControllerPtr, deviceId, callback);
   }
 
+  public void continueCommissioningAfterConnectNetworkRequest(long remoteDeviceId) {
+    continueCommissioningAfterConnectNetworkRequest(deviceControllerPtr, remoteDeviceId);
+  }
+
   /**
    * This function stops a pairing or commissioning process that is in progress.
    *
@@ -1717,6 +1721,8 @@ public class ChipDeviceController {
 
   private native void unpairDeviceCallback(
       long deviceControllerPtr, long deviceId, UnpairDeviceCallback callback);
+
+  private native void continueCommissioningAfterConnectNetworkRequest(long deviceControllerPtr, long remoteDeviceId);
 
   private native void stopDevicePairing(long deviceControllerPtr, long deviceId);
 


### PR DESCRIPTION
The PR https://github.com/project-chip/connectedhomeip/pull/40783 has added a new function called "**ContinueCommissioningAfterConnectNetworkRequest()**" to CHIPDeviceController.cpp. 

The current PR updates CHIPDeviceController's JNI to add this function.

#### Testing

In my local environment, I have a modified version of Chiptool for Android using the code present in the current PR. I use it to perform NFC based commissioning without power:
- I perform the 1st commissioning phase via NFC. 
- The UI asks to the user to power ON the device and then click on a button to confirm when it is done.
- Chiptool Android app then calls **ContinueCommissioningAfterConnectNetworkRequest** JNI to start the 2nd commissioning phase, on the operational network.
- The commissioning completes successfully.

I have tested that it is working fine.
FYI, this is the last PR with SDK changes for NFC-based commissioning. I will then do a PR containing Chiptool for Android modifications.
