### PR TITLE
[ICD][Client]Improve sigma1 retransmission delay for LIT

### DIFF
--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -40,8 +40,11 @@ struct CASEClientInitParams
     // claiming different MRP parameters for the same node.
     Optional<ReliableMessageProtocolConfig> mrpLocalConfig = NullOptional;
 
-    // The minimum backoff interval for LIT devices. This is used to calculate
-    // the sigma1 retransmission timeout for LIT devices.
+    // The minimum backoff interval for LIT devices. This is used to calculate the sigma1
+    // retransmission timeout for LIT devices, ensuring it's at least `minimumLITBackoffInterval`.
+    // Specifically, the timeout is `max(LIT activeRetransTimeout,
+    // minimumLITBackoffInterval)`. This prevents issues with MRP retransmission in Thread
+    // networks when activeRetransTimeout is too small.
     Optional<uint32_t> minimumLITBackoffInterval = NullOptional;
 
     CHIP_ERROR Validate() const

--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -45,6 +45,7 @@ struct CASEClientInitParams
     // Specifically, the timeout is `max(LIT activeRetransTimeout,
     // minimumLITBackoffInterval)`. This prevents issues with MRP retransmission in Thread
     // networks when activeRetransTimeout is too small.
+    // Note: This parameter is not spec-compliant.
     Optional<uint32_t> minimumLITBackoffInterval = NullOptional;
 
     CHIP_ERROR Validate() const

--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -45,7 +45,7 @@ struct CASEClientInitParams
     // Specifically, the timeout is `max(LIT activeRetransTimeout,
     // minimumLITBackoffInterval)`. This prevents issues with MRP retransmission in Thread
     // networks when activeRetransTimeout is too small.
-    // Note: This parameter is not spec-compliant.
+    // Note: Setting this parameter to a nonzero value is not spec-compliant.
     Optional<uint32_t> minimumLITBackoffInterval = NullOptional;
 
     CHIP_ERROR Validate() const

--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -40,7 +40,9 @@ struct CASEClientInitParams
     // claiming different MRP parameters for the same node.
     Optional<ReliableMessageProtocolConfig> mrpLocalConfig = NullOptional;
 
