### PR TITLE
[NXP] Allow extra customization of default lock app

### DIFF
--- a/examples/lock-app/nxp/common/main/AppTask.cpp
+++ b/examples/lock-app/nxp/common/main/AppTask.cpp
@@ -168,7 +168,9 @@ LockApp::AppTask & LockApp::AppTask::GetDefaultInstance()
     return sAppTask;
 }
 
+#ifndef CONFIG_APP_TASK_CUSTOM_SINGLETON_IMPL
 chip::NXP::App::AppTaskBase & chip::NXP::App::GetAppTask()
 {
     return LockApp::AppTask::GetDefaultInstance();
 }
+#endif

--- a/examples/lock-app/nxp/common/main/DeviceCallbacks.cpp
+++ b/examples/lock-app/nxp/common/main/DeviceCallbacks.cpp
@@ -93,7 +93,9 @@ LockApp::DeviceCallbacks & LockApp::DeviceCallbacks::GetDefaultInstance()
     return sDeviceCallbacks;
 }
 
+#ifndef CONFIG_APP_DEVICE_CALLBACKS_CUSTOM_SINGLETON_IMPL
 chip::DeviceManager::CHIPDeviceManagerCallbacks & chip::NXP::App::GetDeviceCallbacks()
 {
     return LockApp::DeviceCallbacks::GetDefaultInstance();
 }
+#endif

--- a/examples/platform/nxp/common/Kconfig
+++ b/examples/platform/nxp/common/Kconfig
@@ -74,21 +74,27 @@ if CHIP_APP_BLE_MANAGER
 
     endchoice # CHIP_APP_BLE_MANAGER
 
-    config CHIP_APP_EXTRA_GATT_DB_HEADER
-        string "Extra application Gatt db header"
-        default "<$(CHIP_ROOT)/examples/platform/nxp/mcxw71/app_ble/include/extra_gatt_db.h>" if CHIP_NXP_PLATFORM_MCXW71 || CHIP_NXP_PLATFORM_MCXW72
-        depends on CHIP_NXP_MULTIPLE_BLE_CONNECTIONS
-        help
+endif # CHIP_APP_BLE_MANAGER
+
+config CHIP_APP_CUSTOMIZE_EXTRA_GATT_INFO
+    bool "Enable customization of GATT service on MCXW platform"
+    default y if CHIP_NXP_MULTIPLE_BLE_CONNECTIONS
+    help
+        Enable customization of GATT service on MCXW platform
+
+if CHIP_APP_CUSTOMIZE_EXTRA_GATT_INFO
+config CHIP_APP_EXTRA_GATT_DB_HEADER
+    string "Extra application Gatt db header"
+    default "<$(CHIP_ROOT)/examples/platform/nxp/mcxw71/app_ble/include/extra_gatt_db.h>" if CHIP_NXP_PLATFORM_MCXW71 || CHIP_NXP_PLATFORM_MCXW72
+    help
         Set path to extra application Gatt db header.
 
-    config CHIP_APP_EXTRA_GATT_UUID_HEADER
-        string "Extra application Gatt UUID header"
-        default "<$(CHIP_ROOT)/examples/platform/nxp/mcxw71/app_ble/include/extra_gatt_uuid128.h>" if CHIP_NXP_PLATFORM_MCXW71 || CHIP_NXP_PLATFORM_MCXW72
-        depends on CHIP_NXP_MULTIPLE_BLE_CONNECTIONS
-        help
+config CHIP_APP_EXTRA_GATT_UUID_HEADER
+    string "Extra application Gatt UUID header"
+    default "<$(CHIP_ROOT)/examples/platform/nxp/mcxw71/app_ble/include/extra_gatt_uuid128.h>" if CHIP_NXP_PLATFORM_MCXW71 || CHIP_NXP_PLATFORM_MCXW72
+    help
         Set path to extra application Gatt UUID header.
-
-endif # CHIP_APP_BLE_MANAGER
+endif
 
 config DIAG_LOGS_DEMO
 	bool "Diagnostic log demo"


### PR DESCRIPTION
Allow selecting extra gatt db header without depending on other config options. 
Allow deriving the base lock app AppTask and DeviceCallbacks classes.

#### Testing

This change only affects NXP examples. Tested the examples build internally.
