### PR TITLE
[DCL Check] Print Warning message if Certification Declaration is not present in DCL for current software version

### DIFF
--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -230,7 +230,9 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
         sub_key = 'cDCertificateId'
         logging.info(f'Found compliance info for {self.vid_pid_sv_str} in the DCL:')
         logging.info(f'{entry[key]}')
-        if not entry[key][sub_key]:
+        if not key in entry.keys():
+            asserts.fail(f'Unable to find compliance info for {self.vid_pid_sv_str} in the DCL')
+        if key in entry.keys() and not entry[key][sub_key]:
             logging.warning(f'Certification declaration ID is empty for {self.vid_pid_sv_str}')
 
     def steps_CertifiedModel(self):

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -232,8 +232,8 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
             asserts.fail(f'Unable to find compliance info for {self.vid_pid_sv_str} in the DCL')
         logging.info(f'Found compliance info for {self.vid_pid_sv_str} in the DCL:')
         logging.info(f'{entry[key]}')
-        if not entry[key][sub_key]:
-            logging.warning(f'Certification declaration ID is empty for {self.vid_pid_sv_str}')
+        if sub_key not in entry[key] or not entry[key][sub_key]:
+            logging.warning(f'Certification declaration ID is missing or empty for {self.vid_pid_sv_str}')
 
     def steps_CertifiedModel(self):
         return [TestStep(1, "Query the information about all software versions for this PID/VID", "DCL entry exists"),

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -228,10 +228,10 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
             f"{self.url}/dcl/compliance/compliance-info/{self.vid}/{self.pid}/{self.software_version}/matter").json()
         key = 'complianceInfo'
         sub_key = 'cDCertificateId'
-        logging.info(f'Found compliance info for {self.vid_pid_sv_str} in the DCL:')
-        logging.info(f'{entry[key]}')
         if key not in entry.keys():
             asserts.fail(f'Unable to find compliance info for {self.vid_pid_sv_str} in the DCL')
+        logging.info(f'Found compliance info for {self.vid_pid_sv_str} in the DCL:')
+        logging.info(f'{entry[key]}')
         if not entry[key][sub_key]:
             logging.warning(f'Certification declaration ID is empty for {self.vid_pid_sv_str}')
 

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -232,7 +232,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
         logging.info(f'{entry[key]}')
         if key not in entry.keys():
             asserts.fail(f'Unable to find compliance info for {self.vid_pid_sv_str} in the DCL')
-        if key in entry.keys() and not entry[key][sub_key]:
+        if not entry[key][sub_key]:
             logging.warning(f'Certification declaration ID is empty for {self.vid_pid_sv_str}')
 
     def steps_CertifiedModel(self):

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -219,6 +219,20 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
         asserts.assert_true(found_versions,
                             f"Unable to find at least one compliance entry for the versions {software_versions}")
 
+    def steps_CertificationDeclaration(self):
+        return [TestStep(1, "Query the certification declaration for this VID/PID/SoftwareVersion", "Warn if certification declaration ID is empty"),]
+
+    def test_CertificationDeclaration(self):
+        self.step(1)
+        entry = requests.get(
+            f"{self.url}/dcl/compliance/compliance-info/{self.vid}/{self.pid}/{self.software_version}/matter").json()
+        key = 'complianceInfo'
+        sub_key = 'cDCertificateId'
+        logging.info(f'Found compliance info for {self.vid_pid_sv_str} in the DCL:')
+        logging.info(f'{entry[key]}')
+        if not entry[key][sub_key]:
+            logging.warning(f'Certification declaration ID is empty for {self.vid_pid_sv_str}')
+
     def steps_CertifiedModel(self):
         return [TestStep(1, "Query the information about all software versions for this PID/VID", "DCL entry exists"),
                 TestStep(2, "Query the certified version information for the specified software versions",

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -230,7 +230,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
         sub_key = 'cDCertificateId'
         logging.info(f'Found compliance info for {self.vid_pid_sv_str} in the DCL:')
         logging.info(f'{entry[key]}')
-        if not key in entry.keys():
+        if key not in entry.keys():
             asserts.fail(f'Unable to find compliance info for {self.vid_pid_sv_str} in the DCL')
         if key in entry.keys() and not entry[key][sub_key]:
             logging.warning(f'Certification declaration ID is empty for {self.vid_pid_sv_str}')

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -220,7 +220,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
                             f"Unable to find at least one compliance entry for the versions {software_versions}")
 
     def steps_CertificationDeclaration(self):
-        return [TestStep(1, "Query the certification declaration for this VID/PID/SoftwareVersion", "Warn if certification declaration ID is empty"),]
+        return [TestStep(1, "Query the certification declaration for this VID/PID/SoftwareVersion", "Warn if certification declaration ID is empty")]
 
     def test_CertificationDeclaration(self):
         self.step(1)


### PR DESCRIPTION
#### Summary

In the DCL test case warn if a certification declaration is not specified in DCL for a given software version.

#### Related issues

None

#### Testing

Will test this using IDT tool manually