-    Optional<uint32_t> minimumLitBackoffInterval = NullOptional;
+    // The minimum backoff interval for LIT devices. This is used to calculate
+    // the sigma1 retransmission timeout for LIT devices.
+    Optional<uint32_t> minimumLITBackoffInterval = NullOptional;
 
     CHIP_ERROR Validate() const
     {

--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -40,6 +40,8 @@ struct CASEClientInitParams
     // claiming different MRP parameters for the same node.
     Optional<ReliableMessageProtocolConfig> mrpLocalConfig = NullOptional;
 
+    Optional<uint32_t> minimumLitBackoffInterval = NullOptional;
+
     CHIP_ERROR Validate() const
     {
         // sessionResumptionStorage can be nullptr when resumption is disabled.

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -300,17 +300,16 @@ CHIP_ERROR OperationalSessionSetup::EstablishConnection(const ResolveResult & re
 
     if (result.isICDOperatingAsLIT)
     {
-        // When an ICD operates as a LIT, the SII is missing in DNS-SD advertisement, resulting in
-        // mIdleRetransTimeout being 0, which is not a usable value. Since CASE
-        // is set up for LIT ICDs only when they are active, it is known that
-        // the ICD is in active mode. Therefore, using mActiveRetransTimeout
-        // for the initial message in the exchange is appropriate. If
-        // mActiveRetransTimeout is insufficient, consider setting it further
-        // using minimumLitBackoffInterval so that it is guaranteed to be larger
-        // than minimum lit backoff set by client and don't need worry about how larger or smaller we need to compensate.
+        // When an ICD operates as a LIT, the DNS-SD advertisement lacks the Session Idle Interval
+        // (SII). This would cause mIdleRetransTimeout to be 0, which is not a usable value. Since
+        // CASE is established with LIT ICDs only when they are active, we can base
+        // mIdleRetransTimeout on active mode parameters. To ensure sufficient time for MRP
+        // retransmissions, particularly in Thread networks where mActiveRetransTimeout might be too
+        // small, we use the maximum of config.mActiveRetransTimeout and
+        // mInitParams.minimumLITBackoffInterval
 
         config.mIdleRetransTimeout =
-            std::max(config.mActiveRetransTimeout, System::Clock::Milliseconds32(mInitParams.minimumLitBackoffInterval.ValueOr(0)));
+            std::max(config.mActiveRetransTimeout, System::Clock::Milliseconds32(mInitParams.minimumLITBackoffInterval.ValueOr(0)));
     }
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     if (mTransportPayloadCapability == TransportPayloadCapability::kLargePayload)

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -276,8 +276,8 @@ public:
     void OnNodeAddressResolved(const PeerId & peerId, const AddressResolve::ResolveResult & result) override;
     void OnNodeAddressResolutionFailed(const PeerId & peerId, CHIP_ERROR reason) override;
 
-    static void SetAdditionalLitBackoffInterval(const Optional<System::Clock::Milliseconds32> & additionalTime);
-    static System::Clock::Milliseconds32 GetAdditionalLitBackoffInterval();
+    static void SetMinimumLitBackoffInterval(const Optional<System::Clock::Milliseconds32> & minimumTime);
+    static System::Clock::Milliseconds32 GetMinimumLitBackoffInterval();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
     // Update our remaining attempt count to be at least the given value.

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -276,9 +276,6 @@ public:
     void OnNodeAddressResolved(const PeerId & peerId, const AddressResolve::ResolveResult & result) override;
     void OnNodeAddressResolutionFailed(const PeerId & peerId, CHIP_ERROR reason) override;
 
-    static void SetMinimumLitBackoffInterval(const Optional<System::Clock::Milliseconds32> & minimumTime);
-    static System::Clock::Milliseconds32 GetMinimumLitBackoffInterval();
-
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
     // Update our remaining attempt count to be at least the given value.
     void UpdateAttemptCount(uint8_t attemptCount);

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -333,7 +333,8 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         .groupDataProvider         = stateParams.groupDataProvider,
         // Don't provide an MRP local config, so each CASE initiation will use
         // the then-current value.
-        .mrpLocalConfig = NullOptional,
+        .mrpLocalConfig            = NullOptional,
+        .minimumLitBackoffInterval = params.minimumLitBackoffInterval,
     };
 
     CASESessionManagerConfig sessionManagerConfig = {

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -334,7 +334,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         // Don't provide an MRP local config, so each CASE initiation will use
         // the then-current value.
         .mrpLocalConfig            = NullOptional,
-        .minimumLitBackoffInterval = params.minimumLitBackoffInterval,
+        .minimumLITBackoffInterval = params.minimumLITBackoffInterval,
     };
 
     CASESessionManagerConfig sessionManagerConfig = {

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -171,8 +171,11 @@ struct FactoryInitParams
 
     std::optional<Inet::InterfaceId> interfaceId;
 
-    // The minimum backoff interval for LIT devices. This is used to calculate
-    // the sigma1 retransmission timeout for LIT devices.
+    // The minimum backoff interval for LIT devices. This is used to calculate the sigma1
+    // retransmission timeout for LIT devices, ensuring it's at least `minimumLITBackoffInterval`.
+    // Specifically, the timeout is `max(LIT activeRetransTimeout,
+    // minimumLITBackoffInterval)`. This prevents issues with MRP retransmission in Thread
+    // networks when activeRetransTimeout is too small.
     Optional<uint32_t> minimumLITBackoffInterval;
 };
 

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -171,7 +171,7 @@ struct FactoryInitParams
 
     std::optional<Inet::InterfaceId> interfaceId;
 
-    std::optional<uint32_t> minimumLitBackoffInterval;
+    Optional<uint32_t> minimumLitBackoffInterval;
 };
 
 class DeviceControllerFactory

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -170,6 +170,8 @@ struct FactoryInitParams
     chip::app::DataModel::Provider * dataModelProvider = nullptr;
 
     std::optional<Inet::InterfaceId> interfaceId;
+
+    std::optional<uint32_t> minimumLitBackoffInterval;
 };
 
 class DeviceControllerFactory

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -171,7 +171,9 @@ struct FactoryInitParams
 
     std::optional<Inet::InterfaceId> interfaceId;
 
