### PR TITLE
[DRAFT] Add unit tests for default values of `AdministratorCommissioning` cluster attributes

### DIFF
--- a/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
+++ b/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
@@ -26,7 +26,9 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/app/clusters/administrator-commissioning-server",
+    "${chip_root}/src/app/clusters/operational-credentials-server",
     "${chip_root}/src/app/server-cluster/testing",
+    "${chip_root}/src/credentials/tests:CHIPCert_unit_test_vectors",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
   ]

--- a/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
+++ b/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
@@ -27,8 +27,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/app/clusters/administrator-commissioning-server",
     "${chip_root}/src/app/clusters/operational-credentials-server",
-    "${chip_root}/src/app/server-cluster/testing",
-    "${chip_root}/src/credentials/tests:CHIPCert_unit_test_vectors",
+    "${chip_root}/src/credentials/tests:cert_test_vectors",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
   ]

--- a/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
+++ b/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
@@ -27,7 +27,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/app/clusters/administrator-commissioning-server",
     "${chip_root}/src/app/clusters/operational-credentials-server",
-    "${chip_root}/src/app/clusters/testing",
+    "${chip_root}/src/app/server-cluster/testing",
     "${chip_root}/src/credentials/tests:cert_test_vectors",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",

--- a/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
+++ b/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
@@ -27,6 +27,9 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/app/clusters/administrator-commissioning-server",
     "${chip_root}/src/app/clusters/operational-credentials-server",
+    "${chip_root}/src/app/clusters/testing",
+    "${chip_root}/src/app/data-model-provider/tests",
+    "${chip_root}/src/app/persistence",
     "${chip_root}/src/credentials/tests:cert_test_vectors",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",

