### PR TITLE
Disable NuttX: they have an invalid configuration.

### DIFF
--- a/.github/workflows/examples-nuttx.yaml
+++ b/.github/workflows/examples-nuttx.yaml
@@ -15,12 +15,21 @@
 name: Build example - NuttX
 
 on:
-  push:
-    branches:
-      - master
-      - 'v*-branch'
-  pull_request:
-  merge_group:
+  # NuttX disabled: it maintains an out-of source build that cannot be fixed by SDK updates.
+  #
+  # In particular the build is NOT valid:
+  #   https://github.com/apache/nuttx-apps/blob/f000ed733fc749004cbf0922fbf036abedbe91cf/netutils/connectedhomeip/CMakeLists.txt#L175
+  #
+  # adds `src/app/util/mock` as standard includes, which essentially overrides real light example builds.
+  #
+  # Will need re-enabling once NuttX integrations are more stable and SDK CI can be fixed without requiring upstream NuttX changes.
+  #
+  # push:
+  #   branches:
+  #     - master
+  #     - 'v*-branch'
+  # pull_request:
+  # merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/examples-nuttx.yaml
+++ b/.github/workflows/examples-nuttx.yaml
@@ -15,7 +15,7 @@
 name: Build example - NuttX
 
 on:
-  # NuttX disabled: it maintains an out-of source build that cannot be fixed by SDK updates.
+  # NuttX disabled: it maintains an out-of-source build that cannot be fixed by SDK updates.
   #
   # In particular the build is NOT valid:
   #   https://github.com/apache/nuttx-apps/blob/f000ed733fc749004cbf0922fbf036abedbe91cf/netutils/connectedhomeip/CMakeLists.txt#L175


### PR DESCRIPTION
#### Summary

This blocks other PRs - specifically scenes updates start failing on changes that should not fail (all other platforms are ok). We don't seem to have control over the build system here, so disabling this on the SDK size.

Specifically https://github.com/apache/nuttx-apps/blob/f000ed733fc749004cbf0922fbf036abedbe91cf/netutils/connectedhomeip/CMakeLists.txt#L175 (which is current TipOfTree/master and seemingly what we use today) uses mock includes to build applications, which is not valid.

#### Testing

Trivial disable