### PR TITLE
TCP: Make HandleConnCloseTest[46] work reliably on Darwin and related fixes

### DIFF
--- a/src/inet/TCPEndPointImplSockets.cpp
+++ b/src/inet/TCPEndPointImplSockets.cpp
@@ -1010,6 +1010,12 @@ CHIP_ERROR TCPEndPointImplSockets::HandleIncomingConnection()
         return CHIP_ERROR_POSIX(errno);
     }
 
+#ifdef __APPLE__
+    // On Darwin, if the client closes the connection just as it is being accepted, it is
+    // possible for accept() to return a socket but saLen is 0. Ignore the connection.
+    VerifyOrReturnError(saLen != 0, CHIP_NO_ERROR);
+#endif
+
     // If there's no callback available, fail with an error.
     VerifyOrReturnError(OnConnectionReceived != nullptr, CHIP_ERROR_NO_CONNECTION_HANDLER);
 

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -97,12 +97,12 @@ public:
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     /**
-     * Connect to the specified peer.
+     * Connect to the specified peer. On success, outPeerConnHandle will be populated with a handle to the connection.
      */
     virtual CHIP_ERROR TCPConnect(const PeerAddress & address, Transport::AppTCPConnectionCallbackCtxt * appState,
-                                  ActiveTCPConnectionHandle & peerConnState)
+                                  ActiveTCPConnectionHandle & outPeerConnHandle)
     {
-        return CHIP_NO_ERROR;
+        return CHIP_ERROR_INTERNAL;
     }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -639,16 +639,9 @@ CHIP_ERROR TCPBase::DoHandleIncomingConnection(const Inet::TCPEndPointHandle & l
     }
 #endif
 
+    // GetPeerAddress may fail if the client has already closed the connection, just drop it.
     PeerAddress addr;
-    CHIP_ERROR getPeerError = GetPeerAddress(*endPoint, addr);
-    // See https://github.com/project-chip/connectedhomeip/issues/41746
-    // Failures here must be handled carefully so that broken connections
-    // continue to propagate to failure callbacks to avoid flaky tests
-    if (getPeerError != CHIP_NO_ERROR)
-    {
-        ChipLogFailure(getPeerError, Inet, "Failure getting peer info, using fallback");
-        addr = PeerAddress::TCP(peerAddress, peerPort, Inet::InterfaceId::Null());
-    }
+    ReturnErrorOnFailure(GetPeerAddress(*endPoint, addr));
 
     ActiveTCPConnectionState * activeConnection = AllocateConnection(endPoint, addr);
     VerifyOrReturnError(activeConnection != nullptr, CHIP_ERROR_TOO_MANY_CONNECTIONS);

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -632,6 +632,13 @@ CHIP_ERROR TCPBase::DoHandleIncomingConnection(const Inet::TCPEndPointHandle & l
                                                const Inet::TCPEndPointHandle & endPoint, const Inet::IPAddress & peerAddress,
                                                uint16_t peerPort)
 {
+#if INET_CONFIG_TEST
+    if (sForceFailureInDoHandleIncomingConnection)
+    {
+        return CHIP_ERROR_INTERNAL;
+    }
+#endif
+
     PeerAddress addr;
     CHIP_ERROR getPeerError = GetPeerAddress(*endPoint, addr);
     // See https://github.com/project-chip/connectedhomeip/issues/41746
@@ -642,11 +649,9 @@ CHIP_ERROR TCPBase::DoHandleIncomingConnection(const Inet::TCPEndPointHandle & l
         ChipLogFailure(getPeerError, Inet, "Failure getting peer info, using fallback");
         addr = PeerAddress::TCP(peerAddress, peerPort, Inet::InterfaceId::Null());
     }
+
     ActiveTCPConnectionState * activeConnection = AllocateConnection(endPoint, addr);
-    if (activeConnection == nullptr)
-    {
-        return CHIP_ERROR_TOO_MANY_CONNECTIONS;
-    }
+    VerifyOrReturnError(activeConnection != nullptr, CHIP_ERROR_TOO_MANY_CONNECTIONS);
 
     auto connectionCleanup = ScopeExit([&]() { activeConnection->Free(); });
 
@@ -740,6 +745,10 @@ void TCPBase::InitEndpoint(const Inet::TCPEndPointHandle & endpoint)
     endpoint->OnConnectComplete = HandleTCPEndPointConnectComplete;
     endpoint->SetConnectTimeout(mConnectTimeout);
 }
+
+#if INET_CONFIG_TEST
+bool TCPBase::sForceFailureInDoHandleIncomingConnection = false;
+#endif
 
 } // namespace Transport
 } // namespace chip

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -202,6 +202,10 @@ public:
      */
     void CloseActiveConnections();
 
+#if INET_CONFIG_TEST
+    static bool sForceFailureInDoHandleIncomingConnection;
+#endif
+
 private:
     // Allow tests to access private members.
     template <size_t kActiveConnectionsSize, size_t kPendingPacketSize>


### PR DESCRIPTION
#### Summary

Make TCP tests work reliably on Darwin. The key flake was HandleConnCloseTest[46] which needs to wait longer before closing the connection, to make sure the server has actually accepted the connection properly (otherwise we can't expect to get the OnClose callback).

The other key change in terms of test reliability is to do the retries on EADDRINUSE with a *different* port, since we're not waiting long enough for TIME_WAIT states to actually expire.

Also
- Work around a special-case Darwin quirk where accept() returns a socket but no address.
- TCPConnect base implementation should not return CHIP_NO_ERROR
- The "fallback" workaround for GetPeerAddress failure is no longer needed (with the other changes I encountered no test failures in 1000 repetitions on either Linux or Darwin.)

It's probably easiest to review the commits individually.

#### Testing

New and existing unit tests.