### PR TITLE
Auto clean ccache to not grow it forever.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -434,7 +434,7 @@ jobs:
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
             - name: Ensure only useful ccache is kept
-              if: env.DISABLE_CCACHE != 'true'
+              if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               run: ccache --evict-older-than 1d || true
             - name: Delete existing ccache before save
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
@@ -602,7 +602,7 @@ jobs:
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
             - name: Ensure only useful ccache is kept
-              if: env.DISABLE_CCACHE != 'true'
+              if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               run: ccache --evict-older-than 1d || true
             - name: Delete existing ccache before save
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
@@ -856,7 +856,7 @@ jobs:
                 if-no-files-found: error
                 overwrite: true
             - name: Ensure only useful ccache is kept
-              if: env.DISABLE_CCACHE != 'true'
+              if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               run: ccache --evict-older-than 1d || true
             - name: Delete existing ccache before save
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -434,7 +434,8 @@ jobs:
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
             - name: Ensure only useful ccache is kept
-              run: ccache --evict-older-than 1d
+              if: env.DISABLE_CCACHE != 'true'
+              run: ccache --evict-older-than 1d || true
             - name: Delete existing ccache before save
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: ./.github/actions/delete-cache
@@ -601,7 +602,8 @@ jobs:
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
             - name: Ensure only useful ccache is kept
-              run: ccache --evict-older-than 1d
+              if: env.DISABLE_CCACHE != 'true'
+              run: ccache --evict-older-than 1d || true
             - name: Delete existing ccache before save
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: ./.github/actions/delete-cache
@@ -854,7 +856,8 @@ jobs:
                 if-no-files-found: error
                 overwrite: true
             - name: Ensure only useful ccache is kept
-              run: ccache --evict-older-than 1d
+              if: env.DISABLE_CCACHE != 'true'
+              run: ccache --evict-older-than 1d || true
             - name: Delete existing ccache before save
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: ./.github/actions/delete-cache

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -433,6 +433,8 @@ jobs:
                   path: objdir-clone/
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
+            - name: Ensure only useful ccache is kept
+              run: ccache --evict-older-than 1d
             - name: Delete existing ccache before save
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: ./.github/actions/delete-cache
@@ -598,6 +600,8 @@ jobs:
                   path: objdir-clone/
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
+            - name: Ensure only useful ccache is kept
+              run: ccache --evict-older-than 1d
             - name: Delete existing ccache before save
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: ./.github/actions/delete-cache
@@ -849,7 +853,8 @@ jobs:
                 retention-days: 2
                 if-no-files-found: error
                 overwrite: true
-
+            - name: Ensure only useful ccache is kept
+              run: ccache --evict-older-than 1d
             - name: Delete existing ccache before save
               if: github.ref == 'refs/heads/master' && env.DISABLE_CCACHE != 'true'
               uses: ./.github/actions/delete-cache


### PR DESCRIPTION
#### Summary

Ensure that only up to date ccache entries are kept (so that we do not increase our cache forever with potentially unused entries).

Given that we have consistent cache refreshes, we really only want the latest caches kept to keep sizes smaller.

#### Testing

CI will validate. Change is small/trivial.