-    Optional<uint32_t> minimumLitBackoffInterval;
+    // The minimum backoff interval for LIT devices. This is used to calculate
+    // the sigma1 retransmission timeout for LIT devices.
+    Optional<uint32_t> minimumLITBackoffInterval;
 };
 
 class DeviceControllerFactory

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -176,7 +176,7 @@ struct FactoryInitParams
     // Specifically, the timeout is `max(LIT activeRetransTimeout,
     // minimumLITBackoffInterval)`. This prevents issues with MRP retransmission in Thread
     // networks when activeRetransTimeout is too small.
-    // Note: This parameter is not spec-compliant.
+    // Note: Setting this parameter to a nonzero value is not spec-compliant.
     Optional<uint32_t> minimumLITBackoffInterval;
 };
 

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -176,6 +176,7 @@ struct FactoryInitParams
     // Specifically, the timeout is `max(LIT activeRetransTimeout,
     // minimumLITBackoffInterval)`. This prevents issues with MRP retransmission in Thread
     // networks when activeRetransTimeout is too small.
+    // Note: This parameter is not spec-compliant.
     Optional<uint32_t> minimumLITBackoffInterval;
 };
 

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2000,16 +2000,16 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif // CHIP_CONFIG_TLS_MAX_CLIENT_CERTS_PER_FABRIC_TABLE_SIZE
 
 /**
- *  @def CHIP_CONFIG_ADDITIONAL_LIT_BACKOFF_INTERVAL
+ *  @def CHIP_CONFIG_MINIMUM_LIT_BACKOFF_INTERVAL
  *
  *  @brief
- *    A duration, in milliseconds, to be added to the backoff interval for sigma1 message retransmission in controller side if the
- * remote device is LIT. This additional interval is to mitigate the issue that the sigma2 message may not be able to reach the
+ *    A duration, in milliseconds, to be set as a minimum interval for sigma1 message retransmission in controller side if the
+ * remote device is LIT. This minimum interval is to mitigate the issue that the sigma2 message may not be able to reach the
  * controller in congested network in time.
  */
-#ifndef CHIP_CONFIG_ADDITIONAL_LIT_BACKOFF_INTERVAL
-#define CHIP_CONFIG_ADDITIONAL_LIT_BACKOFF_INTERVAL 0
-#endif // CHIP_CONFIG_ADDITIONAL_LIT_BACKOFF_INTERVAL
+#ifndef CHIP_CONFIG_MINIMUM_LIT_BACKOFF_INTERVAL
+#define CHIP_CONFIG_MINIMUM_LIT_BACKOFF_INTERVAL 0
+#endif // CHIP_CONFIG_MINIMUM_LIT_BACKOFF_INTERVAL
 
 /**
  * @def CHIP_CONFIG_TLS_MAX_ROOT_PER_FABRIC_CERTS_TABLE_SIZE

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -2000,18 +2000,6 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif // CHIP_CONFIG_TLS_MAX_CLIENT_CERTS_PER_FABRIC_TABLE_SIZE
 
 /**
- *  @def CHIP_CONFIG_MINIMUM_LIT_BACKOFF_INTERVAL
- *
- *  @brief
- *    A duration, in milliseconds, to be set as a minimum interval for sigma1 message retransmission in controller side if the
- * remote device is LIT. This minimum interval is to mitigate the issue that the sigma2 message may not be able to reach the
- * controller in congested network in time.
- */
-#ifndef CHIP_CONFIG_MINIMUM_LIT_BACKOFF_INTERVAL
-#define CHIP_CONFIG_MINIMUM_LIT_BACKOFF_INTERVAL 0
-#endif // CHIP_CONFIG_MINIMUM_LIT_BACKOFF_INTERVAL
-
-/**
  * @def CHIP_CONFIG_TLS_MAX_ROOT_PER_FABRIC_CERTS_TABLE_SIZE
  *
  * @brief The maximum number of root certificates per fabric for the TLS table


### PR DESCRIPTION
#### Summary
It is not that easy to choose the additionalLITBackOffInterval introduced from  #41350, it is better to set a minimum LITBackoffInterval, so that OperationalSessionSetup can choose the max between config.mActiveRetransTimeout and minimumLITBackoffInterval. 

In addition, it may be better to setup this parameter from controller's factory parameter and put it as a member for OperationalSessionSetup finally,  instead of creating a static one in OperationalSessionSetup

#### Related issues
N/A
#### Testing
local testing

#### Readability checklist

