### PR TITLE
[NXP] Fix read last-networking-status and read last-network-id issue for ethernet and wifi

### DIFF
--- a/examples/platform/nxp/common/wifi_connect/source/WifiConnect.cpp
+++ b/examples/platform/nxp/common/wifi_connect/source/WifiConnect.cpp
@@ -45,6 +45,10 @@ CHIP_ERROR WifiConnectAtboot(chip::DeviceLayer::NetworkCommissioning::WiFiDriver
         VerifyOrReturnError(status == chip::DeviceLayer::NetworkCommissioning::Status::kSuccess, CHIP_ERROR_CONNECTION_ABORTED);
         wifiDriver->ConnectNetwork(ssidSpan, nullptr);
     }
+    if (networks != nullptr)
+    {
+        networks->Release();
+    }
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -399,6 +399,7 @@ void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
         {
             sInstance._SetWiFiStationState(kWiFiStationState_Connecting_Succeeded);
             sInstance._SetWiFiStationState(kWiFiStationState_Connected);
+            NetworkCommissioning::NXPWiFiDriver::GetInstance().OnNetworkStatusChange();
             NetworkCommissioning::NXPWiFiDriver::GetInstance().OnConnectWiFiNetwork(NetworkCommissioning::Status::kSuccess,
                                                                                     CharSpan(), wlanEvent);
             sInstance.OnStationConnected();

--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
@@ -64,12 +64,40 @@ void NxpEthDriver::eth_netif_ext_status_callback(struct netif * netif, netif_nsc
         {
             ChipLogError(DeviceLayer, "Failed to schedule work: %" CHIP_ERROR_FORMAT, err.Format());
         }
+        SystemLayer().ScheduleLambda([]() { NxpEthDriver::Instance().OnNetworkStatusChange(); });
+    }
+}
+
+void NxpEthDriver::OnNetworkStatusChange()
+{
+    ChipLogProgress(NetworkProvisioning, "NxpEthDriver::OnNetworkStatusChange\r\n");
+    VerifyOrReturn(mpStatusChangeCallback != nullptr);
+    NetworkIterator* networkIterator = GetNetworks();
+    
+    if (networkIterator != nullptr) {
+        EthernetNetworkIterator* ethIterator = static_cast<EthernetNetworkIterator*>(networkIterator);
+        
+        if (ethIterator->interfaceNameLen)
+        {
+            mpStatusChangeCallback->OnNetworkingStatusChange(
+                Status::kSuccess, MakeOptional(ByteSpan(ethIterator->interfaceName, ethIterator->interfaceNameLen)), NullOptional);
+        }
+        else{
+            mpStatusChangeCallback->OnNetworkingStatusChange(
+            Status::kUnknownError, MakeOptional(ByteSpan(ethIterator->interfaceName, ethIterator->interfaceNameLen)),
+            NullOptional);
+        } 
+    }
+    if (networkIterator != nullptr)
+    {
+        networkIterator->Release();
     }
 }
 
 CHIP_ERROR NxpEthDriver::Init(NetworkStatusChangeCallback * networkStatusChangeCallback)
 {
     err_t err;
+    mpStatusChangeCallback = networkStatusChangeCallback;
     ethernetif_config_t enet_config = {
         .phyHandle   = &phyHandle,
         .phyAddr     = EXAMPLE_PHY_ADDRESS,

--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
@@ -72,20 +72,22 @@ void NxpEthDriver::OnNetworkStatusChange()
 {
     ChipLogProgress(NetworkProvisioning, "NxpEthDriver::OnNetworkStatusChange\r\n");
     VerifyOrReturn(mpStatusChangeCallback != nullptr);
-    NetworkIterator* networkIterator = GetNetworks();
+    NetworkIterator * networkIterator = GetNetworks();
 
-    if (networkIterator != nullptr) {
-        EthernetNetworkIterator* ethIterator = static_cast<EthernetNetworkIterator*>(networkIterator);
+    if (networkIterator != nullptr)
+    {
+        EthernetNetworkIterator * ethIterator = static_cast<EthernetNetworkIterator *>(networkIterator);
 
         if (ethIterator->interfaceNameLen)
         {
             mpStatusChangeCallback->OnNetworkingStatusChange(
                 Status::kSuccess, MakeOptional(ByteSpan(ethIterator->interfaceName, ethIterator->interfaceNameLen)), NullOptional);
         }
-        else{
+        else
+        {
             mpStatusChangeCallback->OnNetworkingStatusChange(
-            Status::kUnknownError, MakeOptional(ByteSpan(ethIterator->interfaceName, ethIterator->interfaceNameLen)),
-            NullOptional);
+                Status::kUnknownError, MakeOptional(ByteSpan(ethIterator->interfaceName, ethIterator->interfaceNameLen)),
+                NullOptional);
         }
         networkIterator->Release();
     }
@@ -94,7 +96,7 @@ void NxpEthDriver::OnNetworkStatusChange()
 CHIP_ERROR NxpEthDriver::Init(NetworkStatusChangeCallback * networkStatusChangeCallback)
 {
     err_t err;
-    mpStatusChangeCallback = networkStatusChangeCallback;
+    mpStatusChangeCallback          = networkStatusChangeCallback;
     ethernetif_config_t enet_config = {
         .phyHandle   = &phyHandle,
         .phyAddr     = EXAMPLE_PHY_ADDRESS,

--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
@@ -73,10 +73,10 @@ void NxpEthDriver::OnNetworkStatusChange()
     ChipLogProgress(NetworkProvisioning, "NxpEthDriver::OnNetworkStatusChange\r\n");
     VerifyOrReturn(mpStatusChangeCallback != nullptr);
     NetworkIterator* networkIterator = GetNetworks();
-    
+
     if (networkIterator != nullptr) {
         EthernetNetworkIterator* ethIterator = static_cast<EthernetNetworkIterator*>(networkIterator);
-        
+
         if (ethIterator->interfaceNameLen)
         {
             mpStatusChangeCallback->OnNetworkingStatusChange(
@@ -86,7 +86,7 @@ void NxpEthDriver::OnNetworkStatusChange()
             mpStatusChangeCallback->OnNetworkingStatusChange(
             Status::kUnknownError, MakeOptional(ByteSpan(ethIterator->interfaceName, ethIterator->interfaceNameLen)),
             NullOptional);
-        } 
+        }
         networkIterator->Release();
     }
 }

--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
@@ -87,9 +87,6 @@ void NxpEthDriver::OnNetworkStatusChange()
             Status::kUnknownError, MakeOptional(ByteSpan(ethIterator->interfaceName, ethIterator->interfaceNameLen)),
             NullOptional);
         } 
-    }
-    if (networkIterator != nullptr)
-    {
         networkIterator->Release();
     }
 }

--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.h
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.h
@@ -76,11 +76,13 @@ public:
     }
 
 private:
