### PR TITLE
Check for self-conflict on TLS endpoint update

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -279,7 +279,8 @@ ClusterStatusCode TlsClientManagementCommandDelegate::ProvisionEndpoint(
         {
             numInFabric++;
             auto & endpointStruct = endpoint.mEndpoint;
-            if (endpointStruct.hostname.data_equal(provisionReq.hostname) && (endpointStruct.port == provisionReq.port))
+            if (endpointStruct.hostname.data_equal(provisionReq.hostname) && (endpointStruct.port == provisionReq.port) &&
+                (provisionReq.endpointID.IsNull() || provisionReq.endpointID.Value() != endpointStruct.endpointID))
             {
                 installedCheck = ClusterStatusCode::ClusterSpecificFailure(StatusCodeEnum::kEndpointAlreadyInstalled);
                 return CHIP_ERROR_BAD_REQUEST;

--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -279,6 +279,9 @@ ClusterStatusCode TlsClientManagementCommandDelegate::ProvisionEndpoint(
         {
             numInFabric++;
             auto & endpointStruct = endpoint.mEndpoint;
+            // A host/port collision is detected if we are either:
+            //  - provisioning a new endpoint (endpointID is null)
+            //  - updating an existing endpoint, but the colliding endpoint is not the one being updated.
             if (endpointStruct.hostname.data_equal(provisionReq.hostname) && (endpointStruct.port == provisionReq.port) &&
                 (provisionReq.endpointID.IsNull() || provisionReq.endpointID.Value() != endpointStruct.endpointID))
             {


### PR DESCRIPTION
#### Summary

This updates the host/port collision check to account for non-null endpoint ids (when an existing TLS endpoint is being updated) such that it shouldn't consider the update as a conflict when the passed-in values match the provisioned ones.

#### Related issues

Fixes https://github.com/project-chip/connectedhomeip/issues/42028

Relevant spec text update: https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/12551

#### Testing

Obvious fix