### PR TITLE
Manage DataModel::Provider lifecycle in DeviceControllerFactory

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -69,6 +69,7 @@ CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
     mCertificateValidityPolicy = params.certificateValidityPolicy;
     mSessionResumptionStorage  = params.sessionResumptionStorage;
     mEnableServerInteractions  = params.enableServerInteractions;
+    mDataModelProvider         = params.dataModelProvider;
 
     // Initialize the system state. Note that it is left in a somewhat
     // special state where it is initialized, but has a ref count of 0.
@@ -102,10 +103,7 @@ CHIP_ERROR DeviceControllerFactory::ReinitSystemStateIfNecessary()
     params.opCertStore               = mOpCertStore;
     params.certificateValidityPolicy = mCertificateValidityPolicy;
     params.sessionResumptionStorage  = mSessionResumptionStorage;
-
-    // re-initialization keeps any previously initialized values. The only place where
-    // a provider exists is in the InteractionModelEngine, so just say "keep it as is".
-    params.dataModelProvider = app::InteractionModelEngine::GetInstance()->GetDataModelProvider();
+    params.dataModelProvider         = mDataModelProvider;
 
     return InitSystemState(params);
 }
@@ -481,6 +479,7 @@ void DeviceControllerFactory::Shutdown()
     mOpCertStore               = nullptr;
     mCertificateValidityPolicy = nullptr;
     mSessionResumptionStorage  = nullptr;
+    mDataModelProvider         = nullptr;
 }
 
 void DeviceControllerSystemState::Shutdown()
@@ -563,6 +562,7 @@ void DeviceControllerSystemState::Shutdown()
 
     // Shut down the interaction model
     app::InteractionModelEngine::GetInstance()->Shutdown();
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(nullptr);
 
     // Shut down the TransportMgr. This holds Inet::UDPEndPoints so it must be shut down
     // before PlatformMgr().Shutdown() shuts down Inet.

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -313,6 +313,7 @@ private:
     Credentials::OperationalCertificateStore * mOpCertStore             = nullptr;
     Credentials::CertificateValidityPolicy * mCertificateValidityPolicy = nullptr;
     SessionResumptionStorage * mSessionResumptionStorage                = nullptr;
+    app::DataModel::Provider * mDataModelProvider                       = nullptr;
     bool mEnableServerInteractions                                      = false;
 };
 


### PR DESCRIPTION
Manage DataModel::Provider lifecycle in DeviceControllerFactory
    
* On Shutdown call InteractionModelEngine::SetDataModelProvider with
   nullptr
* Cache DataModel::Provider within DeviceControllerFactory to allow it
   it reinitialize.

#### Summary

InteractionModelEngine is a global singleton and does not get re-instantiated for each test. DataModelProvider delegate is never cleaned up during Shutdown, thus the pointer leaks across tests. During a second test InteractionModelEngine::SetDataModelProvider() will attempt to call Shutdown on the existing pointer. If DataModelProvider is local to the test this will crash as the old DataModelProvider would have been deleted.

#### Testing

CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
