### PR TITLE
Update the naming of modeselect command to be consistent with modebase.

### DIFF
--- a/src/app/clusters/on-off-server/codegen/mode-select-integration.cpp
+++ b/src/app/clusters/on-off-server/codegen/mode-select-integration.cpp
@@ -26,7 +26,7 @@ using chip::Protocols::InteractionModel::Status;
 
 namespace chip::app::Clusters::OnOff::Internal::ModeSelect {
 
-void SetStartupOnMode(EndpointId endpoint)
+void UpdateCurrentModeToOnMode(EndpointId endpoint)
 {
     VerifyOrReturn(emberAfContainsAttribute(endpoint, Clusters::ModeSelect::Id, Clusters::ModeSelect::Attributes::OnMode::Id));
 

--- a/src/app/clusters/on-off-server/codegen/mode-select-integration.h
+++ b/src/app/clusters/on-off-server/codegen/mode-select-integration.h
@@ -22,11 +22,11 @@ namespace chip::app::Clusters::OnOff::Internal::ModeSelect {
 
 #ifdef MATTER_DM_PLUGIN_MODE_SELECT
 
-void SetStartupOnMode(chip::EndpointId endpoint);
+void UpdateCurrentModeToOnMode(chip::EndpointId endpoint);
 
 #else
 
-inline void SetStartupOnMode(chip::EndpointId endpoint) {}
+inline void UpdateCurrentModeToOnMode(chip::EndpointId endpoint) {}
 
 #endif // MATTER_DM_PLUGIN_MODE_SELECT
 

--- a/src/app/clusters/on-off-server/codegen/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/codegen/on-off-server.cpp
@@ -242,9 +242,7 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
             Internal::LevelControl::EffectCallback(endpoint, newValue);
         }
 
-        Internal::ModeSelect::SetStartupOnMode(endpoint);
-
-        // If OnMode is not a null value, then change the current mode to it.
+        Internal::ModeSelect::UpdateCurrentModeToOnMode(endpoint);
         Internal::ModeBase::UpdateCurrentModeToOnMode(endpoint);
     }
     else // Set Off
@@ -312,7 +310,7 @@ void OnOffServer::initOnOffServer(chip::EndpointId endpoint)
 
         if (onOffValueForStartUp)
         {
-            Internal::ModeSelect::SetStartupOnMode(endpoint);
+            Internal::ModeSelect::UpdateCurrentModeToOnMode(endpoint);
         }
     }
 #endif // IGNORE_ON_OFF_CLUSTER_START_UP_ON_OFF
@@ -736,8 +734,8 @@ static inline void unreg(OnOffEffect * inst)
 
 OnOffEffect::OnOffEffect(chip::EndpointId endpoint, OffWithEffectTriggerCommand offWithEffectTrigger,
                          EffectIdentifierEnum effectIdentifier, uint8_t effectVariant) :
-    mEndpoint(endpoint),
-    mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier), mEffectVariant(effectVariant)
+    mEndpoint(endpoint), mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier),
+    mEffectVariant(effectVariant)
 {
     reg(this);
 };

--- a/src/app/clusters/on-off-server/codegen/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/codegen/on-off-server.cpp
@@ -734,8 +734,8 @@ static inline void unreg(OnOffEffect * inst)
 
 OnOffEffect::OnOffEffect(chip::EndpointId endpoint, OffWithEffectTriggerCommand offWithEffectTrigger,
                          EffectIdentifierEnum effectIdentifier, uint8_t effectVariant) :
-    mEndpoint(endpoint), mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier),
-    mEffectVariant(effectVariant)
+    mEndpoint(endpoint),
+    mOffWithEffectTrigger(offWithEffectTrigger), mEffectIdentifier(effectIdentifier), mEffectVariant(effectVariant)
 {
     reg(this);
 };


### PR DESCRIPTION
#### Summary

This is based on 
https://github.com/project-chip/connectedhomeip/pull/42200#pullrequestreview-3526827366
Although modeselect uses this method in startup, it is not used only in startup .... so keeping the name the same.

#### Testing

just API name change ... no functionality behavior (so CI still applies)