### PR TITLE
[Silabs] Add Support for RGB led in Thread build (part 1)

### DIFF
--- a/examples/lighting-app/silabs/src/LightingManager.cpp
+++ b/examples/lighting-app/silabs/src/LightingManager.cpp
@@ -366,8 +366,8 @@ bool LightingManager::InitiateLightCtrlAction(int32_t aActor, Action_t aAction, 
 
         if (aAttributeId == ColorControl::Attributes::CurrentX::Id)
         {
-            VerifyOrReturnValue(colorData.xy.y != *reinterpret_cast<uint16_t *>(value), action_initiated);
-            colorData.xy.y   = *reinterpret_cast<uint16_t *>(value);
+            VerifyOrReturnValue(colorData.xy.x != *reinterpret_cast<uint16_t *>(value), action_initiated);
+            colorData.xy.x   = *reinterpret_cast<uint16_t *>(value);
             action_initiated = true;
         }
         else if (aAttributeId == ColorControl::Attributes::CurrentY::Id)
@@ -385,13 +385,15 @@ bool LightingManager::InitiateLightCtrlAction(int32_t aActor, Action_t aAction, 
         {
             VerifyOrReturnValue(colorData.hsv.h != *value, action_initiated);
             colorData.hsv.h  = *value;
+            mCurrentHue      = *value;
             action_initiated = true;
         }
         else if (aAttributeId == ColorControl::Attributes::CurrentSaturation::Id)
         {
             VerifyOrReturnValue(colorData.hsv.s != *value, action_initiated);
-            colorData.hsv.s  = *value;
-            action_initiated = true;
+            colorData.hsv.s    = *value;
+            mCurrentSaturation = *value;
+            action_initiated   = true;
         }
         break;
 

--- a/examples/platform/silabs/LEDWidget.cpp
+++ b/examples/platform/silabs/LEDWidget.cpp
@@ -38,6 +38,7 @@ void LEDWidget::Init(const uint8_t led)
     mBlinkOffTimeMS   = 0;
     mLed              = led;
     mLedStatus        = false;
+    mLevel            = 0;
     Set(false);
 }
 

--- a/examples/platform/silabs/LEDWidget.h
+++ b/examples/platform/silabs/LEDWidget.h
@@ -37,10 +37,10 @@ public:
     uint8_t GetLevel();
 
 private:
-    uint8_t mLed;
-    uint8_t mLevel;
-    bool mLedStatus;
-    uint64_t mLastChangeTimeMS;
-    uint32_t mBlinkOnTimeMS;
-    uint32_t mBlinkOffTimeMS;
+    uint8_t mLed               = 0;
+    uint8_t mLevel             = 0;
+    bool mLedStatus            = false;
+    uint64_t mLastChangeTimeMS = 0;
+    uint32_t mBlinkOnTimeMS    = 0;
+    uint32_t mBlinkOffTimeMS   = 0;
 };

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -185,8 +185,8 @@ source_set("efr32-common") {
   }
 
   if (sl_enable_rgb_led) {
-    sources += [ "${silabs_common_plat_dir}/led/RGBLEDWidget.cpp" ]
-    include_dirs = [ "${silabs_common_plat_dir}/rgb_led" ]
+    sources += [ "${silabs_common_plat_dir}/rgb_led/RGBLEDWidget.cpp" ]
+    include_dirs += [ "${silabs_common_plat_dir}/rgb_led" ]
   }
 
   if (chip_build_libshell) {

--- a/examples/platform/silabs/rgb_led/RGBLEDWidget.cpp
+++ b/examples/platform/silabs/rgb_led/RGBLEDWidget.cpp
@@ -64,18 +64,19 @@ void RGBLEDWidget::GetColor(uint16_t & r, uint16_t & g, uint16_t & b)
  */
 void RGBLEDWidget::SetColorFromHSV(uint8_t hue, uint8_t saturation)
 {
-    ChipLogDetails(Zcl, "SetColorFromHSV : H:%u|S:%u|V:%u", hue, saturation, GetLevel());
-
-    float h = (hue * 360.0f) / 254.0f, s = (saturation / 254.0f), v = 1.0;
+    ChipLogDetail(Zcl, "SetColorFromHSV : H:%u|S:%u|V:%u", hue, saturation, GetLevel());
+    // Per spec max value for each attribute is 254
+    float h = (hue * 360.0f) / 254.0f, s = (saturation / 254.0f), v = (GetLevel() / 254.0f);
     float hh, p, q, t, ff, r, g, b;
     long i;
 
-    ChipLogDetails(Zcl, "HUE Values: H=%u S=%u V=%u", static_cast<uint8_t>(h), static_cast<uint8_t>(s * 100.0),
-                   static_cast<uint8_t>(v * 100.0));
+    ChipLogDetail(Zcl, "HUE Values: H=%u S=%u V=%u", static_cast<uint8_t>(h), static_cast<uint8_t>(s * 100.0),
+                  static_cast<uint8_t>(v * 100.0));
 
     if (s <= 0.0)
     { // Achromatic (grey)
         SetColor(static_cast<uint8_t>(v * 255), static_cast<uint8_t>(v * 255), static_cast<uint8_t>(v * 255));
+        return;
     }
 
     hh = h;

--- a/examples/platform/silabs/rgb_led/RGBLEDWidget.h
+++ b/examples/platform/silabs/rgb_led/RGBLEDWidget.h
@@ -77,9 +77,4 @@ private:
     float CalculateRed(float ct);
     float CalculateGreen(float ct);
     float CalculateBlue(float ct);
-
-    uint8_t CalculateP(uint8_t v, uint8_t s);
-    uint8_t CalculateQ(uint8_t v, uint8_t s, uint32_t remainder);
-    uint8_t CalculateT(uint8_t v, uint8_t s, uint32_t remainder);
-    void SetRgbByRegion(uint8_t region, uint8_t v, uint8_t p, uint8_t q, uint8_t t, RgbColor_t & rgb);
 };

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -269,7 +269,7 @@ CHIP_ERROR SilabsPlatform::GetLedColor(uint8_t led, uint16_t & r, uint16_t & g, 
     sl_led_get_rgb_color(SL_SIMPLE_LED_INSTANCE(led), &r, &g, &b);
     return CHIP_NO_ERROR;
 }
-#endif // (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED)
+#endif // (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 extern "C" void sl_button_on_change(const sl_button_t * handle)

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -35,8 +35,27 @@
 
 #ifdef ENABLE_WSTK_LEDS
 extern "C" {
+#if (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
+#include "sl_simple_rgb_pwm_led.h"
+#include "sl_simple_rgb_pwm_led_instances.h"
+#define SL_SIMPLE_LED_INSTANCE(x) (&sl_simple_rgb_pwm_led_rgb_led0)
+#define SL_SIMPLE_LED_COUNT 1
+#define SL_LED_INIT_INTANCES() sl_simple_rgb_pwm_led_init_instances();
+#define SL_LED_GET_STATE(x) (x->led_common.context->state)
+#define SL_LED_TURN_ON(x) sl_led_turn_on(&(x->led_common))
+#define SL_LED_TURN_OFF(x) sl_led_turn_off(&(x->led_common))
+#define SL_LED_TOGGLE(x) sl_led_toggle(&(x->led_common))
+#else
 #include "sl_simple_led_instances.h"
+#define SL_LED_INIT_INTANCES() sl_simple_led_init_instances();
+#define SL_LED_GET_STATE(x) sl_simple_led_get_state(const_cast<sl_led_t *>(x))
+#define SL_LED_TURN_ON(x) sl_simple_led_turn_on(const_cast<sl_led_t *>(x))
+#define SL_LED_TURN_OFF(x) sl_simple_led_turn_off(const_cast<sl_led_t *>(x))
+#define SL_LED_TOGGLE(x) sl_simple_led_toggle(const_cast<sl_led_t *>(x))
+
+#endif // (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
 }
+
 #endif
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
@@ -193,7 +212,7 @@ CHIP_ERROR SilabsPlatform::FlashWritePage(uint32_t addr, const uint8_t * data, s
 #ifdef ENABLE_WSTK_LEDS
 void SilabsPlatform::InitLed(void)
 {
-    sl_simple_led_init_instances();
+    SL_LED_INIT_INTANCES();
 }
 
 CHIP_ERROR SilabsPlatform::SetLed(bool state, uint8_t led)
@@ -203,7 +222,7 @@ CHIP_ERROR SilabsPlatform::SetLed(bool state, uint8_t led)
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    (state) ? sl_led_turn_on(SL_SIMPLE_LED_INSTANCE(led)) : sl_led_turn_off(SL_SIMPLE_LED_INSTANCE(led));
+    (state) ? SL_LED_TURN_ON(SL_SIMPLE_LED_INSTANCE(led)) : SL_LED_TURN_OFF(SL_SIMPLE_LED_INSTANCE(led));
     return CHIP_NO_ERROR;
 }
 
@@ -213,8 +232,7 @@ bool SilabsPlatform::GetLedState(uint8_t led)
     {
         return false;
     }
-
-    return sl_led_get_state(SL_SIMPLE_LED_INSTANCE(led));
+    return SL_LED_GET_STATE(SL_SIMPLE_LED_INSTANCE(led));
 }
 
 CHIP_ERROR SilabsPlatform::ToggleLed(uint8_t led)
