### PR TITLE
[Silabs] Added BSSID and SSID in the ap_info structure for wf200

### DIFF
--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -873,7 +873,7 @@ void WifiInterfaceImpl::ConnectionEventCallback(sl_wfx_connect_ind_body_t connec
     case WFM_STATUS_SUCCESS: {
         ChipLogProgress(DeviceLayer, "STA-Connected");
 
-        ap_info.chan  = connect_indication_body.channel;
+        ap_info.chan = connect_indication_body.channel;
         chip::ByteSpan securitySpan(reinterpret_cast<const uint8_t *>(&wifi_provision.security), sizeof(wifi_provision.security));
         chip::MutableByteSpan apSecurityMutableSpan(reinterpret_cast<uint8_t *>(&ap_info.security), sizeof(ap_info.security));
         chip::CopySpanToMutableSpan(securitySpan, apSecurityMutableSpan);

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -873,7 +873,6 @@ void WifiInterfaceImpl::ConnectionEventCallback(sl_wfx_connect_ind_body_t connec
     case WFM_STATUS_SUCCESS: {
         ChipLogProgress(DeviceLayer, "STA-Connected");
 
-        uint8_t * mac = connect_indication_body.mac;
         ap_info.chan  = connect_indication_body.channel;
         chip::ByteSpan securitySpan(reinterpret_cast<const uint8_t *>(&wifi_provision.security), sizeof(wifi_provision.security));
         chip::MutableByteSpan apSecurityMutableSpan(reinterpret_cast<uint8_t *>(&ap_info.security), sizeof(ap_info.security));
@@ -886,10 +885,11 @@ void WifiInterfaceImpl::ConnectionEventCallback(sl_wfx_connect_ind_body_t connec
         ap_info.ssid_length = wifi_provision.ssidLength;
 
         // Store BSSID
-        chip::ByteSpan macSpan(mac, kWifiMacAddressLength);
+        chip::ByteSpan macSpan(connect_indication_body.mac, kWifiMacAddressLength);
         chip::MutableByteSpan apBssidMutableSpan(ap_info.bssid, kWifiMacAddressLength);
         chip::CopySpanToMutableSpan(macSpan, apBssidMutableSpan);
 
+        // TODO: Refactor WifiInterface to use single representation of MAC address
         chip::MutableByteSpan apMacMutableSpan(ap_mac.data(), kWifiMacAddressLength);
         chip::CopySpanToMutableSpan(macSpan, apMacMutableSpan);
 

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -867,27 +867,31 @@ void WifiInterfaceImpl::CancelScanNetworks()
 
 void WifiInterfaceImpl::ConnectionEventCallback(sl_wfx_connect_ind_body_t connect_indication_body)
 {
-    uint8_t * mac   = connect_indication_body.mac;
     uint32_t status = connect_indication_body.status;
-    ap_info.chan    = connect_indication_body.channel;
-    memcpy(&ap_info.security, &wifi_provision.security, sizeof(wifi_provision.security));
-
-    // Store SSID
-    chip::ByteSpan apSsidSpan(wifi_provision.ssid, wifi_provision.ssidLength);
-    chip::MutableByteSpan apSsidMutableSpan(ap_info.ssid, WFX_MAX_SSID_LENGTH);
-    chip::CopySpanToMutableSpan(apSsidSpan, apSsidMutableSpan);
-    ap_info.ssid_length = wifi_provision.ssidLength;
-
-    // Store BSSID
-    chip::ByteSpan macSpan(mac, kWifiMacAddressLength);
-    chip::MutableByteSpan apBssidMutableSpan(ap_info.bssid, kWifiMacAddressLength);
-    chip::CopySpanToMutableSpan(macSpan, apBssidMutableSpan);
-
     switch (status)
     {
     case WFM_STATUS_SUCCESS: {
         ChipLogProgress(DeviceLayer, "STA-Connected");
-        memcpy(ap_mac.data(), mac, kWifiMacAddressLength);
+
+        uint8_t * mac   = connect_indication_body.mac;
+        ap_info.chan    = connect_indication_body.channel;
+        chip::ByteSpan securitySpan(reinterpret_cast<const uint8_t *>(&wifi_provision.security), sizeof(wifi_provision.security));
+        chip::MutableByteSpan apSecurityMutableSpan(reinterpret_cast<uint8_t *>(&ap_info.security), sizeof(ap_info.security));
+        chip::CopySpanToMutableSpan(securitySpan, apSecurityMutableSpan);
+
+        // Store SSID
+        chip::ByteSpan apSsidSpan(wifi_provision.ssid, wifi_provision.ssidLength);
+        chip::MutableByteSpan apSsidMutableSpan(ap_info.ssid, WFX_MAX_SSID_LENGTH);
+        chip::CopySpanToMutableSpan(apSsidSpan, apSsidMutableSpan);
+        ap_info.ssid_length = wifi_provision.ssidLength;
+
+        // Store BSSID
+        chip::ByteSpan macSpan(mac, kWifiMacAddressLength);
+        chip::MutableByteSpan apBssidMutableSpan(ap_info.bssid, kWifiMacAddressLength);
+        chip::CopySpanToMutableSpan(macSpan, apBssidMutableSpan);
+
+        chip::MutableByteSpan apMacMutableSpan(ap_mac.data(), kWifiMacAddressLength);
+        chip::CopySpanToMutableSpan(macSpan, apMacMutableSpan);
 
         wifi_extra.Set(WifiInterface::WifiState::kStationConnected);
         xEventGroupSetBits(sl_wfx_event_group, SL_WFX_CONNECT);

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -873,8 +873,8 @@ void WifiInterfaceImpl::ConnectionEventCallback(sl_wfx_connect_ind_body_t connec
     case WFM_STATUS_SUCCESS: {
         ChipLogProgress(DeviceLayer, "STA-Connected");
 
-        uint8_t * mac   = connect_indication_body.mac;
-        ap_info.chan    = connect_indication_body.channel;
+        uint8_t * mac = connect_indication_body.mac;
+        ap_info.chan  = connect_indication_body.channel;
         chip::ByteSpan securitySpan(reinterpret_cast<const uint8_t *>(&wifi_provision.security), sizeof(wifi_provision.security));
         chip::MutableByteSpan apSecurityMutableSpan(reinterpret_cast<uint8_t *>(&ap_info.security), sizeof(ap_info.security));
         chip::CopySpanToMutableSpan(securitySpan, apSecurityMutableSpan);

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -698,13 +698,11 @@ CHIP_ERROR WifiInterfaceImpl::GetAccessPointInfo(wfx_wifi_scan_result_t & info)
 {
     uint32_t signal_strength = 0;
 
-    // TODO: The ap_info.ssid isn't populated anywhere. The returned value is always 0.
     chip::ByteSpan apSsidSpan(ap_info.ssid, ap_info.ssid_length);
     chip::MutableByteSpan apSsidMutableSpan(info.ssid, WFX_MAX_SSID_LENGTH);
     chip::CopySpanToMutableSpan(apSsidSpan, apSsidMutableSpan);
     info.ssid_length = apSsidMutableSpan.size();
 
-    // TODO: The ap_info.bssid isn't populated anywhere. The returned value is always 0.
     chip::ByteSpan apBssidSpan(ap_info.bssid, kWifiMacAddressLength);
     chip::MutableByteSpan apBssidMutableSpan(info.bssid, kWifiMacAddressLength);
     chip::CopySpanToMutableSpan(apBssidSpan, apBssidMutableSpan);
@@ -873,6 +871,15 @@ void WifiInterfaceImpl::ConnectionEventCallback(sl_wfx_connect_ind_body_t connec
     uint32_t status = connect_indication_body.status;
     ap_info.chan    = connect_indication_body.channel;
     memcpy(&ap_info.security, &wifi_provision.security, sizeof(wifi_provision.security));
+
+    // Store SSID
+    chip::MutableByteSpan apSsidSpan(ap_info.ssid, WFX_MAX_SSID_LENGTH);
+    chip::CopySpanToMutableSpan(chip::ByteSpan(wifi_provision.ssid, wifi_provision.ssidLength), apSsidSpan);
+    ap_info.ssid_length = wifi_provision.ssidLength;
+
+    // Store BSSID
+    memcpy(ap_info.bssid, mac, kWifiMacAddressLength);
+
     switch (status)
     {
     case WFM_STATUS_SUCCESS: {

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -873,12 +873,15 @@ void WifiInterfaceImpl::ConnectionEventCallback(sl_wfx_connect_ind_body_t connec
     memcpy(&ap_info.security, &wifi_provision.security, sizeof(wifi_provision.security));
 
     // Store SSID
-    chip::MutableByteSpan apSsidSpan(ap_info.ssid, WFX_MAX_SSID_LENGTH);
-    chip::CopySpanToMutableSpan(chip::ByteSpan(wifi_provision.ssid, wifi_provision.ssidLength), apSsidSpan);
+    chip::ByteSpan apSsidSpan(wifi_provision.ssid, wifi_provision.ssidLength);
+    chip::MutableByteSpan apSsidMutableSpan(ap_info.ssid, WFX_MAX_SSID_LENGTH);
+    chip::CopySpanToMutableSpan(apSsidSpan, apSsidMutableSpan);
     ap_info.ssid_length = wifi_provision.ssidLength;
 
     // Store BSSID
-    memcpy(ap_info.bssid, mac, kWifiMacAddressLength);
+    chip::ByteSpan macSpan(mac, kWifiMacAddressLength);
+    chip::MutableByteSpan apBssidMutableSpan(ap_info.bssid, kWifiMacAddressLength);
+    chip::CopySpanToMutableSpan(macSpan, apBssidMutableSpan);
 
     switch (status)
     {


### PR DESCRIPTION
#### Summary
For WF200 board, the SSID and BSSID data structures are never populated so when we read it from the wifi diagnostic cluster it always returns "" and 0.0.0.0.

Failure Logs:
```text
[00:33:43.018][detail][DL] WIFI:SSID     : 
[00:33:43.018][detail][DL] WIFI:BSSID    : 00:00:00:00:00:00
[00:33:43.019][detail][DL] WIFI:security : 4
[00:33:43.019][detail][DL] WIFI:channel  :  10
```
Therefore, the SSID and BSSID fields were added to the ap_info structure within the WifiInterfaceImpl::ConnectionEventCallback function. Additionally, the corresponding code block was relocated inside the switch statement to ensure these fields are populated only when the connection status indicates success

#### Related issues
N/A

#### Testing
- Tested local builds for light and lock app for WF200.
- Validated using the `mattertool  wifinetworkdiagnostics read bssid 1 0` command
Device Logs:
```text
[00:01:05.033][detail][DL] WIFI:SSID     : mtr_openwrt_wpa2
[00:01:05.034][detail][DL] WIFI:BSSID    : 5c:e9:31:1b:1e:e9
[00:01:05.034][detail][DL] WIFI:security : 4
[00:01:05.034][detail][DL] WIFI:channel  :  6
[00:01:05.034][detail][DL] signal_strength: 174
```

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
