### PR TITLE
[Silabs] Add Support for RGB led in Thread build (part 2)

### DIFF
--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -41,7 +41,7 @@ extern "C" {
 #define SL_SIMPLE_LED_INSTANCE(x) (&sl_simple_rgb_pwm_led_rgb_led0)
 #define SL_SIMPLE_LED_COUNT 1
 #define SL_LED_INIT_INTANCES() sl_simple_rgb_pwm_led_init_instances();
-#define SL_LED_GET_STATE(x) (x->led_common.context->state)
+#define SL_LED_GET_STATE(x) sl_led_get_state(&(x->led_common))
 #define SL_LED_TURN_ON(x) sl_led_turn_on(&(x->led_common))
 #define SL_LED_TURN_OFF(x) sl_led_turn_off(&(x->led_common))
 #define SL_LED_TOGGLE(x) sl_led_toggle(&(x->led_common))

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -155,6 +155,7 @@ if (is_si917_board) {
   silabs_mcu = "EFR32MG24B310F1536IM48"
 
   sl_enable_rgb_led = true
+
   # ThunderBoards don't have a LCD,
   show_qr_code = false
   disable_lcd = true

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -154,7 +154,6 @@ if (is_si917_board) {
   silabs_family = "efr32mg24"
   silabs_mcu = "EFR32MG24B310F1536IM48"
 
-  # TODO enable me once submodule is updated
   sl_enable_rgb_led = true
   # ThunderBoards don't have a LCD,
   show_qr_code = false

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -155,7 +155,7 @@ if (is_si917_board) {
   silabs_mcu = "EFR32MG24B310F1536IM48"
 
   # TODO enable me once submodule is updated
-  # sl_enable_rgb_led = true
+  sl_enable_rgb_led = true
   # ThunderBoards don't have a LCD,
   show_qr_code = false
   disable_lcd = true
@@ -231,6 +231,7 @@ if (is_si917_board) {
   # ThunderBoards don't have a LCD,
   show_qr_code = false
   disable_lcd = true
+  sl_enable_rgb_led = true
 
   # Custom Board ----------
 } else if (silabs_board == "CUSTOM") {


### PR DESCRIPTION
#### Summary
Added matter_support changes for autogen/config files for supported thread boards when rgb led enabled.
Fixed build and enabled rgb led by default for BRD2601B and BRD2608A boards.

#### Related issues
N/A

#### Testing
Need to update

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
