### PR TITLE
[Cherry-pick] Fix missing report generation for PushAV and TLS clusters when Commands change attributes (#41837)

### DIFF
--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-logic.cpp
@@ -1012,6 +1012,9 @@ PushAvStreamTransportServerLogic::HandleModifyPushTransport(CommandHandler & han
     if (status == Status::Success)
     {
         transportConfiguration->SetTransportOptionsPtr(transportOptionsPtr);
+
+        MatterReportingAttributeChangeCallback(mEndpointId, PushAvStreamTransport::Id,
+                                               PushAvStreamTransport::Attributes::CurrentConnections::Id);
     }
 
     handler.AddStatus(commandPath, status);
@@ -1079,6 +1082,9 @@ PushAvStreamTransportServerLogic::HandleSetTransportStatus(CommandHandler & hand
                 }
             }
         }
+
+        MatterReportingAttributeChangeCallback(mEndpointId, PushAvStreamTransport::Id,
+                                               PushAvStreamTransport::Attributes::CurrentConnections::Id);
     }
     handler.AddStatus(commandPath, status);
 

--- a/src/app/clusters/tls-certificate-management-server/tls-certificate-management-server.cpp
+++ b/src/app/clusters/tls-certificate-management-server/tls-certificate-management-server.cpp
@@ -257,7 +257,11 @@ void TlsCertificateManagementServer::HandleProvisionRootCertificate(HandlerConte
     }
 
     VerifyOrDieWithMsg(response.caid <= kMaxRootCertId, NotSpecified, "Spec requires CAID to be < kMaxRootCertId");
+
     ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
+
+    MatterReportingAttributeChangeCallback(ctx.mRequestPath.mEndpointId, TlsCertificateManagement::Id,
+                                           TlsCertificateManagement::Attributes::ProvisionedRootCertificates::Id);
 }
 
 void TlsCertificateManagementServer::HandleFindRootCertificate(HandlerContext & ctx, const FindRootCertificate::DecodableType & req)
@@ -338,6 +342,13 @@ void TlsCertificateManagementServer::HandleRemoveRootCertificate(HandlerContext 
                     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidInState));
 
     auto result = mDelegate.RemoveRootCert(ctx.mRequestPath.mEndpointId, ctx.mCommandHandler.GetAccessingFabricIndex(), req.caid);
+
+    if (result == Status::Success)
+    {
+        MatterReportingAttributeChangeCallback(ctx.mRequestPath.mEndpointId, TlsCertificateManagement::Id,
+                                               TlsCertificateManagement::Attributes::ProvisionedRootCertificates::Id);
+    }
+
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, result);
 }
 
@@ -412,6 +423,13 @@ void TlsCertificateManagementServer::HandleProvisionClientCertificate(HandlerCon
                     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::NotFound));
 
     auto status = mDelegate.ProvisionClientCert(ctx.mRequestPath.mEndpointId, fabric, req);
+
+    if (status == Status::Success)
+    {
+        MatterReportingAttributeChangeCallback(ctx.mRequestPath.mEndpointId, TlsCertificateManagement::Id,
+                                               TlsCertificateManagement::Attributes::ProvisionedClientCertificates::Id);
+    }
+
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
@@ -498,6 +516,13 @@ void TlsCertificateManagementServer::HandleRemoveClientCertificate(HandlerContex
 
     auto result =
         mDelegate.RemoveClientCert(ctx.mRequestPath.mEndpointId, ctx.mCommandHandler.GetAccessingFabricIndex(), req.ccdid);
+
+    if (result == Status::Success)
+    {
+        MatterReportingAttributeChangeCallback(ctx.mRequestPath.mEndpointId, TlsCertificateManagement::Id,
+                                               TlsCertificateManagement::Attributes::ProvisionedClientCertificates::Id);
+    }
+
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, result);
 }
 

--- a/src/app/clusters/tls-client-management-server/tls-client-management-server.cpp
+++ b/src/app/clusters/tls-client-management-server/tls-client-management-server.cpp
@@ -169,6 +169,9 @@ void TlsClientManagementServer::HandleProvisionEndpoint(HandlerContext & ctx,
     if (status.IsSuccess())
     {
         ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
+
+        MatterReportingAttributeChangeCallback(ctx.mRequestPath.mEndpointId, TlsClientManagement::Id,
+                                               TlsClientManagement::Attributes::ProvisionedEndpoints::Id);
     }
     else
     {
@@ -209,6 +212,13 @@ void TlsClientManagementServer::HandleRemoveEndpoint(HandlerContext & ctx, const
 
     auto status = mDelegate.RemoveProvisionedEndpointByID(ctx.mRequestPath.mEndpointId,
                                                           ctx.mCommandHandler.GetAccessingFabricIndex(), req.endpointID);
+
+    if (status == Status::Success)
+    {
+        MatterReportingAttributeChangeCallback(ctx.mRequestPath.mEndpointId, TlsClientManagement::Id,
+                                               TlsClientManagement::Attributes::ProvisionedEndpoints::Id);
+    }
+
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 


### PR DESCRIPTION
#### Summary

* [PushAV] Add call to report generation on SetTransportStatus and ModifyPushTransport.

* [TLSCert and TLSClient Management] Add attribute change reporting when commands update the corresponding list attributes.

#### Testing

CI validation

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
