### PR TITLE
Imgui generic path resolving via pkg-config

### DIFF
--- a/third_party/imgui/BUILD.gn
+++ b/third_party/imgui/BUILD.gn
@@ -36,6 +36,8 @@ config("imgui_config") {
       "-framework",
       "OpenGL",
     ]
+  } else {
+    defines += [ "_REENTRANT" ]
   }
 }
 

--- a/third_party/imgui/BUILD.gn
+++ b/third_party/imgui/BUILD.gn
@@ -14,6 +14,11 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+import("${build_root}/config/linux/pkg_config.gni")
+
+pkg_config("sdl2_pkgconfig") {
+  packages = [ "sdl2" ]
+}
 
 config("imgui_config") {
   include_dirs = [
@@ -22,19 +27,15 @@ config("imgui_config") {
   ]
   defines = [ "CHIP_IMGUI_ENABLED=1" ]
 
-  # FUTURE: these should be parsed from `sdl2-config --cflags`
+  # Use pkg-config for SDL2 on all platforms
+  configs = [ ":sdl2_pkgconfig" ]
+
   if (current_os == "mac") {
-    # Default path setup by `brew install sdl2`
-    include_dirs += [ "/usr/local/include/SDL2" ]
     defines += [ "_THREAD_SAFE" ]
     ldflags = [
       "-framework",
       "OpenGL",
     ]
-  } else {
-    # Linux defaults
-    include_dirs += [ "/usr/include/SDL2" ]
-    defines += [ "_REENTRANT" ]
   }
 }
 
@@ -61,14 +62,12 @@ source_set("imgui") {
     "repo/backends/imgui_impl_sdl2.h",
   ]
 
-  # FUTURE: SDL2 libs should be from `sdl2-config --libs`
-  libs = [
-    "SDL2",
-    "dl",
-  ]
-
+  # Additional libs needed on Linux beyond what pkg-config provides
   if (current_os == "linux") {
-    libs += [ "GL" ]
+    libs = [
+      "dl",
+      "GL",
+    ]
   }
 
   public_configs = [ ":imgui_config" ]

--- a/third_party/imgui/BUILD.gn
+++ b/third_party/imgui/BUILD.gn
@@ -28,6 +28,7 @@ config("imgui_config") {
   defines = [ "CHIP_IMGUI_ENABLED=1" ]
 
   # Use pkg-config for SDL2 on all platforms
+  # FUTURE: SDL2 libs should be from `sdl2-config --libs`
   configs = [ ":sdl2_pkgconfig" ]
 
   if (current_os == "mac") {


### PR DESCRIPTION
#### Summary

Building sdl2 based examples on recent macos machines fails because of not finding sdl2 headers.
They were in ```/opt/homebrew/inlcude/SDL2``` but the hardcoded linux path was used: ```/usr/local/include/SDL2```.

Unnecessary ```libdl``` on macOS does not need external linking as for macOS it is always linked in libSystem.

#### Related issues

There was a note in code (see the changes) which was mentioning this change as ```todo```

#### Testing

- running on macos on m1 machines with homebrew installed sdl2
- running on linux ubuntu machine with apt instaled libsdl2

Commands:
```scripts/build/build_examples.py --target linux-x64-air-quality-sensor-with-ui  build```
```scripts/build/build_examples.py --target darwin-arm64-air-quality-sensor-with-ui  build```

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