--- a/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
+++ b/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
@@ -28,8 +28,6 @@ chip_test_suite("tests") {
     "${chip_root}/src/app/clusters/administrator-commissioning-server",
     "${chip_root}/src/app/clusters/operational-credentials-server",
     "${chip_root}/src/app/clusters/testing",
-    "${chip_root}/src/app/data-model-provider/tests",
-    "${chip_root}/src/app/persistence",
     "${chip_root}/src/credentials/tests:cert_test_vectors",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -29,14 +29,6 @@
 #include <platform/NetworkCommissioning.h>
 #include <platform/TestOnlyCommissionableDataProvider.h>
 
-<<<<<<< HEAD
->>>>>>> 02e7e35d88 (TODO: Fix dependency issue of test certificates and use these certificates for fabric initialization) namespace
-{
-
-    using namespace chip;
-    using namespace chip::app::Clusters;
-    using namespace chip::app::Clusters::AdministratorCommissioning;
-=======
 #include <app/clusters/testing/ClusterTester.h>
 #include <app/clusters/testing/ValidateGlobalAttributes.h>
 #include <credentials/PersistentStorageOpCertStore.h>
@@ -48,356 +40,266 @@
 #include <app/clusters/testing/ClusterTester.h>
 #include <app/clusters/testing/ValidateGlobalAttributes.h>
 
-    namespace {
+namespace {
 
-    using namespace chip;
-    using namespace chip::app::Clusters;
-    using namespace chip::app::Clusters::AdministratorCommissioning;
+using namespace chip;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::AdministratorCommissioning;
 
-    using chip::app::DataModel::AcceptedCommandEntry;
-    using chip::app::DataModel::AttributeEntry;
+using chip::app::DataModel::AcceptedCommandEntry;
+using chip::app::DataModel::AttributeEntry;
 
-    // initialize memory as ReadOnlyBufferBuilder may allocate
-    struct TestAdministratorCommissioningCluster : public ::testing::Test
-    {
-        static chip::DeviceLayer::TestOnlyCommissionableDataProvider sTestCommissionableDataProvider;
-        static chip::Credentials::PersistentStorageOpCertStore sTestOpCertStore;
-        static chip::PersistentStorageOperationalKeystore sTestOpKeystore;
-        static chip::TestPersistentStorageDelegate sStorageDelegate;
-
-        static void SetUpTestSuite()
-        {
-            ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
-            ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
-
-            ASSERT_EQ(sTestOpCertStore.Init(&sStorageDelegate), CHIP_NO_ERROR);
-            ASSERT_EQ(sTestOpKeystore.Init(&sStorageDelegate), CHIP_NO_ERROR);
-
-            auto & fabricTable = Server::GetInstance().GetFabricTable();
-            FabricTable::InitParams initParams;
-            initParams.storage             = &sStorageDelegate;
-            initParams.operationalKeystore = &sTestOpKeystore;
-            initParams.opCertStore         = &sTestOpCertStore;
-            ASSERT_EQ(fabricTable.Init(initParams), CHIP_NO_ERROR);
-        }
-        static void TearDownTestSuite()
-        {
-            chip::Server::GetInstance().GetFabricTable().Shutdown();
-            sTestOpCertStore.Finish();
-            sTestOpKeystore.Finish();
-            chip::DeviceLayer::PlatformMgr().Shutdown();
-            chip::Platform::MemoryShutdown();
-        }
-    };
-
-    chip::DeviceLayer::TestOnlyCommissionableDataProvider TestAdministratorCommissioningCluster::sTestCommissionableDataProvider;
-    chip::Credentials::PersistentStorageOpCertStore TestAdministratorCommissioningCluster::sTestOpCertStore;
-    chip::PersistentStorageOperationalKeystore TestAdministratorCommissioningCluster::sTestOpKeystore;
-    chip::TestPersistentStorageDelegate TestAdministratorCommissioningCluster::sStorageDelegate;
-
-    const chip::FabricIndex kTestFabricIndex = chip::app::Testing::kTestFabrixIndex;
->>>>>>> c019cc8afd (Initialize FabricTable in)
-
-    using chip::app::DataModel::AcceptedCommandEntry;
-    using chip::app::DataModel::AttributeEntry;
-
-    // initialize memory as ReadOnlyBufferBuilder may allocate
-    struct TestAdministratorCommissioningCluster : public ::testing::Test
-    {
-        static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
-        static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
-    };
-
+// initialize memory as ReadOnlyBufferBuilder may allocate
+struct TestAdministratorCommissioningCluster : public ::testing::Test
+{
     static chip::DeviceLayer::TestOnlyCommissionableDataProvider sTestCommissionableDataProvider;
+    static chip::Credentials::PersistentStorageOpCertStore sTestOpCertStore;
+    static chip::PersistentStorageOperationalKeystore sTestOpKeystore;
+    static chip::TestPersistentStorageDelegate sStorageDelegate;
 
-    TEST_F(TestAdministratorCommissioningCluster, TestAttributes)
+    static void SetUpTestSuite()
     {
-        {
-            AdministratorCommissioningCluster cluster(kRootEndpointId, {});
+        ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
+        ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
 
-            ReadOnlyBufferBuilder<AttributeEntry> builder;
-            ASSERT_EQ(cluster.Attributes({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
+        ASSERT_EQ(sTestOpCertStore.Init(&sStorageDelegate), CHIP_NO_ERROR);
+        ASSERT_EQ(sTestOpKeystore.Init(&sStorageDelegate), CHIP_NO_ERROR);
 
-            ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
-            ASSERT_EQ(expectedBuilder.AppendElements({
-                          AdministratorCommissioning::Attributes::WindowStatus::kMetadataEntry,
-                          AdministratorCommissioning::Attributes::AdminFabricIndex::kMetadataEntry,
-                          AdministratorCommissioning::Attributes::AdminVendorId::kMetadataEntry,
-                      }),
-                      CHIP_NO_ERROR);
-            ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
-
-            ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
-        }
-
-        {
-            AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId,
-                                                                                  BitFlags<Feature>{ Feature::kBasic });
-
-            ReadOnlyBufferBuilder<AttributeEntry> builder;
-            ASSERT_EQ(cluster.Attributes({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
-
-            ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
-            ASSERT_EQ(expectedBuilder.AppendElements({
-                          AdministratorCommissioning::Attributes::WindowStatus::kMetadataEntry,
-                          AdministratorCommissioning::Attributes::AdminFabricIndex::kMetadataEntry,
-                          AdministratorCommissioning::Attributes::AdminVendorId::kMetadataEntry,
-                      }),
-                      CHIP_NO_ERROR);
-            ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
-
-            ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
-        }
+        auto & fabricTable = Server::GetInstance().GetFabricTable();
+        FabricTable::InitParams initParams;
+        initParams.storage             = &sStorageDelegate;
+        initParams.operationalKeystore = &sTestOpKeystore;
+        initParams.opCertStore         = &sTestOpCertStore;
+        ASSERT_EQ(fabricTable.Init(initParams), CHIP_NO_ERROR);
     }
-
-    TEST_F(TestAdministratorCommissioningCluster, TestCommands)
+    static void TearDownTestSuite()
     {
-        {
-            AdministratorCommissioningCluster cluster(kRootEndpointId, {});
-
-            ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
-            ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
-
-            ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
-            ASSERT_EQ(expectedBuilder.AppendElements({
-                          AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
-                          AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
-                      }),
-                      CHIP_NO_ERROR);
-
-            EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
-        }
-
-        {
-            AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId, BitFlags<Feature>{});
-
-            ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
-            ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
-
-            ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
-            ASSERT_EQ(expectedBuilder.AppendElements({
-                          AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
-                          AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
-                      }),
-                      CHIP_NO_ERROR);
-
-            EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
-        }
-
-        {
-            AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId,
-                                                                                  BitFlags<Feature>{ Feature::kBasic });
-
-            ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
-            ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
-
-            ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
-            ASSERT_EQ(expectedBuilder.AppendElements({
-                          AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
-                          AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
-                          AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::kMetadataEntry,
-                      }),
-                      CHIP_NO_ERROR);
-
-            EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
-        }
+        chip::Server::GetInstance().GetFabricTable().Shutdown();
+        sTestOpCertStore.Finish();
+        sTestOpKeystore.Finish();
+        chip::DeviceLayer::PlatformMgr().Shutdown();
+        chip::Platform::MemoryShutdown();
     }
+};
 
-    } // namespace
+chip::DeviceLayer::TestOnlyCommissionableDataProvider TestAdministratorCommissioningCluster::sTestCommissionableDataProvider;
+chip::Credentials::PersistentStorageOpCertStore TestAdministratorCommissioningCluster::sTestOpCertStore;
+chip::PersistentStorageOperationalKeystore TestAdministratorCommissioningCluster::sTestOpKeystore;
+chip::TestPersistentStorageDelegate TestAdministratorCommissioningCluster::sStorageDelegate;
 
-    TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
+const chip::FabricIndex kTestFabricIndex = chip::app::Testing::kTestFabrixIndex;
+
+TEST_F(TestAdministratorCommissioningCluster, TestAttributes)
+{
     {
         AdministratorCommissioningCluster cluster(kRootEndpointId, {});
-        chip::Test::ClusterTester tester(cluster);
 
-        {
-            Attributes::FeatureMap::TypeInfo::Type feature{};
-            ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, feature), CHIP_NO_ERROR);
-            ASSERT_EQ(feature, 0u);
-        }
+        ReadOnlyBufferBuilder<AttributeEntry> builder;
+        ASSERT_EQ(cluster.Attributes({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
 
-        {
-            uint16_t revision;
-            ASSERT_EQ(tester.ReadAttribute(Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
-            ASSERT_EQ(revision, 1u);
-        }
-
-        {
-            Attributes::WindowStatus::TypeInfo::Type winStatus;
-            auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
-            ASSERT_TRUE(status.IsSuccess());
-            EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
-        }
-
-        {
-            Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
-            ASSERT_EQ(tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric), CHIP_NO_ERROR);
-            ASSERT_TRUE(adminFabric.IsNull());
-        }
-
-        {
-            Attributes::AdminVendorId::TypeInfo::Type adminVendor;
-            ASSERT_EQ(tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor), CHIP_NO_ERROR);
-            ASSERT_TRUE(adminVendor.IsNull());
-        }
-    }
-
-    TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOpeningWindow)
-    {
-        AdministratorCommissioningCluster cluster(kRootEndpointId, {});
-        chip::Test::ClusterTester tester(cluster);
-
-        Attributes::WindowStatus::TypeInfo::DecodableType winStatus;
-        auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
-        ASSERT_TRUE(status.IsSuccess());
-        EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
-
-        Commands::OpenCommissioningWindow::Type request;
-        request.commissioningTimeout = 900;
-        uint16_t originDiscriminator;
-        EXPECT_EQ(sTestCommissionableDataProvider.GetSetupDiscriminator(originDiscriminator), CHIP_NO_ERROR);
-        request.discriminator = static_cast<uint16_t>(originDiscriminator + 1);
-        chip::Crypto::Spake2pVerifier verifier{};
-        request.PAKEPasscodeVerifier = chip::ByteSpan(reinterpret_cast<const uint8_t *>(&verifier), sizeof(verifier));
-        request.iterations           = chip::Crypto::kSpake2p_Min_PBKDF_Iterations;
-
-        auto & fabricTable          = Server::GetInstance().GetFabricTable();
-        FabricIndex testFabricIndex = chip::kUndefinedFabricIndex;
-        ASSERT_EQ(fabricTable.AddNewFabricForTest(
-                      chip::TestCerts::GetRootACertAsset().mCert, chip::TestCerts::GetIAA1CertAsset().mCert,
-                      chip::TestCerts::GetNodeA1CertAsset().mCert, chip::TestCerts::GetNodeA1CertAsset().mKey, &testFabricIndex),
+        ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
+        ASSERT_EQ(expectedBuilder.AppendElements({
+                      AdministratorCommissioning::Attributes::WindowStatus::kMetadataEntry,
+                      AdministratorCommissioning::Attributes::AdminFabricIndex::kMetadataEntry,
+                      AdministratorCommissioning::Attributes::AdminVendorId::kMetadataEntry,
+                  }),
                   CHIP_NO_ERROR);
-        ASSERT_NE(testFabricIndex, chip::kUndefinedFabricIndex);
+        ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
 
-        // Read Fabrics attribute to verify the fabric was added
-        OperationalCredentials::Attributes::Fabrics::TypeInfo::DecodableType fabrics;
-        auto stat = opCredsTester.ReadAttribute(OperationalCredentials::Attributes::Fabrics::Id, fabrics);
-        ASSERT_TRUE(stat.IsSuccess());
-
-        auto result = tester.Invoke(Commands::OpenCommissioningWindow::Id, request);
-        ASSERT_TRUE(result.status.has_value());
-
-        if (result.status->IsSuccess()) // NOLINT(bugprone-unchecked-optional-access)
-        {
-            status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
-            ASSERT_TRUE(status.IsSuccess());
-            EXPECT_EQ(winStatus,
-                      chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kEnhancedWindowOpen);
-
-            Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
-            status = tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric);
-            ASSERT_TRUE(status.IsSuccess());
-            ASSERT_FALSE(adminFabric.IsNull());
-
-            Attributes::AdminVendorId::TypeInfo::Type adminVendor;
-            status = tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor);
-            ASSERT_TRUE(status.IsSuccess());
-            ASSERT_FALSE(adminVendor.IsNull());
-        }
+        ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
     }
 
-    TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
+    {
+        AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId,
+                                                                              BitFlags<Feature>{ Feature::kBasic });
+
+        ReadOnlyBufferBuilder<AttributeEntry> builder;
+        ASSERT_EQ(cluster.Attributes({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
+
+        ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
+        ASSERT_EQ(expectedBuilder.AppendElements({
+                      AdministratorCommissioning::Attributes::WindowStatus::kMetadataEntry,
+                      AdministratorCommissioning::Attributes::AdminFabricIndex::kMetadataEntry,
+                      AdministratorCommissioning::Attributes::AdminVendorId::kMetadataEntry,
+                  }),
+                  CHIP_NO_ERROR);
+        ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
+
+        ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+    }
+}
+
+TEST_F(TestAdministratorCommissioningCluster, TestCommands)
+{
     {
         AdministratorCommissioningCluster cluster(kRootEndpointId, {});
-        chip::Test::ClusterTester tester(cluster);
 
-        {
-            Attributes::FeatureMap::TypeInfo::Type feature{};
-            ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, feature), CHIP_NO_ERROR);
-            ASSERT_EQ(feature, 0u);
-        }
+        ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
+        ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
 
-        {
-            uint16_t revision;
-            ASSERT_EQ(tester.ReadAttribute(Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
-            ASSERT_EQ(revision, 1u);
-        }
+        ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
+        ASSERT_EQ(expectedBuilder.AppendElements({
+                      AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
+                      AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
+                  }),
+                  CHIP_NO_ERROR);
 
-        {
-            Attributes::WindowStatus::TypeInfo::Type winStatus;
-            auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
-            ASSERT_TRUE(status.IsSuccess());
-            EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
-        }
-
-        {
-            Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
-            ASSERT_EQ(tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric), CHIP_NO_ERROR);
-            ASSERT_TRUE(adminFabric.IsNull());
-        }
-
-        {
-            Attributes::AdminVendorId::TypeInfo::Type adminVendor;
-            ASSERT_EQ(tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor), CHIP_NO_ERROR);
-            ASSERT_TRUE(adminVendor.IsNull());
-        }
+        EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
     }
 
-    TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOpeningWindow)
     {
-        AdministratorCommissioningCluster cluster(kRootEndpointId, {});
-        chip::Test::ClusterTester tester(cluster);
+        AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId, BitFlags<Feature>{});
 
-        Attributes::WindowStatus::TypeInfo::DecodableType winStatus;
+        ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
+        ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
+
+        ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
+        ASSERT_EQ(expectedBuilder.AppendElements({
+                      AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
+                      AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
+                  }),
+                  CHIP_NO_ERROR);
+
+        EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+    }
+
+    {
+        AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId,
+                                                                              BitFlags<Feature>{ Feature::kBasic });
+
+        ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
+        ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
+
+        ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
+        ASSERT_EQ(expectedBuilder.AppendElements({
+                      AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
+                      AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
+                      AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::kMetadataEntry,
+                  }),
+                  CHIP_NO_ERROR);
+
+        EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+    }
+}
+
+} // namespace
+
+TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
+{
+    AdministratorCommissioningCluster cluster(kRootEndpointId, {});
+    chip::Test::ClusterTester tester(cluster);
+
+    {
+        Attributes::FeatureMap::TypeInfo::Type feature{};
+        ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, feature), CHIP_NO_ERROR);
+        ASSERT_EQ(feature, 0u);
+    }
+
+    {
+        uint16_t revision;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
+        ASSERT_EQ(revision, 1u);
+    }
+
+    {
+        Attributes::WindowStatus::TypeInfo::Type winStatus;
         auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
         ASSERT_TRUE(status.IsSuccess());
         EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
-
-        Commands::OpenCommissioningWindow::Type request;
-        request.commissioningTimeout = 900;
-        uint16_t originDiscriminator;
-        EXPECT_EQ(sTestCommissionableDataProvider.GetSetupDiscriminator(originDiscriminator), CHIP_NO_ERROR);
-        request.discriminator = static_cast<uint16_t>(originDiscriminator + 1);
-        chip::Crypto::Spake2pVerifier verifier{};
-        request.PAKEPasscodeVerifier = chip::ByteSpan(reinterpret_cast<const uint8_t *>(&verifier), sizeof(verifier));
-        request.iterations           = chip::Crypto::kSpake2p_Min_PBKDF_Iterations;
-
-        // FabricTable & fabricTable = Server::GetInstance().GetFabricTable();
-        // FabricTable::InitParams initParams;
-        // initParams.opCertStore         = &mMockOpCertStore;
-        // initParams.storage             = &mTestContext.StorageDelegate();
-        // initParams.operationalKeystore = nullptr;
-        // fabricTable.Init(initParams);
-        auto context = OperationalCredentialsCluster::Context{
-            .fabricTable                = Server::GetInstance().GetFabricTable(),
-            .failSafeContext            = Server::GetInstance().GetFailSafeContext(),
-            .sessionManager             = Server::GetInstance().GetSecureSessionManager(),
-            .dnssdServer                = app::DnssdServer::Instance(),
-            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(),
-        };
-        OperationalCredentialsCluster opCreds(kRootEndpointId, context);
-        chip::Test::ClusterTester opCredsTester(opCreds);
-        EXPECT_EQ(opCreds.Startup(opCredsTester.GetServerClusterContext()), CHIP_NO_ERROR);
-        opCredsTester.SetFabricIndex(kTestFabricIndex);
-
-        // 1. Arm FailSafe because AddNOC command requires it.
-        auto & failSafe = context.failSafeContext;
-        ASSERT_EQ(failSafe.ArmFailSafe(kTestFabricIndex, System::Clock::Seconds16(900)), CHIP_NO_ERROR);
-        // 2. Add Trusted Root Cert for the fabric.
-        OperationalCredentials::Commands::AddTrustedRootCertificate::Type addRcaRequest;
-        addRcaRequest.rootCACertificate = chip::TestCerts::GetRootACertAsset().mCert;
-        auto root = opCredsTester.Invoke(OperationalCredentials::Commands::AddTrustedRootCertificate::Id, addRcaRequest);
-        ASSERT_TRUE(root.status.has_value());
-        ASSERT_TRUE(root.status->IsSuccess());
-
-        auto result = tester.Invoke(Commands::OpenCommissioningWindow::Id, request);
-        ASSERT_TRUE(result.status.has_value());
-
-        if (result.status->IsSuccess()) // NOLINT(bugprone-unchecked-optional-access)
-        {
-            status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
-            ASSERT_TRUE(status.IsSuccess());
-            EXPECT_EQ(winStatus,
-                      chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kEnhancedWindowOpen);
-
-            Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
-            status = tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric);
-            ASSERT_TRUE(status.IsSuccess());
-            ASSERT_FALSE(adminFabric.IsNull());
-
-            Attributes::AdminVendorId::TypeInfo::Type adminVendor;
-            status = tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor);
-            ASSERT_TRUE(status.IsSuccess());
-            ASSERT_FALSE(adminVendor.IsNull());
-        }
     }
