### PR TITLE
[Chef] Add support to build Sleepy devices

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -843,7 +843,7 @@ def main() -> int:
                 nrf_build_cmds.append(
                     f"-DCONFIG_OPENTHREAD_POLL_PERIOD={_SLEEPY_DEVICE_POLL_PERIOD_MS}")
 
-            flush_print(f"NRF Build command args: f{' '.join(nrf_build_cmds)}")
+            flush_print(f"NRF Build command args: {' '.join(nrf_build_cmds)}")
             shell.run_cmd(" ".join(nrf_build_cmds))
 
         elif options.build_target == "silabs-thread":

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -484,7 +484,8 @@ def main() -> int:
             try:
                 sleepy_device_name = f"sleepy_{device_name}"
                 for ext in [".zap", ".matter"]:
-                    src_item = os.path.join(_DEVICE_FOLDER, f"{device_name}{ext}")
+                    src_item = os.path.join(
+                        _DEVICE_FOLDER, f"{device_name}{ext}")
                     dest_item = os.path.join(
                         _DEVICE_FOLDER, f"{sleepy_device_name}{ext}")
                     shutil.copy(src_item, dest_item)
@@ -839,7 +840,8 @@ def main() -> int:
                 f"-DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION_STRING='\"{sw_ver_string}\"'")
             if re.search(_SLEEPY_DEVICE_PATTERN, options.sample_device_type_name):
                 nrf_build_cmds.append("-DCONFIG_OPENTHREAD_MTD_SED=y")
-                nrf_build_cmds.append(f"-DCONFIG_OPENTHREAD_POLL_PERIOD={_SLEEPY_DEVICE_POLL_PERIOD_MS}")
+                nrf_build_cmds.append(
+                    f"-DCONFIG_OPENTHREAD_POLL_PERIOD={_SLEEPY_DEVICE_POLL_PERIOD_MS}")
 
             flush_print("NRF Build command args: ", " ".join(nrf_build_cmds))
             shell.run_cmd(" ".join(nrf_build_cmds))

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -475,11 +475,6 @@ def main() -> int:
         archive_prefix = "/workspace/artifacts/"
         archive_suffix = ".tar.gz"
         failed_builds = []
-        # TODO: Remove this once tested.
-        _dev_list = [
-            "rootnode_dimmablelight_bCwGYSDpoe",
-            "rootnode_contactsensor_lFAGG1bfRO",
-        ]
         # Sleepy variants have no ZAP differences from their non-sleepy counterparts,
         # so we can just copy the ZAP files.
         sleepy_device_names = []
@@ -497,7 +492,7 @@ def main() -> int:
                 flush_print(
                     'Failed to copy ZAP and matter files for sleepy variant of ' + device_name + f': {str(copy_fail_error)}')
                 continue
-        for device_name in _dev_list + sleepy_device_names:
+        for device_name in _DEVICE_LIST + sleepy_device_names:
             for platform, label_args in cicd_config["cd_platforms"].items():
                 if re.search(_SLEEPY_DEVICE_PATTERN, device_name) and platform != "nrfconnect":
                     continue

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -843,7 +843,7 @@ def main() -> int:
                 nrf_build_cmds.append(
                     f"-DCONFIG_OPENTHREAD_POLL_PERIOD={_SLEEPY_DEVICE_POLL_PERIOD_MS}")
 
-            flush_print("NRF Build command args: ", " ".join(nrf_build_cmds))
+            flush_print(f"NRF Build command args: f{' '.join(nrf_build_cmds)}")
             shell.run_cmd(" ".join(nrf_build_cmds))
 
         elif options.build_target == "silabs-thread":

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -476,7 +476,7 @@ def main() -> int:
         archive_suffix = ".tar.gz"
         failed_builds = []
         # TODO: Remove this once tested.
