### PR TITLE
Enforce best practices when using async in Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ exclude = [
 select = [
     # Standard errors and warnings
     "E", "W", "F",
+    # Ensure that async is used properly
+    "ASYNC",
     # Consistent commas
     "COM",
     # Simplify the code if possible
@@ -40,6 +42,8 @@ select = [
     "SLOT",
 ]
 ignore = [
+    "ASYNC109", # Sometimes we use "timeout" argument in async functions
+    "ASYNC230", # Allow open() calls in async functions
     "COM812", # Do not enforce trailing commas in multi-line collections for now
     "LOG015", # Do not enforce non-root loggers in the entire codebase for now
     "E501", # Do not report line length issues (formatter should handle this)

--- a/scripts/py_matter_yamltests/matter/yamltests/pseudo_clusters/clusters/delay_commands.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/pseudo_clusters/clusters/delay_commands.py
@@ -13,8 +13,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import asyncio
 import sys
-import time
 
 from ..pseudo_cluster import PseudoCluster
 from .accessory_server_bridge import AccessoryServerBridge
@@ -59,7 +59,7 @@ class DelayCommands(PseudoCluster):
                 duration_in_ms = argument['value']
 
         sys.stdout.flush()
-        time.sleep(int(duration_in_ms) / 1000)
+        await asyncio.sleep(int(duration_in_ms) / 1000)
 
     async def WaitForMessage(self, request):
         AccessoryServerBridge.waitForMessage(request)

--- a/scripts/py_matter_yamltests/matter/yamltests/websocket_runner.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/websocket_runner.py
@@ -108,7 +108,7 @@ class WebSocketRunner(TestRunner):
         if command:
             start_time = time.time()
 
-            instance = subprocess.Popen(
+            instance = subprocess.Popen(    # noqa: ASYNC220
                 command,
                 bufsize=0,                  # unbuffered
                 text=False,                 # keep output as bytes

--- a/scripts/py_matter_yamltests/matter/yamltests/websocket_runner.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/websocket_runner.py
@@ -13,6 +13,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import asyncio
 import logging
 import re
 import select
@@ -92,7 +93,7 @@ class WebSocketRunner(TestRunner):
                 duration = round((time.time() - start) * 1000, 0)
                 self._hooks.failure(duration)
                 self._hooks.retry(interval_between_retries)
-                time.sleep(interval_between_retries)
+                await asyncio.sleep(interval_between_retries)
                 return await self._start_client(url, max_retries - 1, interval_between_retries + 1)
 
         self._hooks.abort(url)

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -1108,10 +1108,9 @@ class ChipDeviceControllerBase():
                     self.devCtrl, int(filterType), str(filter).encode("utf-8")))
 
             async def _wait_discovery():
-                while not await self._ChipStack.CallAsyncWithResult(
+                while not await self._ChipStack.CallAsyncWithResult(  # noqa: ASYNC110
                         lambda: self._dmLib.pychip_DeviceController_HasDiscoveredCommissionableNode(self.devCtrl)):
                     await asyncio.sleep(0.1)
-                return
 
             try:
                 if stopOnFirst:

--- a/src/controller/python/matter/ChipStack.py
+++ b/src/controller/python/matter/ChipStack.py
@@ -120,6 +120,11 @@ class AsyncioCallableHandle:
         return self._future
 
     def _done(self):
+        if self._future.cancelled():
+            # If this helper is used with the asyncio.wait_for(), it might
+            # happen that the future will be cancelled before the callback
+            # is called. Do not raise an exception in this case.
+            return
         if self._exception:
             self._future.set_exception(self._exception)
         else:

--- a/src/controller/python/tests/scripts/base.py
+++ b/src/controller/python/tests/scripts/base.py
@@ -1458,7 +1458,7 @@ class BaseTestHelper:
             restartRemoteThread.start()
 
             # Wait for some time so that the device will be resolving the address of the first controller after restarting
-            time.sleep(8)
+            await asyncio.sleep(8)
             restartRemoteThread.join(10.0)
 
             self.logger.info("Send a new subscription request from the second controller")

--- a/src/python_testing/TC_ACL_2_10.py
+++ b/src/python_testing/TC_ACL_2_10.py
@@ -32,10 +32,9 @@
 #       --endpoint 0
 # === END CI TEST ARGUMENTS ===
 
-
+import asyncio
 import logging
 import random
-import time
 
 from mobly import asserts
 
@@ -247,7 +246,7 @@ class TC_ACL_2_10(MatterBaseTest):
 
                 # The test runner will automatically wait for the app-ready-pattern before continuing
                 # Waiting 1 second after the app-ready-pattern is detected as we need to wait a tad longer for the app to be ready and stable, otherwise TH2 connection fails later on in test step 14.
-                time.sleep(1)
+                await asyncio.sleep(1)
 
                 # Expire sessions and re-establish connections
                 self.th1.ExpireSessions(self.dut_node_id)

--- a/src/python_testing/TC_CADMIN_1_11.py
+++ b/src/python_testing/TC_CADMIN_1_11.py
@@ -31,10 +31,9 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-
+import asyncio
 import logging
 import random
-from time import sleep
 
 from mobly import asserts
 from support_modules.cadmin_support import CADMINBaseTest
@@ -144,7 +143,7 @@ class TC_CADMIN_1_11(CADMINBaseTest):
         revokeCmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
         await self.th1.SendCommand(nodeId=self.dut_node_id, endpoint=0, payload=revokeCmd, timedRequestTimeoutMs=6000)
         # The failsafe cleanup is scheduled after the command completes, so give it a bit of time to do that
-        sleep(1)
+        await asyncio.sleep(1)
 
         self.step(9)
 
@@ -178,7 +177,7 @@ class TC_CADMIN_1_11(CADMINBaseTest):
             revokeCmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
             await self.th1.SendCommand(nodeId=self.dut_node_id, endpoint=0, payload=revokeCmd, timedRequestTimeoutMs=6000)
             # The failsafe cleanup is scheduled after the command completes, so give it a bit of time to do that
-            sleep(1)
+            await asyncio.sleep(1)
 
         else:
             self.skip_step("9a")

--- a/src/python_testing/TC_CADMIN_1_3_4.py
+++ b/src/python_testing/TC_CADMIN_1_3_4.py
@@ -44,9 +44,9 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 import random
-from time import sleep
 
 from mobly import asserts
 from support_modules.cadmin_support import CADMINBaseTest
@@ -221,7 +221,7 @@ class TC_CADMIN(CADMINBaseTest):
             revokeCmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
             await self.th1.SendCommand(nodeId=self.dut_node_id, endpoint=0, payload=revokeCmd, timedRequestTimeoutMs=6000)
             # The failsafe cleanup is scheduled after the command completes, so give it a bit of time to do that
-            sleep(1)
+            await asyncio.sleep(1)
 
         if commission_type == "ECM":
             self.step(13)

--- a/src/python_testing/TC_CADMIN_1_5.py
+++ b/src/python_testing/TC_CADMIN_1_5.py
@@ -31,9 +31,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import asyncio.exceptions as ae
+import asyncio
 import logging
-from time import sleep
 
 from mobly import asserts
 from support_modules.cadmin_support import CADMINBaseTest
@@ -63,7 +62,7 @@ class TC_CADMIN_1_5(CADMINBaseTest):
                     nodeId=self.dut_node_id, setupPinCode=setup_code,
                     filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=discriminator)
 
-            except ae.CancelledError:
+            except asyncio.CancelledError:
                 # This is expected to fail due to timeout, however there is no code to validate here, so just passing since the correct exception was raised to get to this point
                 pass
 
@@ -104,6 +103,10 @@ class TC_CADMIN_1_5(CADMINBaseTest):
     def pics_TC_CADMIN_1_5(self) -> list[str]:
         return ["CADMIN.S"]
 
+    @property
+    def default_timeout(self) -> int:
+        return 5 * 60  # 5 minutes
+
     @async_test_body
     async def test_TC_CADMIN_1_5(self):
         self.step(1)
@@ -125,7 +128,7 @@ class TC_CADMIN_1_5(CADMINBaseTest):
             expected_discriminator=params.randomDiscriminator
         )
         logging.info(f"Successfully found service with CM={service.txt.get('CM')}, D={service.txt.get('D')}")
-        sleep(190)
+        await asyncio.sleep(190)
 
         self.step(4)
         await self.commission_on_network(setup_code=params.commissioningParameters.setupPinCode, discriminator=params.randomDiscriminator)
@@ -136,7 +139,7 @@ class TC_CADMIN_1_5(CADMINBaseTest):
         self.step(6)
         revokeCmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
         await self.th1.SendCommand(nodeId=self.dut_node_id, endpoint=0, payload=revokeCmd, timedRequestTimeoutMs=6000)
-        sleep(1)
+        await asyncio.sleep(1)
 
         self.step(7)
         await self.commission_on_network(setup_code=params2.commissioningParameters.setupPinCode, discriminator=params2.randomDiscriminator, expected_error=0x00000032)

--- a/src/python_testing/TC_CADMIN_1_9.py
+++ b/src/python_testing/TC_CADMIN_1_9.py
@@ -31,9 +31,9 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 from copy import deepcopy
-from time import sleep
 
 from mobly import asserts
 from support_modules.cadmin_support import CADMINBaseTest
@@ -127,7 +127,7 @@ class TC_CADMIN_1_9(CADMINBaseTest):
         revokeCmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
         await self.th1.SendCommand(nodeId=self.dut_node_id, endpoint=0, payload=revokeCmd, timedRequestTimeoutMs=6000)
         # The failsafe cleanup is scheduled after the command completes, so give it a bit of time to do that
-        sleep(1)
+        await asyncio.sleep(1)
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -57,6 +57,7 @@
 
 # This test requires a TH_SERVER application. Please specify with --string-arg th_server_app_path:<path_to_app>
 
+import asyncio
 import logging
 import os
 import random
@@ -288,7 +289,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
         self.step(19)
         logging.info("Test now waits for 30 seconds")
         if not self.is_pics_sdk_ci_only:
-            time.sleep(30)
+            await asyncio.sleep(30)
 
         self.step(20)
         print(f'server node id {self.server_nodeid}')
@@ -341,7 +342,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
         previous_number_th_server_fabrics = len(th_server_fabrics_new)
 
         while time_remaining > 0:
-            time.sleep(2)
+            await asyncio.sleep(2)
             th_server_fabrics_new = await self.read_single_attribute_check_success(cluster=Clusters.OperationalCredentials, attribute=Clusters.OperationalCredentials.Attributes.Fabrics, dev_ctrl=self.TH_server_controller, node_id=self.server_nodeid, endpoint=0, fabric_filtered=False)
             if previous_number_th_server_fabrics != len(th_server_fabrics_new):
                 break

--- a/src/python_testing/TC_CCTRL_2_3.py
+++ b/src/python_testing/TC_CCTRL_2_3.py
@@ -57,6 +57,7 @@
 
 # This test requires a TH_SERVER application. Please specify with --string-arg th_server_app_path:<path_to_app>
 
+import asyncio
 import logging
 import os
 import random
@@ -221,7 +222,7 @@ class TC_CCTRL_2_3(MatterBaseTest):
 
         th_server_fabrics_new = None
         while time_remaining > 0:
-            time.sleep(2)
+            await asyncio.sleep(2)
             th_server_fabrics_new = await self.read_single_attribute_check_success(cluster=Clusters.OperationalCredentials, attribute=Clusters.OperationalCredentials.Attributes.Fabrics, dev_ctrl=self.TH_server_controller, node_id=self.server_nodeid, endpoint=0, fabric_filtered=False)
             if previous_number_th_server_fabrics != len(th_server_fabrics_new):
                 break

--- a/src/python_testing/TC_CC_2_2.py
+++ b/src/python_testing/TC_CC_2_2.py
@@ -36,8 +36,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 from test_plan_support import commission_if_required, read_attribute, verify_success
@@ -168,10 +168,10 @@ class TC_CC_2_3(MatterBaseTest):
         sub_handler = AttributeSubscriptionHandler(expected_cluster=cc)
         await sub_handler.start(self.default_controller, self.dut_node_id, self.matter_test_config.endpoint)
 
-        def accumulate_reports():
+        async def accumulate_reports():
             sub_handler.reset()
             logging.info(f"Test will now wait {gather_time} seconds to accumulate reports")
-            time.sleep(gather_time)
+            await asyncio.sleep(gather_time)
 
         def check_report_counts(attr: ClusterObjects.ClusterAttributeDescriptor):
             count = sub_handler.attribute_report_counts[attr]
@@ -198,7 +198,7 @@ class TC_CC_2_3(MatterBaseTest):
             await self.send_single_cmd(cmd)
 
             self.step(11)
-            accumulate_reports()
+            await accumulate_reports()
 
             self.step(12)
             check_report_counts(cc.Attributes.ColorTemperatureMireds)
@@ -227,7 +227,7 @@ class TC_CC_2_3(MatterBaseTest):
             await self.send_single_cmd(cmd)
 
             self.step(17)
-            accumulate_reports()
+            await accumulate_reports()
 
             self.step(18)
             check_report_counts(cc.Attributes.CurrentHue)
@@ -237,7 +237,7 @@ class TC_CC_2_3(MatterBaseTest):
             await self.send_single_cmd(cmd)
 
             self.step(20)
-            accumulate_reports()
+            await accumulate_reports()
 
             self.step(21)
             check_report_counts(cc.Attributes.CurrentSaturation)
@@ -260,7 +260,7 @@ class TC_CC_2_3(MatterBaseTest):
             await self.send_single_cmd(cmd)
 
             self.step(25)
-            accumulate_reports()
+            await accumulate_reports()
 
             self.step(26)
             # reports for x and y are both accumulated in a dict - done above
@@ -283,7 +283,7 @@ class TC_CC_2_3(MatterBaseTest):
             await self.send_single_cmd(cmd)
 
             self.step(31)
-            accumulate_reports()
+            await accumulate_reports()
 
             self.step(32)
             check_report_counts(cc.Attributes.EnhancedCurrentHue)
@@ -298,7 +298,7 @@ class TC_CC_2_3(MatterBaseTest):
         await self.send_single_cmd(cmd)
 
         self.step(35)
-        accumulate_reports()
+        await accumulate_reports()
 
         self.step(36)
         cmd = cc.Commands.MoveToColorTemperature(colorTemperatureMireds=colorTempPhysicalMaxMireds/2, transitionTime=100)
@@ -306,7 +306,7 @@ class TC_CC_2_3(MatterBaseTest):
 
         self.step(37)
         logging.info("Test will now wait for 5 seconds")
-        time.sleep(5)
+        await asyncio.sleep(5)
 
         self.step(38)
         cmd = cc.Commands.MoveToColorTemperature(colorTemperatureMireds=colorTempPhysicalMaxMireds, transitionTime=150)
@@ -314,7 +314,7 @@ class TC_CC_2_3(MatterBaseTest):
 
         self.step(39)
         logging.info("Test will now wait for 20 seconds")
-        time.sleep(20)
+        await asyncio.sleep(20)
 
         self.step(40)
         logging.info(f'received reports: {sub_handler.attribute_reports[cc.Attributes.RemainingTime]}')

--- a/src/python_testing/TC_CGEN_2_4.py
+++ b/src/python_testing/TC_CGEN_2_4.py
@@ -34,9 +34,9 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 import random
-import time
 
 from mobly import asserts
 
@@ -94,7 +94,7 @@ class TC_CGEN_2_4(MatterBaseTest):
         revokeCmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
         await self.th1.SendCommand(nodeId=self.dut_node_id, endpoint=0, payload=revokeCmd, timedRequestTimeoutMs=6000)
         # The failsafe cleanup is scheduled after the command completes, so give it a bit of time to do that
-        time.sleep(1)
+        await asyncio.sleep(1)
 
     @async_test_body
     async def test_TC_CGEN_2_4(self):

--- a/src/python_testing/TC_CLCTRL_4_1.py
+++ b/src/python_testing/TC_CLCTRL_4_1.py
@@ -34,8 +34,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 
@@ -1021,7 +1021,7 @@ class TC_CLCTRL_4_1(MatterBaseTest):
             # STEP 15d: Wait 2 seconds and TH reads from the DUT the OverallCurrentState.Position = FullyOpened.
             self.step("15d")
 
-            time.sleep(2)
+            await asyncio.sleep(2)
 
             overall_current_state = await self.read_clctrl_attribute_expect_success(endpoint, attributes.OverallCurrentState)
             logging.info(f"OverallCurrentState: {overall_current_state}")
@@ -1064,7 +1064,7 @@ class TC_CLCTRL_4_1(MatterBaseTest):
             # STEP 15h: Wait 2 seconds and TH reads from the DUT the OverallCurrentState.Position = FullyClosed.
             self.step("15h")
 
-            time.sleep(2)
+            await asyncio.sleep(2)
             overall_current_state = await self.read_clctrl_attribute_expect_success(endpoint, attributes.OverallCurrentState)
             logging.info(f"OverallCurrentState: {overall_current_state}")
 

--- a/src/python_testing/TC_CLCTRL_6_1.py
+++ b/src/python_testing/TC_CLCTRL_6_1.py
@@ -34,8 +34,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 
@@ -766,7 +766,7 @@ class TC_CLCTRL_6_1(MatterBaseTest):
             # STEP 9k: TH sends command MoveTo with Position = MoveToFullyOpen.
             self.step("9k")
 
-            time.sleep(2)  # Adding a small delay to ensure the previous command is processed
+            await asyncio.sleep(2)  # Adding a small delay to ensure the previous command is processed
             try:
                 await self.send_single_cmd(cmd=Clusters.ClosureControl.Commands.MoveTo(
                     position=Clusters.ClosureControl.Enums.TargetPositionEnum.kMoveToFullyOpen,

--- a/src/python_testing/TC_DA_1_9.py
+++ b/src/python_testing/TC_DA_1_9.py
@@ -44,9 +44,9 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import os
 import signal
-import subprocess
 
 from mobly import asserts
 
@@ -187,7 +187,8 @@ class TC_DA_1_9(MatterBaseTest):
             self.step(idx + 1)
 
             # Clean up any existing KVS files
-            subprocess.call("rm -f all-clusters-kvs*", shell=True)
+            proc = await asyncio.create_subprocess_shell("rm -f all-clusters-kvs*")
+            await proc.wait()
 
             # Create log files for this test case
             log_path = os.path.join(self.matter_test_config.logs_path, 'TC_DA_1_9')
@@ -205,10 +206,9 @@ class TC_DA_1_9(MatterBaseTest):
                     discriminator = test_case['discriminator']
                     app_args += f' --discriminator {discriminator}'
 
-                app_cmd = f"{self.app_path} {app_args}"
-
                 # Run the all-clusters-app in background
-                app_process = subprocess.Popen(app_cmd.split(), stdout=app_log_file, stderr=app_log_file)
+                app_process = await asyncio.create_subprocess_exec(self.app_path, *app_args.split(),
+                                                                   stdout=app_log_file, stderr=app_log_file)
 
                 revocation_set = os.path.join(self.revocation_set_base_path, test_case['revocation_set'])
                 # Prompt user with instructions
@@ -238,7 +238,7 @@ class TC_DA_1_9(MatterBaseTest):
                 commissioning_success = resp.lower() == 'y'
 
                 app_process.send_signal(signal.SIGTERM.value)
-                app_process.wait()
+                await app_process.wait()
 
                 # Verify results
                 asserts.assert_equal(

--- a/src/python_testing/TC_DEM_2_10.py
+++ b/src/python_testing/TC_DEM_2_10.py
@@ -43,10 +43,9 @@
 
 """Define Matter test case TC_DEM_2_10."""
 
-
+import asyncio
 import logging
 import sys
-import time
 
 from mobly import asserts
 from TC_DEMTestBase import DEMTestBase
@@ -167,9 +166,9 @@ class TC_DEM_2_10(MatterBaseTest, DEMTestBase):
                                 min_interval_sec=0,
                                 max_interval_sec=10, keepSubscriptions=False)
 
-        def accumulate_reports(wait_time):
+        async def accumulate_reports(wait_time):
             logging.info(f"Test will now wait {wait_time} seconds to accumulate reports")
-            time.sleep(wait_time)
+            await asyncio.sleep(wait_time)
 
         self.step("5")
         await self.send_test_event_trigger_user_opt_out_clear_all()
@@ -199,7 +198,7 @@ class TC_DEM_2_10(MatterBaseTest, DEMTestBase):
             self.step("8")
             wait = 12  # Wait 12 seconds - the spec says we should only get reports every 10s at most, unless a command changes it
             sub_handler.reset()
-            accumulate_reports(wait)
+            await accumulate_reports(wait)
 
             self.step("9")
             count = sub_handler.attribute_report_counts[Clusters.DeviceEnergyManagement.Attributes.Forecast]
@@ -229,7 +228,7 @@ class TC_DEM_2_10(MatterBaseTest, DEMTestBase):
 
             self.step("13")
             wait = 5  # We expect a change to the forecast attribute after the cancel, Wait 5 seconds - allow time for the report to come in
-            accumulate_reports(wait)
+            await accumulate_reports(wait)
 
             self.step("13a")
             count = sub_handler.attribute_report_counts[Clusters.DeviceEnergyManagement.Attributes.Forecast]
@@ -281,7 +280,7 @@ class TC_DEM_2_10(MatterBaseTest, DEMTestBase):
 
             self.step("18")
             wait = 12  # Wait 12 seconds - the spec says we should only get reports every 10s at most, unless a command changes it
-            accumulate_reports(wait)
+            await accumulate_reports(wait)
 
             self.step("18a")
             count = sub_handler.attribute_report_counts[Clusters.DeviceEnergyManagement.Attributes.PowerAdjustmentCapability]
@@ -294,7 +293,7 @@ class TC_DEM_2_10(MatterBaseTest, DEMTestBase):
 
             self.step("20")
             wait = 5  # We expect a change to the forecast attribute after the cancel, Wait 5 seconds - allow time for the report to come in
-            accumulate_reports(wait)
+            await accumulate_reports(wait)
 
             self.step("20a")
             count = sub_handler.attribute_report_counts[Clusters.DeviceEnergyManagement.Attributes.PowerAdjustmentCapability]

--- a/src/python_testing/TC_DEM_2_2.py
+++ b/src/python_testing/TC_DEM_2_2.py
@@ -44,11 +44,10 @@
 
 """Define Matter test case TC_DEM_2_2."""
 
-
+import asyncio
 import datetime
 import logging
 import sys
-import time
 
 from mobly import asserts
 from TC_DEMTestBase import DEMTestBase
@@ -365,7 +364,7 @@ class TC_DEM_2_2(MatterBaseTest, DEMTestBase):
                              Clusters.DeviceEnergyManagement.Enums.PowerAdjustReasonEnum.kLocalOptimizationAdjustment)
 
         self.step("20")
-        time.sleep(10)
+        await asyncio.sleep(10)
 
         # Allow a little tolerance checking the duration returned in the event as CI tests can run "slower"
         event_data = events_callback.wait_for_event_report(Clusters.DeviceEnergyManagement.Events.PowerAdjustEnd)

--- a/src/python_testing/TC_DEM_2_4.py
+++ b/src/python_testing/TC_DEM_2_4.py
@@ -41,8 +41,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 from TC_DEMTestBase import DEMTestBase
@@ -353,7 +353,7 @@ class TC_DEM_2_4(MatterBaseTest, DEMTestBase):
 
         self.step("18")
         logging.info(f"Sleeping for forecast.slots[0].minPauseDuration {forecast.slots[0].minPauseDuration}s")
-        time.sleep(forecast.slots[0].minPauseDuration)
+        await asyncio.sleep(forecast.slots[0].minPauseDuration)
         event_data = events_callback.wait_for_event_report(Clusters.DeviceEnergyManagement.Events.Resumed)
         asserts.assert_equal(event_data.cause, Clusters.DeviceEnergyManagement.Enums.CauseEnum.kNormalCompletion)
 

--- a/src/python_testing/TC_EEM_2_2.py
+++ b/src/python_testing/TC_EEM_2_2.py
@@ -39,7 +39,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import time
+import asyncio
 
 from mobly import asserts
 from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
@@ -88,13 +88,13 @@ class TC_EEM_2_2(MatterBaseTest, EnergyReportingBaseTestHelper):
         await self.send_test_event_trigger_start_fake_1kw_load_2s()
 
         self.step("4")
-        time.sleep(3)
+        await asyncio.sleep(3)
 
         self.step("4a")
         cumulative_energy_imported = await self.read_eem_attribute_expect_success("CumulativeEnergyImported")
 
         self.step("5")
-        time.sleep(3)
+        await asyncio.sleep(3)
 
         self.step("5a")
         cumulative_energy_imported_2 = await self.read_eem_attribute_expect_success("CumulativeEnergyImported")

--- a/src/python_testing/TC_EEM_2_3.py
+++ b/src/python_testing/TC_EEM_2_3.py
@@ -39,7 +39,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import time
+import asyncio
 
 from mobly import asserts
 from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
@@ -88,13 +88,13 @@ class TC_EEM_2_3(MatterBaseTest, EnergyReportingBaseTestHelper):
         await self.send_test_event_trigger_start_fake_3kw_generator_5s()
 
         self.step("4")
-        time.sleep(6)
+        await asyncio.sleep(6)
 
         self.step("4a")
         cumulative_energy_exported = await self.read_eem_attribute_expect_success("CumulativeEnergyExported")
 
         self.step("5")
-        time.sleep(6)
+        await asyncio.sleep(6)
 
         self.step("5a")
         cumulative_energy_exported_2 = await self.read_eem_attribute_expect_success("CumulativeEnergyExported")

--- a/src/python_testing/TC_EEM_2_4.py
+++ b/src/python_testing/TC_EEM_2_4.py
@@ -39,7 +39,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import time
+import asyncio
 
 from mobly import asserts
 from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
@@ -88,13 +88,13 @@ class TC_EEM_2_4(MatterBaseTest, EnergyReportingBaseTestHelper):
         await self.send_test_event_trigger_start_fake_1kw_load_2s()
 
         self.step("4")
-        time.sleep(3)
+        await asyncio.sleep(3)
 
         self.step("4a")
         periodic_energy_imported = await self.read_eem_attribute_expect_success("PeriodicEnergyImported")
 
         self.step("5")
-        time.sleep(3)
+        await asyncio.sleep(3)
 
         self.step("5a")
         periodic_energy_imported_2 = await self.read_eem_attribute_expect_success("PeriodicEnergyImported")

--- a/src/python_testing/TC_EEM_2_5.py
+++ b/src/python_testing/TC_EEM_2_5.py
@@ -39,7 +39,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import time
+import asyncio
 
 from mobly import asserts
 from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
@@ -88,13 +88,13 @@ class TC_EEM_2_5(MatterBaseTest, EnergyReportingBaseTestHelper):
         await self.send_test_event_trigger_start_fake_3kw_generator_5s()
 
         self.step("4")
-        time.sleep(6)
+        await asyncio.sleep(6)
 
         self.step("4a")
         periodic_energy_exported = await self.read_eem_attribute_expect_success("PeriodicEnergyExported")
 
         self.step("5")
-        time.sleep(6)
+        await asyncio.sleep(6)
 
         self.step("5a")
         periodic_energy_exported_2 = await self.read_eem_attribute_expect_success("PeriodicEnergyExported")

--- a/src/python_testing/TC_EEVSE_2_10.py
+++ b/src/python_testing/TC_EEVSE_2_10.py
@@ -40,8 +40,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 from datetime import datetime, timedelta, timezone
 
 from mobly import asserts
@@ -325,7 +325,7 @@ class TC_EEVSE_2_10(MatterBaseTest, EEVSEBaseTestHelper):
         self.step("9")
         # Wait 7 seconds
         logger.info("Waiting for 7 seconds for discharge timer to expire")
-        time.sleep(7)
+        await asyncio.sleep(7)
 
         self.step("9a")
         # TH reads from the DUT the SupplyState
@@ -361,7 +361,7 @@ class TC_EEVSE_2_10(MatterBaseTest, EEVSEBaseTestHelper):
         self.step("10")
         # Wait 10 seconds
         logger.info("Waiting for 10 seconds for charging timer to expire")
-        time.sleep(10)
+        await asyncio.sleep(10)
 
         self.step("10a")
         # TH reads from the DUT the SupplyState

--- a/src/python_testing/TC_EEVSE_2_2.py
+++ b/src/python_testing/TC_EEVSE_2_2.py
@@ -40,8 +40,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 from datetime import datetime, timedelta, timezone
 
 from mobly import asserts
@@ -183,7 +183,7 @@ class TC_EEVSE_2_2(MatterBaseTest, EEVSEBaseTestHelper):
         await self.send_test_event_trigger_basic()
 
         # After a few seconds...
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.step("3a")
         await self.check_evse_attribute("State", Clusters.EnergyEvse.Enums.StateEnum.kNotPluggedIn)
@@ -248,7 +248,7 @@ class TC_EEVSE_2_2(MatterBaseTest, EEVSEBaseTestHelper):
 
         self.step("7")
         # Sleep for the charging duration plus a couple of seconds to check it has stopped
-        time.sleep(charging_duration + 2)
+        await asyncio.sleep(charging_duration + 2)
         # check EnergyTransferredStoped (EvseStopped)
         event_data = events_callback.wait_for_event_report(
             Clusters.EnergyEvse.Events.EnergyTransferStopped)
@@ -301,7 +301,7 @@ class TC_EEVSE_2_2(MatterBaseTest, EEVSEBaseTestHelper):
             await self.write_user_max_charge(1, user_max_charge_current)
 
             self.step("9a")
-            time.sleep(3)
+            await asyncio.sleep(3)
 
             expected_max_charge = min(
                 user_max_charge_current, circuit_capacity)

--- a/src/python_testing/TC_EEVSE_2_4.py
+++ b/src/python_testing/TC_EEVSE_2_4.py
@@ -40,8 +40,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from TC_EEVSE_Utils import EEVSEBaseTestHelper
 
@@ -138,7 +138,7 @@ class TC_EEVSE_2_4(MatterBaseTest, EEVSEBaseTestHelper):
         await self.send_test_event_trigger_basic()
 
         # After a few seconds...
-        time.sleep(3)
+        await asyncio.sleep(3)
 
         self.step("3a")
         await self.check_evse_attribute("State", Clusters.EnergyEvse.Enums.StateEnum.kNotPluggedIn)

--- a/src/python_testing/TC_EEVSE_2_6.py
+++ b/src/python_testing/TC_EEVSE_2_6.py
@@ -40,8 +40,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 from TC_EEVSE_Utils import EEVSEBaseTestHelper
@@ -162,9 +162,9 @@ class TC_EEVSE_2_6(MatterBaseTest, EEVSEBaseTestHelper):
                                 min_interval_sec=0,
                                 max_interval_sec=10, keepSubscriptions=True)
 
-        def accumulate_reports(wait_time):
+        async def accumulate_reports(wait_time):
             logging.info(f"Test will now wait {wait_time} seconds to accumulate reports")
-            time.sleep(wait_time)
+            await asyncio.sleep(wait_time)
 
         self.step("6")
         await self.send_test_event_trigger_basic()
@@ -193,7 +193,7 @@ class TC_EEVSE_2_6(MatterBaseTest, EEVSEBaseTestHelper):
         self.step("10")
         wait = 12  # Wait 12 seconds - the spec says we should only get reports every 10s at most, unless a command changes it
         sub_handler.reset()
-        accumulate_reports(wait)
+        await accumulate_reports(wait)
 
         self.step("10a")
         count = sub_handler.attribute_report_counts[Clusters.EnergyEvse.Attributes.SessionID]
@@ -237,7 +237,7 @@ class TC_EEVSE_2_6(MatterBaseTest, EEVSEBaseTestHelper):
 
         self.step("15")
         wait = 5  # We expect a change to the Session attributes after the EV is unplugged, Wait 5 seconds - allow time for the report to come in
-        accumulate_reports(wait)
+        await accumulate_reports(wait)
 
         self.step("15a")
         count = sub_handler.attribute_report_counts[Clusters.EnergyEvse.Attributes.SessionID]
@@ -270,7 +270,7 @@ class TC_EEVSE_2_6(MatterBaseTest, EEVSEBaseTestHelper):
 
         self.step("18")
         wait = 5  # We expect a change to the Session attributes after the EV is plugged in again, Wait 5 seconds - allow time for the report to come in
-        accumulate_reports(wait)
+        await accumulate_reports(wait)
 
         self.step("18a")
         count = sub_handler.attribute_report_counts[Clusters.EnergyEvse.Attributes.SessionID]

--- a/src/python_testing/TC_EPM_2_2.py
+++ b/src/python_testing/TC_EPM_2_2.py
@@ -39,8 +39,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
@@ -101,7 +101,7 @@ class TC_EPM_2_2(MatterBaseTest, EnergyReportingBaseTestHelper):
 
         # After 3 seconds...
         self.step("4")
-        time.sleep(3)
+        await asyncio.sleep(3)
 
         self.step("4a")
         # Active power is Mandatory
@@ -120,7 +120,7 @@ class TC_EPM_2_2(MatterBaseTest, EnergyReportingBaseTestHelper):
 
         self.step("5")
         # After 3 seconds...
-        time.sleep(3)
+        await asyncio.sleep(3)
 
         self.step("5a")
         # Active power is Mandatory

--- a/src/python_testing/TC_EWATERHTR_2_2.py
+++ b/src/python_testing/TC_EWATERHTR_2_2.py
@@ -42,9 +42,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 from TC_EWATERHTRBase import EWATERHTRBase
@@ -282,7 +281,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         await self.check_whm_attribute("BoostState", Clusters.WaterHeaterManagement.Enums.BoostStateEnum.kActive)
 
         self.step("10")
-        time.sleep(6)
+        await asyncio.sleep(6)
         event_data = events_callback.wait_for_event_report(Clusters.WaterHeaterManagement.Events.BoostEnded)
 
         self.step("10a")

--- a/src/python_testing/TC_FAN_3_4.py
+++ b/src/python_testing/TC_FAN_3_4.py
@@ -105,7 +105,7 @@ class TC_FAN_3_4(MatterBaseTest):
         if wind_support & Clusters.FanControl.Bitmaps.WindBitmap.kSleepWind:
             self.step(3)
             await self.write_wind_setting(endpoint=endpoint, wind_setting=Clusters.FanControl.Bitmaps.WindBitmap.kSleepWind)
-            # time.sleep(1)
+            # await asyncio.sleep(1)
 
             self.step(4)
             wind_setting = await self.read_wind_setting(endpoint=endpoint)
@@ -122,7 +122,7 @@ class TC_FAN_3_4(MatterBaseTest):
         if wind_support & Clusters.FanControl.Bitmaps.WindBitmap.kNaturalWind:
             self.step(6)
             await self.write_wind_setting(endpoint=endpoint, wind_setting=Clusters.FanControl.Bitmaps.WindBitmap.kNaturalWind)
-            # time.sleep(1)
+            # await asyncio.sleep(1)
 
             self.step(7)
             wind_setting = await self.read_wind_setting(endpoint=endpoint)

--- a/src/python_testing/TC_FAN_3_5.py
+++ b/src/python_testing/TC_FAN_3_5.py
@@ -34,8 +34,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 
@@ -98,7 +98,7 @@ class TC_FAN_3_5(MatterBaseTest):
         self.print_step("2a", "writes to the DUT the PercentSetting attribute with 50")
         await self.write_percent_setting(endpoint=endpoint, percent_setting=50)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("2b", "Read from the DUT the PercentCurrent attribute and store")
         percent_current = await self.read_percent_current(endpoint=endpoint)
@@ -106,7 +106,7 @@ class TC_FAN_3_5(MatterBaseTest):
         self.print_step("2c", "TH sends Step command to DUT with Direction set to Increase")
         await self.send_step_command(endpoint=endpoint, direction=Clusters.Objects.FanControl.Enums.StepDirectionEnum.kIncrease)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("2d", "Read from the DUT the PercentCurrent attribute and check its higher than the stored value")
         percent_current_after = await self.read_percent_current(endpoint=endpoint)
@@ -117,7 +117,7 @@ class TC_FAN_3_5(MatterBaseTest):
         self.print_step("3a", "writes to the DUT the PercentSetting attribute with 50")
         await self.write_percent_setting(endpoint=endpoint, percent_setting=50)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("3b", "Read from the DUT the PercentCurrent attribute and store")
         percent_current = await self.read_percent_current(endpoint=endpoint)
@@ -136,12 +136,12 @@ class TC_FAN_3_5(MatterBaseTest):
         self.print_step("4b", "TH writes to the DUT the SpeedSetting attribute with the value of SpeedMax")
         await self.write_speed_setting(endpoint=endpoint, speed_setting=speed_max)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("4c", "TH sends Step command to DUT with Direction set to Increase and Wrap set to False")
         await self.send_step_command(endpoint=endpoint, direction=Clusters.Objects.FanControl.Enums.StepDirectionEnum.kIncrease, wrap=False)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("4d", "Read from the DUT the SpeedCurrent attribute and check its equal to SpeedMax")
         speed_current = await self.read_speed_current(endpoint=endpoint)
@@ -151,12 +151,12 @@ class TC_FAN_3_5(MatterBaseTest):
         self.print_step("5a", "TH writes to the DUT the SpeedSetting attribute with the value of SpeedMax")
         await self.write_speed_setting(endpoint=endpoint, speed_setting=speed_max)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("5b", "TH sends Step command to DUT with Direction set to Increase and Wrap set to True")
         await self.send_step_command(endpoint=endpoint, direction=Clusters.Objects.FanControl.Enums.StepDirectionEnum.kIncrease, wrap=True)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("5c", "Read from the DUT the SpeedCurrent attribute and check its equal to 1")
         speed_current = await self.read_speed_current(endpoint=endpoint)
@@ -166,12 +166,12 @@ class TC_FAN_3_5(MatterBaseTest):
         self.print_step("6a", "TH writes to the DUT the SpeedSetting attribute with the value of SpeedMax")
         await self.write_speed_setting(endpoint=endpoint, speed_setting=speed_max)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("6b", "TH sends Step command to DUT with Direction set to Increase, Wrap set to True and LowestOff set to True")
         await self.send_step_command(endpoint=endpoint, direction=Clusters.Objects.FanControl.Enums.StepDirectionEnum.kIncrease, wrap=True, lowestOff=True)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("6c", "Read from the DUT the SpeedCurrent attribute and check its equal to 0")
         speed_current = await self.read_speed_current(endpoint=endpoint)
@@ -181,12 +181,12 @@ class TC_FAN_3_5(MatterBaseTest):
         self.print_step("7a", "TH writes to the DUT the SpeedSetting attribute with the value of 1")
         await self.write_speed_setting(endpoint=endpoint, speed_setting=1)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("7b", "TH sends Step command to DUT with Direction set to Decrease, Wrap set to False and LowestOff set to False")
         await self.send_step_command(endpoint=endpoint, direction=Clusters.Objects.FanControl.Enums.StepDirectionEnum.kDecrease, wrap=False, lowestOff=False)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("7c", "Read from the DUT the SpeedCurrent attribute and check its equal to 1")
         speed_current = await self.read_speed_current(endpoint=endpoint)
@@ -196,12 +196,12 @@ class TC_FAN_3_5(MatterBaseTest):
         self.print_step("8b", "TH writes to the DUT the SpeedSetting attribute with the value of 1")
         await self.write_speed_setting(endpoint=endpoint, speed_setting=1)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("8c", "TH sends Step command to DUT with Direction set to Decrease, Wrap set to True and LowestOff set to False")
         await self.send_step_command(endpoint=endpoint, direction=Clusters.Objects.FanControl.Enums.StepDirectionEnum.kDecrease, wrap=True, lowestOff=False)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("8d", "Read from the DUT the SpeedCurrent attribute and check its equal to SpeedMax")
         speed_current = await self.read_speed_current(endpoint=endpoint)
@@ -212,12 +212,12 @@ class TC_FAN_3_5(MatterBaseTest):
         self.print_step("9b", "TH writes to the DUT the SpeedSetting attribute with the value of 0")
         await self.write_speed_setting(endpoint=endpoint, speed_setting=0)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("9c", "TH sends Step command to DUT with Direction set to Decrease, Wrap set to True and LowestOff set to True")
         await self.send_step_command(endpoint=endpoint, direction=Clusters.Objects.FanControl.Enums.StepDirectionEnum.kDecrease, wrap=True, lowestOff=True)
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.print_step("9d", "Read from the DUT the SpeedCurrent attribute and check its equal to SpeedMax")
         speed_current = await self.read_speed_current(endpoint=endpoint)

--- a/src/python_testing/TC_FAN_4_1.py
+++ b/src/python_testing/TC_FAN_4_1.py
@@ -36,8 +36,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 from typing import Optional
 
 from mobly import asserts
@@ -251,7 +251,7 @@ class TC_FAN_4_1(MatterBaseTest):
 
             self.step(step_num + 3)
             logging.info(f"Waiting for {wait_s} seconds to give the fan a chance to respond")
-            time.sleep(wait_s)
+            await asyncio.sleep(wait_s)
 
             self.step(step_num + 4)
             percent_current = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.PercentCurrent)

--- a/src/python_testing/TC_ICDM_3_2.py
+++ b/src/python_testing/TC_ICDM_3_2.py
@@ -36,8 +36,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 from dataclasses import dataclass
 
 from mobly import asserts
@@ -245,7 +245,7 @@ class TC_ICDM_3_2(MatterBaseTest):
 
             self.step("2d")
             if not is_ci:
-                time.sleep(wait_time_reboot)
+                await asyncio.sleep(wait_time_reboot)
 
             self.step("2e")
             registeredClients = await self._read_icdm_attribute_expect_success(

--- a/src/python_testing/TC_ICDM_3_4.py
+++ b/src/python_testing/TC_ICDM_3_4.py
@@ -36,8 +36,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 
@@ -118,7 +118,7 @@ class TC_ICDM_3_4(MatterBaseTest):
 
         self.step("2b")
         if not is_ci:
-            time.sleep(wait_time_reboot)
+            await asyncio.sleep(wait_time_reboot)
 
         self.step(3)
         if not is_ci:

--- a/src/python_testing/TC_I_2_4.py
+++ b/src/python_testing/TC_I_2_4.py
@@ -37,8 +37,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 import test_plan_support
 from mobly import asserts
@@ -142,7 +142,7 @@ class TC_I_2_4(MatterBaseTest):
 
         self.step(6)
         logging.info("Test waits for 12 seconds")
-        time.sleep(12)
+        await asyncio.sleep(12)
 
         self.step(7)
         count = sub_handler.attribute_report_counts[cluster.Attributes.IdentifyTime]
@@ -175,7 +175,7 @@ class TC_I_2_4(MatterBaseTest):
 
         self.step(14)
         logging.info("Test waits for 1 seconds")
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.step(15)
         count = sub_handler.attribute_report_counts[cluster.Attributes.IdentifyTime]
@@ -212,7 +212,7 @@ class TC_I_2_4(MatterBaseTest):
 
         self.step(21)
         logging.info("Test waits for 12 seconds")
-        time.sleep(12)
+        await asyncio.sleep(12)
 
         self.step(22)
         count = sub_handler.attribute_report_counts[cluster.Attributes.IdentifyTime]
@@ -251,7 +251,7 @@ class TC_I_2_4(MatterBaseTest):
 
         self.step(29)
         logging.info("Test waits for 1 seconds")
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.step(30)
         count = sub_handler.attribute_report_counts[cluster.Attributes.IdentifyTime]

--- a/src/python_testing/TC_JFADMIN_2_2.py
+++ b/src/python_testing/TC_JFADMIN_2_2.py
@@ -32,12 +32,12 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import base64
 import logging
 import os
 import random
 import tempfile
-import time
 from configparser import ConfigParser
 
 from mobly import asserts
@@ -208,7 +208,7 @@ class TC_JFADMIN_2_2(MatterBaseTest):
 
         self.step("5")
         # Wait for ArmFailSafe timer to expire
-        time.sleep(11)
+        await asyncio.sleep(11)
 
         self.step("6")
         # Get the ICAC from JF-Admin

--- a/src/python_testing/TC_LVL_2_3.py
+++ b/src/python_testing/TC_LVL_2_3.py
@@ -37,8 +37,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 import test_plan_support
 from mobly import asserts
@@ -126,7 +126,7 @@ class TC_LVL_2_3(MatterBaseTest):
         await self.send_single_cmd(cmd)
         # NOTE: added this sleep to let the DUT have some time to move
         logging.info("Test waits for 1 seconds")
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         self.step(5)
         start_current_level = await self.read_single_attribute_check_success(cluster=lvl, attribute=lvl.Attributes.CurrentLevel)
@@ -141,7 +141,7 @@ class TC_LVL_2_3(MatterBaseTest):
 
         self.step(8)
         logging.info('Test will now collect data for 30 seconds')
-        time.sleep(30)
+        await asyncio.sleep(30)
 
         self.step(9)
         count = sub_handler.attribute_report_counts[lvl.Attributes.CurrentLevel]
@@ -184,7 +184,7 @@ class TC_LVL_2_3(MatterBaseTest):
 
         self.step(17)
         logging.info("Test waits for 5 seconds")
-        time.sleep(5)
+        await asyncio.sleep(5)
 
         self.step(18)
         cmd = Clusters.LevelControl.Commands.MoveToLevel(
@@ -193,7 +193,7 @@ class TC_LVL_2_3(MatterBaseTest):
 
         self.step(19)
         logging.info("Test waits for 20 seconds")
-        time.sleep(20)
+        await asyncio.sleep(20)
 
         self.step(20)
         count = sub_handler.attribute_report_counts[lvl.Attributes.RemainingTime]

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -56,6 +56,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 import os
 import random
@@ -229,7 +230,7 @@ class TC_MCORE_FS_1_1(MatterBaseTest):
 
         th_fsa_server_fabrics_new = None
         while time_remaining > 0:
-            time.sleep(2)
+            await asyncio.sleep(2)
             th_fsa_server_fabrics_new = await self.read_single_attribute_check_success(cluster=Clusters.OperationalCredentials, attribute=Clusters.OperationalCredentials.Attributes.Fabrics, dev_ctrl=self.TH_server_controller, node_id=self.server_nodeid, endpoint=0, fabric_filtered=False)
             if previous_number_th_server_fabrics != len(th_fsa_server_fabrics_new):
                 break

--- a/src/python_testing/TC_OCC_3_1.py
+++ b/src/python_testing/TC_OCC_3_1.py
@@ -38,8 +38,8 @@
 #  [TC-OCC-3.1] test procedure step 3, 4
 #  [TC-OCC-3.2] test precedure step 3a, 3c
 
+import asyncio
 import logging
-import time
 from typing import Any, Optional
 
 from mobly import asserts
@@ -172,7 +172,7 @@ class TC_OCC_3_1(MatterBaseTest):
             self.write_to_app_pipe({"Name": "SetOccupancy", "EndpointId": 1, "Occupancy": 0})
 
         if has_hold_time:
-            time.sleep(hold_time + 2.0)  # add some extra 2 seconds to ensure hold time has passed.
+            await asyncio.sleep(hold_time + 2.0)  # add some extra 2 seconds to ensure hold time has passed.
         else:
             self.wait_for_user_input(
                 prompt_msg="Type any letter and press ENTER after the sensor occupancy is back to unoccupied state (occupancy attribute = 0)")

--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -15,9 +15,9 @@
 #    limitations under the License.
 #
 
+import asyncio
 import logging
 import queue
-import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -661,7 +661,7 @@ class TC_OPSTATE_BASE():
         # STEP 10: TH waits for {PIXIT.WAITTIME.COUNTDOWN}
         self.step(10)
         if await self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
-            time.sleep(wait_time)
+            await asyncio.sleep(wait_time)
 
         # STEP 11: TH reads from the DUT the CountdownTime attribute
         self.step(11)
@@ -815,7 +815,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 7: TH waits for {PIXIT.WAITTIME.COUNTDOWN}
         self.step(7)
-        time.sleep(wait_time)
+        await asyncio.sleep(wait_time)
 
         # STEP 8: TH reads from the DUT the CountdownTime attribute
         self.step(8)
@@ -1099,7 +1099,7 @@ class TC_OPSTATE_BASE():
         # STEP 11: TH waits for initial-countdown-time
         self.step(11)
         logging.info(f'Sleeping for {initial_countdown_time:.1f} seconds.')
-        time.sleep(initial_countdown_time)
+        await asyncio.sleep(initial_countdown_time)
 
         # STEP 12: TH sends Stop command to the DUT
         self.step(12)
@@ -1145,7 +1145,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 16: TH waits for {PIXIT.WAITTIME.REBOOT}
         self.step(16)
-        time.sleep(wait_time_reboot)
+        await asyncio.sleep(wait_time_reboot)
 
         # STEP 17: TH sends Start command to the DUT
         self.step(17)
@@ -1175,7 +1175,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 21: TH waits for half of initial-countdown-time
         self.step(21)
-        time.sleep((initial_countdown_time / 2))
+        await asyncio.sleep((initial_countdown_time / 2))
 
         # STEP 22: TH sends Resume command to the DUT
         self.step(22)
@@ -1192,7 +1192,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 24: TH waits for initial-countdown-time
         self.step(24)
-        time.sleep(initial_countdown_time)
+        await asyncio.sleep(initial_countdown_time)
 
         # STEP 25: TH sends Stop command to the DUT
         self.step(25)
@@ -1276,7 +1276,7 @@ class TC_OPSTATE_BASE():
                                              device=self.device,
                                              operation="Start",
                                              msg="Put DUT in running state")
-            time.sleep(1)
+            await asyncio.sleep(1)
             await self.read_and_expect_value(endpoint=endpoint,
                                              attribute=attributes.OperationalState,
                                              expected_value=cluster.Enums.OperationalStateEnum.kRunning)
@@ -1291,7 +1291,7 @@ class TC_OPSTATE_BASE():
         if countdownTime is not NullValue:
             self.step(5)
             logging.info('Test will now collect data for 10 seconds')
-            time.sleep(10)
+            await asyncio.sleep(10)
 
             count = sub_handler.attribute_report_counts[attributes.CountdownTime]
             sub_handler.reset()
@@ -1309,7 +1309,7 @@ class TC_OPSTATE_BASE():
             self.step(7)
             wait_count = 0
             while (attr_value != cluster.Enums.OperationalStateEnum.kStopped) and (wait_count < 20):
-                time.sleep(1)
+                await asyncio.sleep(1)
                 wait_count = wait_count + 1
                 attr_value = await self.read_expect_success(
                     endpoint=endpoint,
@@ -1327,7 +1327,7 @@ class TC_OPSTATE_BASE():
                                              device=self.device,
                                              operation="Start",
                                              msg="Put DUT in running state")
-            time.sleep(1)
+            await asyncio.sleep(1)
             await self.read_and_expect_value(endpoint=endpoint,
                                              attribute=attributes.OperationalState,
                                              expected_value=cluster.Enums.OperationalStateEnum.kRunning)
@@ -1350,7 +1350,7 @@ class TC_OPSTATE_BASE():
                                              device=self.device,
                                              operation="Pause",
                                              msg="Put DUT in paused state")
-            time.sleep(1)
+            await asyncio.sleep(1)
             count = sub_handler.attribute_report_counts[attributes.CountdownTime]
             asserts.assert_greater(count, 0, "Did not receive any reports for CountdownTime")
         else:

--- a/src/python_testing/TC_PAVST_2_9.py
+++ b/src/python_testing/TC_PAVST_2_9.py
@@ -37,8 +37,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
@@ -161,7 +161,7 @@ class TC_PAVST_2_9(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
                             pvcluster.Enums.TransportStatusEnum.kInactive, "Transport status should be Inactive")
 
         logger.info("Wait for 6 secs to PushAVTransport expiry")
-        time.sleep(6)
+        await asyncio.sleep(6)
 
         self.step(7)
         transport_configs = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_PS_2_3.py
+++ b/src/python_testing/TC_PS_2_3.py
@@ -34,8 +34,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 
@@ -67,7 +67,7 @@ class TC_PS_2_3(MatterBaseTest):
 
         self.step(3)
         logging.info("This test will now wait for 30 seconds.")
-        time.sleep(30)
+        await asyncio.sleep(30)
 
         counts = sub_handler.attribute_report_counts
         asserts.assert_less_equal(counts[ps.Attributes.BatTimeToFullCharge], 4, "Too many reports for BatTimeToFullCharge")

--- a/src/python_testing/TC_REFALM_2_2.py
+++ b/src/python_testing/TC_REFALM_2_2.py
@@ -37,10 +37,10 @@
 #       --app-pipe /tmp/refalm_2_2_fifo
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 import typing
 from dataclasses import dataclass
-from time import sleep
 
 from mobly import asserts
 
@@ -168,10 +168,10 @@ class TC_REFALM_2_2(MatterBaseTest):
             attribute=Clusters.RefrigeratorAlarm.Attributes.State
         )
 
