### PR TITLE
Add callback on passcode error

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -641,7 +641,6 @@ void CastingPlayer::OnCommissioningSessionStopped()
     ChipLogProgress(AppServer, "CastingPlayer::OnCommissioningSessionStopped()");
     if (mOnCompleted != nullptr)
     {
-        // stopped?
         mOnCompleted(CHIP_ERROR_CANCELLED, nullptr);
     }
 }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -332,10 +332,10 @@ void CastingPlayer::resetState(CHIP_ERROR err)
     support::ChipDeviceEventHandler::SetUdcStatus(false);
     mConnectionState               = CASTING_PLAYER_NOT_CONNECTED;
     mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
-    
+
     // Unregister from CommissioningWindowManager when unsetting mTargetCastingPlayer
     chip::Server::GetInstance().GetCommissioningWindowManager().SetAppDelegate(nullptr);
-    
+
     mTargetCastingPlayer.reset();
     if (mOnCompleted)
     {
@@ -349,10 +349,10 @@ void CastingPlayer::Disconnect()
 {
     ChipLogProgress(AppServer, "CastingPlayer::Disconnect()");
     mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
-    
+
     // Unregister from CommissioningWindowManager when unsetting mTargetCastingPlayer
     chip::Server::GetInstance().GetCommissioningWindowManager().SetAppDelegate(nullptr);
-    
+
     mTargetCastingPlayer.reset();
     CastingPlayerDiscovery::GetInstance()->ClearCastingPlayersInternal();
 }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -631,6 +631,7 @@ void CastingPlayer::OnCommissioningSessionEstablishmentError(CHIP_ERROR err)
     ChipLogProgress(AppServer, "CastingPlayer::OnCommissioningSessionEstablishmentError() err: %" CHIP_ERROR_FORMAT, err.Format());
     if (mOnCompleted != nullptr)
     {
+        // err = 0x38 = CHIP_ERROR_INVALID_PASE_PARAMETER upon bad passcode
         mOnCompleted(err, nullptr);
     }
 }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -27,6 +27,7 @@
 #include "support/EndpointListLoader.h"
 
 #include "lib/support/logging/CHIPLogging.h"
+#include <app/server/AppDelegate.h>
 #include <inet/IPAddress.h>
 #include <inet/InetInterface.h>
 #include <string.h>
@@ -92,7 +93,7 @@ class CastingPlayer;
  * @brief CastingPlayer represents a Matter Commissioner that is able to play media to a physical
  * output or to a display screen which is part of the device.
  */
-class CastingPlayer : public std::enable_shared_from_this<CastingPlayer>
+class CastingPlayer : public std::enable_shared_from_this<CastingPlayer>, public AppDelegate
 {
 public:
     CastingPlayer(CastingPlayerAttributes playerAttributes) { mAttributes = playerAttributes; }
@@ -295,6 +296,14 @@ public:
         ChipLogError(AppServer, "CastingPlayer::GetConnectionState() state: %d", mConnectionState);
         return mConnectionState;
     }
+
+    // AppDelegate implementation
+    void OnCommissioningSessionEstablishmentStarted() override;
+    void OnCommissioningSessionStarted() override;
+    void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) override;
+    void OnCommissioningSessionStopped() override;
+    void OnCommissioningWindowOpened() override;
+    void OnCommissioningWindowClosed() override;
 
 private:
     std::vector<memory::Strong<Endpoint>> mEndpoints;


### PR DESCRIPTION
#### Summary

Currently there is no callback to higher layer when commissioning attempt fails due to bad passcode

#### Testing

Manually test on android