### PR TITLE
Use namespace.so for coverage runs (faster, more disk)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -510,7 +510,9 @@ jobs:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
 
         if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
-        runs-on: ubuntu-latest
+        # Use namespace to get more disk space and slightly better performance (Compile and unit tests
+        # are CPU bound)
+        runs-on: namespace-profile-4x8
 
         container:
             image: ghcr.io/project-chip/chip-build:174


### PR DESCRIPTION
#### Summary

Github is running out of space (I believe the runner image was updated recently and a lot of our builds are out of space). Move this build to namespace.so (paid tier, but we probably make good use of it this way)

#### Testing

Will check if CI works.