### PR TITLE
[CP][1.4.2][ICD][Server]Bump default CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE to 3

### DIFF
--- a/examples/lit-icd-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/lit-icd-app/silabs/include/CHIPProjectConfig.h
@@ -90,6 +90,6 @@
 /**
  * @brief CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE
  *
- * Increase default(2) by 1 to account for the AppTask registering
+ * The SDK default is 3; this app adds 1 (AppTask), for a total of 4.
  */
-#define CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE 3
+#define CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE 4

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1874,10 +1874,10 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  * @def CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE
  *
  * @brief Defines the entry iterator delegate pool size of the ICDObserver object pool in ICDManager.h.
- *        Two are used in the default implementation. Users can increase it to register more observers.
+ *        Three are used in the default implementation. Users can increase it to register more observers.
  */
 #ifndef CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE
-#define CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE 2
+#define CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE 3
 #endif
 
 /**


### PR DESCRIPTION
#### Summary
CP https://github.com/project-chip/connectedhomeip/pull/42046

#### Related issues
N/A

#### Testing
local testing between controller and lit icd device.

#### Readability checklist
N/A
