### PR TITLE
[bridge-app/esp32] Add shell commands to add/remove/rename/toggle bridged endpoints.

### DIFF
--- a/examples/bridge-app/esp32/README.md
+++ b/examples/bridge-app/esp32/README.md
@@ -29,14 +29,14 @@ On/Off Light to Matter controllers.
 After flashing and commissioning the bridge, use these shell commands to manage
 bridged devices:
 
-| Command | Description |
-|---------|-------------|
+| Command                        | Description                    |
+| ------------------------------ | ------------------------------ |
 | `bridge add [name] [location]` | Add a new bridged light device |
-| `bridge remove <endpoint>` | Remove a device by endpoint ID |
-| `bridge list` | List all bridged devices |
-| `bridge toggle [endpoint]` | Toggle device(s) on/off |
-| `bridge max` | Show endpoint limits |
-| `bridge removeall` | Remove all bridged devices |
+| `bridge remove <endpoint>`     | Remove a device by endpoint ID |
+| `bridge list`                  | List all bridged devices       |
+| `bridge toggle [endpoint]`     | Toggle device(s) on/off        |
+| `bridge max`                   | Show endpoint limits           |
+| `bridge removeall`             | Remove all bridged devices     |
 
 ### Adding Devices
 
@@ -67,6 +67,7 @@ bridge list
 ```
 
 Output example:
+
 ```
 Bridged devices (2/16):
   "Kitchen Light" @ Kitchen (endpoint 3, ON)

--- a/examples/bridge-app/esp32/README.md
+++ b/examples/bridge-app/esp32/README.md
@@ -36,7 +36,7 @@ bridged devices:
 | `bridge list`                  | List all bridged devices       |
 | `bridge toggle [endpoint]`     | Toggle device(s) on/off        |
 | `bridge max`                   | Show endpoint limits           |
-| `bridge remove_all`             | Remove all bridged devices     |
+| `bridge remove_all`            | Remove all bridged devices     |
 
 ### Adding Devices
 

--- a/examples/bridge-app/esp32/README.md
+++ b/examples/bridge-app/esp32/README.md
@@ -36,7 +36,7 @@ bridged devices:
 | `bridge list`                  | List all bridged devices       |
 | `bridge toggle [endpoint]`     | Toggle device(s) on/off        |
 | `bridge max`                   | Show endpoint limits           |
-| `bridge removeall`             | Remove all bridged devices     |
+| `bridge remove_all`             | Remove all bridged devices     |
 
 ### Adding Devices
 

