### PR TITLE
CI update macOS 14 to 26

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -418,7 +418,7 @@ jobs:
 
     build_darwin:
         name: Build on Darwin (clang, simulated)
-        runs-on: macos-14
+        runs-on: macos-26
         if: github.actor != 'restyled-io[bot]'  && inputs.run-codeql != true
 
         steps:

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: macos-14
+        - os: macos-26
           arch: arm64     # observed, not configured
           dry-run: true
           build_variant: no-ble-no-shell-asan-clang

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -40,7 +40,7 @@ jobs:
         
         strategy:
             matrix:
-                os: [ macos-14 ]
+                os: [ macos-26 ]
                 options: # We don't need a full matrix
                     - flavor: macos-release
                       arguments: -sdk macosx -configuration Release
@@ -84,7 +84,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ macos-14 ]
+                os: [ macos-26 ]
                 options: # We don't need a full matrix
                     - flavor: asan
                       arguments:

--- a/.github/workflows/example-tv-casting-darwin.yaml
+++ b/.github/workflows/example-tv-casting-darwin.yaml
@@ -37,7 +37,7 @@ jobs:
     tv-casting-bridge:
         name: Build TV Casting Bridge example
         if: github.actor != 'restyled-io[bot]'
-        runs-on: macos-14
+        runs-on: macos-26
         steps:
             - name: Checkout
               uses: actions/checkout@v5

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -68,7 +68,7 @@ jobs:
 
     build_darwin_fuzzing:
         name: Build on Darwin
-        runs-on: macos-14
+        runs-on: macos-26
         if: github.actor != 'restyled-io[bot]'
 
         steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -452,10 +452,10 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - os: macos-14
+                    - os: macos-26
                       arch: arm64     # observed, not configured
                       build_variant: no-ble-no-shell-asan-clang
-                    - os: macos-14
+                    - os: macos-26
                       arch: arm64     # observed, not configured
                       build_variant: no-ble-no-shell-tsan-clang
         env:
@@ -1019,7 +1019,7 @@ jobs:
         strategy:
             matrix:
                 include:
-                - os: macos-14
+                - os: macos-26
                   arch: arm64   # observed, not configured
                   build_variant: no-ble-no-wifi-tsan-clang
                 # - os: macos-15-intel

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -537,6 +537,12 @@ jobs:
             - name: Clean out
               run: rm -rf out/
             - name: Run Tests using the python parser sending commands to chip-tool
+              # Use sudo to avoid Local Network Privacy restrictions on macOS 15+.
+              # macOS 15 introduced Local Network Privacy which restricts multicast traffic in several ways.
+              # Running from ssh, running from Terminal.app, or accepting a UI prompt can allow access, but those 
+              # aren't great options in CI.
+              # Processes run as root are exempt from these restrictions.
+              # For details, see https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy#macOS-considerations
               run: |
                   sudo ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
@@ -561,6 +567,8 @@ jobs:
                   "
 
             - name: Run purposeful failure tests using the python parser sending commands to chip-tool
+              # Use sudo to avoid Local Network Privacy restrictions on macOS 15+.
+              # See comment on earlier step about Local Network Privacy and root exemption.
               run: |
                   sudo ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -539,7 +539,7 @@ jobs:
             - name: Run Tests using the python parser sending commands to chip-tool
               # Use sudo to avoid Local Network Privacy restrictions on macOS 15+.
               # macOS 15 introduced Local Network Privacy which restricts multicast traffic in several ways.
-              # Running from ssh, running from Terminal.app, or accepting a UI prompt can allow access, but those 
+              # Running from ssh, running from Terminal.app, or accepting a UI prompt can allow access, but those
               # aren't great options in CI.
               # Processes run as root are exempt from these restrictions.
               # For details, see https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy#macOS-considerations

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -537,9 +537,8 @@ jobs:
             - name: Clean out
               run: rm -rf out/
             - name: Run Tests using the python parser sending commands to chip-tool
-              # tests that failed macOS 15/26 last check: TestGroupMessaging,Test_TC_ACE_1_6,Test_TC_G_*,Test_TC_GRPKEY_*,Test_TC_S_*
               run: |
-                  ./scripts/run_in_build_env.sh \
+                  sudo ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --runner chip_tool_python \
                      --chip-tool ./objdir-clone/darwin-${{matrix.arch}}-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT}/chip-tool \
