### PR TITLE
[ICD][Server]Add restriction for SetMaxReportingInterval for ICD

### DIFF
--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -268,9 +268,21 @@ public:
      * from the OnSubscriptionRequested callback above. The restriction is as below
      * MinIntervalFloor ≤ MaxInterval ≤ MAX(SUBSCRIPTION_MAX_INTERVAL_PUBLISHER_LIMIT, MaxIntervalCeiling)
      * Where SUBSCRIPTION_MAX_INTERVAL_PUBLISHER_LIMIT is set to 60m in the spec.
+     * For ICD publishers, this is set to the IdleModeDuration defined in the ICD Management Cluster.
+     * If the new max interval is less than the idle mode duration for an ICD device, the function will return
+     * CHIP_ERROR_INVALID_ARGUMENT.
      */
     CHIP_ERROR SetMaxReportingInterval(uint16_t aMaxInterval)
     {
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+        if (aMaxInterval < mMaxInterval)
+        {
+            ChipLogProgress(DataManagement,
+                            "Fail to set MaxReportingInterval to %d as it is less than the current MaxInterval %d for ICD device",
+                            aMaxInterval, mMaxInterval);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
         VerifyOrReturnError(IsIdle(), CHIP_ERROR_INCORRECT_STATE);
         VerifyOrReturnError(mMinIntervalFloorSeconds <= aMaxInterval, CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(aMaxInterval <= std::max(GetPublisherSelectedIntervalLimit(), mSubscriberRequestedMaxInterval),

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -863,15 +863,22 @@ void TestReadInteraction::TestReadHandlerSetMaxReportingInterval()
         readHandler.GetReportingIntervals(minInterval, maxInterval);
         EXPECT_EQ(kMaxIntervalCeiling, maxInterval);
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+        // TC2: MaxInterval == MinIntervalFloor
+        EXPECT_EQ(readHandler.SetMaxReportingInterval(kMinInterval), CHIP_ERROR_INVALID_ARGUMENT);
+#else
         // TC2: MaxInterval == MinIntervalFloor
         EXPECT_EQ(readHandler.SetMaxReportingInterval(kMinInterval), CHIP_NO_ERROR);
-
         readHandler.GetReportingIntervals(minInterval, maxInterval);
         EXPECT_EQ(kMinInterval, maxInterval);
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+        // TC3: Minterval < MaxInterval < max(GetPublisherSelectedIntervalLimit(), mSubscriberRequestedMaxInterval)
+        EXPECT_EQ(readHandler.SetMaxReportingInterval(kMinInterval + 1), CHIP_ERROR_INVALID_ARGUMENT);
+#else
         // TC3: Minterval < MaxInterval < max(GetPublisherSelectedIntervalLimit(), mSubscriberRequestedMaxInterval)
         EXPECT_EQ(readHandler.SetMaxReportingInterval(kMaxIntervalCeiling), CHIP_NO_ERROR);
-
         readHandler.GetReportingIntervals(minInterval, maxInterval);
         EXPECT_EQ(kMaxIntervalCeiling, maxInterval);
 
@@ -880,6 +887,7 @@ void TestReadInteraction::TestReadHandlerSetMaxReportingInterval()
 
         readHandler.GetReportingIntervals(minInterval, maxInterval);
         EXPECT_EQ(readHandler.GetSubscriberRequestedMaxInterval(), maxInterval);
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
         // TC4: MaxInterval == GetPublisherSelectedIntervalLimit()
         EXPECT_EQ(readHandler.SetMaxReportingInterval(readHandler.GetPublisherSelectedIntervalLimit()), CHIP_NO_ERROR);


### PR DESCRIPTION
#### Summary
When LIT device works in LIT mode, device should prevent device application modifying maxInterval, and use the default Idle duration as maxInterval of subscription. We see some manufacturer are setting the maxInterval as 6min, and Idle duration is 1 hour, as a result, ecosystem is experiencing the frequent offline. In fact, when max interval(6min) elapsed, the device would not wake-up per current code. Solution is to set up the restriction for ReadHandler::SetMaxReportingInterval and prevent the interval being changed to the one less than mMaxInterval.
After https://github.com/project-chip/connectedhomeip/pull/42115, this should be also applied in SIT ICD.

#### Related issues
N/A

#### Testing
Local testing using both controller and LIT example app for SIT mode and LIT mode

#### Readability checklist
N/A
