### PR TITLE
[scenes] look to decouple scenes handler/table from codegen/ember

### DIFF
--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -145,10 +145,8 @@ static constexpr size_t kModeSelectMaxEnpointCount =
 static void timerCallback(System::Layer *, void * callbackContext);
 static void sceneModeSelectCallback(EndpointId endpoint);
 using ModeSelectEndPointPair            = scenes::DefaultSceneHandlerImpl::EndpointStatePair<uint8_t>;
-using ModeSelectTransitionTimeInterface = scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<
-    kModeSelectMaxEnpointCount,
-    scenes::CodegenEndpointToIndex<ModeSelect::Id, MATTER_DM_MODE_SELECT_CLUSTER_SERVER_ENDPOINT_COUNT,
-                                   kModeSelectMaxEnpointCount>>;
+using ModeSelectTransitionTimeInterface = scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<scenes::CodegenEndpointToIndex<
+    ModeSelect::Id, MATTER_DM_MODE_SELECT_CLUSTER_SERVER_ENDPOINT_COUNT, kModeSelectMaxEnpointCount>>;
 
 class DefaultModeSelectSceneHandler : public scenes::DefaultSceneHandlerImpl
 {

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -34,6 +34,7 @@
 #include <tracing/macros.h>
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
+#include <app/clusters/scenes-server/CodegenEndpointToIndex.h>
 #include <app/clusters/scenes-server/scenes-server.h>
 #endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
 
@@ -143,10 +144,11 @@ static constexpr size_t kModeSelectMaxEnpointCount =
 
 static void timerCallback(System::Layer *, void * callbackContext);
 static void sceneModeSelectCallback(EndpointId endpoint);
-using ModeSelectEndPointPair = scenes::DefaultSceneHandlerImpl::EndpointStatePair<uint8_t>;
-using ModeSelectTransitionTimeInterface =
-    scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<kModeSelectMaxEnpointCount,
-                                                             MATTER_DM_MODE_SELECT_CLUSTER_SERVER_ENDPOINT_COUNT>;
+using ModeSelectEndPointPair            = scenes::DefaultSceneHandlerImpl::EndpointStatePair<uint8_t>;
+using ModeSelectTransitionTimeInterface = scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<
+    kModeSelectMaxEnpointCount,
+    scenes::CodegenEndpointToIndex<ModeSelect::Id, MATTER_DM_MODE_SELECT_CLUSTER_SERVER_ENDPOINT_COUNT,
+                                   kModeSelectMaxEnpointCount>>;
 
 class DefaultModeSelectSceneHandler : public scenes::DefaultSceneHandlerImpl
 {
@@ -236,8 +238,7 @@ public:
     }
 
 private:
-    ModeSelectTransitionTimeInterface mTransitionTimeInterface =
-        ModeSelectTransitionTimeInterface(ModeSelect::Id, sceneModeSelectCallback);
+    ModeSelectTransitionTimeInterface mTransitionTimeInterface = ModeSelectTransitionTimeInterface(sceneModeSelectCallback);
 };
 static DefaultModeSelectSceneHandler sModeSelectSceneHandler;
 

--- a/src/app/clusters/on-off-server/codegen/scenes-integration.cpp
+++ b/src/app/clusters/on-off-server/codegen/scenes-integration.cpp
@@ -13,13 +13,15 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include "zap-generated/gen_config.h"
 #include <app/clusters/on-off-server/codegen/scenes-integration.h>
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/clusters/on-off-server/on-off-server.h>
-#include <app/clusters/scenes-server/scenes-server.h> // nogncheck
+#include <app/clusters/scenes-server/CodegenEndpointToIndex.h> // nogncheck
+#include <app/clusters/scenes-server/scenes-server.h>          // nogncheck
 
 using namespace chip;
 using namespace chip::app::Clusters;
@@ -31,10 +33,10 @@ static constexpr size_t kOnOffMaxEndpointCount =
     MATTER_DM_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
 static void sceneOnOffCallback(EndpointId endpoint);
-using OnOffEndPointPair = scenes::DefaultSceneHandlerImpl::EndpointStatePair<bool>;
-using OnOffTransitionTimeInterface =
-    scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<kOnOffMaxEndpointCount,
-                                                             MATTER_DM_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT>;
+using OnOffEndPointPair            = scenes::DefaultSceneHandlerImpl::EndpointStatePair<bool>;
+using OnOffTransitionTimeInterface = scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<
+    kOnOffMaxEndpointCount,
+    scenes::CodegenEndpointToIndex<OnOff::Id, MATTER_DM_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT, kOnOffMaxEndpointCount>>;
 
 #if CHIP_CONFIG_SCENES_USE_DEFAULT_HANDLERS
 
@@ -125,7 +127,7 @@ public:
     }
 
 private:
-    OnOffTransitionTimeInterface mTransitionTimeInterface = OnOffTransitionTimeInterface(OnOff::Id, sceneOnOffCallback);
+    OnOffTransitionTimeInterface mTransitionTimeInterface = OnOffTransitionTimeInterface(sceneOnOffCallback);
 };
 static DefaultOnOffSceneHandler sOnOffSceneHandler;
 