@@ -563,7 +562,7 @@ jobs:
 
             - name: Run purposeful failure tests using the python parser sending commands to chip-tool
               run: |
-                  ./scripts/run_in_build_env.sh \
+                  sudo ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --runner chip_tool_python \
                      --include-tags PURPOSEFUL_FAILURE \

--- a/scripts/tests/gn_tests.sh
+++ b/scripts/tests/gn_tests.sh
@@ -44,8 +44,8 @@ env
 
 set -x
 
-# Run tests with sudo on Darwin to allow mDNS/multicast operations (e.g., TestDnssd)
-if [[ "$OSTYPE" == "darwin"* ]]; then
+# Run tests with sudo on Darwin in CI to allow mDNS/multicast operations (e.g., TestDnssd)
+if [[ "$OSTYPE" == "darwin"* ]] && [[ "$GITHUB_ACTION_RUN" == "1" ]]; then
     sudo ninja -v -C "$CHIP_ROOT/out/$BUILD_TYPE" -k 0 check
 else
     ninja -v -C "$CHIP_ROOT/out/$BUILD_TYPE" -k 0 check

--- a/scripts/tests/gn_tests.sh
+++ b/scripts/tests/gn_tests.sh
@@ -44,10 +44,10 @@ env
 
 set -x
 
-if [[ "$OSTYPE" == "darwin"* ]] && [[ "$GITHUB_ACTION_RUN" == "1" ]]; then
+if [[ "$OSTYPE" == "darwin"* ]] && [[ "$GITHUB_ACTIONS" == "true" ]]; then
     # Use sudo to avoid Local Network Privacy restrictions on macOS 15+.
     # macOS 15 introduced Local Network Privacy which restricts multicast traffic in several ways.
-    # Running from ssh, running from Terminal.app, or accepting a UI prompt can allow access, but those 
+    # Running from ssh, running from Terminal.app, or accepting a UI prompt can allow access, but those
     # aren't great options in CI.
     # Processes run as root are exempt from these restrictions.
     # For details, see https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy#macOS-considerations

--- a/scripts/tests/gn_tests.sh
+++ b/scripts/tests/gn_tests.sh
@@ -44,8 +44,13 @@ env
 
 set -x
 
-# Run tests with sudo on Darwin in CI to allow mDNS/multicast operations (e.g., TestDnssd)
 if [[ "$OSTYPE" == "darwin"* ]] && [[ "$GITHUB_ACTION_RUN" == "1" ]]; then
+    # Use sudo to avoid Local Network Privacy restrictions on macOS 15+.
+    # macOS 15 introduced Local Network Privacy which restricts multicast traffic in several ways.
+    # Running from ssh, running from Terminal.app, or accepting a UI prompt can allow access, but those 
+    # aren't great options in CI.
+    # Processes run as root are exempt from these restrictions.
+    # For details, see https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy#macOS-considerations
     sudo ninja -v -C "$CHIP_ROOT/out/$BUILD_TYPE" -k 0 check
 else
     ninja -v -C "$CHIP_ROOT/out/$BUILD_TYPE" -k 0 check

--- a/scripts/tests/gn_tests.sh
+++ b/scripts/tests/gn_tests.sh
@@ -44,4 +44,9 @@ env
 
 set -x
 
-ninja -v -C "$CHIP_ROOT/out/$BUILD_TYPE" -k 0 check
+# Run tests with sudo on Darwin to allow mDNS/multicast operations (e.g., TestDnssd)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sudo ninja -v -C "$CHIP_ROOT/out/$BUILD_TYPE" -k 0 check
+else
+    ninja -v -C "$CHIP_ROOT/out/$BUILD_TYPE" -k 0 check
+fi


### PR DESCRIPTION
#### Summary

Updating CI to latest macOS.

On a previous branch, had to do some troubleshooting on some tests that involve Groups - they passed on macOS 26 locally, but not in GitHub Actions. Filed https://github.com/project-chip/connectedhomeip/issues/41873 to investigate.  Investigation revealed that on macOS 15 and macOS 26, multicast traffic was disallowed for the `runner` user where it was allowed on macOS 14.  Using `sudo`, multicast traffic is allowed.

#### Related issues

#41873 should be fixed if this passes CI.

#### Testing

CI changes only.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase