### PR TITLE
Remove `TestServerClusterContext::Create`

### DIFF
--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -175,14 +175,13 @@ struct TestBasicInformationReadWrite : public ::testing::Test
         chip::Platform::MemoryShutdown();
     }
 
-    TestBasicInformationReadWrite() : testContext(), context(testContext.Create()) {}
+    TestBasicInformationReadWrite() {}
 
-    void SetUp() override { ASSERT_EQ(basicInformationClusterInstance.Startup(context), CHIP_NO_ERROR); }
+    void SetUp() override { ASSERT_EQ(basicInformationClusterInstance.Startup(testContext.Get()), CHIP_NO_ERROR); }
 
     void TearDown() override { basicInformationClusterInstance.Shutdown(); }
 
     chip::Test::TestServerClusterContext testContext;
-    ServerClusterContext context;
     static BasicInformationCluster & basicInformationClusterInstance;
     static chip::Test::ClusterTester tester;
 };
@@ -196,7 +195,7 @@ TEST_F(TestBasicInformationReadWrite, TestNodeLabelLoadAndSave)
     CharSpan oldLabelSpan = "Old Label"_span;
 
     // Initialize AttributePersistence with the provider from *this test's* context
-    AttributePersistence persistence(context.attributeStorage);
+    AttributePersistence persistence(testContext.AttributePersistenceProvider());
 
     Storage::String<32> labelStorage;
     ASSERT_EQ(labelStorage.SetContent(oldLabelSpan), true); // ensure it fits
@@ -206,7 +205,7 @@ TEST_F(TestBasicInformationReadWrite, TestNodeLabelLoadAndSave)
     // 2. WHEN: The BasicInformationCluster starts up.
     // We must shut down the one from SetUp and re-start it to force a load.
     basicInformationClusterInstance.Shutdown();
-    ASSERT_EQ(basicInformationClusterInstance.Startup(context), CHIP_NO_ERROR);
+    ASSERT_EQ(basicInformationClusterInstance.Startup(testContext.Get()), CHIP_NO_ERROR);
 
     // 3. THEN: The cluster should have loaded "Old Label" into its memory.
     char readBuffer[32];

--- a/src/app/clusters/boolean-state-server/tests/TestBooleanStateCluster.cpp
+++ b/src/app/clusters/boolean-state-server/tests/TestBooleanStateCluster.cpp
@@ -40,14 +40,13 @@ struct TestBooleanStateCluster : public ::testing::Test
 
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
 
-    void SetUp() override { ASSERT_EQ(booleanState.Startup(context), CHIP_NO_ERROR); }
+    void SetUp() override { ASSERT_EQ(booleanState.Startup(testContext.Get()), CHIP_NO_ERROR); }
 
     void TearDown() override { booleanState.Shutdown(); }
 
-    TestBooleanStateCluster() : context(testContext.Create()), booleanState(kRootEndpointId) {}
+    TestBooleanStateCluster() : booleanState(kRootEndpointId) {}
 
     chip::Test::TestServerClusterContext testContext;
-    ServerClusterContext context;
     BooleanStateCluster booleanState;
 };
 

--- a/src/app/clusters/fixed-label-server/tests/TestFixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/tests/TestFixedLabelCluster.cpp
@@ -40,14 +40,13 @@ struct TestFixedLabelCluster : public ::testing::Test
 
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
 
-    void SetUp() override { ASSERT_EQ(fixedLabel.Startup(context), CHIP_NO_ERROR); }
+    void SetUp() override { ASSERT_EQ(fixedLabel.Startup(testContext.Get()), CHIP_NO_ERROR); }
 
     void TearDown() override { fixedLabel.Shutdown(); }
 
-    TestFixedLabelCluster() : context(testContext.Create()), fixedLabel(kRootEndpointId) {}
+    TestFixedLabelCluster() : fixedLabel(kRootEndpointId) {}
 
     chip::Test::TestServerClusterContext testContext;
-    ServerClusterContext context;
     FixedLabelCluster fixedLabel;
 };
 

--- a/src/app/clusters/soil-measurement-server/tests/TestSoilMeasurementCluster.cpp
+++ b/src/app/clusters/soil-measurement-server/tests/TestSoilMeasurementCluster.cpp
@@ -67,16 +67,13 @@ struct TestSoilMeasurementCluster : public ::testing::Test
 
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
 
-    void SetUp() override { ASSERT_EQ(soilMeasurement.Startup(context), CHIP_NO_ERROR); }
+    void SetUp() override { ASSERT_EQ(soilMeasurement.Startup(testContext.Get()), CHIP_NO_ERROR); }
 
     void TearDown() override { soilMeasurement.Shutdown(); }
 
