### PR TITLE
Fix TC_ICDM_3_1 test case

### DIFF
--- a/src/python_testing/TC_ICDM_3_1.py
+++ b/src/python_testing/TC_ICDM_3_1.py
@@ -155,11 +155,11 @@ class TC_ICDM_3_1(MatterBaseTest):
 
             # Step 2a: Read TestEventTriggersEnabled from General Diagnostics Cluster
             self.step("2a")
-            self.check_test_event_triggers_enabled()
+            await self.check_test_event_triggers_enabled()
 
             # Step 2b: Send TestEventTrigger command to General Diagnostics Cluster
             self.step("2b")
-            self.send_test_event_triggers(eventTrigger=ICDTestEventTriggerOperations.kAddActiveModeReq)
+            await self.send_test_event_triggers(eventTrigger=ICDTestEventTriggerOperations.kAddActiveModeReq)
 
             # Step 3: Read RegisteredClients, clear if not empty
             self.step(3)


### PR DESCRIPTION
Fix the script to await async method in TC_ICDM_3_1

#### Summary

Currently while running the test case step 2a and step 2b are not awaited.
It may cause the script the issue. Additionally  while running the test script - have following logs:

```
RuntimeWarning: coroutine 'MatterBaseTest.check_test_event_triggers_enabled' was never awaited
  await self.check_test_event_triggers_enabled()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

#### Testing

Tested on the nrfconnect platform 
