### PR TITLE
Update the StreamUsagePriorities in the delegate when the SetStreamPriorities command changes the attribute.

### DIFF
--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -614,6 +614,10 @@ void CameraAVStreamManager::OnAttributeChanged(AttributeId attributeId)
         mCameraDeviceHAL->GetCameraHALInterface().SetHDRMode(GetCameraAVStreamMgmtServer()->GetHDRModeEnabled());
         break;
     }
+    case StreamUsagePriorities::Id: {
+        mCameraDeviceHAL->GetCameraHALInterface().SetStreamUsagePriorities(GetCameraAVStreamMgmtServer()->GetStreamUsagePriorities());
+        break;
+    }
     case SoftRecordingPrivacyModeEnabled::Id: {
         mCameraDeviceHAL->GetCameraHALInterface().SetSoftRecordingPrivacyModeEnabled(
             GetCameraAVStreamMgmtServer()->GetSoftRecordingPrivacyModeEnabled());


### PR DESCRIPTION
#### Summary
The StreamUsagePriorities is a read-only attribute but can be changed by the SetStreamPriorities command. Currently the attribute in the SDK was being updated by the command but the camera-app delegate was not synched.
This fix updates it in the camera-app on the attribute change.

#### Testing
Execute `SetStreamPriorities` command against the `chip-camera-app`

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