+
+    {
+        Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric), CHIP_NO_ERROR);
+        ASSERT_TRUE(adminFabric.IsNull());
+    }
+
+    {
+        Attributes::AdminVendorId::TypeInfo::Type adminVendor;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor), CHIP_NO_ERROR);
+        ASSERT_TRUE(adminVendor.IsNull());
+    }
+}
+
+TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOpeningWindow)
+{
+    AdministratorCommissioningCluster cluster(kRootEndpointId, {});
+    chip::Test::ClusterTester tester(cluster);
+
+    Attributes::WindowStatus::TypeInfo::DecodableType winStatus;
+    auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
+    ASSERT_TRUE(status.IsSuccess());
+    EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
+
+    Commands::OpenCommissioningWindow::Type request;
+    request.commissioningTimeout = 900;
+    uint16_t originDiscriminator;
+    EXPECT_EQ(sTestCommissionableDataProvider.GetSetupDiscriminator(originDiscriminator), CHIP_NO_ERROR);
+    request.discriminator = static_cast<uint16_t>(originDiscriminator + 1);
+    chip::Crypto::Spake2pVerifier verifier{};
+    request.PAKEPasscodeVerifier = chip::ByteSpan(reinterpret_cast<const uint8_t *>(&verifier), sizeof(verifier));
+    request.iterations           = chip::Crypto::kSpake2p_Min_PBKDF_Iterations;
+    request.salt = { 0x53, 0x50, 0x41, 0x4B, 0x45, 0x32, 0x50, 0x20, 0x4B, 0x65, 0x79, 0x20, 0x53, 0x61, 0x6C, 0x74 };
+
+    // auto optCertStore = chip::Server::GetInstance().GetOpCertStore();
+    // chip::CommonCaseDeviceServerInitParams initParams;
+    // EXPECT_EQ(initParams.opCertStore, nullptr);
+    auto & fabricTable          = Server::GetInstance().GetFabricTable();
+    FabricIndex testFabricIndex = kTestFabricIndex;
+    ASSERT_EQ(fabricTable.AddNewFabricForTest(chip::TestCerts::GetRootACertAsset().mCert, chip::TestCerts::GetIAA1CertAsset().mCert,
+                                              chip::TestCerts::GetNodeA1CertAsset().mCert,
+                                              chip::TestCerts::GetNodeA1CertAsset().mKey, &testFabricIndex),
+              CHIP_NO_ERROR);
+    ASSERT_NE(testFabricIndex, chip::kUndefinedFabricIndex);
+    tester.SetFabricIndex(testFabricIndex);
+    // ASSERT_EQ(optCertStore, nullptr);
+
+    // OperationalCredentialsCluster::Context context = { .fabricTable     = Server::GetInstance().GetFabricTable(),
+    //                                                    .failSafeContext = Server::GetInstance().GetFailSafeContext(),
+    //                                                    .sessionManager  = Server::GetInstance().GetSecureSessionManager(),
+    //                                                    .dnssdServer     = app::DnssdServer::Instance(),
+    //                                                    .commissioningWindowManager =
+    //                                                        Server::GetInstance().GetCommissioningWindowManager() };
+    // OperationalCredentialsCluster opCreds(kRootEndpointId, context);
+    // chip::Test::ClusterTester opCredsTester(opCreds);
+    // EXPECT_EQ(opCreds.Startup(opCredsTester.GetServerClusterContext()), CHIP_NO_ERROR);
+    // opCredsTester.SetFabricIndex(testFabricIndex);
+
+    // 1. Arm FailSafe because AddNOC command requires it.
+    // auto & failSafe = context.failSafeContext;
+    // ASSERT_EQ(failSafe.ArmFailSafe(testFabricIndex, System::Clock::Seconds16(900)), CHIP_NO_ERROR);
+
+    // 2. Add Trusted Root Cert for the fabric.
+    // OperationalCredentials::Commands::AddTrustedRootCertificate::Type addRcaRequest;
+    // addRcaRequest.rootCACertificate = chip::TestCerts::GetRootACertAsset().mCert;
+    // auto root = opCredsTester.Invoke(OperationalCredentials::Commands::AddTrustedRootCertificate::Id, addRcaRequest);
+    // ASSERT_TRUE(root.status.has_value());
+    // ASSERT_TRUE(root.status->IsSuccess());
+
+    // Read Fabrics attribute to verify the fabric was added
+    // OperationalCredentials::Attributes::Fabrics::TypeInfo::DecodableType fabrics;
+    // auto stat = opCredsTester.ReadAttribute(OperationalCredentials::Attributes::Fabrics::Id, fabrics);
+    // ASSERT_TRUE(stat.IsSuccess());
+
+    auto result = tester.Invoke(Commands::OpenCommissioningWindow::Id, request);
+    // ASSERT_EQ(result.status, std::nullopt);
+    ASSERT_TRUE(result.status.has_value());
+    ASSERT_TRUE(result.status->IsSuccess());
+
+    if (result.status->IsSuccess()) // NOLINT(bugprone-unchecked-optional-access)
+    {
+        status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
+        ASSERT_TRUE(status.IsSuccess());
+        EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kEnhancedWindowOpen);
+
+        Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
+        status = tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric);
+        ASSERT_TRUE(status.IsSuccess());
+        ASSERT_FALSE(adminFabric.IsNull());
+
+        Attributes::AdminVendorId::TypeInfo::Type adminVendor;
+        status = tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor);
+        ASSERT_TRUE(status.IsSuccess());
+        ASSERT_FALSE(adminVendor.IsNull());
+    }
+}

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -16,27 +16,22 @@
 #include <pw_unit_test/framework.h>
 
 #include <app/clusters/administrator-commissioning-server/AdministratorCommissioningCluster.h>
-#include <app/clusters/operational-credentials-server/OperationalCredentialsCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
+#include <app/server-cluster/testing/ClusterTester.h>
 #include <clusters/AdministratorCommissioning/Enums.h>
 #include <clusters/AdministratorCommissioning/Metadata.h>
-#include <credentials/tests/CHIPCert_unit_test_vectors.h>
-#include <lib/core/CHIPError.h>
-#include <lib/core/DataModelTypes.h>
-#include <lib/support/ReadOnlyBuffer.h>
-#include <platform/CommissionableDataProvider.h>
-#include <platform/NetworkCommissioning.h>
-
-#include <app/clusters/testing/ClusterTester.h>
-#include <app/clusters/testing/ValidateGlobalAttributes.h>
-#include <app/server-cluster/testing/EmptyProvider.h>
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <credentials/tests/CHIPCert_unit_test_vectors.h>
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#include <lib/core/CHIPError.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/ReadOnlyBuffer.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
+#include <platform/CommissionableDataProvider.h>
+#include <platform/NetworkCommissioning.h>
 #include <platform/TestOnlyCommissionableDataProvider.h>
 
 namespace {
@@ -186,8 +181,6 @@ TEST_F(TestAdministratorCommissioningCluster, TestCommands)
     }
 }
 
-} // namespace
-
 TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
 {
     AdministratorCommissioningCluster cluster(kRootEndpointId, {});
@@ -274,3 +267,4 @@ TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOp
     ASSERT_TRUE(status.IsSuccess());
     ASSERT_FALSE(adminVendor.IsNull());
 }
+} // namespace

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -71,9 +71,13 @@ struct TestAdministratorCommissioningCluster : public ::testing::Test
         initParams.operationalKeystore = &sTestOpKeystore;
         initParams.opCertStore         = &sTestOpCertStore;
         ASSERT_EQ(fabricTable.Init(initParams), CHIP_NO_ERROR);
+
+        // Initialize CommissioningWindowManager so it has a valid Server pointer
+        ASSERT_EQ(Server::GetInstance().GetCommissioningWindowManager().Init(&Server::GetInstance()), CHIP_NO_ERROR);
     }
     static void TearDownTestSuite()
     {
+        chip::Server::GetInstance().GetCommissioningWindowManager().Shutdown();
         chip::Server::GetInstance().GetFabricTable().Shutdown();
         sTestOpCertStore.Finish();
         sTestOpKeystore.Finish();
@@ -283,23 +287,24 @@ TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOp
 
     auto result = tester.Invoke(Commands::OpenCommissioningWindow::Id, request);
     // ASSERT_EQ(result.status, std::nullopt);
-    ASSERT_TRUE(result.status.has_value());
-    ASSERT_TRUE(result.status->IsSuccess());
+    // ASSERT_TRUE(result.status.has_value());
+    // ASSERT_TRUE(result.status->IsSuccess());
+    ASSERT_TRUE(result.IsSuccess());
 
-    if (result.status->IsSuccess()) // NOLINT(bugprone-unchecked-optional-access)
-    {
-        status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
-        ASSERT_TRUE(status.IsSuccess());
-        EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kEnhancedWindowOpen);
+    // if (result.status->IsSuccess()) // NOLINT(bugprone-unchecked-optional-access)
+    // {
+    status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
+    ASSERT_TRUE(status.IsSuccess());
+    EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kEnhancedWindowOpen);
 
