### PR TITLE
CodegenDataModelProvider: Don't allow delegate change once started

### DIFF
--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -133,7 +133,9 @@ CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort, F
     factoryParams.fabricIndependentStorage = &gServerStorage;
     factoryParams.fabricTable              = &Server::GetInstance().GetFabricTable();
     factoryParams.sessionKeystore          = &gSessionKeystore;
-    factoryParams.dataModelProvider        = chip::app::CodegenDataModelProviderInstance(&gServerStorage);
+    // We're running alongside an existing Server, so use the existing DataModelProvider
+    // without changing the underlying persistent storage delegate.
+    factoryParams.dataModelProvider = chip::app::CodegenDataModelProviderInstance(nullptr);
 
     gGroupDataProvider.SetStorageDelegate(&gServerStorage);
     gGroupDataProvider.SetSessionKeystore(factoryParams.sessionKeystore);

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -108,6 +108,21 @@ protected:
 
     template <class T>
     void EncodeAttributeListIntoTLV(const DataModel::List<T> & aListAttribute, TLV::ScopedBufferTLVReader & outTlvReader);
+
+    void SetUp() override
+    {
+        AppContext::SetUp();
+        mOldProvider =
+            InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
+    }
+    void TearDown() override
+    {
+        InteractionModelEngine::GetInstance()->SetDataModelProvider(mOldProvider);
+        AppContext::TearDown();
+    }
+
+private:
+    chip::app::DataModel::Provider * mOldProvider = nullptr;
 };
 
 // Encodes an attribute of List Data Type into a TLV Reader object for testing WriteClient::PutPreencodedAttribute
@@ -343,7 +358,6 @@ TEST_F(TestWriteChunking, TestListChunking)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -434,7 +448,6 @@ TEST_F(TestWriteChunking, TestListChunking_NonEmptyReplaceAllList)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -538,7 +551,6 @@ TEST_F(TestWriteChunking, TestBadChunking)
     bool atLeastOneRequestFailed = false;
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -621,7 +633,6 @@ TEST_F(TestWriteChunking, TestBadChunking_NonEmptyReplaceAllList)
     bool atLeastOneRequestFailed = false;
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -706,7 +717,6 @@ TEST_F(TestWriteChunking, TestConflictWrite)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -781,7 +791,6 @@ TEST_F(TestWriteChunking, TestConflictWrite_NonEmptyReplaceAllList)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -865,7 +874,6 @@ TEST_F(TestWriteChunking, TestNonConflictWrite)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -929,7 +937,6 @@ TEST_F(TestWriteChunking, TestNonConflictWrite_NonEmptyReplaceAllList)
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -1114,7 +1121,6 @@ void TestWriteChunking::RunTest(Instructions instructions, EncodingMethod encodi
 TEST_F(TestWriteChunking, TestTransactionalList)
 {
     // Initialize the ember side server logic
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(&gStorageDelegate));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.
@@ -1370,7 +1376,6 @@ void TestWriteChunking::RunTest_NonEmptyReplaceAll(Instructions instructions,
 TEST_F(TestWriteChunking, TestTransactionalList_NonEmptyReplaceAllList)
 {
     // Initialize the ember side server logic.
-    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
     InitDataModelHandler();
 
     // Register our fake dynamic endpoint.

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.h
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.h
@@ -31,7 +31,7 @@
 namespace chip {
 namespace app {
 
-/// An implementation of `InteractionModel::Model` that relies on code-generation
+/// An implementation of `DataModel::Provider` that relies on code-generation
 /// via zap/ember.
 ///
 /// The Ember framework uses generated files (like endpoint-config.h and various
@@ -41,8 +41,8 @@ namespace app {
 /// as well as application-specific overrides to provide data model functionality.
 ///
 /// Given that this relies on global data at link time, there generally can be
-/// only one CodegenDataModelProvider per application (you can create more instances,
-/// however they would share the exact same underlying data and storage).
+/// only one CodegenDataModelProvider per application. Per-cluster CodegenIntegration
+/// functions access the global singleton instance via `CodegenDataModelProvider::Instance()`.
 class CodegenDataModelProvider : public DataModel::Provider
 {
 public:
@@ -53,7 +53,11 @@ public:
     /// where path caching does not really apply (the same path may result in different outcomes)
     void Reset() { mPreviouslyFoundCluster = std::nullopt; }
 
-    void SetPersistentStorageDelegate(PersistentStorageDelegate * delegate) { mPersistentStorageDelegate = delegate; }
+    void SetPersistentStorageDelegate(PersistentStorageDelegate * delegate)
+    {
+        VerifyOrDie(!mContext.has_value()); // can't change once started
+        mPersistentStorageDelegate = delegate;
+    }
     PersistentStorageDelegate * GetPersistentStorageDelegate() { return mPersistentStorageDelegate; }
 
     SingleEndpointServerClusterRegistry & Registry() { return mRegistry; }

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -197,6 +197,10 @@ public:
     const TestProviderChangeListener & ChangeListener() const { return mChangeListener; }
 
 private:
+    // Test cases that explicitly manage the provider should not use this sub-class
+    using CodegenDataModelProvider::SetPersistentStorageDelegate;
+    using CodegenDataModelProvider::Startup;
+
     LogOnlyEvents mEventGenerator;
     TestProviderChangeListener mChangeListener;
     TestActionContext mActionContext;
@@ -2178,7 +2182,7 @@ TEST_F(TestCodegenModelViaMocks, AttributeAccessInterfaceTakesPrecedenceOverServ
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);
@@ -2232,7 +2236,7 @@ TEST_F(TestCodegenModelViaMocks, AAISkippedIfNoEmberMetadata)
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);
@@ -2745,7 +2749,7 @@ TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesWrite)
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);
@@ -2787,7 +2791,7 @@ TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesRead)
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);
@@ -2815,7 +2819,7 @@ TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesRegistration)
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);
@@ -2939,7 +2943,7 @@ TEST_F(TestCodegenModelViaMocks, ServerClusterInterfacesListClusters)
     TestServerClusterContext testContext;
 
     UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
+    CodegenDataModelProvider model;
 
     model.SetPersistentStorageDelegate(&testContext.StorageDelegate());
     ASSERT_EQ(model.Startup(testContext.ImContext()), CHIP_NO_ERROR);


### PR DESCRIPTION
#### Summary

CodegenDataModelProvider: Don't allow delegate change once started
Also fix a couple of tests that were a bit sloppy with managing the provider.

#### Testing

Existing tests.