### PR TITLE
[SU] Add method that cancels subscriptions in integration tests

### DIFF
--- a/src/python_testing/TC_CADMIN_1_3_4.py
+++ b/src/python_testing/TC_CADMIN_1_3_4.py
@@ -25,6 +25,7 @@
 #       --discriminator 1234
 #       --passcode 20202021
 #       --endpoint 0
+#       --timeout 200
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
@@ -38,7 +39,6 @@
 #       --discriminator 1234
 #       --passcode 20202021
 #       --endpoint 0
-#       --timeout 200
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: false

--- a/src/python_testing/TC_CADMIN_1_3_4.py
+++ b/src/python_testing/TC_CADMIN_1_3_4.py
@@ -38,6 +38,7 @@
 #       --discriminator 1234
 #       --passcode 20202021
 #       --endpoint 0
+#       --timeout 200
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: false

--- a/src/python_testing/TC_COMMTR_3_1.py
+++ b/src/python_testing/TC_COMMTR_3_1.py
@@ -190,7 +190,7 @@ class TC_COMMTR_3_1(CommodityMeteringTestBaseHelper):
 
         self.step("14")
         # TH removes the subscription to MeteredQuantity attribute.
-        await subscription_handler.cancel()
+        subscription_handler.cancel()
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_DEM_2_10.py
+++ b/src/python_testing/TC_DEM_2_10.py
@@ -301,7 +301,7 @@ class TC_DEM_2_10(MatterBaseTest, DEMTestBase):
             await self.send_test_event_trigger_power_adjustment_clear()
 
         self.step("22")
-        await sub_handler.cancel()
+        sub_handler.cancel()
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_EEVSE_2_6.py
+++ b/src/python_testing/TC_EEVSE_2_6.py
@@ -300,7 +300,7 @@ class TC_EEVSE_2_6(MatterBaseTest, EEVSEBaseTestHelper):
         await self.send_test_event_trigger_basic_clear()
 
         self.step("21")
-        await sub_handler.cancel()
+        sub_handler.cancel()
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_MTRID_3_1.py
+++ b/src/python_testing/TC_MTRID_3_1.py
@@ -280,7 +280,7 @@ class TC_MTRID_3_1(MeterIdentificationTestBaseHelper):
         await self.send_test_event_clear()
 
         self.step("16")
-        await subscription_handler.cancel()
+        subscription_handler.cancel()
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_SETRF_3_1.py
+++ b/src/python_testing/TC_SETRF_3_1.py
@@ -723,7 +723,7 @@ class TC_SETRF_3_1(CommodityTariffTestBaseHelper):
 
         self.step("44")
         # TH removes the subscription to Commodity Tariff cluster attributes
-        await subscription_handler.cancel()
+        subscription_handler.cancel()
 
 
 if __name__ == "__main__":

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
@@ -111,8 +111,10 @@ class EventSubscriptionHandler:
 
     async def cancel(self, timeout_sec: float = 5.0):
         """This cancels a subscription."""
-        # Wait for the asyncio.CancelledError to be called before returning
+        # Allow time for the subscription shutdown to complete before returning
         try:
+            # Shutdown is synchronous, but it may trigger async cleanup. We sleep
+            # briefly to allow this cleanup to happen before the test continues.
             self._subscription.Shutdown()
             await asyncio.sleep(timeout_sec)
         except asyncio.CancelledError:
@@ -260,6 +262,8 @@ class AttributeSubscriptionHandler:
         """This cancels a subscription."""
         # Allow time for the subscription shutdown to complete before returning
         try:
+            # Shutdown is synchronous, but it may trigger async cleanup. We sleep
+            # briefly to allow this cleanup to happen before the test continues.
             self._subscription.Shutdown()
             await asyncio.sleep(timeout_sec)
         except asyncio.CancelledError:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
@@ -111,8 +111,6 @@ class EventSubscriptionHandler:
 
     async def cancel(self, timeout_sec: float = 5.0):
         """This cancels a subscription."""
-        # Shutdown is synchronous, but it may trigger async cleanup. We wait
-        # for up to `timeout_sec` seconds (default 5.0) to allow this cleanup to happen before the test continues.
         self._subscription.Shutdown()
         await asyncio.sleep(timeout_sec)
 
