### PR TITLE
SystemLayer: simplify wake event implementation

### DIFF
--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -240,8 +240,6 @@ static_library("system") {
     "TLVPacketBufferBackingStore.cpp",
     "TLVPacketBufferBackingStore.h",
     "TimeSource.h",
-    "WakeEvent.cpp",
-    "WakeEvent.h",
   ]
 
   if (chip_system_layer_impl_config_file == "") {
@@ -266,6 +264,13 @@ static_library("system") {
         "SystemLayerImpl${chip_system_config_event_loop}.h",
       ]
     }
+  }
+
+  if (chip_system_config_event_loop == "Select") {
+    sources += [
+      "WakeEvent.cpp",
+      "WakeEvent.h",
+    ]
   }
 
   cflags = [ "-Wconversion" ]

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR LayerImplSelect::Init()
 
 #if !CHIP_SYSTEM_CONFIG_USE_LIBEV
     // Create an event to allow an arbitrary thread to wake the thread in the select loop.
-    ReturnErrorOnFailure(mWakeEvent.Open(*this));
+    ReturnErrorOnFailure(mWakeEvent.Open());
 #endif // !CHIP_SYSTEM_CONFIG_USE_LIBEV
 
     VerifyOrReturnError(mLayerState.SetInitialized(), CHIP_ERROR_INCORRECT_STATE);
@@ -98,11 +98,8 @@ void LayerImplSelect::Shutdown()
 #else
     mTimerList.Clear();
     mTimerPool.ReleaseAll();
+    mWakeEvent.Close();
 #endif // CHIP_SYSTEM_CONFIG_USE_LIBEV
-
-#if !CHIP_SYSTEM_CONFIG_USE_LIBEV
-    mWakeEvent.Close(*this);
-#endif // !CHIP_SYSTEM_CONFIG_USE_LIBEV
 
     mLayerState.ResetFromShuttingDown(); // Return to uninitialized state to permit re-initialization.
 }
@@ -558,6 +555,11 @@ void LayerImplSelect::PrepareEvents()
     FD_ZERO(&mSelected.mErrorSet);
     // NOLINTEND(clang-analyzer-security.insecureAPI.bzero)
 
+#if !CHIP_SYSTEM_CONFIG_USE_LIBEV
+    FD_SET(mWakeEvent.GetReadFD(), &mSelected.mReadSet);
+    mMaxFd = mWakeEvent.GetReadFD();
+#endif
+
     for (auto & w : mSocketWatchPool)
     {
         if (w.mFD != kInvalidFd)
@@ -593,6 +595,13 @@ void LayerImplSelect::HandleEvents()
         ChipLogError(DeviceLayer, "Select failed: %" CHIP_ERROR_FORMAT, CHIP_ERROR_POSIX(errno).Format());
         return;
     }
+
+#if !CHIP_SYSTEM_CONFIG_USE_LIBEV
+    if (mSelectResult > 0 && FD_ISSET(mWakeEvent.GetReadFD(), &mSelected.mReadSet))
+    {
+        mWakeEvent.Confirm();
+    }
+#endif
 
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
     mHandleSelectThread = pthread_self();

--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -142,9 +142,6 @@ protected:
     int mSelectResult;
 
     ObjectLifeCycle mLayerState;
-#if !CHIP_SYSTEM_CONFIG_USE_LIBEV
-    WakeEvent mWakeEvent;
-#endif
 
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
     std::atomic<pthread_t> mHandleSelectThread;
@@ -152,6 +149,8 @@ protected:
 
 #if CHIP_SYSTEM_CONFIG_USE_LIBEV
     struct ev_loop * mLibEvLoopP;
+#else
+    WakeEvent mWakeEvent;
 #endif
 };
 

--- a/src/system/WakeEvent.cpp
+++ b/src/system/WakeEvent.cpp
@@ -23,7 +23,7 @@
 
 #include <system/SystemConfig.h>
 
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS && !CHIP_SYSTEM_CONFIG_USE_LIBEV
+#if !CHIP_SYSTEM_CONFIG_USE_LIBEV
 
 #include <system/WakeEvent.h>
 
