### PR TITLE
[CI] Fix android compile error

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1367,6 +1367,7 @@ JNI_METHOD(void, unpairDeviceCallback)(JNIEnv * env, jobject self, jlong handle,
     }
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
 // Method used in case of NFC-based Commissioning without power.
 // At end of 1st commissioning phase, the user is asked to install and power ON the device.
 // Present function is used to confirm that this action has been done.
@@ -1393,6 +1394,7 @@ exit:
         JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
     }
 }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
 
 JNI_METHOD(void, stopDevicePairing)(JNIEnv * env, jobject self, jlong handle, jlong deviceId)
 {


### PR DESCRIPTION
#### Summary

Master CI was broken. The issue was that:

The C++ method [ContinueCommissioningAfterConnectNetworkRequest] in [CHIPDeviceController.h] is only available when [CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING] is defined
The JNI wrapper was calling this method unconditionally, causing a compilation error when the NFC-based commissioning feature is not enabled

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
