### PR TITLE
Call code-driven cluster inits before emberAf... callbacks

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -477,11 +477,13 @@ static void initializeEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
     {
         const EmberAfCluster * cluster = &(epType->cluster[clusterIndex]);
         EmberAfGenericClusterFunction f;
-        emberAfClusterInitCallback(definedEndpoint->endpoint, cluster->clusterId);
         if (cluster->IsServer())
         {
+            // Call the code-driven init callback before the emberAf... one,
+            // so the latter can be used to configure code-driven clusters
             MatterClusterServerInitCallback(definedEndpoint->endpoint, cluster->clusterId);
         }
+        emberAfClusterInitCallback(definedEndpoint->endpoint, cluster->clusterId);
         f = emberAfFindClusterFunction(cluster, MATTER_CLUSTER_FLAG_INIT_FUNCTION);
         if (f != nullptr)
         {


### PR DESCRIPTION
#### Summary

This allows app code to implement the emberAf callback to configure the cluster instance after it has been created but before it is started, e.g. to set delegates or similar objects.

#### Testing

Existing unit and integration tests should ensure this doesn't break anything.