### PR TITLE
ESP32: use idf version compatible API for custom gatt indication

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -615,11 +615,14 @@ CHIP_ERROR BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const Chi
         ExitNow();
     }
 
+#if ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 0, 0)
+    err = MapBLEError(ble_gattc_indicate_custom(conId, mTXCharCCCDAttrHandle, om));
+#else
     err = MapBLEError(ble_gatts_indicate_custom(conId, mTXCharCCCDAttrHandle, om));
+#endif
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "ble_gatts_indicate_custom() failed: %" CHIP_ERROR_FORMAT, err.Format());
-        ExitNow();
+        ChipLogError(DeviceLayer, "ble gatt indicate custom failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:


### PR DESCRIPTION
#### Summary
- Build fails on  esp-idf > v5.0 [`idf.py build`]
```
../../../../../../config/esp32/third_party/connectedhomeip/src/platform/ESP32/nimble/BLEManagerImpl.cpp:618:23: error: 'ble_gatts_indicate_custom' was not declared in this scope; did you mean 'ble_gattc_indicate_custom'?
  618 |     err = MapBLEError(ble_gatts_indicate_custom(conId, mTXCharCCCDAttrHandle, om));
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~
      |                       ble_gattc_indicate_custom
../../../../../../config/esp32/third_party/connectedhomeip/src/platform/ESP32/nimble/BLEManagerImpl.cpp:618:23: note: maximum limit of 1000 namespaces searched for 'ble_gatts_indicate_custom'
```

https://github.com/project-chip/connectedhomeip/pull/41741 changed `ble_gattc_indicate_custom()` to `ble_gatts_indicate_custom()`.

But the new API, `ble_gatts_indicate_custom()` was introduced in esp-idf v5.0.1.

So, use the appropriate API as per esp-idf version.

#### Testing

- Locally built [`idf.py build`] the lighting-app/esp32 with esp-idf v5.0 and build was successful.