@@ -256,8 +254,6 @@ class AttributeSubscriptionHandler:
 
     async def cancel(self, timeout_sec: float = 5.0):
         """This cancels a subscription."""
-        # Shutdown is synchronous, but it may trigger async cleanup. Sleep for timeout_sec seconds
-        # to allow cleanup to happen before the test continues (default: 5.0 seconds).
         self._subscription.Shutdown()
         await asyncio.sleep(timeout_sec)
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
@@ -256,8 +256,8 @@ class AttributeSubscriptionHandler:
 
     async def cancel(self, timeout_sec: float = 5.0):
         """This cancels a subscription."""
-        # Shutdown is synchronous, but it may trigger async cleanup. We sleep
-        # briefly to allow this cleanup to happen before the test continues.
+        # Shutdown is synchronous, but it may trigger async cleanup. Sleep for timeout_sec seconds
+        # to allow cleanup to happen before the test continues (default: 5.0 seconds).
         self._subscription.Shutdown()
         await asyncio.sleep(timeout_sec)
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
@@ -109,7 +109,7 @@ class EventSubscriptionHandler:
         self._subscription.SetEventUpdateCallback(self.__call__)
         return self._subscription
 
-    async def cancel(self):
+    def cancel(self):
         """This cancels a subscription."""
         self._subscription.Shutdown()
 
@@ -251,7 +251,7 @@ class AttributeSubscriptionHandler:
         self._subscription.SetAttributeUpdateCallback(self.__call__)
         return self._subscription
 
-    async def cancel(self):
+    def cancel(self):
         """This cancels a subscription."""
         self._subscription.Shutdown()
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
@@ -109,6 +109,15 @@ class EventSubscriptionHandler:
         self._subscription.SetEventUpdateCallback(self.__call__)
         return self._subscription
 
+    async def cancel(self, timeout_sec: float = 5.0):
+        """This cancels a subscription."""
+        # Wait for the asyncio.CancelledError to be called before returning
+        try:
+            self._subscription.Shutdown()
+            await asyncio.sleep(timeout_sec)
+        except asyncio.CancelledError:
+            pass
+
     def wait_for_event_report(self, expected_event: ClusterObjects.ClusterEvent, timeout_sec: float = 10.0) -> Any:
         """This function allows a test script to block waiting for the specific event to be the next event
            to arrive within a timeout (specified in seconds). It returns the event data so that the values can be checked."""
@@ -247,12 +256,12 @@ class AttributeSubscriptionHandler:
         self._subscription.SetAttributeUpdateCallback(self.__call__)
         return self._subscription
 
-    async def cancel(self):
+    async def cancel(self, timeout_sec: float = 5.0):
         """This cancels a subscription."""
         # Wait for the asyncio.CancelledError to be called before returning
         try:
             self._subscription.Shutdown()
-            await asyncio.sleep(5)
+            await asyncio.sleep(timeout_sec)
         except asyncio.CancelledError:
             pass
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
@@ -111,8 +111,8 @@ class EventSubscriptionHandler:
 
     async def cancel(self, timeout_sec: float = 5.0):
         """This cancels a subscription."""
