### PR TITLE
Small fixes to cluster unit testing infrastructure

### DIFF
--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -117,8 +117,7 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
 
     chip::app::Testing::MockCommandHandler cmdHandler;
     chip::Test::ClusterTester tester(cluster);
-    auto result =
-        tester.Invoke<Commands::JoinGroup::Type::ResponseType, Commands::JoinGroup::Type>(Commands::JoinGroup::Id, cmdData);
+    auto result = tester.Invoke(Commands::JoinGroup::Id, cmdData);
     ASSERT_TRUE(result.status.has_value());
     EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
               Protocols::InteractionModel::Status::Failure);     // Currently expect Failure as JoinGroup command returns

--- a/src/app/clusters/testing/AttributeTesting.h
+++ b/src/app/clusters/testing/AttributeTesting.h
@@ -14,6 +14,7 @@
  *    limitations under the License.
  */
 
+#pragma once
 #include <app/data-model-provider/MetadataTypes.h>
 #include <lib/support/Span.h>
 

--- a/src/app/clusters/testing/ClusterTester.h
+++ b/src/app/clusters/testing/ClusterTester.h
@@ -144,10 +144,9 @@ public:
     };
 
     // Invoke a command and return the decoded result.
-    // The `RequestType`, `ResponseType` type-parameters must be of the correct type for the command being invoked.
-    // Use `app::Clusters::<ClusterName>::Commands::<CommandName>::Type` for the `RequestType` type-parameter to be spec compliant
-    // Use `app::Clusters::<ClusterName>::Commands::<CommandName>::Type::ResponseType` for the `ResponseType` type-parameter to be
-    // spec compliant Will construct the command path using the first path returned by `GetPaths()` on the cluster.
+    // The `request` parameter must be of the correct type for the command being invoked.
+    // Use `app::Clusters::<ClusterName>::Commands::<CommandName>::Type` for the `request` parameter to be spec compliant
+    // Will construct the command path using the first path returned by `GetPaths()` on the cluster.
     // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
     template <typename RequestType, typename ResponseType = typename RequestType::ResponseType>
     [[nodiscard]] InvokeResult<ResponseType> Invoke(chip::CommandId commandId, const RequestType & request)

--- a/src/app/clusters/testing/ClusterTester.h
+++ b/src/app/clusters/testing/ClusterTester.h
@@ -199,7 +199,10 @@ public:
     }
 
     // Returns the next generated event from the event generator in the test server cluster context
-    std::optional<LogOnlyEvents::EventInformation> GetNextGeneratedEvent() { return mTestServerClusterContext.EventsGenerator().GetNextEvent(); }
+    std::optional<LogOnlyEvents::EventInformation> GetNextGeneratedEvent()
+    {
+        return mTestServerClusterContext.EventsGenerator().GetNextEvent();
+    }
 
 private:
     bool VerifyClusterPathsValid()

--- a/src/app/clusters/testing/ClusterTester.h
+++ b/src/app/clusters/testing/ClusterTester.h
@@ -149,7 +149,7 @@ public:
     // Use `app::Clusters::<ClusterName>::Commands::<CommandName>::Type::ResponseType` for the `ResponseType` type-parameter to be
     // spec compliant Will construct the command path using the first path returned by `GetPaths()` on the cluster.
     // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
-    template <typename ResponseType, typename RequestType>
+    template <typename RequestType, typename ResponseType = typename RequestType::ResponseType>
     [[nodiscard]] InvokeResult<ResponseType> Invoke(chip::CommandId commandId, const RequestType & request)
     {
         InvokeResult<ResponseType> result;
@@ -197,6 +197,9 @@ public:
 
         return result;
     }
+
+    // Returns the next generated event from the event generator in the test server cluster context
+    std::optional<LogOnlyEvents::EventInformation> GetNextGeneratedEvent() { return mTestServerClusterContext.EventsGenerator().GetNextEvent(); }
 
 private:
     bool VerifyClusterPathsValid()

--- a/src/app/clusters/testing/ClusterTester.h
+++ b/src/app/clusters/testing/ClusterTester.h
@@ -14,6 +14,7 @@
  *    limitations under the License.
  */
 
+#pragma once
 #include <app/AttributeValueDecoder.h>
 #include <app/AttributeValueEncoder.h>
 #include <app/CommandHandler.h>

--- a/src/app/clusters/testing/ValidateGlobalAttributes.cpp
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.cpp
@@ -65,7 +65,7 @@ bool IsAcceptedCommandsListEqualTo(app::ServerClusterInterface & cluster,
     return EqualAcceptedCommandSets(commandsBuilder.TakeBuffer(), expectedBuilder.TakeBuffer());
 }
 
