### PR TITLE
EventSubscriptionHandler updates.

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
@@ -109,6 +109,8 @@ class EventSubscriptionHandler:
         self._subscription.SetEventUpdateCallback(self.__call__)
         return self._subscription
 
+    # TODO: Inlude cancel method to cancel subscription
+
     def wait_for_event_report(self, expected_event: ClusterObjects.ClusterEvent, timeout_sec: float = 10.0) -> Any:
         """This function allows a test script to block waiting for the specific event to be the next event
            to arrive within a timeout (specified in seconds). It returns the event data so that the values can be checked."""


### PR DESCRIPTION
### Summary   

This PR is focused on Following the feedback from [TC-SU-2.2 python](https://github.com/project-chip/connectedhomeip/pull/40366), the following generic logic should be moved out of TC-SU-2.2 and centralized into this PR so it can be reused by SU 2.3, 2.5, 2.7 and/or others.
Fixes: [Software Update base class updates and improve EventSubscriptionHandler #735](https://github.com/project-chip/matter-test-scripts/issues/735)
Test plan: [OTA SU Test cases](https://github.com/CHIP-Specifications/chip-test-plans/blob/master/src/softwareupdate.adoc#test-cases)

### Scope

**Event Reporting**
Add `EventSubscriptionHandler.cancel()` timing to support sleeping devices (up to 15 seconds). [Feedback link](https://github.com/project-chip/connectedhomeip/pull/40366#discussion_r2523075561)

#### Testing

### Related Issues & PRs
[Software Update base class #41145](https://github.com/project-chip/connectedhomeip/pull/41145)

#### Testing
To run the automated TC-SU-2.2 test

