### PR TITLE
Post Merge comments addressed.

### DIFF
--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -253,7 +253,7 @@ void NetworkCommissioningCluster::SetLastNetworkingStatusValue(
 {
     if (mLastNetworkingStatusValue.Update(networkingStatusValue))
     {
-        NotifyAttributeChanged(Attributes::LastNetworkingStatus::TypeInfo::GetAttributeId());
+        NotifyAttributeChanged(Attributes::LastNetworkingStatus::Id);
     }
 }
 

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
@@ -94,22 +94,6 @@ public:
     // with that name, with different semantics.
     void Deinit();
 
-    // BaseDriver::NetworkStatusChangeCallback
-    void OnNetworkingStatusChange(DeviceLayer::NetworkCommissioning::Status aCommissioningError, Optional<ByteSpan> aNetworkId,
-                                  Optional<int32_t> aConnectStatus) override;
-
-    // WirelessDriver::ConnectCallback
-    void OnResult(DeviceLayer::NetworkCommissioning::Status commissioningError, CharSpan errorText,
-                  int32_t interfaceStatus) override;
-
-    // WiFiDriver::ScanCallback
-    void OnFinished(DeviceLayer::NetworkCommissioning::Status err, CharSpan debugText,
-                    DeviceLayer::NetworkCommissioning::WiFiScanResponseIterator * networks) override;
-
-    // ThreadDriver::ScanCallback
-    void OnFinished(DeviceLayer::NetworkCommissioning::Status err, CharSpan debugText,
-                    DeviceLayer::NetworkCommissioning::ThreadScanResponseIterator * networks) override;
-
     // Actual handlers of the commands
     std::optional<DataModel::ActionReturnStatus>
     HandleScanNetworks(CommandHandler & handler, const ConcreteCommandPath & commandPath,
@@ -264,6 +248,22 @@ private:
 
     // Sets the breadcrumb attribute in GeneralCommissioning cluster, no-op when breadcrumbValue is NullOptional.
     void UpdateBreadcrumb(const Optional<uint64_t> & breadcrumbValue);
+
+    // BaseDriver::NetworkStatusChangeCallback
+    void OnNetworkingStatusChange(DeviceLayer::NetworkCommissioning::Status aCommissioningError, Optional<ByteSpan> aNetworkId,
+                                  Optional<int32_t> aConnectStatus) override;
+
+    // WirelessDriver::ConnectCallback
+    void OnResult(DeviceLayer::NetworkCommissioning::Status commissioningError, CharSpan errorText,
+                  int32_t interfaceStatus) override;
+
+    // WiFiDriver::ScanCallback
+    void OnFinished(DeviceLayer::NetworkCommissioning::Status err, CharSpan debugText,
+                    DeviceLayer::NetworkCommissioning::WiFiScanResponseIterator * networks) override;
+
+    // ThreadDriver::ScanCallback
+    void OnFinished(DeviceLayer::NetworkCommissioning::Status err, CharSpan debugText,
+                    DeviceLayer::NetworkCommissioning::ThreadScanResponseIterator * networks) override;
 };
 
 } // namespace Clusters

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
@@ -94,26 +94,24 @@ public:
     // with that name, with different semantics.
     void Deinit();
 
-    // Actual handlers of the commands
-    std::optional<DataModel::ActionReturnStatus>
-    HandleScanNetworks(CommandHandler & handler, const ConcreteCommandPath & commandPath,
-                       const NetworkCommissioning::Commands::ScanNetworks::DecodableType & req);
-    std::optional<DataModel::ActionReturnStatus>
-    HandleAddOrUpdateWiFiNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
-                                 const NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::DecodableType & req);
-    std::optional<DataModel::ActionReturnStatus>
-    HandleAddOrUpdateThreadNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
-                                   const NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::DecodableType & req);
-    std::optional<DataModel::ActionReturnStatus>
-    HandleRemoveNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
-                        const NetworkCommissioning::Commands::RemoveNetwork::DecodableType & req);
-    std::optional<DataModel::ActionReturnStatus>
-    HandleConnectNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
-                         const NetworkCommissioning::Commands::ConnectNetwork::DecodableType & req);
-    std::optional<DataModel::ActionReturnStatus>
-    HandleReorderNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
-                         const NetworkCommissioning::Commands::ReorderNetwork::DecodableType & req);
-    std::optional<DataModel::ActionReturnStatus> HandleNonConcurrentConnectNetwork();
+    // Sets the breadcrumb attribute in GeneralCommissioning cluster, no-op when breadcrumbValue is NullOptional.
+    void UpdateBreadcrumb(const Optional<uint64_t> & breadcrumbValue);
+
+    // BaseDriver::NetworkStatusChangeCallback
+    void OnNetworkingStatusChange(DeviceLayer::NetworkCommissioning::Status aCommissioningError, Optional<ByteSpan> aNetworkId,
+                                  Optional<int32_t> aConnectStatus) override;
+
+    // WirelessDriver::ConnectCallback
+    void OnResult(DeviceLayer::NetworkCommissioning::Status commissioningError, CharSpan errorText,
+                  int32_t interfaceStatus) override;
+
+    // WiFiDriver::ScanCallback
+    void OnFinished(DeviceLayer::NetworkCommissioning::Status err, CharSpan debugText,
+                    DeviceLayer::NetworkCommissioning::WiFiScanResponseIterator * networks) override;
+
+    // ThreadDriver::ScanCallback
+    void OnFinished(DeviceLayer::NetworkCommissioning::Status err, CharSpan debugText,
+                    DeviceLayer::NetworkCommissioning::ThreadScanResponseIterator * networks) override;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
     std::optional<DataModel::ActionReturnStatus>
