### PR TITLE
[WebRTCR] Remove unit tests for WebRTCTransportRequestorDelegate

### DIFF
--- a/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
@@ -17,6 +17,7 @@
 
 #include <app/CommandHandler.h>
 #include <app/clusters/testing/AttributeTesting.h>
+#include <app/clusters/testing/ValidateGlobalAttributes.h>
 #include <app/clusters/webrtc-transport-requestor-server/WebRTCTransportRequestorCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/data-model/Decode.h>
@@ -36,6 +37,8 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WebRTCTransportRequestor;
+using chip::Testing::IsAcceptedCommandsListEqualTo;
+using chip::Testing::IsAttributesListEqualTo;
 
 using ICEServerDecodableStruct = chip::app::Clusters::Globals::Structs::ICEServerStruct::DecodableType;
 using WebRTCSessionStruct      = chip::app::Clusters::Globals::Structs::WebRTCSessionStruct::Type;
@@ -45,64 +48,20 @@ using WebRTCEndReasonEnum      = chip::app::Clusters::Globals::WebRTCEndReasonEn
 
 static constexpr chip::EndpointId kTestEndpointId = 1;
 
-// Mock delegate for testing
+// Minimal mock delegate for testing
 class MockWebRTCTransportRequestorDelegate : public Delegate
 {
 public:
-    MockWebRTCTransportRequestorDelegate() : mLastSessionId(0), mLastEndReason(WebRTCEndReasonEnum::kUnknownEnumValue) {}
+    CHIP_ERROR HandleOffer(const WebRTCSessionStruct & session, const OfferArgs & args) override { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR HandleOffer(const WebRTCSessionStruct & session, const OfferArgs & args) override
-    {
-        mLastSessionId = session.id;
-        mLastOfferArgs = args;
-        return mOfferResult;
-    }
-
-    CHIP_ERROR HandleAnswer(const WebRTCSessionStruct & session, const std::string & sdpAnswer) override
-    {
-        mLastSessionId = session.id;
-        mLastSdpAnswer = sdpAnswer;
-        return mAnswerResult;
-    }
+    CHIP_ERROR HandleAnswer(const WebRTCSessionStruct & session, const std::string & sdpAnswer) override { return CHIP_NO_ERROR; }
 
     CHIP_ERROR HandleICECandidates(const WebRTCSessionStruct & session, const std::vector<ICECandidateStruct> & candidates) override
     {
-        mLastSessionId  = session.id;
-        mLastCandidates = candidates;
-        return mICECandidatesResult;
+        return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR HandleEnd(const WebRTCSessionStruct & session, WebRTCEndReasonEnum reasonCode) override
-    {
-        mLastSessionId = session.id;
-        mLastEndReason = reasonCode;
-        return mEndResult;
-    }
-
-    // Test setup methods
-    void SetOfferResult(CHIP_ERROR result) { mOfferResult = result; }
-    void SetAnswerResult(CHIP_ERROR result) { mAnswerResult = result; }
-    void SetICECandidatesResult(CHIP_ERROR result) { mICECandidatesResult = result; }
-    void SetEndResult(CHIP_ERROR result) { mEndResult = result; }
-
-    // Getters for verification
-    uint16_t GetLastSessionId() const { return mLastSessionId; }
-    const OfferArgs & GetLastOfferArgs() const { return mLastOfferArgs; }
-    const std::string & GetLastSdpAnswer() const { return mLastSdpAnswer; }
-    const std::vector<ICECandidateStruct> & GetLastCandidates() const { return mLastCandidates; }
-    WebRTCEndReasonEnum GetLastEndReason() const { return mLastEndReason; }
-
-private:
-    uint16_t mLastSessionId;
-    OfferArgs mLastOfferArgs;
-    std::string mLastSdpAnswer;
-    std::vector<ICECandidateStruct> mLastCandidates;
-    WebRTCEndReasonEnum mLastEndReason;
-
-    CHIP_ERROR mOfferResult         = CHIP_NO_ERROR;
-    CHIP_ERROR mAnswerResult        = CHIP_NO_ERROR;
-    CHIP_ERROR mICECandidatesResult = CHIP_NO_ERROR;
-    CHIP_ERROR mEndResult           = CHIP_NO_ERROR;
+    CHIP_ERROR HandleEnd(const WebRTCSessionStruct & session, WebRTCEndReasonEnum reasonCode) override { return CHIP_NO_ERROR; }
 };
 
 // initialize memory as ReadOnlyBufferBuilder may allocate
@@ -117,15 +76,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestAttributes)
     MockWebRTCTransportRequestorDelegate mockDelegate;
     WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
 
-    ReadOnlyBufferBuilder<DataModel::AttributeEntry> builder;
-    ASSERT_EQ(server.Attributes({ kTestEndpointId, WebRTCTransportRequestor::Id }, builder), CHIP_NO_ERROR);
-
-    ReadOnlyBufferBuilder<DataModel::AttributeEntry> expectedBuilder;
-    ASSERT_EQ(expectedBuilder.AppendElements({
-                  WebRTCTransportRequestor::Attributes::CurrentSessions::kMetadataEntry,
-              }),
-              CHIP_NO_ERROR);
-    ASSERT_EQ(expectedBuilder.ReferenceExisting(chip::app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
+    ASSERT_TRUE(IsAttributesListEqualTo(server, { WebRTCTransportRequestor::Attributes::CurrentSessions::kMetadataEntry }));
 }
 
 TEST_F(TestWebRTCTransportRequestorCluster, TestCommands)
@@ -133,19 +84,13 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestCommands)
     MockWebRTCTransportRequestorDelegate mockDelegate;
     WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
 
-    ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> builder;
-    ASSERT_EQ(server.AcceptedCommands({ kTestEndpointId, WebRTCTransportRequestor::Id }, builder), CHIP_NO_ERROR);
-
-    ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> expectedBuilder;
-    ASSERT_EQ(expectedBuilder.AppendElements({
-                  WebRTCTransportRequestor::Commands::Offer::kMetadataEntry,
-                  WebRTCTransportRequestor::Commands::Answer::kMetadataEntry,
-                  WebRTCTransportRequestor::Commands::ICECandidates::kMetadataEntry,
-                  WebRTCTransportRequestor::Commands::End::kMetadataEntry,
-              }),
-              CHIP_NO_ERROR);
-
-    EXPECT_TRUE(Testing::EqualAcceptedCommandSets(builder.TakeBuffer(), expectedBuilder.TakeBuffer()));
+    ASSERT_TRUE(IsAcceptedCommandsListEqualTo(server,
+                                              {
+                                                  WebRTCTransportRequestor::Commands::Offer::kMetadataEntry,
+                                                  WebRTCTransportRequestor::Commands::Answer::kMetadataEntry,
+                                                  WebRTCTransportRequestor::Commands::ICECandidates::kMetadataEntry,
+                                                  WebRTCTransportRequestor::Commands::End::kMetadataEntry,
+                                              }));
 }
 
 TEST_F(TestWebRTCTransportRequestorCluster, TestCurrentSessionsAttribute)
