### PR TITLE
stop nodiscard compilation error in sample-mei-server

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -45,7 +45,6 @@ _EXCLUDE_DEVICE_FROM_LINUX_CI = [
     "rootnode_genericswitch_2dfff6e516",  # not actively developed,
     "rootnode_mounteddimmableloadcontrol_a9a1a87f2d",  # not actively developed,
     "rootnode_mountedonoffcontrol_ec30c757a6",  # not actively developed,
-    "rootnode_onofflight_samplemei",  # not actively developed,
     "rootnode_watervalve_6bb39f1f67",  # not actively developed,
 ]
 # Pattern to filter (based on device-name) devices that need ICD support.

--- a/src/app/clusters/sample-mei-server/sample-mei-server.cpp
+++ b/src/app/clusters/sample-mei-server/sample-mei-server.cpp
@@ -36,14 +36,14 @@ void MatterSampleMeiPluginServerInitCallback()
 
 void MatterSampleMeiPluginServerShutdownCallback()
 {
-    CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&SampleMeiServer::Instance());
+    TEMPORARY_RETURN_IGNORED CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&SampleMeiServer::Instance());
     AttributeAccessInterfaceRegistry::Instance().Unregister(&SampleMeiServer::Instance());
 }
 
 void emberAfSampleMeiClusterServerInitCallback(chip::EndpointId endpoint)
 {
     ChipLogProgress(Zcl, "Creating Sample MEI cluster, Ep %d", endpoint);
-    SampleMeiServer::Instance().RegisterEndpoint(endpoint);
+    TEMPORARY_RETURN_IGNORED SampleMeiServer::Instance().RegisterEndpoint(endpoint);
 }
 
 void MatterSampleMeiClusterServerShutdownCallback(chip::EndpointId endpoint)
@@ -51,7 +51,7 @@ void MatterSampleMeiClusterServerShutdownCallback(chip::EndpointId endpoint)
     // There's currently no whole-cluster shutdown callback. That would trigger
     // call to `Shutdown`. Thus ep-based shutdown calls `UnregisterEndpoint`
     ChipLogProgress(Zcl, "Shutting down Sample MEI cluster, Ep %d", endpoint);
-    SampleMeiServer::Instance().UnregisterEndpoint(endpoint);
+    TEMPORARY_RETURN_IGNORED SampleMeiServer::Instance().UnregisterEndpoint(endpoint);
 }
 
 // *****************************************************************************


### PR DESCRIPTION
#### Summary

`src/app/clusters/sample-mei-server.cpp` fails compilation as return values of type `CHIP_ERROR` are ignored in some places - `‘CHIP_ERROR’ {aka ‘chip::ChipError’}, declared with attribute ‘nodiscard’ [-Werror=unused-result]`. This PR stops the compilation failures by adding a `TEMPORARY_RETURN_IGNORED` where required. 

#### Testing

Compilation successful: `./chef.py -br -d rootnode_onofflight_samplemei -t linux`. Will also run in CI.