### PR TITLE
Fix parsing InstanceName in UDCServer when missing null string terminator

### DIFF
--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -56,8 +56,8 @@ void UserDirectedCommissioningServer::OnMessageReceived(const Transport::PeerAdd
 
     ChipLogProgress(AppServer, "IdentityDeclaration DataLength()=%" PRIu32, static_cast<uint32_t>(msg->DataLength()));
 
-    uint8_t udcPayload[IdentificationDeclaration::kUdcTLVDataMaxBytes];
-    size_t udcPayloadLength = std::min<size_t>(msg->DataLength(), sizeof(udcPayload));
+    uint8_t udcPayload[IdentificationDeclaration::kUdcTLVDataMaxBytes] = {};
+    size_t udcPayloadLength                                            = std::min<size_t>(msg->DataLength(), sizeof(udcPayload));
     TEMPORARY_RETURN_IGNORED msg->Read(udcPayload, udcPayloadLength);
 
     IdentificationDeclaration id;


### PR DESCRIPTION
#### Summary
Zero-initialize the udcPayload buffer for OnMessageReceived and pass back the processed udcPayloadLength when reading the IdentificationDeclaration of the UDC packet.
This fix addresses issue #41748.

#### Related issues
On receipt of udcPayload where InstanceName is missing nullptr, it is possible the instanceName can include an extra random byte due to a non-zero initialized buffer and passing back of the udcPayload with the incorrect length.
Fixes: #41748.

#### Testing
Test with packet received where UDC DataLength()=16. Verified that the instanceName was read as `D112DD4E4BF204FC` and did not have an extra byte.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase
