### PR TITLE
[NXP] Fix BootReason for successful OTA

### DIFF
--- a/src/platform/nxp/common/NXPConfig.cpp
+++ b/src/platform/nxp/common/NXPConfig.cpp
@@ -565,7 +565,7 @@ bool NXPConfig::ValidConfigKey(Key key)
 {
     // Returns true if the key is in the valid CHIP Config PDM key range.
 
-    if ((key >= kMinConfigKey_ChipFactory) && (key <= kMaxConfigKey_KVS))
+    if ((key >= kMinConfigKey_ChipFactory) && (key <= kMaxConfigKey_App))
     {
         return true;
     }

--- a/src/platform/nxp/common/NXPConfig.h
+++ b/src/platform/nxp/common/NXPConfig.h
@@ -81,8 +81,8 @@ public:
                                                                        * runtime. Retained during factory reset. */
     static constexpr uint8_t kFileId_KVS = CATEGORY_BASE + 3;         /**< Category containing KVS set at runtime.
                                                                        *  Cleared during factory reset. */
-    static constexpr uint8_t kFileId_App = CATEGORY_BASE + 4;         /**< Category containing custom application values set at runtime.
-                                                                       *  Cleared during factory reset. */
+    static constexpr uint8_t kFileId_App = CATEGORY_BASE + 4; /**< Category containing custom application values set at runtime.
+                                                               *  Cleared during factory reset. */
 
     using Key = uint16_t;
 

--- a/src/platform/nxp/common/NXPConfig.h
+++ b/src/platform/nxp/common/NXPConfig.h
@@ -81,6 +81,8 @@ public:
                                                                        * runtime. Retained during factory reset. */
     static constexpr uint8_t kFileId_KVS = CATEGORY_BASE + 3;         /**< Category containing KVS set at runtime.
                                                                        *  Cleared during factory reset. */
+    static constexpr uint8_t kFileId_App = CATEGORY_BASE + 4;         /**< Category containing custom application values set at runtime.
+                                                                       *  Cleared during factory reset. */
 
     using Key = uint16_t;
 
@@ -146,6 +148,9 @@ public:
     static constexpr Key kConfigKey_GroupKeyMax  = config_key(kFileId_ChipConfig, 0x1E);
     ; // Allows 16 Group Keys to be created.
 
+    // Application Custom Keys
+    static constexpr Key kConfigKey_AppOTADone = config_key(kFileId_App, 0x00);
+
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_ChipFactory = config_key(kFileId_ChipFactory, 0x00);
     static constexpr Key kMaxConfigKey_ChipFactory = config_key(kFileId_ChipFactory, 0x08);
@@ -155,6 +160,8 @@ public:
     static constexpr Key kMaxConfigKey_ChipCounter = config_key(kFileId_ChipCounter, 0x1F); // Allows 32 Counters to be created.
     static constexpr Key kMinConfigKey_KVS         = config_key(kFileId_KVS, 0x00);
     static constexpr Key kMaxConfigKey_KVS         = config_key(kFileId_KVS, 0xFF);
+    static constexpr Key kMinConfigKey_App         = config_key(kFileId_App, 0x00);
+    static constexpr Key kMaxConfigKey_App         = config_key(kFileId_App, 0xFF);
 
     static CHIP_ERROR Init(void);
 

--- a/src/platform/nxp/common/NXPConfigKS.cpp
+++ b/src/platform/nxp/common/NXPConfigKS.cpp
@@ -450,7 +450,7 @@ bool NXPConfig::ValidConfigKey(Key key)
 {
     // Returns true if the key is in the valid CHIP Config PDM key range.
 
-    if ((key >= kMinConfigKey_ChipFactory) && (key <= kMaxConfigKey_KVS))
+    if ((key >= kMinConfigKey_ChipFactory) && (key <= kMaxConfigKey_App))
     {
         return true;
     }

--- a/src/platform/nxp/common/NXPConfigNVS.cpp
+++ b/src/platform/nxp/common/NXPConfigNVS.cpp
@@ -397,7 +397,7 @@ CHIP_ERROR NXPConfig::FactoryResetConfig(void)
 bool NXPConfig::ValidConfigKey(Key key)
 {
     // Returns true if the key is in the valid CHIP Config PDM key range.
-    return (key >= kMinConfigKey_ChipFactory) && (key <= kMaxConfigKey_KVS);
+    return (key >= kMinConfigKey_ChipFactory) && (key <= kMaxConfigKey_App);
 }
 
 void NXPConfig::RunConfigUnitTest(void) {}

--- a/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
@@ -67,16 +67,16 @@ CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint32_t reason)
         bool otaDone   = false;
 
         err = ReadConfigValue(NXPConfig::kConfigKey_AppOTADone, otaDone);
-        if (err != CHIP_NO_ERROR && err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+        if (err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
         {
-            ChipLogError(DeviceLayer, "Failed to read OTA completion flag: %s", ErrorStr(err));
+            SuccessOrLog(err, DeviceLayer, "Failed to read OTA completion flag");
         }
 
         if (otaDone)
         {
             bootReason = BootReasonType::kSoftwareUpdateCompleted;
-            err        = WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, false);
-            ReturnErrorAndLogOnFailure(err, DeviceLayer, "Failed to store OTA completion flag: %s", ErrorStr(err));
+            ReturnErrorAndLogOnFailure(WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, false),
+                                        DeviceLayer, "Failed to store OTA completion flag");
         }
 #endif
     }
