### PR TITLE
[On/Off cluster] split logic to separate integration points (separate out ifdefs)

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -49,22 +49,6 @@ public:
     DefaultColorControlSceneHandler() = default;
     ~DefaultColorControlSceneHandler() override {}
 
-    // Default function for ColorControl cluster, only puts the ColorControl cluster ID in the span if supported on the caller
-    // endpoint
-    void GetSupportedClusters(EndpointId endpoint, Span<ClusterId> & clusterBuffer) override
-    {
-        ClusterId * buffer = clusterBuffer.data();
-        if (emberAfContainsServer(endpoint, ColorControl::Id) && clusterBuffer.size() >= 1)
-        {
-            buffer[0] = ColorControl::Id;
-            clusterBuffer.reduce_size(1);
-        }
-        else
-        {
-            clusterBuffer.reduce_size(0);
-        }
-    }
-
     // Default function for ColorControl cluster, only checks if ColorControl is enabled on the endpoint
     bool SupportsCluster(EndpointId endpoint, ClusterId cluster) override
     {

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -138,21 +138,6 @@ public:
     DefaultLevelControlSceneHandler() = default;
     ~DefaultLevelControlSceneHandler() override {}
 
-    // Default function for LevelControl cluster, only puts the LevelControl cluster ID in the span if supported on the caller
-    // endpoint
-    virtual void GetSupportedClusters(EndpointId endpoint, Span<ClusterId> & clusterBuffer) override
-    {
-        if (emberAfContainsServer(endpoint, LevelControl::Id) && clusterBuffer.size() >= 1)
-        {
-            clusterBuffer[0] = LevelControl::Id;
-            clusterBuffer.reduce_size(1);
-        }
-        else
-        {
-            clusterBuffer.reduce_size(0);
-        }
-    }
-
     // Default function for LevelControl cluster, only checks if LevelControl is enabled on the endpoint
     bool SupportsCluster(EndpointId endpoint, ClusterId cluster) override
     {

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -158,21 +158,6 @@ public:
     DefaultModeSelectSceneHandler() = default;
     ~DefaultModeSelectSceneHandler() override {}
 
-    // Default function for the mode select cluster, only puts the mode select cluster ID in the span if supported on the given
-    // endpoint
-    virtual void GetSupportedClusters(EndpointId endpoint, Span<ClusterId> & clusterBuffer) override
-    {
-        if (emberAfContainsServer(endpoint, ModeSelect::Id) && clusterBuffer.size() >= 1)
-        {
-            clusterBuffer[0] = ModeSelect::Id;
-            clusterBuffer.reduce_size(1);
-        }
-        else
-        {
-            clusterBuffer.reduce_size(0);
-        }
-    }
-
     // Default function for mode select cluster, only checks if mode select is enabled on the endpoint
     bool SupportsCluster(EndpointId endpoint, ClusterId cluster) override
     {

--- a/src/app/clusters/on-off-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/on-off-server/app_config_dependent_sources.cmake
@@ -20,6 +20,8 @@ TARGET_SOURCES(
     "${CLUSTER_DIR}/level-control-integration.h"
     "${CLUSTER_DIR}/mode-base-integration.cpp"
     "${CLUSTER_DIR}/mode-base-integration.h"
+    "${CLUSTER_DIR}/mode-select-integration.cpp"
+    "${CLUSTER_DIR}/mode-select-integration.h"
     "${CLUSTER_DIR}/on-off-server.cpp"
     "${CLUSTER_DIR}/on-off-server.h"
 )

--- a/src/app/clusters/on-off-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/on-off-server/app_config_dependent_sources.cmake
@@ -24,4 +24,6 @@ TARGET_SOURCES(
     "${CLUSTER_DIR}/mode-select-integration.h"
     "${CLUSTER_DIR}/on-off-server.cpp"
     "${CLUSTER_DIR}/on-off-server.h"
+    "${CLUSTER_DIR}/scenes-integration.cpp"
+    "${CLUSTER_DIR}/scenes-integration.h"
 )

--- a/src/app/clusters/on-off-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/on-off-server/app_config_dependent_sources.cmake
@@ -16,6 +16,10 @@
 TARGET_SOURCES(
   ${APP_TARGET}
   PRIVATE
+    "${CLUSTER_DIR}/level-control-integration.cpp"
+    "${CLUSTER_DIR}/level-control-integration.h"
+    "${CLUSTER_DIR}/mode-base-integration.cpp"
+    "${CLUSTER_DIR}/mode-base-integration.h"
     "${CLUSTER_DIR}/on-off-server.cpp"
     "${CLUSTER_DIR}/on-off-server.h"
 )

--- a/src/app/clusters/on-off-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/on-off-server/app_config_dependent_sources.gni
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 app_config_dependent_sources = [
+  "level-control-integration.cpp",
+  "level-control-integration.h",
+  "mode-base-integration.cpp",
+  "mode-base-integration.h",
   "on-off-server.cpp",
   "on-off-server.h",
 ]

--- a/src/app/clusters/on-off-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/on-off-server/app_config_dependent_sources.gni
@@ -16,6 +16,8 @@ app_config_dependent_sources = [
   "level-control-integration.h",
   "mode-base-integration.cpp",
   "mode-base-integration.h",
+  "mode-select-integration.cpp",
+  "mode-select-integration.h",
   "on-off-server.cpp",
   "on-off-server.h",
 ]

--- a/src/app/clusters/on-off-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/on-off-server/app_config_dependent_sources.gni
@@ -20,4 +20,6 @@ app_config_dependent_sources = [
   "mode-select-integration.h",
   "on-off-server.cpp",
   "on-off-server.h",
+  "scenes-integration.cpp",
+  "scenes-integration.h",
 ]

--- a/src/app/clusters/on-off-server/level-control-integration.cpp
+++ b/src/app/clusters/on-off-server/level-control-integration.cpp
@@ -17,7 +17,7 @@
 
 #ifdef MATTER_DM_PLUGIN_LEVEL_CONTROL
 
-#include <app/clusters/level-control/level-control.h> //nogncheck
+#include <app/clusters/level-control/level-control.h> // nogncheck
 #include <app/util/attribute-storage.h>
 
 namespace chip::app::Clusters::OnOff::Internal::LevelControl {

--- a/src/app/clusters/on-off-server/level-control-integration.cpp
+++ b/src/app/clusters/on-off-server/level-control-integration.cpp
@@ -13,11 +13,11 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "level-control-integration.h"
+#include <app/clusters/on-off-server/level-control-integration.h>
 
 #ifdef MATTER_DM_PLUGIN_LEVEL_CONTROL
 
-#include <app/clusters/level-control/level-control.h>
+#include <app/clusters/level-control/level-control.h> //nogncheck
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/on-off-server/level-control-integration.cpp
+++ b/src/app/clusters/on-off-server/level-control-integration.cpp
@@ -1,0 +1,48 @@
+/**
+ *    Copyright (c) 2020-2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include "level-control-integration.h"
+
+#ifdef MATTER_DM_PLUGIN_LEVEL_CONTROL
+
+#include <app/clusters/level-control/level-control.h>
+#include <app/util/attribute-storage.h>
+
+using namespace chip;
+using namespace chip::app::Clusters;
+
+static bool LevelControlWithOnOffFeaturePresent(EndpointId endpoint)
+{
+    if (!emberAfContainsServer(endpoint, LevelControl::Id))
+    {
+        return false;
+    }
+
+    return LevelControlHasFeature(endpoint, LevelControl::Feature::kOnOff);
+}
+
+namespace chip::app::Clusters::OnOff::Internal {
+
+bool OnOffControlChangeForLevelControl(EndpointId endpoint, bool newValue)
+{
+    VerifyOrReturnValue(LevelControlWithOnOffFeaturePresent(endpoint), false);
+
+    emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
+    return true;
+}
+
+} // namespace chip::app::Clusters::OnOff::Internal
+
+#endif // MATTER_DM_PLUGIN_LEVEL_CONTROL

--- a/src/app/clusters/on-off-server/level-control-integration.cpp
+++ b/src/app/clusters/on-off-server/level-control-integration.cpp
@@ -22,7 +22,7 @@
 
 namespace chip::app::Clusters::OnOff::Internal::LevelControl {
 
-bool EfectCallback(EndpointId endpoint, bool newValue)
+bool EffectCallback(EndpointId endpoint, bool newValue)
 {
     VerifyOrReturnValue(emberAfContainsServer(endpoint, Clusters::LevelControl::Id), false);
     VerifyOrReturnValue(LevelControlHasFeature(endpoint, Clusters::LevelControl::Feature::kOnOff), false);

--- a/src/app/clusters/on-off-server/level-control-integration.cpp
+++ b/src/app/clusters/on-off-server/level-control-integration.cpp
@@ -20,29 +20,17 @@
 #include <app/clusters/level-control/level-control.h> //nogncheck
 #include <app/util/attribute-storage.h>
 
-using namespace chip;
-using namespace chip::app::Clusters;
+namespace chip::app::Clusters::OnOff::Internal::LevelControl {
 
-static bool LevelControlWithOnOffFeaturePresent(EndpointId endpoint)
+bool EfectCallback(EndpointId endpoint, bool newValue)
 {
-    if (!emberAfContainsServer(endpoint, LevelControl::Id))
-    {
-        return false;
-    }
-
-    return LevelControlHasFeature(endpoint, LevelControl::Feature::kOnOff);
-}
-
-namespace chip::app::Clusters::OnOff::Internal {
-
-bool OnOffControlChangeForLevelControl(EndpointId endpoint, bool newValue)
-{
-    VerifyOrReturnValue(LevelControlWithOnOffFeaturePresent(endpoint), false);
+    VerifyOrReturnValue(emberAfContainsServer(endpoint, Clusters::LevelControl::Id), false);
+    VerifyOrReturnValue(LevelControlHasFeature(endpoint, Clusters::LevelControl::Feature::kOnOff), false);
 
     emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
     return true;
 }
 
-} // namespace chip::app::Clusters::OnOff::Internal
+} // namespace chip::app::Clusters::OnOff::Internal::LevelControl
 
 #endif // MATTER_DM_PLUGIN_LEVEL_CONTROL

--- a/src/app/clusters/on-off-server/level-control-integration.h
+++ b/src/app/clusters/on-off-server/level-control-integration.h
@@ -18,8 +18,6 @@
 #include <app/util/config.h>
 #include <lib/core/DataModelTypes.h>
 
-#ifdef MATTER_DM_PLUGIN_LEVEL_CONTROL
-
 /** @brief On/off Cluster Level Control Effect
  *
  * This is called by the framework when the on/off cluster initiates a command
@@ -33,6 +31,8 @@ void emberAfOnOffClusterLevelControlEffectCallback(chip::EndpointId endpoint, bo
 
 namespace chip::app::Clusters::OnOff::Internal {
 
+#ifdef MATTER_DM_PLUGIN_LEVEL_CONTROL
+
 /**
  * Called by the on-off cluster to conditionally trigger emberAfOnOffClusterLevelControlEffectCallback.
  *
@@ -40,17 +40,13 @@ namespace chip::app::Clusters::OnOff::Internal {
  */
 bool OnOffControlChangeForLevelControl(chip::EndpointId endpoint, bool newValue);
 
-} // namespace chip::app::Clusters::OnOff::Internal
-
 #else
-
-namespace chip::app::Clusters::OnOff::Internal {
 
 inline bool OnOffControlChangeForLevelControl(chip::EndpointId endpoint, bool newValue)
 {
     return false;
 }
 
-} // namespace chip::app::Clusters::OnOff::Internal
-
 #endif // MATTER_DM_PLUGIN_LEVEL_CONTROL
+//
+} // namespace chip::app::Clusters::OnOff::Internal

--- a/src/app/clusters/on-off-server/level-control-integration.h
+++ b/src/app/clusters/on-off-server/level-control-integration.h
@@ -48,5 +48,4 @@ inline bool EfectCallback(chip::EndpointId endpoint, bool newValue)
 }
 
 #endif // MATTER_DM_PLUGIN_LEVEL_CONTROL
-//
 } // namespace chip::app::Clusters::OnOff::Internal::LevelControl

