### PR TITLE
[TEST] Add a flag to disable/enable TCP endpoint in runtime

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -69,6 +69,7 @@ CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
     mCertificateValidityPolicy = params.certificateValidityPolicy;
     mSessionResumptionStorage  = params.sessionResumptionStorage;
     mEnableServerInteractions  = params.enableServerInteractions;
+    mEnableTcpEndpoint         = params.enableTcpEndpoint;
 
     // Initialize the system state. Note that it is left in a somewhat
     // special state where it is initialized, but has a ref count of 0.
@@ -102,6 +103,7 @@ CHIP_ERROR DeviceControllerFactory::ReinitSystemStateIfNecessary()
     params.opCertStore               = mOpCertStore;
     params.certificateValidityPolicy = mCertificateValidityPolicy;
     params.sessionResumptionStorage  = mSessionResumptionStorage;
+    params.enableTcpEndpoint         = mEnableTcpEndpoint;
 
     // re-initialization keeps any previously initialized values. The only place where
     // a provider exists is in the InteractionModelEngine, so just say "keep it as is".
@@ -138,7 +140,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     auto tcpListenParams = Transport::TcpListenParameters(stateParams.tcpEndPointManager)
                                .SetAddressType(IPAddressType::kIPv6)
                                .SetListenPort(params.listenPort)
-                               .SetServerListenEnabled(false); // Initialize as a TCP Client
+                               .SetServerListenEnabled(mEnableTcpEndpoint); // Control TCP via runtime flag
 #endif
 
     if (params.dataModelProvider == nullptr)
@@ -199,7 +201,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
                                                         Transport::TcpListenParameters(stateParams.tcpEndPointManager)
                                                             .SetAddressType(Inet::IPAddressType::kIPv4)
                                                             .SetListenPort(params.listenPort)
-                                                            .SetServerListenEnabled(false)
+                                                            .SetServerListenEnabled(mEnableTcpEndpoint)
 #endif
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -179,6 +179,10 @@ struct FactoryInitParams
     // networks when activeRetransTimeout is too small.
     // Note: Setting this parameter to a nonzero value is not spec-compliant.
     Optional<uint32_t> minimumLITBackoffInterval;
+
+    // Controls whether TCP endpoints should be enabled during transport manager initialization.
+    // When false, TCP endpoints will not be initialized even if INET_CONFIG_ENABLE_TCP_ENDPOINT is defined.
+    bool enableTcpEndpoint = true;
 };
 
 class DeviceControllerFactory
@@ -314,6 +318,7 @@ private:
     Credentials::CertificateValidityPolicy * mCertificateValidityPolicy = nullptr;
     SessionResumptionStorage * mSessionResumptionStorage                = nullptr;
     bool mEnableServerInteractions                                      = false;
+    bool mEnableTcpEndpoint                                             = true;
 };
 
 } // namespace Controller


### PR DESCRIPTION
#### Summary

This flag is used to control (1) advertisement of TCP support, (2) handling of TCP requests, ..

#### Related issues

N/A

#### Testing

<!--
    This section will help the reviewer understand how this PR change was tested.
    As a general rule, a proposed PR change must not break the existing code and must be well-tested.
    Please include information about testing.

    See testing guidelines: https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#testing

    Examples:
        added unit tests
        verified by YAML test: TC_ABC.yaml
        added Python test: TC_DEF.py
        manually tested (mention steps to reproduce)

    Please replace this HTML comment with the actual information about how the testing was done.
 -->

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
