### PR TITLE
Run ruff auto-fixer before autopep8 and isort

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -223,13 +223,18 @@ restylers:
       include:
           - "**/*.sh"
           - "**/*.bash"
-    - name: autopep8
-      image: public.ecr.aws/restyled-io/restyler-autopep8:v2.3
-    - name: isort
-      image: public.ecr.aws/restyled-io/restyler-isort:v7.0
+
+    # NOTE: The order of the Python restylers is important. The ruff auto-fixer
+    #       needs to run first because the changes it makes may break style which
+    #       then autopep8 and isort can fix. Also, the isort needs to run last
+    #       because autopep8 may move some imports but without sorting them.
     - name: ruff
       image: public.ecr.aws/restyled-io/restyler-ruff:v0.14
       command:
           - ruff
           - check
           - --fix-only
+    - name: autopep8
+      image: public.ecr.aws/restyled-io/restyler-autopep8:v2.3
+    - name: isort
+      image: public.ecr.aws/restyled-io/restyler-isort:v7.0

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -227,7 +227,7 @@ restylers:
     # NOTE: The order of the Python restylers is important. The ruff auto-fixer
     #       needs to run first because the changes it makes may break style which
     #       then autopep8 and isort can fix. Also, the isort needs to run last
-    #       because autopep8 may move some imports but without sorting them.
+    #       because autopep8 may reformat import lines without sorting them.
     - name: ruff
       image: public.ecr.aws/restyled-io/restyler-ruff:v0.14
       command:


### PR DESCRIPTION
#### Summary

Ruff auto-fixer might leave unnecessary empty lines or keep arguments over/under indented, e.g.:

```diff
diff --git a/scripts/tests/chipyaml/adapters/chiptool/encoder.py b/scripts/tests/chipyaml/adapters/chiptool/encoder.py
index a3b35ef741..2d48f0116c 100644
--- a/scripts/tests/chipyaml/adapters/chiptool/encoder.py
+++ b/scripts/tests/chipyaml/adapters/chiptool/encoder.py
@@ -337,8 +337,7 @@ class Encoder:
         arguments = self.__maybe_add(
             arguments, request.identity, "commissioner-name")
         return self.__maybe_add(arguments, request.fabric_filtered,
-                                     "fabric-filtered")
-
+                                "fabric-filtered")

     def __maybe_add_destination(self, rv, request):
         if not self._supports_destination(request):
```

#### Testing

CI will verify, but this change should be noop for current master.