### PR TITLE
[1.4.2] Add precommit config from master (to avoid CI redness)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/google/keep-sorted
+    rev: v0.7.1
+    hooks:
+      - id: keep-sorted


### PR DESCRIPTION
#### Summary

pre-commit CI is enabled globally, including our branches. Want to keep LTS 1.4.2 generally green throughout.

#### Testing

Trivial change, will just check for green CI for pre-commit