-    TestSoilMeasurementCluster() :
-        context(testContext.Create()), soilMeasurement(kEndpointWithSoilMeasurement, kDefaultSoilMoistureMeasurementLimits)
-    {}
+    TestSoilMeasurementCluster() : soilMeasurement(kEndpointWithSoilMeasurement, kDefaultSoilMoistureMeasurementLimits) {}
 
     chip::Test::TestServerClusterContext testContext;
-    ServerClusterContext context;
     SoilMeasurementClusterLocal soilMeasurement;
 };
 

--- a/src/app/clusters/time-synchronization-server/tests/TestTimeSynchronizationCluster.cpp
+++ b/src/app/clusters/time-synchronization-server/tests/TestTimeSynchronizationCluster.cpp
@@ -41,10 +41,9 @@ struct TestTimeSynchronizationCluster : public ::testing::Test
 
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
 
-    TestTimeSynchronizationCluster() : context(testContext.Create()) {}
+    TestTimeSynchronizationCluster() {}
 
     chip::Test::TestServerClusterContext testContext;
-    ServerClusterContext context;
     TimeSynchronization::DefaultTimeSyncDelegate delegate;
 };
 
@@ -57,7 +56,7 @@ TEST_F(TestTimeSynchronizationCluster, AttributeTest)
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features,
                                                        TimeSynchronizationCluster::OptionalAttributeSet(),
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ReadOnlyBufferBuilder<DataModel::AttributeEntry> attributes;
         ASSERT_EQ(timeSynchronization.Attributes(ConcreteClusterPath(kRootEndpointId, TimeSynchronization::Id), attributes),
@@ -78,7 +77,7 @@ TEST_F(TestTimeSynchronizationCluster, AttributeTest)
         const BitFlags<Feature> features{ 0U };
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features, optionalAttributeSet,
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ReadOnlyBufferBuilder<DataModel::AttributeEntry> attributes;
         ASSERT_EQ(timeSynchronization.Attributes(ConcreteClusterPath(kRootEndpointId, TimeSynchronization::Id), attributes),
@@ -97,7 +96,7 @@ TEST_F(TestTimeSynchronizationCluster, AttributeTest)
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features,
                                                        TimeSynchronizationCluster::OptionalAttributeSet(),
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ReadOnlyBufferBuilder<DataModel::AttributeEntry> attributes;
         ASSERT_EQ(timeSynchronization.Attributes(ConcreteClusterPath(kRootEndpointId, TimeSynchronization::Id), attributes),
@@ -120,7 +119,7 @@ TEST_F(TestTimeSynchronizationCluster, AttributeTest)
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features,
                                                        TimeSynchronizationCluster::OptionalAttributeSet(),
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ReadOnlyBufferBuilder<DataModel::AttributeEntry> attributes;
         ASSERT_EQ(timeSynchronization.Attributes(ConcreteClusterPath(kRootEndpointId, TimeSynchronization::Id), attributes),
@@ -144,7 +143,7 @@ TEST_F(TestTimeSynchronizationCluster, AttributeTest)
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features,
                                                        TimeSynchronizationCluster::OptionalAttributeSet(),
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ReadOnlyBufferBuilder<DataModel::AttributeEntry> attributes;
         ASSERT_EQ(timeSynchronization.Attributes(ConcreteClusterPath(kRootEndpointId, TimeSynchronization::Id), attributes),
@@ -167,7 +166,7 @@ TEST_F(TestTimeSynchronizationCluster, AttributeTest)
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features,
                                                        TimeSynchronizationCluster::OptionalAttributeSet(),
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ReadOnlyBufferBuilder<DataModel::AttributeEntry> attributes;
         ASSERT_EQ(timeSynchronization.Attributes(ConcreteClusterPath(kRootEndpointId, TimeSynchronization::Id), attributes),
@@ -203,7 +202,7 @@ TEST_F(TestTimeSynchronizationCluster, ReadAttributeTest)
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features,
                                                        TimeSynchronizationCluster::OptionalAttributeSet(),
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ClusterTester tester(timeSynchronization);
 
@@ -228,7 +227,7 @@ TEST_F(TestTimeSynchronizationCluster, ReadAttributeTest)
         const BitFlags<Feature> features{ 0U };
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features, optionalAttributeSet,
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ClusterTester tester(timeSynchronization);
 
@@ -255,7 +254,7 @@ TEST_F(TestTimeSynchronizationCluster, ReadAttributeTest)
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features,
                                                        TimeSynchronizationCluster::OptionalAttributeSet(),
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ClusterTester tester(timeSynchronization);
 
@@ -282,7 +281,7 @@ TEST_F(TestTimeSynchronizationCluster, ReadAttributeTest)
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features,
                                                        TimeSynchronizationCluster::OptionalAttributeSet(),
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ClusterTester tester(timeSynchronization);
 
@@ -312,7 +311,7 @@ TEST_F(TestTimeSynchronizationCluster, ReadAttributeTest)
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features,
                                                        TimeSynchronizationCluster::OptionalAttributeSet(),
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ClusterTester tester(timeSynchronization);
 
@@ -339,7 +338,7 @@ TEST_F(TestTimeSynchronizationCluster, ReadAttributeTest)
         TimeSynchronizationCluster timeSynchronization(kRootEndpointId, features,
                                                        TimeSynchronizationCluster::OptionalAttributeSet(),
                                                        TimeSynchronizationCluster::StartupConfiguration{ .delegate = &delegate });
-        ASSERT_EQ(timeSynchronization.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(timeSynchronization.Startup(testContext.Get()), CHIP_NO_ERROR);
 
         ClusterTester tester(timeSynchronization);
 

--- a/src/app/clusters/user-label-server/tests/TestUserLabelCluster.cpp
+++ b/src/app/clusters/user-label-server/tests/TestUserLabelCluster.cpp
@@ -70,7 +70,7 @@ struct TestUserLabelCluster : public ::testing::Test
     void SetUp() override
     {
         DeviceLayer::SetDeviceInfoProvider(&mDeviceInfoProvider);
-        ASSERT_EQ(userLabel.Startup(context), CHIP_NO_ERROR);
+        ASSERT_EQ(userLabel.Startup(testContext.Get()), CHIP_NO_ERROR);
     }
 
     void TearDown() override
@@ -79,10 +79,9 @@ struct TestUserLabelCluster : public ::testing::Test
         DeviceLayer::SetDeviceInfoProvider(nullptr);
     }
 
-    TestUserLabelCluster() : context(testContext.Create()), userLabel(kRootEndpointId) {}
+    TestUserLabelCluster() : userLabel(kRootEndpointId) {}
 
     chip::Test::TestServerClusterContext testContext;
-    ServerClusterContext context;
     UserLabelCluster userLabel;
     MockDeviceInfoProvider mDeviceInfoProvider;
 };

--- a/src/app/server-cluster/testing/TestServerClusterContext.h
+++ b/src/app/server-cluster/testing/TestServerClusterContext.h
@@ -66,17 +66,6 @@ public:
     /// Get a stable pointer to the underlying context
     app::ServerClusterContext & Get() { return mContext; }
 
-    /// Create a new context bound to this test context
-    app::ServerClusterContext Create()
-    {
-        return {
-            .provider           = mTestProvider,
-            .storage            = mTestStorage,
-            .attributeStorage   = mDefaultAttributePersistenceProvider,
-            .interactionContext = mTestContext,
-        };
-    };
-
     LogOnlyEvents & EventsGenerator() { return mTestEventsGenerator; }
     TestProviderChangeListener & ChangeListener() { return mTestDataModelChangeListener; }
     TestPersistentStorageDelegate & StorageDelegate() { return mTestStorage; }

--- a/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
+++ b/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
@@ -239,7 +239,7 @@ TEST_F(TestServerClusterInterfaceRegistry, Context)
 
         // set up the registry
         TestServerClusterContext context;
-        EXPECT_EQ(registry.SetContext(context.Create()), CHIP_NO_ERROR);
+        EXPECT_EQ(registry.SetContext(ServerClusterContext{ context.Get() }), CHIP_NO_ERROR);
 
         EXPECT_TRUE(cluster1.HasContext());
         EXPECT_FALSE(cluster2.HasContext());
@@ -255,7 +255,7 @@ TEST_F(TestServerClusterInterfaceRegistry, Context)
         EXPECT_FALSE(cluster2.HasContext());
         EXPECT_FALSE(cluster3.HasContext());
 
-        EXPECT_EQ(registry.SetContext(context.Create()), CHIP_NO_ERROR);
+        EXPECT_EQ(registry.SetContext(ServerClusterContext{ context.Get() }), CHIP_NO_ERROR);
         EXPECT_TRUE(cluster1.HasContext());
         EXPECT_TRUE(cluster2.HasContext());
         EXPECT_FALSE(cluster3.HasContext());
@@ -270,7 +270,7 @@ TEST_F(TestServerClusterInterfaceRegistry, Context)
         EXPECT_TRUE(cluster3.HasContext());
 
         // re-setting context works
-        EXPECT_EQ(registry.SetContext(context.Create()), CHIP_NO_ERROR);
+        EXPECT_EQ(registry.SetContext(ServerClusterContext{ context.Get() }), CHIP_NO_ERROR);
         EXPECT_TRUE(cluster1.HasContext());
         EXPECT_FALSE(cluster2.HasContext());
         EXPECT_TRUE(cluster3.HasContext());
@@ -278,7 +278,7 @@ TEST_F(TestServerClusterInterfaceRegistry, Context)
         // also not valid, but different
         TestServerClusterContext otherContext;
 
-        EXPECT_EQ(registry.SetContext(otherContext.Create()), CHIP_NO_ERROR);
+        EXPECT_EQ(registry.SetContext(ServerClusterContext{ otherContext.Get() }), CHIP_NO_ERROR);
         EXPECT_TRUE(cluster1.HasContext());
         EXPECT_FALSE(cluster2.HasContext());
         EXPECT_TRUE(cluster3.HasContext());
@@ -373,7 +373,7 @@ TEST_F(TestServerClusterInterfaceRegistry, StartupShutdownWithoutContext)
 
         // the clusters are explicitly set to fail startup, so SetContext returns an error.
         // TODO: is this sane? Register() with a startup failure does NOT return a failure.
-        EXPECT_EQ(registry.SetContext(context.Create()), CHIP_ERROR_HAD_FAILURES);
+        EXPECT_EQ(registry.SetContext(ServerClusterContext{ context.Get() }), CHIP_ERROR_HAD_FAILURES);
 
         // Startup called after registration, with failure that is NOT reported (only logged)
         EXPECT_EQ(cluster3.Cluster().GetStartupCallCount(), 0u);

--- a/src/app/server-cluster/tests/TestSingleEndpointServerClusterRegistry.cpp
+++ b/src/app/server-cluster/tests/TestSingleEndpointServerClusterRegistry.cpp
@@ -373,7 +373,7 @@ TEST_F(TestSingleEndpointServerClusterRegistry, Context)
 
         // set up the registry
         TestServerClusterContext context;
-        EXPECT_EQ(registry.SetContext(context.Create()), CHIP_NO_ERROR);
+        EXPECT_EQ(registry.SetContext(ServerClusterContext{ context.Get() }), CHIP_NO_ERROR);
 
         EXPECT_TRUE(cluster1.HasContext());
         EXPECT_FALSE(cluster2.HasContext());
@@ -389,7 +389,7 @@ TEST_F(TestSingleEndpointServerClusterRegistry, Context)
         EXPECT_FALSE(cluster2.HasContext());
         EXPECT_FALSE(cluster3.HasContext());
 
-        EXPECT_EQ(registry.SetContext(context.Create()), CHIP_NO_ERROR);
+        EXPECT_EQ(registry.SetContext(ServerClusterContext{ context.Get() }), CHIP_NO_ERROR);
         EXPECT_TRUE(cluster1.HasContext());
         EXPECT_TRUE(cluster2.HasContext());
         EXPECT_FALSE(cluster3.HasContext());
@@ -404,7 +404,7 @@ TEST_F(TestSingleEndpointServerClusterRegistry, Context)
         EXPECT_TRUE(cluster3.HasContext());
 
         // re-setting context works
-        EXPECT_EQ(registry.SetContext(context.Create()), CHIP_NO_ERROR);
+        EXPECT_EQ(registry.SetContext(ServerClusterContext{ context.Get() }), CHIP_NO_ERROR);
         EXPECT_TRUE(cluster1.HasContext());
         EXPECT_FALSE(cluster2.HasContext());
         EXPECT_TRUE(cluster3.HasContext());
@@ -412,7 +412,7 @@ TEST_F(TestSingleEndpointServerClusterRegistry, Context)
         // also not valid, but different
         TestServerClusterContext otherContext;
 
-        EXPECT_EQ(registry.SetContext(otherContext.Create()), CHIP_NO_ERROR);
+        EXPECT_EQ(registry.SetContext(ServerClusterContext{ otherContext.Get() }), CHIP_NO_ERROR);
         EXPECT_TRUE(cluster1.HasContext());
         EXPECT_FALSE(cluster2.HasContext());
         EXPECT_TRUE(cluster3.HasContext());
@@ -542,7 +542,7 @@ TEST_F(TestSingleEndpointServerClusterRegistry, StartupErrors)
         EXPECT_FALSE(cluster2.HasContext());
 
         TestServerClusterContext context;
-        EXPECT_EQ(registry.SetContext(context.Create()), CHIP_ERROR_HAD_FAILURES);
+        EXPECT_EQ(registry.SetContext(ServerClusterContext{ context.Get() }), CHIP_ERROR_HAD_FAILURES);
         EXPECT_TRUE(cluster1.HasContext());
         EXPECT_FALSE(cluster2.HasContext());
 


### PR DESCRIPTION
#### Summary

Having a `::Create` encourages odd patterns of creating temporary variables, which are generally not needed for server cluster testing (only registry testing needs something like this and they can create temporaries)

Without create, we have cleaner code.

#### Testing

Code cleanup only, CI still applies.