--- a/src/app/clusters/on-off-server/level-control-integration.h
+++ b/src/app/clusters/on-off-server/level-control-integration.h
@@ -29,7 +29,7 @@
  */
 void emberAfOnOffClusterLevelControlEffectCallback(chip::EndpointId endpoint, bool newValue);
 
-namespace chip::app::Clusters::OnOff::Internal {
+namespace chip::app::Clusters::OnOff::Internal::LevelControl {
 
 #ifdef MATTER_DM_PLUGIN_LEVEL_CONTROL
 
@@ -38,15 +38,15 @@ namespace chip::app::Clusters::OnOff::Internal {
  *
  * @return true if the effect callback is called (i.e. level control was enabled on the endpoint)
  */
-bool OnOffControlChangeForLevelControl(chip::EndpointId endpoint, bool newValue);
+bool EfectCallback(chip::EndpointId endpoint, bool newValue);
 
 #else
 
-inline bool OnOffControlChangeForLevelControl(chip::EndpointId endpoint, bool newValue)
+inline bool EfectCallback(chip::EndpointId endpoint, bool newValue)
 {
     return false;
 }
 
 #endif // MATTER_DM_PLUGIN_LEVEL_CONTROL
 //
-} // namespace chip::app::Clusters::OnOff::Internal
+} // namespace chip::app::Clusters::OnOff::Internal::LevelControl

--- a/src/app/clusters/on-off-server/level-control-integration.h
+++ b/src/app/clusters/on-off-server/level-control-integration.h
@@ -1,0 +1,56 @@
+/**
+ *    Copyright (c) 2020-2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/util/config.h>
+#include <lib/core/DataModelTypes.h>
+
+#ifdef MATTER_DM_PLUGIN_LEVEL_CONTROL
+
+/** @brief On/off Cluster Level Control Effect
+ *
+ * This is called by the framework when the on/off cluster initiates a command
+ * that must effect a level control change. The implementation assumes that the
+ * client will handle any effect on the On/Off Cluster.
+ *
+ * @param endpoint   Ver.: always
+ * @param newValue   Ver.: always
+ */
+void emberAfOnOffClusterLevelControlEffectCallback(chip::EndpointId endpoint, bool newValue);
+
+namespace chip::app::Clusters::OnOff::Internal {
+
+/**
+ * Called by the on-off cluster to conditionally trigger emberAfOnOffClusterLevelControlEffectCallback.
+ *
+ * @return true if the effect callback is called (i.e. level control was enabled on the endpoint)
+ */
+bool OnOffControlChangeForLevelControl(chip::EndpointId endpoint, bool newValue);
+
+} // namespace chip::app::Clusters::OnOff::Internal
+
+#else
+
+namespace chip::app::Clusters::OnOff::Internal {
+
+inline bool OnOffControlChangeForLevelControl(chip::EndpointId endpoint, bool newValue)
+{
+    return false;
+}
+
+} // namespace chip::app::Clusters::OnOff::Internal
+
+#endif // MATTER_DM_PLUGIN_LEVEL_CONTROL

--- a/src/app/clusters/on-off-server/level-control-integration.h
+++ b/src/app/clusters/on-off-server/level-control-integration.h
@@ -38,11 +38,11 @@ namespace chip::app::Clusters::OnOff::Internal::LevelControl {
  *
  * @return true if the effect callback is called (i.e. level control was enabled on the endpoint)
  */
-bool EfectCallback(chip::EndpointId endpoint, bool newValue);
+bool EffectCallback(chip::EndpointId endpoint, bool newValue);
 
 #else
 
-inline bool EfectCallback(chip::EndpointId endpoint, bool newValue)
+inline bool EffectCallback(chip::EndpointId endpoint, bool newValue)
 {
     return false;
 }

--- a/src/app/clusters/on-off-server/mode-base-integration.cpp
+++ b/src/app/clusters/on-off-server/mode-base-integration.cpp
@@ -23,34 +23,41 @@
 #include <app/clusters/mode-base-server/mode-base-cluster-objects.h> // nogncheck
 #include <app/clusters/mode-base-server/mode-base-server.h>          // nogncheck
 
-using namespace chip;
-using namespace chip::app::Clusters;
 using chip::Protocols::InteractionModel::Status;
 
-void UpdateModeBaseCurrentModeToOnMode(EndpointId endpoint)
+namespace chip::app::Clusters::OnOff::Internal::ModeBase {
+
+void UpdateCurrentModeToOnMode(chip::EndpointId endpoint)
 {
-    for (auto & modeBaseInstance : ModeBase::GetModeBaseInstanceList())
+    for (auto & modeBaseInstance : Clusters::ModeBase::GetModeBaseInstanceList())
     {
-        if (modeBaseInstance.GetEndpointId() == endpoint)
+        if (modeBaseInstance.GetEndpointId() != endpoint)
         {
-            if (modeBaseInstance.HasFeature(ModeBase::Feature::kOnOff))
-            {
-                ModeBase::Attributes::OnMode::TypeInfo::Type onMode = modeBaseInstance.GetOnMode();
-                if (!onMode.IsNull())
-                {
-                    Status status = modeBaseInstance.UpdateCurrentMode(onMode.Value());
-                    if (status == Status::Success)
-                    {
-                        ChipLogProgress(Zcl, "Changed the Current Mode to %x", onMode.Value());
-                    }
-                    else
-                    {
-                        ChipLogError(Zcl, "Failed to Changed the Current Mode to %x: %u", onMode.Value(), to_underlying(status));
-                    }
-                }
-            }
+            continue;
+        }
+
+        if (!modeBaseInstance.HasFeature(Clusters::ModeBase::Feature::kOnOff))
+        {
+            continue;
+        }
+        Clusters::ModeBase::Attributes::OnMode::TypeInfo::Type onMode = modeBaseInstance.GetOnMode();
+        if (onMode.IsNull())
+        {
+            continue;
+        }
+
+        Status status = modeBaseInstance.UpdateCurrentMode(onMode.Value());
+        if (status == Status::Success)
+        {
+            ChipLogProgress(Zcl, "Changed the Current Mode to %x", onMode.Value());
+        }
+        else
+        {
+            ChipLogError(Zcl, "Failed to Changed the Current Mode to %x: %u", onMode.Value(), to_underlying(status));
         }
     }
 }
+
+} // namespace chip::app::Clusters::OnOff::Internal::ModeBase
 
 #endif // MATTER_DM_PLUGIN_MODE_BASE

--- a/src/app/clusters/on-off-server/mode-base-integration.cpp
+++ b/src/app/clusters/on-off-server/mode-base-integration.cpp
@@ -53,7 +53,7 @@ void UpdateCurrentModeToOnMode(chip::EndpointId endpoint)
         }
         else
         {
-            ChipLogError(Zcl, "Failed to Changed the Current Mode to %x: %u", onMode.Value(), to_underlying(status));
+            ChipLogError(Zcl, "Failed to change the Current Mode to %x: %u", onMode.Value(), to_underlying(status));
         }
     }
 }

