### PR TITLE
Clean up and make use of ValidateGlobalAttributes once.

### DIFF
--- a/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
@@ -63,26 +63,17 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
         BasicInformationCluster::Instance().OptionalAttributes() =
             BasicInformationCluster::OptionalAttributesSet().Set<UniqueID::Id>();
 
-        EXPECT_TRUE(Testing::IsAttributesListEqualTo(BasicInformationCluster::Instance(),
-                                                     {
+        EXPECT_TRUE(Testing::IsAttributesListEqualTo(
+            BasicInformationCluster::Instance(),
+            {
 
-                                                         DataModelRevision::kMetadataEntry,
-                                                         VendorName::kMetadataEntry,
-                                                         VendorID::kMetadataEntry,
-                                                         ProductName::kMetadataEntry,
-                                                         ProductID::kMetadataEntry,
-                                                         NodeLabel::kMetadataEntry,
-                                                         Location::kMetadataEntry,
-                                                         HardwareVersion::kMetadataEntry,
-                                                         HardwareVersionString::kMetadataEntry,
-                                                         SoftwareVersion::kMetadataEntry,
-                                                         SoftwareVersionString::kMetadataEntry,
-                                                         CapabilityMinima::kMetadataEntry,
-                                                         SpecificationVersion::kMetadataEntry,
-                                                         MaxPathsPerInvoke::kMetadataEntry,
-                                                         ConfigurationVersion::kMetadataEntry,
-                                                         UniqueID::kMetadataEntry, // required in latest spec
-                                                     }));
+                DataModelRevision::kMetadataEntry, VendorName::kMetadataEntry, VendorID::kMetadataEntry,
+                ProductName::kMetadataEntry, ProductID::kMetadataEntry, NodeLabel::kMetadataEntry, Location::kMetadataEntry,
+                HardwareVersion::kMetadataEntry, HardwareVersionString::kMetadataEntry, SoftwareVersion::kMetadataEntry,
+                SoftwareVersionString::kMetadataEntry, CapabilityMinima::kMetadataEntry, SpecificationVersion::kMetadataEntry,
+                MaxPathsPerInvoke::kMetadataEntry, ConfigurationVersion::kMetadataEntry,
+                UniqueID::kMetadataEntry, // required in latest spec
+            }));
     }
 
     // Check that disabling unique id works

--- a/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
@@ -17,6 +17,7 @@
 
 #include <app/clusters/basic-information/BasicInformationCluster.h>
 #include <app/clusters/testing/AttributeTesting.h>
+#include <app/clusters/testing/ValidateGlobalAttributes.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/BasicInformation/Enums.h>
@@ -62,22 +63,26 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
         BasicInformationCluster::Instance().OptionalAttributes() =
             BasicInformationCluster::OptionalAttributesSet().Set<UniqueID::Id>();
 
-        ReadOnlyBufferBuilder<AttributeEntry> builder;
-        ASSERT_EQ(BasicInformationCluster::Instance().Attributes({ kRootEndpointId, BasicInformation::Id }, builder),
-                  CHIP_NO_ERROR);
+        EXPECT_TRUE(Testing::IsAttributesListEqualTo(BasicInformationCluster::Instance(),
+                                                     {
 
-        ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
-        ASSERT_EQ(expectedBuilder.AppendElements({
-                      DataModelRevision::kMetadataEntry, VendorName::kMetadataEntry, VendorID::kMetadataEntry,
-                      ProductName::kMetadataEntry, ProductID::kMetadataEntry, NodeLabel::kMetadataEntry, Location::kMetadataEntry,
-                      HardwareVersion::kMetadataEntry, HardwareVersionString::kMetadataEntry, SoftwareVersion::kMetadataEntry,
-                      SoftwareVersionString::kMetadataEntry, CapabilityMinima::kMetadataEntry, SpecificationVersion::kMetadataEntry,
-                      MaxPathsPerInvoke::kMetadataEntry, ConfigurationVersion::kMetadataEntry,
-                      UniqueID::kMetadataEntry, // required in latest spec
-                  }),
-                  CHIP_NO_ERROR);
-        ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
-        ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+                                                         DataModelRevision::kMetadataEntry,
+                                                         VendorName::kMetadataEntry,
+                                                         VendorID::kMetadataEntry,
+                                                         ProductName::kMetadataEntry,
+                                                         ProductID::kMetadataEntry,
+                                                         NodeLabel::kMetadataEntry,
+                                                         Location::kMetadataEntry,
+                                                         HardwareVersion::kMetadataEntry,
+                                                         HardwareVersionString::kMetadataEntry,
+                                                         SoftwareVersion::kMetadataEntry,
+                                                         SoftwareVersionString::kMetadataEntry,
+                                                         CapabilityMinima::kMetadataEntry,
+                                                         SpecificationVersion::kMetadataEntry,
+                                                         MaxPathsPerInvoke::kMetadataEntry,
+                                                         ConfigurationVersion::kMetadataEntry,
+                                                         UniqueID::kMetadataEntry, // required in latest spec
+                                                     }));
     }
 
     // Check that disabling unique id works
@@ -85,31 +90,24 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
         // UniqueID is EXPLICITLY NOT SET
         BasicInformationCluster::Instance().OptionalAttributes() = BasicInformationCluster::OptionalAttributesSet();
 
-        ReadOnlyBufferBuilder<AttributeEntry> builder;
-        ASSERT_EQ(BasicInformationCluster::Instance().Attributes({ kRootEndpointId, BasicInformation::Id }, builder),
-                  CHIP_NO_ERROR);
-
-        ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
-        ASSERT_EQ(expectedBuilder.AppendElements({
-                      DataModelRevision::kMetadataEntry,
-                      VendorName::kMetadataEntry,
-                      VendorID::kMetadataEntry,
-                      ProductName::kMetadataEntry,
-                      ProductID::kMetadataEntry,
-                      NodeLabel::kMetadataEntry,
-                      Location::kMetadataEntry,
-                      HardwareVersion::kMetadataEntry,
-                      HardwareVersionString::kMetadataEntry,
-                      SoftwareVersion::kMetadataEntry,
-                      SoftwareVersionString::kMetadataEntry,
-                      CapabilityMinima::kMetadataEntry,
-                      SpecificationVersion::kMetadataEntry,
-                      MaxPathsPerInvoke::kMetadataEntry,
-                      ConfigurationVersion::kMetadataEntry,
-                  }),
-                  CHIP_NO_ERROR);
-        ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
-        ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+        EXPECT_TRUE(Testing::IsAttributesListEqualTo(BasicInformationCluster::Instance(),
+                                                     {
+                                                         DataModelRevision::kMetadataEntry,
+                                                         VendorName::kMetadataEntry,
+                                                         VendorID::kMetadataEntry,
+                                                         ProductName::kMetadataEntry,
+                                                         ProductID::kMetadataEntry,
+                                                         NodeLabel::kMetadataEntry,
+                                                         Location::kMetadataEntry,
+                                                         HardwareVersion::kMetadataEntry,
+                                                         HardwareVersionString::kMetadataEntry,
+                                                         SoftwareVersion::kMetadataEntry,
+                                                         SoftwareVersionString::kMetadataEntry,
+                                                         CapabilityMinima::kMetadataEntry,
+                                                         SpecificationVersion::kMetadataEntry,
+                                                         MaxPathsPerInvoke::kMetadataEntry,
+                                                         ConfigurationVersion::kMetadataEntry,
+                                                     }));
     }
 
     // All attributes
@@ -126,40 +124,34 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
                 .Set<ProductAppearance::Id>()
                 .Set<UniqueID::Id>();
 