@@ -94,10 +94,8 @@ CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint32_t reason)
 
 CHIP_ERROR ConfigurationManagerImpl::StoreSoftwareUpdateCompleted()
 {
-    CHIP_ERROR err;
-
-    err = WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, true);
-    ReturnErrorAndLogOnFailure(err, DeviceLayer, "Failed to store OTA completion flag: %s", ErrorStr(err));
+    ReturnErrorAndLogOnFailure(WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, true),
+                                DeviceLayer, "Failed to store OTA completion flag");
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
@@ -63,8 +63,8 @@ CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint32_t reason)
     {
         bootReason = BootReasonType::kSoftwareReset;
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
-        CHIP_ERROR err  = CHIP_NO_ERROR;
-        bool otaDone = false;
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        bool otaDone   = false;
 
         err = ReadConfigValue(NXPConfig::kConfigKey_AppOTADone, otaDone);
         if (err != CHIP_NO_ERROR)
@@ -75,7 +75,7 @@ CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint32_t reason)
         if (otaDone)
         {
             bootReason = BootReasonType::kSoftwareUpdateCompleted;
-            err = WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, false);
+            err        = WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, false);
             if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(DeviceLayer, "BootReason Write OTA key failed: %s", ErrorStr(err));
@@ -97,7 +97,7 @@ CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint32_t reason)
 
 CHIP_ERROR ConfigurationManagerImpl::StoreSoftwareUpdateCompleted()
 {
-    CHIP_ERROR err  = CHIP_NO_ERROR;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
     err = WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, true);
     if (err != CHIP_NO_ERROR)

--- a/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
@@ -67,19 +67,16 @@ CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint32_t reason)
         bool otaDone   = false;
 
         err = ReadConfigValue(NXPConfig::kConfigKey_AppOTADone, otaDone);
-        if (err != CHIP_NO_ERROR)
+        if (err != CHIP_NO_ERROR && err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
         {
-            ChipLogError(DeviceLayer, "BootReason Read OTA key failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "Failed to read OTA completion flag: %s", ErrorStr(err));
         }
 
         if (otaDone)
         {
             bootReason = BootReasonType::kSoftwareUpdateCompleted;
             err        = WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, false);
-            if (err != CHIP_NO_ERROR)
-            {
-                ChipLogError(DeviceLayer, "BootReason Write OTA key failed: %s", ErrorStr(err));
-            }
+            ReturnErrorAndLogOnFailure(err, DeviceLayer, "Failed to store OTA completion flag: %s", ErrorStr(err));
         }
 #endif
     }
@@ -97,15 +94,12 @@ CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint32_t reason)
 
 CHIP_ERROR ConfigurationManagerImpl::StoreSoftwareUpdateCompleted()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err;
 
     err = WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, true);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "BootReason Write OTA key failed: %s", ErrorStr(err));
-    }
+    ReturnErrorAndLogOnFailure(err, DeviceLayer, "Failed to store OTA completion flag: %s", ErrorStr(err));
 
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ConfigurationManagerImpl::Init()

--- a/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
@@ -75,8 +75,8 @@ CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint32_t reason)
         if (otaDone)
         {
             bootReason = BootReasonType::kSoftwareUpdateCompleted;
-            ReturnErrorAndLogOnFailure(WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, false),
-                                        DeviceLayer, "Failed to store OTA completion flag");
+            ReturnErrorAndLogOnFailure(WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, false), DeviceLayer,
+                                       "Failed to store OTA completion flag");
         }
 #endif
     }
