### PR TITLE
Do not fail-fast on linux REPL tests.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -814,6 +814,7 @@ jobs:
     repl_tests_linux_run:
         name: REPL Tests - Linux (RUN)
         needs: repl_tests_linux_build
+        timeout-minutes: 45
 
         if: github.actor != 'restyled-io[bot]'
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -818,6 +818,8 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         strategy:
+            # Since some of these tests can be flaky, do not fail all matrix parts when a single one fails
+            fail-fast: false
             matrix:
                 # This list is empirically created to have a reasonable time split. The "" that runs the "other"
                 # tests is reasonably fast, the others take about 20-30 minutes each at the time this was split.


### PR DESCRIPTION
#### Summary

fail-fast defaults to "true" but that just causes extra runs on flakyness.

Changes:
  - fail-fast to false
  - add a job timeout, so that if we get a hang (saw some in JF tests), we will stop faster than 6 hours.

#### Testing

CI should pass. No code changes.