### PR TITLE
Make it easier to configure CodegenIntergration clusters from app code

### DIFF
--- a/examples/network-manager-app/linux/main.cpp
+++ b/examples/network-manager-app/linux/main.cpp
@@ -93,7 +93,8 @@ void ApplicationShutdown()
 int main(int argc, char * argv[])
 {
     VerifyOrReturnValue(ChipLinuxAppInit(argc, argv) == 0, -1);
-    ApplicationEarlyInit();
-    ChipLinuxAppMainLoop();
+    auto & serverInitParams = ChipLinuxDefaultServerInitParams();
+    ApplicationEarlyInit(); // configure clusters before starting server
+    ChipLinuxAppMainLoop(serverInitParams);
     return 0;
 }

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -1023,9 +1023,9 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
     // NOLINTEND(bugprone-signal-handler)
 #endif
 #else
-    struct sigaction sa = {};
-    sa.sa_handler       = StopSignalHandler;
-    sa.sa_flags         = SA_RESETHAND;
+    struct sigaction sa                        = {};
+    sa.sa_handler                              = StopSignalHandler;
+    sa.sa_flags                                = SA_RESETHAND;
     sigaction(SIGINT, &sa, nullptr);
     sigaction(SIGTERM, &sa, nullptr);
 #endif

--- a/examples/platform/linux/AppMain.h
+++ b/examples/platform/linux/AppMain.h
@@ -48,12 +48,34 @@ public:
 };
 
 /**
- * Start up the Linux app and use the provided main loop for event processing.
+ * Get default server initialization parameters for Linux example apps.
  *
- * If no main loop implementation is provided, an equivalent of
- * DefaultAppMainLoopImplementation will be used.
+ * Returns a reference to a static CommonCaseDeviceServerInitParams instance that has been
+ * initialized with default resources, including the CodegenDataModelProvider, which will
+ * have been initialized (but not started).
+ *
+ * This is suitable for most Linux example applications. Apps that need to customize
+ * initialization can create their own ServerInitParams and pass it to ChipLinuxAppMainLoop().
  */
-void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl = nullptr);
+chip::CommonCaseDeviceServerInitParams & ChipLinuxDefaultServerInitParams();
+
+/**
+ * Start up the Linux app, optionally with custom server initialization parameters
+ * and/or main loop implementation.
+ *
+ * This overload allows apps to provide their own ServerInitParams for cases where
+ * custom configuration is needed before server initialization.
+ *
+ * @param initParams Server initialization parameters to use
+ * @param impl Optional main loop implementation
+ */
+void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams = ChipLinuxDefaultServerInitParams(),
+                          AppMainLoopImplementation * impl    = nullptr);
+
+inline void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
+{
+    ChipLinuxAppMainLoop(ChipLinuxDefaultServerInitParams(), impl);
+}
 
 // For extra init calls, the function will be called right before running Matter main loop.
 void ApplicationInit();

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -837,23 +837,4 @@ void Server::ResumeSubscriptions()
 
 Credentials::IgnoreCertificateValidityPeriodPolicy Server::sDefaultCertValidityPolicy;
 
-KvsPersistentStorageDelegate CommonCaseDeviceServerInitParams::sKvsPersistenStorageDelegate;
-PersistentStorageOperationalKeystore CommonCaseDeviceServerInitParams::sPersistentStorageOperationalKeystore;
-Credentials::PersistentStorageOpCertStore CommonCaseDeviceServerInitParams::sPersistentStorageOpCertStore;
-Credentials::GroupDataProviderImpl CommonCaseDeviceServerInitParams::sGroupDataProvider;
-app::DefaultTimerDelegate CommonCaseDeviceServerInitParams::sTimerDelegate;
-app::reporting::ReportSchedulerImpl
-    CommonCaseDeviceServerInitParams::sReportScheduler(&CommonCaseDeviceServerInitParams::sTimerDelegate);
-#if CHIP_CONFIG_ENABLE_SESSION_RESUMPTION
-SimpleSessionResumptionStorage CommonCaseDeviceServerInitParams::sSessionResumptionStorage;
-#endif
-#if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
-app::SimpleSubscriptionResumptionStorage CommonCaseDeviceServerInitParams::sSubscriptionResumptionStorage;
-#endif
-app::DefaultAclStorage CommonCaseDeviceServerInitParams::sAclStorage;
-Crypto::DefaultSessionKeystore CommonCaseDeviceServerInitParams::sSessionKeystore;
-#if CHIP_CONFIG_ENABLE_ICD_CIP
-app::DefaultICDCheckInBackOffStrategy CommonCaseDeviceServerInitParams::sDefaultICDCheckInBackOffStrategy;
-#endif
-
 } // namespace chip

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -108,6 +108,21 @@ protected:
 
     template <class T>
     void EncodeAttributeListIntoTLV(const DataModel::List<T> & aListAttribute, TLV::ScopedBufferTLVReader & outTlvReader);
+
+    void SetUp() override
+    {
+        AppContext::SetUp();
+        mOldProvider =
+            InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
+    }
+    void TearDown() override
+    {
+        InteractionModelEngine::GetInstance()->SetDataModelProvider(mOldProvider);
+        AppContext::TearDown();
+    }
+
+private:
+    chip::app::DataModel::Provider * mOldProvider = nullptr;
 };
 
 // Encodes an attribute of List Data Type into a TLV Reader object for testing WriteClient::PutPreencodedAttribute