-    def _wait_thresshold(self):
+    async def _wait_thresshold(self):
         """Wait the defined time at the PIXIT.REFALM.AlarmThreshold to trigger it."""
         logger.info(f"Sleeping for {self.refalm_threshold_seconds} seconds defined at PIXIT.REFALM.AlarmThreshold")
-        sleep(self.refalm_threshold_seconds)
+        await asyncio.sleep(self.refalm_threshold_seconds)
 
     def _send_open_door_command(self):
         command_dict = {"Name": "SetRefrigeratorDoorStatus", "EndpointId": self.endpoint,
@@ -212,7 +212,7 @@ class TC_REFALM_2_2(MatterBaseTest):
 
         # wait  PIXIT.REFALM.AlarmThreshold (1s)
         self.step(5)
-        self._wait_thresshold()
+        await self._wait_thresshold()
 
         # # read the status
         self.step(6)
@@ -254,7 +254,7 @@ class TC_REFALM_2_2(MatterBaseTest):
         logger.info("Manually open the door on the DUT")
         self._ask_for_open_door()
         logger.info("Wait for the time defined in PIXIT.REFALM.AlarmThreshold")
-        self._wait_thresshold()
+        await self._wait_thresshold()
         # Wait for the Notify event with the State value.
         event_data = event_callback.wait_for_event_report(cluster.Events.Notify, timeout_sec=5)
         logger.info(f"Event data {event_data}")

--- a/src/python_testing/TC_RVCOPSTATE_2_3.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_3.py
@@ -37,8 +37,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-from time import sleep
 
 from mobly import asserts
 
@@ -245,7 +245,7 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
                                 "invalid CountdownTime(%s). Must be in between 1 and 259200, or null " % initial_countdown_time)
 
             self.print_step(8, "Waiting for 5 seconds")
