### PR TITLE
[Silabs] Fixing the dishwasher app for the silabs devices

### DIFF
--- a/examples/dishwasher-app/silabs/include/ElectricalEnergyMeasurementInstance.h
+++ b/examples/dishwasher-app/silabs/include/ElectricalEnergyMeasurementInstance.h
@@ -21,6 +21,7 @@
 #include "AppConfig.h"
 #include "AppEvent.h"
 #include "ElectricalPowerMeasurementDelegate.h"
+#include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h>
 #include <app/clusters/electrical-energy-measurement-server/electrical-energy-measurement-server.h>
 #include <cmsis_os2.h>
 


### PR DESCRIPTION
#### Summary
The dishwasher app was failing to build after the Electrical Energy Measurement was moved to the code driven PR:https://github.com/project-chip/connectedhomeip/pull/41654 , the new header include was missed causing build failure

 
#### Related issues
NA

#### Testing
Build for the dishwasher app for 917SoC