--- a/src/app/clusters/on-off-server/mode-base-integration.cpp
+++ b/src/app/clusters/on-off-server/mode-base-integration.cpp
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "mode-base-integration.h"
+#include <app/clusters/on-off-server/mode-base-integration.h>
 
 #ifdef MATTER_DM_PLUGIN_MODE_BASE
 

--- a/src/app/clusters/on-off-server/mode-base-integration.cpp
+++ b/src/app/clusters/on-off-server/mode-base-integration.cpp
@@ -1,0 +1,56 @@
+/**
+ *    Copyright (c) 2020-2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include "mode-base-integration.h"
+
+#ifdef MATTER_DM_PLUGIN_MODE_BASE
+
+// nogncheck because the gn dependency checker does not understand
+// conditional includes, so will fail in an application that has an On/Off
+// cluster but no ModeBase-derived cluster.
+#include <app/clusters/mode-base-server/mode-base-cluster-objects.h> // nogncheck
+#include <app/clusters/mode-base-server/mode-base-server.h>          // nogncheck
+
+using namespace chip;
+using namespace chip::app::Clusters;
+using chip::Protocols::InteractionModel::Status;
+
+void UpdateModeBaseCurrentModeToOnMode(EndpointId endpoint)
+{
+    for (auto & modeBaseInstance : ModeBase::GetModeBaseInstanceList())
+    {
+        if (modeBaseInstance.GetEndpointId() == endpoint)
+        {
+            if (modeBaseInstance.HasFeature(ModeBase::Feature::kOnOff))
+            {
+                ModeBase::Attributes::OnMode::TypeInfo::Type onMode = modeBaseInstance.GetOnMode();
+                if (!onMode.IsNull())
+                {
+                    Status status = modeBaseInstance.UpdateCurrentMode(onMode.Value());
+                    if (status == Status::Success)
+                    {
+                        ChipLogProgress(Zcl, "Changed the Current Mode to %x", onMode.Value());
+                    }
+                    else
+                    {
+                        ChipLogError(Zcl, "Failed to Changed the Current Mode to %x: %u", onMode.Value(), to_underlying(status));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endif // MATTER_DM_PLUGIN_MODE_BASE

--- a/src/app/clusters/on-off-server/mode-base-integration.h
+++ b/src/app/clusters/on-off-server/mode-base-integration.h
@@ -18,6 +18,8 @@
 #include <app/util/config.h>
 #include <lib/core/DataModelTypes.h>
 
+namespace chip::app::Clusters::OnOff::Internal::ModeBase {
+
 #ifdef MATTER_DM_PLUGIN_MODE_BASE
 
 /**
@@ -25,10 +27,12 @@
  * the OnMode attribute is set, update the CurrentMode attribute value to the OnMode value.
  * @param endpoint
  */
-void UpdateModeBaseCurrentModeToOnMode(chip::EndpointId endpoint);
+void UpdateCurrentModeToOnMode(chip::EndpointId endpoint);
 
 #else
 
-inline void UpdateModeBaseCurrentModeToOnMode(chip::EndpointId endpoint) {}
+inline void UpdatCurrentModeToOnMode(chip::EndpointId endpoint) {}
 
 #endif // MATTER_DM_PLUGIN_MODE_BASE
+
+} // namespace chip::app::Clusters::OnOff::Internal::ModeBase

--- a/src/app/clusters/on-off-server/mode-base-integration.h
+++ b/src/app/clusters/on-off-server/mode-base-integration.h
@@ -31,7 +31,7 @@ void UpdateCurrentModeToOnMode(chip::EndpointId endpoint);
 
 #else
 
-inline void UpdatCurrentModeToOnMode(chip::EndpointId endpoint) {}
+inline void UpdateCurrentModeToOnMode(chip::EndpointId endpoint) {}
 
 #endif // MATTER_DM_PLUGIN_MODE_BASE
 

