### PR TITLE
[Camera] Turn off performance profiling/instrumentation by default 

### DIFF
--- a/examples/camera-app/linux/args.gni
+++ b/examples/camera-app/linux/args.gni
@@ -27,7 +27,7 @@ chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 chip_with_nlfaultinjection = true
 
-matter_enable_tracing_support = true
+matter_enable_tracing_support = false
 matter_enable_camera_server = true
 
 # Disable IPv4 to force IPv6 usage for TCP connections

--- a/examples/camera-controller/args.gni
+++ b/examples/camera-controller/args.gni
@@ -24,7 +24,7 @@ chip_project_config_include_dirs =
     [ "${chip_root}/examples/camera-controller/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
-matter_enable_tracing_support = true
+matter_enable_tracing_support = false
 
 matter_log_json_payload_hex = true
 matter_log_json_payload_decode_full = true


### PR DESCRIPTION
#### Summary

Turn matter_enable_tracing_support off by default→ Performance profiling/instrumentation (Perfetto, Instruments)

NOT related to → Regular console logging, cloud uploads, or application logs
When disabled → Zero impact on normal logging, just disables profiling hooks

With this change:

chip-camera-app from 124M to 81M
chip-camera-controller  from 147M to 138M

#### Related issues

N/A

#### Testing

Validate by CI
