### PR TITLE
Fix handling of csrNonce in MTRCommissioningParameters.

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -970,9 +970,17 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             // reference to the operational credential delegate here
             if (mOperationalCredentialsDelegate != nullptr)
             {
-                MutableByteSpan nonce(mCSRNonce);
-                ReturnErrorOnFailure(mOperationalCredentialsDelegate->ObtainCsrNonce(nonce));
-                mParams.SetCSRNonce(ByteSpan(mCSRNonce, sizeof(mCSRNonce)));
+                uint8_t csrNonceBytes[sizeof(mCSRNonce)];
+                MutableByteSpan nonce(csrNonceBytes);
+                CHIP_ERROR csrError = mOperationalCredentialsDelegate->ObtainCsrNonce(nonce);
+                if (csrError != CHIP_ERROR_NOT_IMPLEMENTED)
+                {
+                    ReturnErrorOnFailure(csrError);
+
+                    MutableByteSpan savedCSRNonce(mCSRNonce);
+                    ReturnErrorOnFailure(CopySpanToMutableSpan(nonce, savedCSRNonce));
+                    mParams.SetCSRNonce(savedCSRNonce);
+                }
             }
             break;
         }

--- a/src/controller/OperationalCredentialsDelegate.h
+++ b/src/controller/OperationalCredentialsDelegate.h
@@ -87,6 +87,10 @@ public:
      * should be used, or overridden to return a specific nonce that will be
      * used instead of the one from CommissioningParameters, if AutoCommissioner
      * is used.
+     *
+     * The default implementation of this method generates a random nonce,
+     * which will take precedence over the one from CommissioningParameters
+     * if AutoCommissioner is used.
      */
     virtual CHIP_ERROR ObtainCsrNonce(MutableByteSpan & csrNonce)
     {

--- a/src/controller/OperationalCredentialsDelegate.h
+++ b/src/controller/OperationalCredentialsDelegate.h
@@ -81,6 +81,13 @@ public:
      */
     virtual void SetFabricIdForNextNOCRequest(FabricId fabricId) {}
 
+    /**
+     * ObtainCsrNonce can be overridden to return CHIP_ERROR_NOT_IMPLEMENTED to
+     * indicate that whatever CSR nonce came from the CommissioningParameters
+     * should be used, or overridden to return a specific nonce that will be
+     * used instead of the one from CommissioningParameters, if AutoCommissioner
+     * is used.
+     */
     virtual CHIP_ERROR ObtainCsrNonce(MutableByteSpan & csrNonce)
     {
         VerifyOrReturnError(csrNonce.size() == kCSRNonceLength, CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
@@ -54,6 +54,8 @@ public:
 
     void SetFabricIdForNextNOCRequest(chip::FabricId fabricId) override { mNextFabricId = fabricId; }
 
+    CHIP_ERROR ObtainCsrNonce(chip::MutableByteSpan & csrNonce) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
     void SetDeviceID(chip::NodeId deviceId) { mDeviceBeingPaired = deviceId; }
     void ResetDeviceID() { mDeviceBeingPaired = chip::kUndefinedNodeId; }
 

--- a/src/darwin/Framework/CHIPTests/MTROperationalCertificateIssuerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTROperationalCertificateIssuerTests.m
@@ -28,6 +28,7 @@ static const uint64_t kDeviceId = 0x12344321;
 static NSString * kOnboardingPayload = @"MT:-24J0AFN00KA0648G00";
 static const uint16_t kLocalPort = 5541;
 static const uint16_t kTestVendorId = 0xFFF1u;
+static NSString * csrNonceStr = @"01234567890123456789012345678901"; // 32 chars
 
 // Singleton controller we use.
 static MTRDeviceController * sController = nil;
@@ -53,9 +54,12 @@ static MTRTestKeys * sTestKeys = nil;
 {
     XCTAssertEqual(error.code, 0);
 
+    __auto_type * params = [[MTRCommissioningParameters alloc] init];
+    params.csrNonce = [csrNonceStr dataUsingEncoding:NSUTF8StringEncoding];
+
     NSError * commissionError = nil;
     [sController commissionNodeWithID:@(kDeviceId)
-                  commissioningParams:[[MTRCommissioningParameters alloc] init]
+                  commissioningParams:params
                                 error:&commissionError];
     XCTAssertNil(commissionError);
 
@@ -96,6 +100,8 @@ static MTRTestKeys * sTestKeys = nil;
     XCTAssertNotNil(csrInfo);
     XCTAssertNotNil(attestationInfo);
     XCTAssertEqual(controller, sController);
+
+    XCTAssertEqualObjects(csrInfo.csrNonce, [csrNonceStr dataUsingEncoding:NSUTF8StringEncoding]);
 
     __auto_type * csrInfoCopy = [[MTROperationalCSRInfo alloc] initWithCSRElementsTLV:csrInfo.csrElementsTLV
                                                                  attestationSignature:csrInfo.attestationSignature];

--- a/src/darwin/Framework/CHIPTests/MTROperationalCertificateIssuerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTROperationalCertificateIssuerTests.m
@@ -28,7 +28,7 @@ static const uint64_t kDeviceId = 0x12344321;
 static NSString * kOnboardingPayload = @"MT:-24J0AFN00KA0648G00";
 static const uint16_t kLocalPort = 5541;
 static const uint16_t kTestVendorId = 0xFFF1u;
-static NSString * csrNonceStr = @"01234567890123456789012345678901"; // 32 chars
+static NSString * kCSRNonceStr = @"01234567890123456789012345678901"; // 32 chars
 
 // Singleton controller we use.
 static MTRDeviceController * sController = nil;
@@ -55,7 +55,7 @@ static MTRTestKeys * sTestKeys = nil;
     XCTAssertEqual(error.code, 0);
 
     __auto_type * params = [[MTRCommissioningParameters alloc] init];
-    params.csrNonce = [csrNonceStr dataUsingEncoding:NSUTF8StringEncoding];
+    params.csrNonce = [kCSRNonceStr dataUsingEncoding:NSUTF8StringEncoding];
 
     NSError * commissionError = nil;
     [sController commissionNodeWithID:@(kDeviceId)
@@ -101,7 +101,7 @@ static MTRTestKeys * sTestKeys = nil;
     XCTAssertNotNil(attestationInfo);
     XCTAssertEqual(controller, sController);
 
-    XCTAssertEqualObjects(csrInfo.csrNonce, [csrNonceStr dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertEqualObjects(csrInfo.csrNonce, [kCSRNonceStr dataUsingEncoding:NSUTF8StringEncoding]);
 
     __auto_type * csrInfoCopy = [[MTROperationalCSRInfo alloc] initWithCSRElementsTLV:csrInfo.csrElementsTLV
                                                                  attestationSignature:csrInfo.attestationSignature];


### PR DESCRIPTION
The CSR nonce passed via CommissioningParameters was being ignored by AutoCommisssioner, because it was just fetching a random nonce from the OperationalCredentialsDelegate.

This fix makes it possible for an OperationalCredentialsDelegate to indicate that the AutoCommissioner should use whatever nonce was provided via CommissioningParameters, and uses that in MTROperationalCredentialsDelegate, so we don't override the data from MTRCommissioningParameters.

#### Testing

Unit test added.