### PR TITLE
Make iteration of tracing backends thread-safe using atomics

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1560,6 +1560,7 @@ UnitLocalization
 unittest
 unpair
 unprovisioned
+unregistration
 Unsecure
 Unselect
 untrusted

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -738,6 +738,16 @@
 #endif
 
 /**
+ * @def CHIP_CONFIG_MAX_TRACING_BACKENDS
+ *
+ * @brief The maximum number of tracing backends that can be registered.
+ * This value only takes effect if tracing is enabled at all.
+ */
+#ifndef CHIP_CONFIG_MAX_TRACING_BACKENDS
+#define CHIP_CONFIG_MAX_TRACING_BACKENDS 4
+#endif
+
+/**
  * @def CHIP_CONFIG_ENABLE_ARG_PARSER
  *
  * @brief Enable support functions for parsing command-line arguments

--- a/src/tracing/BUILD.gn
+++ b/src/tracing/BUILD.gn
@@ -39,9 +39,14 @@ static_library("tracing") {
     "metric_event.h",
     "metric_keys.h",
     "metric_macros.h",
-    "registry.cpp",
     "registry.h",
   ]
+
+  if (matter_enable_tracing_support) {
+    sources += [ "registry.cpp" ]
+  } else {
+    sources += [ "registry_disabled.cpp" ]
+  }
 
   public_deps = [
     ":tracing_buildconfig",

--- a/src/tracing/README.md
+++ b/src/tracing/README.md
@@ -7,7 +7,7 @@ compiled out completely.
 
 ## Types of data
 
-### Low-level Tracing
+### Low-Level Tracing
 
 This is mostly intended for following execution flow and measuring time spent
 for various operations. These traces are either

--- a/src/tracing/README.md
+++ b/src/tracing/README.md
@@ -1,8 +1,9 @@
 # Matter Tracing
 
-This library provides a runtime-configurable tracing and logging infrastructure for matter.
-The overall tracing subsystem is enabled or disabled via the `matter_enable_tracing_support` build setting;
-when disabled all tracing code is compiled out completely.
+This library provides a runtime-configurable tracing and logging infrastructure
+for matter. The overall tracing subsystem is enabled or disabled via the
+`matter_enable_tracing_support` build setting; when disabled all tracing code is
+compiled out completely.
 
 ## Types of data
 
@@ -10,23 +11,26 @@ when disabled all tracing code is compiled out completely.
 
 This is mostly intended for following execution flow and measuring time spent
 for various operations. These traces are either
+
 -   **scoped** where separate begin and end events are emitted, or
 -   **instant** where a single notable event is emitted, representing a point in
     time of a notable event.
 
-The low-level tracing API is provided via `MATTER_TRACE_*` macros and is thread-safe.
+The low-level tracing API is provided via `MATTER_TRACE_*` macros and is
+thread-safe.
 
-Tracing labels and instant values MUST be constant strings as some backends rely on
-that property for caching (e.g. pw_trace would do tokenization and perfetto
+Tracing labels and instant values MUST be constant strings as some backends rely
+on that property for caching (e.g. pw_trace would do tokenization and perfetto
 marks them as `perfetto::StaticString`)
 
-The tracing implementation is selected via the `matter_trace_config` build setting;
-the selected implementation directly provides the implementations of the tracing macros,
-allowing these to be bridged to a platform tracing mechanism with very low overhead.
+The tracing implementation is selected via the `matter_trace_config` build
+setting; the selected implementation directly provides the implementations of
+the tracing macros, allowing these to be bridged to a platform tracing mechanism
+with very low overhead.
 
-A `multiplexed` configuration is available that routes tracing macros through the
-runtime backend registry used by the higher-level Data Logging / Metrics API (see below).
-The `none` configuration compiles out trace macros completely.
+A `multiplexed` configuration is available that routes tracing macros through
+the runtime backend registry used by the higher-level Data Logging / Metrics API
+(see below). The `none` configuration compiles out trace macros completely.
 
 ### Data Logging / Metrics
 
@@ -34,18 +38,23 @@ Data logging provides the tracing module the opportunity to report input/output
 data for matter data processing, as well as high-level operational metrics.
 
 The data logging is generally limited in count and covers:
-- **Messages**, specifically sent matter requests and received matter responses
-- **DNSSD operations** as they are a core component of matter, specifically
+
+-   **Messages**, specifically sent matter requests and received matter
+    responses
+-   **DNSSD operations** as they are a core component of matter, specifically
     attempts to discover nodes as well as when a node is discovered or fails
     discovery.
-- **Metrics**, for tracking operational events with associated values and error codes
+-   **Metrics**, for tracking operational events with associated values and
+    error codes
 
-The high-level data logging / metrics API consists of various `MATTER_LOG_*` macros
-(e.g. `MATTER_LOG_MESSAGE_SEND`, `MATTER_LOG_NODE_DISCOVERED`, `MATTER_LOG_METRIC`, ...).
+The high-level data logging / metrics API consists of various `MATTER_LOG_*`
+macros (e.g. `MATTER_LOG_MESSAGE_SEND`, `MATTER_LOG_NODE_DISCOVERED`,
+`MATTER_LOG_METRIC`, ...).
 
-Backends for this data logging layer implement the `chip::Tracing::Backend` API (see `backend.h`),
-and are registered at runtime via `chip::Tracing::Register()` (see `registry.h`).
+Backends for this data logging layer implement the `chip::Tracing::Backend` API
+(see `backend.h`), and are registered at runtime via `chip::Tracing::Register()`
+(see `registry.h`).
 
-Note that while registration and unregistration of backends must be performed while the
-Matter stack lock is being held, data logging itself is thread-safe (and must be implemented
-as such by all backends.)
+Note that while registration and unregistration of backends must be performed
+while the Matter stack lock is being held, data logging itself is thread-safe
+(and must be implemented as such by all backends.)

--- a/src/tracing/backend.h
+++ b/src/tracing/backend.h
@@ -16,16 +16,12 @@
  */
 #pragma once
 