-        Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
-        status = tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric);
-        ASSERT_TRUE(status.IsSuccess());
-        ASSERT_FALSE(adminFabric.IsNull());
+    Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
+    status = tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric);
+    ASSERT_TRUE(status.IsSuccess());
+    ASSERT_FALSE(adminFabric.IsNull());
 
-        Attributes::AdminVendorId::TypeInfo::Type adminVendor;
-        status = tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor);
-        ASSERT_TRUE(status.IsSuccess());
-        ASSERT_FALSE(adminVendor.IsNull());
-    }
+    Attributes::AdminVendorId::TypeInfo::Type adminVendor;
+    status = tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor);
+    ASSERT_TRUE(status.IsSuccess());
+    ASSERT_FALSE(adminVendor.IsNull());
+    // }
 }

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -136,3 +136,44 @@ TEST_F(TestAdministratorCommissioningCluster, TestCommands)
 }
 
 } // namespace
+
+TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
+{
+    AdministratorCommissioningCluster cluster(kRootEndpointId, {});
+    chip::Test::ClusterTester tester(cluster);
+
+    // Test reading FeatureMap (base class)
+    {
+        Attributes::FeatureMap::TypeInfo::Type feature;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, feature), CHIP_NO_ERROR);
+        ASSERT_EQ(feature, 0u);
+    }
+
+    // Revision
+    {
+        uint16_t revision;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
+        ASSERT_EQ(revision, 1u);
+    }
+
+    // Read default value of WindowStatus
+    {
+        Attributes::WindowStatus::TypeInfo::Type winStatus;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus), CHIP_NO_ERROR);
+        EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
+    }
+
+    // AdminFabricIndex
+    {
+        Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric), CHIP_NO_ERROR);
+        ASSERT_TRUE(adminFabric.IsNull());
+    }
+
+    // AdminVendorId
+    {
+        Attributes::AdminVendorId::TypeInfo::Type adminVendor;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor), CHIP_NO_ERROR);
+        ASSERT_TRUE(adminVendor.IsNull());
+    }
+}

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -61,8 +61,9 @@ struct TestAdministratorCommissioningCluster : public ::testing::Test
     {
         ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
         ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
+        git
 
-        ASSERT_EQ(sTestOpCertStore.Init(&sStorageDelegate), CHIP_NO_ERROR);
+            ASSERT_EQ(sTestOpCertStore.Init(&sStorageDelegate), CHIP_NO_ERROR);
         ASSERT_EQ(sTestOpKeystore.Init(&sStorageDelegate), CHIP_NO_ERROR);
 
         auto & fabricTable = Server::GetInstance().GetFabricTable();
@@ -73,7 +74,7 @@ struct TestAdministratorCommissioningCluster : public ::testing::Test
         ASSERT_EQ(fabricTable.Init(initParams), CHIP_NO_ERROR);
 
         // Initialize CommissioningWindowManager so it has a valid Server pointer
-        ASSERT_EQ(Server::GetInstance().GetCommissioningWindowManager().Init(&Server::GetInstance()), CHIP_NO_ERROR);
+        -ASSERT_EQ(Server::GetInstance().GetCommissioningWindowManager().Init(&Server::GetInstance()), CHIP_NO_ERROR);
     }
     static void TearDownTestSuite()
     {
@@ -191,7 +192,7 @@ TEST_F(TestAdministratorCommissioningCluster, TestCommands)
 TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
 {
     AdministratorCommissioningCluster cluster(kRootEndpointId, {});
-    chip::Test::ClusterTester tester(cluster);
+    chip::Testing::ClusterTester tester(cluster);
 
     {
         Attributes::FeatureMap::TypeInfo::Type feature{};
@@ -228,7 +229,7 @@ TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
 TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOpeningWindow)
 {
     AdministratorCommissioningCluster cluster(kRootEndpointId, {});
-    chip::Test::ClusterTester tester(cluster);
+    chip::Testing::ClusterTester tester(cluster);
 
     Attributes::WindowStatus::TypeInfo::DecodableType winStatus;
     auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
@@ -265,7 +266,7 @@ TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOp
     //                                                    .commissioningWindowManager =
     //                                                        Server::GetInstance().GetCommissioningWindowManager() };
     // OperationalCredentialsCluster opCreds(kRootEndpointId, context);
-    // chip::Test::ClusterTester opCredsTester(opCreds);
+    // chip::Testing::ClusterTester opCredsTester(opCreds);
     // EXPECT_EQ(opCreds.Startup(opCredsTester.GetServerClusterContext()), CHIP_NO_ERROR);
     // opCredsTester.SetFabricIndex(testFabricIndex);
 
@@ -286,13 +287,8 @@ TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOp
     // ASSERT_TRUE(stat.IsSuccess());
 
     auto result = tester.Invoke(Commands::OpenCommissioningWindow::Id, request);
-    // ASSERT_EQ(result.status, std::nullopt);
-    // ASSERT_TRUE(result.status.has_value());
-    // ASSERT_TRUE(result.status->IsSuccess());
     ASSERT_TRUE(result.IsSuccess());
 
-    // if (result.status->IsSuccess()) // NOLINT(bugprone-unchecked-optional-access)
-    // {
     status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
     ASSERT_TRUE(status.IsSuccess());
     EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kEnhancedWindowOpen);
@@ -306,5 +302,4 @@ TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOp
     status = tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor);
     ASSERT_TRUE(status.IsSuccess());
     ASSERT_FALSE(adminVendor.IsNull());
-    // }
 }

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -98,7 +98,7 @@ chip::PersistentStorageOperationalKeystore TestAdministratorCommissioningCluster
 chip::TestPersistentStorageDelegate TestAdministratorCommissioningCluster::sStorageDelegate;
 chip::Testing::EmptyProvider TestAdministratorCommissioningCluster::sEmptyProvider;
 
