### PR TITLE
fixing issue for when commissionee has networkCommissioning set to 7

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2552,12 +2552,12 @@ CHIP_ERROR DeviceCommissioner::ParseNetworkCommissioningInfo(ReadCommissioningIn
                 ChipLogProgress(Controller, "NetworkCommissioning Features: has WiFi. endpointid = %u", path.mEndpointId);
                 info.network.wifi.endpoint = path.mEndpointId;
             }
-            else if (features.Has(NetworkCommissioning::Feature::kThreadNetworkInterface))
+            if (features.Has(NetworkCommissioning::Feature::kThreadNetworkInterface))
             {
                 ChipLogProgress(Controller, "NetworkCommissioning Features: has Thread. endpointid = %u", path.mEndpointId);
                 info.network.thread.endpoint = path.mEndpointId;
             }
-            else if (features.Has(NetworkCommissioning::Feature::kEthernetNetworkInterface))
+            if (features.Has(NetworkCommissioning::Feature::kEthernetNetworkInterface))
             {
                 ChipLogProgress(Controller, "NetworkCommissioning Features: has Ethernet. endpointid = %u", path.mEndpointId);
                 info.network.eth.endpoint = path.mEndpointId;


### PR DESCRIPTION
Fixing a bug in the case that the ommissionee returns capability to all 3 networkCommissioning types (7)