### PR TITLE
Do RM-rf out for every build in linux standalone builds.

### DIFF
--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -53,57 +53,55 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-chip-cert \
-                        build"
+                        build" && rm -rf out
             - name: Build minmdns example with platform dns
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-address-resolve-tool-platform-mdns-ipv6only \
-                        build"
+                        build" && rm -rf out
             - name: Build example Standalone chip tool
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-chip-tool \
-                        build"
+                        build" && rm -rf out
             - name: Build example Standalone Shell
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-shell \
-                        build"
+                        build" && rm -rf out
             - name: Build example Standalone All Clusters Server
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-all-clusters \
-                        build"
-            - name: Clean out build output
-              run: rm -rf ./out
+                        build" && rm -rf out
             - name: Build example Standalone All Clusters Minimal Server
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-all-clusters-minimal \
-                        build"
+                        build" && rm -rf out
             - name: Build example TV app
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-tv-app \
-                        build"
+                        build" && rm -rf out
             - name: Build example Standalone TV Casting App
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-tv-casting-app \
-                        build"
+                        build" && rm -rf out
             - name: Build example lighting app with RPCs and UI
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-light-rpc-with-ui \
-                        build"
+                        build" && rm -rf out
             - name: Clean out build output
               run: rm -rf ./out
             - name: Build example Standalone Bridge
@@ -111,75 +109,73 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-bridge \
-                        build"
+                        build" && rm -rf out
             - name: Build example OTA Provider
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-ota-provider \
-                        build"
+                        build" && rm -rf out
             - name: Build example OTA Requestor
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-ota-requestor \
-                        build"
-            - name: Clean out build output
-              run: rm -rf ./out
+                        build" && rm -rf out
             - name: Build example Standalone Lock App
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-lock-no-thread \
-                        build"
+                        build" && rm -rf out
             - name: Build example contact sensor with UI
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-contact-sensor-no-ble-with-ui \
-                        build"
+                        build" && rm -rf out
             - name: Build example Air Purifier
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-air-purifier \
-                        build"
+                        build" && rm -rf out
             - name: Build example Fabric Admin
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-fabric-admin-rpc \
-                        build"
+                        build" && rm -rf out
             - name: Build example Fabric Bridge App
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-fabric-bridge-no-ble-rpc \
-                        build"
+                        build" && rm -rf out
             - name: Build example Fabric Sync
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-fabric-sync-no-ble \
-                        build"
+                        build" && rm -rf out
             - name: Build example Camera App
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-camera \
-                        build"
+                        build" && rm -rf out
             - name: Build example Camera Controller App
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-camera-controller \
-                        build"
+                        build" && rm -rf out
             - name: Build Example Closure App
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-closure \
-                        build"
+                        build" && rm -rf out
 
             - name: CCache statistics
               run: ccache --show-stats

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -102,8 +102,6 @@ jobs:
                      "./scripts/build/build_examples.py \
                         --target linux-x64-light-rpc-with-ui \
                         build" && rm -rf out
-            - name: Clean out build output
-              run: rm -rf ./out
             - name: Build example Standalone Bridge
               run: |
                   ./scripts/run_in_build_env.sh \


### PR DESCRIPTION
#### Summary

Linux standalone builds was doing only occasional cleanout of the out directory. Do more of those. 
We seem to be running out of space recently otherwise.

#### Testing

CI will check.