@@ -223,7 +241,7 @@ CHIP_ERROR SilabsPlatform::ToggleLed(uint8_t led)
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    sl_led_toggle(SL_SIMPLE_LED_INSTANCE(led));
+    SL_LED_TOGGLE(SL_SIMPLE_LED_INSTANCE(led));
     return CHIP_NO_ERROR;
 }
 #endif // ENABLE_WSTK_LEDS
@@ -235,6 +253,23 @@ void SilabsPlatform::StartScheduler()
     sl_system_kernel_start();
 }
 #endif
+
+#if (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED == 1)
+bool SilabsPlatform::GetRGBLedState(uint8_t led)
+{
+    return SL_LED_GET_STATE(SL_SIMPLE_LED_INSTANCE(led));
+}
+CHIP_ERROR SilabsPlatform::SetLedColor(uint8_t led, uint8_t red, uint8_t green, uint8_t blue)
+{
+    sl_led_set_rgb_color(SL_SIMPLE_LED_INSTANCE(led), red, green, blue);
+    return CHIP_NO_ERROR;
+}
+CHIP_ERROR SilabsPlatform::GetLedColor(uint8_t led, uint16_t & r, uint16_t & g, uint16_t & b)
+{
+    sl_led_get_rgb_color(SL_SIMPLE_LED_INSTANCE(led), &r, &g, &b);
+    return CHIP_NO_ERROR;
+}
+#endif // (defined(SL_MATTER_RGB_LED_ENABLED) && SL_MATTER_RGB_LED_ENABLED)
 
 #ifdef SL_CATALOG_SIMPLE_BUTTON_PRESENT
 extern "C" void sl_button_on_change(const sl_button_t * handle)

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -427,6 +427,10 @@ template("efr32_sdk") {
       defines += [ "ENABLE_WSTK_LEDS" ]
     }
 
