### PR TITLE
[Chef] Fix icd compilation - add TEMPORARY_RETURN_IGNORED to ignore CHIP_ERROR

### DIFF
--- a/examples/chef/nrfconnect/AppTask.cpp
+++ b/examples/chef/nrfconnect/AppTask.cpp
@@ -314,14 +314,15 @@ void AppTask::IcdDslsEventHandler(const AppEvent &)
     if (sIsSitModeRequested)
     {
         ChipLogProgress(AppServer, "IcdDslsEventHandler: NotifySITModeRequestWithdrawal");
-        PlatformMgr().ScheduleWork([](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestWithdrawal(); }, 0);
+        TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(
+            [](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestWithdrawal(); }, 0);
         sIsSitModeRequested = false;
     }
     else
     {
         ChipLogProgress(AppServer, "IcdDslsEventHandler: NotifySITModeRequestNotification");
-        PlatformMgr().ScheduleWork([](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestNotification(); },
-                                   0);
+        TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(
+            [](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestNotification(); }, 0);
         sIsSitModeRequested = true;
     }
 }
@@ -331,7 +332,8 @@ void AppTask::IcdUatEventHandler(const AppEvent &)
 {
 #ifdef CONFIG_CHIP_ICD_UAT_SUPPORT
     // Temporarily claim network activity, until we implement a "user trigger" reason for ICD wakeups.
-    PlatformMgr().ScheduleWork([](intptr_t) { ICDNotifier::GetInstance().NotifyNetworkActivityNotification(); });
+    TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(
+        [](intptr_t) { ICDNotifier::GetInstance().NotifyNetworkActivityNotification(); });
 #endif
 }
 


### PR DESCRIPTION
#### Summary

Fixes the following error for chef icd contactsensor on nrfconnect -
```
Step #3 - "CompileICD": ../../AppTask.cpp:317:35: error: ignoring returned value of type 'CHIP_ERROR' {aka 'chip::ChipError'}, declared with attribute 'nodiscard' [-Werror=unused-result]
Step #3 - "CompileICD":   317 |         PlatformMgr().ScheduleWork([](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestWithdrawal(); }, 0);
```

#### Testing

Tested on `chip-build-vscode:175`

```
./examples/chef/chef.py --build_all --build_include "linux_x86-icd|nrf52840dk-icd"
```