### PR TITLE
[WebRTCR] Enable controller to manage multiple cameras

### DIFF
--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -111,11 +111,11 @@ void WebRTCManager::Init()
     }
 }
 
-CHIP_ERROR WebRTCManager::HandleOffer(uint16_t sessionId, const WebRTCRequestorDelegate::OfferArgs & args)
+CHIP_ERROR WebRTCManager::HandleOffer(const WebRTCSessionStruct & session, const WebRTCRequestorDelegate::OfferArgs & args)
 {
     ChipLogProgress(Camera, "WebRTCManager::HandleOffer");
 
-    mWebRTCProviderClient.HandleOfferReceived(sessionId);
+    mWebRTCProviderClient.HandleOfferReceived(session.id);
 
     if (!mPeerConnection)
     {
@@ -132,7 +132,7 @@ CHIP_ERROR WebRTCManager::HandleOffer(uint16_t sessionId, const WebRTCRequestorD
     }
 
     // Store sessionId for the delayed callback
-    mPendingSessionId = sessionId;
+    mPendingSessionId = session.id;
 
     // Schedule the ProvideAnswer() call to run with a small delay to ensure the response is sent first
     DeviceLayer::SystemLayer().StartTimer(
@@ -146,11 +146,11 @@ CHIP_ERROR WebRTCManager::HandleOffer(uint16_t sessionId, const WebRTCRequestorD
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WebRTCManager::HandleAnswer(uint16_t sessionId, const std::string & sdp)
+CHIP_ERROR WebRTCManager::HandleAnswer(const WebRTCSessionStruct & session, const std::string & sdp)
 {
     ChipLogProgress(Camera, "WebRTCManager::HandleAnswer");
 
-    mWebRTCProviderClient.HandleAnswerReceived(sessionId);
+    mWebRTCProviderClient.HandleAnswerReceived(session.id);
 
     if (!mPeerConnection)
     {
@@ -162,7 +162,7 @@ CHIP_ERROR WebRTCManager::HandleAnswer(uint16_t sessionId, const std::string & s
     mPeerConnection->setRemoteDescription(answerDesc);
 
     // Store sessionId for the delayed callback
-    mPendingSessionId = sessionId;
+    mPendingSessionId = session.id;
 
     // Schedule the ProvideICECandidates() call to run with a small delay to ensure the response is sent first
     DeviceLayer::SystemLayer().StartTimer(
@@ -176,7 +176,8 @@ CHIP_ERROR WebRTCManager::HandleAnswer(uint16_t sessionId, const std::string & s
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WebRTCManager::HandleICECandidates(uint16_t sessionId, const std::vector<ICECandidateStruct> & candidates)
+CHIP_ERROR WebRTCManager::HandleICECandidates(const WebRTCSessionStruct & session,
+                                              const std::vector<ICECandidateStruct> & candidates)
 {
     ChipLogProgress(Camera, "WebRTCManager::HandleICECandidates");
 

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -37,6 +37,7 @@ class WebRTCManager
 {
 public:
     using ICECandidateStruct         = chip::app::Clusters::Globals::Structs::ICECandidateStruct::Type;
+    using WebRTCSessionStruct        = chip::app::Clusters::Globals::Structs::WebRTCSessionStruct::Type;
     using StreamUsageEnum            = chip::app::Clusters::Globals::StreamUsageEnum;
     using SessionEstablishedCallback = std::function<void(uint16_t streamId)>;
 
@@ -55,11 +56,11 @@ public:
      */
     void SetSessionEstablishedCallback(SessionEstablishedCallback callback) { mSessionEstablishedCallback = callback; }
 
-    CHIP_ERROR HandleOffer(uint16_t sessionId, const WebRTCRequestorDelegate::OfferArgs & args);
+    CHIP_ERROR HandleOffer(const WebRTCSessionStruct & session, const WebRTCRequestorDelegate::OfferArgs & args);
 
-    CHIP_ERROR HandleAnswer(uint16_t sessionId, const std::string & sdp);
+    CHIP_ERROR HandleAnswer(const WebRTCSessionStruct & session, const std::string & sdp);
 
-    CHIP_ERROR HandleICECandidates(uint16_t sessionId, const std::vector<ICECandidateStruct> & candidates);
+    CHIP_ERROR HandleICECandidates(const WebRTCSessionStruct & session, const std::vector<ICECandidateStruct> & candidates);
 
     CHIP_ERROR Connnect(chip::Controller::DeviceCommissioner & commissioner, chip::NodeId nodeId, chip::EndpointId endpointId);
 

--- a/examples/camera-controller/webrtc-manager/WebRTCProviderClient.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCProviderClient.cpp
@@ -402,7 +402,7 @@ void WebRTCProviderClient::OnSessionEstablishTimeout(chip::System::Layer * syste
 
     if (self->mCurrentSessionId != 0)
     {
-        self->mRequestorServer->RemoveSession(self->mCurrentSessionId);
+        self->mRequestorServer->RemoveSession(self->mCurrentSessionId, self->mPeerId.GetNodeId(), self->mPeerId.GetFabricIndex());
         self->mCurrentSessionId = 0;
     }
 

--- a/examples/camera-controller/webrtc-manager/WebRTCRequestorDelegate.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCRequestorDelegate.cpp
@@ -26,25 +26,26 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WebRTCTransportRequestor;
 
-CHIP_ERROR WebRTCRequestorDelegate::HandleOffer(uint16_t sessionId, const OfferArgs & args)
+CHIP_ERROR WebRTCRequestorDelegate::HandleOffer(const WebRTCSessionStruct & session, const OfferArgs & args)
 {
     ChipLogProgress(Camera, "WebRTCRequestorDelegate::HandleOffer");
-    return WebRTCManager::Instance().HandleOffer(sessionId, args);
+    return WebRTCManager::Instance().HandleOffer(session.id, args);
 }
 
-CHIP_ERROR WebRTCRequestorDelegate::HandleAnswer(uint16_t sessionId, const std::string & sdpAnswer)
+CHIP_ERROR WebRTCRequestorDelegate::HandleAnswer(const WebRTCSessionStruct & session, const std::string & sdpAnswer)
 {
     ChipLogProgress(Camera, "WebRTCRequestorDelegate::HandleAnswer");
-    return WebRTCManager::Instance().HandleAnswer(sessionId, sdpAnswer);
+    return WebRTCManager::Instance().HandleAnswer(session.id, sdpAnswer);
 }
 
-CHIP_ERROR WebRTCRequestorDelegate::HandleICECandidates(uint16_t sessionId, const std::vector<ICECandidateStruct> & candidates)
+CHIP_ERROR WebRTCRequestorDelegate::HandleICECandidates(const WebRTCSessionStruct & session,
+                                                        const std::vector<ICECandidateStruct> & candidates)
 {
     ChipLogProgress(Camera, "WebRTCRequestorDelegate::HandleICECandidates");
-    return WebRTCManager::Instance().HandleICECandidates(sessionId, candidates);
+    return WebRTCManager::Instance().HandleICECandidates(session.id, candidates);
 }
 
-CHIP_ERROR WebRTCRequestorDelegate::HandleEnd(uint16_t sessionId, WebRTCEndReasonEnum reasonCode)
+CHIP_ERROR WebRTCRequestorDelegate::HandleEnd(const WebRTCSessionStruct & session, WebRTCEndReasonEnum reasonCode)
 {
     ChipLogProgress(Camera, "WebRTCRequestorDelegate::HandleEnd");
     return CHIP_NO_ERROR;

--- a/examples/camera-controller/webrtc-manager/WebRTCRequestorDelegate.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCRequestorDelegate.cpp
@@ -29,20 +29,20 @@ using namespace chip::app::Clusters::WebRTCTransportRequestor;
 CHIP_ERROR WebRTCRequestorDelegate::HandleOffer(const WebRTCSessionStruct & session, const OfferArgs & args)
 {
     ChipLogProgress(Camera, "WebRTCRequestorDelegate::HandleOffer");
-    return WebRTCManager::Instance().HandleOffer(session.id, args);
+    return WebRTCManager::Instance().HandleOffer(session, args);
 }
 
 CHIP_ERROR WebRTCRequestorDelegate::HandleAnswer(const WebRTCSessionStruct & session, const std::string & sdpAnswer)
 {
     ChipLogProgress(Camera, "WebRTCRequestorDelegate::HandleAnswer");
-    return WebRTCManager::Instance().HandleAnswer(session.id, sdpAnswer);
+    return WebRTCManager::Instance().HandleAnswer(session, sdpAnswer);
 }
 
 CHIP_ERROR WebRTCRequestorDelegate::HandleICECandidates(const WebRTCSessionStruct & session,
                                                         const std::vector<ICECandidateStruct> & candidates)
 {
     ChipLogProgress(Camera, "WebRTCRequestorDelegate::HandleICECandidates");
-    return WebRTCManager::Instance().HandleICECandidates(session.id, candidates);
+    return WebRTCManager::Instance().HandleICECandidates(session, candidates);
 }
 
 CHIP_ERROR WebRTCRequestorDelegate::HandleEnd(const WebRTCSessionStruct & session, WebRTCEndReasonEnum reasonCode)

--- a/examples/camera-controller/webrtc-manager/WebRTCRequestorDelegate.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCRequestorDelegate.h
@@ -25,16 +25,18 @@ class WebRTCRequestorDelegate : public chip::app::Clusters::WebRTCTransportReque
 {
 public:
     using ICECandidateStruct  = chip::app::Clusters::Globals::Structs::ICECandidateStruct::Type;
+    using WebRTCSessionStruct = chip::app::Clusters::Globals::Structs::WebRTCSessionStruct::Type;
     using WebRTCEndReasonEnum = chip::app::Clusters::Globals::WebRTCEndReasonEnum;
 
     WebRTCRequestorDelegate()  = default;
     ~WebRTCRequestorDelegate() = default;
 
-    CHIP_ERROR HandleOffer(uint16_t sessionId, const OfferArgs & args) override;
+    CHIP_ERROR HandleOffer(const WebRTCSessionStruct & session, const OfferArgs & args) override;
 
-    CHIP_ERROR HandleAnswer(uint16_t sessionId, const std::string & sdpAnswer) override;
+    CHIP_ERROR HandleAnswer(const WebRTCSessionStruct & session, const std::string & sdpAnswer) override;
 
-    CHIP_ERROR HandleICECandidates(uint16_t sessionId, const std::vector<ICECandidateStruct> & candidates) override;
+    CHIP_ERROR HandleICECandidates(const WebRTCSessionStruct & session,
+                                   const std::vector<ICECandidateStruct> & candidates) override;
 
-    CHIP_ERROR HandleEnd(uint16_t sessionId, WebRTCEndReasonEnum reasonCode) override;
+    CHIP_ERROR HandleEnd(const WebRTCSessionStruct & session, WebRTCEndReasonEnum reasonCode) override;
 };

--- a/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
@@ -51,30 +51,30 @@ class MockWebRTCTransportRequestorDelegate : public Delegate
 public:
     MockWebRTCTransportRequestorDelegate() : mLastSessionId(0), mLastEndReason(WebRTCEndReasonEnum::kUnknownEnumValue) {}
 
-    CHIP_ERROR HandleOffer(uint16_t sessionId, const OfferArgs & args) override
+    CHIP_ERROR HandleOffer(const WebRTCSessionStruct & session, const OfferArgs & args) override
     {
-        mLastSessionId = sessionId;
+        mLastSessionId = session.id;
         mLastOfferArgs = args;
         return mOfferResult;
     }
 
-    CHIP_ERROR HandleAnswer(uint16_t sessionId, const std::string & sdpAnswer) override
+    CHIP_ERROR HandleAnswer(const WebRTCSessionStruct & session, const std::string & sdpAnswer) override
     {
-        mLastSessionId = sessionId;
+        mLastSessionId = session.id;
         mLastSdpAnswer = sdpAnswer;
         return mAnswerResult;
     }
 
-    CHIP_ERROR HandleICECandidates(uint16_t sessionId, const std::vector<ICECandidateStruct> & candidates) override
+    CHIP_ERROR HandleICECandidates(const WebRTCSessionStruct & session, const std::vector<ICECandidateStruct> & candidates) override
     {
-        mLastSessionId  = sessionId;
+        mLastSessionId  = session.id;
         mLastCandidates = candidates;
         return mICECandidatesResult;
     }
 
-    CHIP_ERROR HandleEnd(uint16_t sessionId, WebRTCEndReasonEnum reasonCode) override
+    CHIP_ERROR HandleEnd(const WebRTCSessionStruct & session, WebRTCEndReasonEnum reasonCode) override
     {
-        mLastSessionId = sessionId;
+        mLastSessionId = session.id;
         mLastEndReason = reasonCode;
         return mEndResult;
     }
@@ -182,7 +182,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestCurrentSessionsAttribute)
     EXPECT_EQ(sessions[0].streamUsage, StreamUsageEnum::kRecording);
 
     // Remove the session
-    server.RemoveSession(1);
+    server.RemoveSession(1, testSession.peerNodeID, testSession.fabricIndex);
     sessions = server.GetCurrentSessions();
     EXPECT_TRUE(sessions.empty());
 }
@@ -208,13 +208,13 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestSessionManagement)
     EXPECT_EQ(sessions.size(), 2u);
 
     // Remove specific session
-    server.RemoveSession(1);
+    server.RemoveSession(1, session1.peerNodeID, session1.fabricIndex);
     sessions = server.GetCurrentSessions();
     EXPECT_EQ(sessions.size(), 1u);
     EXPECT_EQ(sessions[0].id, 2);
 
     // Remove non-existent session (should be no-op)
-    server.RemoveSession(999);
+    server.RemoveSession(999, 0, 0);
     sessions = server.GetCurrentSessions();
     EXPECT_EQ(sessions.size(), 1u);
 }
@@ -225,7 +225,9 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestDelegateHandleOffer)
     WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
 
     // Setup test data
-    uint16_t testSessionId = 123;
+    WebRTCSessionStruct testSession;
+    testSession.id         = 123;
+    testSession.peerNodeID = 0x1234ULL;
     std::string testSdp    = "test_sdp_offer";
 
     // Test successful offer handling
@@ -235,15 +237,15 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestDelegateHandleOffer)
     offerArgs.sdp        = testSdp;
     offerArgs.peerNodeId = 0x1234ULL; // Use ULL suffix for uint64_t/NodeId
 
-    CHIP_ERROR result = mockDelegate.HandleOffer(testSessionId, offerArgs);
+    CHIP_ERROR result = mockDelegate.HandleOffer(testSession, offerArgs);
     EXPECT_EQ(result, CHIP_NO_ERROR);
-    EXPECT_EQ(mockDelegate.GetLastSessionId(), testSessionId);
+    EXPECT_EQ(mockDelegate.GetLastSessionId(), 123);
     EXPECT_EQ(mockDelegate.GetLastOfferArgs().sdp, testSdp);
     EXPECT_EQ(mockDelegate.GetLastOfferArgs().peerNodeId, 0x1234ULL);
 
     // Test error case
     mockDelegate.SetOfferResult(CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
-    result = mockDelegate.HandleOffer(testSessionId, offerArgs);
+    result = mockDelegate.HandleOffer(testSession, offerArgs);
     EXPECT_EQ(result, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 }
 
@@ -253,20 +255,21 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestDelegateHandleAnswer)
     WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
 
     // Setup test data
-    uint16_t testSessionId    = 456;
+    WebRTCSessionStruct testSession;
+    testSession.id            = 456;
     std::string testSdpAnswer = "test_sdp_answer";
 
     // Test successful answer handling
     mockDelegate.SetAnswerResult(CHIP_NO_ERROR);
 
-    CHIP_ERROR result = mockDelegate.HandleAnswer(testSessionId, testSdpAnswer);
+    CHIP_ERROR result = mockDelegate.HandleAnswer(testSession, testSdpAnswer);
     EXPECT_EQ(result, CHIP_NO_ERROR);
-    EXPECT_EQ(mockDelegate.GetLastSessionId(), testSessionId);
+    EXPECT_EQ(mockDelegate.GetLastSessionId(), 456);
     EXPECT_EQ(mockDelegate.GetLastSdpAnswer(), testSdpAnswer);
 
     // Test error case
     mockDelegate.SetAnswerResult(CHIP_ERROR_INTERNAL);
-    result = mockDelegate.HandleAnswer(testSessionId, testSdpAnswer);
+    result = mockDelegate.HandleAnswer(testSession, testSdpAnswer);
     EXPECT_EQ(result, CHIP_ERROR_INTERNAL);
 }
 
@@ -276,7 +279,8 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestDelegateHandleICECandidates)
     WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
 
     // Setup test data
-    uint16_t testSessionId = 789;
+    WebRTCSessionStruct testSession;
+    testSession.id = 789;
     std::vector<ICECandidateStruct> testCandidates;
 
     ICECandidateStruct candidate1;
@@ -290,14 +294,14 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestDelegateHandleICECandidates)
     // Test successful ICE candidates handling
     mockDelegate.SetICECandidatesResult(CHIP_NO_ERROR);
 
-    CHIP_ERROR result = mockDelegate.HandleICECandidates(testSessionId, testCandidates);
+    CHIP_ERROR result = mockDelegate.HandleICECandidates(testSession, testCandidates);
     EXPECT_EQ(result, CHIP_NO_ERROR);
-    EXPECT_EQ(mockDelegate.GetLastSessionId(), testSessionId);
+    EXPECT_EQ(mockDelegate.GetLastSessionId(), 789);
     EXPECT_EQ(mockDelegate.GetLastCandidates().size(), 2u);
 
     // Test error case
     mockDelegate.SetICECandidatesResult(CHIP_ERROR_INVALID_ARGUMENT);
-    result = mockDelegate.HandleICECandidates(testSessionId, testCandidates);
+    result = mockDelegate.HandleICECandidates(testSession, testCandidates);
     EXPECT_EQ(result, CHIP_ERROR_INVALID_ARGUMENT);
 }
 
@@ -307,26 +311,27 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestDelegateHandleEnd)
     WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
 
     // Setup test data
-    uint16_t testSessionId         = 999;
+    WebRTCSessionStruct testSession;
+    testSession.id                 = 999;
     WebRTCEndReasonEnum testReason = WebRTCEndReasonEnum::kInviteTimeout;
 
     // Test successful end handling
     mockDelegate.SetEndResult(CHIP_NO_ERROR);
 
-    CHIP_ERROR result = mockDelegate.HandleEnd(testSessionId, testReason);
+    CHIP_ERROR result = mockDelegate.HandleEnd(testSession, testReason);
     EXPECT_EQ(result, CHIP_NO_ERROR);
-    EXPECT_EQ(mockDelegate.GetLastSessionId(), testSessionId);
+    EXPECT_EQ(mockDelegate.GetLastSessionId(), 999);
     EXPECT_EQ(mockDelegate.GetLastEndReason(), testReason);
 
     // Test different reason codes
     WebRTCEndReasonEnum testReason2 = WebRTCEndReasonEnum::kUserBusy;
-    result                          = mockDelegate.HandleEnd(testSessionId, testReason2);
+    result                          = mockDelegate.HandleEnd(testSession, testReason2);
     EXPECT_EQ(result, CHIP_NO_ERROR);
     EXPECT_EQ(mockDelegate.GetLastEndReason(), testReason2);
 
     // Test error case
     mockDelegate.SetEndResult(CHIP_ERROR_TIMEOUT);
-    result = mockDelegate.HandleEnd(testSessionId, testReason);
+    result = mockDelegate.HandleEnd(testSession, testReason);
     EXPECT_EQ(result, CHIP_ERROR_TIMEOUT);
 }
 

--- a/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
@@ -160,7 +160,8 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestCurrentSessionsAttribute)
     // Add a test session
     WebRTCSessionStruct testSession;
     testSession.id          = 1;
