### PR TITLE
[DRAFT] example server cluster interface extension

### DIFF
--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -39,6 +39,8 @@ executable("chip-lighting-app") {
     "LightingAppCommandDelegate.cpp",
     "include/CHIPProjectAppConfig.h",
     "main.cpp",
+    "DevKitExtension.cpp",
+    "DevKitExtension.h",
   ]
 
   deps = [

--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -36,11 +36,11 @@ config("includes") {
 
 executable("chip-lighting-app") {
   sources = [
+    "DevKitExtension.cpp",
+    "DevKitExtension.h",
     "LightingAppCommandDelegate.cpp",
     "include/CHIPProjectAppConfig.h",
     "main.cpp",
-    "DevKitExtension.cpp",
-    "DevKitExtension.h",
   ]
 
   deps = [

--- a/examples/lighting-app/linux/DevKitExtension.cpp
+++ b/examples/lighting-app/linux/DevKitExtension.cpp
@@ -25,7 +25,7 @@ constexpr AttributeId kUserLedAttributeId    = 0xFFF10001;
 constexpr DataModel::AttributeEntry kExtraAttributeMetadata[] = {
     { kDevKitNameAttributeId, {} /* qualities */, Access::Privilege::kView /* readPriv */, std::nullopt /* writePriv */ },
     { kUserLedAttributeId, {} /* qualities */, Access::Privilege::kView /* readPriv */, std::nullopt /* writePriv */ },
-}; // namespace LabelList
+};
 
 } // namespace
 

--- a/examples/lighting-app/linux/DevKitExtension.cpp
+++ b/examples/lighting-app/linux/DevKitExtension.cpp
@@ -38,9 +38,9 @@ DataModel::ActionReturnStatus DevKitInformationExtension::ReadAttribute(const Da
         return encoder.Encode(mDevKitName);
     case kUserLedAttributeId:
         return encoder.Encode(mHasLED);
+    default:
+        return mUnderlying.ReadAttribute(request, encoder);
     }
-
-    return mUnderlying.ReadAttribute(request, encoder);
 }
 CHIP_ERROR DevKitInformationExtension::Attributes(const ConcreteClusterPath & path,
                                                   ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)

--- a/examples/lighting-app/linux/DevKitExtension.cpp
+++ b/examples/lighting-app/linux/DevKitExtension.cpp
@@ -1,0 +1,53 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include "DevKitExtension.h"
+
+namespace chip::app {
+namespace {
+// constants. TODO: these should come from codegen for extensions ...
+constexpr AttributeId kDevKitNameAttributeId = 0xFFF10000;
+constexpr AttributeId kUserLedAttributeId    = 0xFFF10001;
+
+constexpr DataModel::AttributeEntry kExtraAttributeMetadata[] = {
+    { kDevKitNameAttributeId, {} /* qualities */, Access::Privilege::kView /* readPriv */, std::nullopt /* writePriv */ },
+    { kUserLedAttributeId, {} /* qualities */, Access::Privilege::kView /* readPriv */, std::nullopt /* writePriv */ },
+}; // namespace LabelList
+
+} // namespace
+
+DataModel::ActionReturnStatus DevKitInformationExtension::ReadAttribute(const DataModel::ReadAttributeRequest & request,
+                                                                        AttributeValueEncoder & encoder)
+{
+    switch (request.path.mAttributeId)
+    {
+    case kDevKitNameAttributeId:
+        return encoder.Encode(mDevKitName);
+    case kUserLedAttributeId:
+        return encoder.Encode(mHasLED);
+    }
+
+    return mUnderlying.ReadAttribute(request, encoder);
+}
+CHIP_ERROR DevKitInformationExtension::Attributes(const ConcreteClusterPath & path,
+                                                  ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
+{
+    ReturnErrorOnFailure(builder.ReferenceExisting(kExtraAttributeMetadata));
+
+    return mUnderlying.Attributes(path, builder);
+}
+
+} // namespace chip::app

--- a/examples/lighting-app/linux/DevKitExtension.h
+++ b/examples/lighting-app/linux/DevKitExtension.h
@@ -20,21 +20,12 @@
 
 namespace chip::app {
 
-// <attribute side="server" code="0xfff10000" define="DEV_KIT_NAME" type="char_string" writable="true" optional="false" default="Nordic Development Kit" name="DevKitName"/>
-// <attribute side="server" code="0xfff10001" define="USER_LED" type="boolean" length="0" writable="false" reportable="false" isNullable="false" default="false" optional="false" apiMaturity="provisional" name="UserLED">
-//   <access op="read" role="view"/>
-// </attribute>
-class DevKitInformationExtension : public ServerClusterExtension {
+class DevKitInformationExtension : public ServerClusterExtension
+{
 public:
-    DevKitInformationExtension(ServerClusterInterface & other,
-        CharSpan devKitName,
-        bool hasLED)
-        : ServerClusterExtension(other)
-        , mDevKitName(devKitName)
-        , mHasLED(hasLED)
-    {
-    }
-
+    DevKitInformationExtension(ServerClusterInterface & other, CharSpan devKitName, bool hasLED) :
+        ServerClusterExtension(other), mDevKitName(devKitName), mHasLED(hasLED)
+    {}
 
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                 AttributeValueEncoder & encoder) override;

--- a/examples/lighting-app/linux/DevKitExtension.h
+++ b/examples/lighting-app/linux/DevKitExtension.h
@@ -1,0 +1,48 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/server-cluster/ServerClusterExtension.h>
+
+namespace chip::app {
+
+// <attribute side="server" code="0xfff10000" define="DEV_KIT_NAME" type="char_string" writable="true" optional="false" default="Nordic Development Kit" name="DevKitName"/>
+// <attribute side="server" code="0xfff10001" define="USER_LED" type="boolean" length="0" writable="false" reportable="false" isNullable="false" default="false" optional="false" apiMaturity="provisional" name="UserLED">
+//   <access op="read" role="view"/>
+// </attribute>
+class DevKitInformationExtension : public ServerClusterExtension {
+public:
+    DevKitInformationExtension(ServerClusterInterface & other,
+        CharSpan devKitName,
+        bool hasLED)
+        : ServerClusterExtension(other)
+        , mDevKitName(devKitName)
+        , mHasLED(hasLED)
+    {
+    }
+
+
+    DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
+                                                AttributeValueEncoder & encoder) override;
+    CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
+
+private:
+    CharSpan mDevKitName;
+    bool mHasLED;
+};
+
+} // namespace chip::app

--- a/examples/lighting-app/linux/args.gni
+++ b/examples/lighting-app/linux/args.gni
@@ -27,6 +27,7 @@ chip_project_config_include_dirs =
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 matter_enable_tracing_support = true
+matter_log_json_payload_decode_full = true
 
 chip_enable_additional_data_advertising = true
 chip_enable_rotating_device_id = true

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -88,11 +88,15 @@ void ApplicationInit()
         TEMPORARY_RETURN_IGNORED sChipNamedPipeCommands.Stop();
     }
 
-    ServerClusterInterface * interface =
-        chip::app::CodegenDataModelProvider::Instance().Registry().Get({ kRootEndpointId, BasicInformation::Id });
+    auto & registry = chip::app::CodegenDataModelProvider::Instance().Registry();
+
+    ServerClusterInterface * interface = registry.Get({ kRootEndpointId, BasicInformation::Id });
     VerifyOrDie(interface != nullptr);
 
     static RegisteredServerCluster<DevKitInformationExtension> sExtension(*interface, "test_dev_kit"_span, true);
+
+    registry.Unregister(interface);
+    VerifyOrDie(registry.Register(sExtension.Registration()) == CHIP_NO_ERROR);
 
     // FIXME: extension
 }

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -16,16 +16,16 @@
  *    limitations under the License.
  */
 
+#include "DevKitExtension.h"
 #include "LightingAppCommandDelegate.h"
 #include "LightingManager.h"
-#include "DevKitExtension.h"
 #include <AppMain.h>
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
-#include <app/server/Server.h>
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
+#include <app/server/Server.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -88,14 +88,13 @@ void ApplicationInit()
         TEMPORARY_RETURN_IGNORED sChipNamedPipeCommands.Stop();
     }
 
