### PR TITLE
[ServerClusterIntrerfaceRegistry] Add consistent behavior on startup failures

### DIFF
--- a/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
+++ b/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
@@ -63,7 +63,7 @@ CHIP_ERROR ServerClusterInterfaceRegistry::Register(ServerClusterRegistration & 
     if (mContext.has_value())
     {
         // To preserve similarity with SetContext, do not fail the register even Startup fails.
-        // This will cause Shutdown to be called for both success and failed startups.
+        // This will cause Shutdown to be called for both successful and failed startups.
         LogErrorOnFailure(entry.serverClusterInterface->Startup(*mContext));
     }
 

--- a/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
+++ b/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
@@ -62,7 +62,9 @@ CHIP_ERROR ServerClusterInterfaceRegistry::Register(ServerClusterRegistration & 
 
     if (mContext.has_value())
     {
-        ReturnErrorOnFailure(entry.serverClusterInterface->Startup(*mContext));
+        // To preserve similarity with SetContext, do not fail the register even Startup fails.
+        // This will cause Shutdown to be called for both success and failed startups.
+        LogErrorOnFailure(entry.serverClusterInterface->Startup(*mContext));
     }
 
     entry.next     = mRegistrations;

--- a/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
+++ b/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
@@ -62,7 +62,7 @@ CHIP_ERROR ServerClusterInterfaceRegistry::Register(ServerClusterRegistration & 
 
     if (mContext.has_value())
     {
-        // To preserve similarity with SetContext, do not fail the register even Startup fails.
+        // To preserve similarity with SetContext, do not fail the register even if Startup fails.
         // This will cause Shutdown to be called for both successful and failed startups.
         LogErrorOnFailure(entry.serverClusterInterface->Startup(*mContext));
     }

--- a/src/app/server-cluster/ServerClusterInterfaceRegistry.h
+++ b/src/app/server-cluster/ServerClusterInterfaceRegistry.h
@@ -155,6 +155,11 @@ public:
     // Set up the underlying context for all clusters that are managed by this registry.
     //
     // The values within context will be moved and used as-is.
+    //
+    // Returns:
+    //   - CHIP_NO_ERROR on success
+    //   - CHIP_ERROR_HAD_FAILURES if some cluster `Startup` calls had errors (Startup
+    //     will be called for all clusters).
     CHIP_ERROR SetContext(ServerClusterContext && context);
 
     // Invalidates current context.

--- a/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
+++ b/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
@@ -106,7 +106,7 @@ public:
     void Shutdown() override { mShutdownCalls++; }
 
     uint32_t GetStartupCallCount() const { return mStartupCalls; }
-    uint32_t GetShutdownCallCout() const { return mShutdownCalls; }
+    uint32_t GetShutdownCallCount() const { return mShutdownCalls; }
 
 private:
     uint32_t mStartupCalls  = 0;
@@ -369,6 +369,9 @@ TEST_F(TestServerClusterInterfaceRegistry, StartupShutdownWithoutContext)
         EXPECT_EQ(cluster2.Cluster().GetStartupCallCount(), 0u);
 
         TestServerClusterContext context;
+
+        // the clusters are explicitly set to fail startup, so create SetContext returns an error.
+        // TODO: is this sane? Register() with a startup failure does NOT return a failure.
         EXPECT_EQ(registry.SetContext(context.Create()), CHIP_ERROR_HAD_FAILURES);
 
         // Startup called after registration, with failure that is NOT reported (only logged)
@@ -379,20 +382,20 @@ TEST_F(TestServerClusterInterfaceRegistry, StartupShutdownWithoutContext)
         EXPECT_EQ(cluster1.Cluster().GetStartupCallCount(), 1u);
         EXPECT_EQ(cluster2.Cluster().GetStartupCallCount(), 1u);
         EXPECT_EQ(cluster3.Cluster().GetStartupCallCount(), 1u);
-        EXPECT_EQ(cluster1.Cluster().GetShutdownCallCout(), 0u);
-        EXPECT_EQ(cluster2.Cluster().GetShutdownCallCout(), 0u);
-        EXPECT_EQ(cluster3.Cluster().GetShutdownCallCout(), 0u);
+        EXPECT_EQ(cluster1.Cluster().GetShutdownCallCount(), 0u);
+        EXPECT_EQ(cluster2.Cluster().GetShutdownCallCount(), 0u);
+        EXPECT_EQ(cluster3.Cluster().GetShutdownCallCount(), 0u);
 
         // unregister will call shutdown
         EXPECT_EQ(registry.Unregister(&cluster2.Cluster()), CHIP_NO_ERROR);
-        EXPECT_EQ(cluster2.Cluster().GetShutdownCallCout(), 1u);
+        EXPECT_EQ(cluster2.Cluster().GetShutdownCallCount(), 1u);
     }
 
     // registry deletion will call shutdown for the rest
     EXPECT_EQ(cluster1.Cluster().GetStartupCallCount(), 1u);
     EXPECT_EQ(cluster2.Cluster().GetStartupCallCount(), 1u);
     EXPECT_EQ(cluster3.Cluster().GetStartupCallCount(), 1u);
-    EXPECT_EQ(cluster1.Cluster().GetShutdownCallCout(), 1u);
-    EXPECT_EQ(cluster2.Cluster().GetShutdownCallCout(), 1u);
-    EXPECT_EQ(cluster3.Cluster().GetShutdownCallCout(), 1u);
+    EXPECT_EQ(cluster1.Cluster().GetShutdownCallCount(), 1u);
+    EXPECT_EQ(cluster2.Cluster().GetShutdownCallCount(), 1u);
+    EXPECT_EQ(cluster3.Cluster().GetShutdownCallCount(), 1u);
 }

--- a/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
+++ b/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
@@ -370,7 +370,7 @@ TEST_F(TestServerClusterInterfaceRegistry, StartupShutdownWithoutContext)
 
         TestServerClusterContext context;
 
-        // the clusters are explicitly set to fail startup, so create SetContext returns an error.
+        // the clusters are explicitly set to fail startup, so SetContext returns an error.
         // TODO: is this sane? Register() with a startup failure does NOT return a failure.
         EXPECT_EQ(registry.SetContext(context.Create()), CHIP_ERROR_HAD_FAILURES);
 

--- a/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
+++ b/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
@@ -378,7 +378,7 @@ TEST_F(TestServerClusterInterfaceRegistry, StartupShutdownWithoutContext)
         EXPECT_EQ(cluster3.Cluster().GetStartupCallCount(), 0u);
         EXPECT_EQ(registry.Register(cluster3.Registration()), CHIP_NO_ERROR);
 
-        // all startups were called, even though error
+        // all startups were called, even though there was an error
         EXPECT_EQ(cluster1.Cluster().GetStartupCallCount(), 1u);
         EXPECT_EQ(cluster2.Cluster().GetStartupCallCount(), 1u);
         EXPECT_EQ(cluster3.Cluster().GetStartupCallCount(), 1u);

--- a/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
+++ b/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
@@ -360,7 +360,7 @@ TEST_F(TestServerClusterInterfaceRegistry, StartupShutdownWithoutContext)
     {
         ServerClusterInterfaceRegistry registry;
 
-        // all register is ok
+        // all registrations are ok
         EXPECT_EQ(registry.Register(cluster1.Registration()), CHIP_NO_ERROR);
         EXPECT_EQ(registry.Register(cluster2.Registration()), CHIP_NO_ERROR);
 


### PR DESCRIPTION
#### Summary

If we return an error on Register if startup fails, it is impossible for the caller to figure out if the cluster was started up or not. This makes it hard to guarantee a "shutdown after every startup" and makes the Register behavior inconsistent between having a context or not.

Updated the code to only log startup failures.

#### Testing

Unit test added.