-            sleep(5)
+            await asyncio.sleep(5)
 
             self.print_step(9, "Read CountdownTime attribute")
             countdown_time = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.CountdownTime)

--- a/src/python_testing/TC_SC_3_5.py
+++ b/src/python_testing/TC_SC_3_5.py
@@ -27,10 +27,10 @@
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 import os
 import tempfile
-from time import sleep
 
 from mobly import asserts
 
@@ -157,7 +157,7 @@ class TC_SC_3_5(MatterBaseTest):
         params = await self.th_client.OpenCommissioningWindow(
             nodeId=self.th_server_local_nodeid, timeout=3*60, iteration=10000, discriminator=self.th_server_discriminator, option=1)
         new_random_passcode = params.setupPinCode
-        sleep(1)
+        await asyncio.sleep(1)
         logging.info("OpenCommissioningWindow complete")
 
         return new_random_passcode
@@ -167,7 +167,7 @@ class TC_SC_3_5(MatterBaseTest):
 
         revokeCmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
         await self.th_client.SendCommand(nodeId=self.th_server_local_nodeid, endpoint=0, payload=revokeCmd, timedRequestTimeoutMs=9000)
-        sleep(1)
+        await asyncio.sleep(1)
 
         return await self.open_commissioning_window()
 

--- a/src/python_testing/TC_SC_3_6.py
+++ b/src/python_testing/TC_SC_3_6.py
@@ -34,7 +34,6 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-
 import asyncio
 import logging
 import queue

