### PR TITLE
[NXP] Fix DnssdImplBr handling of SRP cache resolve

### DIFF
--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -1044,9 +1044,9 @@ static void HandleResolveCleanup(mDnsQueryCtx & resolveContext, ResolveStep step
         break;
     }
 
-    // In this case the resolve operation could not be completed successfully so we need to call 
-    // DispatchResolveError to handle the Matter callback with an error case. No IP address is reported and 
-    // the address resolve operation doesn’t need to be stopped again as was not started in the first place 
+    // In this case the resolve operation could not be completed successfully so we need to call
+    // DispatchResolveError to handle the Matter callback with an error case. No IP address is reported and
+    // the address resolve operation doesn’t need to be stopped again as was not started in the first place
     // or it's already handled by HandleResolveCleanup.
     DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError, reinterpret_cast<intptr_t>(&resolveContext));
 }

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -88,12 +88,16 @@ struct mDnsQueryCtx
 
     mDnsQueryCtx(void * context, DnsBrowseCallback aBrowseCallback)
     {
+        link.next = nullptr;
+        link.list = nullptr;
         matterCtx          = context;
         mDnsBrowseCallback = aBrowseCallback;
         error              = CHIP_NO_ERROR;
     }
     mDnsQueryCtx(void * context, DnsResolveCallback aResolveCallback)
     {
+        link.next = nullptr;
+        link.list = nullptr;
         matterCtx           = context;
         mDnsResolveCallback = aResolveCallback;
         error               = CHIP_NO_ERROR;
@@ -127,6 +131,7 @@ static void DispatchBrowse(intptr_t context);
 static void DispatchTxtResolve(intptr_t context);
 static void DispatchAddressResolve(intptr_t context);
 static void DispatchResolve(intptr_t context);
+static void DispatchResolveSrp(intptr_t context);
 static void DispatchResolveError(intptr_t context);
 
 static void HandleResolveCleanup(mDnsQueryCtx & resolveContext, ResolveStep stepType);
@@ -186,7 +191,6 @@ void NxpChipDnssdShutdown()
         // Stop all browse operations and clean the browse list
         otInstance * thrInstancePtr  = ThreadStackMgrImpl().OTInstance();
         mDnsQueryCtx * pQueryContext = reinterpret_cast<mDnsQueryCtx *>(LIST_GetHead(&mBrowseList));
-        ;
 
         while (pQueryContext)
         {
@@ -609,7 +613,7 @@ CHIP_ERROR ResolveBySrp(otInstance * thrInstancePtr, char * serviceName, mDnsQue
                 error = FromSrpCacheToMdnsData(service, host, mdnsReq, context->mMdnsService, context->mServiceTxtEntry);
                 if (error == CHIP_NO_ERROR)
                 {
-                    DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolve, reinterpret_cast<intptr_t>(context));
+                    DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveSrp, reinterpret_cast<intptr_t>(context));
                 }
                 break;
             }
@@ -879,6 +883,7 @@ static void OtTxtCallback(otInstance * aInstance, const otMdnsTxtResult * aResul
         if (alloc.AnyAllocFailed())
         {
             bSendDispatch = false;
+            pResolveContext->error = CHIP_ERROR_NO_MEMORY;
         }
         else
         {
@@ -992,6 +997,24 @@ static void DispatchResolve(intptr_t context)
     Platform::Delete<mDnsQueryCtx>(pResolveContext);
 }
 
+static void DispatchResolveSrp(intptr_t context)
+{
+    mDnsQueryCtx * pResolveContext = reinterpret_cast<mDnsQueryCtx *>(context);
+    Dnssd::DnssdService & service  = pResolveContext->mMdnsService;
+    Span<Inet::IPAddress> ipAddrs;
+
+    // Address resolver was not started and the resolve context was not added to the resolve list
+    // when the result came directly from SRP.
+
+    if (service.mAddress.has_value())
+    {
+        ipAddrs = Span<Inet::IPAddress>(&*service.mAddress, 1);
+    }
+
+    pResolveContext->mDnsResolveCallback(pResolveContext->matterCtx, &service, ipAddrs, pResolveContext->error);
+    Platform::Delete<mDnsQueryCtx>(pResolveContext);
+}
+
 static void DispatchResolveError(intptr_t context)
 {
     mDnsQueryCtx * pResolveContext = reinterpret_cast<mDnsQueryCtx *>(context);
@@ -1021,7 +1044,7 @@ static void HandleResolveCleanup(mDnsQueryCtx & resolveContext, ResolveStep step
         break;
     }
 
-    DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolve, reinterpret_cast<intptr_t>(&resolveContext));
+    DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError, reinterpret_cast<intptr_t>(&resolveContext));
 }
 
 static mDnsQueryCtx * GetResolveElement(const char * aName, NameType aType)

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -1044,6 +1044,10 @@ static void HandleResolveCleanup(mDnsQueryCtx & resolveContext, ResolveStep step
         break;
     }
 
+    // In this case the resolve operation could not be completed successfully so we need to call 
+    // DispatchResolveError to handle the Matter callback with an error case. No IP address is reported and 
+    // the address resolve operation doesn’t need to be stopped again as was not started in the first place 
+    // or it's already handled by HandleResolveCleanup.
     DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError, reinterpret_cast<intptr_t>(&resolveContext));
 }
 

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -88,16 +88,16 @@ struct mDnsQueryCtx
 
     mDnsQueryCtx(void * context, DnsBrowseCallback aBrowseCallback)
     {
-        link.next = nullptr;
-        link.list = nullptr;
+        link.next          = nullptr;
+        link.list          = nullptr;
         matterCtx          = context;
         mDnsBrowseCallback = aBrowseCallback;
         error              = CHIP_NO_ERROR;
     }
     mDnsQueryCtx(void * context, DnsResolveCallback aResolveCallback)
     {
-        link.next = nullptr;
-        link.list = nullptr;
+        link.next           = nullptr;
+        link.list           = nullptr;
         matterCtx           = context;
         mDnsResolveCallback = aResolveCallback;
         error               = CHIP_NO_ERROR;
@@ -882,7 +882,7 @@ static void OtTxtCallback(otInstance * aInstance, const otMdnsTxtResult * aResul
 
         if (alloc.AnyAllocFailed())
         {
-            bSendDispatch = false;
+            bSendDispatch          = false;
             pResolveContext->error = CHIP_ERROR_NO_MEMORY;
         }
         else


### PR DESCRIPTION
#### Summary

This commit fixes the case where a service query is resolved directly from the SRP cache on a Border Router. In this case there is no need to add the context to the list and start the OT mMDNS client.

#### Testing

Tested on a NXP Border Router Matter node with Matter over Thread devices connected to it. The BR is the SRP server for the Thread devices. 
Tested by issuing queries to _matter_tcp from the Matter CLI to the Matter over Thread nodes.