### PR TITLE
[Bugfix][cherry-pick 1.4.2] make RevokeCommissioning tear down PASESession

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -134,8 +134,6 @@ void CommissioningWindowManager::ResetState()
 
     DeviceLayer::SystemLayer().CancelTimer(HandleCommissioningWindowTimeout, this);
     mCommissioningTimeoutTimerArmed = false;
-
-    DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
 }
 
 void CommissioningWindowManager::Cleanup()
@@ -207,8 +205,6 @@ void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & sess
         mAppDelegate->OnCommissioningSessionStarted();
     }
 
-    DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
-
     StopAdvertisement(/* aShuttingDown = */ false);
 
     auto & failSafeContext = Server::GetInstance().GetFailSafeContext();
@@ -239,6 +235,7 @@ void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & sess
         // When the now-armed fail-safe is disarmed or expires it will handle
         // clearing out mPASESession.
         mPASESession.Grab(session);
+        DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
     }
 }
 
@@ -566,6 +563,8 @@ void CommissioningWindowManager::OnSessionReleased()
     // session, since we arm it when the PASE session is set up, and anything
     // that disarms the fail-safe would also tear down the PASE session.
     ExpireFailSafeIfArmed();
+
+    DeviceLayer::PlatformMgr().RemoveEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
 }
 
 void CommissioningWindowManager::ExpireFailSafeIfArmed()

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -121,6 +121,8 @@ public:
     // commissioning window timeout.
     void OverrideMinCommissioningTimeout(System::Clock::Seconds32 timeout) { mMinCommissioningTimeoutOverride.SetValue(timeout); }
 
+    Optional<SessionHandle> GetPASESession() const { return mPASESession.Get(); }
+
 private:
     //////////// SessionDelegate Implementation ///////////////
     void OnSessionReleased() override;

--- a/src/app/tests/TestCommissioningWindowManager.cpp
+++ b/src/app/tests/TestCommissioningWindowManager.cpp
@@ -35,13 +35,37 @@
 #include <lib/core/StringBuilderAdapters.h>
 #include <pw_unit_test/framework.h>
 
+#include <lib/support/UnitTestUtils.h>
+#include <messaging/tests/MessagingContext.h>
+
+using namespace chip;
 using namespace chip::Crypto;
+using namespace chip::Messaging;
+using namespace System::Clock::Literals;
 
 using chip::CommissioningWindowAdvertisement;
 using chip::CommissioningWindowManager;
 using chip::Server;
 
 namespace {
+
+// Test Set #01 of Spake2p Parameters (PIN Code, Iteration Count, Salt, and matching Verifier):
+constexpr uint32_t sTestSpake2p01_PinCode        = 20202021;
+constexpr uint32_t sTestSpake2p01_IterationCount = 1000;
+constexpr uint8_t sTestSpake2p01_Salt[]          = { 0x53, 0x50, 0x41, 0x4B, 0x45, 0x32, 0x50, 0x20,
+                                                     0x4B, 0x65, 0x79, 0x20, 0x53, 0x61, 0x6C, 0x74 };
+Spake2pVerifier sTestSpake2p01_PASEVerifier = { .mW0 = {
+    0xB9, 0x61, 0x70, 0xAA, 0xE8, 0x03, 0x34, 0x68, 0x84, 0x72, 0x4F, 0xE9, 0xA3, 0xB2, 0x87, 0xC3,
+    0x03, 0x30, 0xC2, 0xA6, 0x60, 0x37, 0x5D, 0x17, 0xBB, 0x20, 0x5A, 0x8C, 0xF1, 0xAE, 0xCB, 0x35,
+},
+    .mL  = {
+    0x04, 0x57, 0xF8, 0xAB, 0x79, 0xEE, 0x25, 0x3A, 0xB6, 0xA8, 0xE4, 0x6B, 0xB0, 0x9E, 0x54, 0x3A,
+    0xE4, 0x22, 0x73, 0x6D, 0xE5, 0x01, 0xE3, 0xDB, 0x37, 0xD4, 0x41, 0xFE, 0x34, 0x49, 0x20, 0xD0,
+    0x95, 0x48, 0xE4, 0xC1, 0x82, 0x40, 0x63, 0x0C, 0x4F, 0xF4, 0x91, 0x3C, 0x53, 0x51, 0x38, 0x39,
+    0xB7, 0xC0, 0x7F, 0xCC, 0x06, 0x27, 0xA1, 0xB8, 0x57, 0x3A, 0x14, 0x9F, 0xCD, 0x1F, 0xA4, 0x66,
+    0xCF
+} };
+
 bool sAdminFabricIndexDirty = false;
 bool sAdminVendorIdDirty    = false;
 bool sWindowStatusDirty     = false;
@@ -110,11 +134,24 @@ static void StopEventLoop(intptr_t context)
     chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
 }
 
