### PR TITLE
[NXP] Fix TC-CGEN-2.4 and TC-CGEN-2.2 issue due to unnecessary wifi connection during revert config

### DIFF
--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -145,6 +145,9 @@ CHIP_ERROR NXPWiFiDriver::RevertConfiguration()
     /* Reset mStagingNetwork as it may have been updated during add/update network operation */
     mStagingNetwork = mSavedNetwork;
 
+    // succeed right away if we are already connected
+    VerifyOrReturnError(!is_sta_connected(), CHIP_NO_ERROR);
+
     // succeed right away if no saved network
     VerifyOrReturnError(mStagingNetwork.ssidLen > 0, CHIP_NO_ERROR);
     // Connect to saved network


### PR DESCRIPTION
#### Summary

Fix TC-CGEN-2.4 and TC-CGEN-2.2 issue due to unnecessary wifi connection during revert config (the device will take fiew seconds to be connected again and due to this delay test is failling):
do not force a wifi connection is we are already connected to a wifi network, revert config could appear after a fail safe timer expired without connection error

#### Testing

Check  TC-CGEN-2.4 and TC-CGEN-2.2 are now passing with rw61x thermostat wifi+otbr configuration:
west build -d build_matter/ -b frdmrw612 examples/thermostat/nxp/ -DCONF_FILE=examples/platform/nxp/config/prj_thread_ftd_wifi_br_ota.conf

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
