### PR TITLE
Attempt to fix time fuzziness for OPSTATE 2.5 tests.

### DIFF
--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -1228,7 +1228,7 @@ class TC_OPSTATE_BASE():
         expected_value = (0.5 * initial_countdown_time)
         asserts.assert_almost_equal(expected_value, event_data.pausedTime,
                                     delta=approx_delta_seconds,
-                                    f"Paused time ({event_data.pausedTime}) shall be about {expected_value:.1f} +/- {approx_delta_seconds}")
+                                    msg=f"Paused time ({event_data.pausedTime}) shall be about {expected_value:.1f} +/- {approx_delta_seconds}")
 
     ############################
     #   TEST CASE 2.6 - Optional Reports with DUT as Server

--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -1215,15 +1215,14 @@ class TC_OPSTATE_BASE():
         if event_data.totalOperationalTime is not NullValue:
             expected_value = (1.5 * initial_countdown_time)
 
-            # Need some fuzzyness. Test plan says:
+            # Need some fuzziness. Test plan says:
             #   TotalOperationalTime is approximately 1.5 times the initial-countdown-time or null
             # however "approximately" does not seem clearly defined
-            #
             asserts.assert_almost_equal(expected_value, event_data.totalOperationalTime,
                                         delta=approx_delta_seconds,
                                         msg=f"The total operation time shall be about {expected_value:.1f} +/- {approx_delta_seconds}")
 
-        # Need some fuzzyness. Test plan says:
+        # Need some fuzziness. Test plan says:
         #   PausedTime is 0.5 times the initial-countdown-time
         # however given time/sleeps, this is highly unlikely to be always accurate, especially in CI
         expected_value = (0.5 * initial_countdown_time)

--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -1226,9 +1226,9 @@ class TC_OPSTATE_BASE():
         #   PausedTime is 0.5 times the initial-countdown-time
         # however given time/sleeps, this is highly unlikely to be always accurate, especially in CI
         expected_value = (0.5 * initial_countdown_time)
-        asserts.assert_almost_less_equal(expected_value, event_data.pausedTime,
-                                         delta=approx_delta_seconds,
-                                         f"Paused time ({event_data.pausedTime}) shall be about {expected_value:.1f} +/- {approx_delta_seconds}")
+        asserts.assert_almost_equal(expected_value, event_data.pausedTime,
+                                    delta=approx_delta_seconds,
+                                    f"Paused time ({event_data.pausedTime}) shall be about {expected_value:.1f} +/- {approx_delta_seconds}")
 
     ############################
     #   TEST CASE 2.6 - Optional Reports with DUT as Server


### PR DESCRIPTION
#### Summary

Opstate 2.5 test seems to be very flaky. The issue seems that we are comparing time intervals in exact manner, which is not ok. Realistically the test seems to use `<=` probably to avoid errors even if the spec says "approximate" or "equal".

I changed the test to use fuzzy/approximate equality and added 3 seconds of fuzzyness (it is unclear to me what the right number should be ... fixing this should be a followup while we unblock CI)

#### Testing

CI will validate.