-class TestCommissioningWindowManager : public ::testing::Test
+class TestSecurePairingDelegate : public SessionEstablishmentDelegate
+{
+public:
+    void OnSessionEstablishmentError(CHIP_ERROR error) override { mNumPairingErrors++; }
+
+    void OnSessionEstablished(const SessionHandle & session) override { mNumPairingComplete++; }
+
+    uint32_t mNumPairingErrors   = 0;
+    uint32_t mNumPairingComplete = 0;
+};
+
+class TestCommissioningWindowManager : public chip::Test::LoopbackMessagingContext
 {
 public:
     static void SetUpTestSuite()
     {
+        LoopbackMessagingContext::SetUpTestSuite();
+
         ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
         ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
 
@@ -151,7 +188,9 @@ public:
         mdnsAdvertiser.RemoveServices();
         mdnsAdvertiser.Shutdown();
 
-        // Server shudown will be called in TearDownTask
+        LoopbackMessagingContext::TearDownTestSuite();
+
+        // Server shutdown will be called in TearDownTask
 
         // TODO: At this point UDP endpoits still seem leaked and the sanitizer
         // builds will attempt a memory free. As a result, we keep Memory initialized
@@ -162,6 +201,83 @@ public:
         //
         // chip::Platform::MemoryShutdown();
     }
+
+    void SetUp() override
+    {
+        ConfigInitializeNodes(false);
+        chip::Test::LoopbackMessagingContext::SetUp();
+    }
+
+    void EstablishPASEHandshake(SessionManager & sessionManager, PASESession & pairingCommissioner,
+                                TestSecurePairingDelegate & delegateCommissioner);
+
+    void ServiceEvents();
+};
+
+void TestCommissioningWindowManager::ServiceEvents()
+{
+    DrainAndServiceIO();
+
+    chip::DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t) -> void { chip::DeviceLayer::PlatformMgr().StopEventLoopTask(); },
+                                                  (intptr_t) nullptr);
+    chip::DeviceLayer::PlatformMgr().RunEventLoop();
+}
+
+void TestCommissioningWindowManager::EstablishPASEHandshake(SessionManager & sessionManager, PASESession & pairingCommissioner,
+                                                            TestSecurePairingDelegate & delegateCommissioner)
+{
+
+    auto & loopback            = GetLoopback();
+    loopback.mSentMessageCount = 0;
+
+    ExchangeContext * contextCommissioner = NewUnauthenticatedExchangeToBob(&pairingCommissioner);
+
+    EXPECT_EQ(GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::PBKDFParamRequest,
+                                                                            &Server::GetInstance().GetCommissioningWindowManager()),
+              CHIP_NO_ERROR);
+
+    DrainAndServiceIO();
+
+    EXPECT_EQ(pairingCommissioner.Pair(sessionManager, sTestSpake2p01_PinCode, Optional<ReliableMessageProtocolConfig>::Missing(),
+                                       contextCommissioner, &delegateCommissioner),
+              CHIP_NO_ERROR);
+    DrainAndServiceIO();
+
+    EXPECT_EQ(delegateCommissioner.mNumPairingErrors, 0u);
+    EXPECT_EQ(delegateCommissioner.mNumPairingComplete, 1u);
+}
+
+class TemporarySessionManager
+{
+public:
+    TemporarySessionManager(TestCommissioningWindowManager & ctx) : mCtx(ctx)
+    {
+        EXPECT_EQ(CHIP_NO_ERROR,
+                  mSessionManager.Init(&ctx.GetSystemLayer(), &ctx.GetTransportMgr(), &ctx.GetMessageCounterManager(), &mStorage,
+                                       &ctx.GetFabricTable(), ctx.GetSessionKeystore()));
+        // The setup here is really weird: we are using one session manager for
+        // the actual messages we send (the PASE handshake, so the
+        // unauthenticated sessions) and a different one for allocating the PASE
+        // sessions.  Since our Init() set us up as the thing to handle messages
+        // on the transport manager, undo that.
+        mCtx.GetTransportMgr().SetSessionManager(&mCtx.GetSecureSessionManager());
+    }
+
+    ~TemporarySessionManager()
+    {
+        mSessionManager.Shutdown();
+        // Reset the session manager on the transport again, just in case
+        // shutdown messed with it.
+        mCtx.GetTransportMgr().SetSessionManager(&mCtx.GetSecureSessionManager());
+    }
+
+    operator SessionManager &() { return mSessionManager; }
+
+    TestCommissioningWindowManager & mCtx;
+
+private:
+    TestPersistentStorageDelegate mStorage;
+    SessionManager mSessionManager;
 };
 
 void CheckCommissioningWindowManagerBasicWindowOpenCloseTask(intptr_t context)