-    ServerClusterInterface * interface = chip::app::CodegenDataModelProvider::Instance().Registry().Get({kRootEndpointId, BasicInformation::Id});
+    ServerClusterInterface * interface =
+        chip::app::CodegenDataModelProvider::Instance().Registry().Get({ kRootEndpointId, BasicInformation::Id });
     VerifyOrDie(interface != nullptr);
 
     static RegisteredServerCluster<DevKitInformationExtension> sExtension(*interface, "test_dev_kit"_span, true);
 
     // FIXME: extension
-    
-    
 }
 
 void ApplicationShutdown()

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -18,12 +18,15 @@
 
 #include "LightingAppCommandDelegate.h"
 #include "LightingManager.h"
+#include "DevKitExtension.h"
 #include <AppMain.h>
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/server/Server.h>
+#include <app/server-cluster/ServerClusterInterfaceRegistry.h>
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #include <string>
@@ -84,6 +87,15 @@ void ApplicationInit()
         ChipLogError(NotSpecified, "Failed to start CHIP NamedPipeCommands");
         TEMPORARY_RETURN_IGNORED sChipNamedPipeCommands.Stop();
     }
+
+    ServerClusterInterface * interface = chip::app::CodegenDataModelProvider::Instance().Registry().Get({kRootEndpointId, BasicInformation::Id});
+    VerifyOrDie(interface != nullptr);
+
+    static RegisteredServerCluster<DevKitInformationExtension> sExtension(*interface, "test_dev_kit"_span, true);
+
+    // FIXME: extension
+    
+    
 }
 
 void ApplicationShutdown()

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -88,6 +88,7 @@ void ApplicationInit()
         TEMPORARY_RETURN_IGNORED sChipNamedPipeCommands.Stop();
     }
 
+    // Replaces the registered `BasicInformation` cluster with a customized on that adds some extra functionality.
     auto & registry = chip::app::CodegenDataModelProvider::Instance().Registry();
 
     ServerClusterInterface * interface = registry.Get({ kRootEndpointId, BasicInformation::Id });
@@ -97,8 +98,6 @@ void ApplicationInit()
 
     registry.Unregister(interface);
     VerifyOrDie(registry.Register(sExtension.Registration()) == CHIP_NO_ERROR);
-
-    // FIXME: extension
 }
 
 void ApplicationShutdown()

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -88,7 +88,7 @@ void ApplicationInit()
         TEMPORARY_RETURN_IGNORED sChipNamedPipeCommands.Stop();
     }
 
-    // Replaces the registered `BasicInformation` cluster with a customized on that adds some extra functionality.
+    // Replaces the registered `BasicInformation` cluster with a customized one that adds some extra functionality.
     auto & registry = chip::app::CodegenDataModelProvider::Instance().Registry();
 
     ServerClusterInterface * interface = registry.Get({ kRootEndpointId, BasicInformation::Id });

--- a/src/app/server-cluster/BUILD.gn
+++ b/src/app/server-cluster/BUILD.gn
@@ -21,6 +21,7 @@ source_set("server-cluster") {
     "DefaultServerCluster.h",
     "OptionalAttributeSet.h",
     "ServerClusterContext.h",
+    "ServerClusterExtension.h",
     "ServerClusterInterface.cpp",
     "ServerClusterInterface.h",
   ]

