### PR TITLE
[1.5 CI cherrypicks] - fix up CI runs for 1.5

### DIFF
--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -38,6 +38,8 @@ jobs:
 
         container:
             image: ghcr.io/project-chip/chip-build:174
+            volumes:
+                - "/:/runner-root-volume"
             options: --user root
 
         steps:
@@ -97,6 +99,8 @@ jobs:
 
         container:
             image: ghcr.io/project-chip/chip-build-esp32:174
+            volumes:
+                - "/:/runner-root-volume"
             options: --user root
 
         steps:
@@ -128,6 +132,8 @@ jobs:
 
         container:
             image: ghcr.io/project-chip/chip-build-nrf-platform:174
+            volumes:
+                - "/:/runner-root-volume"
             options: --user root
 
         steps:
@@ -149,6 +155,8 @@ jobs:
 
         container:
             image: ghcr.io/project-chip/chip-build-telink:174
+            volumes:
+                - "/:/runner-root-volume"
             options: --user root
 
         steps:

--- a/.github/workflows/examples-cc13xx_26xx.yaml
+++ b/.github/workflows/examples-cc13xx_26xx.yaml
@@ -44,6 +44,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-ti:174
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:
             - name: Checkout

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -39,6 +39,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-esp32:174
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
         steps:
@@ -179,6 +180,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-esp32:174
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
         steps:

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -50,24 +50,26 @@ jobs:
 
             - name: Build Some samples
               run: |
-                  ./scripts/run_in_build_env.sh \
-                     "./scripts/build/build_examples.py \
-                        --target linux-arm64-chip-cert-clang \
-                        --target linux-arm64-all-clusters-clang \
-                        --target linux-arm64-chip-tool-ipv6only-clang \
-                        --target linux-arm64-chip-tool-nodeps-ipv6only \
-                        --target linux-arm64-lock-clang \
-                        --target linux-arm64-minmdns-clang \
-                        --target linux-arm64-light-rpc-ipv6only-clang \
-                        --target linux-arm64-thermostat-no-ble-clang \
-                        --target linux-arm64-lit-icd-no-ble-clang \
-                        --target linux-arm64-fabric-admin-clang-rpc \
-                        --target linux-arm64-fabric-bridge-no-ble-clang-rpc \
-                        --target linux-arm64-fabric-sync-no-ble-clang \
-                        --target linux-arm64-camera-controller-clang \
-                        --target linux-arm64-camera-clang \
-                        build \
-                     "
-
+                  for target in \
+                        linux-arm64-chip-cert-clang \
+                        linux-arm64-all-clusters-clang \
+                        linux-arm64-chip-tool-ipv6only-clang \
+                        linux-arm64-chip-tool-nodeps-ipv6only \
+                        linux-arm64-lock-clang \
+                        linux-arm64-minmdns-clang \
+                        linux-arm64-light-rpc-ipv6only-clang \
+                        linux-arm64-thermostat-no-ble-clang \
+                        linux-arm64-lit-icd-no-ble-clang \
+                        linux-arm64-fabric-admin-clang-rpc \
+                        linux-arm64-fabric-bridge-no-ble-clang-rpc \
+                        linux-arm64-fabric-sync-no-ble-clang \
+                        linux-arm64-camera-controller-clang \
+                        linux-arm64-camera-clang\
+                  ; \
+                  do
+                    ./scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target $target build"
+                    echo "Cleaning out directory of size: $(du -sh out)"
+                    rm -rf out
+                  done
             - name: CCache statistics
               run: ccache --show-stats


### PR DESCRIPTION
#### Summary

This cherrypicks #42257, #42258 and #42260 into 1.5 to fix out of space errors in CI.

#### Testing

CI should turn green.