### PR TITLE
Set the `referenced commands` to static in ResrouceMonitoringCluster.

### DIFF
--- a/src/app/clusters/resource-monitoring-server/ResourceMonitoringCluster.cpp
+++ b/src/app/clusters/resource-monitoring-server/ResourceMonitoringCluster.cpp
@@ -311,7 +311,7 @@ CHIP_ERROR ResourceMonitoringCluster::AcceptedCommands(const ConcreteClusterPath
 {
     if (mResetConditionCommandSupported)
     {
-        constexpr DataModel::AcceptedCommandEntry kCommands[] = {
+        static constexpr DataModel::AcceptedCommandEntry kCommands[] = {
             { ResourceMonitoring::Commands::ResetCondition::kMetadataEntry }
         };
         ReturnErrorOnFailure(builder.ReferenceExisting(kCommands));


### PR DESCRIPTION
#### Summary

`ReferenceExisting` saves a pointer instead of copying, so the data MUST be in global/static. Otherwise we would use a freed stack space.


This seems to be shown in https://github.com/project-chip/connectedhomeip/actions/runs/19864378792/job/56925056873?pr=42236:

```
<class 'matter.clusters.Objects.ActivatedCarbonFilterMonitoring.Attributes.AcceptedCommandList'>: [2465701880]
```

which is obviously an invalid command.

#### Testing

CI tests apply.
