### PR TITLE
Rename NotifyAttributeChangedIfSuccess to  NotifyIfAttributeChanged

### DIFF
--- a/docs/guides/migrating_ember_cluster_to_code_driven.md
+++ b/docs/guides/migrating_ember_cluster_to_code_driven.md
@@ -120,8 +120,8 @@ project's Slack channel.
     -   [ ] For persisted attributes, use the `AttributePersistence` helper to
             load in `Startup` and save on writes.
     -   [ ] **Crucially,** after a successful write, call a notification
-            function (e.g., `NotifyIfAttributeChanged`) to ensure
-            subscriptions work correctly.
+            function (e.g., `NotifyIfAttributeChanged`) to ensure subscriptions
+            work correctly.
 
 -   [ ] **2.3: Implement Command Logic:**
 

--- a/docs/guides/migrating_ember_cluster_to_code_driven.md
+++ b/docs/guides/migrating_ember_cluster_to_code_driven.md
@@ -120,7 +120,7 @@ project's Slack channel.
     -   [ ] For persisted attributes, use the `AttributePersistence` helper to
             load in `Startup` and save on writes.
     -   [ ] **Crucially,** after a successful write, call a notification
-            function (e.g., `NotifyAttributeChangedIfSuccess`) to ensure
+            function (e.g., `NotifyIfAttributeChanged`) to ensure
             subscriptions work correctly.
 
 -   [ ] **2.3: Implement Command Logic:**

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -215,7 +215,7 @@ attribute's value changes.
     `interactionContext->dataModelChangeListener->MarkDirty(path)`. A
     `NotifyAttributeChanged` helper exists for paths managed by this cluster.
 
-    -   For write implementations, you can use `NotifyAttributeChangedIfSuccess`
+    -   For write implementations, you can use `NotifyIfAttributeChanged`
         together with a separate `WriteImpl` such that any successful attribute
         write will notify.
 
@@ -226,11 +226,11 @@ attribute's value changes.
                                                                           AttributeValueDecoder & decoder)
         {
                 // Delegate everything to WriteImpl. If write succeeds, notify that the attribute changed.
-                return NotifyAttributeChangedIfSuccess(request.path.mAttributeId, WriteImpl(request, decoder));
+                return NotifyIfAttributeChanged(request.path.mAttributeId, WriteImpl(request, decoder));
         }
         ```
 
-    -   For the `NotifyAttributeChangedIfSuccess` ensure that WriteImpl is
+    -   For the `NotifyIfAttributeChanged` ensure that WriteImpl is
         returning
         [ActionReturnStatus::FixedStatus::kWriteSuccessNoOp](https://github.com/project-chip/connectedhomeip/blob/master/src/app/data-model-provider/ActionReturnStatus.h)
         when no notification should be sent (e.g. write was a `noop` because

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -230,8 +230,7 @@ attribute's value changes.
         }
         ```
 