@@ -220,122 +165,6 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestSessionManagement)
     server.RemoveSession(999, 0, 0);
     sessions = server.GetCurrentSessions();
     EXPECT_EQ(sessions.size(), 1u);
-}
-
-TEST_F(TestWebRTCTransportRequestorCluster, TestDelegateHandleOffer)
-{
-    MockWebRTCTransportRequestorDelegate mockDelegate;
-    WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
-
-    // Setup test data
-    WebRTCSessionStruct testSession;
-    testSession.id         = 123;
-    testSession.peerNodeID = 0x1234ULL;
-    std::string testSdp    = "test_sdp_offer";
-
-    // Test successful offer handling
-    mockDelegate.SetOfferResult(CHIP_NO_ERROR);
-
-    Delegate::OfferArgs offerArgs;
-    offerArgs.sdp        = testSdp;
-    offerArgs.peerNodeId = 0x1234ULL; // Use ULL suffix for uint64_t/NodeId
-
-    CHIP_ERROR result = mockDelegate.HandleOffer(testSession, offerArgs);
-    EXPECT_EQ(result, CHIP_NO_ERROR);
-    EXPECT_EQ(mockDelegate.GetLastSessionId(), 123);
-    EXPECT_EQ(mockDelegate.GetLastOfferArgs().sdp, testSdp);
-    EXPECT_EQ(mockDelegate.GetLastOfferArgs().peerNodeId, 0x1234ULL);
-
-    // Test error case
-    mockDelegate.SetOfferResult(CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
-    result = mockDelegate.HandleOffer(testSession, offerArgs);
-    EXPECT_EQ(result, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
-}
-
-TEST_F(TestWebRTCTransportRequestorCluster, TestDelegateHandleAnswer)
-{
-    MockWebRTCTransportRequestorDelegate mockDelegate;
-    WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
-
-    // Setup test data
-    WebRTCSessionStruct testSession;
-    testSession.id            = 456;
-    std::string testSdpAnswer = "test_sdp_answer";
-
-    // Test successful answer handling
-    mockDelegate.SetAnswerResult(CHIP_NO_ERROR);
-
-    CHIP_ERROR result = mockDelegate.HandleAnswer(testSession, testSdpAnswer);
-    EXPECT_EQ(result, CHIP_NO_ERROR);
-    EXPECT_EQ(mockDelegate.GetLastSessionId(), 456);
-    EXPECT_EQ(mockDelegate.GetLastSdpAnswer(), testSdpAnswer);
-
-    // Test error case
-    mockDelegate.SetAnswerResult(CHIP_ERROR_INTERNAL);
-    result = mockDelegate.HandleAnswer(testSession, testSdpAnswer);
-    EXPECT_EQ(result, CHIP_ERROR_INTERNAL);
-}
-
-TEST_F(TestWebRTCTransportRequestorCluster, TestDelegateHandleICECandidates)
-{
-    MockWebRTCTransportRequestorDelegate mockDelegate;
-    WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
-
-    // Setup test data
-    WebRTCSessionStruct testSession;
-    testSession.id = 789;
-    std::vector<ICECandidateStruct> testCandidates;
-
-    ICECandidateStruct candidate1;
-    candidate1.candidate = chip::CharSpan("candidate1", 10);
-    testCandidates.push_back(candidate1);
-
-    ICECandidateStruct candidate2;
-    candidate2.candidate = chip::CharSpan("candidate2", 10);
-    testCandidates.push_back(candidate2);
-
-    // Test successful ICE candidates handling
-    mockDelegate.SetICECandidatesResult(CHIP_NO_ERROR);
-
-    CHIP_ERROR result = mockDelegate.HandleICECandidates(testSession, testCandidates);
-    EXPECT_EQ(result, CHIP_NO_ERROR);
-    EXPECT_EQ(mockDelegate.GetLastSessionId(), 789);
-    EXPECT_EQ(mockDelegate.GetLastCandidates().size(), 2u);
-
-    // Test error case
-    mockDelegate.SetICECandidatesResult(CHIP_ERROR_INVALID_ARGUMENT);
-    result = mockDelegate.HandleICECandidates(testSession, testCandidates);
-    EXPECT_EQ(result, CHIP_ERROR_INVALID_ARGUMENT);
-}
-
-TEST_F(TestWebRTCTransportRequestorCluster, TestDelegateHandleEnd)
-{
-    MockWebRTCTransportRequestorDelegate mockDelegate;
-    WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
-
-    // Setup test data
-    WebRTCSessionStruct testSession;
-    testSession.id                 = 999;
-    WebRTCEndReasonEnum testReason = WebRTCEndReasonEnum::kInviteTimeout;
-
-    // Test successful end handling
-    mockDelegate.SetEndResult(CHIP_NO_ERROR);
-
-    CHIP_ERROR result = mockDelegate.HandleEnd(testSession, testReason);
-    EXPECT_EQ(result, CHIP_NO_ERROR);
-    EXPECT_EQ(mockDelegate.GetLastSessionId(), 999);
-    EXPECT_EQ(mockDelegate.GetLastEndReason(), testReason);
-
-    // Test different reason codes
-    WebRTCEndReasonEnum testReason2 = WebRTCEndReasonEnum::kUserBusy;
-    result                          = mockDelegate.HandleEnd(testSession, testReason2);
-    EXPECT_EQ(result, CHIP_NO_ERROR);
-    EXPECT_EQ(mockDelegate.GetLastEndReason(), testReason2);
-
-    // Test error case
-    mockDelegate.SetEndResult(CHIP_ERROR_TIMEOUT);
-    result = mockDelegate.HandleEnd(testSession, testReason);
-    EXPECT_EQ(result, CHIP_ERROR_TIMEOUT);
 }
 
 TEST_F(TestWebRTCTransportRequestorCluster, TestReadCurrentSessionsAttribute)


### PR DESCRIPTION
#### Summary

1. WebRTCTransportRequestorDelegate is application-implemented and should not be unit tested directly. Update the test suite to validate only the WebRTCTransportRequestorServer interface

2. Migrate tests to the latest Attribute and Command helper APIs.

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
