### PR TITLE
Disable cadmin 1.5 from CI

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -150,6 +150,8 @@ not_automated:
       reason: Helper methods for Push AV Integration TCs
     - name: TC_TLS_Utils.py
       reason: Helper methods for TC tests dependent on TLS clusters
+    - name: TC_CADMIN_1_5
+      reason: "Flaky/broken: see https://github.com/project-chip/connectedhomeip/issues/42059"
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -150,7 +150,7 @@ not_automated:
       reason: Helper methods for Push AV Integration TCs
     - name: TC_TLS_Utils.py
       reason: Helper methods for TC tests dependent on TLS clusters
-    - name: TC_CADMIN_1_5
+    - name: TC_CADMIN_1_5.py
       reason:
           "Flaky/broken: see
           https://github.com/project-chip/connectedhomeip/issues/42059"

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -151,7 +151,9 @@ not_automated:
     - name: TC_TLS_Utils.py
       reason: Helper methods for TC tests dependent on TLS clusters
     - name: TC_CADMIN_1_5
-      reason: "Flaky/broken: see https://github.com/project-chip/connectedhomeip/issues/42059"
+      reason:
+          "Flaky/broken: see
+          https://github.com/project-chip/connectedhomeip/issues/42059"
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially


### PR DESCRIPTION
#### Summary

Test is broken. see #42059 :

- it is flaky
- it does not match up with test plan (based on #42042) because it does not assert a failure when it should (because often it seems not to fail ....)
- we see errors in CI that still report test as passed


#### Testing

Trivial change