### PR TITLE
[PAVST] Add units to constant name

### DIFF
--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -190,7 +190,7 @@ class PAVSTTestBase:
     async def allocate_one_pushav_transport(self, endpoint, triggerType=Clusters.PushAvStreamTransport.Enums.TransportTriggerTypeEnum.kContinuous,
                                             trigger_Options=None, ingestMethod=Clusters.PushAvStreamTransport.Enums.IngestMethodsEnum.kCMAFIngest,
                                             url="https://localhost:1234/streams/1/", stream_Usage=None, container_Options=None,
-                                            videoStream_ID=None, audioStream_ID=None, expected_cluster_status=None, tlsEndPoint=1, expiryTime=DEFAULT_AV_TRANSPORT_EXPIRY_TIME):
+                                            videoStream_ID=None, audioStream_ID=None, expected_cluster_status=None, tlsEndPoint=1, expiryTime=DEFAULT_AV_TRANSPORT_EXPIRY_TIME_SEC):
         endpoint = self.get_endpoint(default=1)
         cluster = Clusters.PushAvStreamTransport
 

--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class PAVSTTestBase:
-    DEFAULT_AV_TRANSPORT_EXPIRY_TIME = 30  # 30s
+    DEFAULT_AV_TRANSPORT_EXPIRY_TIME_SEC = 30  # 30 seconds
 
     async def read_pavst_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.PushAvStreamTransport


### PR DESCRIPTION
#### Summary

To align with coding practices change the name of the constant in PushAVTestBase to be explicit on the units being represented (Seconds)

#### Related issues



#### Testing

Via CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
