### PR TITLE
chef: fix unterminated string literal in chef.py script

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -91,8 +91,7 @@ def load_config() -> None:
         config["nrfconnect"]["TTY"] = None
         config["esp32"]["IDF_PATH"] = os.environ.get('IDF_PATH')
         config["esp32"]["TTY"] = None
-        config["silabs-thread"]["GECKO_SDK"] = f"{
-            _REPO_BASE_PATH}third_party/efr32_sdk/repo"
+        config["silabs-thread"]["GECKO_SDK"] = f"{_REPO_BASE_PATH}third_party/efr32_sdk/repo"
         config["silabs-thread"]["TTY"] = None
         config["silabs-thread"]["CU"] = None
         config["silabs-thread"]["SILABS_BOARD"] = None
@@ -431,8 +430,7 @@ def main() -> int:
                     f"{device_name} in CICD config but not {_DEVICE_FOLDER}!")
                 exit(1)
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}")
-            command = f"./chef.py -cbr -d {
-                device_name} -t {options.build_target}"
+            command = f"./chef.py -cbr -d {device_name} -t {options.build_target}"
             flush_print(f"Building {command}", with_border=True)
             shell.run_cmd(command)
             bundle(options.build_target, device_name)
@@ -717,8 +715,7 @@ def main() -> int:
             if len(sw_ver_string) >= 64:
                 truncated_sw_ver_string = f"""{branch[:22]}:{commit_id}"""
                 flush_print(
-                    f"Truncate the software version string from \"{
-                        sw_ver_string}\" to "
+                    f"Truncate the software version string from \"{sw_ver_string}\" to "
                     f"\"{truncated_sw_ver_string}\" due to 64 bytes limitation")
                 sw_ver_string = truncated_sw_ver_string
 
@@ -763,8 +760,7 @@ def main() -> int:
             shell.run_cmd("idf.py build")
             shell.run_cmd("idf.py build flashing_script")
             shell.run_cmd(
-                f"(cd build/ && tar cJvf $(git rev-parse HEAD)-{
-                    options.sample_device_type_name}.tar.xz "
+                f"(cd build/ && tar cJvf $(git rev-parse HEAD)-{options.sample_device_type_name}.tar.xz "
                 f"--files-from=chip-shell.flashbundle.txt)")
             shell.run_cmd(
                 f"cp build/$(git rev-parse HEAD)-{options.sample_device_type_name}.tar.xz {_CHEF_SCRIPT_PATH}")
@@ -850,8 +846,7 @@ def main() -> int:
                 shell.run_cmd(
                     f"cd {config['ameba']['AMEBA_SDK']}/project/realtek_amebaz2_v0_example/GCC-RELEASE")
                 shell.run_cmd("rm -f project_include.mk")
-                cmd = f"{config['ameba']['AMEBA_SDK']
-                         }/project/realtek_amebaz2_v0_example/GCC-RELEASE/project_include.mk"
+                cmd = f"{config['ameba']['AMEBA_SDK']}/project/realtek_amebaz2_v0_example/GCC-RELEASE/project_include.mk"
                 with open(cmd, "w") as f:
                     f.write(textwrap.dedent(f"""\
                         SAMPLE_NAME = {options.sample_device_type_name}
@@ -1014,8 +1009,7 @@ def main() -> int:
                 shell.run_cmd(
                     f"cd {config['ameba']['AMEBA_SDK']}/tools/AmebaD/Image_Tool_Linux")
                 shell.run_cmd((
-                    f"{config['ameba']['AMEBA_SDK']
-                       }/tools/AmebaD/Image_Tool_Linux/flash.sh "
+                    f"{config['ameba']['AMEBA_SDK']}/tools/AmebaD/Image_Tool_Linux/flash.sh "
                     f"{config['ameba']['TTY']} {config['ameba']['AMEBA_SDK']}"
                     f"/project/realtek_amebaD_va0_example/GCC-RELEASE/out"
                 ), raise_on_returncode=False)
@@ -1024,8 +1018,7 @@ def main() -> int:
                 shell.run_cmd(
                     f"cd {config['ameba']['AMEBA_SDK']}/tools/AmebaZ2/Image_Tool_Linux")
                 shell.run_cmd((
-                    f"{config['ameba']['AMEBA_SDK']
-                       }/tools/AmebaZ2/Image_Tool_Linux/flash.sh "
+                    f"{config['ameba']['AMEBA_SDK']}/tools/AmebaZ2/Image_Tool_Linux/flash.sh "
                     f"{config['ameba']['TTY']} {config['ameba']['AMEBA_SDK']}"
                     f"/project/realtek_amebaz2_v0_example/GCC-RELEASE/application_is/Debug/bin"
                 ), raise_on_returncode=False)


### PR DESCRIPTION
#### Summary
- running `chef.py` locally on the host runs into issues like unterminated string literal

```
  File "/Users/shubhampatil/esp/connectedhomeip/./examples/chef/chef.py", line 94
    config["silabs-thread"]["GECKO_SDK"] = f"{
                                           ^
SyntaxError: unterminated string literal (detected at line 94)
```

There are multiple such issues in the file.

#### Related issues

This change was introduced in #41174

#### Testing

- re-run the script and examples does build with the change
```
cd examples/chef
./chef.py -t esp32
```

- green chef CI should be another validator...