### PR TITLE
[camera] Clear local ICE candidates cache after successful transmission

### DIFF
--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -483,7 +483,12 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    CHIP_ERROR err = mWebRTCProviderClient.ProvideICECandidates(sessionId, mLocalCandidates);
+    // Make a copy of candidates to send to avoid race condition with onLocalCandidate callback
+    // which can asynchronously add new candidates while we're sending
+    std::vector<ICECandidateInfo> candidatesToSend = mLocalCandidates;
+    size_t candidateCount                          = candidatesToSend.size();
+
+    CHIP_ERROR err = mWebRTCProviderClient.ProvideICECandidates(sessionId, candidatesToSend);
 
     if (err != CHIP_NO_ERROR)
     {
@@ -491,8 +496,24 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
     }
     else
     {
-        ChipLogProgress(Camera, "Sent %lu ICE candidate(s), clearing list", mLocalCandidates.size());
-        mLocalCandidates.clear();
+        ChipLogProgress(Camera, "Sent %lu ICE candidate(s)", candidateCount);
+
+        // Remove only the candidates that were successfully sent
+        // New candidates may have arrived during transmission, so we remove from the front
+        if (mLocalCandidates.size() >= candidateCount)
+        {
+            mLocalCandidates.erase(mLocalCandidates.begin(), mLocalCandidates.begin() + candidateCount);
+            if (!mLocalCandidates.empty())
+            {
+                ChipLogProgress(Camera, "%lu new candidate(s) arrived during transmission, keeping for next batch",
+                                mLocalCandidates.size());
+            }
+        }
+        else
+        {
+            ChipLogProgress(Camera, "Sent %lu ICE candidate(s), clearing list", mLocalCandidates.size());
+            mLocalCandidates.clear();
+        }
     }
 
     return err;

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -489,6 +489,11 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
     {
         ChipLogError(Camera, "Failed to send ICE candidates: %" CHIP_ERROR_FORMAT, err.Format());
     }
+    else
+    {
+        ChipLogProgress(Camera, "Sent %lu ICE candidate(s), clearing list", mLocalCandidates.size());
+        mLocalCandidates.clear();
+    }
 
     return err;
 }

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -500,7 +500,7 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
 
         // Remove only the candidates that were successfully sent
         // New candidates may have arrived during transmission, so we remove from the front
-        if (mLocalCandidates.size() >= candidateCount)
+        if (mLocalCandidates.size() > candidateCount)
         {
             mLocalCandidates.erase(mLocalCandidates.begin(), mLocalCandidates.begin() + candidateCount);
             if (!mLocalCandidates.empty())


### PR DESCRIPTION
#### Summary

Upon successful transmission of local ICE candidates, the cache must be cleared. This action is essential to avoid redundant retransmission of the same candidate list.

#### Related issues

N/a

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