--- a/src/python_testing/TC_SWTCH.py
+++ b/src/python_testing/TC_SWTCH.py
@@ -77,6 +77,7 @@
 #
 # These tests run on every endpoint regardless of whether a switch is present because they are set up to auto-select.
 
+import asyncio
 import logging
 import queue
 import time
@@ -219,7 +220,7 @@ class TC_SwitchTests(MatterBaseTest):
         else:
             # This will await for the events to be generated properly. Note that there is a bit of a
             # race here for the button simulator, but this race is extremely unlikely to be lost.
-            time.sleep(SIMULATED_LONG_PRESS_LENGTH_SECONDS + 0.5)
+            await asyncio.sleep(SIMULATED_LONG_PRESS_LENGTH_SECONDS + 0.5)
 
     def _await_sequence_of_events(self, event_queue: queue.Queue, endpoint_id: int, sequence: list[ClusterObjects.ClusterEvent], timeout_sec: float):
         start_time = time.time()
@@ -386,7 +387,7 @@ class TC_SwitchTests(MatterBaseTest):
         # Step 9: Wait 10 seconds for event reports stable.
         # Verify that last SwitchLatched event received is for NewPosition 0.
         self.step(9)
-        time.sleep(10.0 if not self.is_ci else 1.0)
+        await asyncio.sleep(10.0 if not self.is_ci else 1.0)
 
         expected_switch_position = 0
         last_event = event_listener.get_last_event()

