### PR TITLE
cherry-pick of Add LSAN supression for ErrorStr on v1.5 branch

### DIFF
--- a/scripts/tests/chiptest/lsan-mac-suppressions.txt
+++ b/scripts/tests/chiptest/lsan-mac-suppressions.txt
@@ -90,6 +90,9 @@ leak:_instantiateTLVs
 # macOS 15
 leak:dyld::ThreadLocalVariables::instantiateVariable
 
+# TLS in ErrorStr (using thread local storage for error formatting)
+leak:chip::ErrorStr
+
 # ignore (maybe false-positive?) leaks in macOS key value store init
 leak:KeyValueStoreManagerImpl::Init
 


### PR DESCRIPTION
#### Summary

- cherry pick of https://github.com/project-chip/connectedhomeip/pull/41999


I believe the leak detector is a false positive. We seem to have this for other TLS items, so just adding one more.

This fixes leak reports such as:

```
INFO    Direct leak of 272 byte(s) in 1 object(s) allocated from:
INFO        #0 0x0001044c8b44 in malloc+0x70 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x54b44)
INFO        #1 0x00018e26a4fc  (<unknown module>)
INFO        #2 0x8b6600018e5ef028  (<unknown module>)
INFO        #3 0x1a59800102eee7cc  (<unknown module>)
INFO        #4 0x000102eee108 in chip::ErrorStr(chip::ChipError, bool)+0x40 (chip-lock-app:arm64+0x1001ea108)
INFO        #5 0x000102d3eef8 in chip::ChipError::AsString(bool) const+0x44 (chip-lock-app:arm64+0x10003aef8)
INFO        #6 0x000102d381bc in chip::ChipError::Format() const+0x2c (chip-lock-app:arm64+0x1000341bc)
INFO        #7 0x000102d71d24 in emAfLoadAttributeDefaults(unsigned short, chip::Optional<unsigned int>)+0xfec (chip-lock-app:arm64+0x10006dd24)
INFO        #8 0x000102d70cb4 in emberAfInitializeAttributes(unsigned short)+0x134 (chip-lock-app:arm64+0x10006ccb4)
INFO        #9 0x000102d7b540 in emberAfInit()+0x1c (chip-lock-app:arm64+0x100077540)
INFO        #10 0x000102d696bc in InitDataModelHandler()+0x240 (chip-lock-app:arm64+0x1000656bc)
INFO        #11 0x000102d563ac in chip::app::CodegenDataModelProvider::InitDataModelForTesting()+0x20 (chip-lock-app:arm64+0x1000523ac)
INFO        #12 0x000102d4e4d0 in chip::app::CodegenDataModelProvider::Startup(chip::app::DataModel::InteractionModelContext)+0x4dc (chip-lock-app:arm64+0x10004a4d0)
INFO        #13 0x0001034ba7bc in chip::app::InteractionModelEngine::SetDataModelProvider(chip::app::DataModel::Provider*)+0x95c (chip-lock-app:arm64+0x1007b67bc)
INFO        #14 0x00010364d4a4 in chip::Server::Init(chip::ServerInitParams const&)+0x2bb0 (chip-lock-app:arm64+0x1009494a4)
INFO        #15 0x000102e76394 in ChipLinuxAppMainLoop(AppMainLoopImplementation*)+0x10f8 (chip-lock-app:arm64+0x100172394)
INFO        #16 0x000102d322bc in main+0x344 (chip-lock-app:arm64+0x10002e2bc)
INFO        #17 0x00018e25b150  (<unknown module>)
INFO        #18 0xb90d7ffffffffffc  (<unknown module>)
```


#### Testing

CI should pass