--- a/src/app/clusters/on-off-server/mode-base-integration.h
+++ b/src/app/clusters/on-off-server/mode-base-integration.h
@@ -1,0 +1,34 @@
+/**
+ *    Copyright (c) 2020-2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/util/config.h>
+#include <lib/core/DataModelTypes.h>
+
+#ifdef MATTER_DM_PLUGIN_MODE_BASE
+
+/**
+ * For all ModeBase alias clusters on the given endpoint, if the OnOff feature is supported and
+ * the OnMode attribute is set, update the CurrentMode attribute value to the OnMode value.
+ * @param endpoint
+ */
+void UpdateModeBaseCurrentModeToOnMode(chip::EndpointId endpoint);
+
+#else
+
+inline void UpdateModeBaseCurrentModeToOnMode(chip::EndpointId endpoint) {}
+
+#endif // MATTER_DM_PLUGIN_MODE_BASE

--- a/src/app/clusters/on-off-server/mode-select-integration.cpp
+++ b/src/app/clusters/on-off-server/mode-select-integration.cpp
@@ -13,7 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "mode-select-integration.h"
+#include <app/clusters/on-off-server/mode-select-integration.h>
 
 #ifdef MATTER_DM_PLUGIN_MODE_SELECT
 

--- a/src/app/clusters/on-off-server/mode-select-integration.cpp
+++ b/src/app/clusters/on-off-server/mode-select-integration.cpp
@@ -22,25 +22,23 @@
 #include <app/util/endpoint-config-api.h>
 #include <clusters/ModeSelect/Ids.h>
 
-using namespace chip;
-using namespace chip::app::Clusters;
 using chip::Protocols::InteractionModel::Status;
 
-namespace chip::app::Clusters::OnOff::Internal {
+namespace chip::app::Clusters::OnOff::Internal::ModeSelect {
 
-void ModeSelectSetOnModeFromStartup(EndpointId endpoint)
+void SetStartupOnMode(EndpointId endpoint)
 {
-    VerifyOrReturn(emberAfContainsAttribute(endpoint, ModeSelect::Id, ModeSelect::Attributes::OnMode::Id));
+    VerifyOrReturn(emberAfContainsAttribute(endpoint, Clusters::ModeSelect::Id, Clusters::ModeSelect::Attributes::OnMode::Id));
 
-    ModeSelect::Attributes::OnMode::TypeInfo::Type onMode;
+    Clusters::ModeSelect::Attributes::OnMode::TypeInfo::Type onMode;
 
-    VerifyOrReturn(ModeSelect::Attributes::OnMode::Get(endpoint, onMode) == Status::Success);
+    VerifyOrReturn(Clusters::ModeSelect::Attributes::OnMode::Get(endpoint, onMode) == Status::Success);
     VerifyOrReturn(!onMode.IsNull());
 
     ChipLogProgress(Zcl, "Changing Current Mode to %x", onMode.Value());
-    (void) ModeSelect::Attributes::CurrentMode::Set(endpoint, onMode.Value());
+    (void) Clusters::ModeSelect::Attributes::CurrentMode::Set(endpoint, onMode.Value());
 }
 
-} // namespace chip::app::Clusters::OnOff::Internal
+} // namespace chip::app::Clusters::OnOff::Internal::ModeSelect
 
 #endif