-const chip::FabricIndex kTestFabricIndex = chip::app::Testing::kTestFabrixIndex;
+const chip::FabricIndex kTestFabricIndex = chip::Testing::kTestFabrixIndex;
 
 TEST_F(TestAdministratorCommissioningCluster, TestAttributes)
 {

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -54,15 +54,7 @@ struct TestAdministratorCommissioningCluster : public ::testing::Test
     static void SetUpTestSuite()
     {
         ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
-        // The Server class calls MemoryInit in Init and MemoryShutdown in Shutdown.
-        // However, PlatformMgr().Shutdown() also relies on memory being initialized (e.g. for timer release),
-        // but it doesn't manage the memory refcount itself.
-        // If Server::Shutdown() drops the refcount to 0, PlatformMgr().Shutdown() will abort.
-        // We increment the refcount here to ensure memory remains initialized until after PlatformMgr().Shutdown().
-        ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
         ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
-
-        Server::GetInstance().Shutdown();
 
         SetCommissionableDataProvider(&sTestCommissionableDataProvider);
 
@@ -274,6 +266,7 @@ TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOp
     ASSERT_FALSE(adminFabric.IsNull());
 
     Attributes::AdminVendorId::TypeInfo::Type adminVendor;
+    adminVendor.SetNonNull(static_cast<chip::VendorId>(1));
     status = tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor);
     ASSERT_TRUE(status.IsSuccess());
     ASSERT_FALSE(adminVendor.IsNull());

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -56,6 +56,8 @@ struct TestAdministratorCommissioningCluster : public ::testing::Test
         ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
         ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
 
+        Server::GetInstance().Shutdown();
+
         SetCommissionableDataProvider(&sTestCommissionableDataProvider);
 
         ASSERT_EQ(sTestOpCertStore.Init(&sStorageDelegate), CHIP_NO_ERROR);
@@ -193,13 +195,14 @@ TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
     }
 
     {
-        uint16_t revision;
+        uint16_t revision = 0;
         ASSERT_EQ(tester.ReadAttribute(Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
         ASSERT_EQ(revision, 1u);
     }
 
     {
-        Attributes::WindowStatus::TypeInfo::Type winStatus;
+        Attributes::WindowStatus::TypeInfo::Type winStatus =
+            chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen;
         auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
         ASSERT_TRUE(status.IsSuccess());
         EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -142,35 +142,30 @@ TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
     AdministratorCommissioningCluster cluster(kRootEndpointId, {});
     chip::Test::ClusterTester tester(cluster);
 
-    // Test reading FeatureMap (base class)
     {
         Attributes::FeatureMap::TypeInfo::Type feature;
         ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, feature), CHIP_NO_ERROR);
         ASSERT_EQ(feature, 0u);
     }
 
-    // Revision
     {
         uint16_t revision;
         ASSERT_EQ(tester.ReadAttribute(Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
         ASSERT_EQ(revision, 1u);
     }
 
-    // Read default value of WindowStatus
     {
         Attributes::WindowStatus::TypeInfo::Type winStatus;
         ASSERT_EQ(tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus), CHIP_NO_ERROR);
         EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
     }
 
-    // AdminFabricIndex
     {
         Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
         ASSERT_EQ(tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric), CHIP_NO_ERROR);
         ASSERT_TRUE(adminFabric.IsNull());
     }
 
-    // AdminVendorId
     {
         Attributes::AdminVendorId::TypeInfo::Type adminVendor;
         ASSERT_EQ(tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor), CHIP_NO_ERROR);

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -65,7 +65,6 @@ struct TestAdministratorCommissioningCluster : public ::testing::Test
         serverInitParams.opCertStore               = &sTestOpCertStore;
         serverInitParams.operationalKeystore       = &sTestOpKeystore;
         serverInitParams.persistentStorageDelegate = &sStorageDelegate;
-        serverInitParams.operationalServicePort    = 0;
         static chip::SimpleTestEventTriggerDelegate sSimpleTestEventTriggerDelegate;
         serverInitParams.testEventTriggerDelegate = &sSimpleTestEventTriggerDelegate;
         (void) serverInitParams.InitializeStaticResourcesBeforeServerInit();
@@ -282,10 +281,10 @@ TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOp
         ASSERT_FALSE(result.IsSuccess());
         EXPECT_TRUE(result.status.has_value());
         // On platforms where DNS-SD is disabled, the logic swallows the error and returns kPAKEParameterError
-        auto statusCode = result.status.value().GetStatusCode();
+        auto statusCode = result.status.value().GetStatusCode(); // NOLINT(bugprone-unchecked-optional-access)
         EXPECT_EQ(statusCode.GetStatus(), chip::Protocols::InteractionModel::Status::Failure);
         EXPECT_TRUE(statusCode.GetClusterSpecificCode().has_value());
-        EXPECT_EQ(statusCode.GetClusterSpecificCode().value(),
+        EXPECT_EQ(statusCode.GetClusterSpecificCode().value(), // NOLINT(bugprone-unchecked-optional-access)
                   to_underlying(AdministratorCommissioning::StatusCode::kPAKEParameterError));
     }
 }

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -74,7 +74,13 @@ struct TestAdministratorCommissioningCluster : public ::testing::Test
     }
     static void TearDownTestSuite()
     {
+
+        Server::GetInstance().GetCommissioningWindowManager().CloseCommissioningWindow();
+        Server::GetInstance().GetFabricTable().DeleteAllFabrics();
+        Server::GetInstance().GetSecureSessionManager().ExpireAllSecureSessions();
+
         Server::GetInstance().Shutdown();
+
         sTestOpCertStore.Finish();
         sTestOpKeystore.Finish();
         chip::DeviceLayer::PlatformMgr().Shutdown();

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -53,6 +53,7 @@ struct TestAdministratorCommissioningCluster : public ::testing::Test
 
     static void SetUpTestSuite()
     {
+        chip::DeviceLayer::PlatformMgr().Shutdown();
         ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
         ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
 
@@ -280,7 +281,7 @@ TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOp
         ASSERT_FALSE(result.IsSuccess());
         EXPECT_TRUE(result.status.has_value());
         // On platforms where DNS-SD is disabled, the logic swallows the error and returns kPAKEParameterError
-        auto statusCode = result.status->GetStatusCode();
+        auto statusCode = result.status.value().GetStatusCode();
         EXPECT_EQ(statusCode.GetStatus(), chip::Protocols::InteractionModel::Status::Failure);
         EXPECT_TRUE(statusCode.GetClusterSpecificCode().has_value());
         EXPECT_EQ(statusCode.GetClusterSpecificCode().value(),

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -53,7 +53,6 @@ struct TestAdministratorCommissioningCluster : public ::testing::Test
 
     static void SetUpTestSuite()
     {
-        chip::DeviceLayer::PlatformMgr().Shutdown();
         ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
         ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
 
@@ -67,6 +66,8 @@ struct TestAdministratorCommissioningCluster : public ::testing::Test
         serverInitParams.operationalKeystore       = &sTestOpKeystore;
         serverInitParams.persistentStorageDelegate = &sStorageDelegate;
         serverInitParams.operationalServicePort    = 0;
+        static chip::SimpleTestEventTriggerDelegate sSimpleTestEventTriggerDelegate;
+        serverInitParams.testEventTriggerDelegate = &sSimpleTestEventTriggerDelegate;
         (void) serverInitParams.InitializeStaticResourcesBeforeServerInit();
         serverInitParams.dataModelProvider = &sEmptyProvider;
         ASSERT_EQ(Server::GetInstance().Init(serverInitParams), CHIP_NO_ERROR);

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -22,124 +22,124 @@
 #include <app/server-cluster/testing/AttributeTesting.h>
 #include <clusters/AdministratorCommissioning/Enums.h>
 #include <clusters/AdministratorCommissioning/Metadata.h>
+#include <credentials/tests/CHIPCert_unit_test_vectors.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/ReadOnlyBuffer.h>
 #include <platform/NetworkCommissioning.h>
 #include <platform/TestOnlyCommissionableDataProvider.h>
 
-namespace {
-
-using namespace chip;
-using namespace chip::app::Clusters;
-using namespace chip::app::Clusters::AdministratorCommissioning;
-
-using chip::app::DataModel::AcceptedCommandEntry;
-using chip::app::DataModel::AttributeEntry;
-
-// initialize memory as ReadOnlyBufferBuilder may allocate
-struct TestAdministratorCommissioningCluster : public ::testing::Test
+>>>>>>> 02e7e35d88 (TODO: Fix dependency issue of test certificates and use these certificates for fabric initialization) namespace
 {
-    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
-    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
-};
 
-static chip::DeviceLayer::TestOnlyCommissionableDataProvider sTestCommissionableDataProvider;
+    using namespace chip;
+    using namespace chip::app::Clusters;
+    using namespace chip::app::Clusters::AdministratorCommissioning;
 
-const chip::FabricIndex kTestFabricIndex = chip::app::Testing::kTestFabrixIndex;
+    using chip::app::DataModel::AcceptedCommandEntry;
+    using chip::app::DataModel::AttributeEntry;
 
-TEST_F(TestAdministratorCommissioningCluster, TestAttributes)
-{
+    // initialize memory as ReadOnlyBufferBuilder may allocate
+    struct TestAdministratorCommissioningCluster : public ::testing::Test
     {
-        AdministratorCommissioningCluster cluster(kRootEndpointId, {});
+        static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+        static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+    };
 
-        ReadOnlyBufferBuilder<AttributeEntry> builder;
-        ASSERT_EQ(cluster.Attributes({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
+    static chip::DeviceLayer::TestOnlyCommissionableDataProvider sTestCommissionableDataProvider;
 
-        ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
-        ASSERT_EQ(expectedBuilder.AppendElements({
-                      AdministratorCommissioning::Attributes::WindowStatus::kMetadataEntry,
-                      AdministratorCommissioning::Attributes::AdminFabricIndex::kMetadataEntry,
-                      AdministratorCommissioning::Attributes::AdminVendorId::kMetadataEntry,
-                  }),
-                  CHIP_NO_ERROR);
-        ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
+    TEST_F(TestAdministratorCommissioningCluster, TestAttributes)
+    {
+        {
+            AdministratorCommissioningCluster cluster(kRootEndpointId, {});
 
-        ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+            ReadOnlyBufferBuilder<AttributeEntry> builder;
+            ASSERT_EQ(cluster.Attributes({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
+
+            ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
+            ASSERT_EQ(expectedBuilder.AppendElements({
+                          AdministratorCommissioning::Attributes::WindowStatus::kMetadataEntry,
+                          AdministratorCommissioning::Attributes::AdminFabricIndex::kMetadataEntry,
+                          AdministratorCommissioning::Attributes::AdminVendorId::kMetadataEntry,
+                      }),
+                      CHIP_NO_ERROR);
+            ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
+
+            ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+        }
+
+        {
+            AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId,
+                                                                                  BitFlags<Feature>{ Feature::kBasic });
+
+            ReadOnlyBufferBuilder<AttributeEntry> builder;
+            ASSERT_EQ(cluster.Attributes({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
+
+            ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
+            ASSERT_EQ(expectedBuilder.AppendElements({
+                          AdministratorCommissioning::Attributes::WindowStatus::kMetadataEntry,
+                          AdministratorCommissioning::Attributes::AdminFabricIndex::kMetadataEntry,
+                          AdministratorCommissioning::Attributes::AdminVendorId::kMetadataEntry,
+                      }),
+                      CHIP_NO_ERROR);
+            ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
+
+            ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+        }
     }
 
+    TEST_F(TestAdministratorCommissioningCluster, TestCommands)
     {
-        AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId,
-                                                                              BitFlags<Feature>{ Feature::kBasic });
+        {
+            AdministratorCommissioningCluster cluster(kRootEndpointId, {});
 
-        ReadOnlyBufferBuilder<AttributeEntry> builder;
-        ASSERT_EQ(cluster.Attributes({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
+            ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
+            ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
 
-        ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
-        ASSERT_EQ(expectedBuilder.AppendElements({
-                      AdministratorCommissioning::Attributes::WindowStatus::kMetadataEntry,
-                      AdministratorCommissioning::Attributes::AdminFabricIndex::kMetadataEntry,
-                      AdministratorCommissioning::Attributes::AdminVendorId::kMetadataEntry,
-                  }),
-                  CHIP_NO_ERROR);
-        ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
+            ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
+            ASSERT_EQ(expectedBuilder.AppendElements({
+                          AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
+                          AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
+                      }),
+                      CHIP_NO_ERROR);
 
-        ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+            EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+        }
+
+        {
+            AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId, BitFlags<Feature>{});
+
+            ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
+            ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
+
+            ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
+            ASSERT_EQ(expectedBuilder.AppendElements({
+                          AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
+                          AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
+                      }),
+                      CHIP_NO_ERROR);
+
+            EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+        }
+
+        {
+            AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId,
+                                                                                  BitFlags<Feature>{ Feature::kBasic });
+
+            ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
+            ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
+
+            ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
+            ASSERT_EQ(expectedBuilder.AppendElements({
+                          AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
+                          AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
+                          AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::kMetadataEntry,
+                      }),
+                      CHIP_NO_ERROR);
+
+            EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+        }
     }
-}
-
-TEST_F(TestAdministratorCommissioningCluster, TestCommands)
-{
-    {
-        AdministratorCommissioningCluster cluster(kRootEndpointId, {});
-
-        ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
-        ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
-
-        ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
-        ASSERT_EQ(expectedBuilder.AppendElements({
-                      AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
-                      AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
-                  }),
-                  CHIP_NO_ERROR);
-
-        EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
-    }
-
-    {
-        AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId, BitFlags<Feature>{});
-
-        ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
-        ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
-
-        ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
-        ASSERT_EQ(expectedBuilder.AppendElements({
-                      AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
-                      AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
-                  }),
-                  CHIP_NO_ERROR);
-
-        EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
-    }
-
-    {
-        AdministratorCommissioningWithBasicCommissioningWindowCluster cluster(kRootEndpointId,
-                                                                              BitFlags<Feature>{ Feature::kBasic });
-
-        ReadOnlyBufferBuilder<AcceptedCommandEntry> builder;
-        ASSERT_EQ(cluster.AcceptedCommands({ kRootEndpointId, AdministratorCommissioning::Id }, builder), CHIP_NO_ERROR);
-
-        ReadOnlyBufferBuilder<AcceptedCommandEntry> expectedBuilder;
-        ASSERT_EQ(expectedBuilder.AppendElements({
-                      AdministratorCommissioning::Commands::OpenCommissioningWindow::kMetadataEntry,
-                      AdministratorCommissioning::Commands::RevokeCommissioning::kMetadataEntry,
-                      AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::kMetadataEntry,
-                  }),
-                  CHIP_NO_ERROR);
-
-        EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
-    }
-}
 
 } // namespace
 
@@ -180,169 +180,6 @@ TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
     }
 }
 
-/* class MockOperationalCertificateStore : public chip::Credentials::OperationalCertificateStore
-{
-public:
-    struct CertChain
-    {
-        ByteSpan rcac;
-        ByteSpan icac;
-        ByteSpan noc;
-    };
-
-    MockOperationalCertificateStore()           = default;
-    ~MockOperationalCertificateStore() override = default;
-
-    bool hasPendingRoot      = false;
-    bool hasPendingNoc       = false;
-    bool committed           = false;
-    FabricIndex pendingIndex = kUndefinedFabricIndex;
-
-    std::map<FabricIndex, CertChain> mCommitted;
-    std::map<FabricIndex, CertChain> mPending;
-
-    bool HasPendingRootCert() const override { return hasPendingRoot; }
-    bool HasPendingNocChain() const override { return hasPendingNoc; }
-
-    bool HasCertificateForFabric(FabricIndex fabricIndex, CertChainElement element) const override
-    {
-        auto it = mCommitted.find(fabricIndex);
-        if (it == mCommitted.end())
-            return false;
-
-        switch (element)
-        {
-        case CertChainElement::kRcac:
-            return it->second.rcac.data() != nullptr;
-        case CertChainElement::kIcac:
-            return it->second.icac.data() != nullptr;
-        case CertChainElement::kNoc:
-            return it->second.noc.data() != nullptr;
-        default:
-            return false;
-        }
-    }
-
-    CHIP_ERROR AddNewTrustedRootCertForFabric(FabricIndex fabricIndex, const ByteSpan & rcac) override
-    {
-        if (rcac.empty())
-            return CHIP_ERROR_INVALID_ARGUMENT;
-
-        hasPendingRoot             = true;
-        pendingIndex               = fabricIndex;
-        mPending[fabricIndex].rcac = rcac;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR AddNewOpCertsForFabric(FabricIndex fabricIndex, const ByteSpan & noc, const ByteSpan & icac) override
-    {
-        if (!hasPendingRoot || pendingIndex != fabricIndex)
-            return CHIP_ERROR_INCORRECT_STATE;
-
-        hasPendingNoc              = true;
-        mPending[fabricIndex].noc  = noc;
-        mPending[fabricIndex].icac = icac;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR UpdateOpCertsForFabric(FabricIndex fabricIndex, const ByteSpan & noc, const ByteSpan & icac) override
-    {
-        auto it = mCommitted.find(fabricIndex);
-        if (it == mCommitted.end())
-            return CHIP_ERROR_INCORRECT_STATE;
-
-        mPending[fabricIndex]      = it->second;
-        mPending[fabricIndex].noc  = noc;
-        mPending[fabricIndex].icac = icac;
-        hasPendingNoc              = true;
-        pendingIndex               = fabricIndex;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR CommitOpCertsForFabric(FabricIndex fabricIndex) override
-    {
-        auto it = mPending.find(fabricIndex);
-        if (it == mPending.end())
-            return CHIP_ERROR_INCORRECT_STATE;
-
-        mCommitted[fabricIndex] = it->second;
-        mPending.erase(it);
-        hasPendingNoc  = false;
-        hasPendingRoot = false;
-        committed      = true;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR RemoveOpCertsForFabric(FabricIndex fabricIndex) override
-    {
-        mCommitted.erase(fabricIndex);
-        mPending.erase(fabricIndex);
-        if (pendingIndex == fabricIndex)
-        {
-            hasPendingNoc  = false;
-            hasPendingRoot = false;
-        }
-        return CHIP_NO_ERROR;
-    }
-
-    void RevertPendingOpCerts() override
-    {
-        mPending.clear();
-        hasPendingNoc  = false;
-        hasPendingRoot = false;
-    }
-
-    void RevertPendingOpCertsExceptRoot() override
-    {
-        for (auto & [index, chain] : mPending)
-        {
-            chain.icac = ByteSpan();
-            chain.noc  = ByteSpan();
-        }
-        hasPendingNoc = false;
-    }
-
-    CHIP_ERROR GetCertificate(FabricIndex fabricIndex, CertChainElement element, MutableByteSpan & outCertificate) const override
-    {
-        const CertChain * chain = nullptr;
-
-        auto pendingIt = mPending.find(fabricIndex);
-        if (pendingIt != mPending.end())
-            chain = &pendingIt->second;
-        else
-        {
-            auto committedIt = mCommitted.find(fabricIndex);
-            if (committedIt == mCommitted.end())
-                return CHIP_ERROR_NOT_FOUND;
-            chain = &committedIt->second;
-        }
-
-        const ByteSpan * src = nullptr;
-        switch (element)
-        {
-        case CertChainElement::kRcac:
-            src = &chain->rcac;
-            break;
-        case CertChainElement::kIcac:
-            src = &chain->icac;
-            break;
-        case CertChainElement::kNoc:
-            src = &chain->noc;
-            break;
-        }
-
-        if (src == nullptr || src->empty())
-            return CHIP_ERROR_NOT_FOUND;
-
-        if (outCertificate.size() < src->size())
-            return CHIP_ERROR_BUFFER_TOO_SMALL;
-
-        memcpy(outCertificate.data(), src->data(), src->size());
-        outCertificate.reduce_size(src->size());
-        return CHIP_NO_ERROR;
-    }
-}; */
-
 TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOpeningWindow)
 {
     AdministratorCommissioningCluster cluster(kRootEndpointId, {});
@@ -362,12 +199,27 @@ TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOp
     request.PAKEPasscodeVerifier = chip::ByteSpan(reinterpret_cast<const uint8_t *>(&verifier), sizeof(verifier));
     request.iterations           = chip::Crypto::kSpake2p_Min_PBKDF_Iterations;
 
-    // FabricTable & fabricTable = Server::GetInstance().GetFabricTable();
-    // FabricTable::InitParams initParams;
-    // initParams.opCertStore         = &mMockOpCertStore;
-    // initParams.storage             = &mTestContext.StorageDelegate();
-    // initParams.operationalKeystore = nullptr;
-    // fabricTable.Init(initParams);
+    auto & fabricTable          = Server::GetInstance().GetFabricTable();
+    FabricIndex testFabricIndex = chip::kUndefinedFabricIndex;
+    ASSERT_EQ(fabricTable.AddNewFabricForTest(chip::TestCerts::GetRootACertAsset().mCert, chip::TestCerts::GetIAA1CertAsset().mCert,
+                                              chip::TestCerts::GetNodeA1CertAsset().mCert,
+                                              chip::TestCerts::GetNodeA1CertAsset().mKey, &testFabricIndex),
+              CHIP_NO_ERROR);
+    ASSERT_NE(testFabricIndex, chip::kUndefinedFabricIndex);
+
+    OperationalCredentialsCluster::Context context = { .fabricTable     = Server::GetInstance().GetFabricTable(),
+                                                       .failSafeContext = Server::GetInstance().GetFailSafeContext(),
+                                                       .sessionManager  = Server::GetInstance().GetSecureSessionManager(),
+                                                       .dnssdServer     = app::DnssdServer::Instance(),
+                                                       .commissioningWindowManager =
+                                                           Server::GetInstance().GetCommissioningWindowManager() };
+    OperationalCredentialsCluster opCreds(kRootEndpointId, context);
+    chip::Test::ClusterTester opCredsTester(opCreds);
+
+    // Read Fabrics attribute to verify the fabric was added
+    OperationalCredentials::Attributes::Fabrics::TypeInfo::DecodableType fabrics;
+    auto stat = opCredsTester.ReadAttribute(OperationalCredentials::Attributes::Fabrics::Id, fabrics);
+    ASSERT_TRUE(stat.IsSuccess());
 
     auto result = tester.Invoke(Commands::OpenCommissioningWindow::Id, request);
     ASSERT_TRUE(result.status.has_value());

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -16,7 +16,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <app/clusters/administrator-commissioning-server/AdministratorCommissioningCluster.h>
-#include <app/clusters/operational-credentials-server/operational-credentials-cluster.h>
+#include <app/clusters/operational-credentials-server/OperationalCredentialsCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
@@ -29,12 +29,74 @@
 #include <platform/NetworkCommissioning.h>
 #include <platform/TestOnlyCommissionableDataProvider.h>
 
+<<<<<<< HEAD
 >>>>>>> 02e7e35d88 (TODO: Fix dependency issue of test certificates and use these certificates for fabric initialization) namespace
 {
 
     using namespace chip;
     using namespace chip::app::Clusters;
     using namespace chip::app::Clusters::AdministratorCommissioning;
+=======
+#include <app/clusters/testing/ClusterTester.h>
+#include <app/clusters/testing/ValidateGlobalAttributes.h>
+#include <credentials/PersistentStorageOpCertStore.h>
+#include <credentials/tests/CHIPCert_unit_test_vectors.h>
+#include <crypto/PersistentStorageOperationalKeystore.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+#include <platform/TestOnlyCommissionableDataProvider.h>
+
+#include <app/clusters/testing/ClusterTester.h>
+#include <app/clusters/testing/ValidateGlobalAttributes.h>
+
+    namespace {
+
+    using namespace chip;
+    using namespace chip::app::Clusters;
+    using namespace chip::app::Clusters::AdministratorCommissioning;
+
+    using chip::app::DataModel::AcceptedCommandEntry;
+    using chip::app::DataModel::AttributeEntry;
+
+    // initialize memory as ReadOnlyBufferBuilder may allocate
+    struct TestAdministratorCommissioningCluster : public ::testing::Test
+    {
+        static chip::DeviceLayer::TestOnlyCommissionableDataProvider sTestCommissionableDataProvider;
+        static chip::Credentials::PersistentStorageOpCertStore sTestOpCertStore;
+        static chip::PersistentStorageOperationalKeystore sTestOpKeystore;
+        static chip::TestPersistentStorageDelegate sStorageDelegate;
+
+        static void SetUpTestSuite()
+        {
+            ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
+            ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
+
+            ASSERT_EQ(sTestOpCertStore.Init(&sStorageDelegate), CHIP_NO_ERROR);
+            ASSERT_EQ(sTestOpKeystore.Init(&sStorageDelegate), CHIP_NO_ERROR);
+
+            auto & fabricTable = Server::GetInstance().GetFabricTable();
+            FabricTable::InitParams initParams;
+            initParams.storage             = &sStorageDelegate;
+            initParams.operationalKeystore = &sTestOpKeystore;
+            initParams.opCertStore         = &sTestOpCertStore;
+            ASSERT_EQ(fabricTable.Init(initParams), CHIP_NO_ERROR);
+        }
+        static void TearDownTestSuite()
+        {
+            chip::Server::GetInstance().GetFabricTable().Shutdown();
+            sTestOpCertStore.Finish();
+            sTestOpKeystore.Finish();
+            chip::DeviceLayer::PlatformMgr().Shutdown();
+            chip::Platform::MemoryShutdown();
+        }
+    };
+
+    chip::DeviceLayer::TestOnlyCommissionableDataProvider TestAdministratorCommissioningCluster::sTestCommissionableDataProvider;
+    chip::Credentials::PersistentStorageOpCertStore TestAdministratorCommissioningCluster::sTestOpCertStore;
+    chip::PersistentStorageOperationalKeystore TestAdministratorCommissioningCluster::sTestOpKeystore;
+    chip::TestPersistentStorageDelegate TestAdministratorCommissioningCluster::sStorageDelegate;
+
+    const chip::FabricIndex kTestFabricIndex = chip::app::Testing::kTestFabrixIndex;
+>>>>>>> c019cc8afd (Initialize FabricTable in)
 
     using chip::app::DataModel::AcceptedCommandEntry;
     using chip::app::DataModel::AttributeEntry;
@@ -141,103 +203,201 @@
         }
     }
 
-} // namespace
+    } // namespace
 
-TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
-{
-    AdministratorCommissioningCluster cluster(kRootEndpointId, {});
-    chip::Test::ClusterTester tester(cluster);
-
+    TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
     {
-        Attributes::FeatureMap::TypeInfo::Type feature{};
-        ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, feature), CHIP_NO_ERROR);
-        ASSERT_EQ(feature, 0u);
+        AdministratorCommissioningCluster cluster(kRootEndpointId, {});
+        chip::Test::ClusterTester tester(cluster);
+
+        {
+            Attributes::FeatureMap::TypeInfo::Type feature{};
+            ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, feature), CHIP_NO_ERROR);
+            ASSERT_EQ(feature, 0u);
+        }
+
+        {
+            uint16_t revision;
+            ASSERT_EQ(tester.ReadAttribute(Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
+            ASSERT_EQ(revision, 1u);
+        }
+
+        {
+            Attributes::WindowStatus::TypeInfo::Type winStatus;
+            auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
+            ASSERT_TRUE(status.IsSuccess());
+            EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
+        }
+
+        {
+            Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
+            ASSERT_EQ(tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric), CHIP_NO_ERROR);
+            ASSERT_TRUE(adminFabric.IsNull());
+        }
+
+        {
+            Attributes::AdminVendorId::TypeInfo::Type adminVendor;
+            ASSERT_EQ(tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor), CHIP_NO_ERROR);
+            ASSERT_TRUE(adminVendor.IsNull());
+        }
     }
 
+    TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOpeningWindow)
     {
-        uint16_t revision;
-        ASSERT_EQ(tester.ReadAttribute(Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
-        ASSERT_EQ(revision, 1u);
-    }
+        AdministratorCommissioningCluster cluster(kRootEndpointId, {});
+        chip::Test::ClusterTester tester(cluster);
 
-    {
-        Attributes::WindowStatus::TypeInfo::Type winStatus;
+        Attributes::WindowStatus::TypeInfo::DecodableType winStatus;
         auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
         ASSERT_TRUE(status.IsSuccess());
         EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
+
+        Commands::OpenCommissioningWindow::Type request;
+        request.commissioningTimeout = 900;
+        uint16_t originDiscriminator;
+        EXPECT_EQ(sTestCommissionableDataProvider.GetSetupDiscriminator(originDiscriminator), CHIP_NO_ERROR);
+        request.discriminator = static_cast<uint16_t>(originDiscriminator + 1);
+        chip::Crypto::Spake2pVerifier verifier{};
+        request.PAKEPasscodeVerifier = chip::ByteSpan(reinterpret_cast<const uint8_t *>(&verifier), sizeof(verifier));
+        request.iterations           = chip::Crypto::kSpake2p_Min_PBKDF_Iterations;
+
+        auto & fabricTable          = Server::GetInstance().GetFabricTable();
+        FabricIndex testFabricIndex = chip::kUndefinedFabricIndex;
+        ASSERT_EQ(fabricTable.AddNewFabricForTest(
+                      chip::TestCerts::GetRootACertAsset().mCert, chip::TestCerts::GetIAA1CertAsset().mCert,
+                      chip::TestCerts::GetNodeA1CertAsset().mCert, chip::TestCerts::GetNodeA1CertAsset().mKey, &testFabricIndex),
+                  CHIP_NO_ERROR);
+        ASSERT_NE(testFabricIndex, chip::kUndefinedFabricIndex);
+
+        // Read Fabrics attribute to verify the fabric was added
+        OperationalCredentials::Attributes::Fabrics::TypeInfo::DecodableType fabrics;
+        auto stat = opCredsTester.ReadAttribute(OperationalCredentials::Attributes::Fabrics::Id, fabrics);
+        ASSERT_TRUE(stat.IsSuccess());
+
+        auto result = tester.Invoke(Commands::OpenCommissioningWindow::Id, request);
+        ASSERT_TRUE(result.status.has_value());
+
+        if (result.status->IsSuccess()) // NOLINT(bugprone-unchecked-optional-access)
+        {
+            status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
+            ASSERT_TRUE(status.IsSuccess());
+            EXPECT_EQ(winStatus,
+                      chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kEnhancedWindowOpen);
+
+            Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
+            status = tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric);
+            ASSERT_TRUE(status.IsSuccess());
+            ASSERT_FALSE(adminFabric.IsNull());
+
+            Attributes::AdminVendorId::TypeInfo::Type adminVendor;
+            status = tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor);
+            ASSERT_TRUE(status.IsSuccess());
+            ASSERT_FALSE(adminVendor.IsNull());
+        }
     }
 
+    TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
     {
-        Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
-        ASSERT_EQ(tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric), CHIP_NO_ERROR);
-        ASSERT_TRUE(adminFabric.IsNull());
+        AdministratorCommissioningCluster cluster(kRootEndpointId, {});
+        chip::Test::ClusterTester tester(cluster);
+
+        {
+            Attributes::FeatureMap::TypeInfo::Type feature{};
+            ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, feature), CHIP_NO_ERROR);
+            ASSERT_EQ(feature, 0u);
+        }
+
+        {
+            uint16_t revision;
+            ASSERT_EQ(tester.ReadAttribute(Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
+            ASSERT_EQ(revision, 1u);
+        }
+
+        {
+            Attributes::WindowStatus::TypeInfo::Type winStatus;
+            auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
+            ASSERT_TRUE(status.IsSuccess());
+            EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
+        }
+
+        {
+            Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
+            ASSERT_EQ(tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric), CHIP_NO_ERROR);
+            ASSERT_TRUE(adminFabric.IsNull());
+        }
+
+        {
+            Attributes::AdminVendorId::TypeInfo::Type adminVendor;
+            ASSERT_EQ(tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor), CHIP_NO_ERROR);
+            ASSERT_TRUE(adminVendor.IsNull());
+        }
     }
 
