### PR TITLE
[Update Test] Skipping ProxyView for ACL privileges tested in ACE tests in TC_AccessChecker.py

### DIFF
--- a/src/python_testing/TC_AccessChecker.py
+++ b/src/python_testing/TC_AccessChecker.py
@@ -348,7 +348,7 @@ class AccessChecker(MatterBaseTest, BasicCompositionTests):
         self.step(check_step)
         enum = Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum
         in_progress_clusters = [Clusters.ColorControl.id]
-        privilege_enum = [p for p in enum if p != enum.kUnknownEnumValue]
+        privilege_enum = [p for p in enum if p != enum.kUnknownEnumValue and p != enum.kProxyView]
         for privilege in privilege_enum:
             logging.info(f"Testing for {privilege}")
             self.step(step_number_with_privilege(check_step, 'a', privilege))
@@ -379,7 +379,7 @@ class AccessChecker(MatterBaseTest, BasicCompositionTests):
                  TestStep(2, "TH_commissioner reads the ACL attribute (done during test setup)"),
                  TestStep(3, "Repeat steps 3a and 3b for each permission level")]
         enum = Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum
-        privilege_enum = [p for p in enum if p != enum.kUnknownEnumValue]
+        privilege_enum = [p for p in enum if p != enum.kUnknownEnumValue and p != enum.kProxyView]
         for p in privilege_enum:
             steps.append(TestStep(step_number_with_privilege(3, 'a', p),
                          "TH_commissioner gives TH_second_commissioner the specified privilege"))
@@ -402,7 +402,7 @@ class AccessChecker(MatterBaseTest, BasicCompositionTests):
                  TestStep(4, "TH_second_controller performs a wildcard read"),
                  TestStep(5, "Repeat steps 5a and 5b for each permission level")]
         enum = Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum
-        privilege_enum = [p for p in enum if p != enum.kUnknownEnumValue]
+        privilege_enum = [p for p in enum if p != enum.kUnknownEnumValue and p != enum.kProxyView]
         for p in privilege_enum:
             steps.append(TestStep(step_number_with_privilege(5, 'a', p),
                          "TH_commissioner gives TH_second_commissioner the specified privilege"))
@@ -423,7 +423,7 @@ class AccessChecker(MatterBaseTest, BasicCompositionTests):
                  TestStep(2, "TH_commissioner reads the ACL attribute (done during test setup)"),
                  TestStep(3, "Repeat steps 3a and 3b for each permission level")]
         enum = Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum
-        privilege_enum = [p for p in enum if p != enum.kUnknownEnumValue]
+        privilege_enum = [p for p in enum if p != enum.kUnknownEnumValue and p != enum.kProxyView]
         for p in privilege_enum:
             steps.append(TestStep(step_number_with_privilege(3, 'a', p),
                          "TH_commissioner gives TH_second_controller the specified privilege"))


### PR DESCRIPTION
#### Summary

- Quick update to skip ProxyView ACL privilege from privilege levels tested in ACE tests contained inside of TC_AccessChecker python3 module as requested in issue [41840](https://github.com/project-chip/connectedhomeip/issues/41840). As this appears to have been removed in 1.4.2 spec.

#### Related issues

- Issue: https://github.com/project-chip/connectedhomeip/issues/41840

#### Testing

Validated in WSL Linux using following command:
```
./scripts/tests/run_python_test.py --factory-reset --app out/linux-x64-all-clusters/chip-all-clusters-app --app-args "--discriminator 1234 --KVS kvs1" --script-args "--storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --endpoint 0" --script src/python_testing/TC_AccessChecker.py 
```