@@ -404,6 +520,74 @@ TEST_F(TestCommissioningWindowManager, TestCheckCommissioningWindowManagerEnhanc
     chip::DeviceLayer::PlatformMgr().ScheduleWork(CheckCommissioningWindowManagerEnhancedWindowTask);
     chip::DeviceLayer::PlatformMgr().ScheduleWork(StopEventLoop);
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
+}
+
+void RevokeCommissioningCommandEquivalent()
+{
+    Server::GetInstance().GetFailSafeContext().ForceFailSafeTimerExpiry();
+
+    if (!Server::GetInstance().GetCommissioningWindowManager().IsCommissioningWindowOpen())
+    {
+        ChipLogError(Zcl, "Commissioning window is currently not open");
+        return;
+    }
+
+    Server::GetInstance().GetCommissioningWindowManager().CloseCommissioningWindow();
+    ChipLogProgress(Zcl, "Commissioning window is now closed");
+}
+
+TEST_F(TestCommissioningWindowManager, SecurePairingHandshakeTestECM)
+{
+    TemporarySessionManager sessionManager(*this);
+
+    TestSecurePairingDelegate delegateCommissioner;
+    PASESession pairingCommissioner;
+    auto & loopback = GetLoopback();
+    loopback.Reset();
+
+    // Open an Enhanced Commissioning Window
+    uint16_t originDiscriminator;
+    EXPECT_EQ(chip::DeviceLayer::GetCommissionableDataProvider()->GetSetupDiscriminator(originDiscriminator), CHIP_NO_ERROR);
+    uint16_t newDiscriminator = static_cast<uint16_t>(originDiscriminator + 1);
+
+    constexpr auto fabricIndex = static_cast<chip::FabricIndex>(1);
+    constexpr auto vendorId    = static_cast<chip::VendorId>(0xFFF3);
+
+    CommissioningWindowManager & commissionMgr = Server::GetInstance().GetCommissioningWindowManager();
+    EXPECT_EQ(commissionMgr.OpenEnhancedCommissioningWindow(commissionMgr.MaxCommissioningTimeout(), newDiscriminator,
+                                                            sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
+                                                            ByteSpan(sTestSpake2p01_Salt), fabricIndex, vendorId),
+              CHIP_NO_ERROR);
+
+    EXPECT_TRUE(commissionMgr.IsCommissioningWindowOpen());
+
+    // Establish PASE Handshake to the server's CommissioningWindowManager
+    EstablishPASEHandshake(sessionManager, pairingCommissioner, delegateCommissioner);
+
+    // Ensure that a PASE Session exists for pairingCommissioner
+    auto commissionerSession = pairingCommissioner.CopySecureSession();
+    EXPECT_TRUE(commissionerSession.HasValue());
+    EXPECT_TRUE(commissionerSession.Value()->AsSecureSession()->IsPASESession());
+
+    // Ensure that a PASE Session exists for the CommissioningWindowManager
+    EXPECT_TRUE(commissionMgr.GetPASESession().HasValue());
+    EXPECT_TRUE(commissionMgr.GetPASESession().Value()->AsSecureSession()->IsPASESession());
+
+    // This is the equivalent of AdministratorCommissioningLogic::RevokeCommissioning() in the AdministratorCommissioning Cluster
+    RevokeCommissioningCommandEquivalent();
+
+    // We need to service events here to allow the Async Events to be processed and make sure that the CommissioningWindowManager
+    // successfully shutdown the PASESession
+    ServiceEvents();
+
+    EXPECT_FALSE(commissionMgr.IsCommissioningWindowOpen());
+
+    // This asserts that the CommissioningWindowManager has cleared the PASESession
+    EXPECT_FALSE(commissionMgr.GetPASESession().HasValue());
+
+    // Asserting that PASESession is still present on the Commissioner side
+    commissionerSession = pairingCommissioner.CopySecureSession();
+    EXPECT_TRUE(commissionerSession.HasValue());
 }
 
 } // namespace

