### PR TITLE
Separate PersistenceBuffer out of PersistentStore

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/tls-certificate-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-certificate-management-instance.cpp
@@ -40,13 +40,13 @@ static constexpr uint16_t kMaxIntermediateCerts = 10;
 
 struct InlineBufferedRootCert : CertificateTable::BufferedRootCert
 {
-    PersistentStore<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES> buffer;
+    PersistenceBuffer<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES> buffer;
     InlineBufferedRootCert() : CertificateTable::BufferedRootCert(buffer) {}
 };
 
 struct InlineBufferedClientCert : CertificateTable::BufferedClientCert
 {
-    PersistentStore<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES> buffer;
+    PersistenceBuffer<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES> buffer;
     InlineBufferedClientCert() : CertificateTable::BufferedClientCert(buffer) {}
 };
 

--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -71,7 +71,7 @@ struct BufferedEndpoint
     PersistenceBuffer<kTlsEndpointMaxBytes> mBuffer;
 };
 
-class GlobalEndpointData : public PersistentData<kPersistentBufferNextIdBytes>
+class GlobalEndpointData : public PersistableData<kPersistentBufferNextIdBytes>
 {
     IncrementingIdHelper<TlsEndpointId, kMaxProvisionedEndpoints * CHIP_CONFIG_MAX_FABRICS> mEndpoints;
     EndpointId mEndpointId = kInvalidEndpointId;
@@ -124,9 +124,9 @@ public:
         return reader.ExitContainer(container);
     }
 
