### PR TITLE
TCP: Make HandleConnCloseTest[46] work reliably on Darwin and related fixes

### DIFF
--- a/src/inet/TCPEndPointImplSockets.cpp
+++ b/src/inet/TCPEndPointImplSockets.cpp
@@ -1010,6 +1010,12 @@ CHIP_ERROR TCPEndPointImplSockets::HandleIncomingConnection()
         return CHIP_ERROR_POSIX(errno);
     }
 
+#ifdef __APPLE__
+    // On Darwin, if the client closes the connection just as it is being accepted, it is
+    // possible for accept() to return a socket but saLen is 0. Ignore the connection.
+    VerifyOrReturnError(saLen != 0, CHIP_NO_ERROR);
+#endif
+
     // If there's no callback available, fail with an error.
     VerifyOrReturnError(OnConnectionReceived != nullptr, CHIP_ERROR_NO_CONNECTION_HANDLER);
 

--- a/src/lib/support/tests/ExtraPwTestMacros.h
+++ b/src/lib/support/tests/ExtraPwTestMacros.h
@@ -15,6 +15,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 #pragma once
 
 /**
@@ -61,7 +62,6 @@
  *
  * This macro does not define the body of the test function. It can be used to
  * run a single test case which needs to be run against different fixtures.
- *
  */
 #define TEST_F_FROM_FIXTURE_NO_BODY(test_fixture, test_name)                                                                       \
     TEST_F(test_fixture, test_name)                                                                                                \
@@ -70,33 +70,11 @@
     }
 
 /**
- *  @def EXPECT_SUCCESS(expr)
- *
- *  @brief
- *    Shorthand for EXPECT_EQ(expr, CHIP_NO_ERROR)
- *
- *  Example usage:
- *
- *  @code
- *    EXPECT_SUCCESS(channel->SendMsg(msg));
- *  @endcode
- *
- *  @param[in]  expr        A scalar expression to be evaluated against CHIP_NO_ERROR.
+ * Shorthand for EXPECT_EQ(expr, CHIP_NO_ERROR)
  */
 #define EXPECT_SUCCESS(expr) EXPECT_EQ((expr), CHIP_NO_ERROR)
 
 /**
- *  @def ASSERT_SUCCESS(expr)
- *
- *  @brief
- *    Shorthand for ASSERT_EQ(expr, CHIP_NO_ERROR)
- *
- *  Example usage:
- *
- *  @code
- *    ASSERT_SUCCESS(channel->SendMsg(msg));
- *  @endcode
- *
- *  @param[in]  expr        A scalar expression to be evaluated against CHIP_NO_ERROR.
+ * Shorthand for ASSERT_EQ(expr, CHIP_NO_ERROR)
  */
 #define ASSERT_SUCCESS(expr) ASSERT_EQ((expr), CHIP_NO_ERROR)

--- a/src/lib/support/tests/ExtraPwTestMacros.h
+++ b/src/lib/support/tests/ExtraPwTestMacros.h
@@ -86,17 +86,17 @@
 #define EXPECT_SUCCESS(expr) EXPECT_EQ((expr), CHIP_NO_ERROR)
 
 /**
- *  @def EXPECT_SUCCESS(expr)
+ *  @def ASSERT_SUCCESS(expr)
  *
  *  @brief
- *    Shorthand for EXPECT_EQ(expr, CHIP_NO_ERROR)
+ *    Shorthand for ASSERT_EQ(expr, CHIP_NO_ERROR)
  *
  *  Example usage:
  *
  *  @code
- *    EXPECT_SUCCESS(channel->SendMsg(msg));
+ *    ASSERT_SUCCESS(channel->SendMsg(msg));
  *  @endcode
  *
  *  @param[in]  expr        A scalar expression to be evaluated against CHIP_NO_ERROR.
  */
