### PR TITLE
Introduce a ChipLogFailure

### DIFF
--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -237,7 +237,7 @@
         CHIP_ERROR __lerr = (expr);                                                                                                \
         if (!::chip::ChipError::IsSuccess(__lerr))                                                                                 \
         {                                                                                                                          \
-            ChipLogError(MOD, MSG ": %" CHIP_ERROR_FORMAT, ##__VA_ARGS__, __lerr.Format());                                        \
+            ChipLogFailure(__lerr, MOD, MSG, ##__VA_ARGS__);                                                                       \
         }                                                                                                                          \
     } while (false)
 
@@ -265,7 +265,7 @@
         CHIP_ERROR __err = (expr);                                                                                                 \
         if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
         {                                                                                                                          \
-            SuccessOrLog(__err, MOD, MSG, ##__VA_ARGS__);                                                                          \
+            ChipLogFailure(__err, MOD, MSG, ##__VA_ARGS__);                                                                        \
             return;                                                                                                                \
         }                                                                                                                          \
     } while (false)

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -294,7 +294,7 @@
         CHIP_ERROR __err = (expr);                                                                                                 \
         if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
         {                                                                                                                          \
-            SuccessOrLog(__err, MOD, MSG, ##__VA_ARGS__);                                                                          \
+            ChipLogFailure(__err, MOD, MSG, ##__VA_ARGS__);                                                                        \
             return __err;                                                                                                          \
         }                                                                                                                          \
     } while (false)
@@ -324,7 +324,7 @@
         CHIP_ERROR __err = (expr);                                                                                                 \
         if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
         {                                                                                                                          \
-            SuccessOrLog(__err, MOD, MSG, ##__VA_ARGS__);                                                                          \
+            ChipLogFailure(__err, MOD, MSG, ##__VA_ARGS__);                                                                        \
             return value;                                                                                                          \
         }                                                                                                                          \
     } while (false)

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -98,6 +98,27 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
 #define ChipLogError(MOD, MSG, ...) ((void) 0)
 #endif // CHIP_ERROR_LOGGING
 
+/**
+ * @def ChipLogFailure(err, MOD, MSG, ...)
+ *
+ * @brief
+ *   Log a chip message with a formatted ChipError for the specified module in the 'Error'
+ *   category.
+ *
+ *  Example usage:
+ *
+ *  @code
+ *    ChipLogFailure(errCode, Module, "Failure message: %s", param);
+ *  @endcode
+ *
+ *  @param[in]  ERROR_CODE  A CHIP_ERROR to log.
+ *  @param[in]  MOD         The log module to use.
+ *  @param[in]  MSG         The log message format string.
+ *  @param[in]  ...         Optional arguments for the log message.
+ */
+#define ChipLogFailure(ERROR_CODE, MOD, MSG, ...)                                                                                  \
+    ChipLogError(MOD, MSG ": %" CHIP_ERROR_FORMAT, ##__VA_ARGS__, ERROR_CODE.Format());
+
 #if CHIP_PROGRESS_LOGGING
 /**
  * @def ChipLogProgress(MOD, MSG, ...)


### PR DESCRIPTION
#### Summary

`ChipLogError(MOD, "[msg]: %" CHIP_ERROR_FORMAT, err.Format());` is a pattern used throughout the codebase; this new macro simplifies that to:

```
ChipLogFailure(err, MOD, "[msg]")
```

#### Related issues

Came up in https://github.com/project-chip/connectedhomeip/pull/41751

#### Testing

Covered by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
