### PR TITLE
[PICS Generator] Adding native support for 1.5 and address changes in args handling downstream

### DIFF
--- a/src/tools/PICS-generator/PICSGenerator.py
+++ b/src/tools/PICS-generator/PICSGenerator.py
@@ -365,6 +365,10 @@ parser.add_argument('--pics-output', required=True)
 parser.add_argument('--dm-xml')
 args, unknown = parser.parse_known_args()
 
+# The matter_testing framework does not accept unknown args,
+# so all the handled args are removed from argv
+sys.argv = sys.argv[:1] + unknown
+
 xmlTemplatePathStr = args.pics_template
 if not xmlTemplatePathStr.endswith('/'):
     xmlTemplatePathStr += '/'
@@ -432,6 +436,8 @@ class DeviceMappingTest(MatterBaseTest):
                 xml_clusters, problems = build_xml_clusters(PrebuiltDataModelDirectory.k1_4_1)
             elif specVersion == 0x1040200:
                 xml_clusters, problems = build_xml_clusters(PrebuiltDataModelDirectory.k1_4_2)
+            elif specVersion == 0x1050000:
+                xml_clusters, problems = build_xml_clusters(PrebuiltDataModelDirectory.k1_5)
             else:
                 console.print("FAILURE: Specification version reported by device not supported")
                 return


### PR DESCRIPTION
#### Summary

This PR addresses two fixes for the PICS Generator:

1) Adds native handling for 1.5 data model files
2) Modifies the handling of the additional args needed by the tool to address changes done to the underlaying code

#### Testing

Successfully generated files for 1.5 without providing path for DM files.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
