### PR TITLE
Fix conversion warning

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -95,7 +95,7 @@ CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & i
         return INET_ERROR_UNKNOWN_INTERFACE;
     }
 
-    interface = InterfaceId(intfNum);
+    interface = InterfaceId(static_cast<PlatformType>(intfNum));
     if (intfNum == 0)
     {
         return INET_ERROR_UNKNOWN_INTERFACE;


### PR DESCRIPTION


#### Summary

This commit explicitly cast the interface number to fix the conversion warning:

```bash
error: conversion from ‘long unsigned int’ to ‘chip::Inet::InterfaceId::PlatformType’ {aka ‘unsigned int’} may change value [-Werror=conversion]
```
#### Related issues

Just fix warning.

#### Testing

CI
