### PR TITLE
[CI default timeout test addition] Add default timeouts for TC_CADMIN_1_3 and TC_CADMIN_1_4 for CI test runs

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -152,8 +152,7 @@ slow_tests:
     - { name: mobile-device-test.py, duration: 3 minutes }
     - { name: TC_AccessChecker.py, duration: 1.5 minutes }
     - { name: TC_BRBINFO_4_1.py, duration: 2 minutes }
-    - { name: TC_CADMIN_1_3.py, duration: 3.5 minutes }
-    - { name: TC_CADMIN_1_4.py, duration: 30 seconds }
+    - { name: TC_CADMIN_1_3_4.py, duration: 4 minutes }
     - { name: TC_CADMIN_1_19.py, duration: 30 seconds }
     - { name: TC_CADMIN_1_22_24.py, duration: 3 minutes }
     - { name: TC_CADMIN_1_9.py, duration: 40 seconds }

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -152,10 +152,13 @@ slow_tests:
     - { name: mobile-device-test.py, duration: 3 minutes }
     - { name: TC_AccessChecker.py, duration: 1.5 minutes }
     - { name: TC_BRBINFO_4_1.py, duration: 2 minutes }
+    - { name: TC_CADMIN_1_3.py, duration: 3.5 minutes }
+    - { name: TC_CADMIN_1_4.py, duration: 30 seconds }
     - { name: TC_CADMIN_1_19.py, duration: 30 seconds }
     - { name: TC_CADMIN_1_22_24.py, duration: 3 minutes }
     - { name: TC_CADMIN_1_9.py, duration: 40 seconds }
     - { name: TC_CC_2_2.py, duration: 1.5 minutes }
+    - { name: TC_CLCTRL_4_1.py, duration: 45 seconds }
     - { name: TC_DEM_2_10.py, duration: 40 seconds }
     - { name: TC_DeviceBasicComposition.py, duration: 25 seconds }
     - { name: TC_DRLK_2_12.py, duration: 30 seconds }
@@ -174,4 +177,3 @@ slow_tests:
     - { name: TC_TIMESYNC_2_12.py, duration: 20 seconds }
     - { name: TC_TIMESYNC_2_7.py, duration: 20 seconds }
     - { name: TC_TIMESYNC_2_8.py, duration: 1.5 minutes }
-    - { name: TC_CLCTRL_4_1.py, duration: 45 seconds }


### PR DESCRIPTION
#### Summary

Updated test_metadata.yaml slow_tests to include run times for TC_CADMIN_1_3_4 python3 test module, also minor resort of tests in slow_tests.

#### Related issues

Resolves: https://github.com/project-chip/matter-test-scripts/issues/565

#### Testing

CI checks verify this