--- a/src/app/clusters/on-off-server/mode-select-integration.cpp
+++ b/src/app/clusters/on-off-server/mode-select-integration.cpp
@@ -1,0 +1,46 @@
+/**
+ *    Copyright (c) 2020-2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include "mode-select-integration.h"
+
+#ifdef MATTER_DM_PLUGIN_MODE_SELECT
+
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/util/attribute-storage.h>
+#include <app/util/endpoint-config-api.h>
+#include <clusters/ModeSelect/Ids.h>
+
+using namespace chip;
+using namespace chip::app::Clusters;
+using chip::Protocols::InteractionModel::Status;
+
+namespace chip::app::Clusters::OnOff::Internal {
+
+void ModeSelectSetOnModeFromStartup(EndpointId endpoint)
+{
+    VerifyOrReturn(emberAfContainsAttribute(endpoint, ModeSelect::Id, ModeSelect::Attributes::OnMode::Id));
+
+    ModeSelect::Attributes::OnMode::TypeInfo::Type onMode;
+
+    VerifyOrReturn(ModeSelect::Attributes::OnMode::Get(endpoint, onMode) == Status::Success);
+    VerifyOrReturn(!onMode.IsNull());
+
+    ChipLogProgress(Zcl, "Changing Current Mode to %x", onMode.Value());
+    (void) ModeSelect::Attributes::CurrentMode::Set(endpoint, onMode.Value());
+}
+
+} // namespace chip::app::Clusters::OnOff::Internal
+
+#endif

--- a/src/app/clusters/on-off-server/mode-select-integration.h
+++ b/src/app/clusters/on-off-server/mode-select-integration.h
@@ -18,16 +18,16 @@
 #include <app/util/config.h>
 #include <lib/core/DataModelTypes.h>
 
-namespace chip::app::Clusters::OnOff::Internal {
+namespace chip::app::Clusters::OnOff::Internal::ModeSelect {
 
 #ifdef MATTER_DM_PLUGIN_MODE_SELECT
 
-void ModeSelectSetOnModeFromStartup(chip::EndpointId endpoint);
+void SetStartupOnMode(chip::EndpointId endpoint);
 
 #else
 
-inline void ModeSelectSetOnModeFromStartup(chip::EndpointId endpoint) {}
+inline void SetStartupOnMode(chip::EndpointId endpoint) {}
 
 #endif // MATTER_DM_PLUGIN_MODE_SELECT
 
-} // namespace chip::app::Clusters::OnOff::Internal
+} // namespace chip::app::Clusters::OnOff::Internal::ModeSelect

--- a/src/app/clusters/on-off-server/mode-select-integration.h
+++ b/src/app/clusters/on-off-server/mode-select-integration.h
@@ -1,0 +1,33 @@
+/**
+ *    Copyright (c) 2020-2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/util/config.h>
+#include <lib/core/DataModelTypes.h>
+
+namespace chip::app::Clusters::OnOff::Internal {
+
+#ifdef MATTER_DM_PLUGIN_MODE_SELECT
+
+void ModeSelectSetOnModeFromStartup(chip::EndpointId endpoint);
+
+#else
+
+inline void ModeSelectSetOnModeFromStartup(chip::EndpointId endpoint) {}
+
+#endif // MATTER_DM_PLUGIN_MODE_SELECT
+
+} // namespace chip::app::Clusters::OnOff::Internal

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -234,10 +234,10 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
 
         if (!initiatedByLevelChange)
         {
-            Internal::OnOffControlChangeForLevelControl(endpoint, newValue);
+            Internal::LevelControl::EfectCallback(endpoint, newValue);
         }
 
-        Internal::ModeSelectSetOnModeFromStartup(endpoint);
+        Internal::ModeSelect::SetStartupOnMode(endpoint);
 
         // If OnMode is not a null value, then change the current mode to it.
         Internal::ModeBase::UpdateCurrentModeToOnMode(endpoint);
@@ -246,7 +246,7 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
     {
         // If initiatedByLevelChange is false, then we assume that the level change
         // ZCL stuff has not happened and we do it here
-        if (initiatedByLevelChange || !Internal::OnOffControlChangeForLevelControl(endpoint, newValue))
+        if (initiatedByLevelChange || !Internal::LevelControl::EfectCallback(endpoint, newValue))
         {
             // write the new on/off value
             status = Attributes::OnOff::Set(endpoint, newValue);

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -234,7 +234,7 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
 
         if (!initiatedByLevelChange)
         {
-            Internal::LevelControl::EfectCallback(endpoint, newValue);
+            Internal::LevelControl::EffectCallback(endpoint, newValue);
         }
 
         Internal::ModeSelect::SetStartupOnMode(endpoint);
@@ -246,7 +246,7 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
     {
         // If initiatedByLevelChange is false, then we assume that the level change
         // ZCL stuff has not happened and we do it here
-        if (initiatedByLevelChange || !Internal::LevelControl::EfectCallback(endpoint, newValue))
+        if (initiatedByLevelChange || !Internal::LevelControl::EffectCallback(endpoint, newValue))
         {
             // write the new on/off value
             status = Attributes::OnOff::Set(endpoint, newValue);

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -307,7 +307,7 @@ void OnOffServer::initOnOffServer(chip::EndpointId endpoint)
 
         if (onOffValueForStartUp)
         {
-            Internal::ModeSelectSetOnModeFromStartup(endpoint);
+            Internal::ModeSelect::SetStartupOnMode(endpoint);
         }
     }
 #endif // IGNORE_ON_OFF_CLUSTER_START_UP_ON_OFF

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -31,6 +31,7 @@
 // integration with other clusters
 #include "level-control-integration.h"
 #include "mode-base-integration.h"
+#include "mode-select-integration.h"
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
 #include <app/clusters/scenes-server/scenes-server.h>
@@ -372,19 +373,8 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
             Internal::OnOffControlChangeForLevelControl(endpoint, newValue);
         }
 
-#ifdef MATTER_DM_PLUGIN_MODE_SELECT
-        // If OnMode is not a null value, then change the current mode to it.
-        if (emberAfContainsServer(endpoint, ModeSelect::Id) &&
-            emberAfContainsAttribute(endpoint, ModeSelect::Id, ModeSelect::Attributes::OnMode::Id))
-        {
-            ModeSelect::Attributes::OnMode::TypeInfo::Type onMode;
-            if (ModeSelect::Attributes::OnMode::Get(endpoint, onMode) == Status::Success && !onMode.IsNull())
-            {
-                ChipLogProgress(Zcl, "Changing Current Mode to %x", onMode.Value());
-                status = ModeSelect::Attributes::CurrentMode::Set(endpoint, onMode.Value());
-            }
-        }
-#endif
+        Internal::ModeSelectSetOnModeFromStartup(endpoint);
+
         // If OnMode is not a null value, then change the current mode to it.
         UpdateModeBaseCurrentModeToOnMode(endpoint);
     }
@@ -454,19 +444,9 @@ void OnOffServer::initOnOffServer(chip::EndpointId endpoint)
             status = setOnOffValue(endpoint, onOffValueForStartUp, true);
         }
 
-#ifdef MATTER_DM_PLUGIN_MODE_SELECT
-        // If OnMode is not a null value, then change the current mode to it.
-        if (onOffValueForStartUp && emberAfContainsServer(endpoint, ModeSelect::Id) &&
-            emberAfContainsAttribute(endpoint, ModeSelect::Id, ModeSelect::Attributes::OnMode::Id))
-        {
-            ModeSelect::Attributes::OnMode::TypeInfo::Type onMode;
-            if (ModeSelect::Attributes::OnMode::Get(endpoint, onMode) == Status::Success && !onMode.IsNull())
-            {
-                ChipLogProgress(Zcl, "Changing Current Mode to %x", onMode.Value());
-                status = ModeSelect::Attributes::CurrentMode::Set(endpoint, onMode.Value());
-            }
+        if (onOffValueForStartUp) {
+            Internal::ModeSelectSetOnModeFromStartup(endpoint);
         }
-#endif
     }
 #endif // IGNORE_ON_OFF_CLUSTER_START_UP_ON_OFF
 

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -17,7 +17,7 @@
 
 #include <app/util/config.h>
 
-#include "on-off-server.h"
+#include <app/clusters/on-off-server/on-off-server.h>
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/data-model/Nullable.h>

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -731,8 +731,8 @@ static inline void unreg(OnOffEffect * inst)
 
 OnOffEffect::OnOffEffect(chip::EndpointId endpoint, OffWithEffectTriggerCommand offWithEffectTrigger,
                          EffectIdentifierEnum effectIdentifier, uint8_t effectVariant) :
-    mEndpoint(endpoint), mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier),
-    mEffectVariant(effectVariant)
+    mEndpoint(endpoint),
+    mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier), mEffectVariant(effectVariant)
 {
     reg(this);
 };

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -444,7 +444,8 @@ void OnOffServer::initOnOffServer(chip::EndpointId endpoint)
             status = setOnOffValue(endpoint, onOffValueForStartUp, true);
         }
 
-        if (onOffValueForStartUp) {
+        if (onOffValueForStartUp)
+        {
             Internal::ModeSelectSetOnModeFromStartup(endpoint);
         }
     }

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -98,6 +98,11 @@ void OnOffServer::timerCallback(System::Layer *, void * callbackContext)
     (control->callback)(control->endpoint);
 }
 
+chip::scenes::SceneHandler * OnOffServer::GetSceneHandler()
+{
+    return chip::app::Clusters::OnOff::Internal::Scenes::GlobalHandler();
+}
+
 void OnOffServer::scheduleTimerCallbackMs(EmberEventControl * control, uint32_t delayMs)
 {
     CHIP_ERROR err = DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(delayMs), timerCallback, control);

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -29,10 +29,10 @@
 #include <tracing/macros.h>
 
 // integration with other clusters
-#include "level-control-integration.h"
-#include "mode-base-integration.h"
-#include "mode-select-integration.h"
-#include "scenes-integration.h"
+#include <app/clusters/on-off-server/level-control-integration.h>
+#include <app/clusters/on-off-server/mode-base-integration.h>
+#include <app/clusters/on-off-server/mode-select-integration.h>
+#include <app/clusters/on-off-server/scenes-integration.h>
 
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DiagnosticDataProvider.h>
@@ -731,8 +731,8 @@ static inline void unreg(OnOffEffect * inst)
 
 OnOffEffect::OnOffEffect(chip::EndpointId endpoint, OffWithEffectTriggerCommand offWithEffectTrigger,
                          EffectIdentifierEnum effectIdentifier, uint8_t effectVariant) :
-    mEndpoint(endpoint),
-    mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier), mEffectVariant(effectVariant)
+    mEndpoint(endpoint), mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier),
+    mEffectVariant(effectVariant)
 {
     reg(this);
 };

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -240,7 +240,7 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
         Internal::ModeSelectSetOnModeFromStartup(endpoint);
 
         // If OnMode is not a null value, then change the current mode to it.
-        UpdateModeBaseCurrentModeToOnMode(endpoint);
+        Internal::ModeBase::UpdateCurrentModeToOnMode(endpoint);
     }
     else // Set Off
     {

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -144,21 +144,6 @@ struct OnOffEffect
 };
 
 /**********************************************************
- * Global
- *********************************************************/
-
-/** @brief On/off Cluster Level Control Effect
- *
- * This is called by the framework when the on/off cluster initiates a command
- * that must effect a level control change. The implementation assumes that the
- * client will handle any effect on the On/Off Cluster.
- *
- * @param endpoint   Ver.: always
- * @param newValue   Ver.: always
- */
-void emberAfOnOffClusterLevelControlEffectCallback(chip::EndpointId endpoint, bool newValue);
-
-/**********************************************************
  * Callbacks
  *********************************************************/
 

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -20,12 +20,11 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/clusters/scenes-server/SceneTable.h>
 #include <app/util/af-types.h>
 #include <app/util/basic-types.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <protocols/interaction_model/StatusCode.h>
