### PR TITLE
Remove configuration version from 1.5 branch

### DIFF
--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -66,7 +66,12 @@ constexpr DataModel::AttributeEntry kMandatoryAttributes[] = {
     CapabilityMinima::kMetadataEntry,
     SpecificationVersion::kMetadataEntry,
     MaxPathsPerInvoke::kMetadataEntry,
+// V1.5 BRANCH FIX
+// Configuration version is still provisional and should not be included in 1.5.
+#if 0
     ConfigurationVersion::kMetadataEntry,
+#endif
+
     // NOTE: UniqueID used to NOT be mandatory in previous spec version, so we add
     // this as a separate condition
     // UniqueID::kMetadataEntry,

--- a/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
@@ -68,13 +68,17 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
 
         ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
         ASSERT_EQ(expectedBuilder.AppendElements({
-                      DataModelRevision::kMetadataEntry, VendorName::kMetadataEntry, VendorID::kMetadataEntry,
-                      ProductName::kMetadataEntry, ProductID::kMetadataEntry, NodeLabel::kMetadataEntry, Location::kMetadataEntry,
-                      HardwareVersion::kMetadataEntry, HardwareVersionString::kMetadataEntry, SoftwareVersion::kMetadataEntry,
-                      SoftwareVersionString::kMetadataEntry, CapabilityMinima::kMetadataEntry, SpecificationVersion::kMetadataEntry,
-                      MaxPathsPerInvoke::kMetadataEntry, ConfigurationVersion::kMetadataEntry,
-                      UniqueID::kMetadataEntry, // required in latest spec
-                  }),
+            DataModelRevision::kMetadataEntry, VendorName::kMetadataEntry, VendorID::kMetadataEntry, ProductName::kMetadataEntry,
+                ProductID::kMetadataEntry, NodeLabel::kMetadataEntry, Location::kMetadataEntry, HardwareVersion::kMetadataEntry,
+                HardwareVersionString::kMetadataEntry, SoftwareVersion::kMetadataEntry, SoftwareVersionString::kMetadataEntry,
+                CapabilityMinima::kMetadataEntry, SpecificationVersion::kMetadataEntry, MaxPathsPerInvoke::kMetadataEntry,
+// V1.5 BRANCH FIX
+// Configuration version is still provisional and should not be included in 1.5.
+#if 0
+                      ConfigurationVersion::kMetadataEntry,
+#endif
+                UniqueID::kMetadataEntry, // required in latest spec
+        }),
                   CHIP_NO_ERROR);
         ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
         ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
@@ -91,22 +95,16 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
 
         ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
         ASSERT_EQ(expectedBuilder.AppendElements({
-                      DataModelRevision::kMetadataEntry,
-                      VendorName::kMetadataEntry,
-                      VendorID::kMetadataEntry,
-                      ProductName::kMetadataEntry,
-                      ProductID::kMetadataEntry,
-                      NodeLabel::kMetadataEntry,
-                      Location::kMetadataEntry,
-                      HardwareVersion::kMetadataEntry,
-                      HardwareVersionString::kMetadataEntry,
-                      SoftwareVersion::kMetadataEntry,
-                      SoftwareVersionString::kMetadataEntry,
-                      CapabilityMinima::kMetadataEntry,
-                      SpecificationVersion::kMetadataEntry,
-                      MaxPathsPerInvoke::kMetadataEntry,
+            DataModelRevision::kMetadataEntry, VendorName::kMetadataEntry, VendorID::kMetadataEntry, ProductName::kMetadataEntry,
+                ProductID::kMetadataEntry, NodeLabel::kMetadataEntry, Location::kMetadataEntry, HardwareVersion::kMetadataEntry,
+                HardwareVersionString::kMetadataEntry, SoftwareVersion::kMetadataEntry, SoftwareVersionString::kMetadataEntry,
+                CapabilityMinima::kMetadataEntry, SpecificationVersion::kMetadataEntry, MaxPathsPerInvoke::kMetadataEntry,
+// V1.5 BRANCH FIX
+// Configuration version is still provisional and should not be included in 1.5.
+#if 0
                       ConfigurationVersion::kMetadataEntry,
-                  }),
+#endif
+        }),
                   CHIP_NO_ERROR);
         ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
         ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
