### PR TITLE
[Telink] Increase UNICAST_IPV6_ADDR_COUNT & IPV6_PREFIX_COUNT

### DIFF
--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -1,5 +1,5 @@
 #
-#   Copyright (c) 2023-2024 Project CHIP Authors
+#   Copyright (c) 2023-2025 Project CHIP Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -97,9 +97,15 @@ config NET_IPV6_MLD
     default n if PM
     default y
 
+config NET_IF_UNICAST_IPV6_ADDR_COUNT
+    default 6
+
 config NET_IF_MCAST_IPV6_ADDR_COUNT
     default 8 if PM
     default 15
+
+config NET_IF_IPV6_PREFIX_COUNT
+    default NET_IF_UNICAST_IPV6_ADDR_COUNT if CHIP_WIFI
 
 # Network buffers
 config NET_PKT_RX_COUNT


### PR DESCRIPTION
#### Summary

- Increase UNICAST_IPV6_ADDR_COUNT and IPV6_PREFIX_COUNT for WiFi SoCs to fix an issue where the device occasionally fails to respond after commissioning.

#### Testing

- The change was tested manually on W91.
- A stress test using the chip-tool was performed by internal CI on W91.