### PR TITLE
Speed up CI by removing duplicated Example Builds from Linux Standalone

### DIFF
--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -60,35 +60,17 @@ jobs:
                      "./scripts/build/build_examples.py \
                         --target linux-x64-address-resolve-tool-platform-mdns-ipv6only \
                         build" && rm -rf out
-            - name: Build example Standalone chip tool
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-chip-tool \
-                        build" && rm -rf out
             - name: Build example Standalone Shell
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-shell \
                         build" && rm -rf out
-            - name: Build example Standalone All Clusters Server
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-all-clusters \
-                        build" && rm -rf out
             - name: Build example Standalone All Clusters Minimal Server
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-all-clusters-minimal \
-                        build" && rm -rf out
-            - name: Build example TV app
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-tv-app \
                         build" && rm -rf out
             - name: Build example Standalone TV Casting App
               run: |
@@ -102,77 +84,11 @@ jobs:
                      "./scripts/build/build_examples.py \
                         --target linux-x64-light-rpc-with-ui \
                         build" && rm -rf out
-            - name: Build example Standalone Bridge
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-bridge \
-                        build" && rm -rf out
-            - name: Build example OTA Provider
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-ota-provider \
-                        build" && rm -rf out
-            - name: Build example OTA Requestor
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-ota-requestor \
-                        build" && rm -rf out
-            - name: Build example Standalone Lock App
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-lock-no-thread \
-                        build" && rm -rf out
             - name: Build example contact sensor with UI
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-contact-sensor-no-ble-with-ui \
-                        build" && rm -rf out
-            - name: Build example Air Purifier
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-air-purifier \
-                        build" && rm -rf out
-            - name: Build example Fabric Admin
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-fabric-admin-rpc \
-                        build" && rm -rf out
-            - name: Build example Fabric Bridge App
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-fabric-bridge-no-ble-rpc \
-                        build" && rm -rf out
-            - name: Build example Fabric Sync
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-fabric-sync-no-ble \
-                        build" && rm -rf out
-            - name: Build example Camera App
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-camera \
-                        build" && rm -rf out
-            - name: Build example Camera Controller App
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-camera-controller \
-                        build" && rm -rf out
-            - name: Build Example Closure App
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-x64-closure \
                         build" && rm -rf out
 
             - name: CCache statistics


### PR DESCRIPTION
#### Summary

I noticed one of the longest running CI Jobs now is the [Linux Standalone CI job](https://github.com/project-chip/connectedhomeip/actions/runs/19743441581/job/56572639189?pr=41954) which runs for about 1h18min just to build apps.
Many of these apps are already built by other CI jobs, such as the REPL tests.

In this PR, the "Example Apps builds" removed from .github/workflows/examples-linux-standalone.yaml are covered in  `.github/workflows/tests.yaml`, primarily under the `test_suites_linux` and `repl_tests_linux_build jobs`.

  Here is the mapping of the removed targets to their coverage in tests.yaml:

```
  ┌────────────────────────────────────┬─────────────────────────────┬─────────────────────────────────────────────────────────────────┐
  │ Removed Target                     │ Covered in tests.yaml (Job) │ Target Variant in tests.yaml                                    │
  ├────────────────────────────────────┼─────────────────────────────┼─────────────────────────────────────────────────────────────────┤
  │ linux-x64-chip-tool                │ test_suites_linux             │ linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}          │
  │ linux-x64-all-clusters             │ test_suites_linux             │ linux-x64-all-clusters-${BUILD_VARIANT}                         │
  │ linux-x64-tv-app                   │ test_suites_linux             │ linux-x64-tv-app-${BUILD_VARIANT}                               │
  │ linux-x64-bridge                   │ test_suites_linux             │ linux-x64-bridge-${BUILD_VARIANT}-unified                       │
  │ linux-x64-ota-provider             │ test_suites_linux             │ linux-x64-ota-provider-${BUILD_VARIANT}-unified                 │
  │ linux-x64-ota-requestor            │ test_suites_linux             │ linux-x64-ota-requestor-${BUILD_VARIANT}                        │
  │ linux-x64-lock-no-thread           │ test_suites_linux             │ linux-x64-lock-${BUILD_VARIANT}-unified                         │
  │ linux-x64-air-purifier             │ repl_tests_linux_build        │ linux-x64-air-purifier-${BUILD_VARIANT}-tsan-clang-test-unified │
  │ linux-x64-fabric-admin-rpc         │ repl_tests_linux_build        │ linux-x64-fabric-admin-rpc-${BUILD_VARIANT}-clang               │
  │ linux-x64-fabric-bridge-no-ble-rpc │ repl_tests_linux_build        │ linux-x64-fabric-bridge-rpc-${BUILD_VARIANT}-clang*             │
  │ linux-x64-fabric-sync-no-ble       │ repl_tests_linux_build        │ linux-x64-fabric-sync-${BUILD_VARIANT}-clang*                   │
  │ linux-x64-camera                   │ repl_tests_linux_build        │ linux-x64-camera                                                │
  │ linux-x64-camera-controller        │ repl_tests_linux_build        │ linux-x64-camera-controller                                     │
  │ linux-x64-closure                  │ repl_tests_linux_build        │ linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test-unified      │
  └────────────────────────────────────┴─────────────────────────────┴─────────────────────────────────────────────────────────────────┘

```

This results in a total time saving of 53 minutes for this CI job/per run.
```
Removed Target	Build Time (minutes:seconds)
linux-x64-chip-tool	5:07
linux-x64-all-clusters	7:10
linux-x64-tv-app	4:51
linux-x64-bridge	3:03
linux-x64-ota-provider	3:40
linux-x64-ota-requestor	2:54
linux-x64-lock-no-thread	3:05
linux-x64-air-purifier	2:51
linux-x64-fabric-admin-rpc	3:30
linux-x64-fabric-bridge-no-ble-rpc	1:58
linux-x64-fabric-sync-no-ble	3:37
linux-x64-camera	6:02
linux-x64-camera-controller	3:51
linux-x64-closure	2:03
Total	53:42
```

#### Testing

Manually verified apps removed are covered by other jobs.