-#define EXPECT_SUCCESS(expr) EXPECT_EQ((expr), CHIP_NO_ERROR)
+#define ASSERT_SUCCESS(expr) ASSERT_EQ((expr), CHIP_NO_ERROR)

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -97,12 +97,12 @@ public:
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     /**
-     * Connect to the specified peer.
+     * Connect to the specified peer. On success, outPeerConnHandle will be populated with a handle to the connection.
      */
     virtual CHIP_ERROR TCPConnect(const PeerAddress & address, Transport::AppTCPConnectionCallbackCtxt * appState,
-                                  ActiveTCPConnectionHandle & peerConnState)
+                                  ActiveTCPConnectionHandle & outPeerConnHandle)
     {
-        return CHIP_NO_ERROR;
+        return CHIP_ERROR_INTERNAL;
     }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -639,16 +639,9 @@ CHIP_ERROR TCPBase::DoHandleIncomingConnection(const Inet::TCPEndPointHandle & l
     }
 #endif
 
+    // GetPeerAddress may fail if the client has already closed the connection, just drop it.
     PeerAddress addr;
-    CHIP_ERROR getPeerError = GetPeerAddress(*endPoint, addr);
-    // See https://github.com/project-chip/connectedhomeip/issues/41746
-    // Failures here must be handled carefully so that broken connections
-    // continue to propagate to failure callbacks to avoid flaky tests
-    if (getPeerError != CHIP_NO_ERROR)
-    {
-        ChipLogFailure(getPeerError, Inet, "Failure getting peer info, using fallback");
-        addr = PeerAddress::TCP(peerAddress, peerPort, Inet::InterfaceId::Null());
-    }
+    ReturnErrorOnFailure(GetPeerAddress(*endPoint, addr));
 
     ActiveTCPConnectionState * activeConnection = AllocateConnection(endPoint, addr);
     VerifyOrReturnError(activeConnection != nullptr, CHIP_ERROR_TOO_MANY_CONNECTIONS);

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -632,6 +632,13 @@ CHIP_ERROR TCPBase::DoHandleIncomingConnection(const Inet::TCPEndPointHandle & l
                                                const Inet::TCPEndPointHandle & endPoint, const Inet::IPAddress & peerAddress,
                                                uint16_t peerPort)
 {
+#if INET_CONFIG_TEST
+    if (sForceFailureInDoHandleIncomingConnection)
+    {
+        return CHIP_ERROR_INTERNAL;
+    }
+#endif
+
     PeerAddress addr;
     CHIP_ERROR getPeerError = GetPeerAddress(*endPoint, addr);
     // See https://github.com/project-chip/connectedhomeip/issues/41746
@@ -642,11 +649,9 @@ CHIP_ERROR TCPBase::DoHandleIncomingConnection(const Inet::TCPEndPointHandle & l
         ChipLogFailure(getPeerError, Inet, "Failure getting peer info, using fallback");
         addr = PeerAddress::TCP(peerAddress, peerPort, Inet::InterfaceId::Null());
     }
+
     ActiveTCPConnectionState * activeConnection = AllocateConnection(endPoint, addr);
-    if (activeConnection == nullptr)
-    {
-        return CHIP_ERROR_TOO_MANY_CONNECTIONS;
-    }
+    VerifyOrReturnError(activeConnection != nullptr, CHIP_ERROR_TOO_MANY_CONNECTIONS);
 
     auto connectionCleanup = ScopeExit([&]() { activeConnection->Free(); });
 
@@ -740,6 +745,10 @@ void TCPBase::InitEndpoint(const Inet::TCPEndPointHandle & endpoint)
     endpoint->OnConnectComplete = HandleTCPEndPointConnectComplete;
     endpoint->SetConnectTimeout(mConnectTimeout);
 }
+
+#if INET_CONFIG_TEST
+bool TCPBase::sForceFailureInDoHandleIncomingConnection = false;
+#endif
 
 } // namespace Transport
 } // namespace chip

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -202,6 +202,10 @@ public:
      */
     void CloseActiveConnections();
 
+#if INET_CONFIG_TEST
+    static bool sForceFailureInDoHandleIncomingConnection;
+#endif
+
 private:
     // Allow tests to access private members.
     template <size_t kActiveConnectionsSize, size_t kPendingPacketSize>

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -400,6 +400,25 @@ public:
         EXPECT_EQ(mHandleConnectionCloseCalled, nullptr);
     }
 