--- a/src/python_testing/TestRevokeCommissioningClearsPASE.py
+++ b/src/python_testing/TestRevokeCommissioningClearsPASE.py
@@ -1,0 +1,138 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.exceptions import ChipStackError
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
+
+
+class TestRevokeCommissioningClearsPASE(MatterBaseTest):
+
+    @async_test_body
+    async def test_TestRevokeCommissioningClearsPASE(self):
+
+        self.print_step("precondition", "Commissioning - already done")
+
+        self.TH1 = self.default_controller
+
+        self.print_step("precondition", "Create Second Controller")
+
+        fabric_admin = self.certificate_authority_manager.activeCaList[0].adminList[0]
+        self.TH2_nodeid = self.matter_test_config.controller_node_id + 1
+        self.TH2 = fabric_admin.NewController(
+            nodeId=self.TH2_nodeid,
+            paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
+        )
+
+        self.print_step(1, "TH1 sends an OpenCommissioningWindow command to DUT to allow it to be commissioned by TH2")
+        resp = await self.open_commissioning_window()
+
+        self.print_step(2, "TH2 establishes a PASE session with DUT")
+        pase_node_id = self.dut_node_id + 1
+        await self.TH2.FindOrEstablishPASESession(setupCode=resp.commissioningParameters.setupQRCode, nodeId=pase_node_id)
+
+        self.print_step(3, "Read VendorName from BasicInformation Cluster using TH2 over PASE, to ensure PASE session is established")
+
+        VendorNameAttr = Clusters.BasicInformation.Attributes.VendorName
+        ROOT_NODE_ENDPOINT_ID = 0
+
+        read_step3 = await self.TH2.ReadAttribute(
+            nodeId=pase_node_id,
+            attributes=(ROOT_NODE_ENDPOINT_ID, VendorNameAttr),
+        )
+
+        asserts.assert_in(
+            VendorNameAttr,
+            read_step3[ROOT_NODE_ENDPOINT_ID][Clusters.BasicInformation],
+            "VendorName should be present in the read response"
+        )
+
+        self.print_step(4, "TH1 Sends RevokeCommissioning (over CASE) to clear PASE session on DUT")
+        revokeCmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
+        await self.TH1.SendCommand(nodeId=self.dut_node_id, endpoint=0, payload=revokeCmd, timedRequestTimeoutMs=6000)
+
+        self.print_step(
+            5, "Ensure that the PASE Session got cleared, by attempting to read VendorName using TH2 (over PASE) and Ensuring that the Command times out")
+
+        _CHIP_TIMEOUT_ERROR = 50
+
+        with asserts.assert_raises(ChipStackError) as e:
+            await self.TH2.ReadAttribute(
+                nodeId=pase_node_id,
+                attributes=(ROOT_NODE_ENDPOINT_ID, VendorNameAttr))
+        asserts.assert_equal(e.exception.err, _CHIP_TIMEOUT_ERROR,
+                             f"Expected timeout error reading VendorName attribute over PASE, got {e.exception.err}")
+
+        # ---------------------------- Repeat test, but sending RevokeCommissioning over PASE this time --------------------------------
+
+        self.print_step(
+            6, "recreate Second Controller; to establish a new PASE session and repeat test, but sending RevokeCommissioning over PASE this time")
+
+        self.TH2.Shutdown()
+        fabric_admin = self.certificate_authority_manager.activeCaList[0].adminList[0]
+        self.TH2_nodeId = self.matter_test_config.controller_node_id + 1
+        self.TH2 = fabric_admin.NewController(
+            nodeId=self.TH2_nodeId,
+            paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
+        )
+
+        self.print_step(7, "TH1 sends an OpenCommissioningWindow command to DUT to allow it to be commissioned by TH2")
+        resp = await self.open_commissioning_window()
+
+        self.print_step(8, "TH2 establishes a PASE session with DUT")
+        await self.TH2.FindOrEstablishPASESession(setupCode=resp.commissioningParameters.setupQRCode, nodeId=pase_node_id)
+
+        self.print_step(9, "TH2 Sends RevokeCommissioning (Over PASE) to clear PASE session on DUT")
+
+        await self.TH2.SendCommand(nodeId=pase_node_id, endpoint=0, payload=revokeCmd, timedRequestTimeoutMs=6000)
+
+        self.print_step(
+            10, "Ensure that the PASE Session got cleared, by attempting to read VendorName using TH2 (over PASE) and Ensuring that the Command times out")
+
+        with asserts.assert_raises(ChipStackError) as e:
+            await self.TH2.ReadAttribute(
+                nodeId=pase_node_id,
+                attributes=(ROOT_NODE_ENDPOINT_ID, VendorNameAttr))
+        asserts.assert_equal(e.exception.err, _CHIP_TIMEOUT_ERROR,
+                             f"Expected timeout error reading VendorName attribute over PASE, got {e.exception.err}")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()