@@ -58,7 +58,7 @@ inline int SetNonBlockingMode(int fd)
 }
 } // anonymous namespace
 
-CHIP_ERROR WakeEvent::Open(LayerSockets & systemLayer)
+CHIP_ERROR WakeEvent::Open()
 {
     enum
     {
@@ -79,16 +79,11 @@ CHIP_ERROR WakeEvent::Open(LayerSockets & systemLayer)
     mReadFD  = fds[FD_READ];
     mWriteFD = fds[FD_WRITE];
 
-    ReturnErrorOnFailure(systemLayer.StartWatchingSocket(mReadFD, &mReadWatch));
-    ReturnErrorOnFailure(systemLayer.SetCallback(mReadWatch, Confirm, reinterpret_cast<intptr_t>(this)));
-    ReturnErrorOnFailure(systemLayer.RequestCallbackOnPendingRead(mReadWatch));
-
     return CHIP_NO_ERROR;
 }
 
-void WakeEvent::Close(LayerSockets & systemLayer)
+void WakeEvent::Close()
 {
-    TEMPORARY_RETURN_IGNORED systemLayer.StopWatchingSocket(&mReadWatch);
     VerifyOrDie(::close(mReadFD) == 0);
     VerifyOrDie(::close(mWriteFD) == 0);
     mReadFD  = -1;
@@ -162,7 +157,7 @@ ssize_t WriteEvent(int eventFd)
 
 } // namespace
 
-CHIP_ERROR WakeEvent::Open(LayerSockets & systemLayer)
+CHIP_ERROR WakeEvent::Open()
 {
     mReadFD = ::eventfd(0, 0);
     if (mReadFD == -1)
@@ -170,16 +165,11 @@ CHIP_ERROR WakeEvent::Open(LayerSockets & systemLayer)
         return CHIP_ERROR_POSIX(errno);
     }
 
-    ReturnErrorOnFailure(systemLayer.StartWatchingSocket(mReadFD, &mReadWatch));
-    ReturnErrorOnFailure(systemLayer.SetCallback(mReadWatch, Confirm, reinterpret_cast<intptr_t>(this)));
-    ReturnErrorOnFailure(systemLayer.RequestCallbackOnPendingRead(mReadWatch));
-
     return CHIP_NO_ERROR;
 }
 
-void WakeEvent::Close(LayerSockets & systemLayer)
+void WakeEvent::Close()
 {
-    systemLayer.StopWatchingSocket(&mReadWatch);
     VerifyOrDie(::close(mReadFD) == 0);
     mReadFD = -1;
 }
@@ -207,4 +197,4 @@ CHIP_ERROR WakeEvent::Notify() const
 } // namespace System
 } // namespace chip
 
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && !CHIP_SYSTEM_CONFIG_USE_LIBEV
+#endif // !CHIP_SYSTEM_CONFIG_USE_LIBEV

--- a/src/system/WakeEvent.h
+++ b/src/system/WakeEvent.h
@@ -25,7 +25,7 @@
 // Include configuration headers
 #include <system/SystemConfig.h>
 
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS && !CHIP_SYSTEM_CONFIG_USE_LIBEV
+#if !CHIP_SYSTEM_CONFIG_USE_LIBEV
 
 #include <lib/core/CHIPError.h>
 #include <system/SocketEvents.h>
@@ -33,7 +33,6 @@
 namespace chip {
 namespace System {
 
-class LayerSockets;
 class WakeEventTest;
 
 /**
@@ -45,26 +44,24 @@ class WakeEventTest;
 class WakeEvent
 {
 public:
-    CHIP_ERROR Open(LayerSockets & systemLayer); /**< Initialize the pipeline */
-    void Close(LayerSockets & systemLayer);      /**< Close both ends of the pipeline. */
+    CHIP_ERROR Open(); /**< Initialize the pipeline */
+    void Close();      /**< Close both ends of the pipeline. */
 
     CHIP_ERROR Notify() const; /**< Set the event. */
     void Confirm() const;      /**< Clear the event. */
 
+    int GetReadFD() const { return mReadFD; }
+
 private:
     friend class WakeEventTest;
-
-    int GetReadFD() const { return mReadFD; }
-    static void Confirm(System::SocketEvents events, intptr_t data) { reinterpret_cast<WakeEvent *>(data)->Confirm(); }
 
 #if CHIP_SYSTEM_CONFIG_USE_POSIX_PIPE
     int mWriteFD;
 #endif
     int mReadFD;
-    SocketWatchToken mReadWatch;
 };
 
 } // namespace System
 } // namespace chip
 
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && !CHIP_SYSTEM_CONFIG_USE_LIBEV
+#endif // !CHIP_SYSTEM_CONFIG_USE_LIBEV