--- a/examples/bridge-app/esp32/README.md
+++ b/examples/bridge-app/esp32/README.md
@@ -9,6 +9,7 @@ guides to get started.
 ---
 
 -   [Introduction](#introduction)
+-   [Usage Guide](#usage-guide)
 -   [Dynamic Endpoints](#dynamic-endpoints)
 -   [Cluster control](#cluster-control)
 
@@ -16,15 +17,85 @@ guides to get started.
 
 ## Introduction
 
-A prototype application that demonstrates dynamic endpoint with device
-commissioning and cluster control. It adds the non-chip device as endpoints on a
-bridge(Matter device). In this example four light devices supporting on-off
-cluster have been added as endpoints
+A prototype application that demonstrates a Matter bridge with dynamic endpoint
+management. The bridge allows you to add and remove non-Matter devices as
+endpoints at runtime using shell commands. Each bridged device appears as an
+On/Off Light to Matter controllers.
 
-1. Light1 at endpoint 3
-2. Light2 at endpoint 7
-3. Light3 at endpoint 5
-4. Light4 at endpoint 6
+## Usage Guide
+
+### Shell Commands
+
+After flashing and commissioning the bridge, use these shell commands to manage
+bridged devices:
+
+| Command | Description |
+|---------|-------------|
+| `bridge add [name] [location]` | Add a new bridged light device |
+| `bridge remove <endpoint>` | Remove a device by endpoint ID |
+| `bridge list` | List all bridged devices |
+| `bridge toggle [endpoint]` | Toggle device(s) on/off |
+| `bridge max` | Show endpoint limits |
+| `bridge removeall` | Remove all bridged devices |
+
+### Adding Devices
+
+Add bridged devices with optional name and location:
+
+```
+bridge add                     # Adds "Light 1" in "Room"
+bridge add "Kitchen Light"     # Adds with custom name
+bridge add "Lamp" "Bedroom"    # Adds with name and location
+```
+
+Each device is assigned a unique endpoint ID automatically.
+
+### Removing Devices
+
+Remove a device by its endpoint ID:
+
+```
+bridge remove 3
+```
+
+### Listing Devices
+
+View all bridged devices:
+
+```
+bridge list
+```
+
+Output example:
+```
+Bridged devices (2/16):
+  "Kitchen Light" @ Kitchen (endpoint 3, ON)
+  "Bedroom Lamp" @ Bedroom (endpoint 4, OFF)
+```
+
+### Toggling Devices
+
+Toggle a specific device or all devices:
+
+```
+bridge toggle 3      # Toggle device at endpoint 3
+bridge toggle        # Toggle all devices
+```
+
+### Controlling from Matter Controller
+
+After commissioning, use chip-tool to control bridged devices:
+
+```bash
+# Turn on device at endpoint 3
+chip-tool onoff on <node-id> 3
+
+# Turn off device at endpoint 3
+chip-tool onoff off <node-id> 3
+
+# Toggle device at endpoint 3
+chip-tool onoff toggle <node-id> 3
+```
 
 ## Dynamic Endpoints
 

--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -367,7 +367,7 @@ using chip::Shell::shell_command_t;
 Engine sShellBridgeSubCommands;
 
 // Find device index by endpoint ID
-static CHIP_ERROR FindDeviceByEndpoint(EndpointId endpointId, uint16_t &index)
+static CHIP_ERROR FindDeviceByEndpoint(EndpointId endpointId, uint16_t & index)
 {
     for (size_t i = 0; i < kMaxBridgedDevices; i++)
     {
@@ -456,7 +456,7 @@ static CHIP_ERROR BridgeAddHandler(int argc, char ** argv)
     {
         if (gDevices[i] == nullptr)
         {
-            gDevices[i]      = newDevice;
+            gDevices[i]             = newDevice;
             gBridgedDataVersions[i] = newDataVersions;
             gBridgedDeviceCount++;
             slotFound = true;
@@ -505,13 +505,13 @@ static CHIP_ERROR BridgeRemoveHandler(int argc, char ** argv)
     }
 
     const char * name = gDevices[index]->GetName();
-    err = RemoveDeviceEndpoint(gDevices[index]);
+    err               = RemoveDeviceEndpoint(gDevices[index]);
     if (err == CHIP_NO_ERROR)
     {
         ESP_LOGI(TAG, "Removed '%s' from endpoint %ld", name, endpointId);
         delete gDevices[index];
         delete[] gBridgedDataVersions[index];
-        gDevices[index]      = nullptr;
+        gDevices[index]             = nullptr;
         gBridgedDataVersions[index] = nullptr;
         gBridgedDeviceCount--;
     }
@@ -615,7 +615,7 @@ static CHIP_ERROR BridgeRemoveAllHandler(int argc, char ** argv)
                 ESP_LOGI(TAG, "  Removed '%s'", name);
                 delete gDevices[i];
                 delete[] gBridgedDataVersions[i];
-                gDevices[i]      = nullptr;
+                gDevices[i]             = nullptr;
                 gBridgedDataVersions[i] = nullptr;
                 removedCount++;
             }

--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -186,6 +186,7 @@ int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const E
                 }
                 else if (err != CHIP_ERROR_ENDPOINT_EXISTS)
                 {
+                    gDevices[index] = nullptr;
                     return -1;
                 }
                 // Handle wrap condition
@@ -490,7 +491,7 @@ static CHIP_ERROR BridgeRemoveHandler(int argc, char ** argv)
 
     char * end;
     chip::EndpointId endpointId = strtoul(argv[0], &end, 10);
-    if (end == argv[0] || *end != '\0' || endpointId < 0 || endpointId > 0xFFFF)
+    if (end == argv[0] || *end != '\0' || endpointId > 0xFFFF)
     {
         ESP_LOGE(TAG, "Invalid endpoint ID: %s (must be 0-65535)", argv[0]);
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -508,7 +509,7 @@ static CHIP_ERROR BridgeRemoveHandler(int argc, char ** argv)
     err               = RemoveDeviceEndpoint(gDevices[index]);
     if (err == CHIP_NO_ERROR)
     {
-        ESP_LOGI(TAG, "Removed '%s' from endpoint %ld", name, endpointId);
+        ESP_LOGI(TAG, "Removed '%s' from endpoint %u", name, endpointId);
         delete gDevices[index];
         delete[] gBridgedDataVersions[index];
         gDevices[index]             = nullptr;
@@ -554,7 +555,7 @@ static CHIP_ERROR BridgeToggleHandler(int argc, char ** argv)
         // Perform OnOff::Toggle on the bridged endpoint: bridge toggle <endpoint>
         char * end;
         chip::EndpointId endpointId = strtoul(argv[0], &end, 10);
-        if (end == argv[0] || *end != '\0' || endpointId < 0 || endpointId > 0xFFFF)
+        if (end == argv[0] || *end != '\0' || endpointId > 0xFFFF)
         {
             ESP_LOGE(TAG, "Invalid endpoint ID: %s (must be 0-65535)", argv[0]);
             return CHIP_ERROR_INVALID_ARGUMENT;
@@ -625,7 +626,7 @@ static CHIP_ERROR BridgeRemoveAllHandler(int argc, char ** argv)
             }
         }
     }
-    gBridgedDeviceCount = gBridgedDeviceCount - removedCount;
+    gBridgedDeviceCount -= removedCount;
 
     ESP_LOGI(TAG, "Removed %d devices total", removedCount);
     return CHIP_NO_ERROR;
@@ -730,7 +731,6 @@ extern "C" void app_main()
 
     // bridge will have own database named gDevices.
     // Clear database
-    memset(gDevices, 0, sizeof(gDevices));
     memset(gDevices, 0, sizeof(gDevices));
     memset(gBridgedDataVersions, 0, sizeof(gBridgedDataVersions));
     gBridgedDeviceCount = 0;


### PR DESCRIPTION
#### Summary

Add shell commands to add/remove/rename/toggle bridged device endpoints at runtime for esp32.

#### Related issues

Dynamic addition/removal of bridged endpoints was not supported for testing.

#### Testing

Manually tested and verified using shell commands and chip tool that device types are correctly populate into the parts-list of the descriptor.