+    TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOpeningWindow)
     {
-        Attributes::AdminVendorId::TypeInfo::Type adminVendor;
-        ASSERT_EQ(tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor), CHIP_NO_ERROR);
-        ASSERT_TRUE(adminVendor.IsNull());
+        AdministratorCommissioningCluster cluster(kRootEndpointId, {});
+        chip::Test::ClusterTester tester(cluster);
+
+        Attributes::WindowStatus::TypeInfo::DecodableType winStatus;
+        auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
+        ASSERT_TRUE(status.IsSuccess());
+        EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
+
+        Commands::OpenCommissioningWindow::Type request;
+        request.commissioningTimeout = 900;
+        uint16_t originDiscriminator;
+        EXPECT_EQ(sTestCommissionableDataProvider.GetSetupDiscriminator(originDiscriminator), CHIP_NO_ERROR);
+        request.discriminator = static_cast<uint16_t>(originDiscriminator + 1);
+        chip::Crypto::Spake2pVerifier verifier{};
+        request.PAKEPasscodeVerifier = chip::ByteSpan(reinterpret_cast<const uint8_t *>(&verifier), sizeof(verifier));
+        request.iterations           = chip::Crypto::kSpake2p_Min_PBKDF_Iterations;
+
+        // FabricTable & fabricTable = Server::GetInstance().GetFabricTable();
+        // FabricTable::InitParams initParams;
+        // initParams.opCertStore         = &mMockOpCertStore;
+        // initParams.storage             = &mTestContext.StorageDelegate();
+        // initParams.operationalKeystore = nullptr;
+        // fabricTable.Init(initParams);
+        auto context = OperationalCredentialsCluster::Context{
+            .fabricTable                = Server::GetInstance().GetFabricTable(),
+            .failSafeContext            = Server::GetInstance().GetFailSafeContext(),
+            .sessionManager             = Server::GetInstance().GetSecureSessionManager(),
+            .dnssdServer                = app::DnssdServer::Instance(),
+            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(),
+        };
+        OperationalCredentialsCluster opCreds(kRootEndpointId, context);
+        chip::Test::ClusterTester opCredsTester(opCreds);
+        EXPECT_EQ(opCreds.Startup(opCredsTester.GetServerClusterContext()), CHIP_NO_ERROR);
+        opCredsTester.SetFabricIndex(kTestFabricIndex);
+
+        // 1. Arm FailSafe because AddNOC command requires it.
+        auto & failSafe = context.failSafeContext;
+        ASSERT_EQ(failSafe.ArmFailSafe(kTestFabricIndex, System::Clock::Seconds16(900)), CHIP_NO_ERROR);
+        // 2. Add Trusted Root Cert for the fabric.
+        OperationalCredentials::Commands::AddTrustedRootCertificate::Type addRcaRequest;
+        addRcaRequest.rootCACertificate = chip::TestCerts::GetRootACertAsset().mCert;
+        auto root = opCredsTester.Invoke(OperationalCredentials::Commands::AddTrustedRootCertificate::Id, addRcaRequest);
+        ASSERT_TRUE(root.status.has_value());
+        ASSERT_TRUE(root.status->IsSuccess());
+
+        auto result = tester.Invoke(Commands::OpenCommissioningWindow::Id, request);
+        ASSERT_TRUE(result.status.has_value());
+
+        if (result.status->IsSuccess()) // NOLINT(bugprone-unchecked-optional-access)
+        {
+            status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
+            ASSERT_TRUE(status.IsSuccess());
+            EXPECT_EQ(winStatus,
+                      chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kEnhancedWindowOpen);
+
+            Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
+            status = tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric);
+            ASSERT_TRUE(status.IsSuccess());
+            ASSERT_FALSE(adminFabric.IsNull());
+
+            Attributes::AdminVendorId::TypeInfo::Type adminVendor;
+            status = tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor);
+            ASSERT_TRUE(status.IsSuccess());
+            ASSERT_FALSE(adminVendor.IsNull());
+        }
     }