+    if (sl_enable_rgb_led) {
+      defines += [ "SL_MATTER_RGB_LED_ENABLED=1" ]
+    }
+
     if (use_wstk_buttons) {
       _include_dirs += [ "${efr32_sdk_root}/platform/driver/button/inc" ]
     }
@@ -941,9 +945,15 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform/driver/leddrv/src/sl_led.c",
         "${efr32_sdk_root}/platform/driver/leddrv/src/sl_pwm_led.c",
         "${efr32_sdk_root}/platform/driver/leddrv/src/sl_simple_led.c",
-        "${efr32_sdk_root}/platform/driver/leddrv/src/sl_simple_rgb_pwm_led.c",
-        "${silabs_gen_folder}/autogen/sl_simple_led_instances.c",
       ]
+      if (sl_enable_rgb_led) {
+        sources += [
+          "${efr32_sdk_root}/platform/driver/leddrv/src/sl_simple_rgb_pwm_led.c",
+          "${silabs_gen_folder}/autogen/sl_simple_rgb_pwm_led_instances.c",
+        ]
+      } else {
+        sources += [ "${silabs_gen_folder}/autogen/sl_simple_led_instances.c" ]
+      }
     }
 
     # SPI is only used for Wifi

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -150,6 +150,8 @@ if (is_si917_board) {
   silabs_family = "efr32mg24"
   silabs_mcu = "EFR32MG24B310F1536IM48"
 
+  # TODO enable me once submodule is updated
+  # sl_enable_rgb_led = true
   # ThunderBoards don't have a LCD,
   show_qr_code = false
   disable_lcd = true


### PR DESCRIPTION
#### Summary
Add the necessary piping to build with RGB led support for OpenThread based board. 
Also fix a couple of issue with the LightingManager regarding RGB calculation (unintialized variable, wrong variable set, etc..)

Work done in this PR will need a submodule update from the `matter-support` silabs submodule in order to have full RGB support with the dedicated board.

#### Related issues
None applicable

#### Testing
Tested using a BRD2601B. 
Board was commissionned and then set-Hue-and-saturation command were send to the DUT to see if the color of the LED was changing as well. 


