### PR TITLE
[CI][nrf] run Zephyr Native Unit Tests in PRs when crypto files are changed

### DIFF
--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -68,6 +68,8 @@ jobs:
                         - '**/tests/**'
                       shell:
                         - 'examples/shell/nrfconnect/**'
+                      crypto:
+                        - 'src/crypto/**'
             - name: Set up environment for size reports
               uses: ./.github/actions/setup-size-reports
               if: ${{ !env.ACT }}
@@ -162,7 +164,8 @@ jobs:
                 github.event_name == 'push' ||
                 steps.changed_paths.outputs.tests == 'true' ||
                 steps.changed_paths.outputs.nrfconnect == 'true' ||
-                steps.changed_paths.outputs.pigweed == 'true'
+                steps.changed_paths.outputs.pigweed == 'true' ||
+                steps.changed_paths.outputs.crypto == 'true'
               run: |
                   scripts/run_in_build_env.sh "source $ZEPHYR_BASE/zephyr-env.sh && pip3 install -r scripts/setup/requirements.build.txt && ./scripts/build/build_examples.py --target nrf-native-sim-tests build"
             - name: Uploading Failed Test Logs


### PR DESCRIPTION
#### Summary

- Make nRF's unit tests run for PRs that change the crypto layer.

- This is important since:
1. these are currently the only tests that cover the PSA Crypto Implementation (through Zephyr Native Sim)
2. crypto changes are delicate and it's better to catch errors before they go into master


#### Testing

- This is a workflow change, so CI will test it in the future