-}
-
-TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOpeningWindow)
-{
-    AdministratorCommissioningCluster cluster(kRootEndpointId, {});
-    chip::Test::ClusterTester tester(cluster);
-
-    Attributes::WindowStatus::TypeInfo::DecodableType winStatus;
-    auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
-    ASSERT_TRUE(status.IsSuccess());
-    EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
-
-    Commands::OpenCommissioningWindow::Type request;
-    request.commissioningTimeout = 900;
-    uint16_t originDiscriminator;
-    EXPECT_EQ(sTestCommissionableDataProvider.GetSetupDiscriminator(originDiscriminator), CHIP_NO_ERROR);
-    request.discriminator = static_cast<uint16_t>(originDiscriminator + 1);
-    chip::Crypto::Spake2pVerifier verifier{};
-    request.PAKEPasscodeVerifier = chip::ByteSpan(reinterpret_cast<const uint8_t *>(&verifier), sizeof(verifier));
-    request.iterations           = chip::Crypto::kSpake2p_Min_PBKDF_Iterations;
-
-    auto & fabricTable          = Server::GetInstance().GetFabricTable();
-    FabricIndex testFabricIndex = chip::kUndefinedFabricIndex;
-    ASSERT_EQ(fabricTable.AddNewFabricForTest(chip::TestCerts::GetRootACertAsset().mCert, chip::TestCerts::GetIAA1CertAsset().mCert,
-                                              chip::TestCerts::GetNodeA1CertAsset().mCert,
-                                              chip::TestCerts::GetNodeA1CertAsset().mKey, &testFabricIndex),
-              CHIP_NO_ERROR);
-    ASSERT_NE(testFabricIndex, chip::kUndefinedFabricIndex);
-
-    OperationalCredentialsCluster::Context context = { .fabricTable     = Server::GetInstance().GetFabricTable(),
-                                                       .failSafeContext = Server::GetInstance().GetFailSafeContext(),
-                                                       .sessionManager  = Server::GetInstance().GetSecureSessionManager(),
-                                                       .dnssdServer     = app::DnssdServer::Instance(),
-                                                       .commissioningWindowManager =
-                                                           Server::GetInstance().GetCommissioningWindowManager() };
-    OperationalCredentialsCluster opCreds(kRootEndpointId, context);
-    chip::Test::ClusterTester opCredsTester(opCreds);
-
-    // Read Fabrics attribute to verify the fabric was added
-    OperationalCredentials::Attributes::Fabrics::TypeInfo::DecodableType fabrics;
-    auto stat = opCredsTester.ReadAttribute(OperationalCredentials::Attributes::Fabrics::Id, fabrics);
-    ASSERT_TRUE(stat.IsSuccess());
-
-    auto result = tester.Invoke(Commands::OpenCommissioningWindow::Id, request);
-    ASSERT_TRUE(result.status.has_value());
-
-    if (result.status->IsSuccess()) // NOLINT(bugprone-unchecked-optional-access)
-    {
-        status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
-        ASSERT_TRUE(status.IsSuccess());
-        EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kEnhancedWindowOpen);
-
-        Attributes::AdminFabricIndex::TypeInfo::Type adminFabric;
-        status = tester.ReadAttribute(Attributes::AdminFabricIndex::Id, adminFabric);
-        ASSERT_TRUE(status.IsSuccess());
-        ASSERT_FALSE(adminFabric.IsNull());
-
-        Attributes::AdminVendorId::TypeInfo::Type adminVendor;
-        status = tester.ReadAttribute(Attributes::AdminVendorId::Id, adminVendor);
-        ASSERT_TRUE(status.IsSuccess());
-        ASSERT_FALSE(adminVendor.IsNull());
-    }
-}

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -67,31 +67,24 @@ struct TestAdministratorCommissioningCluster : public ::testing::Test
         ASSERT_EQ(sTestOpCertStore.Init(&sStorageDelegate), CHIP_NO_ERROR);
         ASSERT_EQ(sTestOpKeystore.Init(&sStorageDelegate), CHIP_NO_ERROR);
 
-        // auto & fabricTable = Server::GetInstance().GetFabricTable();
-        // FabricTable::InitParams initParams;
-        // initParams.storage             = &sStorageDelegate;
-        // initParams.operationalKeystore = &sTestOpKeystore;
-        // initParams.opCertStore         = &sTestOpCertStore;
-        // ASSERT_EQ(fabricTable.Init(initParams), CHIP_NO_ERROR);
-
-        // Initialize CommissioningWindowManager so it has a valid Server pointer
-        chip::CommonCaseDeviceServerInitParams serverInitParams;
+        static chip::CommonCaseDeviceServerInitParams serverInitParams;
         static chip::app::DefaultTimerDelegate sTimerDelegate;
         static chip::app::reporting::ReportSchedulerImpl sReportScheduler(&sTimerDelegate);
         serverInitParams.reportScheduler           = &sReportScheduler;
         serverInitParams.opCertStore               = &sTestOpCertStore;
         serverInitParams.operationalKeystore       = &sTestOpKeystore;
         serverInitParams.persistentStorageDelegate = &sStorageDelegate;
+        serverInitParams.operationalServicePort    = 0;
         (void) serverInitParams.InitializeStaticResourcesBeforeServerInit();
         serverInitParams.dataModelProvider = &sEmptyProvider;
         ASSERT_EQ(Server::GetInstance().Init(serverInitParams), CHIP_NO_ERROR);
-        // ASSERT_EQ(Server::GetInstance().GetCommissioningWindowManager().Init(&Server::GetInstance()), CHIP_NO_ERROR);
+        Server::GetInstance().GetCommissioningWindowManager().CloseCommissioningWindow();
     }
     static void TearDownTestSuite()
     {
-        // chip::Server::GetInstance().GetCommissioningWindowManager().Shutdown();
-        // chip::Server::GetInstance().GetFabricTable().Shutdown();
-        // Server::GetInstance().Shutdown();
+        chip::Server::GetInstance().GetCommissioningWindowManager().Shutdown();
+        chip::Server::GetInstance().GetFabricTable().Shutdown();
+        Server::GetInstance().Shutdown();
         sTestOpCertStore.Finish();
         sTestOpKeystore.Finish();
         chip::DeviceLayer::PlatformMgr().Shutdown();

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -146,7 +146,7 @@ TEST_F(TestAdministratorCommissioningCluster, TestReadAttributesDefaultValues)
     chip::Test::ClusterTester tester(cluster);
 
     {
-        Attributes::FeatureMap::TypeInfo::Type feature;
+        Attributes::FeatureMap::TypeInfo::Type feature{};
         ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, feature), CHIP_NO_ERROR);
         ASSERT_EQ(feature, 0u);
     }
@@ -198,7 +198,7 @@ TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOp
     auto result                  = tester.Invoke(Commands::OpenCommissioningWindow::Id, request);
     ASSERT_TRUE(result.status.has_value());
 
-    if (result.status->IsSuccess())
+    if (result.status->IsSuccess()) // NOLINT(bugprone-unchecked-optional-access)
     {
         status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
         ASSERT_TRUE(status.IsSuccess());

--- a/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/tests/TestAdministratorCommissioningCluster.cpp
@@ -226,14 +226,15 @@ TEST_F(TestAdministratorCommissioningCluster, TestAttributeSpecComplianceAfterOp
     AdministratorCommissioningCluster cluster(kRootEndpointId, {});
     chip::Testing::ClusterTester tester(cluster);
 
-    Attributes::WindowStatus::TypeInfo::DecodableType winStatus;
+    Attributes::WindowStatus::TypeInfo::DecodableType winStatus =
+        chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kEnhancedWindowOpen;
     auto status = tester.ReadAttribute(Attributes::WindowStatus::Id, winStatus);
     ASSERT_TRUE(status.IsSuccess());
     EXPECT_EQ(winStatus, chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
 
     Commands::OpenCommissioningWindow::Type request;
     request.commissioningTimeout = 900;
-    uint16_t originDiscriminator;
+    uint16_t originDiscriminator = 0;
     EXPECT_EQ(sTestCommissionableDataProvider.GetSetupDiscriminator(originDiscriminator), CHIP_NO_ERROR);
     request.discriminator = static_cast<uint16_t>(originDiscriminator + 1);
     chip::Crypto::Spake2pVerifier verifier{};

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -302,7 +302,7 @@ private:
     // 256 bytes was chosen as a conservative upper bound for typical command payloads in tests.
     // All command payloads used in tests must fit within this buffer; tests with larger payloads will fail.
     // If protocol or test requirements change, this value may need to be increased.
-    static constexpr size_t kTlvBufferSize = 256;
+    static constexpr size_t kTlvBufferSize = 512;
 
     chip::Testing::MockCommandHandler mHandler;
     uint8_t mTlvBuffer[kTlvBufferSize];


### PR DESCRIPTION
#### Summary
This PR adds unit tests for `AdministratorCommissioning` cluster in app/clusters, focusing on the `ReadAttribute` function for cluster attributes. The tests validate default value scenarios such as:

- `AdminFabricIndex` returning null when no commissioning window is open
- `WindowStatus` returning `kWindowNotOpen`  by default
- `AdminVendorId` returning null in non-commissioned state

Additionally, the tests verify the state of these attributes after successfully opening a commissioning window using the `OpenCommissioningWindow` command.

#### Related issues
[#41128](https://github.com/project-chip/connectedhomeip/issues/41128)

#### Testing
This PR only adds new unit tests. No changes made to production code.