### PR TITLE
[NXP] allow user to connect devices to open network

### DIFF
--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -112,10 +112,11 @@ static CHIP_ERROR WiFiConnectHandler(int argc, char ** argv)
     /* Command accepts running with SSID and password (optional) as parameters */
     VerifyOrReturnError((argc == 1 || argc == 2), CHIP_ERROR_INVALID_ARGUMENT);
 
-    ByteSpan ssidSpan     = ByteSpan(Uint8::from_const_char(argv[0]), strlen(argv[0]));
+    ByteSpan ssidSpan = ByteSpan(Uint8::from_const_char(argv[0]), strlen(argv[0]));
     VerifyOrReturnError(IsSpanUsable(ssidSpan), CHIP_ERROR_INVALID_ARGUMENT);
     ByteSpan passwordSpan;
-    if(argc == 2){
+    if (argc == 2)
+    {
         passwordSpan = ByteSpan(Uint8::from_const_char(argv[1]), strlen(argv[1]));
         VerifyOrReturnError(IsSpanUsable(passwordSpan), CHIP_ERROR_INVALID_ARGUMENT);
     }
@@ -124,9 +125,6 @@ static CHIP_ERROR WiFiConnectHandler(int argc, char ** argv)
         // If no password is provided, use an empty password
         passwordSpan = ByteSpan();
     }
-
-
-
 
     ChipLogProgress(Shell, "Adding/Updating network %s", argv[0]);
 

--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -113,12 +113,12 @@ static CHIP_ERROR WiFiConnectHandler(int argc, char ** argv)
     VerifyOrReturnError((argc == 1 || argc == 2), CHIP_ERROR_INVALID_ARGUMENT);
 
     ByteSpan ssidSpan = ByteSpan(Uint8::from_const_char(argv[0]), strlen(argv[0]));
