### PR TITLE
[VSCode] Prevent recursive connectedhomeip indexing via search and explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -199,5 +199,11 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
     },
-    "autopep8.args": ["--max-line-length", "132"]
+    "autopep8.args": ["--max-line-length", "132"],
+    "search.exclude": {
+        "**/examples/**/third_party/connectedhomeip/**": true
+    },
+    "files.exclude": {
+        "**/examples/**/third_party/connectedhomeip/**": true
+    }
 }


### PR DESCRIPTION
#### Summary

- Without this change, looking up a function definition in VSCode often returns duplicate results: one from the original source  `src/system/SystemClock.h` and another from a nested copy in `examples/window-app/telink/third_party/connectedhomeip/src/system/SystemClock.h`

- The nested duplicate frequently takes precedence, making source navigation confusing.

- This update EXCLUDES the recursive connectedhomeip path from search and file explorer indexing.

<img width="574" height="155" alt="image" src="https://github.com/user-attachments/assets/2b23607e-8afb-45c7-9a97-88511469c3c4" />


#### Testing

After putting this change:
1. Command Palette (Control Shift+P) → "C/C++: Reset IntelliSense Database"
2. Click on Functions again, no more duplicate Header files
3. if you search for files (Control + P) , you wont get the duplicate in `examples/window-app/telink/third_party/connectedhomeip/src`