-        _DEVICE_LIST = [
+        _dev_list = [
             "rootnode_dimmablelight_bCwGYSDpoe",
             "rootnode_contactsensor_lFAGG1bfRO",
         ]
@@ -497,7 +497,7 @@ def main() -> int:
                 flush_print(
                     'Failed to copy ZAP and matter files for sleepy variant of ' + device_name + f': {str(copy_fail_error)}')
                 continue
-        for device_name in _DEVICE_LIST + sleepy_device_names:
+        for device_name in _dev_list + sleepy_device_names:
             for platform, label_args in cicd_config["cd_platforms"].items():
                 if re.search(_SLEEPY_DEVICE_PATTERN, device_name) and platform != "nrfconnect":
                     continue

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -64,12 +64,6 @@ _SLEEPY_DEVICE_PATTERN = "^sleepy_"
 
 gen_dir = ""  # Filled in after sample app type is read from args.
 
-# TODO: Remove this once tested.
-_DEVICE_LIST = [
-    "rootnode_dimmablelight_bCwGYSDpoe",
-    "rootnode_contactsensor_lFAGG1bfRO",
-]
-
 
 def splash() -> None:
     splashText = textwrap.dedent(
@@ -481,6 +475,11 @@ def main() -> int:
         archive_prefix = "/workspace/artifacts/"
         archive_suffix = ".tar.gz"
         failed_builds = []
+        # TODO: Remove this once tested.
+        _DEVICE_LIST = [
+            "rootnode_dimmablelight_bCwGYSDpoe",
+            "rootnode_contactsensor_lFAGG1bfRO",
+        ]
         # Sleepy variants have no ZAP differences from their non-sleepy counterparts,
         # so we can just copy the ZAP files.
         sleepy_device_names = []

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -483,19 +483,16 @@ def main() -> int:
         for device_name in _DEVICES_WITH_SLEEPY_VARIANT_REQUIRED:
             try:
                 sleepy_device_name = f"sleepy_{device_name}"
-                src_item = os.path.join(_DEVICE_FOLDER, f"{device_name}.zap")
-                dest_item = os.path.join(
-                    _DEVICE_FOLDER, f"{sleepy_device_name}.zap")
-                shutil.copy(src_item, dest_item)
-                src_item = os.path.join(
-                    _DEVICE_FOLDER, f"{device_name}.matter")
-                dest_item = os.path.join(
-                    _DEVICE_FOLDER, f"{sleepy_device_name}.matter")
-                shutil.copy(src_item, dest_item)
+                for ext in [".zap", ".matter"]:
+                    src_item = os.path.join(_DEVICE_FOLDER, f"{device_name}{ext}")
+                    dest_item = os.path.join(
+                        _DEVICE_FOLDER, f"{sleepy_device_name}{ext}")
+                    shutil.copy(src_item, dest_item)
                 sleepy_device_names.append(sleepy_device_name)
             except FileNotFoundError as copy_fail_error:
                 flush_print(
-                    'Failed to copy ZAP and matter files for sleepy variant of ' + device_name + f': {str(copy_fail_error)}')
+                    f'Failed to copy ZAP and matter files for sleepy variant of {device_name}: {str(copy_fail_error)}'
+                )
                 continue
         for device_name in _DEVICE_LIST + sleepy_device_names:
             for platform, label_args in cicd_config["cd_platforms"].items():

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -55,6 +55,8 @@ _DEVICES_WITH_SLEEPY_VARIANT_REQUIRED = [
     "rootnode_contactsensor_lFAGG1bfRO",
 ]
 
+_SLEEPY_DEVICE_POLL_PERIOD_MS = 2500
+
 # Pattern to filter (based on device-name) devices that need ICD support.
 _ICD_DEVICE_PATTERN = "^icd_"
 
@@ -840,8 +842,9 @@ def main() -> int:
                 f"-DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION_STRING='\"{sw_ver_string}\"'")
             if re.search(_SLEEPY_DEVICE_PATTERN, options.sample_device_type_name):
                 nrf_build_cmds.append("-DCONFIG_OPENTHREAD_MTD_SED=y")
-                nrf_build_cmds.append("-DCONFIG_OPENTHREAD_POLL_PERIOD=2500")
+                nrf_build_cmds.append(f"-DCONFIG_OPENTHREAD_POLL_PERIOD={_SLEEPY_DEVICE_POLL_PERIOD_MS}")
 
+            flush_print("NRF Build command args: ", " ".join(nrf_build_cmds))
             shell.run_cmd(" ".join(nrf_build_cmds))
 
         elif options.build_target == "silabs-thread":

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -64,6 +64,12 @@ _SLEEPY_DEVICE_PATTERN = "^sleepy_"
 
 gen_dir = ""  # Filled in after sample app type is read from args.
 
+# TODO: Remove this once tested.
+_DEVICE_LIST = [
+    "rootnode_dimmablelight_bCwGYSDpoe",
+    "rootnode_contactsensor_lFAGG1bfRO",
+]
+
 
 def splash() -> None:
     splashText = textwrap.dedent(

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -482,10 +482,13 @@ def main() -> int:
             try:
                 sleepy_device_name = f"sleepy_{device_name}"
                 src_item = os.path.join(_DEVICE_FOLDER, f"{device_name}.zap")
-                dest_item = os.path.join(_DEVICE_FOLDER, f"{sleepy_device_name}.zap")
+                dest_item = os.path.join(
+                    _DEVICE_FOLDER, f"{sleepy_device_name}.zap")
                 shutil.copy(src_item, dest_item)
-                src_item = os.path.join(_DEVICE_FOLDER, f"{device_name}.matter")
-                dest_item = os.path.join(_DEVICE_FOLDER, f"{sleepy_device_name}.matter")
+                src_item = os.path.join(
+                    _DEVICE_FOLDER, f"{device_name}.matter")
+                dest_item = os.path.join(
+                    _DEVICE_FOLDER, f"{sleepy_device_name}.matter")
                 shutil.copy(src_item, dest_item)
                 sleepy_device_names.append(sleepy_device_name)
             except FileNotFoundError as copy_fail_error:


### PR DESCRIPTION
#### Summary

This PR updates the chef.py script build sleepy variants of some devices in the [cloudbuild](https://github.com/project-chip/connectedhomeip/blob/master/integrations/cloudbuild/chef.yaml).

Changes are effective with the use of `build_all` flag on chef.py only.

Adding a device name to `_DEVICES_WITH_SLEEPY_VARIANT_REQUIRED` will build its nrfconnect sleepy variant in addition to the normal one.

Flags for sleepy -
* [CONFIG_OPENTHREAD_MTD_SED](https://docs.nordicsemi.com/bundle/ncs-1.9.0/page/kconfig/CONFIG_OPENTHREAD_MTD_SED.html)
* [CONFIG_OPENTHREAD_POLL_PERIOD](https://docs.nordicsemi.com/bundle/ncs-1.9.0/page/kconfig/CONFIG_OPENTHREAD_POLL_PERIOD.html)

#### Testing

Tested the chef [cloudbuild](https://github.com/project-chip/connectedhomeip/blob/master/integrations/cloudbuild/chef.yaml) job on this branch.