-    VerifyOrReturnError(IsSpanUsable(ssidSpan), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!ssidSpan.empty(), CHIP_ERROR_INVALID_ARGUMENT);
     ByteSpan passwordSpan;
     if (argc == 2)
     {
         passwordSpan = ByteSpan(Uint8::from_const_char(argv[1]), strlen(argv[1]));
-        VerifyOrReturnError(IsSpanUsable(passwordSpan), CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(!passwordSpan.empty(), CHIP_ERROR_INVALID_ARGUMENT);
     }
     else
     {

--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -109,13 +109,24 @@ static CHIP_ERROR WiFiConnectHandler(int argc, char ** argv)
 
     VerifyOrReturnError(GetWiFiDriver() != nullptr, CHIP_ERROR_NOT_IMPLEMENTED);
 
-    /* Command accepts running with SSID and password as parameters */
-    VerifyOrReturnError((argc == 2), CHIP_ERROR_INVALID_ARGUMENT);
+    /* Command accepts running with SSID and password (optional) as parameters */
+    VerifyOrReturnError((argc == 1 || argc == 2), CHIP_ERROR_INVALID_ARGUMENT);
 
     ByteSpan ssidSpan     = ByteSpan(Uint8::from_const_char(argv[0]), strlen(argv[0]));
-    ByteSpan passwordSpan = ByteSpan(Uint8::from_const_char(argv[1]), strlen(argv[1]));
+    VerifyOrReturnError(IsSpanUsable(ssidSpan), CHIP_ERROR_INVALID_ARGUMENT);
+    ByteSpan passwordSpan;
+    if(argc == 2){
+        passwordSpan = ByteSpan(Uint8::from_const_char(argv[1]), strlen(argv[1]));
+        VerifyOrReturnError(IsSpanUsable(passwordSpan), CHIP_ERROR_INVALID_ARGUMENT);
+    }
+    else
+    {
+        // If no password is provided, use an empty password
+        passwordSpan = ByteSpan();
+    }
+    
 
-    VerifyOrReturnError(IsSpanUsable(ssidSpan) && IsSpanUsable(passwordSpan), CHIP_ERROR_INVALID_ARGUMENT);
+    
 
     ChipLogProgress(Shell, "Adding/Updating network %s", argv[0]);
 
@@ -150,7 +161,7 @@ void RegisterWiFiCommands()
 {
     static constexpr Command subCommands[] = {
         { &WiFiModeHandler, "mode", "Get/Set wifi mode. Usage: wifi mode [disable|ap|sta]" },
-        { &WiFiConnectHandler, "connect", "Connect to AP. Usage: wifi connect <ssid> <psk>" },
+        { &WiFiConnectHandler, "connect", "Connect to AP. Usage: wifi connect <ssid> [<psk>]" },
         { &WiFiDisconnectHandler, "disconnect", "Disconnect device from AP. Usage: wifi disconnect" },
     };
 

--- a/src/lib/shell/commands/WiFi.cpp
+++ b/src/lib/shell/commands/WiFi.cpp
@@ -124,9 +124,9 @@ static CHIP_ERROR WiFiConnectHandler(int argc, char ** argv)
         // If no password is provided, use an empty password
         passwordSpan = ByteSpan();
     }
-    
 
-    
+
+
 
     ChipLogProgress(Shell, "Adding/Updating network %s", argv[0]);
 

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -80,12 +80,15 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
 
     err = PersistedStorage::KeyValueStoreMgr().Get(kWiFiCredentialsKeyName, mSavedNetwork.credentials,
                                                    sizeof(mSavedNetwork.credentials), &credentialsLen);
-    if (err != CHIP_NO_ERROR)
+    /* Password could be empty, do not return error if key not found, 
+    password is written in flash before SSID, if SSID is present but not password, it is not an error */
+    if (err != CHIP_NO_ERROR &&  err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         ChipLogProgress(DeviceLayer, "WiFi network credentials not retrieved from persisted storage: %" CHIP_ERROR_FORMAT,
                         err.Format());
         return err;
     }
+
 
     mSavedNetwork.credentialsLen = credentialsLen;
     mSavedNetwork.ssidLen        = ssidLen;
@@ -117,9 +120,9 @@ void NXPWiFiDriver::Shutdown()
 
 CHIP_ERROR NXPWiFiDriver::CommitConfiguration()
 {
-    ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Put(kWiFiSSIDKeyName, mStagingNetwork.ssid, mStagingNetwork.ssidLen));
     ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Put(kWiFiCredentialsKeyName, mStagingNetwork.credentials,
                                                                   mStagingNetwork.credentialsLen));
+    ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Put(kWiFiSSIDKeyName, mStagingNetwork.ssid, mStagingNetwork.ssidLen));
     mSavedNetwork = mStagingNetwork;
 
     return CHIP_NO_ERROR;

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -80,7 +80,7 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
 
     err = PersistedStorage::KeyValueStoreMgr().Get(kWiFiCredentialsKeyName, mSavedNetwork.credentials,
                                                    sizeof(mSavedNetwork.credentials), &credentialsLen);
-    /* Password could be empty, do not return error if key not found, 
+    /* Password could be empty, do not return error if key not found,
     password is written in flash before SSID, if SSID is present but not password, it is not an error */
     if (err != CHIP_NO_ERROR &&  err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -82,13 +82,12 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
                                                    sizeof(mSavedNetwork.credentials), &credentialsLen);
     /* Password could be empty, do not return error if key not found,
     password is written in flash before SSID, if SSID is present but not password, it is not an error */
-    if (err != CHIP_NO_ERROR &&  err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    if (err != CHIP_NO_ERROR && err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         ChipLogProgress(DeviceLayer, "WiFi network credentials not retrieved from persisted storage: %" CHIP_ERROR_FORMAT,
                         err.Format());
         return err;
     }
-
 
     mSavedNetwork.credentialsLen = credentialsLen;
     mSavedNetwork.ssidLen        = ssidLen;


### PR DESCRIPTION
#### Summary

Allow user to connect devices to open wifi network using wifi CLI or during NXP commissionning/init process

#### Testing

NXP rw61x wifi + otbr configuration

connect device to open network using cli and do a on network commissioning:

- wifi connect open_network
- ./chip-tool pairing on-network 1 20202021 3840

do a ble commissioning successfull:

- ./chip-tool pairing ble-wifi 1 matter_open "" 20202021 3840
- reset the board
- check success read attribute: ./chip-tool networkcommissioning read networks 1 0

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
