### PR TITLE
CADMIN-1.5: Expect either error

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -150,10 +150,6 @@ not_automated:
       reason: Helper methods for Push AV Integration TCs
     - name: TC_TLS_Utils.py
       reason: Helper methods for TC tests dependent on TLS clusters
-    - name: TC_CADMIN_1_5.py
-      reason:
-          "Flaky/broken: see
-          https://github.com/project-chip/connectedhomeip/issues/42059"
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially


### PR DESCRIPTION
#### Summary
When the commissioning window is closed, the commissioner can fail in 1 of two ways - it can either fail to find the device because the device is no longer advertising, or it can fail to connect if it has a previous address cached. Either failure mode is fine for this test and we should accept both on either step. 

#### Related issues
https://github.com/project-chip/connectedhomeip/issues/42059

#### Testing

re-enabled in CI, let's see. Works locally, but it always did, so...

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
