### PR TITLE
[WEBRTCR] Send command to DUT via websocket in CI (#41486)

### DIFF
--- a/src/python_testing/TC_WEBRTCRTestBase.py
+++ b/src/python_testing/TC_WEBRTCRTestBase.py
@@ -1,0 +1,80 @@
+#
+#  Copyright (c) 2025 Project CHIP Authors
+#  All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import logging
+
+import websockets
+
+from matter.testing.matter_testing import MatterBaseTest
+
+# WebSocket server URI for sending commands to the DUT
+SERVER_URI = "ws://localhost:9002"
+
+
+class WEBRTCRTestBase(MatterBaseTest):
+    """
+    Base class for WebRTC Transport Requestor test cases.
+
+    Provides common functionality including:
+    - WebSocket-based command sending to the DUT
+    - Shared SERVER_URI constant
+    """
+
+    async def send_command(self, command):
+        """
+        Send a command to the DUT via WebSocket and wait for response.
+
+        Args:
+            command: The command string to send to the DUT
+
+        This method:
+        1. Connects to the WebSocket server at SERVER_URI
+        2. Sends the command
+        3. Waits for and receives the response
+        4. Logs the connection, command, and response status
+
+        Raises:
+            Exception: Re-raises any exceptions after logging them clearly
+        """
+        try:
+            async with websockets.connect(SERVER_URI) as websocket:
+                logging.info(f"Connected to {SERVER_URI}")
+
+                # Send command
+                logging.info(f"Sending command: {command}")
+                await websocket.send(command)
+
+                # Receive response
+                await websocket.recv()
+                logging.info("Received command response")
+
+        except ConnectionRefusedError as e:
+            logging.error(f"Failed to connect to WebSocket server at {SERVER_URI}: Connection refused. "
+                          f"Is the DUT WebSocket server running? Error: {e}")
+            raise
+
+        except websockets.exceptions.WebSocketException as e:
+            logging.error(f"WebSocket error while communicating with {SERVER_URI}: {e}")
+            raise
+
+        except OSError as e:
+            logging.error(f"Network error while connecting to {SERVER_URI}: {e}")
+            raise
+
+        except Exception as e:
+            logging.error(f"Unexpected error while sending command '{command}' to {SERVER_URI}: {e}")
+            raise

--- a/src/python_testing/TC_WEBRTCR_2_1.py
+++ b/src/python_testing/TC_WEBRTCR_2_1.py
@@ -21,6 +21,8 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
+#     app: ${CAMERA_CONTROLLER_APP}
+#     app-args: interactive server
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -38,14 +40,15 @@ import tempfile
 from time import sleep
 
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_1(MatterBaseTest):
+class TC_WebRTCR_2_1(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -152,7 +155,7 @@ class TC_WebRTCR_2_1(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
+            await self.send_command(f"pairing onnetwork 1 {passcode}")
             resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)
@@ -201,8 +204,17 @@ class TC_WebRTCR_2_1(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
-            resp = 'Y'
+            self.th_server.set_output_match("NOT_FOUND")
+            self.th_server.event.clear()
+
+            try:
+                await self.send_command("webrtc establish-session 1 --offer-type 1")
+                # Wait up to 90s until the provider logs that the data‑channel opened
+                if not self.th_server.event.wait(90):
+                    raise TimeoutError("PeerConnection is not connected within 90s")
+                resp = 'Y'
+            except TimeoutError:
+                resp = 'N'
         else:
             resp = self.wait_for_user_input(prompt_msg)
 

--- a/src/python_testing/TC_WEBRTCR_2_3.py
+++ b/src/python_testing/TC_WEBRTCR_2_3.py
@@ -38,16 +38,14 @@ import logging
 import os
 import tempfile
 
-import websockets
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-
-SERVER_URI = "ws://localhost:9002"
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_3(MatterBaseTest):
+class TC_WebRTCR_2_3(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -118,18 +116,6 @@ class TC_WebRTCR_2_3(MatterBaseTest):
     @property
     def default_timeout(self) -> int:
         return 3 * 60
-
-    async def send_command(self, command):
-        async with websockets.connect(SERVER_URI) as websocket:
-            logging.info(f"Connected to {SERVER_URI}")
-
-            # Send command
-            logging.info(f"Sending command: {command}")
-            await websocket.send(command)
-
-            # Receive response
-            await websocket.recv()
-            logging.info("Received command response")
 
     @async_test_body
     async def test_TC_WebRTCR_2_3(self):

--- a/src/python_testing/TC_WEBRTCR_2_4.py
+++ b/src/python_testing/TC_WEBRTCR_2_4.py
@@ -38,16 +38,14 @@ import logging
 import os
 import tempfile
 
-import websockets
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-
-SERVER_URI = "ws://localhost:9002"
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_4(MatterBaseTest):
+class TC_WebRTCR_2_4(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -118,18 +116,6 @@ class TC_WebRTCR_2_4(MatterBaseTest):
     @property
     def default_timeout(self) -> int:
         return 3 * 60
-
-    async def send_command(self, command):
-        async with websockets.connect(SERVER_URI) as websocket:
-            logging.info(f"Connected to {SERVER_URI}")
-
-            # Send command
-            logging.info(f"Sending command: {command}")
-            await websocket.send(command)
-
-            # Receive response
-            await websocket.recv()
-            logging.info("Received command response")
 
     @async_test_body
     async def test_TC_WebRTCR_2_4(self):

--- a/src/python_testing/TC_WEBRTCR_2_5.py
+++ b/src/python_testing/TC_WEBRTCR_2_5.py
@@ -21,6 +21,8 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
+#     app: ${CAMERA_CONTROLLER_APP}
+#     app-args: interactive server
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -38,13 +40,14 @@ import tempfile
 from time import sleep
 
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_5(MatterBaseTest):
+class TC_WebRTCR_2_5(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -156,7 +159,7 @@ class TC_WebRTCR_2_5(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
+            await self.send_command(f"pairing onnetwork 1 {passcode}")
             resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)
@@ -204,8 +207,17 @@ class TC_WebRTCR_2_5(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: establish session via websocket
-            resp = 'Y'
+            self.th_server.set_output_match("PeerConnection State: Connected")
+            self.th_server.event.clear()
+
+            try:
+                await self.send_command("webrtc establish-session 1")
+                # Wait up to 90s until the provider logs that the data‑channel opened
+                if not self.th_server.event.wait(90):
+                    raise TimeoutError("PeerConnection is not connected within 90s")
+                resp = 'Y'
+            except TimeoutError:
+                resp = 'N'
         else:
             resp = self.wait_for_user_input(prompt_msg)
 

--- a/src/python_testing/TC_WEBRTCR_2_6.py
+++ b/src/python_testing/TC_WEBRTCR_2_6.py
@@ -21,6 +21,8 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
+#     app: ${CAMERA_CONTROLLER_APP}
+#     app-args: interactive server
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -38,14 +40,15 @@ import tempfile
 from time import sleep
 
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_6(MatterBaseTest):
+class TC_WebRTCR_2_6(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -153,7 +156,7 @@ class TC_WebRTCR_2_6(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
+            await self.send_command(f"pairing onnetwork 1 {passcode}")
             resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)
@@ -203,8 +206,17 @@ class TC_WebRTCR_2_6(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
-            resp = 'Y'
+            self.th_server.set_output_match("NOT_FOUND")
+            self.th_server.event.clear()
+
+            try:
+                await self.send_command("webrtc establish-session 1")
+                # Wait up to 90s until the provider logs that the data‑channel opened
+                if not self.th_server.event.wait(90):
+                    raise TimeoutError("PeerConnection is not connected within 90s")
+                resp = 'Y'
+            except TimeoutError:
+                resp = 'N'
         else:
             resp = self.wait_for_user_input(prompt_msg)
 

--- a/src/python_testing/TC_WEBRTCR_2_7.py
+++ b/src/python_testing/TC_WEBRTCR_2_7.py
@@ -21,6 +21,8 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
+#     app: ${CAMERA_CONTROLLER_APP}
+#     app-args: interactive server
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -38,14 +40,15 @@ import tempfile
 from time import sleep
 
 from mobly import asserts
+from TC_WEBRTCRTestBase import WEBRTCRTestBase
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter.testing.matter_testing import TestStep, async_test_body, default_matter_test_main
 
 
-class TC_WebRTCR_2_7(MatterBaseTest):
+class TC_WebRTCR_2_7(WEBRTCRTestBase):
     def setup_class(self):
         super().setup_class()
 
@@ -153,7 +156,7 @@ class TC_WebRTCR_2_7(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
+            await self.send_command(f"pairing onnetwork 1 {passcode}")
             resp = 'Y'
         else:
             resp = self.wait_for_user_input(prompt_msg)
@@ -203,8 +206,17 @@ class TC_WebRTCR_2_7(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
-            resp = 'Y'
+            self.th_server.set_output_match("CONSTRAINT_ERROR")
+            self.th_server.event.clear()
+
+            try:
+                await self.send_command("webrtc establish-session 1")
+                # Wait up to 90s until the provider logs that the data‑channel opened
+                if not self.th_server.event.wait(90):
+                    raise TimeoutError("PeerConnection is not connected within 90s")
+                resp = 'Y'
+            except TimeoutError:
+                resp = 'N'
         else:
             resp = self.wait_for_user_input(prompt_msg)
 

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -130,6 +130,9 @@ not_automated:
       reason: Depends on a browser peer for webrtc. CI is not supported.
     - name: TC_CHIMETestBase.py
       reason: Shared code for the Chime Cluster, not a standalone test.
+    - name: TC_WEBRTCRTestBase.py
+      reason:
+          Shared code for the WebRTC Requestor Cluster, not a standalone test.
     - name: TC_WEBRTCPTestBase.py
       reason:
           Shared code for the WebRTC Provider Cluster, not a standalone test.


### PR DESCRIPTION
* [WEBRTCR] Send command to DUT via websocket in CI

* Update src/python_testing/TC_WEBRTCR_2_2.py



* Update src/python_testing/TC_WEBRTCR_2_6.py



* Update src/python_testing/TC_WEBRTCR_2_7.py



* Restyled by autopep8

* Restyled by isort

* Address review comments

---------

#### Summary

Cherry pick [WEBRTCR] Send command to DUT via websocket in CI (#41486)

#### Related issues

N/A

#### Testing

Validate by CI
