### PR TITLE
Preserve old behavior of continuing to setup a TCP connection

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -632,7 +632,7 @@ CHIP_ERROR TCPBase::DoHandleIncomingConnection(const Inet::TCPEndPointHandle & l
     // continue to propagate to failure callbacks to avoid flaky tests
     if (getPeerError != CHIP_NO_ERROR)
     {
-        SuccessOrLog(getPeerError, Inet, "Failure getting peer info, using fallback");
+        ChipLogFailure(getPeerError, Inet, "Failure getting peer info, using fallback");
         addr = PeerAddress::TCP(peerAddress, peerPort, Inet::InterfaceId::Null());
     }
     ActiveTCPConnectionState * activeConnection = AllocateConnection(endPoint, addr);

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -633,7 +633,7 @@ CHIP_ERROR TCPBase::DoHandleIncomingConnection(const Inet::TCPEndPointHandle & l
     if (getPeerError != CHIP_NO_ERROR)
     {
         SuccessOrLog(getPeerError, Inet, "Failure getting peer info, using fallback");
-        addr = PeerAddress::TCP(peerAddress, peerPort, InterfaceId::Null());
+        addr = PeerAddress::TCP(peerAddress, peerPort, Inet::InterfaceId::Null());
     }
     ActiveTCPConnectionState * activeConnection = AllocateConnection(endPoint, addr);
     if (activeConnection == nullptr)

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -632,7 +632,7 @@ CHIP_ERROR TCPBase::DoHandleIncomingConnection(const Inet::TCPEndPointHandle & l
     // continue to propagate to failure callbacks to avoid flaky tests
     if (getPeerError != CHIP_NO_ERROR)
     {
-        SuccessOrLog(getPeerError, "Failure getting peer info, using fallback");
+        SuccessOrLog(getPeerError, Inet, "Failure getting peer info, using fallback");
         addr = PeerAddress::TCP(peerAddress, peerPort, InterfaceId::Null());
     }
     ActiveTCPConnectionState * activeConnection = AllocateConnection(endPoint, addr);

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -626,7 +626,15 @@ CHIP_ERROR TCPBase::DoHandleIncomingConnection(const Inet::TCPEndPointHandle & l
                                                uint16_t peerPort)
 {
     PeerAddress addr;
-    ReturnErrorOnFailure(GetPeerAddress(*endPoint, addr));
+    CHIP_ERROR getPeerError = GetPeerAddress(*endPoint, addr);
+    // See https://github.com/project-chip/connectedhomeip/issues/41746
+    // Failures here must be handled carefully so that broken connections
+    // continue to propagate to failure callbacks to avoid flaky tests
+    if (getPeerError != CHIP_NO_ERROR)
+    {
+        SuccessOrLog(getPeerError, "Failure getting peer info, using fallback");
+        addr = PeerAddress::TCP(peerAddress, peerPort, InterfaceId::Null());
+    }
     ActiveTCPConnectionState * activeConnection = AllocateConnection(endPoint, addr);
     if (activeConnection == nullptr)
     {


### PR DESCRIPTION
Setup closed & failure callbacks when we fail to get peer information (from a connection that's partway through closing)

#### Summary

Prior to the ref-counting & error-handling PRs I submitted to this file, an error while trying to get information about the peer was ignored, resulting in closed callbacks being called.

This PR brings back that old behavior, but using a sensible default instead of uninitialized memory as was done previously
<img width="1754" height="994" alt="image" src="https://github.com/user-attachments/assets/0ca2ce49-0daf-4721-9558-178da6745b0f" />


#### Related issues

Fixes #41746

#### Testing

This is a flaky test failure in CI; if this PR fixes the issue the flaky failure should go away

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
