### PR TITLE
Software Update base class updates

### DIFF
--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -421,12 +421,21 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
 
         asserts.assert_equal(resp[0].Status, Status.Success, "Failed to clear DefaultOTAProviders")
 
-    def clear_kvs(self):
+    def clear_kvs(self, kvs_path_prefix: str = None):
         """
-         Temporary cleanup of provider KVS files at the tmp path.
+        Remove all temporary KVS files matching a given prefix.
+
+        Args:
+            kvs_path_prefix (str, optional): Prefix of KVS files/folders to remove.
+            Defaults to "/tmp/chip_kvs", which removes all temporary chip KVS files
 
         Returns:
             None
         """
         import subprocess
-        subprocess.run("rm -rf /tmp/chip_kvs*", shell=True)
+
+        if kvs_path_prefix is None:
+            kvs_path_prefix = "/tmp/chip_kvs"
+        subprocess.run(f"rm -rf {kvs_path_prefix}*", shell=True)
+
+        logger.info(f'Removed KVS files matching: {kvs_path_prefix}*')

--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -300,3 +300,5 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             nodeId=provider_node_id,
             attributes=[(0, acl_attribute)]
         )
+
+        # TODO: Baseclass updates

--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -335,16 +335,19 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
         )
 
         # Create OTA ACL entries (both directions)
+
+        # Requestor is allowed to access OTA cluster on the Provider (Requestor > Provider)
         await self.create_acl_entry(
             dev_ctrl=controller,
-            provider_node_id=provider_node_id,
-            requestor_node_id=requestor_node_id
+            provider_node_id=provider_node_id,      # write ACLs on the Provider
+            requestor_node_id=requestor_node_id     # the Requestor gets access
         )
 
+        # Provider is allowed to access OTA cluster on the Requestor (Provider > Requestor)
         await self.create_acl_entry(
             dev_ctrl=controller,
-            provider_node_id=requestor_node_id,
-            requestor_node_id=provider_node_id
+            provider_node_id=requestor_node_id,     # write ACLs on the Requestor
+            requestor_node_id=provider_node_id      # the Provider gets access
         )
 
         # Read updated ACLs
@@ -417,3 +420,13 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
         logger.info('Cleanup - DefaultOTAProviders cleared')
 
         asserts.assert_equal(resp[0].Status, Status.Success, "Failed to clear DefaultOTAProviders")
+
+    def clear_kvs(self):
+        """
+         Temporary cleanup of provider KVS files at the tmp path.
+
+        Returns:
+            None
+        """
+        import subprocess
+        subprocess.run("rm -rf /tmp/chip_kvs*", shell=True)

--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -62,7 +62,7 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             kvs_path(str): Str of the path for the kvs path, if not will use temp file.
             log_file (Optional[str], optional): Destination for the app process logs. Defaults to None.
             expected_output (str): Expected string to see after a default timeout. Defaults to "Server initialization complete".
-            timeout (int): Timeout to wait for the expected output. Defaults to 10 seconds
+            timeout (int): Timeout to wait for the expected output. Defaults to 30 seconds
         """
         logger.info(f'Launching provider app with ota image {ota_image_path} over the port: {port}')
         # Image to launch
@@ -309,7 +309,7 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             attributes=[(0, acl_attribute)]
         )
 
-    async def extend_ota_acls(self, controller, provider_node_id, requestor_node_id):
+    async def extend_ota_acls(self, controller: ChipDeviceCtrl, provider_node_id, requestor_node_id):
         """
         Extend ACLs on both Provider and Requestor to allow OTA interaction.
         Preserves existing ACLs to avoid overwriting.
@@ -374,7 +374,7 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             f"OTA ACLs extended between provider {provider_node_id} and requestor {requestor_node_id}"
         )
 
