### PR TITLE
Ignore - Matter Casting: fix init and memory issues

### DIFF
--- a/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
@@ -78,5 +78,8 @@
 
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 
+// Increase memory pools for better attribute reading performance
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 500  // Default is 15
+
 // Include the CHIPProjectConfig from platform implementation config
 #include <CHIPProjectConfig.h>

--- a/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
@@ -79,7 +79,7 @@
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 
 // Increase memory pools for better attribute reading performance
-#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 500  // Default is 15
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 500 // Default is 15
 
 // Include the CHIPProjectConfig from platform implementation config
 #include <CHIPProjectConfig.h>

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
@@ -27,7 +27,6 @@ import java.security.Signature;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPrivateKeySpec;
-import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 
 public class DACProviderStub implements DACProvider {
@@ -109,7 +108,7 @@ public class DACProviderStub implements DACProvider {
       return signature.sign();
 
     } catch (Exception e) {
-      Log.i(TAG, "SignWithDeviceAttestationKey e:"+e, e);
+      Log.i(TAG, "SignWithDeviceAttestationKey e:" + e, e);
       return null;
     }
   }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -123,8 +123,11 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                     AppServer,
                     "CastingPlayer::VerifyOrEstablishConnection() Attempting to Re-establish CASE with cached CastingPlayer");
 
-                ChipLogProgress(AppServer, "Assigning from cache. Current: nodeId=0x" ChipLogFormatX64 " fabricIndex=%d, Cached: nodeId=0x" ChipLogFormatX64 " fabricIndex=%d", ChipLogValueX64(mAttributes.nodeId), mAttributes.fabricIndex,
-                    ChipLogValueX64(it_index->GetNodeId()), it_index->GetFabricIndex());
+                ChipLogProgress(AppServer,
+                                "Assigning from cache. Current: nodeId=0x" ChipLogFormatX64
+                                " fabricIndex=%d, Cached: nodeId=0x" ChipLogFormatX64 " fabricIndex=%d",
+                                ChipLogValueX64(mAttributes.nodeId), mAttributes.fabricIndex,
+                                ChipLogValueX64(it_index->GetNodeId()), it_index->GetFabricIndex());
 
                 // Preserve the IP addresses from the discovered CastingPlayer before overwriting with cached data
                 unsigned int discoveredNumIPs = mAttributes.numIPs;
@@ -134,10 +137,10 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                     discoveredIpAddresses[i] = mAttributes.ipAddresses[i];
                 }
                 chip::Inet::InterfaceId discoveredInterfaceId = mAttributes.interfaceId;
-                *this                          = *it_index;
-                mConnectionState               = CASTING_PLAYER_CONNECTING;
-                mOnCompleted                   = connectionCallbacks.mOnConnectionComplete;
-                mCommissioningWindowTimeoutSec = commissioningWindowTimeoutSec;
+                *this                                         = *it_index;
+                mConnectionState                              = CASTING_PLAYER_CONNECTING;
+                mOnCompleted                                  = connectionCallbacks.mOnConnectionComplete;
+                mCommissioningWindowTimeoutSec                = commissioningWindowTimeoutSec;
 
                 // Restore the IP addresses from the discovered CastingPlayer
                 mAttributes.numIPs = discoveredNumIPs;
@@ -170,7 +173,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                             //
                             // persist the TargetCastingPlayer information into the CastingStore and call mOnCompleted()
                             support::EndpointListLoader::GetInstance()->Initialize(&exchangeMgr, &sessionHandle);