-    testSession.peerNodeID  = chip::kUndefinedNodeId;
+    testSession.peerNodeID  = 1;
+    testSession.fabricIndex = 1;
     testSession.streamUsage = StreamUsageEnum::kLiveView;
 
     auto result = server.UpsertSession(testSession);
@@ -194,12 +195,14 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestSessionManagement)
 
     // Test adding multiple sessions
     WebRTCSessionStruct session1;
-    session1.id         = 1;
-    session1.peerNodeID = 0x1234ULL;
+    session1.id          = 1;
+    session1.peerNodeID  = 0x1234ULL;
+    session1.fabricIndex = 1;
 
     WebRTCSessionStruct session2;
-    session2.id         = 2;
-    session2.peerNodeID = 0x5678ULL;
+    session2.id          = 2;
+    session2.peerNodeID  = 0x5678ULL;
+    session2.fabricIndex = 1;
 
     server.UpsertSession(session1);
     server.UpsertSession(session2);

--- a/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.cpp
@@ -30,8 +30,6 @@ using chip::Protocols::InteractionModel::Status;
 
 namespace {
 
-constexpr uint16_t kMaxSessionId = 65534;
-
 constexpr DataModel::AcceptedCommandEntry kAcceptedCommands[] = {
     Commands::Offer::kMetadataEntry,
     Commands::Answer::kMetadataEntry,

--- a/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.cpp
@@ -142,62 +142,17 @@ CHIP_ERROR WebRTCTransportRequestorServer::Attributes(const ConcreteClusterPath 
     return listBuilder.Append(Span(kMandatoryMetadata), {}, {});
 }
 
-uint16_t WebRTCTransportRequestorServer::GenerateSessionId()
-{
-    static uint16_t lastSessionId = 0;
-    uint16_t candidateId          = 0;
-
-    // Try at most kMaxSessionId+1 attempts to find a free ID
-    // This ensures we never loop infinitely even if all IDs are somehow in use
-    for (uint16_t attempts = 0; attempts <= kMaxSessionId; attempts++)
-    {
-        candidateId = lastSessionId++;
-
-        // Handle wrap-around per spec
-        if (lastSessionId > kMaxSessionId)
-        {
-            lastSessionId = 0;
-        }
-
-        if (FindSession(candidateId) == nullptr)
-        {
-            return candidateId;
-        }
-    }
-
-    // This should never happen in practice since we support 65534 sessions
-    // and typical applications will have far fewer active sessions
-    ChipLogError(Zcl, "All session IDs are in use!");
-    chipDie();
-}
-
-bool WebRTCTransportRequestorServer::IsPeerNodeSessionValid(uint16_t sessionId, const CommandHandler & commandHandler)
-{
-    NodeId peerNodeId           = GetNodeIdFromCtx(commandHandler);
-    FabricIndex peerFabricIndex = commandHandler.GetAccessingFabricIndex();
-
-    // Check if the session ID is in the existing sessions list
-    WebRTCSessionStruct * existingSession = FindSession(sessionId);
-
-    if (!existingSession)
-    {
-        return false;
-    }
-
-    // Also check that the existing session belongs to the same PeerNodeID / Fabric
-    // If it doesn't match, return false
-    return (peerNodeId == existingSession->peerNodeID) && (peerFabricIndex == existingSession->GetFabricIndex());
-}
-
 DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleOffer(const CommandHandler & commandHandler,
                                                                           const Commands::Offer::DecodableType & req)
 {
     uint16_t sessionId = req.webRTCSessionID;
 
-    if (!IsPeerNodeSessionValid(sessionId, commandHandler))
-    {
-        return Status::NotFound;
-    }
+    // Get the session struct to pass to delegate
+    NodeId peerNodeId           = GetNodeIdFromCtx(commandHandler);
+    FabricIndex peerFabricIndex = commandHandler.GetAccessingFabricIndex();
+
+    WebRTCSessionStruct * session = FindSession(sessionId, peerNodeId, peerFabricIndex);
+    VerifyOrReturnValue(session != nullptr, Status::NotFound);
 
     // Create arguments for Delegate.
     Delegate::OfferArgs args;
@@ -228,7 +183,7 @@ DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleOffer(const 
     }
 
     // Delegate processing: handle the SDP offer, gather ICE candidates, SDP answer, etc.
-    return mDelegate.HandleOffer(sessionId, args);
+    return mDelegate.HandleOffer(*session, args);
 }
 
 DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleAnswer(const CommandHandler & commandHandler,
@@ -237,15 +192,17 @@ DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleAnswer(const
     uint16_t sessionId = req.webRTCSessionID;
     auto sdpSpan       = req.sdp;
 
-    if (!IsPeerNodeSessionValid(sessionId, commandHandler))
-    {
-        return Status::NotFound;
-    }
+    // Get the session struct to pass to delegate
+    NodeId peerNodeId           = GetNodeIdFromCtx(commandHandler);
+    FabricIndex peerFabricIndex = commandHandler.GetAccessingFabricIndex();
+
+    WebRTCSessionStruct * session = FindSession(sessionId, peerNodeId, peerFabricIndex);
+    VerifyOrReturnValue(session != nullptr, Status::NotFound);
 
     std::string sdpAnswer(sdpSpan.data(), sdpSpan.size());
 
     // Delegate handles Answer command received.
-    return mDelegate.HandleAnswer(sessionId, sdpAnswer);
+    return mDelegate.HandleAnswer(*session, sdpAnswer);
 }
 
 DataModel::ActionReturnStatus
@@ -286,13 +243,15 @@ WebRTCTransportRequestorServer::HandleICECandidates(const CommandHandler & comma
         return Status::ConstraintError;
     }
 
-    // Check if the session, NodeID are valid
-    if (!IsPeerNodeSessionValid(sessionId, commandHandler))
-    {
-        return Status::NotFound;
-    }
+    // Get the session struct to pass to delegate
+    NodeId peerNodeId           = GetNodeIdFromCtx(commandHandler);
+    FabricIndex peerFabricIndex = commandHandler.GetAccessingFabricIndex();
 
-    return mDelegate.HandleICECandidates(sessionId, candidates);
+    WebRTCSessionStruct * session = FindSession(sessionId, peerNodeId, peerFabricIndex);
+    VerifyOrReturnValue(session != nullptr, Status::NotFound);
+
+    // Pass the full session struct so delegate can identify which camera this is for
+    return mDelegate.HandleICECandidates(*session, candidates);
 }
 
 DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleEnd(const CommandHandler & commandHandler,
@@ -308,24 +267,26 @@ DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleEnd(const Co
         return Status::ConstraintError;
     }
 
-    if (!IsPeerNodeSessionValid(sessionId, commandHandler))
-    {
-        return Status::NotFound;
-    }
+    // Get the session struct to pass to delegate
+    NodeId peerNodeId           = GetNodeIdFromCtx(commandHandler);
+    FabricIndex peerFabricIndex = commandHandler.GetAccessingFabricIndex();
 
-    CHIP_ERROR delegateResult = mDelegate.HandleEnd(sessionId, reason);
+    WebRTCSessionStruct * session = FindSession(sessionId, peerNodeId, peerFabricIndex);
+    VerifyOrReturnValue(session != nullptr, Status::NotFound);
 
-    RemoveSession(sessionId);
+    // Pass the full session struct so delegate can identify which camera this is for
+    CHIP_ERROR delegateResult = mDelegate.HandleEnd(*session, reason);
+    RemoveSession(sessionId, peerNodeId, peerFabricIndex);
 
     return delegateResult;
 }
 
 // Helper functions
-WebRTCSessionStruct * WebRTCTransportRequestorServer::FindSession(uint16_t sessionId)
+WebRTCSessionStruct * WebRTCTransportRequestorServer::FindSession(uint16_t sessionId, NodeId peerNodeId, FabricIndex fabricIndex)
 {
     for (auto & session : mCurrentSessions)
     {
-        if (session.id == sessionId)
+        if (session.id == sessionId && session.peerNodeID == peerNodeId && session.GetFabricIndex() == fabricIndex)
         {
             return &session;
         }
@@ -336,10 +297,13 @@ WebRTCSessionStruct * WebRTCTransportRequestorServer::FindSession(uint16_t sessi
 
 WebRTCTransportRequestorServer::UpsertResultEnum WebRTCTransportRequestorServer::UpsertSession(const WebRTCSessionStruct & session)
 {
-    // Search for a session in the current sessions
+    // Search for a session in the current sessions using the full tuple <id, peerNodeID, fabricIndex>
+    // This is critical because different cameras can allocate the same sessionId
     UpsertResultEnum result;
-    auto it = std::find_if(mCurrentSessions.begin(), mCurrentSessions.end(),
-                           [id = session.id](const auto & existing) { return existing.id == id; });
+    auto it = std::find_if(mCurrentSessions.begin(), mCurrentSessions.end(), [&session](const auto & existing) {
+        return existing.id == session.id && existing.peerNodeID == session.peerNodeID &&
+            existing.GetFabricIndex() == session.GetFabricIndex();
+    });
 
     if (it != mCurrentSessions.end())
     {
@@ -357,12 +321,16 @@ WebRTCTransportRequestorServer::UpsertResultEnum WebRTCTransportRequestorServer:
     return result;
 }
 
-void WebRTCTransportRequestorServer::RemoveSession(uint16_t sessionId)
+void WebRTCTransportRequestorServer::RemoveSession(uint16_t sessionId, NodeId peerNodeId, FabricIndex fabricIndex)
 {
     size_t originalSize = mCurrentSessions.size();
-    // Remove the session if sessionId is matching
+    // Remove the session if the full tuple <sessionId, peerNodeId, fabricIndex> matches
+    // This is critical: different cameras can have the same sessionId, so we must match all three fields
     mCurrentSessions.erase(std::remove_if(mCurrentSessions.begin(), mCurrentSessions.end(),
-                                          [sessionId](const WebRTCSessionStruct & s) { return s.id == sessionId; }),
+                                          [sessionId, peerNodeId, fabricIndex](const WebRTCSessionStruct & s) {
+                                              return s.id == sessionId && s.peerNodeID == peerNodeId &&
+                                                  s.GetFabricIndex() == fabricIndex;
+                                          }),
                            mCurrentSessions.end());
 
     // Check whether session was removed

--- a/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.h
+++ b/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.h
@@ -61,48 +61,49 @@ public:
      * @brief
      *   Handles the Offer command received by the server.
      *
-     * @param[in] args
-     *   Structure containing all input arguments for the command.
+     * @param[in] session  The WebRTC session for this offer.
+     * @param[in] args     Structure containing all input arguments for the command.
      *
      * @return CHIP_ERROR
      *   - Returns error if the session is invalid or the candidates cannot be processed
      */
-    virtual CHIP_ERROR HandleOffer(uint16_t sessionId, const OfferArgs & args) = 0;
+    virtual CHIP_ERROR HandleOffer(const WebRTCSessionStruct & session, const OfferArgs & args) = 0;
     /**
      * @brief
      *   Handles the Answer command received by the server.
      *
-     * @param[in]  sessionId Current session ID.
-     * @param[in]  sdpAnswer  SDP answer received.
+     * @param[in] session    The WebRTC session for this answer.
+     * @param[in] sdpAnswer  SDP answer received.
      *
      * @return CHIP_ERROR
      *   - Returns error if the session is invalid or the candidates cannot be processed
      */
-    virtual CHIP_ERROR HandleAnswer(uint16_t sessionId, const std::string & sdpAnswer) = 0;
+    virtual CHIP_ERROR HandleAnswer(const WebRTCSessionStruct & session, const std::string & sdpAnswer) = 0;
     /**
      * @brief
      *   Called when the server receives the ICECandidates command.
      *
-     * @param[in] sessionId  Current session ID.
-     * @param[in] candidates List of ICE candidate structs.
+     * @param[in] session     The WebRTC session for these candidates.
+     * @param[in] candidates  List of ICE candidate structs.
      * Note: The callee cannot reference the `candidates` vector after this call
      * returns, and must copy the contents over for later use, if required.
      *
      * @return CHIP_ERROR
      *   - Returns error if the session is invalid or the candidates cannot be processed
      */
-    virtual CHIP_ERROR HandleICECandidates(uint16_t sessionId, const std::vector<ICECandidateStruct> & candidates) = 0;
+    virtual CHIP_ERROR HandleICECandidates(const WebRTCSessionStruct & session,
+                                           const std::vector<ICECandidateStruct> & candidates) = 0;
     /**
      * @brief
      *   Called when the server receives the End command.
      *
-     * @param[in] sessionId  Current session ID to end.
-     * @param[in] reasonCode Reason to end the session.
+     * @param[in] session     The WebRTC session to end.
+     * @param[in] reasonCode  Reason to end the session.
      *
      * @return CHIP_ERROR
      *   - Returns error if the session is invalid or the candidates cannot be processed
      */
-    virtual CHIP_ERROR HandleEnd(uint16_t sessionId, WebRTCEndReasonEnum reasonCode) = 0;
+    virtual CHIP_ERROR HandleEnd(const WebRTCSessionStruct & session, WebRTCEndReasonEnum reasonCode) = 0;
 };
 
 class WebRTCTransportRequestorServer : public DefaultServerCluster
@@ -152,21 +153,21 @@ public:
 
     /**
      * @brief
-     *   Removes a session identified by its session ID from the internal list of current sessions.
+     *   Removes a session identified by its session ID, peer node ID, and fabric index from the internal list of current sessions.
      *
      * @param sessionId  The session ID of the session to remove.
-     *                   If the ID is not found, the call is a no‑op.
+     * @param peerNodeId The peer node ID of the session to remove.
+     * @param fabricIndex The fabric index of the session to remove.
+     *                   If the session is not found, the call is a no‑op.
      */
-    void RemoveSession(uint16_t sessionId);
+    void RemoveSession(uint16_t sessionId, NodeId peerNodeId, FabricIndex fabricIndex);
 
 private:
     Delegate & mDelegate;
     std::vector<WebRTCSessionStruct> mCurrentSessions;
 
     // Helper functions
-    WebRTCSessionStruct * FindSession(uint16_t sessionId);
-    uint16_t GenerateSessionId();
-    bool IsPeerNodeSessionValid(uint16_t sessionId, const CommandHandler & commandHandler);
+    WebRTCSessionStruct * FindSession(uint16_t sessionId, NodeId peerNodeId, FabricIndex fabricIndex);
 
     // Command handlers
     DataModel::ActionReturnStatus HandleOffer(const CommandHandler & commandHandler, const Commands::Offer::DecodableType & req);

--- a/src/controller/webrtc/WebRTCTransportRequestorManager.cpp
+++ b/src/controller/webrtc/WebRTCTransportRequestorManager.cpp
@@ -73,21 +73,21 @@ void WebRTCTransportRequestorManager::InitCallbacks(OnOfferCallback onOnOfferCal
     gOnEndCallback           = onEndCallback;
 }
 
-CHIP_ERROR WebRTCTransportRequestorManager::HandleOffer(uint16_t sessionId, const OfferArgs & args)
+CHIP_ERROR WebRTCTransportRequestorManager::HandleOffer(const WebRTCSessionStruct & session, const OfferArgs & args)
 {
     std::string offer = args.sdp;
-    int err           = gOnOfferCallback(sessionId, offer.c_str());
+    int err           = gOnOfferCallback(session.id, offer.c_str());
     return err == 0 ? CHIP_NO_ERROR : CHIP_ERROR_INCORRECT_STATE;
 }
 
-CHIP_ERROR WebRTCTransportRequestorManager::HandleAnswer(uint16_t sessionId, const std::string & sdpAnswer)
+CHIP_ERROR WebRTCTransportRequestorManager::HandleAnswer(const WebRTCSessionStruct & session, const std::string & sdpAnswer)
 {
     std::string answer = sdpAnswer;
-    int err            = gOnAnswerCallback(sessionId, answer.c_str());
+    int err            = gOnAnswerCallback(session.id, answer.c_str());
     return err == 0 ? CHIP_NO_ERROR : CHIP_ERROR_INCORRECT_STATE;
 }
 
-CHIP_ERROR WebRTCTransportRequestorManager::HandleICECandidates(uint16_t sessionId,
+CHIP_ERROR WebRTCTransportRequestorManager::HandleICECandidates(const WebRTCSessionStruct & session,
                                                                 const std::vector<ICECandidateStruct> & candidates)
 {
     std::vector<OwnedIceCandidate> remoteCandidates;
@@ -120,13 +120,14 @@ CHIP_ERROR WebRTCTransportRequestorManager::HandleICECandidates(uint16_t session
         cStrings.push_back(candidate.view);
     }
 
-    int err = gOnICECandidatesCallback(sessionId, cStrings.data(), static_cast<int>(cStrings.size()));
+    int err = gOnICECandidatesCallback(session.id, cStrings.data(), static_cast<int>(cStrings.size()));
     return err == 0 ? CHIP_NO_ERROR : CHIP_ERROR_INCORRECT_STATE;
 }
 
-CHIP_ERROR WebRTCTransportRequestorManager::HandleEnd(uint16_t sessionId, WebRTCTransportRequestor::WebRTCEndReasonEnum reasonCode)
+CHIP_ERROR WebRTCTransportRequestorManager::HandleEnd(const WebRTCSessionStruct & session,
+                                                      WebRTCTransportRequestor::WebRTCEndReasonEnum reasonCode)
 {
-    int err = gOnEndCallback(sessionId, static_cast<uint8_t>(reasonCode));
+    int err = gOnEndCallback(session.id, static_cast<uint8_t>(reasonCode));
     return err == 0 ? CHIP_NO_ERROR : CHIP_ERROR_INCORRECT_STATE;
 }
 

--- a/src/controller/webrtc/WebRTCTransportRequestorManager.h
+++ b/src/controller/webrtc/WebRTCTransportRequestorManager.h
@@ -49,6 +49,7 @@ class WebRTCTransportRequestorManager : public chip::app::Clusters::WebRTCTransp
 {
 public:
     using ICECandidateStruct  = chip::app::Clusters::Globals::Structs::ICECandidateStruct::Type;
+    using WebRTCSessionStruct = chip::app::Clusters::Globals::Structs::WebRTCSessionStruct::Type;
     using WebRTCEndReasonEnum = chip::app::Clusters::Globals::WebRTCEndReasonEnum;
 
     static WebRTCTransportRequestorManager & Instance()
@@ -66,13 +67,14 @@ public:
                        OnICECandidatesCallback onICECandidatesCallback, OnEndCallback onEndCallback);
 
     // delegate methods
-    CHIP_ERROR HandleOffer(uint16_t sessionId, const OfferArgs & args) override;
+    CHIP_ERROR HandleOffer(const WebRTCSessionStruct & session, const OfferArgs & args) override;
 
-    CHIP_ERROR HandleAnswer(uint16_t sessionId, const std::string & sdpAnswer) override;
+    CHIP_ERROR HandleAnswer(const WebRTCSessionStruct & session, const std::string & sdpAnswer) override;
 
-    CHIP_ERROR HandleICECandidates(uint16_t sessionId, const std::vector<ICECandidateStruct> & candidates) override;
+    CHIP_ERROR HandleICECandidates(const WebRTCSessionStruct & session,
+                                   const std::vector<ICECandidateStruct> & candidates) override;
 
-    CHIP_ERROR HandleEnd(uint16_t sessionId, WebRTCEndReasonEnum reasonCode) override;
+    CHIP_ERROR HandleEnd(const WebRTCSessionStruct & session, WebRTCEndReasonEnum reasonCode) override;
 
     // method to be called by provider client
     void UpsertSession(const chip::app::Clusters::Globals::Structs::WebRTCSessionStruct::Type & session);


### PR DESCRIPTION
#### Summary

We have a problem when a controller talks to multiple cameras:

1. Camera A allocates sessionId=1 for a session
2. Camera B also allocates sessionId=1 for a different session
3. The controller now has two sessions both with sessionId=1 but from different cameras
4. The original implementation's FindSession(sessionId) would return the first session with that ID, which could be the wrong camera's session.

Since WebRTCSessionStruct already contains peerNodeID and fabricIndex, we need to update the existing methods which takes just sessionId with to receive the complete WebRTCSessionStruct instead.

#### Related issues

N/A

#### Testing

Validate by CI
