### PR TITLE
[Python] Fix build without host unit tests

### DIFF
--- a/src/controller/python/matter/clusters/attribute.cpp
+++ b/src/controller/python/matter/clusters/attribute.cpp
@@ -436,6 +436,7 @@ PyChipError pychip_WriteClient_TestOnlyWriteAttributesWithMismatchedTimedRequest
     size_t interactionTimeoutMsSizeT, size_t busyWaitMsSizeT, python::PyWriteAttributeData * writeAttributesData,
     size_t attributeDataLength)
 {
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     uint16_t timedWriteTimeoutMs  = static_cast<uint16_t>(timedWriteTimeoutMsSizeT);
@@ -472,6 +473,9 @@ PyChipError pychip_WriteClient_TestOnlyWriteAttributesWithMismatchedTimedRequest
 
 exit:
     return ToPyChipError(err);
+#else
+    return ToPyChipError(CHIP_ERROR_NOT_IMPLEMENTED);
+#endif
 }
 
 PyChipError pychip_WriteClient_WriteGroupAttributes(size_t groupIdSizeT, chip::Controller::DeviceCommissioner * devCtrl,


### PR DESCRIPTION
#### Summary

Since #41066 build without host unit test fails with:
```

../src/controller/python/matter/clusters/attribute.cpp:454:22: error: 'TestOnlyOverrideTimedRequestFieldTag' is not a member of 'chip::app::WriteClient'
  454 |         WriteClient::TestOnlyOverrideTimedRequestFieldTag{});
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Apply the common pattern where we return not implemented in case we build the Matter SDK without `CONFIG_BUILD_FOR_HOST_UNIT_TEST` flag.

#### Related issues

#### Testing

By running our CI with the patch applied.

https://github.com/home-assistant-libs/chip-wheels/pull/128
https://github.com/home-assistant-libs/chip-wheels/actions/runs/19496575990

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
