### PR TITLE
Handle a leaked TCP pointer more gracefully

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -158,7 +158,7 @@ ActiveTCPConnectionState * TCPBase::AllocateConnection(const Inet::TCPEndPointHa
             if (!activeConnection->InUse() && (activeConnection->GetReferenceCount() != 0))
             {
                 char addrStr[Transport::PeerAddress::kMaxToStringSize];
-                activeConnection.mPeerAddr.ToString(addrStr);
+                activeConnection->mPeerAddr.ToString(addrStr);
                 ChipLogError(Inet, "Leaked TCP connection %p to %s.", activeConnection, addrStr);
             }
             ActiveTCPConnectionHandle releaseUnclaimed(activeConnection);

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -141,10 +141,9 @@ ActiveTCPConnectionState * TCPBase::AllocateConnection(const Inet::TCPEndPointHa
     {
         for (size_t i = 0; i < mActiveConnectionsSize; i++)
         {
-            if (!mActiveConnections[i].InUse())
+            ActiveTCPConnectionState * activeConnection = &mActiveConnections[i];
+            if (!activeConnection->InUse() && (activeConnection->GetReferenceCount() == 0))
             {
-                ActiveTCPConnectionState * activeConnection = &mActiveConnections[i];
-                VerifyOrDie(activeConnection->GetReferenceCount() == 0);
                 // Update state for the active connection
                 activeConnection->Init(endpoint, address, [this](auto & conn) { TCPDisconnect(conn, true); });
                 return activeConnection;
@@ -155,7 +154,14 @@ ActiveTCPConnectionState * TCPBase::AllocateConnection(const Inet::TCPEndPointHa
         // (i.e. that have a ref count of 0)
         for (size_t i = 0; i < mActiveConnectionsSize; i++)
         {
-            ActiveTCPConnectionHandle releaseUnclaimed(&mActiveConnections[i]);
+            ActiveTCPConnectionState * activeConnection = &mActiveConnections[i];
+            if (!activeConnection->InUse() && (activeConnection->GetReferenceCount() != 0))
+            {
+                char addrStr[Transport::PeerAddress::kMaxToStringSize];
+                activeConnection.mPeerAddr.ToString(addrStr);
+                ChipLogError(Inet, "Leaked TCP connection %p to %s.", activeConnection, addrStr);
+            }
+            ActiveTCPConnectionHandle releaseUnclaimed(activeConnection);
         }
     }
     return nullptr;


### PR DESCRIPTION
This is ~ a use-after-free, i.e. someone keeping a pointer to a connection that has been closed & not using `HandleConnectionClosed` to clear the pointer

A `VerifyOrDie` here does not help us track the culprit

It is safe to proceed, we simply lose a slot & at some point, if the culprit does not release their pointer, will run out of TCP connection slots

#### Testing

CI coverage for TCP tests makes sure this does not introduce new errors

#### Related issues

Fixes #41705

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
