### PR TITLE
[CI, NRF] Clean more output dirs, to avoid running out of space

### DIFF
--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -42,6 +42,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-nrf-platform:174
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
         steps:
@@ -84,6 +85,7 @@ jobs:
                     nrfconnect nrf52840dk_nrf52840 lock-app \
                     examples/lock-app/nrfconnect/build/nrfconnect/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
+                  rm -rf examples/lock-app/nrfconnect/build/nrfconnect
             - name: Build example nRF Connect SDK Lock App on nRF54L15 DK
               if: github.event_name == 'push' || steps.changed_paths.outputs.nrfconnect == 'true'
               run: |
@@ -92,6 +94,7 @@ jobs:
                     nrfconnect nrf54l15dk_nrf54l15_cpuapp lock-app \
                     examples/lock-app/nrfconnect/build/nrfconnect/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
+                  rm -rf examples/lock-app/nrfconnect/build/nrfconnect
             - name: Build example nRF Connect SDK Lighting App on nRF52840 Dongle
               if: github.event_name == 'push' || steps.changed_paths.outputs.nrfconnect == 'true'
               run: |
@@ -100,6 +103,7 @@ jobs:
                     nrfconnect nrf52840dongle_nrf52840 lighting-app \
                     examples/lighting-app/nrfconnect/build/nrfconnect/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
+                  rm -rf examples/lighting-app/nrfconnect/build/nrfconnect
             - name: Build example nRF Connect SDK Lighting App on nRF54L15 DK
               if: github.event_name == 'push' || steps.changed_paths.outputs.nrfconnect == 'true'
               run: |
@@ -108,6 +112,7 @@ jobs:
                     nrfconnect nrf54l15dk_nrf54l15_cpuapp lighting-app \
                     examples/lighting-app/nrfconnect/build/nrfconnect/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
+                  rm -rf examples/lighting-app/nrfconnect/build/nrfconnect
             - name: Build example nRF Connect SDK Lighting App on nRF52840 DK with RPC
               if: github.event_name == 'push' || steps.changed_paths.outputs.nrfconnect == 'true'
               run: |
@@ -116,6 +121,7 @@ jobs:
                     nrfconnect nrf52840dk_nrf52840+rpc lighting-app \
                     examples/lighting-app/nrfconnect/build/nrfconnect/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
+                  rm -rf examples/lighting-app/nrfconnect/build/nrfconnect
             - name: Build example nRF Connect SDK Light Switch App on nRF52840 DK
               if: github.event_name == 'push' || steps.changed_paths.outputs.nrfconnect == 'true'
               run: |
@@ -124,6 +130,7 @@ jobs:
                     nrfconnect nrf52840dk_nrf52840 light-switch-app \
                     examples/light-switch-app/nrfconnect/build/nrfconnect/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
+                  rm -rf examples/light-switch-app/nrfconnect/build/nrfconnect
             - name: Build example nRF Connect SDK Shell on nRF52840 DK
               if: github.event_name == 'push' || steps.changed_paths.outputs.shell == 'true' || steps.changed_paths.outputs.nrfconnect == 'true'
               run: |
@@ -132,6 +139,7 @@ jobs:
                     nrfconnect nrf52840dk_nrf52840 shell \
                     examples/shell/nrfconnect/build/nrfconnect/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
+                  rm -rf examples/shell/nrfconnect/build/nrfconnect
             - name: Build example nRF Connect SDK All Clusters App on nRF52840 DK
               run: |
                   scripts/examples/nrfconnect_example.sh all-clusters-app nrf52840dk/nrf52840
@@ -139,6 +147,7 @@ jobs:
                     nrfconnect nrf52840dk_nrf52840 all-clusters-app \
                     examples/all-clusters-app/nrfconnect/build/nrfconnect/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
+                  rm -rf examples/all-clusters-app/nrfconnect/build/nrfconnect
             - name: Build example nRF Connect SDK All Clusters App on nRF54L15 DK
               if: github.event_name == 'push' || steps.changed_paths.outputs.nrfconnect == 'true'
               run: |
@@ -147,6 +156,7 @@ jobs:
                     nrfconnect nrf54l15dk_nrf54l15_cpuapp all-clusters-app \
                     examples/all-clusters-app/nrfconnect/build/nrfconnect/zephyr/zephyr.elf \
                     /tmp/bloat_reports/
+                  rm -rf examples/all-clusters-app/nrfconnect/build/nrfconnect
             - name: Run unit tests for Zephyr native_posix_64 platform
               if: >
                 github.event_name == 'push' ||


### PR DESCRIPTION
#### Summary

CI is running out of space. Do:
- remove output after every build
- mount the root directory in a way that bootstrap can clean up some space

#### Testing

CI will validate as this is a CI change