### PR TITLE
[NXP] Add CHIP_ICD_DSLS_SUPPORT cmake config & Add prj_thread_mtd_low_power_lit.conf

### DIFF
--- a/config/nxp/cmake/Kconfig.matter.common
+++ b/config/nxp/cmake/Kconfig.matter.common
@@ -400,6 +400,13 @@ config CHIP_ICD_UAT_SUPPORT
 	  Enables the User Active Mode Trigger (UAT) support in Matter. It allows the User to use application specific
 	  means (e.g. button press) to trigger an ICD device to enter the active mode and become responsive.
 
+config CHIP_ICD_DSLS_SUPPORT
+	bool "Intermittently Connected Device Dynamic SIT LIT support"
+	depends on CHIP_ICD_LIT_SUPPORT
+	help
+	  Enables the Dynamic SIT LIT support in Matter. It allows the application to dynamically switch between
+	  SIT and LIT modes, as long as the requirements for these modes are met (e.g. device has at least one active ICD client).
+
 config CHIP_ICD_CLIENTS_PER_FABRIC
 	int "Intermittently Connected Device number of clients per fabric"
 	default 2

--- a/config/nxp/cmake/common.cmake
+++ b/config/nxp/cmake/common.cmake
@@ -49,6 +49,7 @@ matter_add_gn_arg_bool("chip_enable_ethernet" CONFIG_CHIP_ETHERNET)
 matter_add_gn_arg_bool("chip_system_config_provide_statistics" CONFIG_CHIP_STATISTICS)
 matter_add_gn_arg_bool("chip_enable_icd_server" CONFIG_CHIP_ENABLE_ICD_SUPPORT)
 matter_add_gn_arg_bool("chip_enable_icd_lit" CONFIG_CHIP_ICD_LIT_SUPPORT)
+matter_add_gn_arg_bool("chip_enable_icd_dsls" CONFIG_CHIP_ICD_DSLS_SUPPORT)
 matter_add_gn_arg_bool("chip_enable_ota_requestor" CONFIG_CHIP_OTA_REQUESTOR)
 matter_add_gn_arg_bool("chip_system_config_use_openthread_inet_endpoints" CONFIG_CHIP_USE_OT_ENDPOINT)
 

--- a/examples/platform/nxp/config/prj_thread_mtd_low_power_lit.conf
+++ b/examples/platform/nxp/config/prj_thread_mtd_low_power_lit.conf
@@ -1,0 +1,39 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This file is used to set configs or override default configurations for NXP platforms.
+
+CONFIG_NET_L2_OPENTHREAD=y
+CONFIG_CHIP_IPV4=n
+CONFIG_CHIP_OPENTHREAD_FTD=n
+CONFIG_SLEEPY_END_DEVICE=y
+CONFIG_CHIP_LIB_SHELL=n
+CONFIG_NXP_USE_LOW_POWER=y
+CONFIG_CHIP_ENABLE_ICD_SUPPORT=y
+CONFIG_CHIP_PERSISTENT_SUBSCRIPTIONS=y
+CONFIG_CHIP_APP_UI_FEEDBACK=n
+CONFIG_CHIP_APP_PLATFORM_LED_ON_OFF=n
+CONFIG_ENABLE_FEEDBACK=n
+
+# ICD LIT configs
+
+CONFIG_CHIP_ICD_LIT_SUPPORT=y
+CONFIG_CHIP_ICD_DSLS_SUPPORT=y
+CONFIG_CHIP_ICD_SLOW_POLL_INTERVAL=15000
+CONFIG_CHIP_ICD_FAST_POLLING_INTERVAL=500
+CONFIG_CHIP_ICD_IDLE_MODE_DURATION=60
+CONFIG_CHIP_ICD_ACTIVE_MODE_DURATION=15000
+CONFIG_CHIP_ICD_ACTIVE_MODE_THRESHOLD=30000


### PR DESCRIPTION
#### Summary

This PR adds the CHIP_ICD_DSLS_SUPPORT config to NXP cmake build.
It also adds a prj_thread_mtd_low_power_lit.conf config file with configs to LIT ICD.

#### Testing

Compiled locally.
