### PR TITLE
Add StopIdentifying() method to IdentifyCluster

### DIFF
--- a/src/app/clusters/identify-server/IdentifyCluster.cpp
+++ b/src/app/clusters/identify-server/IdentifyCluster.cpp
@@ -98,6 +98,11 @@ void IdentifyCluster::TimerFired()
     }
 }
 
+void IdentifyCluster::StopIdentifying()
+{
+    NotifyAttributeChangedIfSuccess(Attributes::IdentifyTime::Id, SetIdentifyTime(IdentifyTimeChangeSource::kClient, 0));
+}
+
 // According to the spec, section 5.1 - IdentifyTime Attribute:
 // Changes to this attribute SHALL only be marked as reportable in the following cases:
 // 1. When it changes from 0 to any other value and vice versa, or

--- a/src/app/clusters/identify-server/IdentifyCluster.h
+++ b/src/app/clusters/identify-server/IdentifyCluster.h
@@ -131,6 +131,14 @@ public:
      */
     void TimerFired() override;
 
+    /**
+     * @brief Stops the identification process.
+     *
+     * This method sets the IdentifyTime attribute to 0, which effectively stops the identification.
+     * It triggers the OnIdentifyStop callback if identification was in progress.
+     */
+    void StopIdentifying();
+
     Identify::EffectIdentifierEnum GetEffectIdentifier() const { return mEffectIdentifier; }
     Identify::EffectVariantEnum GetEffectVariant() const { return mEffectVariant; }
     Identify::IdentifyTypeEnum GetIdentifyType() const { return mIdentifyType; }

--- a/src/app/clusters/identify-server/tests/TestIdentifyCluster.cpp
+++ b/src/app/clusters/identify-server/tests/TestIdentifyCluster.cpp
@@ -433,6 +433,31 @@ TEST_F(TestIdentifyCluster, TriggerEffectStopEffectTest)
     EXPECT_EQ(identifyTime, 0u);
 }
 
+TEST_F(TestIdentifyCluster, StopIdentifyingTest)
+{
+    chip::Test::TestServerClusterContext context;
+    IdentifyCluster cluster(IdentifyCluster::Config(kTestEndpointId, mMockTimerDelegate).WithDelegate(&gTestIdentifyDelegate));
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    // Start identifying.
+    EXPECT_EQ(WriteAttribute(cluster, IdentifyTime::Id, static_cast<uint16_t>(10)), CHIP_NO_ERROR);
+
+    // Verify identifying started
+    uint16_t identifyTime;
+    EXPECT_EQ(ReadNumericAttribute(cluster, IdentifyTime::Id, identifyTime), CHIP_NO_ERROR);
+    EXPECT_EQ(identifyTime, 10u);
+
+    // Stop identifying.
+    cluster.StopIdentifying();
+
+    // Verify identifying stopped
+    EXPECT_EQ(ReadNumericAttribute(cluster, IdentifyTime::Id, identifyTime), CHIP_NO_ERROR);
+    EXPECT_EQ(identifyTime, 0u);
+
+    // Verify stop callback was called
+    EXPECT_TRUE(onIdentifyStopCalled);
+}
+
 TEST_F(TestIdentifyCluster, IdentifyTimeAttributeReportingTest)
 {
     chip::Test::TestServerClusterContext context;


### PR DESCRIPTION
#### Summary

Add StopIdentifying() method to IdentifyCluster so the identification process can be stopped from the device side (for exmaple, if the user dismiss it from a display, etc.).

#### Testing

Added unit tests.