-#include <lib/support/IntrusiveList.h>
 #include <tracing/log_declares.h>
 
 namespace chip {
 namespace Tracing {
 
 /// Represents a generic tracing back-end.
-///
-/// Derived from an intrusive list base as multiple
-/// tracing back-ends may exist per application.
 ///
 /// THREAD SAFETY:
 ///   Implementations of backends are expected to be thread safe as

--- a/src/tracing/backend.h
+++ b/src/tracing/backend.h
@@ -31,7 +31,7 @@ namespace Tracing {
 ///   Implementations of backends are expected to be thread safe as
 ///   separate threads may call its functions (e.g. BLE and CASE processing
 ///   may be traced and run on different threads)
-class Backend : public ::chip::IntrusiveListNodeBase<>
+class Backend
 {
 public:
     virtual ~Backend() = default;

--- a/src/tracing/json/json_tracing.h
+++ b/src/tracing/json/json_tracing.h
@@ -17,9 +17,11 @@
  */
 #pragma once
 
+#include <lib/core/CHIPError.h>
+#include <tracing/backend.h>
+
 #include <fstream>
 #include <string>
-#include <tracing/backend.h>
 #include <unordered_map>
 
 namespace Json {

--- a/src/tracing/registry.cpp
+++ b/src/tracing/registry.cpp
@@ -27,7 +27,7 @@
 namespace chip::Tracing {
 
 namespace {
-// Contains the registerted tracing backends. Modifications of the backend array
+// Contains the registered tracing backends. Modifications of the backend array
 // are protected by the Matter stack lock, but iteration can happen from any
 // thread at any time.
 //

--- a/src/tracing/registry.cpp
+++ b/src/tracing/registry.cpp
@@ -31,7 +31,7 @@ namespace chip::Tracing {
 namespace {
 // Modifications of the backend array are protected by the Matter stack lock,
 // but iteration can happen from any thread at any time. Slots must be filled
-// from the begining of the array, so iteration can stop at the first nullptr.
+// from the beginning of the array, so iteration can stop at the first nullptr.
 std::atomic<Backend *> gTracingBackends[CHIP_CONFIG_MAX_TRACING_BACKENDS]{};
 
 // A marker value to represent an empty slot in the backend array.
@@ -60,6 +60,7 @@ void ForEachBackend(Fn && fn)
 
 void Register(Backend & aBackend)
 {
+    assertChipStackLockedByCurrentThread();
     for (auto & slot : gTracingBackends)
     {
         Backend * backend = slot.load();
@@ -165,6 +166,6 @@ void Unregister(Backend & backend)
     /* no-op if tracing is disabled */
 }
 
-#endif // MATTTER_TRACING_ENABLED
+#endif // MATTER_TRACING_ENABLED
 
 } // namespace chip::Tracing

--- a/src/tracing/registry_disabled.cpp
+++ b/src/tracing/registry_disabled.cpp
@@ -17,16 +17,18 @@
 
 #include <tracing/registry.h>
 
+#include <lib/support/logging/CHIPLogging.h>
+
 namespace chip::Tracing {
 
 void Register(Backend & backend)
 {
-    /* no-op if tracing is disabled */
+    ChipLogProgress(NotSpecified, "Ignoring tracing backend registration because tracing is disabled");
 }
 
 void Unregister(Backend & backend)
 {
-    /* no-op if tracing is disabled */
+    /* no-op */
 }
 
 } // namespace chip::Tracing

--- a/src/tracing/registry_disabled.cpp
+++ b/src/tracing/registry_disabled.cpp
@@ -1,0 +1,32 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <tracing/registry.h>
+
+namespace chip::Tracing {
+
+void Register(Backend & backend)
+{
+    /* no-op if tracing is disabled */
+}
+
+void Unregister(Backend & backend)
+{
+    /* no-op if tracing is disabled */
+}
+
+} // namespace chip::Tracing

--- a/src/tracing/tests/TestTracing.cpp
+++ b/src/tracing/tests/TestTracing.cpp
@@ -37,6 +37,9 @@ public:
     LoggingTraceBackend() {}
     const std::vector<std::string> & traces() const { return mTraces; }
 
+    void Open() override { mTraces.push_back("OPEN"); }
+    void Close() override { mTraces.push_back("CLOSE"); }
+
     // Implementation
     void TraceBegin(const char * label, const char * group) override
     {
@@ -77,10 +80,9 @@ TEST(TestTracing, TestBasicTracing)
         }
     }
 
-    std::vector<std::string> expected = {
-        "BEGIN:Group:A", "BEGIN:Group:B", "BEGIN:Group:C", "BEGIN:Group:D", "END:Group:D", "INSTANT:Group:FOO",
-        "END:Group:C",   "END:Group:B",   "BEGIN:Group:E", "END:Group:E",   "END:Group:A",
-    };
+    std::vector<std::string> expected = { "OPEN",        "BEGIN:Group:A",     "BEGIN:Group:B", "BEGIN:Group:C", "BEGIN:Group:D",
+                                          "END:Group:D", "INSTANT:Group:FOO", "END:Group:C",   "END:Group:B",   "BEGIN:Group:E",
+                                          "END:Group:E", "END:Group:A",       "CLOSE" };
 
     EXPECT_EQ(backend.traces().size(), expected.size());
     EXPECT_TRUE(std::equal(backend.traces().begin(), backend.traces().end(), expected.begin(), expected.end()));
@@ -110,24 +112,20 @@ TEST(TestTracing, TestMultipleBackends)
         }
     }
 
-    std::vector<std::string> expected1 = {
-        "BEGIN:G:1", "BEGIN:G:2", "BEGIN:G:3", "END:G:3", "BEGIN:G:4", "END:G:4", "END:G:2", "END:G:1",
-    };
+    std::vector<std::string> expected1 = { "OPEN",      "BEGIN:G:1", "BEGIN:G:2", "BEGIN:G:3", "END:G:3",
+                                           "BEGIN:G:4", "END:G:4",   "END:G:2",   "END:G:1",   "CLOSE" };
 
     EXPECT_EQ(b1.traces().size(), expected1.size());
     EXPECT_TRUE(std::equal(b1.traces().begin(), b1.traces().end(), expected1.begin(), expected1.end()));
 
     std::vector<std::string> expected2 = {
-        "BEGIN:G:2", "BEGIN:G:3", "END:G:3", "BEGIN:G:4", "END:G:4", "END:G:2",
+        "OPEN", "BEGIN:G:2", "BEGIN:G:3", "END:G:3", "BEGIN:G:4", "END:G:4", "END:G:2", "CLOSE"
     };
 
     EXPECT_EQ(b2.traces().size(), expected2.size());
     EXPECT_TRUE(std::equal(b2.traces().begin(), b2.traces().end(), expected2.begin(), expected2.end()));
 
-    std::vector<std::string> expected3 = {
-        "BEGIN:G:3",
-        "END:G:3",
-    };
+    std::vector<std::string> expected3 = { "OPEN", "BEGIN:G:3", "END:G:3", "CLOSE" };
 
     EXPECT_EQ(b3.traces().size(), expected3.size());
     EXPECT_TRUE(std::equal(b3.traces().begin(), b3.traces().end(), expected3.begin(), expected3.end()));


### PR DESCRIPTION
#### Summary

Use a fixed-sized array of atomic pointers instead of IntrusiveList to manage the list of registered backends. Also update the README to provide some additional clarity around the two levels of tracing APIs.

#### Related Issues

Fixes #42232

#### Testing

Existing TestTracing and TestMetricEvents tests cover backend registration / unregistration.
Added extra checks in to ensure Open / Close is called correctly.
