### PR TITLE
[NXP][wifi-otbr] fix TC-CGEN-2.2 issue due to multiple dns advertising updates in short time

### DIFF
--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -247,7 +247,9 @@ CHIP_ERROR NxpChipDnssdRemoveServices()
 
         if ((0 == strcmp(mServiceList[mServiceListFreeIndex]->mHostName, hostName)) &&
             ((0 == strcmp(mServiceList[mServiceListFreeIndex]->mServiceType, "_matter._tcp")) ||
-             (0 == strcmp(mServiceList[mServiceListFreeIndex]->mServiceType, "_matterc._udp"))))
+             (0 == strcmp(mServiceList[mServiceListFreeIndex]->mServiceType, "_matterc._udp"))) &&
+            (mServiceList[mServiceListFreeIndex]->mTtl > 0))
+        // if mTtl = 0 , the service is already in the removal process but not yet removed
         {
             mServiceListFreeIndex++;
         }


### PR DESCRIPTION
#### Summary

This fix addresses the TC-CGEN-2.2 failure caused by multiple DNS advertising updates occurring in a short time frame. The root issue is that OpenThread’s DNS service removal is asynchronous. When a service is removed and immediately re-added, the OpenThread task may not have completed the removal yet. As a result:

- Matter assumes the service is still present and does not re-add it.
- Later, when the OpenThread task executes, the service is removed.
- Matter then incorrectly believes the device is advertising the UDP service, but it is not.

To resolve this, we check if mTtl > 0. When mTtl is zero, the service is scheduled for removal, so we must re-add it to ensure proper advertisement.
This scenario was observed during TC-CGEN-2.2 with an RW61x thermostat using Wi-Fi + OTBR configuration. The test failed at step 26 during on-network commissioning because the device was not advertising the Matter UDP service, preventing commissioning from starting.

#### Testing

Re-ran TC-CGEN-2.2 after applying this fix. The test now passes successfully.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