+    void HandleConnLateFailureTest(TCPImpl & tcp, const IPAddress & addr, uint16_t port)
+    {
+        TCPBase::sForceFailureInDoHandleIncomingConnection = true;
+
+        // Connect and wait for seeing active connection and connection complete
+        CHIP_ERROR err = tcp.TCPConnect(Transport::PeerAddress::TCP(addr, port), nullptr, activeTCPConnState);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(activeTCPConnState);
+
+        mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(5), [this]() { return mHandleConnectionCompleteCalled; });
+        EXPECT_EQ(mHandleConnectionCompleteCalled, &*activeTCPConnState);
+
+        // Wait for client to receive close callback (server endpoint destroyed and closed socket)
+        mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(5), [this]() { return mHandleConnectionCloseCalled; });
+        EXPECT_EQ(mHandleConnectionCloseCalled, &*activeTCPConnState);
+
+        TCPBase::sForceFailureInDoHandleIncomingConnection = false;
+    }
+
     void DisconnectTest(TCPImpl & tcp)
     {
         // Disconnect and wait for seeing peer close
@@ -574,7 +593,8 @@ class TestTCP : public ::testing::Test
 public:
     static void SetUpTestSuite()
     {
-        TCPEndPoint::sForceEarlyFailureIncomingConnection = false;
+        TCPEndPoint::sForceEarlyFailureIncomingConnection  = false;
+        TCPBase::sForceFailureInDoHandleIncomingConnection = false;
         if (mIOContext == nullptr)
         {
             mIOContext = new IOContext();
@@ -681,6 +701,16 @@ protected:
         gMockTransportMgrDelegate.DisconnectTest(tcp);
 
         TCPEndPoint::sForceEarlyFailureIncomingConnection = false;
+    }
+
+    void HandleConnLateFailureTest(const IPAddress & addr)
+    {
+        TCPImpl tcp;
+        uint16_t port;
+        MockTransportMgrDelegate gMockTransportMgrDelegate(mIOContext);
+        ASSERT_SUCCESS(gMockTransportMgrDelegate.InitializeMessageTest(tcp, addr, port));
+        gMockTransportMgrDelegate.HandleConnLateFailureTest(tcp, addr, port);
+        gMockTransportMgrDelegate.DisconnectTest(tcp);
     }
 
     // Callback used by CheckProcessReceivedBuffer.
@@ -813,6 +843,13 @@ TEST_F(TestTCP, HandleConnEarlyFailureTest4)
     IPAddress::FromString("127.0.0.1", addr);
     HandleConnEarlyFailureTest(addr);
 }
+
+TEST_F(TestTCP, HandleConnLateFailureTest4)
+{
+    IPAddress addr;
+    IPAddress::FromString("127.0.0.1", addr);
+    HandleConnLateFailureTest(addr);
+}
 #endif // INET_CONFIG_ENABLE_IPV4
 
 TEST_F(TestTCP, ConnectSendMessageThenCloseTest6)
@@ -841,6 +878,13 @@ TEST_F(TestTCP, HandleConnEarlyFailureTest6)
     IPAddress addr;
     IPAddress::FromString("::1", addr);
     HandleConnEarlyFailureTest(addr);
+}
+
+TEST_F(TestTCP, HandleConnLateFailureTest6)
+{
+    IPAddress addr;
+    IPAddress::FromString("::1", addr);
+    HandleConnLateFailureTest(addr);
 }
 
 TEST_F(TestTCP, CheckTCPEndpointAfterCloseTest)


### PR DESCRIPTION
#### Summary

Make TCP tests work reliably on Darwin. The key flake was HandleConnCloseTest[46] which needs to wait longer before closing the connection, to make sure the server has actually accepted the connection properly (otherwise we can't expect to get the OnClose callback).

The other key change in terms of test reliability is to do the retries on EADDRINUSE with a *different* port, since we're not waiting long enough for TIME_WAIT states to actually expire.

Also
- Work around a special-case Darwin quirk where accept() returns a socket but no address.
- TCPConnect base implementation should not return CHIP_NO_ERROR
- The "fallback" workaround for GetPeerAddress failure is no longer needed (with the other changes I encountered no test failures in 1000 repetitions on either Linux or Darwin.)

It's probably easiest to review the commits individually.

#### Testing

New and existing unit tests.

#### Related Issues

#41746, #41751