@@ -132,31 +130,19 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
 
         ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
         ASSERT_EQ(expectedBuilder.AppendElements({
-                      DataModelRevision::kMetadataEntry,
-                      VendorName::kMetadataEntry,
-                      VendorID::kMetadataEntry,
-                      ProductName::kMetadataEntry,
-                      ProductID::kMetadataEntry,
-                      NodeLabel::kMetadataEntry,
-                      Location::kMetadataEntry,
-                      HardwareVersion::kMetadataEntry,
-                      HardwareVersionString::kMetadataEntry,
-                      SoftwareVersion::kMetadataEntry,
-                      SoftwareVersionString::kMetadataEntry,
-                      CapabilityMinima::kMetadataEntry,
-                      SpecificationVersion::kMetadataEntry,
-                      MaxPathsPerInvoke::kMetadataEntry,
+            DataModelRevision::kMetadataEntry, VendorName::kMetadataEntry, VendorID::kMetadataEntry, ProductName::kMetadataEntry,
+                ProductID::kMetadataEntry, NodeLabel::kMetadataEntry, Location::kMetadataEntry, HardwareVersion::kMetadataEntry,
+                HardwareVersionString::kMetadataEntry, SoftwareVersion::kMetadataEntry, SoftwareVersionString::kMetadataEntry,
+                CapabilityMinima::kMetadataEntry, SpecificationVersion::kMetadataEntry, MaxPathsPerInvoke::kMetadataEntry,
+// V1.5 BRANCH FIX
+// Configuration version is still provisional and should not be included in 1.5.
+#if 0
                       ConfigurationVersion::kMetadataEntry,
-                      UniqueID::kMetadataEntry,
-                      ManufacturingDate::kMetadataEntry,
-                      PartNumber::kMetadataEntry,
-                      ProductURL::kMetadataEntry,
-                      ProductLabel::kMetadataEntry,
-                      SerialNumber::kMetadataEntry,
-                      LocalConfigDisabled::kMetadataEntry,
-                      Reachable::kMetadataEntry,
-                      ProductAppearance::kMetadataEntry,
-                  }),
+#endif
+                UniqueID::kMetadataEntry, ManufacturingDate::kMetadataEntry, PartNumber::kMetadataEntry, ProductURL::kMetadataEntry,
+                ProductLabel::kMetadataEntry, SerialNumber::kMetadataEntry, LocalConfigDisabled::kMetadataEntry,
+                Reachable::kMetadataEntry, ProductAppearance::kMetadataEntry,
+        }),
                   CHIP_NO_ERROR);
         ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
         ASSERT_TRUE(Testing::EqualAttributeSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));

--- a/src/app/tests/suites/TestBasicInformation.yaml
+++ b/src/app/tests/suites/TestBasicInformation.yaml
@@ -81,7 +81,6 @@ tests:
                         20,
                         21,
                         22,
-                        24,
                         0xFFF8, # GeneratedCommandList
                         0xFFF9, # AcceptedCommandList
                         0xFFFB, # AttributeList

--- a/src/app/tests/suites/certification/ci-pics-values
+++ b/src/app/tests/suites/certification/ci-pics-values
@@ -1706,7 +1706,7 @@ BINFO.S.A0013=1
 BINFO.S.A0014=1
 BINFO.S.A0015=1
 BINFO.S.A0016=1
-BINFO.S.A0018=0 // V1.5 BRANCH FIX - Configuration version is still provisional
+BINFO.S.A0018=0 # V1.5 BRANCH FIX - Configuration version is still provisional
 
 # Events
 BINFO.S.E00=1

--- a/src/app/tests/suites/certification/ci-pics-values
+++ b/src/app/tests/suites/certification/ci-pics-values
@@ -1706,7 +1706,7 @@ BINFO.S.A0013=1
 BINFO.S.A0014=1
 BINFO.S.A0015=1
 BINFO.S.A0016=1
-BINFO.S.A0018=1
+BINFO.S.A0018=0 // V1.5 BRANCH FIX - Configuration version is still provisional
 
 # Events
 BINFO.S.E00=1

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -150,6 +150,8 @@ not_automated:
       reason: Helper methods for Push AV Integration TCs
     - name: TC_TLS_Utils.py
       reason: Helper methods for TC tests dependent on TLS clusters
+    - name: TC_BINFO_3_2.py
+      reason: V1.5 BRANCH FIX - Configuration version is still provisional
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially


### PR DESCRIPTION
#### Summary

This PR removes the `ConfigurationVersion` attribute from the BasicInformation cluster in the 1.5 branch, as this is still provisional.

#### Testing

Used the chip-lock app to run the conformance test TC_IDM-10.2 test before and after the fix.
Confirmed `TC_IDM_10_2` now succeeds (previously failed conformance due to the provisional attribute being included).

Command used to run the test:

```
./scripts/build/build_examples.py --target linux-x64-lock-no-shell-tsan-clang-unified build && ./scripts/tests/run_python_test.py --app ./out/unified-build/standalone/chip-lock-app --app-args "--trace-to json:log" --script src/python_testing/TC_DeviceConformance.py --script-args "--manual-code 34970112332 --tests test_TC_IDM_10_2"
```

Also ran basic info tests with:
1.  `./scripts/tests/local.py python-tests --test-filter TC_BINFO`
2. `./scripts/tests/local.py chip-tool-tests --target TestBasicInformation`