### PR TITLE
[ICD] Undo some changes from #41862: preserve the logic of always calling check in complete.

### DIFF
--- a/src/app/icd/client/CheckInHandler.cpp
+++ b/src/app/icd/client/CheckInHandler.cpp
@@ -136,7 +136,7 @@ CHIP_ERROR CheckInHandler::OnMessageReceived(Messaging::ExchangeContext * ec, co
     }
     else
     {
-        ReturnErrorOnFailure(mpICDClientStorage->StoreEntry(clientInfo));
+        TEMPORARY_RETURN_IGNORED mpICDClientStorage->StoreEntry(clientInfo);
         mpCheckInDelegate->OnCheckInComplete(clientInfo);
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
         mpImEngine->OnActiveModeNotification(clientInfo.peer_node, clientInfo.monitored_subject);


### PR DESCRIPTION
#### Summary

Undo based on https://github.com/project-chip/connectedhomeip/pull/41862/files/b07051ec2af64e568d2a1248f4bd13a4580073b9#r2514241128

Previously code would call check in complete regardless of errors, after update it would error out. This needs to be more carefully reviewed to not allow behavior changes.

#### Testing

Generally an UNDO only, keeping existing tests (which generally are unclear ... since they never seem to have covered the original code ... then again this is essentially a revert only anway).