### PR DESCRIPTION
#### Summary

- Cherry pick of https://github.com/project-chip/connectedhomeip/pull/41715 which is a Fix of https://github.com/project-chip/connectedhomeip/issues/41379

- Currently, Invoking the Command `RevokeCommissioning` while a  PASE Session is still active will fail to kill off that PASE Session.
- This happens due to a race; when we call RevokeCommissioning,  `FailSafeContext` will post an asynchronous event `FailSafeTimerExpired`. However, `CommissioningWindowManager` will stop listening to the events BEFORE the`FailSafeTimerExpired` is processed. 

#### Fix 

- within `CommissioningWindowManager`: only stop listening to platform events much later than before;  AFTER  the actual PASE session is released; by moving `RemoveEventHandler(OnPlatformEventWrapper)` to `CommissioningWindowManager::OnSessionReleased()`

#### Testing

- Added Integration Test and Unit Test

- using Chip-tool **interactive mode,** against any app, the last command should time out

```bash
#ADMIN 1
pairing code 33 MT:-24J042C00KA0648G00

#ADMIN 1
pairing open-commissioning-window 33 1 400 1000 3840

#ADMIN 2
pairing code-paseonly 34 {Generated Manual Pairing Code here}  --commissioner-name beta

#ADMIN 2: Make sure we are reading this using PASE
basicinformation read vendor-name 34 0 --commissioner-name beta

# This can be run by either ADMIN 1 or 2
administratorcommissioning revoke-commissioning 34 0 --timedInteractionTimeoutMs 9000 

#This command should time out
basicinformation read vendor-name 34 0 --commissioner-name beta
```