-        ReadOnlyBufferBuilder<AttributeEntry> builder;
-        ASSERT_EQ(BasicInformationCluster::Instance().Attributes({ kRootEndpointId, BasicInformation::Id }, builder),
-                  CHIP_NO_ERROR);
+        EXPECT_TRUE(Testing::IsAttributesListEqualTo(BasicInformationCluster::Instance(),
 
-        ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
-        ASSERT_EQ(expectedBuilder.AppendElements({
-                      DataModelRevision::kMetadataEntry,
-                      VendorName::kMetadataEntry,
-                      VendorID::kMetadataEntry,
-                      ProductName::kMetadataEntry,
-                      ProductID::kMetadataEntry,
-                      NodeLabel::kMetadataEntry,
-                      Location::kMetadataEntry,
-                      HardwareVersion::kMetadataEntry,
-                      HardwareVersionString::kMetadataEntry,
-                      SoftwareVersion::kMetadataEntry,
-                      SoftwareVersionString::kMetadataEntry,
-                      CapabilityMinima::kMetadataEntry,
-                      SpecificationVersion::kMetadataEntry,
-                      MaxPathsPerInvoke::kMetadataEntry,
-                      ConfigurationVersion::kMetadataEntry,
-                      UniqueID::kMetadataEntry,
-                      ManufacturingDate::kMetadataEntry,
-                      PartNumber::kMetadataEntry,
-                      ProductURL::kMetadataEntry,
-                      ProductLabel::kMetadataEntry,
-                      SerialNumber::kMetadataEntry,
-                      LocalConfigDisabled::kMetadataEntry,
-                      Reachable::kMetadataEntry,
-                      ProductAppearance::kMetadataEntry,
-                  }),
-                  CHIP_NO_ERROR);
-        ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
-        ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+                                                     {
+                                                         DataModelRevision::kMetadataEntry,
+                                                         VendorName::kMetadataEntry,
+                                                         VendorID::kMetadataEntry,
+                                                         ProductName::kMetadataEntry,
+                                                         ProductID::kMetadataEntry,
+                                                         NodeLabel::kMetadataEntry,
+                                                         Location::kMetadataEntry,
+                                                         HardwareVersion::kMetadataEntry,
+                                                         HardwareVersionString::kMetadataEntry,
+                                                         SoftwareVersion::kMetadataEntry,
+                                                         SoftwareVersionString::kMetadataEntry,
+                                                         CapabilityMinima::kMetadataEntry,
+                                                         SpecificationVersion::kMetadataEntry,
+                                                         MaxPathsPerInvoke::kMetadataEntry,
+                                                         ConfigurationVersion::kMetadataEntry,
+                                                         UniqueID::kMetadataEntry,
+                                                         ManufacturingDate::kMetadataEntry,
+                                                         PartNumber::kMetadataEntry,
+                                                         ProductURL::kMetadataEntry,
+                                                         ProductLabel::kMetadataEntry,
+                                                         SerialNumber::kMetadataEntry,
+                                                         LocalConfigDisabled::kMetadataEntry,
+                                                         Reachable::kMetadataEntry,
+                                                         ProductAppearance::kMetadataEntry,
+                                                     }));
     }
 }
 

--- a/src/app/clusters/testing/BUILD.gn
+++ b/src/app/clusters/testing/BUILD.gn
@@ -23,6 +23,7 @@ source_set("testing") {
     "ClusterTester.h",
     "MockCommandHandler.cpp",
     "MockCommandHandler.h",
+    "ValidateGlobalAttributes.cpp",
     "ValidateGlobalAttributes.h",
   ]
 

