### PR TITLE
[v1.5] ESP32: use idf version compatible API for custom gatt indication (#42…

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -615,11 +615,14 @@ CHIP_ERROR BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const Chi
         ExitNow();
     }
 
+#if ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 0, 0)
+    err = MapBLEError(ble_gattc_indicate_custom(conId, mTXCharCCCDAttrHandle, om));
+#else
     err = MapBLEError(ble_gatts_indicate_custom(conId, mTXCharCCCDAttrHandle, om));
+#endif
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "ble_gatts_indicate_custom() failed: %" CHIP_ERROR_FORMAT, err.Format());
-        ExitNow();
+        ChipLogError(DeviceLayer, "ble gatt indicate custom failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:


### PR DESCRIPTION
…094)

#### Summary
- Cherry-picking https://github.com/project-chip/connectedhomeip/pull/42094 on v1.5-branch

#### Testing
- Locally built [`idf.py build`] the lighting-app/esp32 with esp-idf v5.0 and build was successful.