-    -   For the `NotifyIfAttributeChanged` ensure that WriteImpl is
-        returning
+    -   For the `NotifyIfAttributeChanged` ensure that WriteImpl is returning
         [ActionReturnStatus::FixedStatus::kWriteSuccessNoOp](https://github.com/project-chip/connectedhomeip/blob/master/src/app/data-model-provider/ActionReturnStatus.h)
         when no notification should be sent (e.g. write was a `noop` because
         existing value was already the same).

--- a/src/app/clusters/access-control-server/access-control-cluster.cpp
+++ b/src/app/clusters/access-control-server/access-control-cluster.cpp
@@ -518,7 +518,7 @@ DataModel::ActionReturnStatus AccessControlCluster::ReadAttribute(const DataMode
 DataModel::ActionReturnStatus AccessControlCluster::WriteAttribute(const DataModel::WriteAttributeRequest & request,
                                                                    AttributeValueDecoder & decoder)
 {
-    return NotifyAttributeChangedIfSuccess(request.path.mAttributeId, ChipErrorToImErrorMap(WriteImpl(request, decoder, mContext)));
+    return NotifyIfAttributeChanged(request.path.mAttributeId, ChipErrorToImErrorMap(WriteImpl(request, decoder, mContext)));
 }
 
 CHIP_ERROR AccessControlCluster::Attributes(const ConcreteClusterPath & path,

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -354,7 +354,7 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
 DataModel::ActionReturnStatus BasicInformationCluster::WriteAttribute(const DataModel::WriteAttributeRequest & request,
                                                                       AttributeValueDecoder & decoder)
 {
-    return NotifyAttributeChangedIfSuccess(request.path.mAttributeId, WriteImpl(request, decoder));
+    return NotifyIfAttributeChanged(request.path.mAttributeId, WriteImpl(request, decoder));
 }
 
 DataModel::ActionReturnStatus BasicInformationCluster::WriteImpl(const DataModel::WriteAttributeRequest & request,

--- a/src/app/clusters/general-commissioning-server/general-commissioning-cluster.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-cluster.cpp
@@ -263,7 +263,7 @@ DataModel::ActionReturnStatus GeneralCommissioningCluster::WriteAttribute(const 
         uint64_t value;
         ReturnErrorOnFailure(decoder.Decode(value));
         // SetBreadCrumb handles notification internally via NotifyAttributeChanged(),
-        // so we don't need to call NotifyAttributeChangedIfSuccess here.
+        // so we don't need to call NotifyIfAttributeChanged here.
         SetBreadCrumb(value);
         return CHIP_NO_ERROR;
     }

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-cluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-cluster.cpp
@@ -703,7 +703,7 @@ DataModel::ActionReturnStatus GroupKeyManagementCluster::WriteAttribute(const Da
     switch (request.path.mAttributeId)
     {
     case GroupKeyMap::Id: {
-        return NotifyAttributeChangedIfSuccess(request.path.mAttributeId, WriteGroupKeyMap(request.path, decoder));
+        return NotifyIfAttributeChanged(request.path.mAttributeId, WriteGroupKeyMap(request.path, decoder));
     }
     default:
         return Protocols::InteractionModel::Status::UnsupportedWrite;

--- a/src/app/clusters/identify-server/IdentifyCluster.cpp
+++ b/src/app/clusters/identify-server/IdentifyCluster.cpp
@@ -92,9 +92,8 @@ void IdentifyCluster::TimerFired()
 {
     if (mIdentifyTime > 0)
     {
-        NotifyIfAttributeChanged(
-            Attributes::IdentifyTime::Id,
-            SetIdentifyTime(IdentifyTimeChangeSource::kTimer, static_cast<uint16_t>(mIdentifyTime - 1)));
+        NotifyIfAttributeChanged(Attributes::IdentifyTime::Id,
+                                 SetIdentifyTime(IdentifyTimeChangeSource::kTimer, static_cast<uint16_t>(mIdentifyTime - 1)));
     }
 }
 
@@ -182,14 +181,12 @@ IdentifyCluster::InvokeCommand(const DataModel::InvokeRequest & request, TLV::TL
         // Currently identifying: handle stop/finish effects, otherwise cancel Identify process and trigger new effect.
         if (mEffectIdentifier == Identify::EffectIdentifierEnum::kFinishEffect)
         {
-            return NotifyIfAttributeChanged(Attributes::IdentifyTime::Id,
-                                            SetIdentifyTime(IdentifyTimeChangeSource::kClient, 1));
+            return NotifyIfAttributeChanged(Attributes::IdentifyTime::Id, SetIdentifyTime(IdentifyTimeChangeSource::kClient, 1));
         }
 
         if (mEffectIdentifier == Identify::EffectIdentifierEnum::kStopEffect)
         {
-            return NotifyIfAttributeChanged(Attributes::IdentifyTime::Id,
-                                            SetIdentifyTime(IdentifyTimeChangeSource::kClient, 0));
+            return NotifyIfAttributeChanged(Attributes::IdentifyTime::Id, SetIdentifyTime(IdentifyTimeChangeSource::kClient, 0));
         }
 
         // Other effects: cancel and trigger new effect.

--- a/src/app/clusters/identify-server/IdentifyCluster.cpp
+++ b/src/app/clusters/identify-server/IdentifyCluster.cpp
@@ -74,8 +74,8 @@ DataModel::ActionReturnStatus IdentifyCluster::WriteAttribute(const DataModel::W
     case Attributes::IdentifyTime::Id: {
         uint16_t newIdentifyTime;
         ReturnErrorOnFailure(decoder.Decode(newIdentifyTime));
-        return NotifyAttributeChangedIfSuccess(request.path.mAttributeId,
-                                               SetIdentifyTime(IdentifyTimeChangeSource::kClient, newIdentifyTime));
+        return NotifyIfAttributeChanged(request.path.mAttributeId,
+                                        SetIdentifyTime(IdentifyTimeChangeSource::kClient, newIdentifyTime));
     }
     default:
         return Protocols::InteractionModel::Status::UnsupportedAttribute;
@@ -92,7 +92,7 @@ void IdentifyCluster::TimerFired()
 {
     if (mIdentifyTime > 0)
     {
-        NotifyAttributeChangedIfSuccess(
+        NotifyIfAttributeChanged(
             Attributes::IdentifyTime::Id,
             SetIdentifyTime(IdentifyTimeChangeSource::kTimer, static_cast<uint16_t>(mIdentifyTime - 1)));
     }
@@ -153,8 +153,8 @@ IdentifyCluster::InvokeCommand(const DataModel::InvokeRequest & request, TLV::TL
         Identify::Commands::Identify::DecodableType data;
         ReturnErrorOnFailure(data.Decode(input_arguments));
         MATTER_TRACE_SCOPE("IdentifyCommand", "Identify");
-        return NotifyAttributeChangedIfSuccess(Attributes::IdentifyTime::Id,
-                                               SetIdentifyTime(IdentifyTimeChangeSource::kClient, data.identifyTime));
+        return NotifyIfAttributeChanged(Attributes::IdentifyTime::Id,
+                                        SetIdentifyTime(IdentifyTimeChangeSource::kClient, data.identifyTime));
     }
     case Identify::Commands::TriggerEffect::Id: {
         Identify::Commands::TriggerEffect::DecodableType data;
@@ -182,18 +182,18 @@ IdentifyCluster::InvokeCommand(const DataModel::InvokeRequest & request, TLV::TL
         // Currently identifying: handle stop/finish effects, otherwise cancel Identify process and trigger new effect.
         if (mEffectIdentifier == Identify::EffectIdentifierEnum::kFinishEffect)
         {
-            return NotifyAttributeChangedIfSuccess(Attributes::IdentifyTime::Id,
-                                                   SetIdentifyTime(IdentifyTimeChangeSource::kClient, 1));
+            return NotifyIfAttributeChanged(Attributes::IdentifyTime::Id,
+                                            SetIdentifyTime(IdentifyTimeChangeSource::kClient, 1));
         }
 
         if (mEffectIdentifier == Identify::EffectIdentifierEnum::kStopEffect)
         {
-            return NotifyAttributeChangedIfSuccess(Attributes::IdentifyTime::Id,
-                                                   SetIdentifyTime(IdentifyTimeChangeSource::kClient, 0));
+            return NotifyIfAttributeChanged(Attributes::IdentifyTime::Id,
+                                            SetIdentifyTime(IdentifyTimeChangeSource::kClient, 0));
         }
 
         // Other effects: cancel and trigger new effect.
-        auto err = NotifyAttributeChangedIfSuccess(
+        auto err = NotifyIfAttributeChanged(
             Attributes::IdentifyTime::Id, SetIdentifyTime(IdentifyTimeChangeSource::kClient, 0)); // This will call onIdentifyStop.
         mIdentifyDelegate->OnTriggerEffect(*this);
         return err;

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -1081,7 +1081,7 @@ DataModel::ActionReturnStatus NetworkCommissioningCluster::WriteAttribute(const 
     {
         bool value;
         ReturnErrorOnFailure(decoder.Decode(value));
-        return NotifyAttributeChangedIfSuccess(request.path.mAttributeId, SetInterfaceEnabled(value));
+        return NotifyIfAttributeChanged(request.path.mAttributeId, SetInterfaceEnabled(value));
     }
 
     return Protocols::InteractionModel::Status::InvalidAction;

--- a/src/app/clusters/time-format-localization-server/time-format-localization-cluster.cpp
+++ b/src/app/clusters/time-format-localization-server/time-format-localization-cluster.cpp
@@ -142,7 +142,7 @@ CHIP_ERROR TimeFormatLocalizationCluster::Startup(ServerClusterContext & context
 DataModel::ActionReturnStatus TimeFormatLocalizationCluster::WriteAttribute(const DataModel::WriteAttributeRequest & request,
                                                                             AttributeValueDecoder & decoder)
 {
-    return NotifyAttributeChangedIfSuccess(request.path.mAttributeId, WriteImpl(request, decoder));
+    return NotifyIfAttributeChanged(request.path.mAttributeId, WriteImpl(request, decoder));
 }
 
 DataModel::ActionReturnStatus TimeFormatLocalizationCluster::WriteImpl(const DataModel::WriteAttributeRequest & request,

--- a/src/app/clusters/time-synchronization-server/time-synchronization-cluster.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-cluster.cpp
@@ -599,7 +599,7 @@ CHIP_ERROR TimeSynchronizationCluster::SetTrustedTimeSource(const DataModel::Nul
         return err;
     };
 
-    return NotifyAttributeChangedIfSuccess(TrustedTimeSource::Id, setAttribute(tts)).GetUnderlyingError();
+    return NotifyIfAttributeChanged(TrustedTimeSource::Id, setAttribute(tts)).GetUnderlyingError();
 }
 
 inline CHIP_ERROR TimeSynchronizationCluster::SetDefaultNTP(const DataModel::Nullable<CharSpan> & dntp)
@@ -612,7 +612,7 @@ inline CHIP_ERROR TimeSynchronizationCluster::SetDefaultNTP(const DataModel::Nul
         return mTimeSyncDataProvider.ClearDefaultNtp();
     };
 
-    return NotifyAttributeChangedIfSuccess(DefaultNTP::Id, setAttribute(dntp)).GetUnderlyingError();
+    return NotifyIfAttributeChanged(DefaultNTP::Id, setAttribute(dntp)).GetUnderlyingError();
 }
 
 void TimeSynchronizationCluster::InitTimeZone()
@@ -736,7 +736,7 @@ CHIP_ERROR TimeSynchronizationCluster::SetTimeZone(const DataModel::DecodableLis
         return mTimeSyncDataProvider.StoreTimeZone(GetTimeZone());
     };
 
-    return NotifyAttributeChangedIfSuccess(TimeZone::Id, setAttribute(tzL)).GetUnderlyingError();
+    return NotifyIfAttributeChanged(TimeZone::Id, setAttribute(tzL)).GetUnderlyingError();
 }
 
 CHIP_ERROR TimeSynchronizationCluster::LoadTimeZone()
@@ -822,7 +822,7 @@ CHIP_ERROR TimeSynchronizationCluster::SetDSTOffset(const DataModel::DecodableLi
         return mTimeSyncDataProvider.StoreDSTOffset(GetDSTOffset());
     };
 
-    return NotifyAttributeChangedIfSuccess(DSTOffset::Id, setAttribute(dstL)).GetUnderlyingError();
+    return NotifyIfAttributeChanged(DSTOffset::Id, setAttribute(dstL)).GetUnderlyingError();
 }
 
 CHIP_ERROR TimeSynchronizationCluster::LoadDSTOffset()
@@ -886,7 +886,7 @@ CHIP_ERROR TimeSynchronizationCluster::SetUTCTime(uint64_t utcTime, GranularityE
         return CHIP_NO_ERROR;
     };
 
-    return NotifyAttributeChangedIfSuccess(UTCTime::Id, setAttribute(utcTime, granularity, source)).GetUnderlyingError();
+    return NotifyIfAttributeChanged(UTCTime::Id, setAttribute(utcTime, granularity, source)).GetUnderlyingError();
 }
 
 CHIP_ERROR TimeSynchronizationCluster::GetLocalTime(DataModel::Nullable<uint64_t> & localTime)

--- a/src/app/clusters/user-label-server/user-label-cluster.cpp
+++ b/src/app/clusters/user-label-server/user-label-cluster.cpp
@@ -146,7 +146,7 @@ DataModel::ActionReturnStatus UserLabelCluster::WriteAttribute(const DataModel::
     switch (request.path.mAttributeId)
     {
     case LabelList::Id:
-        return NotifyAttributeChangedIfSuccess(LabelList::Id, WriteLabelList(request.path, decoder));
+        return NotifyIfAttributeChanged(LabelList::Id, WriteLabelList(request.path, decoder));
     default:
         return Protocols::InteractionModel::Status::UnsupportedWrite;
     }

--- a/src/app/server-cluster/DefaultServerCluster.cpp
+++ b/src/app/server-cluster/DefaultServerCluster.cpp
@@ -132,7 +132,7 @@ CHIP_ERROR DefaultServerCluster::GeneratedCommands(const ConcreteClusterPath & p
 }
 
 DataModel::ActionReturnStatus DefaultServerCluster::NotifyIfAttributeChanged(AttributeId attributeId,
-                                                                                    DataModel::ActionReturnStatus status)
+                                                                             DataModel::ActionReturnStatus status)
 {
     if (status.IsSuccess() && !status.IsNoOpSuccess())
     {

--- a/src/app/server-cluster/DefaultServerCluster.cpp
+++ b/src/app/server-cluster/DefaultServerCluster.cpp
@@ -131,7 +131,7 @@ CHIP_ERROR DefaultServerCluster::GeneratedCommands(const ConcreteClusterPath & p
     return CHIP_NO_ERROR;
 }
 
-DataModel::ActionReturnStatus DefaultServerCluster::NotifyAttributeChangedIfSuccess(AttributeId attributeId,
+DataModel::ActionReturnStatus DefaultServerCluster::NotifyIfAttributeChanged(AttributeId attributeId,
                                                                                     DataModel::ActionReturnStatus status)
 {
     if (status.IsSuccess() && !status.IsNoOpSuccess())

--- a/src/app/server-cluster/DefaultServerCluster.h
+++ b/src/app/server-cluster/DefaultServerCluster.h
@@ -118,7 +118,7 @@ protected:
     /// Marks that a specific attribute has changed value, if `status` is success.
     ///
     /// Will return `status`
-    DataModel::ActionReturnStatus NotifyAttributeChangedIfSuccess(AttributeId attributeId, DataModel::ActionReturnStatus status);
+    DataModel::ActionReturnStatus NotifyIfAttributeChanged(AttributeId attributeId, DataModel::ActionReturnStatus status);
 
 private:
     DataVersion mDataVersion; // will be random-initialized as per spec

--- a/src/app/server-cluster/DefaultServerCluster.h
+++ b/src/app/server-cluster/DefaultServerCluster.h
@@ -115,9 +115,11 @@ protected:
     /// notify that the attribute has changed.
     void NotifyAttributeChanged(AttributeId attributeId);
 
-    /// Marks that a specific attribute has changed value, if `status` is success.
+    /// Marks that a specific attribute has changed value, if `status` is success and NOT a NoOp.
     ///
-    /// Will return `status`
+    /// This is a helper to wrap write operations that return an action status.
+    ///
+    /// Will return `status` unchanged.
     DataModel::ActionReturnStatus NotifyIfAttributeChanged(AttributeId attributeId, DataModel::ActionReturnStatus status);
 
 private:

--- a/src/app/server-cluster/tests/TestDefaultServerCluster.cpp
+++ b/src/app/server-cluster/tests/TestDefaultServerCluster.cpp
@@ -64,9 +64,9 @@ public:
 
     void TestIncreaseDataVersion() { IncreaseDataVersion(); }
     void TestNotifyAttributeChanged(AttributeId attributeId) { NotifyAttributeChanged(attributeId); }
-    ActionReturnStatus TestNotifyAttributeChangedIfSuccess(AttributeId attributeId, ActionReturnStatus status)
+    ActionReturnStatus TestNotifyIfAttributeChanged(AttributeId attributeId, ActionReturnStatus status)
     {
-        return NotifyAttributeChangedIfSuccess(attributeId, status);
+        return NotifyIfAttributeChanged(attributeId, status);
     }
 };
 
@@ -198,7 +198,7 @@ TEST(TestDefaultServerCluster, NotifyAttributeChanged)
     ASSERT_EQ(context.ChangeListener().DirtyList()[0], AttributePathParams(kEndpointId, kClusterId, 234));
 }
 
-TEST(TestDefaultServerCluster, NotifyAttributeChangedIfSuccess)
+TEST(TestDefaultServerCluster, NotifyIfAttributeChanged)
 {
     constexpr ClusterId kEndpointId = 321;
     constexpr ClusterId kClusterId  = 1122;
@@ -207,12 +207,12 @@ TEST(TestDefaultServerCluster, NotifyAttributeChangedIfSuccess)
     // When no ServerClusterContext is set, only the data version should change.
     DataVersion oldVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
 
-    ASSERT_EQ(cluster.TestNotifyAttributeChangedIfSuccess(123, Status::Success), Status::Success);
+    ASSERT_EQ(cluster.TestNotifyIfAttributeChanged(123, Status::Success), Status::Success);
     DataVersion newVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
     ASSERT_NE(newVersion, oldVersion);
 
     oldVersion = newVersion;
-    ASSERT_EQ(cluster.TestNotifyAttributeChangedIfSuccess(123, Status::Failure), Status::Failure);
+    ASSERT_EQ(cluster.TestNotifyIfAttributeChanged(123, Status::Failure), Status::Failure);
     newVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
     ASSERT_EQ(newVersion, oldVersion);
 
@@ -221,7 +221,7 @@ TEST(TestDefaultServerCluster, NotifyAttributeChangedIfSuccess)
     ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
     oldVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
-    ASSERT_EQ(cluster.TestNotifyAttributeChangedIfSuccess(234, Status::Success), Status::Success);
+    ASSERT_EQ(cluster.TestNotifyIfAttributeChanged(234, Status::Success), Status::Success);
     ASSERT_NE(cluster.GetDataVersion({ kEndpointId, kClusterId }), oldVersion);
 
     ASSERT_EQ(context.ChangeListener().DirtyList().size(), 1u);
@@ -230,7 +230,7 @@ TEST(TestDefaultServerCluster, NotifyAttributeChangedIfSuccess)
     // now test a failure - nothing should be marked dirty
     oldVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
     context.ChangeListener().DirtyList().clear();
-    ASSERT_EQ(cluster.TestNotifyAttributeChangedIfSuccess(345, Status::Failure), Status::Failure);
+    ASSERT_EQ(cluster.TestNotifyIfAttributeChanged(345, Status::Failure), Status::Failure);
     ASSERT_EQ(cluster.GetDataVersion({ kEndpointId, kClusterId }), oldVersion);
     ASSERT_TRUE(context.ChangeListener().DirtyList().empty());
 }


### PR DESCRIPTION
#### Summary

Rename `NotifyAttributeChangedIfSuccess(id, status)` to `NotifyIfAttributeChanged(id, status)` to avoid confusion as kNoOp is also considered success but won't notify.

#### Testing

Searched the codebase and didn't find occurrences of the old method. CI will confirm. 