--- a/src/app/clusters/testing/ValidateGlobalAttributes.cpp
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.cpp
@@ -1,0 +1,78 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <app/clusters/testing/ValidateGlobalAttributes.h>
+
+namespace chip::Testing {
+
+bool IsAttributesListEqualTo(app::ServerClusterInterface & cluster,
+                             std::initializer_list<const app::DataModel::AttributeEntry> expected)
+{
+    VerifyOrDie(cluster.GetPaths().size() == 1);
+    auto path = cluster.GetPaths()[0];
+    ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> attributesBuilder;
+    if (cluster.Attributes(path, attributesBuilder) != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    // build expectation with global attributes
+    ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> expectedBuilder;
+
+    SuccessOrDie(expectedBuilder.EnsureAppendCapacity(expected.size()));
+    for (const auto entry : expected)
+    {
+        SuccessOrDie(expectedBuilder.Append(entry));
+    }
+    SuccessOrDie(expectedBuilder.AppendElements(app::DefaultServerCluster::GlobalAttributes()));
+
+    return EqualAttributeSets(attributesBuilder.TakeBuffer(), expectedBuilder.TakeBuffer());
+}
+
+bool IsAcceptedCommandsListEqualTo(app::ServerClusterInterface & cluster,
+                                   std::initializer_list<const app::DataModel::AcceptedCommandEntry> expected)
+{
+    VerifyOrDie(cluster.GetPaths().size() == 1);
+    auto path = cluster.GetPaths()[0];
+    ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> commandsBuilder;
+    if (cluster.AcceptedCommands(path, commandsBuilder) != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> expectedBuilder;
+
+    SuccessOrDie(expectedBuilder.EnsureAppendCapacity(expected.size()));
+    for (const auto entry : expected)
+    {
+        SuccessOrDie(expectedBuilder.Append(entry));
+    }
+
+    return EqualAcceptedCommandSets(commandsBuilder.TakeBuffer(), expectedBuilder.TakeBuffer());
+}
+
+bool IsGeneratedCommandsListEqualTo(app::ServerClusterInterface & cluster, Span<CommandId> expected)
+{
+    VerifyOrDie(cluster.GetPaths().size() == 1);
+    auto path = cluster.GetPaths()[0];
+    ReadOnlyBufferBuilder<CommandId> commandsBuilder;
+    if (cluster.GeneratedCommands(path, commandsBuilder) != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+    return EqualGeneratedCommandSets(commandsBuilder.TakeBuffer(), expected);
+}
+
+} // namespace chip::Testing

--- a/src/app/clusters/testing/ValidateGlobalAttributes.cpp
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.cpp
@@ -32,7 +32,7 @@ bool IsAttributesListEqualTo(app::ServerClusterInterface & cluster,
     ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> expectedBuilder;
 
     SuccessOrDie(expectedBuilder.EnsureAppendCapacity(expected.size()));
-    for (const auto entry : expected)
+    for (const auto & entry : expected)
     {
         SuccessOrDie(expectedBuilder.Append(entry));
     }

--- a/src/app/clusters/testing/ValidateGlobalAttributes.cpp
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.cpp
@@ -55,7 +55,7 @@ bool IsAcceptedCommandsListEqualTo(app::ServerClusterInterface & cluster,
     ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> expectedBuilder;
 
     SuccessOrDie(expectedBuilder.EnsureAppendCapacity(expected.size()));
-    for (const auto entry : expected)
+    for (const auto & entry : expected)
     {
         SuccessOrDie(expectedBuilder.Append(entry));
     }

--- a/src/app/clusters/testing/ValidateGlobalAttributes.h
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.h
@@ -35,7 +35,7 @@ bool IsAttributesListEqualTo(app::ServerClusterInterface & cluster,
 /// This function retrieves the accepted commands for the first path returned by `cluster.GetPaths()`
 /// and compares them against the `expected` list of items.
 ///
-/// Parameter:
+/// Parameters:
 ///     cluster - The cluster interface to test.
 ///     expected - An initializer list of expected accepted command entries. May be empty.
 ///

--- a/src/app/clusters/testing/ValidateGlobalAttributes.h
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.h
@@ -69,26 +69,7 @@ bool IsAttributesListEqualTo(app::ServerClusterInterface & cluster,
 /// ASSERT_TRUE(IsAcceptedCommandsListEqualTo(cluster, { Commands::SomeCommand::kMetadataEntry }));
 /// ```
 bool IsAcceptedCommandsListEqualTo(app::ServerClusterInterface & cluster,
-                                   std::initializer_list<const app::DataModel::AcceptedCommandEntry> expected)
-{
-    VerifyOrDie(cluster.GetPaths().size() == 1);
-    auto path = cluster.GetPaths()[0];
-    ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> commandsBuilder;
-    if (cluster.AcceptedCommands(path, commandsBuilder) != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> expectedBuilder;
-
-    SuccessOrDie(expectedBuilder.EnsureAppendCapacity(expected.size()));
-    for (const auto entry : expected)
-    {
-        SuccessOrDie(expectedBuilder.Append(entry));
-    }
-
-    return EqualAcceptedCommandSets(commandsBuilder.TakeBuffer(), expectedBuilder.TakeBuffer());
-}
+                                   std::initializer_list<const app::DataModel::AcceptedCommandEntry> expected);
 
 /// Compares the generated commands of a cluster against an expected set.
 ///
@@ -106,17 +87,7 @@ bool IsAcceptedCommandsListEqualTo(app::ServerClusterInterface & cluster,
 /// ClusterImpl cluster(kTestEndpointId, ...);
 /// ASSERT_TRUE(IsGeneratedCommandsListEqualTo(cluster, { Commands::SomeCommandResponse::kMetadataEntry }));
 /// ```
-bool IsGeneratedCommandsListEqualTo(app::ServerClusterInterface & cluster, Span<CommandId> expected)
-{
-    VerifyOrDie(cluster.GetPaths().size() == 1);
-    auto path = cluster.GetPaths()[0];
-    ReadOnlyBufferBuilder<CommandId> commandsBuilder;
-    if (cluster.GeneratedCommands(path, commandsBuilder) != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-    return EqualGeneratedCommandSets(commandsBuilder.TakeBuffer(), expected);
-}
+bool IsGeneratedCommandsListEqualTo(app::ServerClusterInterface & cluster, Span<CommandId> expected);
 
 } // namespace Testing
 } // namespace chip

--- a/src/app/clusters/testing/ValidateGlobalAttributes.h
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "AttributeTesting.h"
-#include "lib/core/CHIPError.h"
 
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/ServerClusterInterface.h>
+#include <lib/core/CHIPError.h>
 #include <lib/support/ReadOnlyBuffer.h>
 
 namespace chip {

--- a/src/app/clusters/testing/ValidateGlobalAttributes.h
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.h
@@ -41,12 +41,12 @@ bool IsAttributesListEqualTo(app::ServerClusterInterface & cluster,
     // build expectation with global attributes
     ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> expectedBuilder;
 
-    VerifyOrDie(expectedBuilder.EnsureAppendCapacity(expected.size()) == CHIP_NO_ERROR);
+    SuccessOrDie(expectedBuilder.EnsureAppendCapacity(expected.size()));
     for (const auto entry : expected)
     {
-        VerifyOrDie(expectedBuilder.Append(entry) == CHIP_NO_ERROR);
+        SuccessOrDie(expectedBuilder.Append(entry));
     }
-    VerifyOrDie(expectedBuilder.AppendElements(app::DefaultServerCluster::GlobalAttributes()) == CHIP_NO_ERROR);
+    SuccessOrDie(expectedBuilder.AppendElements(app::DefaultServerCluster::GlobalAttributes()));
 
     return EqualAttributeSets(attributesBuilder.TakeBuffer(), expectedBuilder.TakeBuffer());
 }
@@ -54,7 +54,7 @@ bool IsAttributesListEqualTo(app::ServerClusterInterface & cluster,
 /// Compares the accepted commands of a cluster against an expected set.
 ///
 /// This function retrieves the accepted commands for the first path returned by `cluster.GetPaths()`
-/// and compares them against the `expected` list.
+/// and compares them against the `expected` list of items.
 ///
 /// Parameter:
 ///     cluster - The cluster interface to test.
@@ -81,10 +81,10 @@ bool IsAcceptedCommandsListEqualTo(app::ServerClusterInterface & cluster,
 
     ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> expectedBuilder;
 
-    VerifyOrDie(expectedBuilder.EnsureAppendCapacity(expected.size()) == CHIP_NO_ERROR);
+    SuccessOrDie(expectedBuilder.EnsureAppendCapacity(expected.size()));
     for (const auto entry : expected)
     {
-        VerifyOrDie(expectedBuilder.Append(entry) == CHIP_NO_ERROR);
+        SuccessOrDie(expectedBuilder.Append(entry));
     }
 
     return EqualAcceptedCommandSets(commandsBuilder.TakeBuffer(), expectedBuilder.TakeBuffer());
@@ -93,7 +93,7 @@ bool IsAcceptedCommandsListEqualTo(app::ServerClusterInterface & cluster,
 /// Compares the generated commands of a cluster against an expected set.
 ///
 /// This function retrieves the generated commands for the first path returned by `cluster.GetPaths()`
-/// and compares them against the `expected` span.
+/// and compares them against the `expected` list of items.
 ///
 /// Parameter:
 ///     cluster - The cluster interface to test.

--- a/src/app/clusters/testing/ValidateGlobalAttributes.h
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.h
@@ -28,28 +28,7 @@ namespace Testing {
 /// ASSERT_TRUE(IsAttributesListEqualTo(cluster, { Attributes::SomeAttribute::kMetadataEntry }));
 /// ```
 bool IsAttributesListEqualTo(app::ServerClusterInterface & cluster,
-                             std::initializer_list<const app::DataModel::AttributeEntry> expected)
-{
-    VerifyOrDie(cluster.GetPaths().size() == 1);
-    auto path = cluster.GetPaths()[0];
-    ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> attributesBuilder;
-    if (cluster.Attributes(path, attributesBuilder) != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-
-    // build expectation with global attributes
-    ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> expectedBuilder;
-
-    SuccessOrDie(expectedBuilder.EnsureAppendCapacity(expected.size()));
-    for (const auto entry : expected)
-    {
-        SuccessOrDie(expectedBuilder.Append(entry));
-    }
-    SuccessOrDie(expectedBuilder.AppendElements(app::DefaultServerCluster::GlobalAttributes()));
-
-    return EqualAttributeSets(attributesBuilder.TakeBuffer(), expectedBuilder.TakeBuffer());
-}
+                             std::initializer_list<const app::DataModel::AttributeEntry> expected);
 
 /// Compares the accepted commands of a cluster against an expected set.
 ///

--- a/src/app/clusters/testing/ValidateGlobalAttributes.h
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.h
@@ -55,7 +55,7 @@ bool IsAcceptedCommandsListEqualTo(app::ServerClusterInterface & cluster,
 /// This function retrieves the generated commands for the first path returned by `cluster.GetPaths()`
 /// and compares them against the `expected` list of items.
 ///
-/// Parameter:
+/// Parameters:
 ///     cluster - The cluster interface to test.
 ///     expected - An initializer list of expected generated command entries. May be empty.
 ///


### PR DESCRIPTION
#### Summary

- adds a pragma once
- comments 
- use initializer list for validate global attributes.
- move implementation to cpp file (otherwise builds like NRF will complain of double definition at link time because the methods are not inline)

#### Testing

One unit test updated to make use of the new functionality.