--- a/src/python_testing/TC_SWTCH.py
+++ b/src/python_testing/TC_SWTCH.py
@@ -211,7 +211,7 @@ class TC_SwitchTests(MatterBaseTest):
         else:
             self._send_long_press_named_pipe_command(endpoint_id, pressed_position, feature_map)
 
-    def _ask_for_release(self):
+    async def _ask_for_release(self):
         # Since we used a long press for this, "ask for release" on the button simulator just means waiting out the delay
         if not self._use_button_simulator():
             self.wait_for_user_input(
@@ -461,7 +461,7 @@ class TC_SwitchTests(MatterBaseTest):
         asserts.assert_equal(button_val, self.pressed_position, f"Button value is not {self.pressed_position}")
 
         self.step(7)
-        self._ask_for_release()
+        await self._ask_for_release()
 
         self.step("8a")
         if has_msr_feature and not has_msl_feature:

--- a/src/python_testing/TC_TIMESYNC_2_10.py
+++ b/src/python_testing/TC_TIMESYNC_2_10.py
@@ -35,7 +35,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import time
+import asyncio
 import typing
 from datetime import datetime, timedelta, timezone
 
@@ -113,7 +113,7 @@ class TC_TIMESYNC_2_10(MatterBaseTest):
         await self.send_set_dst_cmd(dst)
 
         self.print_step(8, "Wait until th_utc + 15s")
-        time.sleep(get_wait_seconds_from_set_time(th_utc, 15))
+        await asyncio.sleep(get_wait_seconds_from_set_time(th_utc, 15))
 
         self.print_step(9, "Read LocalTime from the DUT")
         await self.read_single_attribute_check_success(cluster=Clusters.TimeSynchronization,

--- a/src/python_testing/TC_TIMESYNC_2_11.py
+++ b/src/python_testing/TC_TIMESYNC_2_11.py
@@ -35,8 +35,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import queue
-import time
 import typing
 from datetime import datetime, timedelta, timezone
 
@@ -150,7 +150,7 @@ class TC_TIMESYNC_2_11(MatterBaseTest):
 
         self.print_step(9, "If dst_list_size > 1, TH waits until th_utc + 15s")
         if dst_list_size > 1:
-            time.sleep(get_wait_seconds_from_set_time(th_utc, 15))
+            await asyncio.sleep(get_wait_seconds_from_set_time(th_utc, 15))
 
         self.print_step(10, "If dst_list_size > 1, TH reads LocalTime")
         if dst_list_size > 1:
@@ -162,7 +162,7 @@ class TC_TIMESYNC_2_11(MatterBaseTest):
 
         self.print_step(12, "If dst_list_size > 1, TH waits until th_utc + 30s")
         if dst_list_size > 1:
-            time.sleep(get_wait_seconds_from_set_time(th_utc, 30))
+            await asyncio.sleep(get_wait_seconds_from_set_time(th_utc, 30))
 
         self.print_step(13, "If dst_list_size > 1, TH reads LocalTime")
         if dst_list_size > 1:

--- a/src/python_testing/TC_TIMESYNC_2_12.py
+++ b/src/python_testing/TC_TIMESYNC_2_12.py
@@ -35,8 +35,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import queue
-import time
 import typing
 from datetime import datetime, timedelta, timezone
 
@@ -152,7 +152,7 @@ class TC_TIMESYNC_2_12(MatterBaseTest):
 
         self.print_step(10, "If tz_list_size > 1, TH waits until th_utc + 15s")
         if tz_list_size > 1:
-            time.sleep(get_wait_seconds_from_set_time(th_utc, 15))
+            await asyncio.sleep(get_wait_seconds_from_set_time(th_utc, 15))
 
         self.print_step(11, "If tz_list_size > 1, TH reads LocalTime")
         if tz_list_size > 1:

--- a/src/python_testing/TC_TIMESYNC_2_13.py
+++ b/src/python_testing/TC_TIMESYNC_2_13.py
@@ -35,8 +35,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import queue
-import time
 
 from mobly import asserts
 
@@ -119,7 +119,7 @@ class TC_TIMESYNC_2_13(MatterBaseTest):
         await self.send_single_cmd(cmd=Clusters.TimeSynchronization.Commands.SetTrustedTimeSource(trustedTimeSource=tts))
 
         self.print_step(9, "TH1 waits 5 seconds")
-        time.sleep(5)
+        await asyncio.sleep(5)
 
         self.print_step(10, "TH1 sends the SetTrustedTimeSource command with TrustedTimeSource set to NULL")
         await self.send_single_cmd(cmd=Clusters.TimeSynchronization.Commands.SetTrustedTimeSource(NullValue))

--- a/src/python_testing/TC_TIMESYNC_2_7.py
+++ b/src/python_testing/TC_TIMESYNC_2_7.py
@@ -35,7 +35,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import time
+import asyncio
 import typing
 from datetime import timedelta
 
@@ -148,7 +148,7 @@ class TC_TIMESYNC_2_7(MatterBaseTest):
 
         self.print_step(14, "Wait 15s and read LocalTime")
         if tz_list_size > 1:
-            time.sleep(15)
+            await asyncio.sleep(15)
             local = await self.read_ts_attribute_expect_success(local_attr)
             compare_time(received=local, offset=timedelta(seconds=7200), tolerance=timedelta(seconds=5))
 

--- a/src/python_testing/TC_TIMESYNC_2_8.py
+++ b/src/python_testing/TC_TIMESYNC_2_8.py
@@ -35,7 +35,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import time
+import asyncio
 import typing
 from datetime import datetime, timedelta, timezone
 
@@ -127,7 +127,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
         compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
 
         self.print_step(9, "Wait 15s")
-        time.sleep(15)
+        await asyncio.sleep(15)
 
         self.print_step(10, "Read UTCTime")
         utc = await self.read_ts_attribute_expect_success(utc_attr)
@@ -146,7 +146,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
         compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
 
         self.print_step(14, "Wait 15s")
-        time.sleep(15)
+        await asyncio.sleep(15)
 
         self.print_step(15, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
@@ -169,7 +169,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
 
         self.print_step(19, "Wait 15s")
         if dst_list_size > 1:
-            time.sleep(15)
+            await asyncio.sleep(15)
 
         self.print_step(20, "Read LocalTime")
         if dst_list_size > 1:
@@ -178,7 +178,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
 
         self.print_step(21, "Wait 15s")
         if dst_list_size > 1:
-            time.sleep(15)
+            await asyncio.sleep(15)
 
         self.print_step(22, "Read LocalTime")
         if dst_list_size > 1:
@@ -187,7 +187,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
 
         self.print_step(23, "Wait 15s")
         if dst_list_size > 1:
-            time.sleep(15)
+            await asyncio.sleep(15)
 
         self.print_step(24, "Read LocalTime")
         if dst_list_size > 1:
@@ -212,7 +212,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
         compare_time(received=local, offset=timedelta(seconds=0), tolerance=timedelta(seconds=5))
 
         self.print_step(29, "Wait 15s")
-        time.sleep(15)
+        await asyncio.sleep(15)
 
         self.print_step(30, "Read Localtime")
         local = await self.read_ts_attribute_expect_success(local_attr)

--- a/src/python_testing/TC_VALCC_4_1.py
+++ b/src/python_testing/TC_VALCC_4_1.py
@@ -32,7 +32,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import time
+import asyncio
 
 from mobly import asserts
 
@@ -97,7 +97,7 @@ class TC_VALCC_4_1(MatterBaseTest):
         asserts.assert_less_equal(remaining_duration_dut, 60, "RemainingDuration is not in the expected range")
 
         self.step(5)
-        time.sleep(5)
+        await asyncio.sleep(5)
 
         self.step(6)
         remaining_duration_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.RemainingDuration)

--- a/src/python_testing/TC_VALCC_4_2.py
+++ b/src/python_testing/TC_VALCC_4_2.py
@@ -32,7 +32,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import time
+import asyncio
 
 from mobly import asserts
 
@@ -108,7 +108,7 @@ class TC_VALCC_4_2(MatterBaseTest):
         asserts.assert_less_equal(remaining_duration_dut, defaultOpenDuration, "RemainingDuration is not in the expected range")
 
         self.step(6)
-        time.sleep(5)
+        await asyncio.sleep(5)
 
         self.step(7)
         remaining_duration_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.RemainingDuration)

--- a/src/python_testing/TC_VALCC_4_5.py
+++ b/src/python_testing/TC_VALCC_4_5.py
@@ -32,7 +32,7 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import time
+import asyncio
 
 from mobly import asserts
 
@@ -101,7 +101,7 @@ class TC_VALCC_4_5(MatterBaseTest):
         asserts.assert_true(current_state_dut is not NullValue, "CurrentState is null")
 
         while current_state_dut is Clusters.Objects.ValveConfigurationAndControl.Enums.ValveStateEnum.kTransitioning:
-            time.sleep(1)
+            await asyncio.sleep(1)
 
             current_state_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentState)
             asserts.assert_true(current_state_dut is not NullValue, "CurrentState is null")
