### PR TITLE
[Silabs] Fix for loop iterator type

### DIFF
--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -91,7 +91,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
     if (threadIdTable != nullptr)
     {
         osThreadEnumerate(threadIdTable, threadCount);
-        for (uint8_t tIdIndex = 0; tIdIndex < threadCount; tIdIndex++)
+        for (uint32_t tIdIndex = 0; tIdIndex < threadCount; tIdIndex++)
         {
             osThreadId_t tId       = threadIdTable[tIdIndex];
             ThreadMetrics * thread = new ThreadMetrics();

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -90,7 +90,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
 
     if (threadIdTable != nullptr)
     {
-        osThreadEnumerate(threadIdTable, threadCount);
+        threadCount = osThreadEnumerate(threadIdTable, threadCount);
         for (uint32_t tIdIndex = 0; tIdIndex < threadCount; tIdIndex++)
         {
             osThreadId_t tId       = threadIdTable[tIdIndex];


### PR DESCRIPTION
#### Summary
Fix for loop iterator type that could theoretically cause an infinite loop when `threadCount` (a uint32) is greater than 255.


#### Related issues
n/a

#### Testing
The change is minimal. I just confirmed it builds.
