### PR TITLE
fix esp32 compile error

### DIFF
--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -27,7 +27,7 @@
 #include <sdkconfig.h>
 #include <string>
 
-#if CONFIG_BT_NIMBLE_ENABLED
+#ifdef CONFIG_BT_NIMBLE_ENABLED
 #include <vector>
 #endif
 


### PR DESCRIPTION
#### Summary

This fixes an error when trying to build with CONFIG_BT_BLUEDROID_ENABLED=y for ESP32 builds 
Internally this undefines CONFIG_BT_NIMBLE_ENABLED and throws an error when compiling.

#### Related issues
N/A

#### Testing
after the patch the project builds fine

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
