### PR TITLE
[NXP] Upadte NXP freertos SDK version to 25.09.00

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-175 : [Telink] Update Docker image (Zephyr update)
+176 : [NXP] Update NXP SDK docker to 25.09.00

--- a/integrations/docker/images/stage-2/chip-build-nxp/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp/Dockerfile
@@ -13,9 +13,9 @@ WORKDIR /opt/nxp/
 RUN set -x \
     && git clone https://github.com/NXP/nxp_matter_support.git \
     && cd nxp_matter_support \
-    # Checkout commit aligned with updated west manifest using MCUX SDK 25.06.00,
+    # Checkout commit aligned with updated west manifest using MCUX SDK 25.09.00,
     # including patches for Matter support in specific components
-    && git checkout deb06197654ed2e4a688be05467a0954b91fd61d \
+    && git checkout d5e65670b37c6bef48b310da5540a9ef0492106e \
     && pip3 install --break-system-packages -U --no-cache-dir west \
     && ./scripts/update_nxp_sdk.py --platform common \
     && : # last line


### PR DESCRIPTION
#### Summary

This PR is updating the NXP SDK docker image to get MCUX SDK 25.09.00 version.

#### Testing

Testing done by building and running locally the docker image.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
