### PR TITLE
[Python] Improve FindCommandClusterObject helper function

### DIFF
--- a/src/controller/python/matter/clusters/ClusterObjects.py
+++ b/src/controller/python/matter/clusters/ClusterObjects.py
@@ -250,6 +250,10 @@ class ClusterCommand(ClusterObject):
         raise NotImplementedError()
 
     @ChipUtility.classproperty
+    def is_client(self) -> bool:
+        raise NotImplementedError()
+
+    @ChipUtility.classproperty
     def must_use_timed_invoke(cls) -> bool:
         return False
 


### PR DESCRIPTION
#### Summary

The `FindCommandClusterObject` function uses `eval` which is hard to handle by static code analysers like pylance. Also the O() complexity of these nested for loops is not so great.

#### Testing

Locally tested that new implementation is 100x faster:
```python
>>> import matter.clusters.Command, timeit
>>> path = matter.clusters.Command.CommandPath(EndpointId=1, ClusterId=153, CommandId=0)
>>> timeit.timeit('matter.clusters.Command.FindCommandClusterObjectNew(True, path)', globals=globals(), number=1000)  # NEW implementation
0.022968026998569258
>>> timeit.timeit('matter.clusters.Command.FindCommandClusterObject(True, path)', globals=globals(), number=1000)
16.618735364012537
```

CI will verify for potential breaks.