--- a/src/app/server-cluster/BUILD.gn
+++ b/src/app/server-cluster/BUILD.gn
@@ -21,6 +21,7 @@ source_set("server-cluster") {
     "DefaultServerCluster.h",
     "OptionalAttributeSet.h",
     "ServerClusterContext.h",
+    "ServerClusterExtension.cpp",
     "ServerClusterExtension.h",
     "ServerClusterInterface.cpp",
     "ServerClusterInterface.h",

--- a/src/app/server-cluster/ServerClusterExtension.cpp
+++ b/src/app/server-cluster/ServerClusterExtension.cpp
@@ -1,0 +1,108 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/server-cluster/ServerClusterExtension.h>
+
+namespace chip {
+namespace app {
+
+CHIP_ERROR ServerClusterExtension::Startup(ServerClusterContext & context)
+{
+    mContext      = &context;
+    mVersionDelta = 0;
+    return mUnderlying.Startup(context);
+}
+
+void ServerClusterExtension::Shutdown()
+{
+    mUnderlying.Shutdown();
+    mContext = nullptr;
+}
+
+void ServerClusterExtension::NotifyAttributeChanged(const AttributePathParams & path)
+{
+    VerifyOrReturn(mContext != nullptr);
+    // NOTE: this changes ALL paths, which may not be desirable. However extensions
+    //       generally handle a single cluster, so this should mostly be ok
+    mVersionDelta++;
+    mContext->interactionContext.dataModelChangeListener.MarkDirty(path);
+}
+
+Span<const ConcreteClusterPath> ServerClusterExtension::GetPaths() const
+{
+    return mUnderlying.GetPaths();
+}
+
+DataVersion ServerClusterExtension::GetDataVersion(const ConcreteClusterPath & path) const
+{
+    return mUnderlying.GetDataVersion(path) + mVersionDelta;
+}
+
+BitFlags<DataModel::ClusterQualityFlags> ServerClusterExtension::GetClusterFlags(const ConcreteClusterPath & path) const
+{
+    return mUnderlying.GetClusterFlags(path);
+}
+
+DataModel::ActionReturnStatus ServerClusterExtension::WriteAttribute(const DataModel::WriteAttributeRequest & request,
+                                                                     AttributeValueDecoder & decoder)
+{
+    return mUnderlying.WriteAttribute(request, decoder);
+}
+
+void ServerClusterExtension::ListAttributeWriteNotification(const ConcreteAttributePath & path,
+                                                            DataModel::ListWriteOperation opType, FabricIndex accessingFabric)
+{
+    mUnderlying.ListAttributeWriteNotification(path, opType, accessingFabric);
+}
+
+DataModel::ActionReturnStatus ServerClusterExtension::ReadAttribute(const DataModel::ReadAttributeRequest & request,
+                                                                    AttributeValueEncoder & encoder)
+{
+    return mUnderlying.ReadAttribute(request, encoder);
+}
+
+CHIP_ERROR ServerClusterExtension::Attributes(const ConcreteClusterPath & path,
+                                              ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
+{
+    return mUnderlying.Attributes(path, builder);
+}
+
+CHIP_ERROR ServerClusterExtension::EventInfo(const ConcreteEventPath & path, DataModel::EventEntry & eventInfo)
+{
+    return mUnderlying.EventInfo(path, eventInfo);
+}
+
+std::optional<DataModel::ActionReturnStatus> ServerClusterExtension::InvokeCommand(const DataModel::InvokeRequest & request,
+                                                                                   chip::TLV::TLVReader & input_arguments,
+                                                                                   CommandHandler * handler)
+{
+    return mUnderlying.InvokeCommand(request, input_arguments, handler);
+}
+
+CHIP_ERROR ServerClusterExtension::AcceptedCommands(const ConcreteClusterPath & path,
+                                                    ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder)
+{
+    return mUnderlying.AcceptedCommands(path, builder);
+}
+
+CHIP_ERROR ServerClusterExtension::GeneratedCommands(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<CommandId> & builder)
+{
+    return mUnderlying.GeneratedCommands(path, builder);
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/server-cluster/ServerClusterExtension.h
+++ b/src/app/server-cluster/ServerClusterExtension.h
@@ -1,0 +1,74 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/server-cluster/ServerClusterContext.h>
+#include <app/server-cluster/ServerClusterInterface.h>
+#include <lib/support/Span.h>
+
+namespace chip {
+namespace app {
+
+/// A proxy for a ServerClusterInterface that adds data version management and attribute change notifications.
+///
+/// This class wraps an existing ServerClusterInterface instance and is intended to be
+/// used as a base class for extending cluster functionality, like adding new attributes
+/// or commands to an existing server cluster interface.
+///
+/// NOTE: class is generally designed to override a SINGLE cluster even though ServerClusterInterface
+///       could support multiple server clusters: it maintains a single data version delta that will
+///       apply globally whenever an extension attribute is notified as changed.
+class ServerClusterExtension : public ServerClusterInterface
+{
+public:
+    explicit ServerClusterExtension(ServerClusterInterface & underlying) : mUnderlying(underlying) {}
+
+    CHIP_ERROR Startup(ServerClusterContext & context) override;
+    void Shutdown() override;
+    [[nodiscard]] Span<const ConcreteClusterPath> GetPaths() const override;
+    [[nodiscard]] DataVersion GetDataVersion(const ConcreteClusterPath & path) const override;
+    [[nodiscard]] BitFlags<DataModel::ClusterQualityFlags> GetClusterFlags(const ConcreteClusterPath & path) const override;
+    DataModel::ActionReturnStatus WriteAttribute(const DataModel::WriteAttributeRequest & request,
+                                                 AttributeValueDecoder & decoder) override;
+    void ListAttributeWriteNotification(const ConcreteAttributePath & path, DataModel::ListWriteOperation opType,
+                                        FabricIndex accessingFabric) override;
+    DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
+                                                AttributeValueEncoder & encoder) override;
+    CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
+    CHIP_ERROR EventInfo(const ConcreteEventPath & path, DataModel::EventEntry & eventInfo) override;
+    std::optional<DataModel::ActionReturnStatus> InvokeCommand(const DataModel::InvokeRequest & request,
+                                                               chip::TLV::TLVReader & input_arguments,
+                                                               CommandHandler * handler) override;
+    CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path,
+                                ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder) override;
+    CHIP_ERROR GeneratedCommands(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<CommandId> & builder) override;
+
+protected:
+    ServerClusterInterface & mUnderlying;
+    ServerClusterContext * mContext = nullptr;
+
+    // A data version increment for when the underlying cluster data changes
+    DataVersion mVersionDelta = 0;
+
+    /// Mark the given path as changed:
+    ///   - calls the underlying context if available (i.e. make sure reporting works)
+    ///   - updates internal version delta
+    void NotifyAttributeChanged(const AttributePathParams & path);
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/server-cluster/ServerClusterExtension.h
+++ b/src/app/server-cluster/ServerClusterExtension.h
@@ -20,8 +20,7 @@
 #include <app/server-cluster/ServerClusterInterface.h>
 #include <lib/support/Span.h>
 
-namespace chip {
-namespace app {
+namespace chip::app {
 
 /// A proxy for a ServerClusterInterface that adds data version management and attribute change notifications.
 ///
@@ -70,5 +69,4 @@ protected:
     void NotifyAttributeChanged(const AttributePathParams & path);
 };
 
-} // namespace app
-} // namespace chip
+} // namespace chip::app

--- a/test_attributes.ipynb
+++ b/test_attributes.ipynb
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 17,
    "id": "4d50cd6a-5ee5-40b0-a139-981c03264510",
    "metadata": {},
    "outputs": [
@@ -231,7 +231,7 @@
        "\u001b[1m)\u001b[0m"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -245,8 +245,6 @@
     "class DevKitName(ClusterAttributeDescriptor):\n",
     "    cluster_id = matter.clusters.BasicInformation.id\n",
     "    attribute_id = 0xFFF10000\n",
-    "    attribute_type = ClusterObjectFieldDescriptor(Type=str)\n",
-    "    standard_attribute = False\n",
     "    \n",
     "devCtrl.ExpireSessions(2)\n",
     "result = await devCtrl.Read(nodeId=2, attributes=[(0, DevKitName)])\n",

--- a/test_attributes.ipynb
+++ b/test_attributes.ipynb
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "id": "4d50cd6a-5ee5-40b0-a139-981c03264510",
    "metadata": {},
    "outputs": [
@@ -216,7 +216,7 @@
        "\u001b[2;32m│   \u001b[0m\u001b[33mattributes\u001b[0m=\u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1;36m0\u001b[0m: \u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;39m{\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Attribute.DataVersion'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1;36m908104951\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Attribute.DataVersion'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1;36m1582374516\u001b[0m\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m}\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m}\u001b[0m\n",
        "\u001b[2;32m│   \u001b[0m\u001b[1m}\u001b[0m,\n",
@@ -231,7 +231,7 @@
        "\u001b[1m)\u001b[0m"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -242,27 +242,14 @@
     "from matter import ChipUtility\n",
     "\n",
     "@dataclass\n",
-    "class TempAttribute(ClusterAttributeDescriptor):\n",
-    "    @ChipUtility.classproperty\n",
-    "    def cluster_id(cls) -> int:\n",
-    "        return matter.clusters.BasicInformation.id\n",
-    "\n",
-    "    @ChipUtility.classproperty\n",
-    "    def attribute_id(cls) -> int:\n",
-    "        return 0xFFF10000\n",
-    "\n",
-    "    @ChipUtility.classproperty\n",
-    "    def attribute_type(cls) -> ClusterObjectFieldDescriptor:\n",
-    "        return ClusterObjectFieldDescriptor(Type=str)\n",
-    "\n",
-    "    @ChipUtility.classproperty\n",
-    "    def standard_attribute(cls) -> bool:\n",
-    "        return False\n",
-    "\n",
-    "    value: 'str' = '123'\n",
-    "\n",
+    "class DevKitName(ClusterAttributeDescriptor):\n",
+    "    cluster_id = matter.clusters.BasicInformation.id\n",
+    "    attribute_id = 0xFFF10000\n",
+    "    attribute_type = ClusterObjectFieldDescriptor(Type=str)\n",
+    "    standard_attribute = False\n",
+    "    \n",
     "devCtrl.ExpireSessions(2)\n",
-    "result = await devCtrl.Read(nodeId=2, attributes=[(0, TempAttribute)])\n",
+    "result = await devCtrl.Read(nodeId=2, attributes=[(0, DevKitName)])\n",
     "result"
    ]
   },

--- a/test_attributes.ipynb
+++ b/test_attributes.ipynb
@@ -10,22 +10,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[0;32m[1764005211.607] [1574639:1574639] [CTL] Setting attestation nonce to random value\u001b[0m\n",
-      "\u001b[0;32m[1764005211.607] [1574639:1574639] [CTL] Setting CSR nonce to random value\u001b[0m\n",
-      "\u001b[0;32m[1764005211.608] [1574639:1574639] [DL] NVS set: chip-config/unique-id = \"A191F98E4C9981A8\"\u001b[0m\n",
-      "\u001b[0;32m[1764005211.608] [1574639:1574639] [DL] NVS set: chip-factory/vendor-id = 65521 (0xFFF1)\u001b[0m\n",
-      "\u001b[0;32m[1764005211.608] [1574639:1574639] [DL] NVS set: chip-factory/product-id = 32769 (0x8001)\u001b[0m\n",
-      "\u001b[0;32m[1764005211.608] [1574639:1574639] [DL] NVS set: chip-counters/reboot-count = 1 (0x1)\u001b[0m\n",
-      "\u001b[0;32m[1764005211.608] [1574639:1574639] [DL] NVS set: chip-counters/total-operational-hours = 0 (0x0)\u001b[0m\n",
-      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] NVS set: chip-counters/boot-reason = 0 (0x0)\u001b[0m\n",
-      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] NVS set: chip-config/regulatory-location = 0 (0x0)\u001b[0m\n",
-      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] NVS set: chip-config/location-capability = 2 (0x2)\u001b[0m\n",
-      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] NVS set: chip-config/configuration-version = 1 (0x1)\u001b[0m\n",
-      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] Got Ethernet interface: enp57s0\u001b[0m\n",
-      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] Found the primary Ethernet interface:enp57s0\u001b[0m\n",
-      "\u001b[0;32m[1764005211.610] [1574639:1574639] [DL] Got WiFi interface: wlan0\u001b[0m\n",
-      "\u001b[0;32m[1764005211.611] [1574639:1574639] [DL] Found the primary WiFi interface:wlan0\u001b[0m\n",
-      "\u001b[0;32m[1764005211.611] [1574639:1574639] [PAF] WiFiPAF: WiFiPAFLayer::Init()\u001b[0m\n"
+      "\u001b[0;32m[1764006881.814] [1595194:1595194] [CTL] Setting attestation nonce to random value\u001b[0m\n",
+      "\u001b[0;32m[1764006881.814] [1595194:1595194] [CTL] Setting CSR nonce to random value\u001b[0m\n",
+      "\u001b[0;32m[1764006881.815] [1595194:1595194] [DL] NVS set: chip-counters/reboot-count = 2 (0x2)\u001b[0m\n",
+      "\u001b[0;32m[1764006881.815] [1595194:1595194] [DL] Got Ethernet interface: enp57s0\u001b[0m\n",
+      "\u001b[0;32m[1764006881.816] [1595194:1595194] [DL] Found the primary Ethernet interface:enp57s0\u001b[0m\n",
+      "\u001b[0;32m[1764006881.816] [1595194:1595194] [DL] Got WiFi interface: wlan0\u001b[0m\n",
+      "\u001b[0;32m[1764006881.817] [1595194:1595194] [DL] Found the primary WiFi interface:wlan0\u001b[0m\n",
+      "\u001b[0;32m[1764006881.817] [1595194:1595194] [PAF] WiFiPAF: WiFiPAFLayer::Init()\u001b[0m\n"
      ]
     },
     {
@@ -122,10 +114,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "33fc7915-ba32-45dc-8d73-3f8fe47f55e2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-11-24 12:54:45 andrei-wk2 matter.native.CTL[1595194] ERROR Ignoring failure to read IsCommissioningWithoutPower: src/app/ClusterStateCache.cpp:294: CHIP Error 0x000000CA: Interaction Model Error\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[1;36m2\u001b[0m"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "devices = await devCtrl.DiscoverCommissionableNodes(filterType=matter.discovery.FilterType.LONG_DISCRIMINATOR, filter=3840, stopOnFirst=True, timeoutSecond=2)\n",
     "await devices[0].Commission(2, 20202021)"
@@ -133,10 +153,98 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "0bd571f8-f043-4688-8ba5-95a12728d801",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "\u001b[1m{\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1;36m0\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;39m{\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Attribute.DataVersion'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m2746109702\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.VendorName'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'TEST_VENDOR'\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.HardwareVersion'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m0\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ProductID'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m32769\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.SoftwareVersionString'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'1.0'\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ProductURL'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m''\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.CapabilityMinima'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;35mCapabilityMinimaStruct\u001b[0m\u001b[1;39m(\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[33mcaseSessionsPerFabric\u001b[0m\u001b[39m=\u001b[0m\u001b[1;36m3\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[33msubscriptionsPerFabric\u001b[0m\u001b[39m=\u001b[0m\u001b[1;36m65535\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1;39m)\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.LocalConfigDisabled'\u001b[0m\u001b[39m>: \u001b[0m\u001b[3;91mFalse\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.MaxPathsPerInvoke'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m1\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ClusterRevision'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m5\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.DataModelRevision'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m19\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ProductName'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'TEST_PRODUCT'\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.SoftwareVersion'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m1\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.Location'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'XX'\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.PartNumber'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m''\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.SerialNumber'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'TEST_SN'\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.SpecificationVersion'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m17104896\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.FeatureMap'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m0\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.UniqueID'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'F43FAB355272E32B'\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ConfigurationVersion'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m1\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.AcceptedCommandList'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;39m[\u001b[0m\u001b[1;39m]\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.VendorID'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m65521\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.NodeLabel'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m''\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.HardwareVersionString'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'TEST_VERSION'\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ProductLabel'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m''\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ManufacturingDate'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'20200101'\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.GeneratedCommandList'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;39m[\u001b[0m\u001b[1;39m]\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.AttributeList'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m[\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m4293984256\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m4293984257\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m0\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m1\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m2\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m3\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m4\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m5\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m6\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m7\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m8\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m9\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m10\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m19\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m21\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m22\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m24\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m11\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m12\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m13\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m14\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m15\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m16\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m18\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m65532\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m65533\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m65528\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m65529\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m65531\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m]\u001b[0m\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[1m}\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1m}\u001b[0m\n",
+       "\u001b[1m}\u001b[0m"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "devCtrl.ExpireSessions(2)\n",
     "await devCtrl.ReadAttribute(2, [matter.clusters.BasicInformation])"

--- a/test_attributes.ipynb
+++ b/test_attributes.ipynb
@@ -10,14 +10,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[0;32m[1764006881.814] [1595194:1595194] [CTL] Setting attestation nonce to random value\u001b[0m\n",
-      "\u001b[0;32m[1764006881.814] [1595194:1595194] [CTL] Setting CSR nonce to random value\u001b[0m\n",
-      "\u001b[0;32m[1764006881.815] [1595194:1595194] [DL] NVS set: chip-counters/reboot-count = 2 (0x2)\u001b[0m\n",
-      "\u001b[0;32m[1764006881.815] [1595194:1595194] [DL] Got Ethernet interface: enp57s0\u001b[0m\n",
-      "\u001b[0;32m[1764006881.816] [1595194:1595194] [DL] Found the primary Ethernet interface:enp57s0\u001b[0m\n",
-      "\u001b[0;32m[1764006881.816] [1595194:1595194] [DL] Got WiFi interface: wlan0\u001b[0m\n",
-      "\u001b[0;32m[1764006881.817] [1595194:1595194] [DL] Found the primary WiFi interface:wlan0\u001b[0m\n",
-      "\u001b[0;32m[1764006881.817] [1595194:1595194] [PAF] WiFiPAF: WiFiPAFLayer::Init()\u001b[0m\n"
+      "\u001b[0;32m[1764011113.873] [1641787:1641787] [CTL] Setting attestation nonce to random value\u001b[0m\n",
+      "\u001b[0;32m[1764011113.873] [1641787:1641787] [CTL] Setting CSR nonce to random value\u001b[0m\n",
+      "\u001b[0;32m[1764011113.874] [1641787:1641787] [DL] NVS set: chip-counters/reboot-count = 7 (0x7)\u001b[0m\n",
+      "\u001b[0;32m[1764011113.874] [1641787:1641787] [DL] Got Ethernet interface: enp57s0\u001b[0m\n",
+      "\u001b[0;32m[1764011113.875] [1641787:1641787] [DL] Found the primary Ethernet interface:enp57s0\u001b[0m\n",
+      "\u001b[0;32m[1764011113.875] [1641787:1641787] [DL] Got WiFi interface: wlan0\u001b[0m\n",
+      "\u001b[0;32m[1764011113.876] [1641787:1641787] [DL] Found the primary WiFi interface:wlan0\u001b[0m\n",
+      "\u001b[0;32m[1764011113.876] [1641787:1641787] [PAF] WiFiPAF: WiFiPAFLayer::Init()\u001b[0m\n"
      ]
     },
     {
@@ -109,7 +109,7 @@
     "%reset -f\n",
     "import importlib.util\n",
     "spec = importlib.util.find_spec('matter.ReplStartup')\n",
-    "%run {spec.origin}\n"
+    "%run {spec.origin}"
    ]
   },
   {
@@ -122,7 +122,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-11-24 12:54:45 andrei-wk2 matter.native.CTL[1595194] ERROR Ignoring failure to read IsCommissioningWithoutPower: src/app/ClusterStateCache.cpp:294: CHIP Error 0x000000CA: Interaction Model Error\n"
+      "2025-11-24 13:40:37 andrei-wk2 matter.native.CTL[1624056] ERROR Ignoring failure to read IsCommissioningWithoutPower: src/app/ClusterStateCache.cpp:294: CHIP Error 0x000000CA: Interaction Model Error\n"
      ]
     },
     {
@@ -153,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "0bd571f8-f043-4688-8ba5-95a12728d801",
    "metadata": {},
    "outputs": [
@@ -174,80 +174,127 @@
        "\u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   \u001b[0m\u001b[1;36m0\u001b[0m: \u001b[1m{\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;39m{\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Attribute.DataVersion'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m2746109702\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.VendorName'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'TEST_VENDOR'\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.HardwareVersion'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m0\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ProductID'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m32769\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.SoftwareVersionString'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'1.0'\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ProductURL'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m''\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.CapabilityMinima'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;35mCapabilityMinimaStruct\u001b[0m\u001b[1;39m(\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[33mcaseSessionsPerFabric\u001b[0m\u001b[39m=\u001b[0m\u001b[1;36m3\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[33msubscriptionsPerFabric\u001b[0m\u001b[39m=\u001b[0m\u001b[1;36m65535\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1;39m)\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.LocalConfigDisabled'\u001b[0m\u001b[39m>: \u001b[0m\u001b[3;91mFalse\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.MaxPathsPerInvoke'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m1\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ClusterRevision'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m5\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.DataModelRevision'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m19\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ProductName'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'TEST_PRODUCT'\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.SoftwareVersion'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m1\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.Location'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'XX'\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.PartNumber'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m''\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.SerialNumber'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'TEST_SN'\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.SpecificationVersion'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m17104896\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.FeatureMap'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m0\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.UniqueID'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'F43FAB355272E32B'\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ConfigurationVersion'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m1\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.AcceptedCommandList'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;39m[\u001b[0m\u001b[1;39m]\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.VendorID'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m65521\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.NodeLabel'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m''\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.HardwareVersionString'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'TEST_VERSION'\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ProductLabel'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m''\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.ManufacturingDate'\u001b[0m\u001b[39m>: \u001b[0m\u001b[32m'20200101'\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.GeneratedCommandList'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;39m[\u001b[0m\u001b[1;39m]\u001b[0m\u001b[39m,\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.AttributeList'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1m[\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m4293984256\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m4293984257\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m0\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m1\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m2\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m3\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m4\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m5\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m6\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m7\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m8\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m9\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m10\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m19\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m21\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m22\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m24\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m11\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m12\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m13\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m14\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m15\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m16\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m18\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m65532\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m65533\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m65528\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m65529\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m65531\u001b[0m\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m]\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Attribute.DataVersion'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;36m4018660743\u001b[0m\u001b[39m,\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation.Attributes.VendorName'\u001b[0m\u001b[1m>\u001b[0m: \u001b[32m'TEST_VENDOR'\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m}\u001b[0m\n",
        "\u001b[2;32m│   \u001b[0m\u001b[1m}\u001b[0m\n",
        "\u001b[1m}\u001b[0m"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "devCtrl.ExpireSessions(2)\n",
-    "await devCtrl.ReadAttribute(2, [matter.clusters.BasicInformation])"
+    "# await devCtrl.ReadAttribute(2, [matter.clusters.BasicInformation])\n",
+    "await devCtrl.ReadAttribute(2, [(0, matter.clusters.BasicInformation.Attributes.VendorName)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4d50cd6a-5ee5-40b0-a139-981c03264510",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "\u001b[1;35mReadResponse\u001b[0m\u001b[1m(\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[33mattributes\u001b[0m=\u001b[1m{\u001b[0m\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[1;36m0\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m<\u001b[0m\u001b[1;95mclass\u001b[0m\u001b[39m \u001b[0m\u001b[32m'matter.clusters.Objects.BasicInformation'\u001b[0m\u001b[39m>: \u001b[0m\u001b[1;39m{\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[39m<class \u001b[0m\u001b[32m'matter.clusters.Attribute.DataVersion'\u001b[0m\u001b[1m>\u001b[0m: \u001b[1;36m908104951\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m}\u001b[0m\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[1m}\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1m}\u001b[0m,\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[33mevents\u001b[0m=\u001b[1m[\u001b[0m\u001b[1m]\u001b[0m,\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[33mtlvAttributes\u001b[0m=\u001b[1m{\u001b[0m\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[1;36m0\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1;36m40\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[1;36m4293984256\u001b[0m: \u001b[32m'test_dev_kit'\u001b[0m\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m}\u001b[0m\n",
+       "\u001b[2;32m│   │   \u001b[0m\u001b[1m}\u001b[0m\n",
+       "\u001b[2;32m│   \u001b[0m\u001b[1m}\u001b[0m\n",
+       "\u001b[1m)\u001b[0m"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from dataclasses import dataclass\n",
+    "from matter.clusters.ClusterObjects import ClusterAttributeDescriptor, ClusterObjectFieldDescriptor\n",
+    "from matter import ChipUtility\n",
+    "\n",
+    "@dataclass\n",
+    "class TempAttribute(ClusterAttributeDescriptor):\n",
+    "    @ChipUtility.classproperty\n",
+    "    def cluster_id(cls) -> int:\n",
+    "        return matter.clusters.BasicInformation.id\n",
+    "\n",
+    "    @ChipUtility.classproperty\n",
+    "    def attribute_id(cls) -> int:\n",
+    "        return 0xFFF10000\n",
+    "\n",
+    "    @ChipUtility.classproperty\n",
+    "    def attribute_type(cls) -> ClusterObjectFieldDescriptor:\n",
+    "        return ClusterObjectFieldDescriptor(Type=str)\n",
+    "\n",
+    "    @ChipUtility.classproperty\n",
+    "    def standard_attribute(cls) -> bool:\n",
+    "        return False\n",
+    "\n",
+    "    value: 'str' = '123'\n",
+    "\n",
+    "devCtrl.ExpireSessions(2)\n",
+    "result = await devCtrl.Read(nodeId=2, attributes=[(0, TempAttribute)])\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7c25d775-c639-47dc-8fa0-a87fe104be57",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[1;36m40\u001b[0m"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matter.clusters.BasicInformation.id"
    ]
   }
  ],

--- a/test_attributes.ipynb
+++ b/test_attributes.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "95bd90ed-39a7-4be0-a354-5107507125ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[0;32m[1764005211.607] [1574639:1574639] [CTL] Setting attestation nonce to random value\u001b[0m\n",
+      "\u001b[0;32m[1764005211.607] [1574639:1574639] [CTL] Setting CSR nonce to random value\u001b[0m\n",
+      "\u001b[0;32m[1764005211.608] [1574639:1574639] [DL] NVS set: chip-config/unique-id = \"A191F98E4C9981A8\"\u001b[0m\n",
+      "\u001b[0;32m[1764005211.608] [1574639:1574639] [DL] NVS set: chip-factory/vendor-id = 65521 (0xFFF1)\u001b[0m\n",
+      "\u001b[0;32m[1764005211.608] [1574639:1574639] [DL] NVS set: chip-factory/product-id = 32769 (0x8001)\u001b[0m\n",
+      "\u001b[0;32m[1764005211.608] [1574639:1574639] [DL] NVS set: chip-counters/reboot-count = 1 (0x1)\u001b[0m\n",
+      "\u001b[0;32m[1764005211.608] [1574639:1574639] [DL] NVS set: chip-counters/total-operational-hours = 0 (0x0)\u001b[0m\n",
+      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] NVS set: chip-counters/boot-reason = 0 (0x0)\u001b[0m\n",
+      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] NVS set: chip-config/regulatory-location = 0 (0x0)\u001b[0m\n",
+      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] NVS set: chip-config/location-capability = 2 (0x2)\u001b[0m\n",
+      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] NVS set: chip-config/configuration-version = 1 (0x1)\u001b[0m\n",
+      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] Got Ethernet interface: enp57s0\u001b[0m\n",
+      "\u001b[0;32m[1764005211.609] [1574639:1574639] [DL] Found the primary Ethernet interface:enp57s0\u001b[0m\n",
+      "\u001b[0;32m[1764005211.610] [1574639:1574639] [DL] Got WiFi interface: wlan0\u001b[0m\n",
+      "\u001b[0;32m[1764005211.611] [1574639:1574639] [DL] Found the primary WiFi interface:wlan0\u001b[0m\n",
+      "\u001b[0;32m[1764005211.611] [1574639:1574639] [PAF] WiFiPAF: WiFiPAFLayer::Init()\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">─────────────────────────────────────────────────── </span>Matter REPL<span style=\"color: #00ff00; text-decoration-color: #00ff00\"> ───────────────────────────────────────────────────</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[92m─────────────────────────────────────────────────── \u001b[0mMatter REPL\u001b[92m ───────────────────────────────────────────────────\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "            Welcome to the Matter Python REPL!\n",
+       "\n",
+       "            For help, please type <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">matterhelp()</span>\n",
+       "\n",
+       "            To get more information on a particular object/class, you can pass\n",
+       "            that into <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">matterhelp()</span> as well.\n",
+       "            \n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n",
+       "            Welcome to the Matter Python REPL!\n",
+       "\n",
+       "            For help, please type \u001b[1;32mmatterhelp\u001b[0m\u001b[1;32m(\u001b[0m\u001b[1;32m)\u001b[0m\n",
+       "\n",
+       "            To get more information on a particular object/class, you can pass\n",
+       "            that into \u001b[1;32mmatterhelp\u001b[0m\u001b[1;32m(\u001b[0m\u001b[1;32m)\u001b[0m as well.\n",
+       "            \n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">───────────────────────────────────────────────────────────────────────────────────────────────────────────────────</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[92m───────────────────────────────────────────────────────────────────────────────────────────────────────────────────\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "The following objects have been created:\n",
+       "\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">certificateAuthorityManager</span>:    Manages a list of CertificateAuthority instances\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">caList</span>:                         The list of CertificateAuthority instances\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">caList[n].adminList[m]</span>:         A specific FabricAdmin object at index m for the nth CertificateAuthority \n",
+       "instance\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">devCtrl</span>:                        Default Matter Device Controller <span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">nodeId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0x000000000001B669</span><span style=\"font-weight: bold\">)</span> to manage \n",
+       "<span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">caList[</span><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">0</span><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">].adminList[</span><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">0</span><span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">]</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">fabricId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1</span><span style=\"font-weight: bold\">)</span>\n",
+       "    \n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n",
+       "The following objects have been created:\n",
+       "\n",
+       "        \u001b[1;32mcertificateAuthorityManager\u001b[0m:    Manages a list of CertificateAuthority instances\n",
+       "        \u001b[1;32mcaList\u001b[0m:                         The list of CertificateAuthority instances\n",
+       "        \u001b[1;32mcaList\u001b[0m\u001b[1;32m[\u001b[0m\u001b[1;32mn\u001b[0m\u001b[1;32m]\u001b[0m\u001b[1;32m.adminList\u001b[0m\u001b[1;32m[\u001b[0m\u001b[1;32mm\u001b[0m\u001b[1;32m]\u001b[0m:         A specific FabricAdmin object at index m for the nth CertificateAuthority \n",
+       "instance\n",
+       "        \u001b[1;32mdevCtrl\u001b[0m:                        Default Matter Device Controller \u001b[1m(\u001b[0m\u001b[33mnodeId\u001b[0m=\u001b[1;36m0x000000000001B669\u001b[0m\u001b[1m)\u001b[0m to manage \n",
+       "\u001b[1;32mcaList\u001b[0m\u001b[1;32m[\u001b[0m\u001b[1;32m0\u001b[0m\u001b[1;32m]\u001b[0m\u001b[1;32m.adminList\u001b[0m\u001b[1;32m[\u001b[0m\u001b[1;32m0\u001b[0m\u001b[1;32m]\u001b[0m \u001b[1m(\u001b[0m\u001b[33mfabricId\u001b[0m=\u001b[1;36m1\u001b[0m\u001b[1m)\u001b[0m\n",
+       "    \n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%reset -f\n",
+    "import importlib.util\n",
+    "spec = importlib.util.find_spec('matter.ReplStartup')\n",
+    "%run {spec.origin}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33fc7915-ba32-45dc-8d73-3f8fe47f55e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "devices = await devCtrl.DiscoverCommissionableNodes(filterType=matter.discovery.FilterType.LONG_DISCRIMINATOR, filter=3840, stopOnFirst=True, timeoutSecond=2)\n",
+    "await devices[0].Commission(2, 20202021)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bd571f8-f043-4688-8ba5-95a12728d801",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "devCtrl.ExpireSessions(2)\n",
+    "await devCtrl.ReadAttribute(2, [matter.clusters.BasicInformation])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
#### Summary

To review server cluster interface development:

- defines a server cluster interface extension class
- Uses this class to add an extension that exposes 2 new attributes to a basic information cluster

#### Testing

Read data with chip tool via `./out/linux-x64-chip-tool/chip-tool basicinformation read-by-id 0xffffffff 123 0`:

<img width="2238" height="1508" alt="image" src="https://github.com/user-attachments/assets/d97339e1-e09a-481d-bd55-d7f687942325" />