@@ -343,7 +358,6 @@ TEST_F(TestWriteChunking, TestListChunking)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -434,7 +448,6 @@ TEST_F(TestWriteChunking, TestListChunking_NonEmptyReplaceAllList)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -538,7 +551,6 @@ TEST_F(TestWriteChunking, TestBadChunking)
     bool atLeastOneRequestFailed = false;
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -621,7 +633,6 @@ TEST_F(TestWriteChunking, TestBadChunking_NonEmptyReplaceAllList)
     bool atLeastOneRequestFailed = false;
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -706,7 +717,6 @@ TEST_F(TestWriteChunking, TestConflictWrite)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -781,7 +791,6 @@ TEST_F(TestWriteChunking, TestConflictWrite_NonEmptyReplaceAllList)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -865,7 +874,6 @@ TEST_F(TestWriteChunking, TestNonConflictWrite)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -929,7 +937,6 @@ TEST_F(TestWriteChunking, TestNonConflictWrite_NonEmptyReplaceAllList)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -1114,7 +1121,6 @@ void TestWriteChunking::RunTest(Instructions instructions, EncodingMethod encodi
 TEST_F(TestWriteChunking, TestTransactionalList)
 {
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -1370,7 +1376,6 @@ void TestWriteChunking::RunTest_NonEmptyReplaceAll(Instructions instructions,
 TEST_F(TestWriteChunking, TestTransactionalList_NonEmptyReplaceAllList)
 {
     // Initialize the ember side server logic.
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.h
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.h
@@ -42,7 +42,7 @@ namespace app {
 ///
 /// Given that this relies on global data at link time, there generally can be
 /// only one CodegenDataModelProvider per application. Per-cluster CodegenIntegration
-/// function access the global singleton instance via `CodegenDataModelProvider::Instance()`.
+/// functions access the global singleton instance via `CodegenDataModelProvider::Instance()`.
 class CodegenDataModelProvider : public DataModel::Provider
 {
 public:

--- a/src/data-model-providers/codegen/Instance.cpp
+++ b/src/data-model-providers/codegen/Instance.cpp
@@ -27,7 +27,7 @@ CodegenDataModelProvider & CodegenDataModelProvider::Instance()
     return gCodegenModel;
 }
 
-DataModel::Provider * CodegenDataModelProviderInstance(PersistentStorageDelegate * delegate)
+CodegenDataModelProvider * CodegenDataModelProviderInstance(PersistentStorageDelegate * delegate)
 {
     auto instance = &CodegenDataModelProvider::Instance();
 

--- a/src/data-model-providers/codegen/Instance.h
+++ b/src/data-model-providers/codegen/Instance.h
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include <app/data-model-provider/Provider.h>
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 
 namespace chip {
@@ -29,7 +29,7 @@ namespace app {
 ///                   in case default ember storage is required. Applications can also
 ///                   call SetAttributeStorageProvider themselves and provide nullptr here
 ///                   if required.
-DataModel::Provider * CodegenDataModelProviderInstance(PersistentStorageDelegate * delegate);
+CodegenDataModelProvider * CodegenDataModelProviderInstance(PersistentStorageDelegate * delegate);
 
 } // namespace app
 } // namespace chip

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -198,6 +198,10 @@ public:
     const TestProviderChangeListener & ChangeListener() const { return mChangeListener; }
 
 private:
+    // Test cases that explicitly manage the provider should not use this sub-class
+    using CodegenDataModelProvider::SetPersistentStorageDelegate;
+    using CodegenDataModelProvider::Startup;
+
     LogOnlyEvents mEventGenerator;
     TestProviderChangeListener mChangeListener;
     TestActionContext mActionContext;
@@ -2179,7 +2183,7 @@ TEST_F(TestCodegenModelViaMocks, AttributeAccessInterfaceTakesPrecedenceOverServ
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);
@@ -2233,7 +2237,7 @@ TEST_F(TestCodegenModelViaMocks, AAISkippedIfNoEmberMetadata)
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);
@@ -2746,7 +2750,7 @@ TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesWrite)
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);
@@ -2788,7 +2792,7 @@ TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesRead)
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);
@@ -2816,7 +2820,7 @@ TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesRegistration)
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);
@@ -2940,7 +2944,7 @@ TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesListClusters)
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);


### PR DESCRIPTION
#### Summary

The main change here is to make CodegenDataModelProvider have an Init() method that's distinct from Startup() (which is called from Server::Init()). After Init(), codegen-integration clusters will have been created but not started, making it straightforward for application code to obtain references to cluster instances and doing things like setting a delegate. Startup() will call Init() if necessary, so calling it up-front is optional.

Linux AppMain.h now exposes ChipLinuxDefaultServerInitParams() which creates the Server dependencies including the initialized (but not started) codegen data model provider, and add an ChipLinuxAppMainLoop() overload that takes ServerInitParams.

Also make the resources held by CommonCaseDeviceServerInitParams non-static members; this makes the class behave sanely if more than one instance is created, e.g. in a test. It also removes those static data members from Server.cpp. In all in-tree usages, the CommonCaseDeviceServerInitParams instance itself is already static anyway, so this doesn't change the lifetime of the resources.

#### Testing

Existing tests exercise all of this code.