### PR TITLE
Disable Kotlin static code analysis

### DIFF
--- a/.github/workflows/kotlin-style.yaml
+++ b/.github/workflows/kotlin-style.yaml
@@ -13,8 +13,11 @@ concurrency:
 
 
 jobs:
+
+  # This test is currently disabled due to Issue #41932
   detekt:
     name: Static code analysis
+    if: false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
#### Summary

Disabling the Kotlin static code analysis test due to issues in action-detekt-all repo.

#### Related issues

#41932

#### Testing

- CI should still pass, kotlin static code analysis test should not be ran
