### PR TITLE
Fix TC_SC_4_1 in CI (broken sleep usage and conflict with default removal on get_endpoint)

### DIFF
--- a/src/python_testing/TC_SC_4_1.py
+++ b/src/python_testing/TC_SC_4_1.py
@@ -687,7 +687,7 @@ class TC_SC_4_1(MatterBaseTest):
 
     @async_test_body
     async def test_TC_SC_4_1(self):
-        self.endpoint = self.get_endpoint(default=1)
+        self.endpoint = self.get_endpoint()
         self.supports_icd = False
         self.supports_lit = False
         self.setup_code_type = None

--- a/src/python_testing/TC_SC_4_1.py
+++ b/src/python_testing/TC_SC_4_1.py
@@ -55,9 +55,9 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import enum
 import logging
-from time import sleep
 from typing import Optional
 
 from mdns_discovery.mdns_discovery import MdnsDiscovery, MdnsServiceType
@@ -680,7 +680,7 @@ class TC_SC_4_1(MatterBaseTest):
                                                   endpoint=0,
                                                   payload=revoke_cmd,
                                                   timedRequestTimeoutMs=6000)
-        sleep(1)  # Give some time for failsafe cleanup scheduling
+        await asyncio.sleep(1)  # Give some time for failsafe cleanup scheduling
 
     def desc_TC_TC_SC_4_1(self) -> str:
         return "[TC-SC-4.1] Commissionable Node Discovery with DUT as Commissionee"


### PR DESCRIPTION
#### Summary

Fix failing CI, see error @ https://github.com/project-chip/connectedhomeip/actions/runs/19678294845/job/56365462321?pr=41955

<img width="1771" height="482" alt="image" src="https://github.com/user-attachments/assets/b62701cb-4544-46f2-ad63-15cad7623752" />


#### Testing

CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
