### PR TITLE
Remove unreachable code in DCLCommandBase

### DIFF
--- a/examples/chip-tool/commands/dcl/DCLCommands.h
+++ b/examples/chip-tool/commands/dcl/DCLCommands.h
@@ -37,8 +37,6 @@ public:
     {
         auto client = chip::tool::dcl::DCLClient(mHostName, mPort);
         return RunCommand(client);
-
-        return CHIP_NO_ERROR;
     }
 
     virtual CHIP_ERROR RunCommand(chip::tool::dcl::DCLClient & client) = 0;


### PR DESCRIPTION
#### Problem
The Run method in DCLCommandBase contained a 'return' statement that was unreachable because another 'return' preceded it.

#### Change
This commit removes the dead code to improve code clarity and maintainability.

---
### Testing
This is a trivial refactoring that removes dead code. No functional change is introduced, so no specific testing is required beyond ensuring the code continues to compile.