### PR TITLE
test: speed up running test_suite

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -314,6 +314,8 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
+                     --find-path $PWD/objdir-clone \
+                     --find-path $PWD/scripts \
                      --runner chip_tool_python \
                      --chip-tool ./objdir-clone/linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
                      run \
@@ -337,6 +339,8 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
+                     --find-path $PWD/objdir-clone \
+                     --find-path $PWD/scripts \
                      --runner chip_tool_python \
                      --include-tags PURPOSEFUL_FAILURE \
                      --chip-tool ./objdir-clone/linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
@@ -357,6 +361,8 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
+                     --find-path $PWD/objdir-clone \
+                     --find-path $PWD/scripts \
                      --runner chip_tool_python \
                      --target TestOperationalState \
                      --chip-tool ./objdir-clone/linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
@@ -372,6 +378,8 @@ jobs:
               run: |
                   ./scripts/run_in_python_env.sh out/venv \
                   "./scripts/tests/run_test_suite.py \
+                     --find-path $PWD/objdir-clone \
+                     --find-path $PWD/scripts \
                      --runner matter_repl_python \
                      --exclude-tags MANUAL \
                      --exclude-tags FLAKY \
@@ -400,6 +408,8 @@ jobs:
               run: |
                   ./scripts/run_in_python_env.sh out/venv \
                   "./scripts/tests/run_test_suite.py \
+                     --find-path $PWD/objdir-clone \
+                     --find-path $PWD/scripts \
                      --runner matter_repl_python \
                      run \
                      --iterations 1 \
@@ -541,6 +551,8 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
+                     --find-path $PWD/objdir-clone \
+                     --find-path $PWD/scripts \
                      --runner chip_tool_python \
                      --chip-tool ./objdir-clone/darwin-${{matrix.arch}}-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
                      --target-skip-glob '{Test_TC_DGTHREAD_2_1,Test_TC_DGTHREAD_2_2,Test_TC_DGTHREAD_2_3,Test_TC_DGTHREAD_2_4}' \
@@ -565,6 +577,8 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
+                     --find-path $PWD/objdir-clone \
+                     --find-path $PWD/scripts \
                      --runner chip_tool_python \
                      --include-tags PURPOSEFUL_FAILURE \
                      --chip-tool ./objdir-clone/darwin-${{matrix.arch}}-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \

--- a/scripts/tests/chipyaml/paths_finder.py
+++ b/scripts/tests/chipyaml/paths_finder.py
@@ -16,6 +16,7 @@
 
 import os
 import tempfile
+import typing
 from pathlib import Path
 
 import click
@@ -29,8 +30,8 @@ DEFAULT_CHIP_ROOT = os.path.abspath(
 
 
 class PathsFinder:
-    def __init__(self, root_dir: str = DEFAULT_CHIP_ROOT):
-        self.__root_dir = root_dir
+    def __init__(self, roots: typing.List[str] = [DEFAULT_CHIP_ROOT]):
+        self._roots = roots
 
     def get(self, target_name: str) -> str:
         path = _PATHS_CACHE.get(target_name)
@@ -40,7 +41,14 @@ class PathsFinder:
         if path:
             del _PATHS_CACHE[target_name]
 
-        for path in Path(self.__root_dir).rglob(target_name):
+        for root in self._roots:
+            if (path := self._find_from_root(root, target_name)):
+                return path
+
+        return None
+
+    def _find_from_root(self, root: str, target_name: str) -> str | None:
+        for path in Path(root).rglob(target_name):
             if not path.is_file() or path.name != target_name:
                 continue
 

--- a/scripts/tests/chipyaml/paths_finder.py
+++ b/scripts/tests/chipyaml/paths_finder.py
@@ -47,7 +47,7 @@ class PathsFinder:
 
         return None
 
-    def _find_from_root(self, root: str, target_name: str) -> str | None:
+    def _find_from_root(self, root: str, target_name: str) -> typing.Optional[str]:
         for path in Path(root).rglob(target_name):
             if not path.is_file() or path.name != target_name:
                 continue


### PR DESCRIPTION
#### Summary

This commit aims at limiting the directories to find targets to save time running a test. A command line option `--find-path` is added to specify the paths to start from. The `PathsFinder` is also updated to accept a list of paths instead of a single one.

For tests in `tests.yaml`, the search directory is set to `['scripts', 'objdir-clone']`.

#### Related issues

Currently running the test suites would result in minutes delay because of looking for targets. The root cause is it start searching from the root of the chip project.

#### Testing

I tested it locally. It's also verified by `tests.yaml` in CI. This reduces the time looking for targets from 35s to 2s.