### PR TITLE
esp32: remove the built artifacts after build completion

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -73,7 +73,7 @@ jobs:
                      /tmp/bloat_reports/
 
             - name: Remove built artifacts for all-clusters
-              run: rm -rf out/esp32-c3devkit-all-clusters
+              run: rm -rf out/esp32-c3devkit-all-clusters examples/all-clusters-app/esp32/managed_components
 
             - name: Prepare code pregen and ensure compile time pregen not possible
               run: |
@@ -101,7 +101,7 @@ jobs:
                   mv scripts/tools/zap/generate.py.renamed scripts/tools/zap/generate.py
 
             - name: Remove built artifacts for all-clusters-minimal
-              run: rm -rf out/esp32-m5stack-all-clusters-minimal
+              run: rm -rf out/esp32-m5stack-all-clusters-minimal examples/all-clusters-minimal-app/esp32/managed_components
 
             - name: Check for changed paths
               uses: dorny/paths-filter@v3
@@ -139,21 +139,30 @@ jobs:
                      "
 
             - name: Remove built artifacts for all-clusters-rpc-ipv6only
-              run: rm -rf out/esp32-devkitc-all-clusters-rpc-ipv6only
+              run: rm -rf out/esp32-devkitc-all-clusters-rpc-ipv6only examples/all-clusters-app/esp32/managed_components
 
             - name: Build example Lighting App (Target:ESP32C6)
-              run: scripts/examples/esp_example.sh lighting-app sdkconfig.wifi_thread.defaults esp32c6
+              run: |
+                scripts/examples/esp_example.sh lighting-app sdkconfig.wifi_thread.defaults esp32c6
+                rm -rf examples/lighting-app/esp32/{build,managed_components}
+              
 
             - name: Build example Lighting App (external platform)
-              run: scripts/examples/esp_example.sh lighting-app sdkconfig.ext_plat.defaults
+              run: |
+                scripts/examples/esp_example.sh lighting-app sdkconfig.ext_plat.defaults
+                rm -rf examples/lighting-app/esp32/{build,managed_components}
 
             - name: Build example Energy Gateway App
               if: steps.changed_paths.outputs.energy_gateway == 'true'
-              run: scripts/examples/esp_example.sh energy-gateway-app sdkconfig.defaults
+              run: |
+                scripts/examples/esp_example.sh energy-gateway-app sdkconfig.defaults
+                rm -rf examples/energy-gateway-app/esp32/{build,managed_components}
 
             - name: Build example Energy Management App
               if: steps.changed_paths.outputs.energy_management == 'true'
-              run: scripts/examples/esp_example.sh energy-management-app sdkconfig.defaults
+              run: |
+                scripts/examples/esp_example.sh energy-management-app sdkconfig.defaults
+                rm -rf examples/energy-management-app/esp32/{build,managed_components}
 
             - name: Uploading Size Reports
               uses: ./.github/actions/upload-size-reports


### PR DESCRIPTION
This is needed as we are running out of space on the runners!

#### Summary

There have been few occurrences of ESP32 example builds running out of space, so cleaning up build artefacts after build completion.

#### Related issues
- https://github.com/project-chip/connectedhomeip/actions/runs/19432527034/job/55594811138
- https://github.com/project-chip/connectedhomeip/actions/runs/19441527101/job/55625717787


#### Testing
- Green CI should be enough