### PR TITLE
[Linux] Fix bootstrap failure after python update

### DIFF
--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -141,6 +141,7 @@ _bootstrap_or_activate() {
     $_CHIP_ROOT/scripts/setup/gen_pigweed_cipd_json.py \
         -i $_PIGWEED_CIPD_JSON                         \
         -o $_GENERATED_PIGWEED_CIPD_JSON               \
+        -e linux:$_PYTHON_CIPD_JSON                    \
         -e darwin:$_PYTHON_CIPD_JSON                   \
         -e windows:$_PYTHON_CIPD_JSON
 


### PR DESCRIPTION
#### Summary

The bootstrap script is trying to use Python 3.11 specifically, when your Linux system has been updated to Python 3.13. The error message mentions python3.11-venv but you have python3-venv for Python 3.13 installed.

The issue is on line 153-154 of bootstrap.sh. It's hardcoding python311.json for Darwin and Windows, but NOT for Linux. The script assumes Linux will use the system Python, which now is Python 3.13, but the Pigweed setup is trying to create a venv with Python 3.11 specific packages.

This PR use Python from CIPD for Linux, just like it does for Darwin and Windows. This will ensure that Python 3.11 is downloaded and used consistently across all platforms, avoiding conflicts with your system's Python 3.13.

Re-run the bootstrap script:

This should now download Python 3.11 from CIPD for Linux and create the virtual environment successfully, avoiding the conflict with your system's Python 3.13.

The change I made adds -e linux:$_PYTHON_CIPD_JSON to the gen_pigweed_cipd_json.py command, which tells it to include the Python 3.11 CIPD package for Linux as well.

#### Related issues

N/A

#### Testing

1. Remove the [.environment] directory again to start fresh:
rm -rf .environment

Re-run the bootstrap script:
source scripts/bootstrap.sh --platform linux

#### Readability checklist
