### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-174 : [Telink] Update Docker image (Zephyr update)
+175 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
@@ -18,8 +18,8 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 3.3.0; branch: develop_3.3
-ARG ZEPHYR_REVISION=db1c965219cb9bac28b059b4f4a1c0f349b446cf
-ARG N22_BIN_REVISION=0274673a35327d2c822739fdc622f55fb226ffc8
+ARG ZEPHYR_REVISION=2b91b8fca283cd58db1519ad211a1ea570f56e2d
+ARG N22_BIN_REVISION=02505ff9ae825cbb5d1884b6d323ffa82c85b726
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,8 +18,8 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 4.1.0; branch: develop
-ARG ZEPHYR_REVISION=f88abc25ab51a6e1bafaea05e57f7ca01bdec7be
-ARG N22_BIN_REVISION=0274673a35327d2c822739fdc622f55fb226ffc8
+ARG ZEPHYR_REVISION=bdf2a03bd32ce7c1f8a277f898c7229855d52b4e
+ARG N22_BIN_REVISION=02505ff9ae825cbb5d1884b6d323ffa82c85b726
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview:**

- kconfig: update N22 binary revision
- west.yml: Update hal telink submodule
- drivers: gpio: tlx: fix wrong interrupts restoring from deep sleep
- drivers: ieee802154: telink: Update B9X & TLX IEEE802.15.4
- drivers: ieee802154: telink: Fix adding enh-ack IE with zero length.
- telink: Update AndeSight Toolchain
- kconfig: update N22 binary revision
- soc: update size of IPC RX work queue stack
- soc: update priority of IPC RX work queue thread
- kconfig: update N22 binary revision
- telink: soc: fix assert in icmsg_workq thread for W91
- soc: telink: tlsr: Fix PLIC with deep-sleep
- kconfig: update N22 binary revision
- soc: telink: tlsr: power.c: Fix external interrupts
- drivers: ieee802154: telink: Fix ACK encryption
- telink: soc: fix fatal error during blocking D25 core in W91

**Changes of N22 binary:**
(latest hash 02505ff9ae825cbb5d1884b6d323ffa82c85b726)

- audio:opus:doc: fix OPUS demo after PM added
- scripts:ci:opus: exclude PM from OPUS demo CI build
- Update connect.c
- Update protocol_common.h
- Update main.c
- [refactor]:sync src 1.1.2.11 code
- Fix issues after updating to SCM-1.2.11
- Update Makefile
- update makefile.lib
- update makefile.lib
- [refactor]:add utc demo
- [refactor]:add distribute net by ble/softap
- [refactor] : Remove dulicate files included
- [refactor] : Add minimp3 lib
- Update tlsr9xxxs_defconfig for low power
- [refactor] : add audio defconfig file
- [refactor] : modify customer demo Kconfig and Makefile to add audio demo
- [refactor] : Modify customer demo Makefile
- [refacotr] : add audio http demo
- [refactor] : add audio common file
- [refactor] : rm audio_pm.o
- [refactor] : modify http audio demo README
- [refactor] : add audio demo Kconfig and Makefile
- [refactor] : add mqtt audio demo Makefile and README
- [refactor] : add mqtt audio demo
- [refactor] : modify i2s driver
- commit for make problem
- commit for make problem
- [refactor] : Fix Windows IDE build error problem
- [refactor] : fix Windows VScode file permission issue
- [bug]Fix uart demo compiling issue.
- Fix build issues
- audio:opus: migrate Opus demo to /customer_demo
- audio:opus:ci: fixed command to build Opus demo

#### Testing
Tested manually.

**Steps:**

- Build image
- Run docker
- Check if Telink examples able to be built successfully