### PR TITLE
Fix typo in Ids.h generator.

### DIFF
--- a/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/Ids.h.jinja
+++ b/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/Ids.h.jinja
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster {{cluster.name}} (cluster code: {{"%d/0x04%X" | format(cluster.code, cluster.code)}})
+// Identifier constant values for cluster {{cluster.name}} (cluster code: {{"%d/0x%04X" | format(cluster.code, cluster.code)}})
 // based on {{input_name}}
 #pragma once
 
@@ -8,4 +8,3 @@
 #include <clusters/{{cluster.name}}/ClusterId.h>
 #include <clusters/{{cluster.name}}/CommandIds.h>
 #include <clusters/{{cluster.name}}/EventIds.h>
-

--- a/zzz_generated/app-common/clusters/AccessControl/Ids.h
+++ b/zzz_generated/app-common/clusters/AccessControl/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster AccessControl (cluster code: 31/0x041F)
+// Identifier constant values for cluster AccessControl (cluster code: 31/0x001F)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/AccountLogin/Ids.h
+++ b/zzz_generated/app-common/clusters/AccountLogin/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster AccountLogin (cluster code: 1294/0x0450E)
+// Identifier constant values for cluster AccountLogin (cluster code: 1294/0x050E)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Actions/Ids.h
+++ b/zzz_generated/app-common/clusters/Actions/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Actions (cluster code: 37/0x0425)
+// Identifier constant values for cluster Actions (cluster code: 37/0x0025)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/Ids.h
+++ b/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ActivatedCarbonFilterMonitoring (cluster code: 114/0x0472)
+// Identifier constant values for cluster ActivatedCarbonFilterMonitoring (cluster code: 114/0x0072)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/AdministratorCommissioning/Ids.h
+++ b/zzz_generated/app-common/clusters/AdministratorCommissioning/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster AdministratorCommissioning (cluster code: 60/0x043C)
+// Identifier constant values for cluster AdministratorCommissioning (cluster code: 60/0x003C)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/AirQuality/Ids.h
+++ b/zzz_generated/app-common/clusters/AirQuality/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster AirQuality (cluster code: 91/0x045B)
+// Identifier constant values for cluster AirQuality (cluster code: 91/0x005B)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ApplicationBasic/Ids.h
+++ b/zzz_generated/app-common/clusters/ApplicationBasic/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ApplicationBasic (cluster code: 1293/0x0450D)
+// Identifier constant values for cluster ApplicationBasic (cluster code: 1293/0x050D)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ApplicationLauncher/Ids.h
+++ b/zzz_generated/app-common/clusters/ApplicationLauncher/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ApplicationLauncher (cluster code: 1292/0x0450C)
+// Identifier constant values for cluster ApplicationLauncher (cluster code: 1292/0x050C)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/AudioOutput/Ids.h
+++ b/zzz_generated/app-common/clusters/AudioOutput/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster AudioOutput (cluster code: 1291/0x0450B)
+// Identifier constant values for cluster AudioOutput (cluster code: 1291/0x050B)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/BallastConfiguration/Ids.h
+++ b/zzz_generated/app-common/clusters/BallastConfiguration/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster BallastConfiguration (cluster code: 769/0x04301)
+// Identifier constant values for cluster BallastConfiguration (cluster code: 769/0x0301)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/BasicInformation/Ids.h
+++ b/zzz_generated/app-common/clusters/BasicInformation/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster BasicInformation (cluster code: 40/0x0428)
+// Identifier constant values for cluster BasicInformation (cluster code: 40/0x0028)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Binding/Ids.h
+++ b/zzz_generated/app-common/clusters/Binding/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Binding (cluster code: 30/0x041E)
+// Identifier constant values for cluster Binding (cluster code: 30/0x001E)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/BooleanState/Ids.h
+++ b/zzz_generated/app-common/clusters/BooleanState/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster BooleanState (cluster code: 69/0x0445)
+// Identifier constant values for cluster BooleanState (cluster code: 69/0x0045)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/BooleanStateConfiguration/Ids.h
+++ b/zzz_generated/app-common/clusters/BooleanStateConfiguration/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster BooleanStateConfiguration (cluster code: 128/0x0480)
+// Identifier constant values for cluster BooleanStateConfiguration (cluster code: 128/0x0080)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/Ids.h
+++ b/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster BridgedDeviceBasicInformation (cluster code: 57/0x0439)
+// Identifier constant values for cluster BridgedDeviceBasicInformation (cluster code: 57/0x0039)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster CameraAvSettingsUserLevelManagement (cluster code: 1362/0x04552)
+// Identifier constant values for cluster CameraAvSettingsUserLevelManagement (cluster code: 1362/0x0552)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/CameraAvStreamManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/CameraAvStreamManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster CameraAvStreamManagement (cluster code: 1361/0x04551)
+// Identifier constant values for cluster CameraAvStreamManagement (cluster code: 1361/0x0551)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/CarbonDioxideConcentrationMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/CarbonDioxideConcentrationMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster CarbonDioxideConcentrationMeasurement (cluster code: 1037/0x0440D)
+// Identifier constant values for cluster CarbonDioxideConcentrationMeasurement (cluster code: 1037/0x040D)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/CarbonMonoxideConcentrationMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/CarbonMonoxideConcentrationMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster CarbonMonoxideConcentrationMeasurement (cluster code: 1036/0x0440C)
+// Identifier constant values for cluster CarbonMonoxideConcentrationMeasurement (cluster code: 1036/0x040C)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Channel/Ids.h
+++ b/zzz_generated/app-common/clusters/Channel/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Channel (cluster code: 1284/0x04504)
+// Identifier constant values for cluster Channel (cluster code: 1284/0x0504)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Chime/Ids.h
+++ b/zzz_generated/app-common/clusters/Chime/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Chime (cluster code: 1366/0x04556)
+// Identifier constant values for cluster Chime (cluster code: 1366/0x0556)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ClosureControl/Ids.h
+++ b/zzz_generated/app-common/clusters/ClosureControl/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ClosureControl (cluster code: 260/0x04104)
+// Identifier constant values for cluster ClosureControl (cluster code: 260/0x0104)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ClosureDimension/Ids.h
+++ b/zzz_generated/app-common/clusters/ClosureDimension/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ClosureDimension (cluster code: 261/0x04105)
+// Identifier constant values for cluster ClosureDimension (cluster code: 261/0x0105)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ColorControl/Ids.h
+++ b/zzz_generated/app-common/clusters/ColorControl/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ColorControl (cluster code: 768/0x04300)
+// Identifier constant values for cluster ColorControl (cluster code: 768/0x0300)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/CommissionerControl/Ids.h
+++ b/zzz_generated/app-common/clusters/CommissionerControl/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster CommissionerControl (cluster code: 1873/0x04751)
+// Identifier constant values for cluster CommissionerControl (cluster code: 1873/0x0751)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/CommodityMetering/Ids.h
+++ b/zzz_generated/app-common/clusters/CommodityMetering/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster CommodityMetering (cluster code: 2823/0x04B07)
+// Identifier constant values for cluster CommodityMetering (cluster code: 2823/0x0B07)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/CommodityPrice/Ids.h
+++ b/zzz_generated/app-common/clusters/CommodityPrice/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster CommodityPrice (cluster code: 149/0x0495)
+// Identifier constant values for cluster CommodityPrice (cluster code: 149/0x0095)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/CommodityTariff/Ids.h
+++ b/zzz_generated/app-common/clusters/CommodityTariff/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster CommodityTariff (cluster code: 1792/0x04700)
+// Identifier constant values for cluster CommodityTariff (cluster code: 1792/0x0700)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ContentAppObserver/Ids.h
+++ b/zzz_generated/app-common/clusters/ContentAppObserver/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ContentAppObserver (cluster code: 1296/0x04510)
+// Identifier constant values for cluster ContentAppObserver (cluster code: 1296/0x0510)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ContentControl/Ids.h
+++ b/zzz_generated/app-common/clusters/ContentControl/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ContentControl (cluster code: 1295/0x0450F)
+// Identifier constant values for cluster ContentControl (cluster code: 1295/0x050F)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ContentLauncher/Ids.h
+++ b/zzz_generated/app-common/clusters/ContentLauncher/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ContentLauncher (cluster code: 1290/0x0450A)
+// Identifier constant values for cluster ContentLauncher (cluster code: 1290/0x050A)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Descriptor/Ids.h
+++ b/zzz_generated/app-common/clusters/Descriptor/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Descriptor (cluster code: 29/0x041D)
+// Identifier constant values for cluster Descriptor (cluster code: 29/0x001D)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster DeviceEnergyManagement (cluster code: 152/0x0498)
+// Identifier constant values for cluster DeviceEnergyManagement (cluster code: 152/0x0098)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/Ids.h
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster DeviceEnergyManagementMode (cluster code: 159/0x049F)
+// Identifier constant values for cluster DeviceEnergyManagementMode (cluster code: 159/0x009F)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/DiagnosticLogs/Ids.h
+++ b/zzz_generated/app-common/clusters/DiagnosticLogs/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster DiagnosticLogs (cluster code: 50/0x0432)
+// Identifier constant values for cluster DiagnosticLogs (cluster code: 50/0x0032)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/DishwasherAlarm/Ids.h
+++ b/zzz_generated/app-common/clusters/DishwasherAlarm/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster DishwasherAlarm (cluster code: 93/0x045D)
+// Identifier constant values for cluster DishwasherAlarm (cluster code: 93/0x005D)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/DishwasherMode/Ids.h
+++ b/zzz_generated/app-common/clusters/DishwasherMode/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster DishwasherMode (cluster code: 89/0x0459)
+// Identifier constant values for cluster DishwasherMode (cluster code: 89/0x0059)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/DoorLock/Ids.h
+++ b/zzz_generated/app-common/clusters/DoorLock/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster DoorLock (cluster code: 257/0x04101)
+// Identifier constant values for cluster DoorLock (cluster code: 257/0x0101)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/EcosystemInformation/Ids.h
+++ b/zzz_generated/app-common/clusters/EcosystemInformation/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster EcosystemInformation (cluster code: 1872/0x04750)
+// Identifier constant values for cluster EcosystemInformation (cluster code: 1872/0x0750)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ElectricalEnergyMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/ElectricalEnergyMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ElectricalEnergyMeasurement (cluster code: 145/0x0491)
+// Identifier constant values for cluster ElectricalEnergyMeasurement (cluster code: 145/0x0091)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ElectricalGridConditions/Ids.h
+++ b/zzz_generated/app-common/clusters/ElectricalGridConditions/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ElectricalGridConditions (cluster code: 160/0x04A0)
+// Identifier constant values for cluster ElectricalGridConditions (cluster code: 160/0x00A0)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ElectricalPowerMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/ElectricalPowerMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ElectricalPowerMeasurement (cluster code: 144/0x0490)
+// Identifier constant values for cluster ElectricalPowerMeasurement (cluster code: 144/0x0090)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/EnergyEvse/Ids.h
+++ b/zzz_generated/app-common/clusters/EnergyEvse/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster EnergyEvse (cluster code: 153/0x0499)
+// Identifier constant values for cluster EnergyEvse (cluster code: 153/0x0099)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/EnergyEvseMode/Ids.h
+++ b/zzz_generated/app-common/clusters/EnergyEvseMode/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster EnergyEvseMode (cluster code: 157/0x049D)
+// Identifier constant values for cluster EnergyEvseMode (cluster code: 157/0x009D)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/EnergyPreference/Ids.h
+++ b/zzz_generated/app-common/clusters/EnergyPreference/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster EnergyPreference (cluster code: 155/0x049B)
+// Identifier constant values for cluster EnergyPreference (cluster code: 155/0x009B)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/Ids.h
+++ b/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster EthernetNetworkDiagnostics (cluster code: 55/0x0437)
+// Identifier constant values for cluster EthernetNetworkDiagnostics (cluster code: 55/0x0037)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/FanControl/Ids.h
+++ b/zzz_generated/app-common/clusters/FanControl/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster FanControl (cluster code: 514/0x04202)
+// Identifier constant values for cluster FanControl (cluster code: 514/0x0202)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/FaultInjection/Ids.h
+++ b/zzz_generated/app-common/clusters/FaultInjection/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster FaultInjection (cluster code: 4294048774/0x04FFF1FC06)
+// Identifier constant values for cluster FaultInjection (cluster code: 4294048774/0xFFF1FC06)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/FixedLabel/Ids.h
+++ b/zzz_generated/app-common/clusters/FixedLabel/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster FixedLabel (cluster code: 64/0x0440)
+// Identifier constant values for cluster FixedLabel (cluster code: 64/0x0040)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/FlowMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/FlowMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster FlowMeasurement (cluster code: 1028/0x04404)
+// Identifier constant values for cluster FlowMeasurement (cluster code: 1028/0x0404)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/FormaldehydeConcentrationMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/FormaldehydeConcentrationMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster FormaldehydeConcentrationMeasurement (cluster code: 1067/0x0442B)
+// Identifier constant values for cluster FormaldehydeConcentrationMeasurement (cluster code: 1067/0x042B)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/GeneralCommissioning/Ids.h
+++ b/zzz_generated/app-common/clusters/GeneralCommissioning/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster GeneralCommissioning (cluster code: 48/0x0430)
+// Identifier constant values for cluster GeneralCommissioning (cluster code: 48/0x0030)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/GeneralDiagnostics/Ids.h
+++ b/zzz_generated/app-common/clusters/GeneralDiagnostics/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster GeneralDiagnostics (cluster code: 51/0x0433)
+// Identifier constant values for cluster GeneralDiagnostics (cluster code: 51/0x0033)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/GroupKeyManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/GroupKeyManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster GroupKeyManagement (cluster code: 63/0x043F)
+// Identifier constant values for cluster GroupKeyManagement (cluster code: 63/0x003F)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Groupcast/Ids.h
+++ b/zzz_generated/app-common/clusters/Groupcast/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Groupcast (cluster code: 101/0x0465)
+// Identifier constant values for cluster Groupcast (cluster code: 101/0x0065)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Groups/Ids.h
+++ b/zzz_generated/app-common/clusters/Groups/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Groups (cluster code: 4/0x044)
+// Identifier constant values for cluster Groups (cluster code: 4/0x0004)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/HepaFilterMonitoring/Ids.h
+++ b/zzz_generated/app-common/clusters/HepaFilterMonitoring/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster HepaFilterMonitoring (cluster code: 113/0x0471)
+// Identifier constant values for cluster HepaFilterMonitoring (cluster code: 113/0x0071)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/IcdManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/IcdManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster IcdManagement (cluster code: 70/0x0446)
+// Identifier constant values for cluster IcdManagement (cluster code: 70/0x0046)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Identify/Ids.h
+++ b/zzz_generated/app-common/clusters/Identify/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Identify (cluster code: 3/0x043)
+// Identifier constant values for cluster Identify (cluster code: 3/0x0003)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/IlluminanceMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/IlluminanceMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster IlluminanceMeasurement (cluster code: 1024/0x04400)
+// Identifier constant values for cluster IlluminanceMeasurement (cluster code: 1024/0x0400)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/JointFabricAdministrator/Ids.h
+++ b/zzz_generated/app-common/clusters/JointFabricAdministrator/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster JointFabricAdministrator (cluster code: 1875/0x04753)
+// Identifier constant values for cluster JointFabricAdministrator (cluster code: 1875/0x0753)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/JointFabricDatastore/Ids.h
+++ b/zzz_generated/app-common/clusters/JointFabricDatastore/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster JointFabricDatastore (cluster code: 1874/0x04752)
+// Identifier constant values for cluster JointFabricDatastore (cluster code: 1874/0x0752)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/KeypadInput/Ids.h
+++ b/zzz_generated/app-common/clusters/KeypadInput/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster KeypadInput (cluster code: 1289/0x04509)
+// Identifier constant values for cluster KeypadInput (cluster code: 1289/0x0509)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/LaundryDryerControls/Ids.h
+++ b/zzz_generated/app-common/clusters/LaundryDryerControls/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster LaundryDryerControls (cluster code: 74/0x044A)
+// Identifier constant values for cluster LaundryDryerControls (cluster code: 74/0x004A)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/LaundryWasherControls/Ids.h
+++ b/zzz_generated/app-common/clusters/LaundryWasherControls/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster LaundryWasherControls (cluster code: 83/0x0453)
+// Identifier constant values for cluster LaundryWasherControls (cluster code: 83/0x0053)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/LaundryWasherMode/Ids.h
+++ b/zzz_generated/app-common/clusters/LaundryWasherMode/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster LaundryWasherMode (cluster code: 81/0x0451)
+// Identifier constant values for cluster LaundryWasherMode (cluster code: 81/0x0051)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/LevelControl/Ids.h
+++ b/zzz_generated/app-common/clusters/LevelControl/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster LevelControl (cluster code: 8/0x048)
+// Identifier constant values for cluster LevelControl (cluster code: 8/0x0008)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/LocalizationConfiguration/Ids.h
+++ b/zzz_generated/app-common/clusters/LocalizationConfiguration/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster LocalizationConfiguration (cluster code: 43/0x042B)
+// Identifier constant values for cluster LocalizationConfiguration (cluster code: 43/0x002B)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/LowPower/Ids.h
+++ b/zzz_generated/app-common/clusters/LowPower/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster LowPower (cluster code: 1288/0x04508)
+// Identifier constant values for cluster LowPower (cluster code: 1288/0x0508)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/MediaInput/Ids.h
+++ b/zzz_generated/app-common/clusters/MediaInput/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster MediaInput (cluster code: 1287/0x04507)
+// Identifier constant values for cluster MediaInput (cluster code: 1287/0x0507)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/MediaPlayback/Ids.h
+++ b/zzz_generated/app-common/clusters/MediaPlayback/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster MediaPlayback (cluster code: 1286/0x04506)
+// Identifier constant values for cluster MediaPlayback (cluster code: 1286/0x0506)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Messages/Ids.h
+++ b/zzz_generated/app-common/clusters/Messages/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Messages (cluster code: 151/0x0497)
+// Identifier constant values for cluster Messages (cluster code: 151/0x0097)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/MeterIdentification/Ids.h
+++ b/zzz_generated/app-common/clusters/MeterIdentification/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster MeterIdentification (cluster code: 2822/0x04B06)
+// Identifier constant values for cluster MeterIdentification (cluster code: 2822/0x0B06)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/MicrowaveOvenControl/Ids.h
+++ b/zzz_generated/app-common/clusters/MicrowaveOvenControl/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster MicrowaveOvenControl (cluster code: 95/0x045F)
+// Identifier constant values for cluster MicrowaveOvenControl (cluster code: 95/0x005F)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/MicrowaveOvenMode/Ids.h
+++ b/zzz_generated/app-common/clusters/MicrowaveOvenMode/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster MicrowaveOvenMode (cluster code: 94/0x045E)
+// Identifier constant values for cluster MicrowaveOvenMode (cluster code: 94/0x005E)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ModeSelect/Ids.h
+++ b/zzz_generated/app-common/clusters/ModeSelect/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ModeSelect (cluster code: 80/0x0450)
+// Identifier constant values for cluster ModeSelect (cluster code: 80/0x0050)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/NetworkCommissioning/Ids.h
+++ b/zzz_generated/app-common/clusters/NetworkCommissioning/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster NetworkCommissioning (cluster code: 49/0x0431)
+// Identifier constant values for cluster NetworkCommissioning (cluster code: 49/0x0031)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/NitrogenDioxideConcentrationMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/NitrogenDioxideConcentrationMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster NitrogenDioxideConcentrationMeasurement (cluster code: 1043/0x04413)
+// Identifier constant values for cluster NitrogenDioxideConcentrationMeasurement (cluster code: 1043/0x0413)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/OccupancySensing/Ids.h
+++ b/zzz_generated/app-common/clusters/OccupancySensing/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster OccupancySensing (cluster code: 1030/0x04406)
+// Identifier constant values for cluster OccupancySensing (cluster code: 1030/0x0406)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/OnOff/Ids.h
+++ b/zzz_generated/app-common/clusters/OnOff/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster OnOff (cluster code: 6/0x046)
+// Identifier constant values for cluster OnOff (cluster code: 6/0x0006)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/OperationalCredentials/Ids.h
+++ b/zzz_generated/app-common/clusters/OperationalCredentials/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster OperationalCredentials (cluster code: 62/0x043E)
+// Identifier constant values for cluster OperationalCredentials (cluster code: 62/0x003E)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/OperationalState/Ids.h
+++ b/zzz_generated/app-common/clusters/OperationalState/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster OperationalState (cluster code: 96/0x0460)
+// Identifier constant values for cluster OperationalState (cluster code: 96/0x0060)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/Ids.h
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster OtaSoftwareUpdateProvider (cluster code: 41/0x0429)
+// Identifier constant values for cluster OtaSoftwareUpdateProvider (cluster code: 41/0x0029)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/Ids.h
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster OtaSoftwareUpdateRequestor (cluster code: 42/0x042A)
+// Identifier constant values for cluster OtaSoftwareUpdateRequestor (cluster code: 42/0x002A)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/OvenCavityOperationalState/Ids.h
+++ b/zzz_generated/app-common/clusters/OvenCavityOperationalState/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster OvenCavityOperationalState (cluster code: 72/0x0448)
+// Identifier constant values for cluster OvenCavityOperationalState (cluster code: 72/0x0048)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/OvenMode/Ids.h
+++ b/zzz_generated/app-common/clusters/OvenMode/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster OvenMode (cluster code: 73/0x0449)
+// Identifier constant values for cluster OvenMode (cluster code: 73/0x0049)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/OzoneConcentrationMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/OzoneConcentrationMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster OzoneConcentrationMeasurement (cluster code: 1045/0x04415)
+// Identifier constant values for cluster OzoneConcentrationMeasurement (cluster code: 1045/0x0415)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Pm10ConcentrationMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/Pm10ConcentrationMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Pm10ConcentrationMeasurement (cluster code: 1069/0x0442D)
+// Identifier constant values for cluster Pm10ConcentrationMeasurement (cluster code: 1069/0x042D)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Pm1ConcentrationMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/Pm1ConcentrationMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Pm1ConcentrationMeasurement (cluster code: 1068/0x0442C)
+// Identifier constant values for cluster Pm1ConcentrationMeasurement (cluster code: 1068/0x042C)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Pm25ConcentrationMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/Pm25ConcentrationMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Pm25ConcentrationMeasurement (cluster code: 1066/0x0442A)
+// Identifier constant values for cluster Pm25ConcentrationMeasurement (cluster code: 1066/0x042A)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/PowerSource/Ids.h
+++ b/zzz_generated/app-common/clusters/PowerSource/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster PowerSource (cluster code: 47/0x042F)
+// Identifier constant values for cluster PowerSource (cluster code: 47/0x002F)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/PowerSourceConfiguration/Ids.h
+++ b/zzz_generated/app-common/clusters/PowerSourceConfiguration/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster PowerSourceConfiguration (cluster code: 46/0x042E)
+// Identifier constant values for cluster PowerSourceConfiguration (cluster code: 46/0x002E)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/PowerTopology/Ids.h
+++ b/zzz_generated/app-common/clusters/PowerTopology/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster PowerTopology (cluster code: 156/0x049C)
+// Identifier constant values for cluster PowerTopology (cluster code: 156/0x009C)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/PressureMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/PressureMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster PressureMeasurement (cluster code: 1027/0x04403)
+// Identifier constant values for cluster PressureMeasurement (cluster code: 1027/0x0403)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ProxyConfiguration/Ids.h
+++ b/zzz_generated/app-common/clusters/ProxyConfiguration/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ProxyConfiguration (cluster code: 66/0x0442)
+// Identifier constant values for cluster ProxyConfiguration (cluster code: 66/0x0042)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ProxyDiscovery/Ids.h
+++ b/zzz_generated/app-common/clusters/ProxyDiscovery/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ProxyDiscovery (cluster code: 67/0x0443)
+// Identifier constant values for cluster ProxyDiscovery (cluster code: 67/0x0043)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ProxyValid/Ids.h
+++ b/zzz_generated/app-common/clusters/ProxyValid/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ProxyValid (cluster code: 68/0x0444)
+// Identifier constant values for cluster ProxyValid (cluster code: 68/0x0044)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/PulseWidthModulation/Ids.h
+++ b/zzz_generated/app-common/clusters/PulseWidthModulation/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster PulseWidthModulation (cluster code: 28/0x041C)
+// Identifier constant values for cluster PulseWidthModulation (cluster code: 28/0x001C)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/PumpConfigurationAndControl/Ids.h
+++ b/zzz_generated/app-common/clusters/PumpConfigurationAndControl/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster PumpConfigurationAndControl (cluster code: 512/0x04200)
+// Identifier constant values for cluster PumpConfigurationAndControl (cluster code: 512/0x0200)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/PushAvStreamTransport/Ids.h
+++ b/zzz_generated/app-common/clusters/PushAvStreamTransport/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster PushAvStreamTransport (cluster code: 1365/0x04555)
+// Identifier constant values for cluster PushAvStreamTransport (cluster code: 1365/0x0555)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/RadonConcentrationMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/RadonConcentrationMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster RadonConcentrationMeasurement (cluster code: 1071/0x0442F)
+// Identifier constant values for cluster RadonConcentrationMeasurement (cluster code: 1071/0x042F)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/RefrigeratorAlarm/Ids.h
+++ b/zzz_generated/app-common/clusters/RefrigeratorAlarm/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster RefrigeratorAlarm (cluster code: 87/0x0457)
+// Identifier constant values for cluster RefrigeratorAlarm (cluster code: 87/0x0057)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/Ids.h
+++ b/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster RefrigeratorAndTemperatureControlledCabinetMode (cluster code: 82/0x0452)
+// Identifier constant values for cluster RefrigeratorAndTemperatureControlledCabinetMode (cluster code: 82/0x0052)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/RelativeHumidityMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/RelativeHumidityMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster RelativeHumidityMeasurement (cluster code: 1029/0x04405)
+// Identifier constant values for cluster RelativeHumidityMeasurement (cluster code: 1029/0x0405)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/RvcCleanMode/Ids.h
+++ b/zzz_generated/app-common/clusters/RvcCleanMode/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster RvcCleanMode (cluster code: 85/0x0455)
+// Identifier constant values for cluster RvcCleanMode (cluster code: 85/0x0055)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/RvcOperationalState/Ids.h
+++ b/zzz_generated/app-common/clusters/RvcOperationalState/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster RvcOperationalState (cluster code: 97/0x0461)
+// Identifier constant values for cluster RvcOperationalState (cluster code: 97/0x0061)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/RvcRunMode/Ids.h
+++ b/zzz_generated/app-common/clusters/RvcRunMode/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster RvcRunMode (cluster code: 84/0x0454)
+// Identifier constant values for cluster RvcRunMode (cluster code: 84/0x0054)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/SampleMei/Ids.h
+++ b/zzz_generated/app-common/clusters/SampleMei/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster SampleMei (cluster code: 4294048800/0x04FFF1FC20)
+// Identifier constant values for cluster SampleMei (cluster code: 4294048800/0xFFF1FC20)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ScenesManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/ScenesManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ScenesManagement (cluster code: 98/0x0462)
+// Identifier constant values for cluster ScenesManagement (cluster code: 98/0x0062)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ServiceArea/Ids.h
+++ b/zzz_generated/app-common/clusters/ServiceArea/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ServiceArea (cluster code: 336/0x04150)
+// Identifier constant values for cluster ServiceArea (cluster code: 336/0x0150)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/SmokeCoAlarm/Ids.h
+++ b/zzz_generated/app-common/clusters/SmokeCoAlarm/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster SmokeCoAlarm (cluster code: 92/0x045C)
+// Identifier constant values for cluster SmokeCoAlarm (cluster code: 92/0x005C)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/SoftwareDiagnostics/Ids.h
+++ b/zzz_generated/app-common/clusters/SoftwareDiagnostics/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster SoftwareDiagnostics (cluster code: 52/0x0434)
+// Identifier constant values for cluster SoftwareDiagnostics (cluster code: 52/0x0034)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/SoilMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/SoilMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster SoilMeasurement (cluster code: 1072/0x04430)
+// Identifier constant values for cluster SoilMeasurement (cluster code: 1072/0x0430)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Switch/Ids.h
+++ b/zzz_generated/app-common/clusters/Switch/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Switch (cluster code: 59/0x043B)
+// Identifier constant values for cluster Switch (cluster code: 59/0x003B)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/TargetNavigator/Ids.h
+++ b/zzz_generated/app-common/clusters/TargetNavigator/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster TargetNavigator (cluster code: 1285/0x04505)
+// Identifier constant values for cluster TargetNavigator (cluster code: 1285/0x0505)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/TemperatureControl/Ids.h
+++ b/zzz_generated/app-common/clusters/TemperatureControl/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster TemperatureControl (cluster code: 86/0x0456)
+// Identifier constant values for cluster TemperatureControl (cluster code: 86/0x0056)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/TemperatureMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/TemperatureMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster TemperatureMeasurement (cluster code: 1026/0x04402)
+// Identifier constant values for cluster TemperatureMeasurement (cluster code: 1026/0x0402)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Thermostat/Ids.h
+++ b/zzz_generated/app-common/clusters/Thermostat/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Thermostat (cluster code: 513/0x04201)
+// Identifier constant values for cluster Thermostat (cluster code: 513/0x0201)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ThermostatUserInterfaceConfiguration/Ids.h
+++ b/zzz_generated/app-common/clusters/ThermostatUserInterfaceConfiguration/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ThermostatUserInterfaceConfiguration (cluster code: 516/0x04204)
+// Identifier constant values for cluster ThermostatUserInterfaceConfiguration (cluster code: 516/0x0204)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ThreadBorderRouterManagement (cluster code: 1106/0x04452)
+// Identifier constant values for cluster ThreadBorderRouterManagement (cluster code: 1106/0x0452)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/Ids.h
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ThreadNetworkDiagnostics (cluster code: 53/0x0435)
+// Identifier constant values for cluster ThreadNetworkDiagnostics (cluster code: 53/0x0035)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ThreadNetworkDirectory/Ids.h
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDirectory/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ThreadNetworkDirectory (cluster code: 1107/0x04453)
+// Identifier constant values for cluster ThreadNetworkDirectory (cluster code: 1107/0x0453)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/TimeFormatLocalization/Ids.h
+++ b/zzz_generated/app-common/clusters/TimeFormatLocalization/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster TimeFormatLocalization (cluster code: 44/0x042C)
+// Identifier constant values for cluster TimeFormatLocalization (cluster code: 44/0x002C)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/TimeSynchronization/Ids.h
+++ b/zzz_generated/app-common/clusters/TimeSynchronization/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster TimeSynchronization (cluster code: 56/0x0438)
+// Identifier constant values for cluster TimeSynchronization (cluster code: 56/0x0038)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/Timer/Ids.h
+++ b/zzz_generated/app-common/clusters/Timer/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster Timer (cluster code: 71/0x0447)
+// Identifier constant values for cluster Timer (cluster code: 71/0x0047)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/TlsCertificateManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/TlsCertificateManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster TlsCertificateManagement (cluster code: 2049/0x04801)
+// Identifier constant values for cluster TlsCertificateManagement (cluster code: 2049/0x0801)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/TlsClientManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/TlsClientManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster TlsClientManagement (cluster code: 2050/0x04802)
+// Identifier constant values for cluster TlsClientManagement (cluster code: 2050/0x0802)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurement/Ids.h
+++ b/zzz_generated/app-common/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster TotalVolatileOrganicCompoundsConcentrationMeasurement (cluster code: 1070/0x0442E)
+// Identifier constant values for cluster TotalVolatileOrganicCompoundsConcentrationMeasurement (cluster code: 1070/0x042E)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/UnitLocalization/Ids.h
+++ b/zzz_generated/app-common/clusters/UnitLocalization/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster UnitLocalization (cluster code: 45/0x042D)
+// Identifier constant values for cluster UnitLocalization (cluster code: 45/0x002D)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/UnitTesting/Ids.h
+++ b/zzz_generated/app-common/clusters/UnitTesting/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster UnitTesting (cluster code: 4294048773/0x04FFF1FC05)
+// Identifier constant values for cluster UnitTesting (cluster code: 4294048773/0xFFF1FC05)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/UserLabel/Ids.h
+++ b/zzz_generated/app-common/clusters/UserLabel/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster UserLabel (cluster code: 65/0x0441)
+// Identifier constant values for cluster UserLabel (cluster code: 65/0x0041)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Ids.h
+++ b/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ValveConfigurationAndControl (cluster code: 129/0x0481)
+// Identifier constant values for cluster ValveConfigurationAndControl (cluster code: 129/0x0081)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/WakeOnLan/Ids.h
+++ b/zzz_generated/app-common/clusters/WakeOnLan/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster WakeOnLan (cluster code: 1283/0x04503)
+// Identifier constant values for cluster WakeOnLan (cluster code: 1283/0x0503)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/WaterHeaterManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/WaterHeaterManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster WaterHeaterManagement (cluster code: 148/0x0494)
+// Identifier constant values for cluster WaterHeaterManagement (cluster code: 148/0x0094)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/WaterHeaterMode/Ids.h
+++ b/zzz_generated/app-common/clusters/WaterHeaterMode/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster WaterHeaterMode (cluster code: 158/0x049E)
+// Identifier constant values for cluster WaterHeaterMode (cluster code: 158/0x009E)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/WaterTankLevelMonitoring/Ids.h
+++ b/zzz_generated/app-common/clusters/WaterTankLevelMonitoring/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster WaterTankLevelMonitoring (cluster code: 121/0x0479)
+// Identifier constant values for cluster WaterTankLevelMonitoring (cluster code: 121/0x0079)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/WebRTCTransportProvider/Ids.h
+++ b/zzz_generated/app-common/clusters/WebRTCTransportProvider/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster WebRTCTransportProvider (cluster code: 1363/0x04553)
+// Identifier constant values for cluster WebRTCTransportProvider (cluster code: 1363/0x0553)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/WebRTCTransportRequestor/Ids.h
+++ b/zzz_generated/app-common/clusters/WebRTCTransportRequestor/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster WebRTCTransportRequestor (cluster code: 1364/0x04554)
+// Identifier constant values for cluster WebRTCTransportRequestor (cluster code: 1364/0x0554)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/Ids.h
+++ b/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster WiFiNetworkDiagnostics (cluster code: 54/0x0436)
+// Identifier constant values for cluster WiFiNetworkDiagnostics (cluster code: 54/0x0036)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/WiFiNetworkManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/WiFiNetworkManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster WiFiNetworkManagement (cluster code: 1105/0x04451)
+// Identifier constant values for cluster WiFiNetworkManagement (cluster code: 1105/0x0451)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/WindowCovering/Ids.h
+++ b/zzz_generated/app-common/clusters/WindowCovering/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster WindowCovering (cluster code: 258/0x04102)
+// Identifier constant values for cluster WindowCovering (cluster code: 258/0x0102)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 

--- a/zzz_generated/app-common/clusters/ZoneManagement/Ids.h
+++ b/zzz_generated/app-common/clusters/ZoneManagement/Ids.h
@@ -1,6 +1,6 @@
 // DO NOT EDIT MANUALLY - Generated file
 //
-// Identifier constant values for cluster ZoneManagement (cluster code: 1360/0x04550)
+// Identifier constant values for cluster ZoneManagement (cluster code: 1360/0x0550)
 // based on src/controller/data_model/controller-clusters.matter
 #pragma once
 


### PR DESCRIPTION
#### Summary

This is a small change to fix a typo in the `Ids.h.jinja` file that is used to generate the `Ids.h` files for each cluster.

This typo caused that and additional "4" was added to each cluster hex code in the file header, this only affects the comment and code remains unchanged.

#### Testing

CI should validate, change only affects comments so no functional change is expected.
