### PR TITLE
Remove extra status message sent after GetTargets response in EVSE

### DIFF
--- a/src/app/clusters/energy-evse-server/energy-evse-server.cpp
+++ b/src/app/clusters/energy-evse-server/energy-evse-server.cpp
@@ -481,7 +481,6 @@ void Instance::HandleGetTargets(HandlerContext & ctx, const Commands::GetTargets
     }
 
     ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
-    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::Success);
 }
 
 void Instance::HandleClearTargets(HandlerContext & ctx, const Commands::ClearTargets::DecodableType & commandData)


### PR DESCRIPTION
#### Summary

It seems that the energy EVSE server sends extra status message after command response message which triggers asyncio error in the test:
```console
$ scripts/tests/run_python_test.py --script src/python_testing/TC_EEVSE_2_3.py --load-from-env=test-env.yaml --no-quiet
...
handle: <Handle AsyncCommandTransaction._handleResponse(CommandPath(E..., CommandId=6), Status(IMStat...terStatus=255), b'')>
Traceback (most recent call last):
  File "/usr/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/local/lib/python3.12/dist-packages/matter/clusters/Command.py", line 95, in _handleResponse
    self._future.set_result(None)
asyncio.exceptions.InvalidStateError: invalid state
```

which was caused by the command async handler being called twice.

There will be a follow-up PR (hopefully if it is be possible in current design) which which will "fix" python binding, so in such case in the future a test script will report failure instead of silently printing exception.

#### Testing

CI should verify