### PR TITLE
Speed up Darwin CI by enabling unified build on darwin-tests.yaml

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -90,20 +90,29 @@ jobs:
       - name: Clean Build
         run: xcodebuild clean
         working-directory: src/darwin/Framework
-      - name: Build Apps
+      - name: Build Apps Using Unified Build
+        run: |
+          ./scripts/run_in_build_env.sh \
+             "./scripts/build/build_examples.py \
+                --target darwin-${{matrix.arch}}-lock-${BUILD_VARIANT}-unified \
+                --target darwin-${{matrix.arch}}-bridge-${BUILD_VARIANT}-unified \
+                --target darwin-${{matrix.arch}}-microwave-oven-${BUILD_VARIANT}-unified \
+                --target darwin-${{matrix.arch}}-rvc-${BUILD_VARIANT}-unified \
+                --target darwin-${{matrix.arch}}-ota-provider-${BUILD_VARIANT}-unified \
+                build \
+                --copy-artifacts-to objdir-clone \
+             "
+      - name: Clean out
+        run: rm -rf out/
+      - name: Build Remaining Apps That Don't Support Unified Build
         run: |
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \
                 --target darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL} \
                 --target darwin-${{matrix.arch}}-all-clusters-${BUILD_VARIANT} \
-                --target darwin-${{matrix.arch}}-lock-${BUILD_VARIANT} \
-                --target darwin-${{matrix.arch}}-ota-provider-${BUILD_VARIANT} \
                 --target darwin-${{matrix.arch}}-ota-requestor-${BUILD_VARIANT} \
                 --target darwin-${{matrix.arch}}-tv-app-${BUILD_VARIANT} \
-                --target darwin-${{matrix.arch}}-bridge-${BUILD_VARIANT} \
                 --target darwin-${{matrix.arch}}-lit-icd-${BUILD_VARIANT} \
-                --target darwin-${{matrix.arch}}-microwave-oven-${BUILD_VARIANT} \
-                --target darwin-${{matrix.arch}}-rvc-${BUILD_VARIANT} \
                 --target darwin-${{matrix.arch}}-network-manager-${BUILD_VARIANT} \
                 --target darwin-${{matrix.arch}}-energy-gateway-${BUILD_VARIANT} \
                 --target darwin-${{matrix.arch}}-energy-management-${BUILD_VARIANT} \
@@ -115,30 +124,30 @@ jobs:
           ./scripts/run_in_build_env.sh \
           "./scripts/tests/run_test_suite.py \
              --runner darwin_framework_tool_python \
-             --chip-tool ./out/darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
+             --chip-tool ./objdir-clone/darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
              --target-skip-glob '{TestAccessControlConstraints}' \
              run \
              --iterations 1 \
              --test-timeout-seconds 120 \
-             --all-clusters-app ./out/darwin-${{matrix.arch}}-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
-             --lock-app ./out/darwin-${{matrix.arch}}-lock-${BUILD_VARIANT}/chip-lock-app \
-             --ota-provider-app ./out/darwin-${{matrix.arch}}-ota-provider-${BUILD_VARIANT}/chip-ota-provider-app \
-             --ota-requestor-app ./out/darwin-${{matrix.arch}}-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
-             --tv-app ./out/darwin-${{matrix.arch}}-tv-app-${BUILD_VARIANT}/chip-tv-app \
-             --bridge-app ./out/darwin-${{matrix.arch}}-bridge-${BUILD_VARIANT}/chip-bridge-app \
-             --microwave-oven-app ./out/darwin-${{matrix.arch}}-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
-             --rvc-app ./out/darwin-${{matrix.arch}}-rvc-${BUILD_VARIANT}/chip-rvc-app \
-             --network-manager-app ./out/darwin-${{matrix.arch}}-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
-             --energy-gateway-app ./out/darwin-${{matrix.arch}}-energy-gateway-${BUILD_VARIANT}/chip-energy-gateway-app \
-             --energy-management-app ./out/darwin-${{matrix.arch}}-energy-management-${BUILD_VARIANT}/chip-energy-management-app \
+             --all-clusters-app ./objdir-clone/darwin-${{matrix.arch}}-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
+             --lock-app ./objdir-clone/darwin-${{matrix.arch}}-lock-${BUILD_VARIANT}-unified/chip-lock-app \
+             --ota-provider-app ./objdir-clone/darwin-${{matrix.arch}}-ota-provider-${BUILD_VARIANT}-unified/chip-ota-provider-app \
+             --ota-requestor-app ./objdir-clone/darwin-${{matrix.arch}}-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
+             --tv-app ./objdir-clone/darwin-${{matrix.arch}}-tv-app-${BUILD_VARIANT}/chip-tv-app \
+             --bridge-app ./objdir-clone/darwin-${{matrix.arch}}-bridge-${BUILD_VARIANT}-unified/chip-bridge-app \
+             --microwave-oven-app ./objdir-clone/darwin-${{matrix.arch}}-microwave-oven-${BUILD_VARIANT}-unified/chip-microwave-oven-app \
+             --rvc-app ./objdir-clone/darwin-${{matrix.arch}}-rvc-${BUILD_VARIANT}-unified/chip-rvc-app \
+             --network-manager-app ./objdir-clone/darwin-${{matrix.arch}}-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
+             --energy-gateway-app ./objdir-clone/darwin-${{matrix.arch}}-energy-gateway-${BUILD_VARIANT}/chip-energy-gateway-app \
+             --energy-management-app ./objdir-clone/darwin-${{matrix.arch}}-energy-management-${BUILD_VARIANT}/chip-energy-management-app \
           "
       - name: Run OTA Test
         run: |
           ./scripts/run_in_build_env.sh \
           "./scripts/tests/run_darwin_framework_ota_test.py \
              run \
-             --darwin-framework-tool ./out/darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
-             --ota-requestor-app ./out/darwin-${{matrix.arch}}-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
+             --darwin-framework-tool ./objdir-clone/darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
+             --ota-requestor-app ./objdir-clone/darwin-${{matrix.arch}}-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
              --ota-data-file /tmp/rawImage \
              --ota-image-file /tmp/otaImage \
              --ota-destination-file /tmp/downloadedImage \

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -124,7 +124,7 @@ jobs:
           ./scripts/run_in_build_env.sh \
           "./scripts/tests/run_test_suite.py \
              --runner darwin_framework_tool_python \
-             --chip-tool ./objdir-clone/darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
+             --chip-tool ./out/darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
              --target-skip-glob '{TestAccessControlConstraints}' \
              run \
              --iterations 1 \
@@ -146,7 +146,7 @@ jobs:
           ./scripts/run_in_build_env.sh \
           "./scripts/tests/run_darwin_framework_ota_test.py \
              run \
-             --darwin-framework-tool ./objdir-clone/darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
+             --darwin-framework-tool ./out/darwin-${{matrix.arch}}-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
              --ota-requestor-app ./objdir-clone/darwin-${{matrix.arch}}-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
              --ota-data-file /tmp/rawImage \
              --ota-image-file /tmp/otaImage \


### PR DESCRIPTION
#### Summary

Similar to what we've done in the past to enable the unified build for the REPL workflow and [darwin-tests defined in tests.yaml](https://github.com/project-chip/connectedhomeip/pull/41969), this PR speeds up CI by enabling unified build on darwin-tests.yaml .


#### Testing
CI will validate