-bool IsGeneratedCommandsListEqualTo(app::ServerClusterInterface & cluster, Span<CommandId> expected)
+bool IsGeneratedCommandsListEqualTo(app::ServerClusterInterface & cluster, std::initializer_list<const CommandId> expected)
 {
     VerifyOrDie(cluster.GetPaths().size() == 1);
     auto path = cluster.GetPaths()[0];
@@ -75,7 +75,16 @@ bool IsGeneratedCommandsListEqualTo(app::ServerClusterInterface & cluster, Span<
         ChipLogError(Test, "Failed to get generated commands list from cluster. Error: %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
-    return EqualGeneratedCommandSets(commandsBuilder.TakeBuffer(), expected);
+
+    ReadOnlyBufferBuilder<CommandId> expectedBuilder;
+
+    SuccessOrDie(expectedBuilder.EnsureAppendCapacity(expected.size()));
+    for (const auto & entry : expected)
+    {
+        SuccessOrDie(expectedBuilder.Append(entry));
+    }
+
+    return EqualGeneratedCommandSets(commandsBuilder.TakeBuffer(), expectedBuilder.TakeBuffer());
 }
 
 } // namespace chip::Testing

--- a/src/app/clusters/testing/ValidateGlobalAttributes.cpp
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.cpp
@@ -23,8 +23,9 @@ bool IsAttributesListEqualTo(app::ServerClusterInterface & cluster,
     VerifyOrDie(cluster.GetPaths().size() == 1);
     auto path = cluster.GetPaths()[0];
     ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> attributesBuilder;
-    if (cluster.Attributes(path, attributesBuilder) != CHIP_NO_ERROR)
+    if (CHIP_ERROR err = cluster.Attributes(path, attributesBuilder); err != CHIP_NO_ERROR)
     {
+        ChipLogError(Test, "Failed to get attributes list from cluster. Error: %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
 
@@ -47,8 +48,9 @@ bool IsAcceptedCommandsListEqualTo(app::ServerClusterInterface & cluster,
     VerifyOrDie(cluster.GetPaths().size() == 1);
     auto path = cluster.GetPaths()[0];
     ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> commandsBuilder;
-    if (cluster.AcceptedCommands(path, commandsBuilder) != CHIP_NO_ERROR)
+    if (CHIP_ERROR err = cluster.AcceptedCommands(path, commandsBuilder); err != CHIP_NO_ERROR)
     {
+        ChipLogError(Test, "Failed to get accepted commands list from cluster. Error: %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
 
@@ -68,8 +70,9 @@ bool IsGeneratedCommandsListEqualTo(app::ServerClusterInterface & cluster, Span<
     VerifyOrDie(cluster.GetPaths().size() == 1);
     auto path = cluster.GetPaths()[0];
     ReadOnlyBufferBuilder<CommandId> commandsBuilder;
-    if (cluster.GeneratedCommands(path, commandsBuilder) != CHIP_NO_ERROR)
+    if (CHIP_ERROR err = cluster.GeneratedCommands(path, commandsBuilder); err != CHIP_NO_ERROR)
     {
+        ChipLogError(Test, "Failed to get generated commands list from cluster. Error: %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
     return EqualGeneratedCommandSets(commandsBuilder.TakeBuffer(), expected);

--- a/src/app/clusters/testing/ValidateGlobalAttributes.h
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.h
@@ -81,7 +81,7 @@ bool IsAcceptedCommandsListEqualTo(app::ServerClusterInterface & cluster,
 /// ClusterImpl cluster(kTestEndpointId, ...);
 /// ASSERT_TRUE(IsGeneratedCommandsListEqualTo(cluster, { Commands::SomeCommandResponse::kMetadataEntry }));
 /// ```
-bool IsGeneratedCommandsListEqualTo(app::ServerClusterInterface & cluster, Span<CommandId> expected);
+bool IsGeneratedCommandsListEqualTo(app::ServerClusterInterface & cluster, std::initializer_list<const CommandId> expected);
 
 } // namespace Testing
 } // namespace chip

--- a/src/app/clusters/testing/ValidateGlobalAttributes.h
+++ b/src/app/clusters/testing/ValidateGlobalAttributes.h
@@ -1,5 +1,20 @@
-#pragma once
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
+#pragma once
 #include "AttributeTesting.h"
 
 #include <app/server-cluster/DefaultServerCluster.h>


### PR DESCRIPTION
#### Summary

This is a small followup PR on unit testing infrastructure.

This PR 

- Adds error logging to the `Is*ListEqualTo` functions in `ValidateGlobalAttributes.h` as these functions return `bool` instead of an `CHIP_ERROR`
- Now `Invoke` can be used without specifying any template paramteres (all of them can be deduced).
- Add `GetNextGeneratedEvent` method to `ClusterTester` for event testing, this meant to be added in #41603. 
- Adds `#pragma once` to all header files in `src/app/cluster/testing` that didn't have it.

#### Related issues

#41512 (this is closed but related)

#### Testing

CI needs to pass

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