-    CHIP_ERROR Load(PersistentStorageDelegate * storage) override
+    CHIP_ERROR Load(PersistentStorageDelegate * storage)
     {
-        CHIP_ERROR err = PersistentData::Load(storage);
+        CHIP_ERROR err = PersistableData::Load(storage);
         VerifyOrReturnError(CHIP_NO_ERROR == err || CHIP_ERROR_NOT_FOUND == err, err);
         if (CHIP_ERROR_NOT_FOUND == err)
         {

--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -68,7 +68,7 @@ static constexpr size_t kTlsEndpointMaxBytes =
 struct BufferedEndpoint
 {
     TlsClientManagementDelegate::EndpointStructType mEndpoint;
-    PersistentStore<kTlsEndpointMaxBytes> mBuffer;
+    PersistenceBuffer<kTlsEndpointMaxBytes> mBuffer;
 };
 
 class GlobalEndpointData : public PersistentData<kPersistentBufferNextIdBytes>

--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -127,7 +127,7 @@ public:
     CHIP_ERROR Load(PersistentStorageDelegate * storage) // NOLINT(bugprone-derived-method-shadowing-base-method)
     {
         CHIP_ERROR err = PersistableData::Load(storage);
-        return (err == CHIP_ERROR_NOT_FOUND) ? CHIP_NO_ERROR : err; // NOT_FOUND is OK; DataAccessor::Load already called Clear()
+        return err.NoErrorIf(CHIP_ERROR_NOT_FOUND); // NOT_FOUND is OK; DataAccessor::Load already called Clear()
     }
 
     CHIP_ERROR GetNextId(FabricIndex fabric, uint16_t & id)

--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -124,16 +124,10 @@ public:
         return reader.ExitContainer(container);
     }
 
-    CHIP_ERROR Load(PersistentStorageDelegate * storage)
+    CHIP_ERROR Load(PersistentStorageDelegate * storage) // NOLINT(bugprone-derived-method-shadowing-base-method)
     {
         CHIP_ERROR err = PersistableData::Load(storage);
-        VerifyOrReturnError(CHIP_NO_ERROR == err || CHIP_ERROR_NOT_FOUND == err, err);
-        if (CHIP_ERROR_NOT_FOUND == err)
-        {
-            Clear();
-        }
-
-        return CHIP_NO_ERROR;
+        return (err == CHIP_ERROR_NOT_FOUND) ? CHIP_NO_ERROR : err; // NOT_FOUND is OK; DataAccessor::Load already called Clear()
     }
 
     CHIP_ERROR GetNextId(FabricIndex fabric, uint16_t & id)

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -600,8 +600,8 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
             commandPath.mEndpointId, handler.GetAccessingFabricIndex(), commandData.transportOptions.TLSEndpointID,
             [&](auto & TLSEndpoint) -> CHIP_ERROR {
                 // Use heap allocation for large certificate buffers to reduce stack usage
-                auto rootCertBuffer   = std::make_unique<PersistentStore<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES>>();
-                auto clientCertBuffer = std::make_unique<PersistentStore<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES>>();
+                auto rootCertBuffer   = std::make_unique<PersistenceBuffer<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES>>();
+                auto clientCertBuffer = std::make_unique<PersistenceBuffer<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES>>();
 
                 Tls::CertificateTable::BufferedClientCert clientCertEntry(*clientCertBuffer);
                 Tls::CertificateTable::BufferedRootCert rootCertEntry(*rootCertBuffer);

--- a/src/app/clusters/scenes-server/SceneTableImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneTableImpl.cpp
@@ -132,14 +132,14 @@ CHIP_ERROR DefaultSceneTableImpl::GetRemainingCapacity(FabricIndex fabric_index,
 CHIP_ERROR DefaultSceneTableImpl::SetSceneTableEntry(FabricIndex fabric_index, const SceneTableEntry & entry)
 {
     // Scene data is small, buffer can be allocated on stack
-    PersistentStore<Serializer::kEntryMaxBytes()> writeBuffer;
+    PersistenceBuffer<Serializer::kEntryMaxBytes()> writeBuffer;
     return this->SetTableEntry(fabric_index, entry.mStorageId, entry.mStorageData, writeBuffer);
 }
 
 CHIP_ERROR DefaultSceneTableImpl::GetSceneTableEntry(FabricIndex fabric_index, SceneStorageId scene_id, SceneTableEntry & entry)
 {
     // All data is copied to SceneTableEntry, buffer can be allocated on stack
-    PersistentStore<Serializer::kEntryMaxBytes()> store;
+    PersistenceBuffer<Serializer::kEntryMaxBytes()> store;
     ReturnErrorOnFailure(this->GetTableEntry(fabric_index, scene_id, entry.mStorageData, store));
     entry.mStorageId = scene_id;
     return CHIP_NO_ERROR;

--- a/src/app/clusters/tls-certificate-management-server/CertificateTable.h
+++ b/src/app/clusters/tls-certificate-management-server/CertificateTable.h
@@ -52,12 +52,11 @@ public:
 
     using IterateRootCertFnType   = std::function<CHIP_ERROR(CommonIterator<RootCertStruct> & iterator)>;
     using IterateClientCertFnType = std::function<CHIP_ERROR(CommonIterator<ClientCertWithKey> & iterator)>;
-    using RootBuffer              = PersistentStore<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES>;
-    using ClientBuffer            = PersistentStore<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES>;
+    using RootBuffer              = PersistenceBuffer<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES>;
+    using ClientBuffer            = PersistenceBuffer<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES>;
 
     /// @brief a root cert along with an associated buffer for the cert payload. RootCertStruct has a ByteSpan,
     /// and this wrapper ensures that the underlying buffer for the ByteSpan has a long-enough lifetime.
-    /// No other functionality from PersistentStore<> is required to be used by the implementation except the underlying buffer.
     struct BufferedRootCert
     {
         BufferedRootCert(RootBuffer & buffer) : mBuffer(buffer) {}
@@ -74,7 +73,6 @@ public:
     /// @brief a client cert along with an associated buffer for the cert payload.  ClientCertStruct contains various
     /// lists and bytespans, and this wrapper ensures that the underlying buffers for those data structures
     /// have long-enough lifetimes.
-    /// No other functionality from PersistentStore<> is required to be used by the implementation except the underlying buffer.
     struct BufferedClientCert
     {
         BufferedClientCert(ClientBuffer & buffer) : mBuffer(buffer) {}
@@ -188,11 +186,11 @@ public:
     virtual CHIP_ERROR RemoveFabric(FabricIndex fabric) = 0;
 
 protected:
-    static inline PersistentStore<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES> & GetBuffer(BufferedRootCert & bufferedCert)
+    static inline PersistenceBuffer<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES> & GetBuffer(BufferedRootCert & bufferedCert)
     {
         return bufferedCert.mBuffer;
     }
-    static inline PersistentStore<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES> & GetBuffer(BufferedClientCert & bufferedCert)
+    static inline PersistenceBuffer<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES> & GetBuffer(BufferedClientCert & bufferedCert)
     {
         return bufferedCert.mBuffer;
     }

--- a/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
+++ b/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
@@ -156,16 +156,10 @@ public:
                                          TLV::ContextTag(TagCertificate::kStoredFabricIndex));
     }
 
-    CHIP_ERROR Load(PersistentStorageDelegate * storage)
+    CHIP_ERROR Load(PersistentStorageDelegate * storage) // NOLINT(bugprone-derived-method-shadowing-base-method)
     {
         CHIP_ERROR err = PersistableData::Load(storage);
-        VerifyOrReturnError(CHIP_NO_ERROR == err || CHIP_ERROR_NOT_FOUND == err, err);
-        if (CHIP_ERROR_NOT_FOUND == err)
-        {
-            Clear();
-        }
-
-        return CHIP_NO_ERROR;
+        return (err == CHIP_ERROR_NOT_FOUND) ? CHIP_NO_ERROR : err; // NOT_FOUND is OK; DataAccessor::Load already called Clear()
     }
 
     CHIP_ERROR GetNextClientCertificateId(FabricIndex fabric, TLSCCDID & id)

--- a/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
+++ b/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
@@ -159,7 +159,7 @@ public:
     CHIP_ERROR Load(PersistentStorageDelegate * storage) // NOLINT(bugprone-derived-method-shadowing-base-method)
     {
         CHIP_ERROR err = PersistableData::Load(storage);
-        return (err == CHIP_ERROR_NOT_FOUND) ? CHIP_NO_ERROR : err; // NOT_FOUND is OK; DataAccessor::Load already called Clear()
+        return err.NoErrorIf(CHIP_ERROR_NOT_FOUND); // NOT_FOUND is OK; DataAccessor::Load already called Clear()
     }
 
     CHIP_ERROR GetNextClientCertificateId(FabricIndex fabric, TLSCCDID & id)

--- a/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
+++ b/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
@@ -72,7 +72,7 @@ static constexpr size_t kPersistentBufferNextIdBytes =
                            EstimateStructOverhead(sizeof(CertificateId), sizeof(FabricIndex)) *
                                (kMaxClientCertificatesPerFabric * CHIP_CONFIG_MAX_FABRICS)); // mClientCertMapping
 
-class GlobalCertificateData : public PersistentData<kPersistentBufferNextIdBytes>
+class GlobalCertificateData : public PersistableData<kPersistentBufferNextIdBytes>
 {
     IncrementingIdHelper<CertificateId, kMaxRootCertificatesPerFabric * CHIP_CONFIG_MAX_FABRICS> mRoot;
     IncrementingIdHelper<CertificateId, kMaxClientCertificatesPerFabric * CHIP_CONFIG_MAX_FABRICS> mClient;
@@ -156,9 +156,9 @@ public:
                                          TLV::ContextTag(TagCertificate::kStoredFabricIndex));
     }
 
-    CHIP_ERROR Load(PersistentStorageDelegate * storage) override
+    CHIP_ERROR Load(PersistentStorageDelegate * storage)
     {
-        CHIP_ERROR err = PersistentData::Load(storage);
+        CHIP_ERROR err = PersistableData::Load(storage);
         VerifyOrReturnError(CHIP_NO_ERROR == err || CHIP_ERROR_NOT_FOUND == err, err);
         if (CHIP_ERROR_NOT_FOUND == err)
         {

--- a/src/app/icd/server/ICDMonitoringTable.h
+++ b/src/app/icd/server/ICDMonitoringTable.h
@@ -50,7 +50,7 @@ static constexpr size_t MaxICDMonitoringEntrySize()
 
 inline constexpr size_t kICDMonitoringBufferSize = MaxICDMonitoringEntrySize();
 
-struct ICDMonitoringEntry : public PersistentData<kICDMonitoringBufferSize>
+struct ICDMonitoringEntry : public PersistableData<kICDMonitoringBufferSize>
 {
     ICDMonitoringEntry(FabricIndex fabric = kUndefinedFabricIndex, NodeId nodeId = kUndefinedNodeId)
     {

--- a/src/app/storage/FabricTableImpl.h
+++ b/src/app/storage/FabricTableImpl.h
@@ -123,7 +123,7 @@ public:
      */
     template <size_t kEntryMaxBytes>
     CHIP_ERROR SetTableEntry(FabricIndex fabric_index, const StorageId & entry_id, const StorageData & data,
-                             PersistentStore<kEntryMaxBytes> & writeBuffer);
+                             PersistenceBuffer<kEntryMaxBytes> & writeBuffer);
 
     /**
      * @brief Loads the entry from persistent storage.
@@ -136,7 +136,7 @@ public:
      */
     template <size_t kEntryMaxBytes>
     CHIP_ERROR GetTableEntry(FabricIndex fabric_index, StorageId & entry_id, StorageData & data,
-                             PersistentStore<kEntryMaxBytes> & buffer);
+                             PersistenceBuffer<kEntryMaxBytes> & buffer);
     CHIP_ERROR FindTableEntry(FabricIndex fabric_index, const StorageId & entry_id, EntryIndex & idx);
     CHIP_ERROR RemoveTableEntry(FabricIndex fabric_index, const StorageId & entry_id);
     CHIP_ERROR RemoveTableEntryAtPosition(EndpointId endpoint, FabricIndex fabric_index, EntryIndex entry_idx);
@@ -164,7 +164,7 @@ public:
      * and IterateEntries returns that same error result.
      */
     template <size_t kEntryMaxBytes, class UnaryFunc>
-    CHIP_ERROR IterateEntries(FabricIndex fabric, PersistentStore<kEntryMaxBytes> & store, UnaryFunc iterateFn);
+    CHIP_ERROR IterateEntries(FabricIndex fabric, PersistenceBuffer<kEntryMaxBytes> & buffer, UnaryFunc iterateFn);
 
 protected:
     // This constructor is meant for test purposes, it allows to change the defined max for entries per fabric and global, which
@@ -188,14 +188,14 @@ protected:
     {
     public:
         EntryIteratorImpl(FabricTableImpl & provider, FabricIndex fabricIdx, EndpointId endpoint, uint16_t maxEntriesPerFabric,
-                          uint16_t maxEntriesPerEndpoint, PersistentStore<kEntryMaxBytes> & store);
+                          uint16_t maxEntriesPerEndpoint, PersistenceBuffer<kEntryMaxBytes> & buffer);
         size_t Count() override;
         bool Next(TableEntry & output) override;
         void Release() override;
 
     protected:
         FabricTableImpl & mProvider;
-        PersistentStore<kEntryMaxBytes> & mStore;
+        PersistenceBuffer<kEntryMaxBytes> & mBuffer;
         FabricIndex mFabric  = kUndefinedFabricIndex;
         EndpointId mEndpoint = kInvalidEndpointId;
         EntryIndex mNextEntryIdx;

--- a/src/app/storage/FabricTableImpl.ipp
+++ b/src/app/storage/FabricTableImpl.ipp
@@ -642,7 +642,7 @@ CHIP_ERROR FabricTableImpl<StorageId, StorageData>::GetTableEntry(FabricIndex fa
     ReturnErrorOnFailure(fabric.Load(mStorage));
     VerifyOrReturnError(fabric.Find(entry_id, table_entry.index) == CHIP_NO_ERROR, CHIP_ERROR_NOT_FOUND);
 
-    CHIP_ERROR err = table_entry.Load(mStorage, MutableByteSpan(buffer.mBuffer));
+    CHIP_ERROR err = table_entry.Load(mStorage, buffer.BufferSpan());
 
     // If entry.Load returns "buffer too small", the entry in memory is too big to be retrieved (this could happen if the
     // kEntryMaxBytes was reduced by OTA) and therefore must be deleted as is is no longer considered accessible.

--- a/src/app/storage/FabricTableImpl.ipp
+++ b/src/app/storage/FabricTableImpl.ipp
@@ -77,7 +77,7 @@ struct BaseEntryCount : public PersistableData<kPersistentBufferEntryCountBytes>
     CHIP_ERROR Load(PersistentStorageDelegate * storage) // NOLINT(bugprone-derived-method-shadowing-base-method)
     {
         CHIP_ERROR err = PersistableData::Load(storage);
-        return (err == CHIP_ERROR_NOT_FOUND) ? CHIP_NO_ERROR : err; // NOT_FOUND is OK; DataAccessor::Load already called Clear()
+        return err.NoErrorIf(CHIP_ERROR_NOT_FOUND); // NOT_FOUND is OK; DataAccessor::Load already called Clear()
     }
 };
 

--- a/src/app/storage/FabricTableImpl.ipp
+++ b/src/app/storage/FabricTableImpl.ipp
@@ -48,7 +48,7 @@ enum class TagEntry : uint8_t
 // byte value, 1 byte end struct. 8 Bytes leaves space for potential increase in count_value size.
 static constexpr size_t kPersistentBufferEntryCountBytes = 8;
 
-struct BaseEntryCount : public PersistentData<kPersistentBufferEntryCountBytes>
+struct BaseEntryCount : public PersistableData<kPersistentBufferEntryCountBytes>
 {
     uint8_t count_value = 0;
     BaseEntryCount(uint8_t count = 0) : count_value(count) {}
@@ -72,9 +72,9 @@ struct BaseEntryCount : public PersistentData<kPersistentBufferEntryCountBytes>
         return reader.ExitContainer(container);
     }
 
-    CHIP_ERROR Load(PersistentStorageDelegate * storage) override
+    CHIP_ERROR Load(PersistentStorageDelegate * storage)
     {
-        CHIP_ERROR err = PersistentData::Load(storage);
+        CHIP_ERROR err = PersistableData::Load(storage);
         VerifyOrReturnError(CHIP_NO_ERROR == err || CHIP_ERROR_NOT_FOUND == err, err);
         if (CHIP_ERROR_NOT_FOUND == err)
         {
@@ -190,7 +190,7 @@ struct TableEntryData : DataAccessor
  * FabricEntryData is an access to a linked list of entries
  */
 template <class StorageId, class StorageData, size_t kEntryMaxBytes, size_t kFabricMaxBytes, uint16_t kMaxPerFabric>
-struct FabricEntryData : public PersistentData<kFabricMaxBytes>
+struct FabricEntryData : public PersistableData<kFabricMaxBytes>
 {
     using Serializer              = DefaultSerializer<StorageId, StorageData>;
     using TypedTableEntryData     = TableEntryData<StorageId, StorageData>;
@@ -464,7 +464,7 @@ struct FabricEntryData : public PersistentData<kFabricMaxBytes>
         return err;
     }
 
-    CHIP_ERROR Load(PersistentStorageDelegate * storage) override
+    CHIP_ERROR Load(PersistentStorageDelegate * storage)
     {
         VerifyOrReturnError(nullptr != storage, CHIP_ERROR_INVALID_ARGUMENT);
         uint8_t deleted_entries_count = 0;

--- a/src/app/tests/TestCertificateTableImpl.cpp
+++ b/src/app/tests/TestCertificateTableImpl.cpp
@@ -43,13 +43,13 @@ static constexpr uint16_t kSpecMaxCertBytes = 3000;
 
 struct InlineBufferedRootCert : CertificateTable::BufferedRootCert
 {
-    PersistentStore<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES> buffer;
+    PersistenceBuffer<CHIP_CONFIG_TLS_PERSISTED_ROOT_CERT_BYTES> buffer;
     InlineBufferedRootCert() : CertificateTable::BufferedRootCert(buffer) {}
 };
 
 struct InlineBufferedClientCert : CertificateTable::BufferedClientCert
 {
-    PersistentStore<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES> buffer;
+    PersistenceBuffer<CHIP_CONFIG_TLS_PERSISTED_CLIENT_CERT_BYTES> buffer;
     InlineBufferedClientCert() : CertificateTable::BufferedClientCert(buffer) {}
 };
 

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -45,7 +45,7 @@ struct FabricList : public CommonPersistentData::FabricList
 
 constexpr size_t kPersistentBufferMax = 128;
 
-struct LinkedData : public PersistentData<kPersistentBufferMax>
+struct LinkedData : public PersistableData<kPersistentBufferMax>
 {
     static constexpr uint16_t kMinLinkId = 1;
 
@@ -59,7 +59,7 @@ struct LinkedData : public PersistentData<kPersistentBufferMax>
     bool first      = true;
 };
 
-struct FabricData : public PersistentData<kPersistentBufferMax>
+struct FabricData : public PersistableData<kPersistentBufferMax>
 {
     static constexpr TLV::Tag TagFirstGroup() { return TLV::ContextTag(1); }
     static constexpr TLV::Tag TagGroupCount() { return TLV::ContextTag(2); }
@@ -247,20 +247,20 @@ struct FabricData : public PersistentData<kPersistentBufferMax>
         return CHIP_ERROR_NOT_FOUND;
     }
 
-    CHIP_ERROR Save(PersistentStorageDelegate * storage) override
+    CHIP_ERROR Save(PersistentStorageDelegate * storage)
     {
         ReturnErrorOnFailure(Register(storage));
-        return PersistentData::Save(storage);
+        return PersistableData::Save(storage);
     }
 
-    CHIP_ERROR Delete(PersistentStorageDelegate * storage) override
+    CHIP_ERROR Delete(PersistentStorageDelegate * storage)
     {
         ReturnErrorOnFailure(Unregister(storage));
-        return PersistentData::Delete(storage);
+        return PersistableData::Delete(storage);
     }
 };
 
-struct GroupData : public GroupDataProvider::GroupInfo, PersistentData<kPersistentBufferMax>
+struct GroupData : public GroupDataProvider::GroupInfo, PersistableData<kPersistentBufferMax>
 {
     static constexpr TLV::Tag TagName() { return TLV::ContextTag(1); }
     static constexpr TLV::Tag TagFirstEndpoint() { return TLV::ContextTag(2); }
@@ -536,7 +536,7 @@ struct KeyMapData : public GroupDataProvider::GroupKey, LinkedData
     }
 };
 
-struct EndpointData : GroupDataProvider::GroupEndpoint, PersistentData<kPersistentBufferMax>
+struct EndpointData : GroupDataProvider::GroupEndpoint, PersistableData<kPersistentBufferMax>
 {
     static constexpr TLV::Tag TagEndpoint() { return TLV::ContextTag(1); }
     static constexpr TLV::Tag TagNext() { return TLV::ContextTag(2); }
@@ -621,7 +621,7 @@ struct EndpointData : GroupDataProvider::GroupEndpoint, PersistentData<kPersiste
     }
 };
 
-struct KeySetData : PersistentData<kPersistentBufferMax>
+struct KeySetData : PersistableData<kPersistentBufferMax>
 {
     static constexpr TLV::Tag TagPolicy() { return TLV::ContextTag(1); }
     static constexpr TLV::Tag TagNumKeys() { return TLV::ContextTag(2); }

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -247,13 +247,13 @@ struct FabricData : public PersistableData<kPersistentBufferMax>
         return CHIP_ERROR_NOT_FOUND;
     }
 
-    CHIP_ERROR Save(PersistentStorageDelegate * storage)
+    CHIP_ERROR Save(PersistentStorageDelegate * storage) // NOLINT(bugprone-derived-method-shadowing-base-method)
     {
         ReturnErrorOnFailure(Register(storage));
         return PersistableData::Save(storage);
     }
 
-    CHIP_ERROR Delete(PersistentStorageDelegate * storage)
+    CHIP_ERROR Delete(PersistentStorageDelegate * storage) // NOLINT(bugprone-derived-method-shadowing-base-method)
     {
         ReturnErrorOnFailure(Unregister(storage));
         return PersistableData::Delete(storage);

--- a/src/lib/support/CommonPersistentData.h
+++ b/src/lib/support/CommonPersistentData.h
@@ -31,9 +31,9 @@ inline constexpr uint8_t kdefaultUndefinedEntry = 0;
 
 /// @brief Generic class to implement storage of a list persistently
 /// @tparam EntryType : Type of entry depends on the stored data
-/// @tparam kMaxSerializedSize : inherited from PersistentData class
+/// @tparam kMaxSerializedSize : inherited from PersistableData
 template <typename EntryType, size_t kMaxSerializedSize>
-struct StoredDataList : public PersistentData<kMaxSerializedSize>
+struct StoredDataList : public PersistableData<kMaxSerializedSize>
 {
     static constexpr TLV::Tag TagFirstEntry() { return TLV::ContextTag(1); }
     static constexpr TLV::Tag TagEntryCount() { return TLV::ContextTag(2); }

--- a/src/lib/support/PersistentData.h
+++ b/src/lib/support/PersistentData.h
@@ -22,7 +22,8 @@
 #include <lib/support/Span.h>
 
 namespace chip {
-/// @brief Data accessor allowing data to be persisted by PersistentStore to be accessed
+
+/// @brief Data that can be persisted via PersistentStorageDelegate in TLV format.
 struct DataAccessor
 {
     virtual ~DataAccessor()                                     = default;
@@ -84,10 +85,13 @@ struct DataAccessor
 
 /// @brief A buffer to be used when loading or serializing persistent data
 /// @tparam kMaxSerializedSize size of the buffer necessary to retrieve an entry from the storage.
+///
+/// Note: Generic APIs that utilize a persistence buffer should prefer taking
+/// a MutableByteSpan, to avoid unnecessarily templating on the buffer size.
 template <size_t kMaxSerializedSize>
 struct PersistenceBuffer
 {
-    uint8_t mBuffer[kMaxSerializedSize] = { 0 };
+    uint8_t mBuffer[kMaxSerializedSize];
 
     // Returns a MutableByteSpan representing this buffer.
     MutableByteSpan BufferSpan() { return MutableByteSpan(mBuffer); }
@@ -97,7 +101,8 @@ struct PersistenceBuffer
 /// Only exists for compatibility with existing code;
 /// new code should use PersistenceBuffer and DataAccessor separately.
 template <size_t kMaxSerializedSize>
-struct PersistentStore : public PersistenceBuffer<kMaxSerializedSize>
+struct [[deprecated("Use PersistenceBuffer and DataAccessor separately")]] PersistentStore
+    : public PersistenceBuffer<kMaxSerializedSize>
 {
     virtual ~PersistentStore() = default;
 

--- a/src/lib/support/PersistentData.h
+++ b/src/lib/support/PersistentData.h
@@ -19,6 +19,7 @@
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/TLV.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
+#include <lib/support/Span.h>
 
 namespace chip {
 /// @brief Data accessor allowing data to be persisted by PersistentStore to be accessed
@@ -29,69 +30,88 @@ struct DataAccessor
     virtual CHIP_ERROR Serialize(TLV::TLVWriter & writer) const = 0;
     virtual CHIP_ERROR Deserialize(TLV::TLVReader & reader)     = 0;
     virtual void Clear()                                        = 0;
-};
 
-/// @brief Interface to PersistentStorageDelegate allowing storage of data of variable size such as TLV, delegating data access
-/// to DataAccessor
-/// @tparam kMaxSerializedSize size of the mBuffer necessary to retrieve an entry from the storage. Varies with the type of data
-/// stored. Will be allocated on the stack so the implementation needs to be aware of this when choosing this value.
-template <size_t kMaxSerializedSize>
-struct PersistentStore
-{
-    virtual ~PersistentStore() = default;
+    /// Non-virtual helper methods ///
 
-    CHIP_ERROR Save(const DataAccessor & persistent, PersistentStorageDelegate * storage)
+    CHIP_ERROR Save(PersistentStorageDelegate * storage, const MutableByteSpan & buffer) const
     {
         VerifyOrReturnError(nullptr != storage, CHIP_ERROR_INVALID_ARGUMENT);
 
         StorageKeyName key = StorageKeyName::Uninitialized();
-        ReturnErrorOnFailure(persistent.UpdateKey(key));
+        ReturnErrorOnFailure(this->UpdateKey(key));
 
         // Serialize the data
         TLV::TLVWriter writer;
-        writer.Init(mBuffer, sizeof(mBuffer));
-
-        ReturnErrorOnFailure(persistent.Serialize(writer));
+        writer.Init(buffer);
+        ReturnErrorOnFailure(this->Serialize(writer));
 
         // Save serialized data
-        return storage->SyncSetKeyValue(key.KeyName(), mBuffer, static_cast<uint16_t>(writer.GetLengthWritten()));
+        return storage->SyncSetKeyValue(key.KeyName(), buffer.data(), static_cast<uint16_t>(writer.GetLengthWritten()));
     }
 
-    CHIP_ERROR Load(DataAccessor & persistent, PersistentStorageDelegate * storage)
+    CHIP_ERROR Load(PersistentStorageDelegate * storage, const MutableByteSpan & buffer)
     {
         VerifyOrReturnError(nullptr != storage, CHIP_ERROR_INVALID_ARGUMENT);
 
         StorageKeyName key = StorageKeyName::Uninitialized();
-
-        // Update storage key
-        ReturnErrorOnFailure(persistent.UpdateKey(key));
+        ReturnErrorOnFailure(this->UpdateKey(key));
 
         // Set data to defaults
-        persistent.Clear();
+        this->Clear();
 
         // Load the serialized data
-        uint16_t size  = static_cast<uint16_t>(sizeof(mBuffer));
-        CHIP_ERROR err = storage->SyncGetKeyValue(key.KeyName(), mBuffer, size);
+        uint16_t size  = (buffer.size() > UINT16_MAX) ? UINT16_MAX : static_cast<uint16_t>(buffer.size());
+        CHIP_ERROR err = storage->SyncGetKeyValue(key.KeyName(), buffer.data(), size);
         VerifyOrReturnError(CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND != err, CHIP_ERROR_NOT_FOUND);
         ReturnErrorOnFailure(err);
 
         // Decode serialized data
         TLV::TLVReader reader;
-        reader.Init(mBuffer, size);
-        return persistent.Deserialize(reader);
+        reader.Init(buffer.data(), size);
+        return this->Deserialize(reader);
     }
 
-    CHIP_ERROR Delete(DataAccessor & persistent, PersistentStorageDelegate * storage)
+    CHIP_ERROR Delete(PersistentStorageDelegate * storage) const
     {
         VerifyOrReturnError(nullptr != storage, CHIP_ERROR_INVALID_ARGUMENT);
 
         StorageKeyName key = StorageKeyName::Uninitialized();
-        ReturnErrorOnFailure(persistent.UpdateKey(key));
+        ReturnErrorOnFailure(this->UpdateKey(key));
 
         return storage->SyncDeleteKeyValue(key.KeyName());
     }
+};
 
+/// @brief A buffer to be used when loading or serializing persistent data
+/// @tparam kMaxSerializedSize size of the buffer necessary to retrieve an entry from the storage.
+template <size_t kMaxSerializedSize>
+struct PersistenceBuffer
+{
     uint8_t mBuffer[kMaxSerializedSize] = { 0 };
+
+    // Returns a MutableByteSpan representing this buffer.
+    MutableByteSpan BufferSpan() { return MutableByteSpan(mBuffer); }
+};
+
+/// @brief Combines a PersistenceBuffer with DataAccessor helpers.
+/// Only exists for compatibility with existing code;
+/// new code should use PersistenceBuffer and DataAccessor separately.
+template <size_t kMaxSerializedSize>
+struct PersistentStore : public PersistenceBuffer<kMaxSerializedSize>
+{
+    virtual ~PersistentStore() = default;
+
+    CHIP_ERROR Save(const DataAccessor & persistent, PersistentStorageDelegate * storage)
+    {
+        return persistent.Save(storage, this->BufferSpan());
+    }
+
+    CHIP_ERROR Load(DataAccessor & persistent, PersistentStorageDelegate * storage)
+    {
+        return persistent.Load(storage, this->BufferSpan());
+    }
+
+    CHIP_ERROR Delete(DataAccessor & persistent, PersistentStorageDelegate * storage) { return persistent.Delete(storage); }
 };
 
 /// @brief Combines PersistentStore and DataAccessor

--- a/src/lib/support/PersistentData.h
+++ b/src/lib/support/PersistentData.h
@@ -98,7 +98,7 @@ struct PersistenceBuffer
 };
 
 /// @brief A DataAccessor with a built-in buffer.
-/// @tparam kMaxSerializedSize inherited from PersistableData
+/// @tparam kMaxSerializedSize inherited from PersistenceBuffer
 ///
 /// Note: Unlike `PersistentData` (deprecated), this class does not make the Load/Save/Delete
 /// methods virtual. PersistableData objects are not intended to be used polymorphically.
@@ -111,11 +111,11 @@ public:
     CHIP_ERROR Load(PersistentStorageDelegate * storage) { return DataAccessor::Load(storage, this->BufferSpan()); }
 };
 
-///// Deprecated types retained for for backward compatibility ////////////////
+///// Deprecated types retained for backward compatibility ////////////////////
 
+// Deprecated: use PersistenceBuffer and DataAccessor separately
 template <size_t kMaxSerializedSize>
-struct [[deprecated("Use PersistenceBuffer and DataAccessor separately")]] PersistentStore
-    : public PersistenceBuffer<kMaxSerializedSize>
+struct PersistentStore : public PersistenceBuffer<kMaxSerializedSize>
 {
     virtual ~PersistentStore() = default;
 
@@ -132,8 +132,9 @@ struct [[deprecated("Use PersistenceBuffer and DataAccessor separately")]] Persi
     CHIP_ERROR Delete(DataAccessor & persistent, PersistentStorageDelegate * storage) { return persistent.Delete(storage); }
 };
 
+// Deprecated: use PersistableData instead
 template <size_t kMaxSerializedSize>
-struct [[deprecated("Use PersistableData")]] PersistentData : PersistentStore<kMaxSerializedSize>, DataAccessor
+struct PersistentData : PersistentStore<kMaxSerializedSize>, DataAccessor
 {
     using SizedStore = PersistentStore<kMaxSerializedSize>;
 


### PR DESCRIPTION
#### Summary

- Separate PersistenceBuffer out of PersistentStore
- Create PersistableData as a simpler version of PersistentData
- Document PersistentStore and PersistentData as deprecated but leave in place for compatibility
- Refactor SDK usages to use the new simpler types.

#### Testing

This code is covered by existing tests.