-    async def write_acl(self, controller, node_id, acl):
+    async def write_acl(self, controller: ChipDeviceCtrl, node_id: int, acl: list):
         """
         Write the ACL list to a device.
 
@@ -385,6 +385,9 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
 
         Returns:
             True if successful.
+
+        Raises:
+            AssertionError: If ACL write fails.
         """
         result = await controller.WriteAttribute(
             nodeId=node_id,

--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -47,8 +47,8 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
                        storage_dir='/tmp',
                        extra_args: list = [],
                        kvs_path: Optional[str] = None,
-                       log_file: Optional[str] = None, expected_output: str = "Status: Satisfied",
-                       timeout: int = 10):
+                       log_file: Optional[str] = None, expected_output: str = "Server initialization complete",
+                       timeout: int = 30):
         """Start the provider process using the provided configuration.
 
         Args:
@@ -61,10 +61,10 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             extra_args (list, optional): Extra args to send to the provider process. Defaults to [].
             kvs_path(str): Str of the path for the kvs path, if not will use temp file.
             log_file (Optional[str], optional): Destination for the app process logs. Defaults to None.
-            expected_output (str): Expected string to see after a default timeout. Defaults to "Status: Satisfied".
+            expected_output (str): Expected string to see after a default timeout. Defaults to "Server initialization complete".
             timeout (int): Timeout to wait for the expected output. Defaults to 10 seconds
         """
-        logger.info(f"Launching provider app with with ota image {ota_image_path}")
+        logger.info(f'Launching provider app with ota image {ota_image_path} over the port: {port}')
         # Image to launch
         self.provider_app_path = provider_app_path
         if not path.exists(provider_app_path):
@@ -102,6 +102,14 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
 
         self.current_provider_app_proc = proc
         logger.info(f"Provider started with PID:  {self.current_provider_app_proc.get_pid()}")
+
+    def terminate_provider(self):
+        if hasattr(self, "current_provider_app_proc") and self.current_provider_app_proc is not None:
+            logger.info("Terminating existing OTA Provider")
+            self.current_provider_app_proc.terminate()
+            self.current_provider_app_proc = None
+        else:
+            logger.info("Provider process not found. Unable to terminate.")
 
     async def announce_ota_provider(self,
                                     controller: ChipDeviceCtrl,
@@ -301,4 +309,108 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             attributes=[(0, acl_attribute)]
         )
 