@@ -94,8 +94,8 @@ CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint32_t reason)
 
 CHIP_ERROR ConfigurationManagerImpl::StoreSoftwareUpdateCompleted()
 {
-    ReturnErrorAndLogOnFailure(WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, true),
-                                DeviceLayer, "Failed to store OTA completion flag");
+    ReturnErrorAndLogOnFailure(WriteConfigValue(NXPConfig::kConfigKey_AppOTADone, true), DeviceLayer,
+                               "Failed to store OTA completion flag");
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/nxp/mcxw71/K32W1Config.cpp
+++ b/src/platform/nxp/mcxw71/K32W1Config.cpp
@@ -417,7 +417,7 @@ CHIP_ERROR NXPConfig::MapRamStorageStatus(rsError rsStatus)
 bool NXPConfig::ValidConfigKey(Key key)
 {
     // Returns true if the key is in the valid CHIP Config PDM key range.
-    if ((key >= kMinConfigKey_ChipFactory) && (key <= kMaxConfigKey_KVSValue))
+    if ((key >= kMinConfigKey_ChipFactory) && (key <= kMaxConfigKey_App))
     {
         return true;
     }

--- a/src/platform/nxp/mcxw71/K32W1Config.h
+++ b/src/platform/nxp/mcxw71/K32W1Config.h
@@ -101,7 +101,7 @@ public:
     static constexpr Key kCounterKey_BootReason            = K32WConfigKey(kFileId_ChipCounter, 0x03);
 
     // Application Custom Keys
-    static constexpr Key kConfigKey_AppOTADone = config_key(kFileId_App, 0x00);
+    static constexpr Key kConfigKey_AppOTADone = K32WConfigKey(kFileId_App, 0x00);
 
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_ChipFactory = K32WConfigKey(kFileId_ChipFactory, 0x00);

--- a/src/platform/nxp/mcxw71/K32W1Config.h
+++ b/src/platform/nxp/mcxw71/K32W1Config.h
@@ -63,6 +63,8 @@ public:
                                                           *  Cleared during factory reset. */
     static constexpr uint8_t kFileId_KVSValue = 0x05;    /**< Category containing KVS values set at runtime.
                                                           *   Cleared during factory reset. */
+    static constexpr uint8_t kFileId_App = 0x06;         /**< Category containing custom application values set at runtime.
+                                                          *   Cleared during factory reset. */
 
     using Key = uint16_t;
 
@@ -98,6 +100,9 @@ public:
     static constexpr Key kCounterKey_TotalOperationalHours = K32WConfigKey(kFileId_ChipCounter, 0x02);
     static constexpr Key kCounterKey_BootReason            = K32WConfigKey(kFileId_ChipCounter, 0x03);
 
+    // Application Custom Keys
+    static constexpr Key kConfigKey_AppOTADone = config_key(kFileId_App, 0x00);
+
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_ChipFactory = K32WConfigKey(kFileId_ChipFactory, 0x00);
     static constexpr Key kMaxConfigKey_ChipFactory = K32WConfigKey(kFileId_ChipFactory, 0xFF);
@@ -109,6 +114,8 @@ public:
     static constexpr Key kMaxConfigKey_KVSKey      = K32WConfigKey(kFileId_KVSKey, 0xFF);
     static constexpr Key kMinConfigKey_KVSValue    = K32WConfigKey(kFileId_KVSValue, 0x00);
     static constexpr Key kMaxConfigKey_KVSValue    = K32WConfigKey(kFileId_KVSValue, 0xFF);
+    static constexpr Key kMinConfigKey_App         = K32WConfigKey(kFileId_App, 0x00);
+    static constexpr Key kMaxConfigKey_App         = K32WConfigKey(kFileId_App, 0xFF);
 
     static CHIP_ERROR Init(void);
 


### PR DESCRIPTION
#### Summary

Fix BootReason for successful OTA by adding an App Key after OTA is done downloading, right before the reset. This key is read at the next boot setting the proper boot reason if needed

- Add read/write ota done nvm key in order to set kSoftwareUpdateCompleted boot reason.
- Add App keys to be used for custom application nvm values set at runtime.
- Add App OTA done key.
- Update ValidConfigKey to account for new keys.

#### Testing

Tested OTA locally. Successfully read the right boot reason.  