-        # Shutdown is synchronous, but it may trigger async cleanup. We sleep
-        # briefly to allow this cleanup to happen before the test continues.
+        # Shutdown is synchronous, but it may trigger async cleanup. We wait
+        # for up to `timeout_sec` seconds (default 5.0) to allow this cleanup to happen before the test continues.
         self._subscription.Shutdown()
         await asyncio.sleep(timeout_sec)
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
@@ -26,7 +26,6 @@ Both classes allow tests to start and manage subscriptions, queue received updat
 block until epected reports are received or fail on timeouts
 """
 
-import asyncio
 import inspect
 import logging
 import queue

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
@@ -258,7 +258,7 @@ class AttributeSubscriptionHandler:
 
     async def cancel(self, timeout_sec: float = 5.0):
         """This cancels a subscription."""
-        # Wait for the asyncio.CancelledError to be called before returning
+        # Allow time for the subscription shutdown to complete before returning
         try:
             self._subscription.Shutdown()
             await asyncio.sleep(timeout_sec)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
@@ -111,14 +111,10 @@ class EventSubscriptionHandler:
 
     async def cancel(self, timeout_sec: float = 5.0):
         """This cancels a subscription."""
-        # Allow time for the subscription shutdown to complete before returning
-        try:
-            # Shutdown is synchronous, but it may trigger async cleanup. We sleep
-            # briefly to allow this cleanup to happen before the test continues.
-            self._subscription.Shutdown()
-            await asyncio.sleep(timeout_sec)
-        except asyncio.CancelledError:
-            pass
+        # Shutdown is synchronous, but it may trigger async cleanup. We sleep
+        # briefly to allow this cleanup to happen before the test continues.
+        self._subscription.Shutdown()
+        await asyncio.sleep(timeout_sec)
 
     def wait_for_event_report(self, expected_event: ClusterObjects.ClusterEvent, timeout_sec: float = 10.0) -> Any:
         """This function allows a test script to block waiting for the specific event to be the next event
@@ -260,14 +256,10 @@ class AttributeSubscriptionHandler:
 
     async def cancel(self, timeout_sec: float = 5.0):
         """This cancels a subscription."""
-        # Allow time for the subscription shutdown to complete before returning
-        try:
-            # Shutdown is synchronous, but it may trigger async cleanup. We sleep
-            # briefly to allow this cleanup to happen before the test continues.
-            self._subscription.Shutdown()
-            await asyncio.sleep(timeout_sec)
-        except asyncio.CancelledError:
-            pass
+        # Shutdown is synchronous, but it may trigger async cleanup. We sleep
+        # briefly to allow this cleanup to happen before the test continues.
+        self._subscription.Shutdown()
+        await asyncio.sleep(timeout_sec)
 
     def __call__(self, path: TypedAttributePath, transaction: SubscriptionTransaction):
         """

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/event_attribute_reporting.py
@@ -109,10 +109,9 @@ class EventSubscriptionHandler:
         self._subscription.SetEventUpdateCallback(self.__call__)
         return self._subscription
 
-    async def cancel(self, timeout_sec: float = 5.0):
+    async def cancel(self):
         """This cancels a subscription."""
         self._subscription.Shutdown()
-        await asyncio.sleep(timeout_sec)
 
     def wait_for_event_report(self, expected_event: ClusterObjects.ClusterEvent, timeout_sec: float = 10.0) -> Any:
         """This function allows a test script to block waiting for the specific event to be the next event
@@ -252,10 +251,9 @@ class AttributeSubscriptionHandler:
         self._subscription.SetAttributeUpdateCallback(self.__call__)
         return self._subscription
 
-    async def cancel(self, timeout_sec: float = 5.0):
+    async def cancel(self):
         """This cancels a subscription."""
         self._subscription.Shutdown()
-        await asyncio.sleep(timeout_sec)
 
     def __call__(self, path: TypedAttributePath, transaction: SubscriptionTransaction):
         """

--- a/src/python_testing/support_modules/cadmin_support.py
+++ b/src/python_testing/support_modules/cadmin_support.py
@@ -263,7 +263,7 @@ class CADMINBaseTest(MatterBaseTest):
         finally:
             # Clean up subscription accumulator and return results
             if window_status_accumulator is not None:
-                await window_status_accumulator.cancel()
+                window_status_accumulator.cancel()
             return results
 
     async def open_commissioning_window_with_subscription_monitoring(


### PR DESCRIPTION
#### Summary

This pull request introduces a `cancel` method for `EventSubscriptionHandler` and updates the existing cancel method in `AttributeSubscriptionHandler` so that it removes all the `asyncio.sleep` calls. This is a useful addition for integration tests.

Catching and swallowing the `asyncio.CancelledError` is incorrect, thus, a test might continue working when it is supposed to be cancelled (for example, when exceeding the Mobly test timeout). This is the reason why the 200 seconds timeout was added to the TC_CADMIN_1_3 test.

#### Related issues

Fixes https://github.com/project-chip/matter-test-scripts/issues/735

#### Testing

Tested manually with TC_SC_2_2.py + REPL tests passing

