### PR TITLE
[CI] Add root volume for chef and TI builds.

### DIFF
--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -38,6 +38,8 @@ jobs:
 
         container:
             image: ghcr.io/project-chip/chip-build:175
+            volumes:
+                - "/:/runner-root-volume"
             options: --user root
 
         steps:
@@ -97,6 +99,8 @@ jobs:
 
         container:
             image: ghcr.io/project-chip/chip-build-esp32:175
+            volumes:
+                - "/:/runner-root-volume"
             options: --user root
 
         steps:
@@ -119,6 +123,8 @@ jobs:
 
         container:
             image: ghcr.io/project-chip/chip-build-nrf-platform:175
+            volumes:
+                - "/:/runner-root-volume"
             options: --user root
 
         steps:
@@ -140,6 +146,8 @@ jobs:
 
         container:
             image: ghcr.io/project-chip/chip-build-telink:175
+            volumes:
+                - "/:/runner-root-volume"
             options: --user root
 
         steps:

--- a/.github/workflows/examples-cc13xx_26xx.yaml
+++ b/.github/workflows/examples-cc13xx_26xx.yaml
@@ -44,6 +44,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-ti:175
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:
             - name: Checkout


### PR DESCRIPTION
#### Summary

Runners in CI are running out of space. This should allow these builds to save another few GB (usually about 6)

#### Testing

CI will validate