@@ -110,7 +110,7 @@ class TC_VALCC_4_5(MatterBaseTest):
                              "CurrentState is not the expected value")
 
         self.step(6)
-        time.sleep(6)
+        await asyncio.sleep(6)
 
         self.step(7)
         open_duration_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.OpenDuration)

--- a/src/python_testing/TC_WEBRTCR_2_1.py
+++ b/src/python_testing/TC_WEBRTCR_2_1.py
@@ -33,11 +33,12 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 import os
 import random
 import tempfile
-from time import sleep
+import time
 
 from mobly import asserts
 from TC_WEBRTCRTestBase import WEBRTCRTestBase
@@ -80,7 +81,7 @@ class TC_WebRTCR_2_1(WEBRTCRTestBase):
             expected_output="Server initialization complete",
             timeout=30)
 
-        sleep(1)
+        time.sleep(1)
 
     def teardown_class(self):
         if self.th_server is not None:
@@ -141,7 +142,7 @@ class TC_WebRTCR_2_1(WEBRTCRTestBase):
         params = await self.default_controller.OpenCommissioningWindow(
             nodeId=self.th_server_local_nodeid, timeout=3*60, iteration=10000, discriminator=self.discriminator, option=1)
         passcode = params.setupPinCode
-        sleep(1)
+        await asyncio.sleep(1)
 
         self.step(3)
         # Prompt user with instructions
