### PR TITLE
Add shell/CLI support to bridge-app ESP32

### DIFF
--- a/examples/bridge-app/esp32/main/CMakeLists.txt
+++ b/examples/bridge-app/esp32/main/CMakeLists.txt
@@ -26,6 +26,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${APP_COMMON_GEN_DIR}/attributes"
                       "${APP_COMMON_GEN_DIR}"
                       "${CHIP_ROOT}/examples/platform/esp32/common"
+                      "${CHIP_ROOT}/examples/platform/esp32/shell_extension"
                       "${CHIP_ROOT}/examples/providers"
                       "${CHIP_ROOT}/examples/bridge-app/bridge-common/src")
 

--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -19,6 +19,8 @@
 #include "DeviceCallbacks.h"
 #include "esp_log.h"
 #include "nvs_flash.h"
+#include "shell_extension/launch.h"
+#include "shell_extension/openthread_cli_register.h"
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
@@ -27,8 +29,6 @@
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <bridged-actions-stub.h>
-#include "shell_extension/launch.h"
-#include "shell_extension/openthread_cli_register.h"
 #include <common/Esp32AppServer.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>

--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -27,6 +27,8 @@
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <bridged-actions-stub.h>
+#include "shell_extension/launch.h"
+#include "shell_extension/openthread_cli_register.h"
 #include <common/Esp32AppServer.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
@@ -428,6 +430,13 @@ extern "C" void app_main()
         ESP_LOGE(TAG, "esp_event_loop_create_default()  failed: %s", esp_err_to_name(err));
         return;
     }
+
+#if CONFIG_ENABLE_CHIP_SHELL
+#if CONFIG_OPENTHREAD_CLI
+    chip::RegisterOpenThreadCliCommands();
+#endif
+    chip::LaunchShell();
+#endif
 
     CHIP_ERROR chip_err = CHIP_NO_ERROR;
 

--- a/examples/bridge-app/esp32/sdkconfig.defaults
+++ b/examples/bridge-app/esp32/sdkconfig.defaults
@@ -29,6 +29,9 @@ CONFIG_BT_NIMBLE_ENABLE_CONN_REATTEMPT=n
 #enable lwip ipv6 autoconfig
 CONFIG_LWIP_IPV6_AUTOCONFIG=y
 
+#enable debug shell
+CONFIG_ENABLE_CHIP_SHELL=y
+
 # Use a custom partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"


### PR DESCRIPTION
#### Summary

This PR adds shell/CLI support to the bridge-app ESP32 example, enabling Matter CLI commands similar to the lighting-app.

**Changes:**
- Added shell initialization (`chip::LaunchShell()`) in `main.cpp`
- Included shell extension headers (`shell_extension/launch.h` and `shell_extension/openthread_cli_register.h`)
- Registered OpenThread CLI commands (when `CONFIG_OPENTHREAD_CLI` is enabled)
- Added `shell_extension` directory to `CMakeLists.txt` source directories
- Enabled `CONFIG_ENABLE_CHIP_SHELL=y` in `sdkconfig.defaults`

This change brings bridge-app ESP32 to feature parity with lighting-app ESP32 in terms of CLI functionality, allowing developers to use Matter shell commands (e.g., `matter help`, `device`, etc.) for debugging and testing.

#### Related issues

N/A

#### Testing

**Manual Testing:**
1. Built bridge-app for ESP32 target
2. Flashed the firmware to ESP32 device
3. Connected via serial monitor (`idf.py monitor`)
4. Verified shell prompt appears after device boot
5. Tested basic shell commands:
   - `matter help` - Lists all available commands
   - `matter device factoryreset` - Factory Reset the Application
  

**Build Verification:**
- Successfully built with `CONFIG_ENABLE_CHIP_SHELL=y`
- No compilation errors or warnings
- All existing functionality remains intact

#### Readability checklist

-   [x] PR title is descriptive: "Add shell/CLI support to bridge-app ESP32"
-   [x] Apply the _"When in Rome…"_ rule (coding style) - Follows existing ESP32 platform patterns
-   [x] PR size is short - Only 3 files changed, 13 insertions
-   [x] Try to avoid "squashing" and "force-update" in commit history - Single clean commit
-   [x] CI time didn't increase - No impact on CI, only adds optional shell feature