-                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance()->Load();
+                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance() -> Load();
                         },
                         [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
                             ChipLogError(AppServer,
@@ -551,18 +554,18 @@ CastingPlayer & CastingPlayer::operator=(const CastingPlayer & other)
         mIdOptions                     = other.mIdOptions;
         mCommissioningWindowTimeoutSec = other.mCommissioningWindowTimeoutSec;
         mOnCompleted                   = other.mOnCompleted;
-        
+
         // Create new Endpoint objects instead of sharing them
         mEndpoints.clear();
         for (const auto & endpoint : other.mEndpoints)
         {
             // Create EndpointAttributes from the existing endpoint
             EndpointAttributes attrs;
-            attrs.mId = endpoint->GetId();
-            attrs.mVendorId = endpoint->GetVendorId();
-            attrs.mProductId = endpoint->GetProductId();
+            attrs.mId             = endpoint->GetId();
+            attrs.mVendorId       = endpoint->GetVendorId();
+            attrs.mProductId      = endpoint->GetProductId();
             attrs.mDeviceTypeList = endpoint->GetDeviceTypeList();
-            
+
             // Create a new Endpoint with the same attributes but pointing to this CastingPlayer
             auto newEndpoint = std::make_shared<Endpoint>(this, attrs);
             // Register the same clusters

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -173,7 +173,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                             //
                             // persist the TargetCastingPlayer information into the CastingStore and call mOnCompleted()
                             support::EndpointListLoader::GetInstance()->Initialize(&exchangeMgr, &sessionHandle);
-                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance() -> Load();
+                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance()->Load();
                         },
                         [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
                             ChipLogError(AppServer,

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -35,8 +35,8 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
     ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() called");
 
     CastingPlayerDiscovery * castingPlayerDiscovery = CastingPlayerDiscovery::GetInstance();
-    std::vector<core::CastingPlayer>::iterator it;
-    std::vector<core::CastingPlayer> cachedCastingPlayers = support::CastingStore::GetInstance()->ReadAll();
+    std::list<core::CastingPlayer>::iterator it;
+    std::list<core::CastingPlayer> cachedCastingPlayers = support::CastingStore::GetInstance()->ReadAll();
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -116,15 +116,15 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
             ChipLogProgress(
                 AppServer,
                 "CastingPlayer::VerifyOrEstablishConnection() *this* CastingPlayer found in cache; checking for TargetApp(s)");
-            unsigned index = (unsigned int) std::distance(cachedCastingPlayers.begin(), it);
-            if (ContainsDesiredTargetApp(&cachedCastingPlayers[index], idOptions.getTargetAppInfoList()))
+            auto it_index = it;
+            if (ContainsDesiredTargetApp(&(*it_index), idOptions.getTargetAppInfoList()))
             {
                 ChipLogProgress(
                     AppServer,
                     "CastingPlayer::VerifyOrEstablishConnection() Attempting to Re-establish CASE with cached CastingPlayer");
 
                 ChipLogProgress(AppServer, "Assigning from cache. Current: nodeId=0x" ChipLogFormatX64 " fabricIndex=%d, Cached: nodeId=0x" ChipLogFormatX64 " fabricIndex=%d", ChipLogValueX64(mAttributes.nodeId), mAttributes.fabricIndex,
-                    ChipLogValueX64(cachedCastingPlayers[index].GetNodeId()), cachedCastingPlayers[index].GetFabricIndex());
+                    ChipLogValueX64(it_index->GetNodeId()), it_index->GetFabricIndex());
 
                 // Preserve the IP addresses from the discovered CastingPlayer before overwriting with cached data
                 unsigned int discoveredNumIPs = mAttributes.numIPs;
@@ -134,7 +134,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                     discoveredIpAddresses[i] = mAttributes.ipAddresses[i];
                 }
                 chip::Inet::InterfaceId discoveredInterfaceId = mAttributes.interfaceId;
-                *this                          = cachedCastingPlayers[index];
+                *this                          = *it_index;
                 mConnectionState               = CASTING_PLAYER_CONNECTING;
                 mOnCompleted                   = connectionCallbacks.mOnConnectionComplete;
                 mCommissioningWindowTimeoutSec = commissioningWindowTimeoutSec;

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -110,6 +110,9 @@
 
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 
+// Increase memory pools for better attribute reading performance
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 500  // Default is 15
+
 // Include the CHIPProjectConfig from config/standalone
 // Add this at the end so that we can hit our #defines first
 #ifndef CHIP_DEVICE_LAYER_TARGET_DARWIN

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -112,7 +112,7 @@
 
 #ifndef CHIP_DEVICE_LAYER_TARGET_DARWIN
 // Increase memory pools for better attribute reading performance
-#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 500  // Default is 15
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 500 // Default is 15
 
 // Include the CHIPProjectConfig from config/standalone
 // Add this at the end so that we can hit our #defines first

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -110,11 +110,11 @@
 
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 
+#ifndef CHIP_DEVICE_LAYER_TARGET_DARWIN
 // Increase memory pools for better attribute reading performance
 #define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 500  // Default is 15
 
 // Include the CHIPProjectConfig from config/standalone
 // Add this at the end so that we can hit our #defines first
-#ifndef CHIP_DEVICE_LAYER_TARGET_DARWIN
 #include <CHIPProjectConfig.h>
 #endif // CHIP_DEVICE_LAYER_TARGET_DARWIN

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -19,8 +19,8 @@
 #include "CastingStore.h"
 
 #include <lib/core/TLV.h>
-#include <platform/KeyValueStoreManager.h>
 #include <list>
+#include <platform/KeyValueStoreManager.h>
 
 namespace matter {
 namespace casting {
@@ -431,7 +431,7 @@ std::list<core::CastingPlayer> CastingStore::ReadAll()
             ChipLogProgress(AppServer, "CastingStore::ReadAll() Created CastingPlayer with deviceName: %s",
                             castingPlayer.GetDeviceName());
             castingPlayers.push_back(castingPlayer);
-            
+
             // Get pointer to the added element (safe with std::list)
             core::CastingPlayer * finalCastingPlayer = &castingPlayers.back();
             for (auto & endpointAttributes : endpointAttributesList)

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -20,6 +20,7 @@
 
 #include <lib/core/TLV.h>
 #include <platform/KeyValueStoreManager.h>
+#include <list>
 
 namespace matter {
 namespace casting {
@@ -44,7 +45,7 @@ CHIP_ERROR CastingStore::AddOrUpdate(core::CastingPlayer castingPlayer)
                     castingPlayer.GetDeviceName(), castingPlayer.GetVendorId(), castingPlayer.GetProductId());
 
     // Read cache of CastingPlayers
-    std::vector<core::CastingPlayer> castingPlayers = ReadAll();
+    std::list<core::CastingPlayer> castingPlayers = ReadAll();
 
     // search for castingPlayer in CastingStore cache and overwrite it, if found
     if (castingPlayers.size() != 0)
@@ -55,8 +56,7 @@ CHIP_ERROR CastingStore::AddOrUpdate(core::CastingPlayer castingPlayer)
 
         if (it != castingPlayers.end())
         {
-            unsigned index        = (unsigned int) std::distance(castingPlayers.begin(), it);
-            castingPlayers[index] = castingPlayer;
+            *it = castingPlayer;
             ChipLogProgress(AppServer, "CastingStore::AddOrUpdate() updating CastingPlayer in CastingStore cache");
             return WriteAll(castingPlayers); // return early
         }
@@ -68,18 +68,18 @@ CHIP_ERROR CastingStore::AddOrUpdate(core::CastingPlayer castingPlayer)
     return WriteAll(castingPlayers);
 }
 
-std::vector<core::CastingPlayer> CastingStore::ReadAll()
+std::list<core::CastingPlayer> CastingStore::ReadAll()
 {
     ChipLogProgress(AppServer, "CastingStore::ReadAll() called");
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    std::vector<core::CastingPlayer> castingPlayers;
+    std::list<core::CastingPlayer> castingPlayers;
     uint8_t castingStoreData[kCastingStoreDataMaxBytes];
     size_t castingStoreDataSize = 0;
     err = chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(kCastingStoreDataKey, castingStoreData,
                                                                       kCastingStoreDataMaxBytes, &castingStoreDataSize);
     VerifyOrReturnValue(
-        err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+        err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
         ChipLogError(AppServer, "CastingStore::ReadAll() KeyValueStoreMgr.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
     ChipLogProgress(AppServer, "CastingStore::ReadAll() Read TLV(CastingStoreData) from KVS store with size: %lu bytes",
                     static_cast<unsigned long>(castingStoreDataSize));
@@ -89,16 +89,16 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
 
     // read the envelope (and version)
     err = reader.Next(chip::TLV::kTLVType_Structure, chip::TLV::AnonymousTag());
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.Next failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     chip::TLV::TLVType outerContainerType;
     err = reader.EnterContainer(outerContainerType);
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = reader.Next();
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.Next failed %" CHIP_ERROR_FORMAT, err.Format()));
     chip::TLV::Tag outerContainerTag = reader.GetTag();
     uint8_t outerContainerTagNum     = static_cast<uint8_t>(chip::TLV::TagNumFromTag(outerContainerTag));
@@ -106,24 +106,24 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                         ChipLogError(AppServer, "CastingStoreDataVersionTag not found"));
     uint32_t version;
     err = reader.Get(version);
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
     ChipLogProgress(AppServer, "CastingStore::ReadAll() TLV(CastingStoreData) version: %d", version);
 
     // Entering CastingPlayers container
     err = reader.Next();
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.Next failed %" CHIP_ERROR_FORMAT, err.Format()));
     chip::TLV::TLVType castingPlayersContainerType;
     err = reader.EnterContainer(castingPlayersContainerType);
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
     while ((err = reader.Next()) == CHIP_NO_ERROR)
     {
         // Entering CastingPlayer container
         chip::TLV::TLVType castingPlayerContainerType;
         err = reader.EnterContainer(castingPlayerContainerType);
-        VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+        VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                             ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
         core::CastingPlayerAttributes attributes;
@@ -132,14 +132,14 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
         while ((err = reader.Next()) == CHIP_NO_ERROR)
         {
             chip::TLV::Tag castingPlayerContainerTag = reader.GetTag();
-            VerifyOrReturnValue(chip::TLV::IsContextTag(castingPlayerContainerTag), std::vector<core::CastingPlayer>(),
+            VerifyOrReturnValue(chip::TLV::IsContextTag(castingPlayerContainerTag), std::list<core::CastingPlayer>(),
                                 ChipLogError(AppServer, "Unexpected non-context TLV tag"));
 
             uint8_t castingPlayerContainerTagNum = static_cast<uint8_t>(chip::TLV::TagNumFromTag(castingPlayerContainerTag));
             if (castingPlayerContainerTagNum == kCastingPlayerIdTag)
             {
                 err = reader.GetBytes(reinterpret_cast<uint8_t *>(attributes.id), core::kIdMaxLength + 1);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.GetBytes failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
             }
@@ -147,7 +147,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
             if (castingPlayerContainerTagNum == kCastingPlayerNodeIdTag)
             {
                 err = reader.Get(attributes.nodeId);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
             }
@@ -155,7 +155,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
             if (castingPlayerContainerTagNum == kCastingPlayerFabricIndexTag)
             {
                 err = reader.Get(attributes.fabricIndex);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
             }
@@ -163,7 +163,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
             if (castingPlayerContainerTagNum == kCastingPlayerVendorIdTag)
             {
                 err = reader.Get(attributes.vendorId);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
             }
@@ -171,7 +171,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
             if (castingPlayerContainerTagNum == kCastingPlayerProductIdTag)
             {
                 err = reader.Get(attributes.productId);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
             }
@@ -179,7 +179,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
             if (castingPlayerContainerTagNum == kCastingPlayerDeviceTypeIdTag)
             {
                 err = reader.Get(attributes.deviceType);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
             }
@@ -187,7 +187,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
             if (castingPlayerContainerTagNum == kCastingPlayerSupportsCommissionerGeneratedPasscodeTag)
             {
                 err = reader.Get(attributes.supportsCommissionerGeneratedPasscode);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
             }
@@ -195,7 +195,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
             if (castingPlayerContainerTagNum == kCastingPlayerPortTag)
             {
                 err = reader.Get(attributes.port);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
             }
@@ -204,7 +204,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
             {
                 err = reader.GetBytes(reinterpret_cast<uint8_t *>(attributes.instanceName),
                                       chip::Dnssd::Commission::kInstanceNameMaxLength + 1);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.GetBytes failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
             }
@@ -212,7 +212,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
             if (castingPlayerContainerTagNum == kCastingPlayerDeviceNameTag)
             {
                 err = reader.GetBytes(reinterpret_cast<uint8_t *>(attributes.deviceName), chip::Dnssd::kMaxDeviceNameLen + 1);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.GetBytes failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
             }
@@ -220,7 +220,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
             if (castingPlayerContainerTagNum == kCastingPlayerHostNameTag)
             {
                 err = reader.GetBytes(reinterpret_cast<uint8_t *>(attributes.hostName), chip::Dnssd::kHostNameMaxLength + 1);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.GetBytes failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
             }
@@ -230,7 +230,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                 // Entering Endpoints container
                 chip::TLV::TLVType endpointsContainerType;
                 err = reader.EnterContainer(endpointsContainerType);
-                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
                 core::EndpointAttributes endpointAttributes;
                 std::vector<chip::ClusterId> serverList;
@@ -240,13 +240,13 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                     chip::TLV::TLVType endpointContainerType;
                     err = reader.EnterContainer(endpointContainerType);
                     VerifyOrReturnValue(
-                        err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                        err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
                     while ((err = reader.Next()) == CHIP_NO_ERROR)
                     {
                         chip::TLV::Tag endpointContainerTag = reader.GetTag();
-                        VerifyOrReturnValue(chip::TLV::IsContextTag(endpointContainerTag), std::vector<core::CastingPlayer>(),
+                        VerifyOrReturnValue(chip::TLV::IsContextTag(endpointContainerTag), std::list<core::CastingPlayer>(),
                                             ChipLogError(AppServer, "Unexpected non-context TLV tag"));
 
                         uint8_t endpointContainerTagNum = static_cast<uint8_t>(chip::TLV::TagNumFromTag(endpointContainerTag));
@@ -256,7 +256,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                             // Log which endpoints we cached.
                             ChipLogProgress(AppServer, "CastingStore::ReadAll() Endpoints container endpointAttributes.mId: %d",
                                             endpointAttributes.mId);
-                            VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                            VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                                 ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                             continue;
                         }
@@ -264,7 +264,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                         if (endpointContainerTagNum == kCastingPlayerEndpointVendorIdTag)
                         {
                             err = reader.Get(endpointAttributes.mVendorId);
-                            VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                            VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                                 ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                             continue;
                         }
@@ -272,7 +272,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                         if (endpointContainerTagNum == kCastingPlayerEndpointProductIdTag)
                         {
                             err = reader.Get(endpointAttributes.mProductId);
-                            VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                            VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                                 ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                             continue;
                         }
@@ -284,7 +284,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                             chip::TLV::TLVType deviceTypeListContainerType;
                             err = reader.EnterContainer(deviceTypeListContainerType);
                             VerifyOrReturnValue(
-                                err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                 ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
                             while ((err = reader.Next()) == CHIP_NO_ERROR)
@@ -293,7 +293,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                                 chip::TLV::TLVType deviceTypeStructContainerType;
                                 err = reader.EnterContainer(deviceTypeStructContainerType);
                                 VerifyOrReturnValue(
-                                    err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                    err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
                                 chip::app::Clusters::Descriptor::Structs::DeviceTypeStruct::DecodableType deviceTypeStruct;
@@ -301,7 +301,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                                 {
                                     chip::TLV::Tag deviceTypeStructContainerTag = reader.GetTag();
                                     VerifyOrReturnValue(chip::TLV::IsContextTag(deviceTypeStructContainerTag),
-                                                        std::vector<core::CastingPlayer>(),
+                                                        std::list<core::CastingPlayer>(),
                                                         ChipLogError(AppServer, "Unexpected non-context TLV tag"));
 
                                     uint8_t deviceTypeStructContainerTagNum =
@@ -310,7 +310,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                                     {
                                         err = reader.Get(deviceTypeStruct.deviceType);
                                         VerifyOrReturnValue(
-                                            err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                            err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                             ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                                         continue;
                                     }
@@ -319,7 +319,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                                     {
                                         err = reader.Get(deviceTypeStruct.revision);
                                         VerifyOrReturnValue(
-                                            err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                            err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                             ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                                         continue;
                                     }
@@ -329,7 +329,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                                 {
                                     // Exiting DeviceTypeStruct container
                                     err = reader.ExitContainer(deviceTypeStructContainerType);
-                                    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                                         ChipLogError(AppServer,
                                                                      "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT,
                                                                      err.Format()));
@@ -343,7 +343,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                                 // Exiting DeviceTypeList container
                                 err = reader.ExitContainer(deviceTypeListContainerType);
                                 VerifyOrReturnValue(
-                                    err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                    err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
                                 endpointAttributes.mDeviceTypeList = deviceTypeList;
@@ -357,14 +357,14 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                             chip::TLV::TLVType serverListContainerType;
                             err = reader.EnterContainer(serverListContainerType);
                             VerifyOrReturnValue(
-                                err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                 ChipLogError(AppServer, "TLVReader.EnterContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
                             while ((err = reader.Next()) == CHIP_NO_ERROR)
                             {
                                 chip::TLV::Tag serverListContainerTag = reader.GetTag();
                                 VerifyOrReturnValue(chip::TLV::IsContextTag(serverListContainerTag),
-                                                    std::vector<core::CastingPlayer>(),
+                                                    std::list<core::CastingPlayer>(),
                                                     ChipLogError(AppServer, "Unexpected non-context TLV tag"));
 
                                 uint8_t serverListContainerTagNum =
@@ -374,7 +374,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                                     chip::ClusterId clusterId;
                                     err = reader.Get(clusterId);
                                     VerifyOrReturnValue(
-                                        err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                        err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                         ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                                     serverList.push_back(clusterId);
                                     continue;
@@ -386,7 +386,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                                 // Exiting ServerList container
                                 err = reader.ExitContainer(serverListContainerType);
                                 VerifyOrReturnValue(
-                                    err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                    err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
                                 continue;
                             }
@@ -398,7 +398,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                         // Exiting Endpoint container
                         err = reader.ExitContainer(endpointContainerType);
                         VerifyOrReturnValue(
-                            err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                            err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                             ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
                         endpointAttributesList.push_back(endpointAttributes);
@@ -413,7 +413,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                     // Exiting Endpoints container
                     err = reader.ExitContainer(endpointsContainerType);
                     VerifyOrReturnValue(
-                        err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                        err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
                     continue;
                 }
@@ -423,17 +423,16 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
         {
             // Exiting CastingPlayer container
             err = reader.ExitContainer(castingPlayerContainerType);
-            VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+            VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                                 ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
             // create a castingPlayer with Endpoints and add it to the castingPlayers to be returned
-            // NOTE: Create without endpoints first to avoid dangling pointer issues
             core::CastingPlayer castingPlayer(attributes);
             ChipLogProgress(AppServer, "CastingStore::ReadAll() Created CastingPlayer with deviceName: %s",
                             castingPlayer.GetDeviceName());
             castingPlayers.push_back(castingPlayer);
             
-            // Now register endpoints on the object in the vector to ensure pointer consistency
+            // Get pointer to the added element (safe with std::list)
             core::CastingPlayer * finalCastingPlayer = &castingPlayers.back();
             for (auto & endpointAttributes : endpointAttributesList)
             {
@@ -448,15 +447,15 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
         }
     }
 
-    VerifyOrReturnValue(err == CHIP_END_OF_TLV, std::vector<core::CastingPlayer>(),
+    VerifyOrReturnValue(err == CHIP_END_OF_TLV, std::list<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLV parsing failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = reader.ExitContainer(castingPlayersContainerType);
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = reader.ExitContainer(outerContainerType);
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, std::list<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     ChipLogProgress(AppServer, "CastingStore::ReadAll() CastingPlayers size: %lu",
@@ -464,7 +463,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
     return castingPlayers;
 }
 
-CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayers)
+CHIP_ERROR CastingStore::WriteAll(std::list<core::CastingPlayer> castingPlayers)
 {
     ChipLogProgress(AppServer, "CastingStore::WriteAll() called");
 
@@ -610,7 +609,7 @@ CHIP_ERROR CastingStore::Delete(core::CastingPlayer castingPlayer)
     ChipLogProgress(AppServer, "CastingStore::Delete()");
 
     // Read cache of CastingPlayers
-    std::vector<core::CastingPlayer> castingPlayers = ReadAll();
+    std::list<core::CastingPlayer> castingPlayers = ReadAll();
 
     // search for castingPlayer in CastingStore cache and delete it, if found
     if (castingPlayers.size() != 0)
@@ -634,7 +633,7 @@ void CastingStore::OnFabricRemoved(const chip::FabricTable & fabricTable, chip::
     ChipLogProgress(AppServer, "CastingStore::OnFabricRemoved()");
 
     // Read cache of CastingPlayers
-    std::vector<core::CastingPlayer> castingPlayers = ReadAll();
+    std::list<core::CastingPlayer> castingPlayers = ReadAll();
 
     // search for castingPlayer in CastingStore cache and delete it, if found
     if (castingPlayers.size() != 0)

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "core/CastingPlayer.h"
+#include <list>
 
 namespace matter {
 namespace casting {
@@ -40,9 +41,9 @@ public:
     CHIP_ERROR AddOrUpdate(core::CastingPlayer castingPlayer);
 
     /**
-     * @brief Reads and returns a vector of all CastingPlayers found in the cache
+     * @brief Reads and returns a list of all CastingPlayers found in the cache
      */
-    std::vector<core::CastingPlayer> ReadAll();
+    std::list<core::CastingPlayer> ReadAll();
 
     /**
      * @brief If castingPlayer is found in the cache, this will delete it. If it is not found, this method is a no-op
@@ -65,9 +66,9 @@ private:
     static CastingStore * _CastingStore;
 
     /**
-     * @brief Writes the vector of CastingPlayers to the cache. This method will overwrite any pre-existing cached data.
+     * @brief Writes the list of CastingPlayers to the cache. This method will overwrite any pre-existing cached data.
      */
-    CHIP_ERROR WriteAll(std::vector<core::CastingPlayer> castingPlayers);
+    CHIP_ERROR WriteAll(std::list<core::CastingPlayer> castingPlayers);
 
     enum CastingStoreTLVTag
     {

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -70,12 +70,20 @@ void ConfigurationManagerImpl::InitiateFactoryReset() {}
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    AndroidConfig::Key configKey{ AndroidConfig::kConfigNamespace_ChipCounters, key };
+ 
+    CHIP_ERROR err = ReadConfigValue(configKey, value);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+    return err;
 }
-
+ 
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    AndroidConfig::Key configKey{ AndroidConfig::kConfigNamespace_ChipCounters, key };
+    return WriteConfigValue(configKey, value);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -71,7 +71,7 @@ void ConfigurationManagerImpl::InitiateFactoryReset() {}
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
     AndroidConfig::Key configKey{ AndroidConfig::kConfigNamespace_ChipCounters, key };
- 
+
     CHIP_ERROR err = ReadConfigValue(configKey, value);
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
@@ -79,7 +79,7 @@ CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform:
     }
     return err;
 }
- 
+
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
     AndroidConfig::Key configKey{ AndroidConfig::kConfigNamespace_ChipCounters, key };

--- a/src/platform/android/java/chip/platform/NsdManagerServiceBrowser.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceBrowser.java
@@ -127,7 +127,11 @@ public class NsdManagerServiceBrowser implements ServiceBrowser {
       mainThreadHandler.removeCallbacksAndMessages(null);
     }
 
-    this.nsdManager.stopServiceDiscovery(discovery);
+    try {
+      this.nsdManager.stopServiceDiscovery(discovery);
+    } catch (Exception e) {
+      Log.d(TAG, "Exception in stopDiscover " + e, e);
+    }
   }
 
   public class NsdManagerDiscovery implements NsdManager.DiscoveryListener {


### PR DESCRIPTION
Replaced this PR with:
https://github.com/project-chip/connectedhomeip/pull/42604

#### Summary

Fixes a number of issues relating to memory and recent changes in master:
- corrupt nodeId/fabric index in Endpoints of CastingPlayer
- "PacketBuffer: pool EMPTY." error when reading cluster list
- android init error in PersistentLifetimeCounter
- helper method for DACProvider when using PKCS8 key format

#### Testing

Tested using linux and android casting video app