### PR TITLE
Fix TC_CADMIN_1_5

### DIFF
--- a/src/python_testing/TC_CADMIN_1_5.py
+++ b/src/python_testing/TC_CADMIN_1_5.py
@@ -46,25 +46,11 @@ from matter.testing.matter_testing import TestStep, async_test_body, default_mat
 
 class TC_CADMIN_1_5(CADMINBaseTest):
 
-    async def commission_on_network(self, setup_code: int, discriminator: int, expected_error: int = 0):
-        # This is expected to error as steps 4 and 7 expects timeout issue or pase connection error to occur due to commissioning window being closed already
-        if expected_error == 50:
-            with asserts.assert_raises(ChipStackError) as cm:
-                await self.th2.CommissionOnNetwork(
-                    nodeId=self.dut_node_id, setupPinCode=setup_code,
-                    filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=discriminator)
-            asserts.assert_true(int(cm.exception.code) == expected_error,
-                                'Unexpected error code returned from Commissioning Attempt')
-
-        else:
-            try:
-                await self.th2.CommissionOnNetwork(
-                    nodeId=self.dut_node_id, setupPinCode=setup_code,
-                    filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=discriminator)
-
-            except asyncio.CancelledError:
-                # This is expected to fail due to timeout, however there is no code to validate here, so just passing since the correct exception was raised to get to this point
-                pass
+    async def assert_commission_on_network_fail(self, setup_code: int, discriminator: int) -> None:
+        with asserts.assert_raises(ChipStackError):
+            await self.th2.CommissionOnNetwork(
+                nodeId=self.dut_node_id, setupPinCode=setup_code,
+                filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=discriminator)
 
     def steps_TC_CADMIN_1_5(self) -> list[TestStep]:
         return [
@@ -131,7 +117,7 @@ class TC_CADMIN_1_5(CADMINBaseTest):
         await asyncio.sleep(190)
 
         self.step(4)
-        await self.commission_on_network(setup_code=params.commissioningParameters.setupPinCode, discriminator=params.randomDiscriminator)
+        await self.assert_commission_on_network_fail(setup_code=params.commissioningParameters.setupPinCode, discriminator=params.randomDiscriminator)
 
         self.step(5)
         params2 = await self.open_commissioning_window(dev_ctrl=self.th1, timeout=180, node_id=self.dut_node_id)
@@ -142,7 +128,7 @@ class TC_CADMIN_1_5(CADMINBaseTest):
         await asyncio.sleep(1)
 
         self.step(7)
-        await self.commission_on_network(setup_code=params2.commissioningParameters.setupPinCode, discriminator=params2.randomDiscriminator, expected_error=0x00000032)
+        await self.assert_commission_on_network_fail(setup_code=params2.commissioningParameters.setupPinCode, discriminator=params2.randomDiscriminator)
 
         self.step(8)
         try:

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -150,10 +150,6 @@ not_automated:
       reason: Helper methods for Push AV Integration TCs
     - name: TC_TLS_Utils.py
       reason: Helper methods for TC tests dependent on TLS clusters
-    - name: TC_CADMIN_1_5.py
-      reason:
-          "Flaky/broken: see
-          https://github.com/project-chip/connectedhomeip/issues/42059"
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially


### PR DESCRIPTION
Test Step 4 is failing because the test case is not expecting the timeout error while the commissioning window is already closed (after timeout).

### Testing:

Using nrfconnect  platform based on Matter 1.5 over Thread version
