### PR TITLE
[Cloudbuild] Fix esp32 compile for chef.yaml and smoke-test.yaml

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -26,12 +26,11 @@ steps:
     # Details on why this is required - https://github.com/project-chip/connectedhomeip/pull/41741
     - name: "ghcr.io/project-chip/chip-build-vscode:174"
       args:
-          - >-
-            ./scripts/run_in_build_env.sh "pip install esp-idf-kconfig==2.5.0"
+          - pip install esp-idf-kconfig==2.5.0
       id: InstallEspIdfKconfig
       waitFor:
           - Bootstrap
-      entrypoint: /usr/bin/bash
+      entrypoint: ./scripts/run_in_build_env.sh
     - name: "ghcr.io/project-chip/chip-build-vscode:174"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -23,24 +23,17 @@ steps:
           - name: pwenv
             path: /pwenv
       timeout: 900s
-    # Details on why this is required - https://github.com/project-chip/connectedhomeip/pull/41741
-    - name: "ghcr.io/project-chip/chip-build-vscode:174"
-      args:
-          - pip install esp-idf-kconfig==2.5.0
-      id: InstallEspIdfKconfig
-      waitFor:
-          - Bootstrap
-      entrypoint: ./scripts/run_in_build_env.sh
     - name: "ghcr.io/project-chip/chip-build-vscode:174"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-
+              pip install esp-idf-kconfig==2.5.0 &&
               perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt &&
               ./examples/chef/chef.py --build_all --build_exclude "noip|icd"
       id: CompileAll
       waitFor:
-          - InstallEspIdfKconfig
+          - Bootstrap
       entrypoint: ./scripts/run_in_build_env.sh
       volumes:
           - name: pwenv

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:169"
+    - name: "ghcr.io/project-chip/chip-build-vscode:174"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:169"
+    - name: "ghcr.io/project-chip/chip-build-vscode:174"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -23,7 +23,16 @@ steps:
           - name: pwenv
             path: /pwenv
       timeout: 900s
-    - name: "ghcr.io/project-chip/chip-build-vscode:169"
+    # Details on why this is required - https://github.com/project-chip/connectedhomeip/pull/41741
+    - name: "ghcr.io/project-chip/chip-build-vscode:174"
+      args:
+          - >-
+            ./scripts/run_in_build_env.sh "pip install esp-idf-kconfig==2.5.0"
+      id: InstallEspIdfKconfig
+      waitFor:
+          - Bootstrap
+      entrypoint: /usr/bin/bash
+    - name: "ghcr.io/project-chip/chip-build-vscode:174"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -32,13 +41,13 @@ steps:
               ./examples/chef/chef.py --build_all --build_exclude "noip|icd"
       id: CompileAll
       waitFor:
-          - Bootstrap
+          - InstallEspIdfKconfig
       entrypoint: ./scripts/run_in_build_env.sh
       volumes:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:169"
+    - name: "ghcr.io/project-chip/chip-build-vscode:174"
       # ICD device is currently not supported for ESP32 and NRF targets. New rule to compile only ICD
       # linux binary.
       env:
@@ -53,7 +62,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:169"
+    - name: "ghcr.io/project-chip/chip-build-vscode:174"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -30,6 +30,7 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-
+              pip install esp-idf-kconfig==2.5.0 &&
               perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt &&
               ./scripts/build/build_examples.py --enable-flashbundle --target
               esp32-devkitc-light-rpc --target


### PR DESCRIPTION
#### Summary

This PR fixes broken ESP32 build in cloudbuild jobs by installing `esp-idf-kconfig` as shown [here](https://github.com/project-chip/connectedhomeip/commit/79e99306c9255e4af419caa825125eb201b16cd6#diff-b31fbe76868557143ca4befd21e25b5289736c91cc7da7b5fe5cb5a6075f2f2f).

#### Testing

Ran cloud build runners manually and checked ESP32 build is successful.