+    void OnNetworkStatusChange();
     static void print_ip_addresses(struct netif * netif);
     static void eth_netif_ext_status_callback(struct netif * netif, netif_nsc_reason_t reason,
                                               const netif_ext_callback_args_t * args);
     phy_handle_t phyHandle;
     struct netif netif_app;
+    NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
 };
 
 } // namespace NetworkCommissioning

--- a/src/platform/nxp/common/NetworkCommissioningDriver.h
+++ b/src/platform/nxp/common/NetworkCommissioningDriver.h
@@ -72,6 +72,7 @@ public:
     Status ReorderNetwork(ByteSpan networkId, uint8_t index, MutableCharSpan & outDebugText) override;
     void ConnectNetwork(ByteSpan networkId, ConnectCallback * callback) override;
     CHIP_ERROR ConnectWiFiStagedNetwork();
+    void OnNetworkStatusChange();
 
     /* Returns the network SSID. User needs to allocate a buffer of size >= DeviceLayer::Internal::kMaxWiFiSSIDLength.
      * ssid - pointer to the returned SSID
@@ -104,6 +105,7 @@ public:
 private:
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
     CHIP_ERROR StartScanWiFiNetworks(ByteSpan ssid);
+    CHIP_ERROR GetConnectedNetwork(Network & network);
 
     WiFiNetworkIterator mWiFiIterator = WiFiNetworkIterator(this);
     WiFiNetwork mSavedNetwork;

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -261,11 +261,9 @@ void NXPWiFiDriver::OnNetworkStatusChange()
     else
     {
         mpStatusChangeCallback->OnNetworkingStatusChange(
-        Status::kUnknownError, MakeOptional(ByteSpan(configuredNetwork.networkID, configuredNetwork.networkIDLen)),
-        NullOptional);
-
+            Status::kUnknownError, MakeOptional(ByteSpan(configuredNetwork.networkID, configuredNetwork.networkIDLen)),
+            NullOptional);
     }
-
 }
 
 void NXPWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callback)
@@ -518,7 +516,7 @@ bool NXPWiFiDriver::WiFiNetworkIterator::Next(Network & item)
     mExhausted        = true;
 
     Network connectedNetwork;
-    CHIP_ERROR err =  mDriver->GetConnectedNetwork(connectedNetwork);
+    CHIP_ERROR err = mDriver->GetConnectedNetwork(connectedNetwork);
 
     if (err == CHIP_NO_ERROR)
     {

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -240,6 +240,34 @@ void NXPWiFiDriver::OnConnectWiFiNetwork(Status commissioningError, CharSpan deb
     }
 }
 
+void NXPWiFiDriver::OnNetworkStatusChange()
+{
+    ChipLogProgress(NetworkProvisioning, "NXPWiFiDriver::OnNetworkStatusChange\r\n");
+    Network configuredNetwork;
+
+    VerifyOrReturn(mpStatusChangeCallback != nullptr);
+    CHIP_ERROR err = GetConnectedNetwork(configuredNetwork);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to get configured network when updating network status: %s", err.AsString());
+        return;
+    }
+
+    if (configuredNetwork.networkIDLen)
+    {
+        mpStatusChangeCallback->OnNetworkingStatusChange(
+            Status::kSuccess, MakeOptional(ByteSpan(configuredNetwork.networkID, configuredNetwork.networkIDLen)), NullOptional);
+    }
+    else
+    {
+        mpStatusChangeCallback->OnNetworkingStatusChange(
+        Status::kUnknownError, MakeOptional(ByteSpan(configuredNetwork.networkID, configuredNetwork.networkIDLen)),
+        NullOptional);
+
+    }
+    
+}
+
 void NXPWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callback)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
@@ -448,7 +476,7 @@ uint32_t NXPWiFiDriver::GetSupportedWiFiBandsMask() const
     return bands;
 }
 
-static CHIP_ERROR GetConnectedNetwork(Network & network)
+CHIP_ERROR NXPWiFiDriver::GetConnectedNetwork(Network & network)
 {
     struct wlan_network wlan_network;
     int result;
@@ -490,7 +518,7 @@ bool NXPWiFiDriver::WiFiNetworkIterator::Next(Network & item)
     mExhausted        = true;
 
     Network connectedNetwork;
-    CHIP_ERROR err = GetConnectedNetwork(connectedNetwork);
+    CHIP_ERROR err =  mDriver->GetConnectedNetwork(connectedNetwork);
 
     if (err == CHIP_NO_ERROR)
     {

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -265,7 +265,7 @@ void NXPWiFiDriver::OnNetworkStatusChange()
         NullOptional);
 
     }
-    
+
 }
 
 void NXPWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callback)


### PR DESCRIPTION
#### Summary

Currently, we don't call OnNetworkingStatusChange when updating the network status. Therefore, the system cannot know the status or the last network ID. The TC-CNET-4.3 Wi-Fi test is successful because, during commissioning, OnResult is executed and updates these values. However, the device will no longer update them afterward.

#### Testing

Build ethernet and wifi+otbr application:

- west build -d build_matter_eth/ -b frdmrw612 examples/thermostat/nxp/ -DCONF_FILE=examples/platform/nxp/config/prj_eth.conf
- west build -d build_matter/ -b frdmrw612 examples/thermostat/nxp/ -DCONF_FILE=examples/platform/nxp/config/prj_thread_ftd_wifi_br_ota.conf

For each do a commissioning, reboot the board and check after network reconnection last network status and last network id, there are now different to null, the status is 0 or connected and the id is equal to the network ID

- ./chip-tool networkcommissioning read last-networking-status 1 0
- ./chip-tool networkcommissioning read last-network-id 1 0

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