@@ -191,7 +192,7 @@ class TC_WebRTCR_2_1(WEBRTCRTestBase):
             endpoint=0,  # Fault‑Injection cluster lives on EP0
             payload=command,
         )
-        sleep(1)
+        await asyncio.sleep(1)
 
         self.step(5)
         # Prompt user with instructions

--- a/src/python_testing/TC_WEBRTCR_2_2.py
+++ b/src/python_testing/TC_WEBRTCR_2_2.py
@@ -33,11 +33,12 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 import os
 import random
 import tempfile
-from time import sleep
+import time
 
 from mobly import asserts
 from TC_WEBRTCRTestBase import WEBRTCRTestBase
@@ -80,7 +81,7 @@ class TC_WebRTCR_2_2(WEBRTCRTestBase):
             expected_output="Server initialization complete",
             timeout=30)
 
-        sleep(1)
+        time.sleep(1)
 
     def teardown_class(self):
         if self.th_server is not None:
@@ -141,7 +142,7 @@ class TC_WebRTCR_2_2(WEBRTCRTestBase):
         params = await self.default_controller.OpenCommissioningWindow(
             nodeId=self.th_server_local_nodeid, timeout=3*60, iteration=10000, discriminator=self.discriminator, option=1)
         passcode = params.setupPinCode
-        sleep(1)
+        await asyncio.sleep(1)
 
         self.step(3)
         # Prompt user with instructions
@@ -191,7 +192,7 @@ class TC_WebRTCR_2_2(WEBRTCRTestBase):
             endpoint=0,  # Fault‑Injection cluster lives on EP0
             payload=command,
         )
-        sleep(1)
+        await asyncio.sleep(1)
 
         self.step(5)
         # Prompt user with instructions

--- a/src/python_testing/TC_WEBRTCR_2_5.py
+++ b/src/python_testing/TC_WEBRTCR_2_5.py
@@ -33,11 +33,12 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 import os
 import random
 import tempfile
-from time import sleep
+import time
 
 from mobly import asserts
 from TC_WEBRTCRTestBase import WEBRTCRTestBase
@@ -80,7 +81,7 @@ class TC_WebRTCR_2_5(WEBRTCRTestBase):
             expected_output="Server initialization complete",
             timeout=30)
 
-        sleep(1)
+        time.sleep(1)
 
     def teardown_class(self):
         if self.th_server is not None:
@@ -145,7 +146,7 @@ class TC_WebRTCR_2_5(WEBRTCRTestBase):
         params = await self.default_controller.OpenCommissioningWindow(
             nodeId=self.th_server_local_nodeid, timeout=3*60, iteration=10000, discriminator=self.discriminator, option=1)
         passcode = params.setupPinCode
-        sleep(1)
+        await asyncio.sleep(1)
 
         self.step(3)
         # Prompt user with instructions

--- a/src/python_testing/TC_WEBRTCR_2_6.py
+++ b/src/python_testing/TC_WEBRTCR_2_6.py
@@ -33,11 +33,12 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 import os
 import random
 import tempfile
-from time import sleep
+import time
 
 from mobly import asserts
 from TC_WEBRTCRTestBase import WEBRTCRTestBase
@@ -81,7 +82,7 @@ class TC_WebRTCR_2_6(WEBRTCRTestBase):
             expected_output="Server initialization complete",
             timeout=30)
 
-        sleep(1)
+        time.sleep(1)
 
     def teardown_class(self):
         if self.th_server is not None:
@@ -142,7 +143,7 @@ class TC_WebRTCR_2_6(WEBRTCRTestBase):
         params = await self.default_controller.OpenCommissioningWindow(
             nodeId=self.th_server_local_nodeid, timeout=3*60, iteration=10000, discriminator=self.discriminator, option=1)
         passcode = params.setupPinCode
-        sleep(1)
+        await asyncio.sleep(1)
 
         self.step(3)
         # Prompt user with instructions
@@ -192,7 +193,7 @@ class TC_WebRTCR_2_6(WEBRTCRTestBase):
             endpoint=0,  # Fault‑Injection cluster lives on EP0
             payload=command,
         )
-        sleep(1)
+        await asyncio.sleep(1)
 
         self.step(5)
         # Prompt user with instructions

