### PR TITLE
[CI] Add runner root volume to esp32.

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -39,6 +39,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-esp32:175
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
         steps:
@@ -179,6 +180,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-esp32:175
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
         steps:


### PR DESCRIPTION
#### Summary

Our action https://github.com/project-chip/connectedhomeip/blob/master/.github/actions/maximize-runner-disk/action.yaml may be able to save some space, but it does so by deleting stuff from the parent image (that GH pre-installs on their runner). since we run in a container, we need this volume mounted.

#### Testing

CI will verify things run