### PR TITLE
fan-control: guard SpeedMax::Get with MultiSpeed feature

### DIFF
--- a/src/app/clusters/fan-control-server/fan-control-server.cpp
+++ b/src/app/clusters/fan-control-server/fan-control-server.cpp
@@ -383,10 +383,6 @@ void MatterFanControlClusterServerAttributeChangedCallback(const app::ConcreteAt
         DataModel::Nullable<Percent> percentSetting;
         Status status = PercentSetting::Get(attributePath.mEndpointId, percentSetting);
         VerifyOrReturn(Status::Success == status && !percentSetting.IsNull());
-        uint8_t speedMax;
-        status = SpeedMax::Get(attributePath.mEndpointId, &speedMax);
-        VerifyOrReturn(Status::Success == status,
-                       ChipLogError(Zcl, "Failed to get SpeedMax with error: 0x%02x", to_underlying(status)));
 
         // Avoid circular callback calls
         ScopedChange PercentWriteInProgress(gPercentWriteInProgress, true);
@@ -400,6 +396,11 @@ void MatterFanControlClusterServerAttributeChangedCallback(const app::ConcreteAt
 
         if (SupportsMultiSpeed(attributePath.mEndpointId))
         {
+            uint8_t speedMax;
+            status = SpeedMax::Get(attributePath.mEndpointId, &speedMax);
+            VerifyOrReturn(Status::Success == status,
+                           ChipLogError(Zcl, "Failed to get SpeedMax with error: 0x%02x", to_underlying(status)));
+
             // Adjust SpeedSetting from a percent value change for PercentSetting
             // speed = ceil( SpeedMax * (percent * 0.01) )
             uint16_t percent = percentSetting.Value();


### PR DESCRIPTION
#### Summary

When we write the FanControl::PercentSetting, and if the Multi Speed feature is not enabled, then we see an error log on the DUT.

```
E (119247) chip[ZCL]: Failed to get SpeedMax with error: 0x86
```

`0x86` meaning UnsupportedAttribute

SpeedMax, SpeedSetting, SpeedCurrent depends on the MultiSpeed feature so feature map must be checked before performing any action on them.

Feature map check was missing at one place, added that.


#### Related issues
Related issue: https://github.com/espressif/esp-matter/issues/1574


#### Testing
Manually tested:
- Crated the data model for Fan device type without MultiSpeed Feature, commission the DUT, and write the percent-setting attribute
    - Without Change: error log appears
    - With Change: error log does not show up

```
chip-tool fancontrol write percent-setting 10 1 1
```