### PR TITLE
Do not error out on utf8 decoding in some files (notably python test runners)

### DIFF
--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -997,8 +997,8 @@ def python_tests(
                             f.write(result.stderr)
 
                     else:
-                        logging.info("STDOUT:\n%s", result.stdout.decode("utf8"))
-                        logging.warning("STDERR:\n%s", result.stderr.decode("utf8"))
+                        logging.info("STDOUT:\n%s", result.stdout.decode("utf8", errors='replace'))
+                        logging.warning("STDERR:\n%s", result.stderr.decode("utf8", errors='replace'))
                     if not keep_going:
                         sys.exit(1)
                     failed_tests.append(script)

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -333,7 +333,7 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
 
         if quiet:
             if exit_code:
-                sys.stdout.write(stream_output.getvalue().decode('utf-8'))
+                sys.stdout.write(stream_output.getvalue().decode('utf-8', errors='replace'))
             else:
                 logging.info("Test completed successfully")
 

--- a/scripts/tools/esp32_log_cat.py
+++ b/scripts/tools/esp32_log_cat.py
@@ -64,7 +64,7 @@ class LogPrinter:
 
         if raw.startswith(b'\x1b['):
             raw = raw[raw.find(b'm')+1:]
-        raw = raw.decode('utf8').strip()
+        raw = raw.decode('utf8', errors='replace').strip()
 
         self.ExtractSeverity(raw)
 


### PR DESCRIPTION
#### Summary

We have various tests failing on utf8 decoding, like the ones reported in #41813:

```
...
 File "/__w/connectedhomeip/connectedhomeip/scripts/tests/run_python_test.py", line 219, in main
    main_impl(run.app, run.factory_reset, run.factory_reset_app_only, run.app_args or "", run.app_ready_pattern,
  File "/__w/connectedhomeip/connectedhomeip/scripts/tests/run_python_test.py", line 336, in main_impl
    sys.stdout.write(stream_output.getvalue().decode('utf-8'))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9b in position 52246: invalid start byte
```

This makes it so that we can see the logs instead of an error. We don't really care about valid utf8 here, we care about the actual log content

#### Testing

Trivial change. Checked locally that errors='replace' actually does the right thing:

```
>>> b'\x9btesting123'.decode('utf8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9b in position 0: invalid start byte

>>> b'\x9btesting123'.decode('utf8', errors='replace')
'�testing123'

```