-        # TODO: Baseclass updates
+    async def extend_ota_acls(self, controller, provider_node_id, requestor_node_id):
+        """
+        Extend ACLs on both Provider and Requestor to allow OTA interaction.
+        Preserves existing ACLs to avoid overwriting.
+
+        Args:
+            controller: The Matter device controller instance.
+            provider_node_id (int): Node ID of the OTA Provider.
+            requestor_node_id (int): Node ID of the OTA Requestor (DUT).
+        """
+        # Read existing ACLs
+        provider_existing_acls = await self.read_single_attribute(
+            dev_ctrl=controller,
+            node_id=provider_node_id,
+            endpoint=0,
+            attribute=Clusters.AccessControl.Attributes.Acl,
+        )
+
+        requestor_existing_acls = await self.read_single_attribute(
+            dev_ctrl=controller,
+            node_id=requestor_node_id,
+            endpoint=0,
+            attribute=Clusters.AccessControl.Attributes.Acl,
+        )
+
+        # Create OTA ACL entries (both directions)
+        await self.create_acl_entry(
+            dev_ctrl=controller,
+            provider_node_id=provider_node_id,
+            requestor_node_id=requestor_node_id
+        )
+
+        await self.create_acl_entry(
+            dev_ctrl=controller,
+            provider_node_id=requestor_node_id,
+            requestor_node_id=provider_node_id
+        )
+
+        # Read updated ACLs
+        provider_current_acls = await self.read_single_attribute(
+            dev_ctrl=controller,
+            node_id=provider_node_id,
+            endpoint=0,
+            attribute=Clusters.AccessControl.Attributes.Acl,
+        )
+
+        requestor_current_acls = await self.read_single_attribute(
+            dev_ctrl=controller,
+            node_id=requestor_node_id,
+            endpoint=0,
+            attribute=Clusters.AccessControl.Attributes.Acl,
+        )
+
+        # Combine original + new entries
+        combined_provider_acls = provider_existing_acls + provider_current_acls
+        combined_requestor_acls = requestor_existing_acls + requestor_current_acls
+
+        # Write back ACLs
+        await self.write_acl(controller, provider_node_id, combined_provider_acls)
+        await self.write_acl(controller, requestor_node_id, combined_requestor_acls)
+
+        logger.info(
+            f"OTA ACLs extended between provider {provider_node_id} and requestor {requestor_node_id}"
+        )
+
+    async def write_acl(self, controller, node_id, acl):
+        """
+        Write the ACL list to a device.
+
+        Args:
+            controller: The Matter controller instance.
+            node_id (int): Node ID of the target device.
+            acl (list): List of AccessControlEntryStruct ACL entries.
+
+        Returns:
+            True if successful.
+        """
+        result = await controller.WriteAttribute(
+            nodeId=node_id,
+            attributes=[(0, Clusters.AccessControl.Attributes.Acl(acl))]
+        )
+
+        asserts.assert_equal(result[0].Status, Status.Success, "ACL write failed")
+        return True
+
+    async def clear_ota_providers(self, controller: ChipDeviceCtrl, requestor_node_id: int):
+        """
+        Clears the DefaultOTAProviders attribute on the Requestor, leaving it empty.
+
+        Args:
+            controller (ChipDeviceCtrl): The controller to use for writing attributes.
+            requestor_node_id (int): Node ID of the Requestor device.
+
+        Returns:
+            None
+        """
+        # Set DefaultOTAProviders to empty list
+        attr_clear = Clusters.OtaSoftwareUpdateRequestor.Attributes.DefaultOTAProviders(value=[])
+        resp = await controller.WriteAttribute(
+            attributes=[(0, attr_clear)],
+            nodeId=requestor_node_id
+        )
+        logger.info('Cleanup - DefaultOTAProviders cleared')
+
+        asserts.assert_equal(resp[0].Status, Status.Success, "Failed to clear DefaultOTAProviders")


### PR DESCRIPTION
### Summary

This PR is focused on Following the feedback from [TC-SU-2.2 python](https://github.com/project-chip/connectedhomeip/pull/40366), the following generic logic should be moved out of TC-SU-2.2 and centralized into the base class so it can be reused by SU 2.3, 2.5, 2.7 and/or others.
Fixes: [Software Update base class updates and improve AttributeSubscriptionHandler #735](https://github.com/project-chip/matter-test-scripts/issues/735)
Test plan: [OTA SU Test cases](https://github.com/CHIP-Specifications/chip-test-plans/blob/master/src/softwareupdate.adoc#test-cases)

### Scope

**BaseClass updates**

- Move `extend_ota_acls` and `write_acl` into TC_SUTestBase. [Feedback link](https://github.com/project-chip/connectedhomeip/pull/40366#discussion_r2517720568)
- Update `start_provider` to support new provider validation. [Feedback link](https://github.com/project-chip/connectedhomeip/pull/40366#discussion_r2517692470)
- Add `clear_ota_providers` to base class for consistent cleanup. [Feedback link](url)
- Add and review/verify `terminate_provider` [Comment link](https://github.com/project-chip/connectedhomeip/pull/40366#discussion_r2534223073)
- Copilot comments [Feedback link](https://github.com/project-chip/connectedhomeip/pull/40366#discussion_r2527841983)
- Add fn to clean the provider KVS at the end of the test (teardown_test)  [Feedback link](https://github.com/project-chip/connectedhomeip/pull/40366#discussion_r2566109730)

#### Testing

### Related Issues & PRs
[Software Update base class #41145](https://github.com/project-chip/connectedhomeip/pull/41145)

#### Testing
To run the automated TC-SU-2.2 test


