### PR TITLE
Harmonize minimum required Python version to 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-python_requires = ">=3.11"
+requires-python = ">=3.11"
 
 [tool.autopep8]
 max_line_length = 132

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+python_requires = ">=3.11"
+
 [tool.autopep8]
 max_line_length = 132
 
@@ -7,7 +10,7 @@ known_first_party = "matter"
 
 [tool.ruff]
 line-length = 132
-target-version = "py310"
+target-version = "py311"
 exclude = [
     ".environment",
     ".git",

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -378,7 +378,7 @@ matter_python_wheel_action("matter-core") {
 
   public_deps = [ ":ChipDeviceCtrl" ]
 
-  output_name = "${py_package_name}-${chip_python_version}-cp37-abi3-${py_platform_tag}.whl"
+  output_name = "${py_package_name}-${chip_python_version}-cp311-abi3-${py_platform_tag}.whl"
 }
 
 matter_python_wheel_action("matter-clusters") {

--- a/src/controller/python/build-matter-wheel.py
+++ b/src/controller/python/build-matter-wheel.py
@@ -132,7 +132,7 @@ try:
             "License :: OSI Approved :: Apache Software License",
             "Programming Language :: Python :: 3"
         ],
-        python_requires=">=3.7",
+        python_requires=">=3.11",
         packages=packages,
         package_dir={
             # By default, look in the tmp directory for packages/modules to be included.
@@ -150,7 +150,7 @@ try:
                 'universal': False,
                 # Place the generated .whl in the dist directory.
                 'dist_dir': distDir,
-                'py_limited_api': 'cp37',
+                'py_limited_api': 'cp311',
                 'plat_name': args.plat_name,
             },
             'egg_info': {

--- a/src/test_driver/linux-cirque/CommissioningFailureOnReportTest.py
+++ b/src/test_driver/linux-cirque/CommissioningFailureOnReportTest.py
@@ -94,7 +94,7 @@ class TestCommissioningFailure(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 

--- a/src/test_driver/linux-cirque/CommissioningFailureTest.py
+++ b/src/test_driver/linux-cirque/CommissioningFailureTest.py
@@ -94,7 +94,7 @@ class TestCommissioningFailure(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 

--- a/src/test_driver/linux-cirque/CommissioningTest.py
+++ b/src/test_driver/linux-cirque/CommissioningTest.py
@@ -135,7 +135,7 @@ class TestCommissioner(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 

--- a/src/test_driver/linux-cirque/CommissioningWindowTest.py
+++ b/src/test_driver/linux-cirque/CommissioningWindowTest.py
@@ -98,7 +98,7 @@ class TestCommissioningWindow(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 

--- a/src/test_driver/linux-cirque/FailsafeTest.py
+++ b/src/test_driver/linux-cirque/FailsafeTest.py
@@ -93,7 +93,7 @@ class TestFailsafe(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 

--- a/src/test_driver/linux-cirque/IcdDeviceTest.py
+++ b/src/test_driver/linux-cirque/IcdDeviceTest.py
@@ -99,7 +99,7 @@ class TestCommissioner(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 

--- a/src/test_driver/linux-cirque/MobileDeviceTest.py
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.py
@@ -92,7 +92,7 @@ class TestPythonController(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 

--- a/src/test_driver/linux-cirque/PythonCommissioningTest.py
+++ b/src/test_driver/linux-cirque/PythonCommissioningTest.py
@@ -107,7 +107,7 @@ class TestCommissioner(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 

--- a/src/test_driver/linux-cirque/SplitCommissioningTest.py
+++ b/src/test_driver/linux-cirque/SplitCommissioningTest.py
@@ -101,7 +101,7 @@ class TestSplitCommissioning(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 

--- a/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
@@ -128,7 +128,7 @@ class TestSubscriptionResumptionCapacity(CHIPVirtualHome):
             self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
                 CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
             self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-                CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+                CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
             self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
                 CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
@@ -105,7 +105,7 @@ class TestSubscriptionResumption(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTimeoutTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTimeoutTest.py
@@ -104,7 +104,7 @@ class TestSubscriptionResumptionTimeout(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_clusters-1.0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_core-1.0.0-cp311-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/matter_repl-1.0.0-py3-none-any.whl")))
 


### PR DESCRIPTION
#### Summary

It would be good to harmonize the Python version requirements for our code before publishing to pypi. I decided to bump all python version tags that I could find to >=3.11 because of the following:
- we use python 3.11 features in our code already as reported by `ruff`
- it is the most recent Python version available in Ubuntu 22.04 LTS (https://documentation.ubuntu.com/ubuntu-for-developers/reference/availability/python/) which is stil supported until 2027

I also bumped the cpython `cp37` abi tag to `cp311` just in case even though afaict we don't use python c api.

#### Related issues

#### Testing

Code itself was not changed. I ran build_python.sh just in case to check if nothing fails.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
