### PR TITLE
[Silabs] remove OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS.

### DIFF
--- a/examples/platform/silabs/efr32/project_include/OpenThreadConfig.h
+++ b/examples/platform/silabs/efr32/project_include/OpenThreadConfig.h
@@ -98,10 +98,6 @@
 // Support udp multicast by enabling Multicast Listener Registration (MLR)
 #define OPENTHREAD_CONFIG_MLR_ENABLE 1
 
-// Define as 1 to stay awake between fragments while transmitting a large packet,
-// and to stay awake after receiving a packet with frame pending set to true.
-#define OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS 1
-
 #define OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS 0
 
 #define OPENTHREAD_CONFIG_DETERMINISTIC_ECDSA_ENABLE 0


### PR DESCRIPTION
#### Summary
Remove OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS, it is not needed anymore.
Removing it improves sleep cycles and slightly reduces power consumption.

#### Related issues
n/a

#### Testing
Validated that Silabs thread platforms still commission and are controllable with chip-tool.