-
-#include "scenes-integration.h" // nogncheck
 
 /**********************************************************
  * Defines and Macros

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -22,12 +22,11 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af-types.h>
 #include <app/util/basic-types.h>
+#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <protocols/interaction_model/StatusCode.h>
 
-#ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-#include <app/clusters/scenes-server/SceneTable.h>
-#endif
+#include "scenes-integration.h" // nogncheck
 
 /**********************************************************
  * Defines and Macros
@@ -54,7 +53,7 @@ public:
     static OnOffServer & Instance();
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    chip::scenes::SceneHandler * GetSceneHandler();
+    chip::scenes::SceneHandler * GetSceneHandler() { return chip::app::Clusters::OnOff::Internal::Scenes::GlobalHandler(); }
 #endif
 
     bool offCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath);

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -111,7 +111,7 @@ struct OnOffEffect
     using OffWithEffectTriggerCommand = void (*)(OnOffEffect *);
     using EffectVariantType           = std::underlying_type_t<chip::app::Clusters::OnOff::DelayedAllOffEffectVariantEnum>;
     static_assert(
-        std::is_same<EffectVariantType, std::underlying_type_t<chip::app::Clusters::OnOff::DyingLightEffectVariantEnum>>::value,
+        std::is_same_v<EffectVariantType, std::underlying_type_t<chip::app::Clusters::OnOff::DyingLightEffectVariantEnum>>,
         "chip::app::Clusters::OnOff::DelayedAllOffEffectVariantEnum and "
         "chip::app::Clusters::OnOff::DyingLightEffectVariantEnum underlying types differ.");
 

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -22,7 +22,6 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/util/af-types.h>
 #include <app/util/basic-types.h>
-#include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <protocols/interaction_model/StatusCode.h>
 
@@ -52,9 +51,8 @@ public:
 
     static OnOffServer & Instance();
 
-#ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    chip::scenes::SceneHandler * GetSceneHandler() { return chip::app::Clusters::OnOff::Internal::Scenes::GlobalHandler(); }
-#endif
+    // Returns nullptr if scenes are not supported/built by the SDK
+    chip::scenes::SceneHandler * GetSceneHandler();
 
     bool offCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath);
     bool onCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath);

--- a/src/app/clusters/on-off-server/scenes-integration.cpp
+++ b/src/app/clusters/on-off-server/scenes-integration.cpp
@@ -161,7 +161,7 @@ chip::scenes::SceneHandler * GlobalHandler()
 
 void RegisterGlobalHandler(chip::EndpointId endpoint)
 {
-    app::Clusters::ScenesManagement::ScenesServer::Instance().RegisterSceneHandler(endpoint, GlobalOnOffSceneHandler());
+    app::Clusters::ScenesManagement::ScenesServer::Instance().RegisterSceneHandler(endpoint, GlobalHandler());
 }
 
 } // namespace chip::app::Clusters::OnOff::Internal::Scenes

--- a/src/app/clusters/on-off-server/scenes-integration.cpp
+++ b/src/app/clusters/on-off-server/scenes-integration.cpp
@@ -153,7 +153,7 @@ static void sceneOnOffCallback(EndpointId endpoint)
 }
 
 namespace chip::app::Clusters::OnOff::Internal::Scenes {
-chip::scenes::SceneHandler * GlobalOnOffSceneHandler()
+chip::scenes::SceneHandler * GlobalHandler()
 {
     return &sOnOffSceneHandler;
 }

--- a/src/app/clusters/on-off-server/scenes-integration.cpp
+++ b/src/app/clusters/on-off-server/scenes-integration.cpp
@@ -1,0 +1,191 @@
+/**
+ *    Copyright (c) 2020-2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include "scenes-integration.h"
+
+#ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
+
+#include "on-off-server.h"
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/clusters/scenes-server/scenes-server.h>
+
+using namespace chip;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::OnOff;
+
+using chip::Protocols::InteractionModel::Status;
+
+static constexpr size_t kOnOffMaxEnpointCount =
+    MATTER_DM_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
+
+static void sceneOnOffCallback(EndpointId endpoint);
+using OnOffEndPointPair = scenes::DefaultSceneHandlerImpl::EndpointStatePair<bool>;
+using OnOffTransitionTimeInterface =
+    scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<kOnOffMaxEnpointCount, MATTER_DM_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT>;
+
+#if CHIP_CONFIG_SCENES_USE_DEFAULT_HANDLERS
+
+class DefaultOnOffSceneHandler : public scenes::DefaultSceneHandlerImpl
+{
+public:
+    DefaultSceneHandlerImpl::StatePairBuffer<bool, kOnOffMaxEnpointCount> mSceneEndpointStatePairs;
+    // As per spec, 1 attribute is scenable in the on off cluster
+    static constexpr uint8_t scenableAttributeCount = 1;
+
+    DefaultOnOffSceneHandler()           = default;
+    ~DefaultOnOffSceneHandler() override = default;
+
+    // Default function for OnOff cluster, only puts the OnOff cluster ID in the span if supported on the given endpoint
+    void GetSupportedClusters(EndpointId endpoint, Span<ClusterId> & clusterBuffer) override
+    {
+        ClusterId * buffer = clusterBuffer.data();
+        if (emberAfContainsServer(endpoint, OnOff::Id) && clusterBuffer.size() >= 1)
+        {
+            buffer[0] = OnOff::Id;
+            clusterBuffer.reduce_size(1);
+        }
+        else
+        {
+            clusterBuffer.reduce_size(0);
+        }
+    }
+
+    // Default function for OnOff cluster, only checks if OnOff is enabled on the endpoint
+    bool SupportsCluster(EndpointId endpoint, ClusterId cluster) override
+    {
+        return (cluster == OnOff::Id) && (emberAfContainsServer(endpoint, OnOff::Id));
+    }
+
+    /// @brief Serialize the Cluster's EFS value
+    /// @param endpoint target endpoint
+    /// @param cluster  target cluster
+    /// @param serializedBytes data to serialize into EFS
+    /// @return CHIP_NO_ERROR if successfully serialized the data, CHIP_ERROR_INVALID_ARGUMENT otherwise
+    CHIP_ERROR SerializeSave(EndpointId endpoint, ClusterId cluster, MutableByteSpan & serializedBytes) override
+    {
+        using AttributeValuePair = ScenesManagement::Structs::AttributeValuePairStruct::Type;
+
+        bool currentValue;
+        // read current on/off value
+        Status status = Attributes::OnOff::Get(endpoint, &currentValue);
+        if (status != Status::Success)
+        {
+            ChipLogError(Zcl, "ERR: reading on/off %x", to_underlying(status));
+            return CHIP_ERROR_READ_FAILED;
+        }
+
+        AttributeValuePair pairs[scenableAttributeCount];
+
+        pairs[0].attributeID = Attributes::OnOff::Id;
+        pairs[0].valueUnsigned8.SetValue(currentValue);
+
+        app::DataModel::List<AttributeValuePair> attributeValueList(pairs);
+
+        return EncodeAttributeValueList(attributeValueList, serializedBytes);
+    }
+
+    /// @brief Default EFS interaction when applying scene to the OnOff Cluster
+    /// @param endpoint target endpoint
+    /// @param cluster  target cluster
+    /// @param serializedBytes Data from nvm
+    /// @param timeMs transition time in ms
+    /// @return CHIP_NO_ERROR if value as expected, CHIP_ERROR_INVALID_ARGUMENT otherwise
+    CHIP_ERROR ApplyScene(EndpointId endpoint, ClusterId cluster, const ByteSpan & serializedBytes,
+                          scenes::TransitionTimeMs timeMs) override
+    {
+        app::DataModel::DecodableList<ScenesManagement::Structs::AttributeValuePairStruct::DecodableType> attributeValueList;
+
+        VerifyOrReturnError(cluster == OnOff::Id, CHIP_ERROR_INVALID_ARGUMENT);
+
+        ReturnErrorOnFailure(DecodeAttributeValueList(serializedBytes, attributeValueList));
+
+        size_t attributeCount = 0;
+        ReturnErrorOnFailure(attributeValueList.ComputeSize(&attributeCount));
+        VerifyOrReturnError(attributeCount <= scenableAttributeCount, CHIP_ERROR_BUFFER_TOO_SMALL);
+
+        auto pair_iterator = attributeValueList.begin();
+        while (pair_iterator.Next())
+        {
+            auto & decodePair = pair_iterator.GetValue();
+            VerifyOrReturnError(decodePair.attributeID == Attributes::OnOff::Id, CHIP_ERROR_INVALID_ARGUMENT);
+            VerifyOrReturnError(decodePair.valueUnsigned8.HasValue(), CHIP_ERROR_INVALID_ARGUMENT);
+            ReturnErrorOnFailure(mSceneEndpointStatePairs.InsertPair(
+                OnOffEndPointPair(endpoint, static_cast<bool>(decodePair.valueUnsigned8.Value()))));
+        }
+        // Verify that the EFS was completely read
+        CHIP_ERROR err = pair_iterator.GetStatus();
+        if (CHIP_NO_ERROR != err)
+        {
+            TEMPORARY_RETURN_IGNORED mSceneEndpointStatePairs.RemovePair(endpoint);
+            return err;
+        }
+
+        VerifyOrReturnError(mTransitionTimeInterface.sceneEventControl(endpoint) != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        OnOffServer::Instance().scheduleTimerCallbackMs(mTransitionTimeInterface.sceneEventControl(endpoint), timeMs);
+
+        return CHIP_NO_ERROR;
+    }
+
+private:
+    OnOffTransitionTimeInterface mTransitionTimeInterface = OnOffTransitionTimeInterface(OnOff::Id, sceneOnOffCallback);
+};
+static DefaultOnOffSceneHandler sOnOffSceneHandler;
+
+static void sceneOnOffCallback(EndpointId endpoint)
+{
+    OnOffEndPointPair savedState;
+    ReturnOnFailure(sOnOffSceneHandler.mSceneEndpointStatePairs.GetPair(endpoint, savedState));
+    CommandId command = (savedState.mValue) ? Commands::On::Id : Commands::Off::Id;
+    OnOffServer::Instance().setOnOffValue(endpoint, command, false);
+    ReturnOnFailure(sOnOffSceneHandler.mSceneEndpointStatePairs.RemovePair(endpoint));
+}
+
+namespace chip::app::Clusters::OnOff::Internal::Scenes {
+chip::scenes::SceneHandler * GlobalOnOffSceneHandler()
+{
+    return &sOnOffSceneHandler;
+}
+
+void RegisterGlobalHandler(chip::EndpointId endpoint)
+{
+    app::Clusters::ScenesManagement::ScenesServer::Instance().RegisterSceneHandler(endpoint, GlobalOnOffSceneHandler());
+}
+
+} // namespace chip::app::Clusters::OnOff::Internal::Scenes
+
+#endif // CHIP_CONFIG_SCENES_USE_DEFAULT_HANDLERS
+
+namespace chip::app::Clusters::OnOff::Internal::Scenes {
+
+void Store(FabricIndex fabricIndex, EndpointId endpoint)
+{
+    ScenesManagement::ScenesServer::Instance().StoreCurrentScene(
+        fabricIndex, endpoint, ScenesManagement::ScenesServer::kGlobalSceneGroupId, ScenesManagement::ScenesServer::kGlobalSceneId);
+}
+
+void Recall(FabricIndex fabricIndex, EndpointId endpoint)
+{
+    ScenesManagement::ScenesServer::Instance().RecallScene(
+        fabricIndex, endpoint, ScenesManagement::ScenesServer::kGlobalSceneGroupId, ScenesManagement::ScenesServer::kGlobalSceneId);
+}
+
+void MarkInvalid(EndpointId endpoint)
+{
+    ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(endpoint);
+}
+
+} // namespace chip::app::Clusters::OnOff::Internal::Scenes
+
+#endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT

--- a/src/app/clusters/on-off-server/scenes-integration.cpp
+++ b/src/app/clusters/on-off-server/scenes-integration.cpp
@@ -27,20 +27,20 @@ using namespace chip::app::Clusters::OnOff;
 
 using chip::Protocols::InteractionModel::Status;
 
-static constexpr size_t kOnOffMaxEnpointCount =
+static constexpr size_t kOnOffMaxEndpointCount =
     MATTER_DM_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 static void sceneOnOffCallback(EndpointId endpoint);
 using OnOffEndPointPair = scenes::DefaultSceneHandlerImpl::EndpointStatePair<bool>;
 using OnOffTransitionTimeInterface =
-    scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<kOnOffMaxEnpointCount, MATTER_DM_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT>;
+    scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<kOnOffMaxEndpointCount, MATTER_DM_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT>;
 
 #if CHIP_CONFIG_SCENES_USE_DEFAULT_HANDLERS
 
 class DefaultOnOffSceneHandler : public scenes::DefaultSceneHandlerImpl
 {
 public:
-    DefaultSceneHandlerImpl::StatePairBuffer<bool, kOnOffMaxEnpointCount> mSceneEndpointStatePairs;
+    DefaultSceneHandlerImpl::StatePairBuffer<bool, kOnOffMaxEndpointCount> mSceneEndpointStatePairs;
     // As per spec, 1 attribute is scenable in the on off cluster
     static constexpr uint8_t scenableAttributeCount = 1;
 

--- a/src/app/clusters/on-off-server/scenes-integration.cpp
+++ b/src/app/clusters/on-off-server/scenes-integration.cpp
@@ -33,7 +33,8 @@ static constexpr size_t kOnOffMaxEndpointCount =
 static void sceneOnOffCallback(EndpointId endpoint);
 using OnOffEndPointPair = scenes::DefaultSceneHandlerImpl::EndpointStatePair<bool>;
 using OnOffTransitionTimeInterface =
-    scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<kOnOffMaxEndpointCount, MATTER_DM_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT>;
+    scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<kOnOffMaxEndpointCount,
+                                                             MATTER_DM_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT>;
 
 #if CHIP_CONFIG_SCENES_USE_DEFAULT_HANDLERS
 

--- a/src/app/clusters/on-off-server/scenes-integration.cpp
+++ b/src/app/clusters/on-off-server/scenes-integration.cpp
@@ -48,21 +48,6 @@ public:
     DefaultOnOffSceneHandler()           = default;
     ~DefaultOnOffSceneHandler() override = default;
 
-    // Default function for OnOff cluster, only puts the OnOff cluster ID in the span if supported on the given endpoint
-    void GetSupportedClusters(EndpointId endpoint, Span<ClusterId> & clusterBuffer) override
-    {
-        ClusterId * buffer = clusterBuffer.data();
-        if (emberAfContainsServer(endpoint, OnOff::Id) && clusterBuffer.size() >= 1)
-        {
-            buffer[0] = OnOff::Id;
-            clusterBuffer.reduce_size(1);
-        }
-        else
-        {
-            clusterBuffer.reduce_size(0);
-        }
-    }
-
     // Default function for OnOff cluster, only checks if OnOff is enabled on the endpoint
     bool SupportsCluster(EndpointId endpoint, ClusterId cluster) override
     {

--- a/src/app/clusters/on-off-server/scenes-integration.cpp
+++ b/src/app/clusters/on-off-server/scenes-integration.cpp
@@ -13,13 +13,13 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "scenes-integration.h"
+#include <app/clusters/on-off-server/scenes-integration.h>
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
 
-#include "on-off-server.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
-#include <app/clusters/scenes-server/scenes-server.h>
+#include <app/clusters/on-off-server/on-off-server.h>
+#include <app/clusters/scenes-server/scenes-server.h> // nogncheck
 
 using namespace chip;
 using namespace chip::app::Clusters;

--- a/src/app/clusters/on-off-server/scenes-integration.h
+++ b/src/app/clusters/on-off-server/scenes-integration.h
@@ -1,0 +1,59 @@
+/**
+ *    Copyright (c) 2020-2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/util/config.h>
+#include <lib/core/CHIPConfig.h>
+
+#ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
+
+#include <app/clusters/scenes-server/SceneTable.h>
+
+namespace chip::app::Clusters::OnOff::Internal::Scenes {
+
+#if CHIP_CONFIG_SCENES_USE_DEFAULT_HANDLERS
+chip::scenes::SceneHandler * GlobalHandler();
+void RegisterGlobalHandler(EndpointId endpoint);
+#else
+inline chip::scenes::SceneHandler * GlobalHandler()
+{
+    return nullptr;
+}
+inline void RegisterGlobalHandler(EndpointId endpoint) {}
+#endif
+
+void Store(FabricIndex fabricIndex, EndpointId endpoint);
+void Recall(FabricIndex fabricIndex, EndpointId endpoint);
+void MarkInvalid(EndpointId endpoint);
+
+} // namespace chip::app::Clusters::OnOff::Internal::Scenes
+
+#else
+
+namespace chip::app::Clusters::OnOff::Internal::Scenes {
+
+inline chip::scenes::SceneHandler * GlobalHandler()
+{
+    return nullptr;
+}
+inline void RegisterGlobalHandler(EndpointId endpoint) {}
+inline void Store(FabricIndex fabricIndex, EndpointId endpoint) {}
+inline void Recall(FabricIndex fabricIndex, EndpointId endpoint) {}
+inline void MarkInvalid(EndpointId endpoint) {}
+
+} // namespace chip::app::Clusters::OnOff::Internal::Scenes
+
+#endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT

--- a/src/app/clusters/on-off-server/scenes-integration.h
+++ b/src/app/clusters/on-off-server/scenes-integration.h
@@ -15,9 +15,9 @@
  */
 #pragma once
 