--- a/src/system/tests/BUILD.gn
+++ b/src/system/tests/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
+import("../system.gni")
 
 chip_test_suite("tests") {
   output_name = "libSystemLayerTests"
@@ -27,7 +28,6 @@ chip_test_suite("tests") {
     "TestSystemPacketBuffer.cpp",
     "TestSystemScheduleLambda.cpp",
     "TestSystemTimer.cpp",
-    "TestSystemWakeEvent.cpp",
     "TestTimeSource.cpp",
   ]
 
@@ -40,6 +40,10 @@ chip_test_suite("tests") {
   #  which tries to size-limit the buffers, does not work correctly there.
   if (chip_device_platform != "nrfconnect") {
     test_sources += [ "TestTLVPacketBufferBackingStore.cpp" ]
+  }
+
+  if (chip_system_config_event_loop == "Select") {
+    test_sources += [ "TestSystemWakeEvent.cpp" ]
   }
 
   cflags = [ "-Wconversion" ]

--- a/src/system/tests/TestSystemWakeEvent.cpp
+++ b/src/system/tests/TestSystemWakeEvent.cpp
@@ -37,7 +37,7 @@
 
 using namespace chip::System;
 
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS && !CHIP_SYSTEM_CONFIG_USE_DISPATCH
+#if !CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
 namespace chip {
 namespace System {
@@ -54,19 +54,10 @@ namespace {
 class TestSystemWakeEvent : public ::testing::Test
 {
 public:
-    void SetUp()
-    {
-        EXPECT_SUCCESS(mSystemLayer.Init());
-        EXPECT_SUCCESS(mWakeEvent.Open(mSystemLayer));
-    }
+    void SetUp() { EXPECT_SUCCESS(mWakeEvent.Open()); }
 
-    void TearDown()
-    {
-        mWakeEvent.Close(mSystemLayer);
-        mSystemLayer.Shutdown();
-    }
+    void TearDown() { mWakeEvent.Close(); }
 
-    ::chip::System::LayerImpl mSystemLayer;
     WakeEvent mWakeEvent;
     fd_set mReadSet;
     fd_set mWriteSet;
@@ -142,14 +133,13 @@ TEST_F(TestSystemWakeEvent, TestBlockingSelect)
 
 TEST_F(TestSystemWakeEvent, TestClose)
 {
-    mWakeEvent.Close(mSystemLayer);
-
+    mWakeEvent.Close();
     const auto notifFD = WakeEventTest::GetReadFD(mWakeEvent);
 
     // Check that Close() has cleaned up itself and reopen is possible
-    EXPECT_EQ(mWakeEvent.Open(mSystemLayer), CHIP_NO_ERROR);
+    EXPECT_EQ(mWakeEvent.Open(), CHIP_NO_ERROR);
     EXPECT_LT(notifFD, 0);
 }
 } // namespace
 
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && !CHIP_SYSTEM_CONFIG_USE_DISPATCH
+#endif // !CHIP_SYSTEM_CONFIG_USE_DISPATCH


### PR DESCRIPTION
#### Summary

This commit simplifying the wake event implementation so that it doesn't depend on the socket related APIs provided by the select loop. Instead, the select loop directly polls the FD on preparing events and calls `Confirm()` on it processing the events.
This change avoids mutual dependency between WakeEvent and Select loop, and allows disabling sockets API on platforms that support select() but no POSIX socket APIs.

#### Related issues

This is pure refactoring for introducing the OpenThread simulation for Matter commissioning over Thread development.

#### Testing

This commit doesn't change the APIs, but select loop's internal refactoring. So the existing unittest and functional tests in the CI covers the changes.