@@ -246,24 +244,26 @@ private:
     // cluster. Will set mCurrentOperationBreadcrumb to NullOptional.
     void CommitSavedBreadcrumb();
 
-    // Sets the breadcrumb attribute in GeneralCommissioning cluster, no-op when breadcrumbValue is NullOptional.
-    void UpdateBreadcrumb(const Optional<uint64_t> & breadcrumbValue);
-
-    // BaseDriver::NetworkStatusChangeCallback
-    void OnNetworkingStatusChange(DeviceLayer::NetworkCommissioning::Status aCommissioningError, Optional<ByteSpan> aNetworkId,
-                                  Optional<int32_t> aConnectStatus) override;
-
-    // WirelessDriver::ConnectCallback
-    void OnResult(DeviceLayer::NetworkCommissioning::Status commissioningError, CharSpan errorText,
-                  int32_t interfaceStatus) override;
-
-    // WiFiDriver::ScanCallback
-    void OnFinished(DeviceLayer::NetworkCommissioning::Status err, CharSpan debugText,
-                    DeviceLayer::NetworkCommissioning::WiFiScanResponseIterator * networks) override;
-
-    // ThreadDriver::ScanCallback
-    void OnFinished(DeviceLayer::NetworkCommissioning::Status err, CharSpan debugText,
-                    DeviceLayer::NetworkCommissioning::ThreadScanResponseIterator * networks) override;
+    // Actual handlers of the commands
+    std::optional<DataModel::ActionReturnStatus>
+    HandleScanNetworks(CommandHandler & handler, const ConcreteCommandPath & commandPath,
+                       const NetworkCommissioning::Commands::ScanNetworks::DecodableType & req);
+    std::optional<DataModel::ActionReturnStatus>
+    HandleAddOrUpdateWiFiNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
+                                 const NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::DecodableType & req);
+    std::optional<DataModel::ActionReturnStatus>
+    HandleAddOrUpdateThreadNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
+                                   const NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::DecodableType & req);
+    std::optional<DataModel::ActionReturnStatus>
+    HandleRemoveNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
+                        const NetworkCommissioning::Commands::RemoveNetwork::DecodableType & req);
+    std::optional<DataModel::ActionReturnStatus>
+    HandleConnectNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
+                         const NetworkCommissioning::Commands::ConnectNetwork::DecodableType & req);
+    std::optional<DataModel::ActionReturnStatus>
+    HandleReorderNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
+                         const NetworkCommissioning::Commands::ReorderNetwork::DecodableType & req);
+    std::optional<DataModel::ActionReturnStatus> HandleNonConcurrentConnectNetwork();
 };
 
 } // namespace Clusters


### PR DESCRIPTION
#### Summary

This PR merges the logic layer into the cluster implementation for `NetworkCommissioningCluster` to simplify the code structure and improve maintainability. Additionally, it applies a restyle to ensure consistent formatting.

**What changed:**
- Merged the `NetworkCommissioningLogic` functionality directly into `NetworkCommissioningCluster`
- Updated `NetworkCommissioningCluster::Init()` to handle attribute change notifications internally
- Replaced all direct calls to `MatterReportingAttributeChangeCallback` with a unified callback mechanism
- Applied a restyle to ensure consistent formatting across the updated code

#### Related issues

[41700](https://github.com/project-chip/connectedhomeip/issues/41700)

#### Testing

- Verified that all existing unit tests pass with the updated implementation

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_"When in Rome…"_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)