+#include <app/clusters/scenes-server/SceneTable.h>
 #include <app/util/config.h>
 #include <lib/core/CHIPConfig.h>
-#include <app/clusters/scenes-server/SceneTable.h>
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
 

--- a/src/app/clusters/on-off-server/scenes-integration.h
+++ b/src/app/clusters/on-off-server/scenes-integration.h
@@ -17,10 +17,9 @@
 
 #include <app/util/config.h>
 #include <lib/core/CHIPConfig.h>
+#include <app/clusters/scenes-server/SceneTable.h>
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-
-#include <app/clusters/scenes-server/SceneTable.h>
 
 namespace chip::app::Clusters::OnOff::Internal::Scenes {
 

--- a/src/app/clusters/scenes-server/SceneTable.h
+++ b/src/app/clusters/scenes-server/SceneTable.h
@@ -55,9 +55,8 @@ static constexpr size_t kScenesMaxTransitionTime = 60'000'000u;
 class SceneHandler : public IntrusiveListNodeBase<>
 {
 public:
-    SceneHandler() = default;
+    SceneHandler()          = default;
     virtual ~SceneHandler() = default;
-
 
     /// @brief Returns whether or not a cluster for scenes is supported on an endpoint
     ///

--- a/src/app/clusters/scenes-server/SceneTable.h
+++ b/src/app/clusters/scenes-server/SceneTable.h
@@ -55,16 +55,9 @@ static constexpr size_t kScenesMaxTransitionTime = 60'000'000u;
 class SceneHandler : public IntrusiveListNodeBase<>
 {
 public:
-    SceneHandler(){};
+    SceneHandler() = default;
     virtual ~SceneHandler() = default;
 
-    /// @brief Copies the list of supported clusters for an endpoint in a Span and resizes the span to fit the actual number of
-    /// supported clusters
-    /// @param endpoint target endpoint
-    /// @param clusterBuffer Buffer to hold the supported cluster IDs, cannot hold more than
-    /// CHIP_CONFIG_SCENES_MAX_CLUSTERS_PER_SCENE. The function shall use the reduce_size() method in the event it is supporting
-    /// less than CHIP_CONFIG_SCENES_MAX_CLUSTERS_PER_SCENE clusters.
-    virtual void GetSupportedClusters(EndpointId endpoint, Span<ClusterId> & clusterBuffer) = 0;
 
     /// @brief Returns whether or not a cluster for scenes is supported on an endpoint
     ///

--- a/src/app/tests/TestSceneTable.cpp
+++ b/src/app/tests/TestSceneTable.cpp
@@ -386,54 +386,6 @@ public:
     TestSceneHandler() = default;
     ~TestSceneHandler() override {}
 
-    // Fills in cluster buffer and adjusts its size to lower than the maximum number of cluster per scenes
-    virtual void GetSupportedClusters(EndpointId endpoint, Span<ClusterId> & clusterBuffer) override
-    {
-        ClusterId * buffer = clusterBuffer.data();
-        if (endpoint == kTestEndpoint1)
-        {
-            if (clusterBuffer.size() >= 2)
-            {
-                buffer[0] = kOnOffClusterId;
-                buffer[1] = kLevelControlClusterId;
-                clusterBuffer.reduce_size(2);
-            }
-        }
-        else if (endpoint == kTestEndpoint2)
-        {
-            if (clusterBuffer.size() >= 2)
-            {
-                buffer[0] = kOnOffClusterId;
-                buffer[1] = kColorControlClusterId;
-                clusterBuffer.reduce_size(2);
-            }
-        }
-        else if (endpoint == kTestEndpoint3)
-        {
-            if (clusterBuffer.size() >= 3)
-            {
-                buffer[0] = kOnOffClusterId;
-                buffer[1] = kLevelControlClusterId;
-                buffer[2] = kColorControlClusterId;
-                clusterBuffer.reduce_size(3);
-            }
-        }
-        else if (endpoint == kTestEndpoint4)
-        {
-            if (clusterBuffer.size() >= 3)
-            {
-                buffer[0] = MockClusterId(kOnOffClusterId);
-                buffer[1] = MockClusterId(kLevelControlClusterId);
-                buffer[2] = MockClusterId(kColorControlClusterId);
-                clusterBuffer.reduce_size(3);
-            }
-        }
-        else
-        {
-            clusterBuffer.reduce_size(0);
-        }
-    }
-
     // Default function only checks if endpoint and clusters are valid
     bool SupportsCluster(EndpointId endpoint, ClusterId cluster) override
     {


### PR DESCRIPTION
#### Summary

On/Off cluster has a lot of conditional defines in its main cpp file. This makes the code harder to maintain, especially looking to convert this to support code driven implementations.

Split out each of the additional cluster integrations into separate files for now, to make separation points clearer. Will look as a followup to make the logic a bit generic, as overall it seems we need some form of "listener" logic instead of the current direct calls.

Changes:
  - separate out clusters into `<cluster>-integration.h/cpp` that contains ifdef specific things
  - onoff cluster now calls integration points always (but they are inlined to empty if that is the right thing)
  - removed unused scenes GetSupportedClusters (so that I have a minor code size decrese along with the slight code increase due to extra calls)


#### Testing

This is not a functional change, so CI is expected to cover and pass as-is.