--- a/src/app/clusters/on-off-server/codegen/scenes-integration.cpp
+++ b/src/app/clusters/on-off-server/codegen/scenes-integration.cpp
@@ -35,7 +35,6 @@ static constexpr size_t kOnOffMaxEndpointCount =
 static void sceneOnOffCallback(EndpointId endpoint);
 using OnOffEndPointPair            = scenes::DefaultSceneHandlerImpl::EndpointStatePair<bool>;
 using OnOffTransitionTimeInterface = scenes::DefaultSceneHandlerImpl::TransitionTimeInterface<
-    kOnOffMaxEndpointCount,
     scenes::CodegenEndpointToIndex<OnOff::Id, MATTER_DM_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT, kOnOffMaxEndpointCount>>;
 
 #if CHIP_CONFIG_SCENES_USE_DEFAULT_HANDLERS

--- a/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
+++ b/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
@@ -25,11 +25,13 @@ namespace chip::scenes {
 /// FixedEndpointCount - the number of fixed endpoints for this cluster in codegen/ember
 /// MaxIndexCount - the number of indexes (return value on success will always be less than this value)
 template <ClusterId ClusterId, size_t FixedEndpointCount, size_t MaxIndexCount>
-struct CodegenEndpointToIndex {
+struct CodegenEndpointToIndex
+{
     static bool EndpointIdToIndex(EndpointId endpointId, uint16_t & index)
     {
         uint16_t idx = emberAfGetClusterServerEndpointIndex(endpointId, ClusterId, FixedEndpointCount);
-        if (idx >= MaxIndexCount) {
+        if (idx >= MaxIndexCount)
+        {
             return false;
         }
         index = idx;

--- a/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
+++ b/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
@@ -29,7 +29,7 @@ struct CodegenEndpointToIndex {
     static bool EndpointIdToIndex(EndpointId endpointId, uint16_t & index)
     {
         uint16_t idx = emberAfGetClusterServerEndpointIndex(endpointId, ClusterId, FixedEndpointCount);
-        if (index >= MaxIndexCount) {
+        if (idx >= MaxIndexCount) {
             return false;
         }
         index = idx;

--- a/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
+++ b/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
@@ -1,0 +1,40 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/util/attribute-storage.h>
+
+namespace chip::scenes {
+
+/// Converts a an endpoint id into a 0-based index using codegen functions.
+///
+/// ClusterId - the cluster that is used
+/// FixedEndpointCount - the number of fixed endpoints for this cluster in codegen/ember
+/// MaxIndexCount - the number of indexes (return value on success will always be less than this value)
+template <ClusterId ClusterId, size_t FixedEndpointCount, size_t MaxIndexCount>
+struct CodegenEndpointToIndex {
+    static bool EndpointIdToIndex(EndpointId endpointId, uint16_t & index)
+    {
+        uint16_t idx = emberAfGetClusterServerEndpointIndex(endpointId, ClusterId, FixedEndpointCount);
+        if (index >= MaxIndexCount) {
+            return false;
+        }
+        index = idx;
+        return true;
+    }
+};
+
+} // namespace chip::scenes

--- a/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
+++ b/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
@@ -19,7 +19,7 @@
 
 namespace chip::scenes {
 
-/// Converts a an endpoint id into a 0-based index using codegen functions.
+/// Converts an endpoint id into a 0-based index using codegen functions.
 ///
 /// ClusterId - the cluster that is used
 /// FixedEndpointCount - the number of fixed endpoints for this cluster in codegen/ember

--- a/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
+++ b/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
@@ -27,6 +27,8 @@ namespace chip::scenes {
 template <ClusterId ClusterId, size_t FixedEndpointCount, size_t MaxIndexCount>
 struct CodegenEndpointToIndex
 {
+    static constexpr size_t kMaxEndpointCount = MaxIndexCount;
+
     static bool EndpointIdToIndex(EndpointId endpointId, uint16_t & index)
     {
         uint16_t idx = emberAfGetClusterServerEndpointIndex(endpointId, ClusterId, FixedEndpointCount);

--- a/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
+++ b/src/app/clusters/scenes-server/CodegenEndpointToIndex.h
@@ -21,9 +21,9 @@ namespace chip::scenes {
 
 /// Converts an endpoint id into a 0-based index using codegen functions.
 ///
-/// ClusterId - the cluster that is used
-/// FixedEndpointCount - the number of fixed endpoints for this cluster in codegen/ember
-/// MaxIndexCount - the number of indexes (return value on success will always be less than this value)
+/// @tparam ClusterId The cluster ID value used for endpoint indexing
+/// @tparam FixedEndpointCount The number of fixed endpoints for this cluster in codegen/ember
+/// @tparam MaxIndexCount The maximum number of indexes (return value on success will always be less than this value)
 template <ClusterId ClusterId, size_t FixedEndpointCount, size_t MaxIndexCount>
 struct CodegenEndpointToIndex
 {

--- a/src/app/clusters/scenes-server/SceneHandlerImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneHandlerImpl.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <app/clusters/scenes-server/SceneHandlerImpl.h>
+#include <app/util/attribute-storage.h>
 #include <app/util/ember-io-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <app/util/odd-sized-integers.h>

--- a/src/app/clusters/scenes-server/SceneHandlerImpl.h
+++ b/src/app/clusters/scenes-server/SceneHandlerImpl.h
@@ -142,7 +142,7 @@ public:
     ///        asynchronous work to perform scene transitions over some period of time.
     ///
     /// Internally maintains an array of `MaxEndpointCount` items and uses the given `Finder` structure
-    /// to convert a endpoint ID into a 0-based index into the internal array using a
+    /// to convert an endpoint ID into a 0-based index into the internal array using a
     /// `bool Finder::EndpointIdToIndex(EndpointId, uint16_t&)` call.
     template <size_t MaxEndpointCount, typename Finder>
     struct TransitionTimeInterface

--- a/src/app/clusters/scenes-server/SceneHandlerImpl.h
+++ b/src/app/clusters/scenes-server/SceneHandlerImpl.h
@@ -182,6 +182,7 @@ public:
         {
             uint16_t index;
             VerifyOrReturnValue(Finder::EndpointIdToIndex(endpoint, index), nullptr);
+            VerifyOrReturnValue(index < eventControlArray.size(), nullptr); // Finder should guarantee this, just double-check
             return &eventControlArray[index];
         }
     };
@@ -189,7 +190,7 @@ public:
     static constexpr uint8_t kMaxAvPair = CHIP_CONFIG_SCENES_MAX_AV_PAIRS_EFS;
 
     DefaultSceneHandlerImpl() = default;
-    ~DefaultSceneHandlerImpl() override{};
+    ~DefaultSceneHandlerImpl() override = default;
 
     /// @brief Encodes an attribute value list into a TLV structure and resizes the buffer to the size of the encoded data
     /// @param aVlist[in] Attribute value list to encode

--- a/src/app/clusters/scenes-server/SceneHandlerImpl.h
+++ b/src/app/clusters/scenes-server/SceneHandlerImpl.h
@@ -141,13 +141,13 @@ public:
     /// @brief Helper struct that allows clusters that do not have an existing mechanism for doing
     ///        asynchronous work to perform scene transitions over some period of time.
     ///
-    /// Internally maintains an array of `MaxEndpointCount` items and uses the given `Finder` structure
+    /// Internally maintains an array of `Finder::kMaxEndpointCount` items and uses the given `Finder` structure
     /// to convert an endpoint ID into a 0-based index into the internal array using a
     /// `bool Finder::EndpointIdToIndex(EndpointId, uint16_t&)` call.
-    template <size_t MaxEndpointCount, typename Finder>
+    template <typename Finder>
     struct TransitionTimeInterface
     {
-        EmberEventControl sceneHandlerEventControls[MaxEndpointCount];
+        EmberEventControl sceneHandlerEventControls[Finder::kMaxEndpointCount];
 
         TransitionTimeInterface(void (*callback)(EndpointId)) : mCallback(callback) {}
 
@@ -189,7 +189,7 @@ public:
 
     static constexpr uint8_t kMaxAvPair = CHIP_CONFIG_SCENES_MAX_AV_PAIRS_EFS;
 
-    DefaultSceneHandlerImpl() = default;
+    DefaultSceneHandlerImpl()           = default;
     ~DefaultSceneHandlerImpl() override = default;
 
     /// @brief Encodes an attribute value list into a TLV structure and resizes the buffer to the size of the encoded data

--- a/src/app/clusters/scenes-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/scenes-server/app_config_dependent_sources.cmake
@@ -16,6 +16,7 @@
 TARGET_SOURCES(
   ${APP_TARGET}
   PRIVATE
+    "${CLUSTER_DIR}/CodegenEndpointToIndex.h"
     "${CLUSTER_DIR}/ExtensionFieldSets.h"
     "${CLUSTER_DIR}/ExtensionFieldSetsImpl.cpp"
     "${CLUSTER_DIR}/ExtensionFieldSetsImpl.h"

--- a/src/app/clusters/scenes-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/scenes-server/app_config_dependent_sources.gni
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 app_config_dependent_sources = [
+  "CodegenEndpointToIndex.h",
   "ExtensionFieldSets.h",
   "ExtensionFieldSetsImpl.cpp",
   "ExtensionFieldSetsImpl.h",


### PR DESCRIPTION
#### Summary

Start decoupling scenes from ember specific call. Starting small for now: the `TransitionTimeInterface` relies on being able to translate an endpointId to a linear 0-based array. Moved the logic to a user provided template parameter and a file specifically named `Codegen`.

There is still quite a bit to remove, but that will be in the CPP file. Looking to have small incremental steps.

#### Testing

No functional changes. Code still compiles and CI will validate.