--- a/src/python_testing/TC_WEBRTCR_2_7.py
+++ b/src/python_testing/TC_WEBRTCR_2_7.py
@@ -33,11 +33,12 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 import os
 import random
 import tempfile
-from time import sleep
+import time
 
 from mobly import asserts
 from TC_WEBRTCRTestBase import WEBRTCRTestBase
@@ -81,7 +82,7 @@ class TC_WebRTCR_2_7(WEBRTCRTestBase):
             expected_output="Server initialization complete",
             timeout=30)
 
-        sleep(1)
+        time.sleep(1)
 
     def teardown_class(self):
         if self.th_server is not None:
@@ -142,7 +143,7 @@ class TC_WebRTCR_2_7(WEBRTCRTestBase):
         params = await self.default_controller.OpenCommissioningWindow(
             nodeId=self.th_server_local_nodeid, timeout=3*60, iteration=10000, discriminator=self.discriminator, option=1)
         passcode = params.setupPinCode
-        sleep(1)
+        await asyncio.sleep(1)
 
         self.step(3)
         # Prompt user with instructions
@@ -192,7 +193,7 @@ class TC_WebRTCR_2_7(WEBRTCRTestBase):
             endpoint=0,  # Fault‑Injection cluster lives on EP0
             payload=command,
         )
-        sleep(1)
+        await asyncio.sleep(1)
 
         self.step(5)
         # Prompt user with instructions

--- a/src/python_testing/TC_ZONEMGMT_2_4.py
+++ b/src/python_testing/TC_ZONEMGMT_2_4.py
@@ -36,8 +36,8 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
-import time
 
 from mobly import asserts
 
@@ -285,7 +285,7 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
                              "Incorrect event type")
         asserts.assert_equal(event.zone, zoneID1, "Unexpected zoneID on ZoneTriggered")
         asserts.assert_equal(event.reason, enums.ZoneEventStoppedReasonEnum.kActionStopped, "Unexpected reason on ZoneStopped")
-        time.sleep(blindDuration)
+        await asyncio.sleep(blindDuration)
 
         self.step("4")
         # Generate 2 triggers in quick succession to see if ZoneStopped comes after Augmentation duration
@@ -314,7 +314,7 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
                              "Incorrect event type")
         asserts.assert_equal(event.zone, zoneID1, "Unexpected zoneID on ZoneTriggered")
         asserts.assert_equal(event.reason, enums.ZoneEventStoppedReasonEnum.kActionStopped, "Unexpected reason on ZoneStopped")
-        time.sleep(blindDuration)
+        await asyncio.sleep(blindDuration)
 
         self.step("5")
         # Repeat Step 3
@@ -335,7 +335,7 @@ class TC_ZONEMGMT_2_4(MatterBaseTest):
         if self.is_pics_sdk_ci_only:
             for i in range(maxDuration):
                 self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zoneID1})
-                time.sleep(1)
+                await asyncio.sleep(1)
         else:
             self.wait_for_user_input(
                 prompt_msg=f"""Press enter and immediately start, and keep generating motion activity from zone {zoneID1} for a period exceeding {maxDuration} seconds.

--- a/src/python_testing/TestReadSubscribeAceExistenceErrors.py
+++ b/src/python_testing/TestReadSubscribeAceExistenceErrors.py
@@ -39,7 +39,7 @@ import copy
 import logging
 from typing import Type, Union
 
-from mobly import asserts
+from mobly import asserts  # type: ignore
 
 import matter.clusters as Clusters
 from matter.exceptions import ChipStackError

--- a/src/python_testing/TestReadSubscribeAceExistenceErrors.py
+++ b/src/python_testing/TestReadSubscribeAceExistenceErrors.py
@@ -39,7 +39,7 @@ import copy
 import logging
 from typing import Type, Union
 
-from mobly import asserts  # type: ignore
+from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.exceptions import ChipStackError

--- a/src/python_testing/drlk_2_x_common.py
+++ b/src/python_testing/drlk_2_x_common.py
@@ -15,10 +15,10 @@
 #    limitations under the License.
 #
 
+import asyncio
 import logging
 import random
 import string
-import time
 
 from mobly import asserts
 
@@ -289,7 +289,7 @@ class DRLK_COMMON:
 
             if self.check_pics("DRLK.S.A0031"):
                 self.print_step("14", "Wait for UserCodeTemporaryDisableTime seconds")
-                time.sleep(userCodeTemporaryDisableTime_dut)
+                await asyncio.sleep(userCodeTemporaryDisableTime_dut)
 
             if not doAutoRelockTest:
                 self.print_step("15", "Send %s with valid Pincode and verify success" % lockUnlockText)
@@ -322,7 +322,7 @@ class DRLK_COMMON:
                 if self.check_pics("DRLK.S.A0000"):
                     self.print_step("18", "TH reads LockState attribute after AutoRelockTime Expires")
                     # Add additional wait time buffer for motor movement, etc.
-                    time.sleep(autoRelockTime_dut + 5)
+                    await asyncio.sleep(autoRelockTime_dut + 5)
                     lockstate_dut = await self.read_drlk_attribute_expect_success(attribute=attributes.LockState)
                     logging.info("Current LockState is %s" % (lockstate_dut))
                     asserts.assert_equal(lockstate_dut, Clusters.DoorLock.Enums.DlLockState.kLocked,

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
@@ -23,7 +23,9 @@ import logging
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
-from mobly import asserts, base_test, signals
+import base_test
+import signals
+from mobly import asserts
 
 import matter.testing.global_stash as global_stash
 from matter import ChipDeviceCtrl, discovery

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
@@ -23,9 +23,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
-import base_test
-import signals
-from mobly import asserts
+from mobly import asserts, base_test, signals
 
 import matter.testing.global_stash as global_stash
 from matter import ChipDeviceCtrl, discovery

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -45,7 +45,9 @@ import matter.CertificateAuthority
 
 # isort: on
 
-from mobly import asserts, base_test, signals
+import base_test
+import signals
+from mobly import asserts
 
 import matter.clusters as Clusters
 import matter.logging

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -45,9 +45,7 @@ import matter.CertificateAuthority
 
 # isort: on
 
-import base_test
-import signals
-from mobly import asserts
+from mobly import asserts, base_test, signals
 
 import matter.clusters as Clusters
 import matter.logging

--- a/src/python_testing/support_modules/cadmin_support.py
+++ b/src/python_testing/support_modules/cadmin_support.py
@@ -24,7 +24,6 @@ import random
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import IntEnum
-from time import sleep
 from typing import Optional
 
 from mdns_discovery import mdns_discovery
@@ -361,7 +360,7 @@ class CADMINBaseTest(MatterBaseTest):
             timedRequestTimeoutMs=6000
         )
         # The failsafe cleanup is scheduled after the command completes
-        sleep(1)
+        await asyncio.sleep(1)
 
     @dataclass
     class TimingResults:
@@ -439,7 +438,7 @@ class CADMINBaseTest(MatterBaseTest):
             if attempt < max_attempts - 1:
                 logging.info(f"Waiting for service with CM={expected_cm_value} and D={expected_discriminator}, "
                              f"attempt {attempt+1}/{max_attempts}")
-                sleep(delay_sec)
+                await asyncio.sleep(delay_sec)
             else:
                 # Final retry attempt failed
                 asserts.fail(f"Failed to find DNS-SD advertisement with CM={expected_cm_value} and "

--- a/src/python_testing/test_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/test_testing/TestMatterTestingSupport.py
@@ -20,8 +20,7 @@ import time
 import typing
 from datetime import datetime, timedelta, timezone
 
-import signals
-from mobly import asserts
+from mobly import asserts, signals
 
 import matter.clusters as Clusters
 from matter.clusters.Types import Nullable, NullValue

--- a/src/python_testing/test_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/test_testing/TestMatterTestingSupport.py
@@ -20,7 +20,8 @@ import time
 import typing
 from datetime import datetime, timedelta, timezone
 
-from mobly import asserts, signals
+import signals
+from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.clusters.Types import Nullable, NullValue

--- a/src/python_testing/test_testing/TestSpecParsingSelection.py
+++ b/src/python_testing/test_testing/TestSpecParsingSelection.py
@@ -16,9 +16,8 @@
 #
 
 
-import signals
 from DeviceConformanceTests import DeviceConformanceTests
-from mobly import asserts
+from mobly import asserts, signals
 
 import matter.clusters as Clusters
 from matter.testing.conformance import ConformanceDecision, ConformanceException

--- a/src/python_testing/test_testing/TestSpecParsingSelection.py
+++ b/src/python_testing/test_testing/TestSpecParsingSelection.py
@@ -16,8 +16,9 @@
 #
 
 
+import signals
 from DeviceConformanceTests import DeviceConformanceTests
-from mobly import asserts, signals
+from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.testing.conformance import ConformanceDecision, ConformanceException

--- a/src/python_testing/test_testing/TestTimeSyncTrustedTimeSource.py
+++ b/src/python_testing/test_testing/TestTimeSyncTrustedTimeSource.py
@@ -14,7 +14,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-import time
+
+import asyncio
 
 from mobly import asserts
 
@@ -66,7 +67,7 @@ class TestTestTimeSyncTrustedTimeSource(MatterBaseTest):
     async def ReadFromTrustedTimeSource(self):
         # Give the node a couple of seconds to reach out and set itself up
         # TODO: Subscribe to granularity instead.
-        time.sleep(6)
+        await asyncio.sleep(6)
         ret = await self.read_single_attribute_check_success(cluster=Clusters.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.UTCTime)
         asserts.assert_not_equal(ret, NullValue, "Returned time is null")
         ret = await self.read_single_attribute_check_success(cluster=Clusters.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.Granularity)


### PR DESCRIPTION
#### Summary

The most common problem in current codebase is that the blocking `time.sleep` is used in async function which counterfeit async concept. This PR adds ruff lint rule which will catch such issues.

Also this PR fixes potential issue with using cancelled `asyncio.Future`. 
A cancelled future due to timeout in `asyncio.wait_for` is set which leads to `asyncio.exceptions.InvalidStateError: invalid state`:
```python
import asyncio

async def main():
    f = asyncio.get_running_loop().create_future()
    try:
        await asyncio.wait_for(f, 1.0)
    except TimeoutError:
        pass
    # This causes asyncio.exceptions.InvalidStateError: invalid state
    f.set_result(42)

asyncio.run(main())
```

#### Testing

CI will verify whether everything still works as expected.