### PR TITLE
[scenes] remove several Impl files from static_library scenes

### DIFF
--- a/src/app/clusters/scenes-server/BUILD.gn
+++ b/src/app/clusters/scenes-server/BUILD.gn
@@ -20,11 +20,7 @@ static_library("scenes") {
     "ExtensionFieldSets.h",
     "ExtensionFieldSetsImpl.cpp",
     "ExtensionFieldSetsImpl.h",
-    "SceneHandlerImpl.cpp",
-    "SceneHandlerImpl.h",
     "SceneTable.h",
-    "SceneTableImpl.cpp",
-    "SceneTableImpl.h",
   ]
 
   deps = [ "${chip_root}/src/app" ]


### PR DESCRIPTION
#### Summary

These files depend on ember: using attribute-storage or various emberAf calls. They cannot be compiled outside of a `data_model` build that has a zap configuration.

Unfortunately this means that scenes are currently fully tied to ember and to support code driven clusters they need decoupling or having a compatible layer.

#### Testing

Compilation should still pass, as this target is never directly used.
