### PR TITLE
[Kotlin] Fix !42301 - Kotlin generation for clusters reading multiple TLV tags

### DIFF
--- a/scripts/py_matter_idl/matter/idl/generators/kotlin/MatterClusters.jinja
+++ b/scripts/py_matter_idl/matter/idl/generators/kotlin/MatterClusters.jinja
@@ -280,10 +280,9 @@ class {{cluster.name}}Cluster(private val controller: MatterController, private 
         {%- else -%}
         {{field.name | lowfirst_except_acronym}}_decoded = {{decode_tlv(cluster, encodable, "tag", 0)}}
         {%- endif -%}
-      }  
-      {% endfor %}
-
-      else {
+      } else
+      {% endfor -%}
+      {
         tlvReader.skipElement()
       }
     }

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/ApplicationLauncherCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/ApplicationLauncherCluster.kt
@@ -136,9 +136,7 @@ class ApplicationLauncherCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -200,9 +198,7 @@ class ApplicationLauncherCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -264,9 +260,7 @@ class ApplicationLauncherCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/CameraAvStreamManagementCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/CameraAvStreamManagementCluster.kt
@@ -678,13 +678,9 @@ class CameraAvStreamManagementCluster(
 
       if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded = tlvReader.getByteArray(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_IMAGE_CODEC)) {
+      } else if (tag == ContextSpecificTag(TAG_IMAGE_CODEC)) {
         imageCodec_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_RESOLUTION)) {
+      } else if (tag == ContextSpecificTag(TAG_RESOLUTION)) {
         resolution_decoded =
           CameraAvStreamManagementClusterVideoResolutionStruct.fromTlv(tag, tlvReader)
       } else {

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/ChannelCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/ChannelCluster.kt
@@ -146,9 +146,7 @@ class ChannelCluster(private val controller: MatterController, private val endpo
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -295,9 +293,7 @@ class ChannelCluster(private val controller: MatterController, private val endpo
 
       if (tag == ContextSpecificTag(TAG_PAGING)) {
         paging_decoded = ChannelClusterChannelPagingStruct.fromTlv(tag, tlvReader)
-      }
-
-      if (tag == ContextSpecificTag(TAG_PROGRAM_LIST)) {
+      } else if (tag == ContextSpecificTag(TAG_PROGRAM_LIST)) {
         programList_decoded =
           buildList<ChannelClusterProgramStruct> {
             tlvReader.enterArray(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/CommissionerControlCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/CommissionerControlCluster.kt
@@ -166,21 +166,13 @@ class CommissionerControlCluster(
 
       if (tag == ContextSpecificTag(TAG_COMMISSIONING_TIMEOUT)) {
         commissioningTimeout_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_PAKE_PASSCODE_VERIFIER)) {
+      } else if (tag == ContextSpecificTag(TAG_PAKE_PASSCODE_VERIFIER)) {
         PAKEPasscodeVerifier_decoded = tlvReader.getByteArray(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DISCRIMINATOR)) {
+      } else if (tag == ContextSpecificTag(TAG_DISCRIMINATOR)) {
         discriminator_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_ITERATIONS)) {
+      } else if (tag == ContextSpecificTag(TAG_ITERATIONS)) {
         iterations_decoded = tlvReader.getUInt(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_SALT)) {
+      } else if (tag == ContextSpecificTag(TAG_SALT)) {
         salt_decoded = tlvReader.getByteArray(tag)
       } else {
         tlvReader.skipElement()

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/CommodityTariffCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/CommodityTariffCluster.kt
@@ -341,9 +341,7 @@ class CommodityTariffCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_DAY_ENTRY_I_DS)) {
+      } else if (tag == ContextSpecificTag(TAG_DAY_ENTRY_I_DS)) {
         dayEntryIDs_decoded =
           buildList<UInt> {
             tlvReader.enterArray(tag)
@@ -352,9 +350,7 @@ class CommodityTariffCluster(
             }
             tlvReader.exitContainer()
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_TARIFF_COMPONENT)) {
+      } else if (tag == ContextSpecificTag(TAG_TARIFF_COMPONENT)) {
         tariffComponent_decoded =
           CommodityTariffClusterTariffComponentStruct.fromTlv(tag, tlvReader)
       } else {

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/ContentAppObserverCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/ContentAppObserverCluster.kt
@@ -118,9 +118,7 @@ class ContentAppObserverCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -132,9 +130,7 @@ class ContentAppObserverCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_ENCODING_HINT)) {
+      } else if (tag == ContextSpecificTag(TAG_ENCODING_HINT)) {
         encodingHint_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/ContentLauncherCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/ContentLauncherCluster.kt
@@ -141,9 +141,7 @@ class ContentLauncherCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -215,9 +213,7 @@ class ContentLauncherCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/DeviceEnergyManagementModeCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/DeviceEnergyManagementModeCluster.kt
@@ -123,9 +123,7 @@ class DeviceEnergyManagementModeCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
         statusText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/DiagnosticLogsCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/DiagnosticLogsCluster.kt
@@ -132,13 +132,9 @@ class DiagnosticLogsCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_LOG_CONTENT)) {
+      } else if (tag == ContextSpecificTag(TAG_LOG_CONTENT)) {
         logContent_decoded = tlvReader.getByteArray(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_UTC_TIME_STAMP)) {
+      } else if (tag == ContextSpecificTag(TAG_UTC_TIME_STAMP)) {
         UTCTimeStamp_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -150,9 +146,7 @@ class DiagnosticLogsCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_TIME_SINCE_BOOT)) {
+      } else if (tag == ContextSpecificTag(TAG_TIME_SINCE_BOOT)) {
         timeSinceBoot_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/DishwasherModeCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/DishwasherModeCluster.kt
@@ -123,9 +123,7 @@ class DishwasherModeCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
         statusText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/DoorLockCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/DoorLockCluster.kt
@@ -388,17 +388,11 @@ class DoorLockCluster(private val controller: MatterController, private val endp
 
       if (tag == ContextSpecificTag(TAG_WEEK_DAY_INDEX)) {
         weekDayIndex_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_USER_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_USER_INDEX)) {
         userIndex_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DAYS_MASK)) {
+      } else if (tag == ContextSpecificTag(TAG_DAYS_MASK)) {
         daysMask_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -410,9 +404,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_START_HOUR)) {
+      } else if (tag == ContextSpecificTag(TAG_START_HOUR)) {
         startHour_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -424,9 +416,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_START_MINUTE)) {
+      } else if (tag == ContextSpecificTag(TAG_START_MINUTE)) {
         startMinute_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -438,9 +428,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_END_HOUR)) {
+      } else if (tag == ContextSpecificTag(TAG_END_HOUR)) {
         endHour_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -452,9 +440,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_END_MINUTE)) {
+      } else if (tag == ContextSpecificTag(TAG_END_MINUTE)) {
         endMinute_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -610,17 +596,11 @@ class DoorLockCluster(private val controller: MatterController, private val endp
 
       if (tag == ContextSpecificTag(TAG_YEAR_DAY_INDEX)) {
         yearDayIndex_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_USER_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_USER_INDEX)) {
         userIndex_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_LOCAL_START_TIME)) {
+      } else if (tag == ContextSpecificTag(TAG_LOCAL_START_TIME)) {
         localStartTime_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -632,9 +612,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_LOCAL_END_TIME)) {
+      } else if (tag == ContextSpecificTag(TAG_LOCAL_END_TIME)) {
         localEndTime_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -783,13 +761,9 @@ class DoorLockCluster(private val controller: MatterController, private val endp
 
       if (tag == ContextSpecificTag(TAG_HOLIDAY_INDEX)) {
         holidayIndex_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_LOCAL_START_TIME)) {
+      } else if (tag == ContextSpecificTag(TAG_LOCAL_START_TIME)) {
         localStartTime_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -801,9 +775,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_LOCAL_END_TIME)) {
+      } else if (tag == ContextSpecificTag(TAG_LOCAL_END_TIME)) {
         localEndTime_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -815,9 +787,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_OPERATING_MODE)) {
+      } else if (tag == ContextSpecificTag(TAG_OPERATING_MODE)) {
         operatingMode_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -981,9 +951,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
 
       if (tag == ContextSpecificTag(TAG_USER_INDEX)) {
         userIndex_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_USER_NAME)) {
+      } else if (tag == ContextSpecificTag(TAG_USER_NAME)) {
         userName_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -996,9 +964,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_USER_UNIQUE_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_USER_UNIQUE_ID)) {
         userUniqueID_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1011,9 +977,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_USER_STATUS)) {
+      } else if (tag == ContextSpecificTag(TAG_USER_STATUS)) {
         userStatus_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1026,9 +990,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_USER_TYPE)) {
+      } else if (tag == ContextSpecificTag(TAG_USER_TYPE)) {
         userType_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1041,9 +1003,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_CREDENTIAL_RULE)) {
+      } else if (tag == ContextSpecificTag(TAG_CREDENTIAL_RULE)) {
         credentialRule_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1056,9 +1016,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_CREDENTIALS)) {
+      } else if (tag == ContextSpecificTag(TAG_CREDENTIALS)) {
         credentials_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1077,9 +1035,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_CREATOR_FABRIC_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_CREATOR_FABRIC_INDEX)) {
         creatorFabricIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1092,9 +1048,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_LAST_MODIFIED_FABRIC_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_LAST_MODIFIED_FABRIC_INDEX)) {
         lastModifiedFabricIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1107,9 +1061,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NEXT_USER_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_NEXT_USER_INDEX)) {
         nextUserIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1227,9 +1179,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_USER_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_USER_INDEX)) {
         userIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1242,9 +1192,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NEXT_CREDENTIAL_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_NEXT_CREDENTIAL_INDEX)) {
         nextCredentialIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1319,9 +1267,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
 
       if (tag == ContextSpecificTag(TAG_CREDENTIAL_EXISTS)) {
         credentialExists_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_USER_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_USER_INDEX)) {
         userIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1334,9 +1280,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_CREATOR_FABRIC_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_CREATOR_FABRIC_INDEX)) {
         creatorFabricIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1349,9 +1293,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_LAST_MODIFIED_FABRIC_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_LAST_MODIFIED_FABRIC_INDEX)) {
         lastModifiedFabricIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1364,9 +1306,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NEXT_CREDENTIAL_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_NEXT_CREDENTIAL_INDEX)) {
         nextCredentialIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1379,9 +1319,7 @@ class DoorLockCluster(private val controller: MatterController, private val endp
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_CREDENTIAL_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_CREDENTIAL_DATA)) {
         credentialData_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/EnergyEvseModeCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/EnergyEvseModeCluster.kt
@@ -123,9 +123,7 @@ class EnergyEvseModeCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
         statusText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/GeneralCommissioningCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/GeneralCommissioningCluster.kt
@@ -161,9 +161,7 @@ class GeneralCommissioningCluster(
 
       if (tag == ContextSpecificTag(TAG_ERROR_CODE)) {
         errorCode_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded = tlvReader.getString(tag)
       } else {
         tlvReader.skipElement()
@@ -227,9 +225,7 @@ class GeneralCommissioningCluster(
 
       if (tag == ContextSpecificTag(TAG_ERROR_CODE)) {
         errorCode_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded = tlvReader.getString(tag)
       } else {
         tlvReader.skipElement()
@@ -281,9 +277,7 @@ class GeneralCommissioningCluster(
 
       if (tag == ContextSpecificTag(TAG_ERROR_CODE)) {
         errorCode_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded = tlvReader.getString(tag)
       } else {
         tlvReader.skipElement()

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/GeneralDiagnosticsCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/GeneralDiagnosticsCluster.kt
@@ -190,9 +190,7 @@ class GeneralDiagnosticsCluster(
 
       if (tag == ContextSpecificTag(TAG_SYSTEM_TIME_MS)) {
         systemTimeMs_decoded = tlvReader.getULong(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_POSIX_TIME_MS)) {
+      } else if (tag == ContextSpecificTag(TAG_POSIX_TIME_MS)) {
         posixTimeMs_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/GroupcastCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/GroupcastCluster.kt
@@ -186,9 +186,7 @@ class GroupcastCluster(private val controller: MatterController, private val end
 
       if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
         groupID_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_ENDPOINTS)) {
+      } else if (tag == ContextSpecificTag(TAG_ENDPOINTS)) {
         endpoints_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -206,9 +204,7 @@ class GroupcastCluster(private val controller: MatterController, private val end
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_LIST_TOO_LARGE)) {
+      } else if (tag == ContextSpecificTag(TAG_LIST_TOO_LARGE)) {
         listTooLarge_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/GroupsCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/GroupsCluster.kt
@@ -119,9 +119,7 @@ class GroupsCluster(private val controller: MatterController, private val endpoi
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
         groupID_decoded = tlvReader.getUShort(tag)
       } else {
         tlvReader.skipElement()
@@ -177,13 +175,9 @@ class GroupsCluster(private val controller: MatterController, private val endpoi
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
         groupID_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_NAME)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_NAME)) {
         groupName_decoded = tlvReader.getString(tag)
       } else {
         tlvReader.skipElement()
@@ -258,9 +252,7 @@ class GroupsCluster(private val controller: MatterController, private val endpoi
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_LIST)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_LIST)) {
         groupList_decoded =
           buildList<UShort> {
             tlvReader.enterArray(tag)
@@ -319,9 +311,7 @@ class GroupsCluster(private val controller: MatterController, private val endpoi
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
         groupID_decoded = tlvReader.getUShort(tag)
       } else {
         tlvReader.skipElement()

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/LaundryWasherModeCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/LaundryWasherModeCluster.kt
@@ -123,9 +123,7 @@ class LaundryWasherModeCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
         statusText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/MediaPlaybackCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/MediaPlaybackCluster.kt
@@ -202,9 +202,7 @@ class MediaPlaybackCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -260,9 +258,7 @@ class MediaPlaybackCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -318,9 +314,7 @@ class MediaPlaybackCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -376,9 +370,7 @@ class MediaPlaybackCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -434,9 +426,7 @@ class MediaPlaybackCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -492,9 +482,7 @@ class MediaPlaybackCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -558,9 +546,7 @@ class MediaPlaybackCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -624,9 +610,7 @@ class MediaPlaybackCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -691,9 +675,7 @@ class MediaPlaybackCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -758,9 +740,7 @@ class MediaPlaybackCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -819,9 +799,7 @@ class MediaPlaybackCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/NetworkCommissioningCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/NetworkCommissioningCluster.kt
@@ -201,9 +201,7 @@ class NetworkCommissioningCluster(
 
       if (tag == ContextSpecificTag(TAG_NETWORKING_STATUS)) {
         networkingStatus_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -215,9 +213,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_WI_FI_SCAN_RESULTS)) {
+      } else if (tag == ContextSpecificTag(TAG_WI_FI_SCAN_RESULTS)) {
         wiFiScanResults_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -240,9 +236,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_THREAD_SCAN_RESULTS)) {
+      } else if (tag == ContextSpecificTag(TAG_THREAD_SCAN_RESULTS)) {
         threadScanResults_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -355,9 +349,7 @@ class NetworkCommissioningCluster(
 
       if (tag == ContextSpecificTag(TAG_NETWORKING_STATUS)) {
         networkingStatus_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -369,9 +361,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NETWORK_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_NETWORK_INDEX)) {
         networkIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -383,9 +373,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_CLIENT_IDENTITY)) {
+      } else if (tag == ContextSpecificTag(TAG_CLIENT_IDENTITY)) {
         clientIdentity_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -397,9 +385,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_POSSESSION_SIGNATURE)) {
+      } else if (tag == ContextSpecificTag(TAG_POSSESSION_SIGNATURE)) {
         possessionSignature_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -480,9 +466,7 @@ class NetworkCommissioningCluster(
 
       if (tag == ContextSpecificTag(TAG_NETWORKING_STATUS)) {
         networkingStatus_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -494,9 +478,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NETWORK_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_NETWORK_INDEX)) {
         networkIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -508,9 +490,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_CLIENT_IDENTITY)) {
+      } else if (tag == ContextSpecificTag(TAG_CLIENT_IDENTITY)) {
         clientIdentity_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -522,9 +502,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_POSSESSION_SIGNATURE)) {
+      } else if (tag == ContextSpecificTag(TAG_POSSESSION_SIGNATURE)) {
         possessionSignature_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -605,9 +583,7 @@ class NetworkCommissioningCluster(
 
       if (tag == ContextSpecificTag(TAG_NETWORKING_STATUS)) {
         networkingStatus_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -619,9 +595,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NETWORK_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_NETWORK_INDEX)) {
         networkIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -633,9 +607,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_CLIENT_IDENTITY)) {
+      } else if (tag == ContextSpecificTag(TAG_CLIENT_IDENTITY)) {
         clientIdentity_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -647,9 +619,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_POSSESSION_SIGNATURE)) {
+      } else if (tag == ContextSpecificTag(TAG_POSSESSION_SIGNATURE)) {
         possessionSignature_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -724,9 +694,7 @@ class NetworkCommissioningCluster(
 
       if (tag == ContextSpecificTag(TAG_NETWORKING_STATUS)) {
         networkingStatus_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -738,9 +706,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_ERROR_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_ERROR_VALUE)) {
         errorValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -820,9 +786,7 @@ class NetworkCommissioningCluster(
 
       if (tag == ContextSpecificTag(TAG_NETWORKING_STATUS)) {
         networkingStatus_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -834,9 +798,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NETWORK_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_NETWORK_INDEX)) {
         networkIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -848,9 +810,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_CLIENT_IDENTITY)) {
+      } else if (tag == ContextSpecificTag(TAG_CLIENT_IDENTITY)) {
         clientIdentity_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -862,9 +822,7 @@ class NetworkCommissioningCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_POSSESSION_SIGNATURE)) {
+      } else if (tag == ContextSpecificTag(TAG_POSSESSION_SIGNATURE)) {
         possessionSignature_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -938,9 +896,7 @@ class NetworkCommissioningCluster(
 
       if (tag == ContextSpecificTag(TAG_IDENTITY)) {
         identity_decoded = tlvReader.getByteArray(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_POSSESSION_SIGNATURE)) {
+      } else if (tag == ContextSpecificTag(TAG_POSSESSION_SIGNATURE)) {
         possessionSignature_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/OperationalCredentialsCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/OperationalCredentialsCluster.kt
@@ -161,9 +161,7 @@ class OperationalCredentialsCluster(
 
       if (tag == ContextSpecificTag(TAG_ATTESTATION_ELEMENTS)) {
         attestationElements_decoded = tlvReader.getByteArray(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_ATTESTATION_SIGNATURE)) {
+      } else if (tag == ContextSpecificTag(TAG_ATTESTATION_SIGNATURE)) {
         attestationSignature_decoded = tlvReader.getByteArray(tag)
       } else {
         tlvReader.skipElement()
@@ -272,9 +270,7 @@ class OperationalCredentialsCluster(
 
       if (tag == ContextSpecificTag(TAG_NOCSR_ELEMENTS)) {
         NOCSRElements_decoded = tlvReader.getByteArray(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_ATTESTATION_SIGNATURE)) {
+      } else if (tag == ContextSpecificTag(TAG_ATTESTATION_SIGNATURE)) {
         attestationSignature_decoded = tlvReader.getByteArray(tag)
       } else {
         tlvReader.skipElement()
@@ -349,9 +345,7 @@ class OperationalCredentialsCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS_CODE)) {
         statusCode_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_FABRIC_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_FABRIC_INDEX)) {
         fabricIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -363,9 +357,7 @@ class OperationalCredentialsCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -434,9 +426,7 @@ class OperationalCredentialsCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS_CODE)) {
         statusCode_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_FABRIC_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_FABRIC_INDEX)) {
         fabricIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -448,9 +438,7 @@ class OperationalCredentialsCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -512,9 +500,7 @@ class OperationalCredentialsCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS_CODE)) {
         statusCode_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_FABRIC_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_FABRIC_INDEX)) {
         fabricIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -526,9 +512,7 @@ class OperationalCredentialsCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -590,9 +574,7 @@ class OperationalCredentialsCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS_CODE)) {
         statusCode_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_FABRIC_INDEX)) {
+      } else if (tag == ContextSpecificTag(TAG_FABRIC_INDEX)) {
         fabricIndex_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -604,9 +586,7 @@ class OperationalCredentialsCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_DEBUG_TEXT)) {
         debugText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -736,13 +716,9 @@ class OperationalCredentialsCluster(
 
       if (tag == ContextSpecificTag(TAG_FABRIC_INDEX)) {
         fabricIndex_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_FABRIC_BINDING_VERSION)) {
+      } else if (tag == ContextSpecificTag(TAG_FABRIC_BINDING_VERSION)) {
         fabricBindingVersion_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_SIGNATURE)) {
+      } else if (tag == ContextSpecificTag(TAG_SIGNATURE)) {
         signature_decoded = tlvReader.getByteArray(tag)
       } else {
         tlvReader.skipElement()

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/OtaSoftwareUpdateProviderCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/OtaSoftwareUpdateProviderCluster.kt
@@ -178,9 +178,7 @@ class OtaSoftwareUpdateProviderCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DELAYED_ACTION_TIME)) {
+      } else if (tag == ContextSpecificTag(TAG_DELAYED_ACTION_TIME)) {
         delayedActionTime_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -192,9 +190,7 @@ class OtaSoftwareUpdateProviderCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_IMAGE_URI)) {
+      } else if (tag == ContextSpecificTag(TAG_IMAGE_URI)) {
         imageURI_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -206,9 +202,7 @@ class OtaSoftwareUpdateProviderCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_SOFTWARE_VERSION)) {
+      } else if (tag == ContextSpecificTag(TAG_SOFTWARE_VERSION)) {
         softwareVersion_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -220,9 +214,7 @@ class OtaSoftwareUpdateProviderCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_SOFTWARE_VERSION_STRING)) {
+      } else if (tag == ContextSpecificTag(TAG_SOFTWARE_VERSION_STRING)) {
         softwareVersionString_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -234,9 +226,7 @@ class OtaSoftwareUpdateProviderCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_UPDATE_TOKEN)) {
+      } else if (tag == ContextSpecificTag(TAG_UPDATE_TOKEN)) {
         updateToken_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -248,9 +238,7 @@ class OtaSoftwareUpdateProviderCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_USER_CONSENT_NEEDED)) {
+      } else if (tag == ContextSpecificTag(TAG_USER_CONSENT_NEEDED)) {
         userConsentNeeded_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -262,9 +250,7 @@ class OtaSoftwareUpdateProviderCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_METADATA_FOR_REQUESTOR)) {
+      } else if (tag == ContextSpecificTag(TAG_METADATA_FOR_REQUESTOR)) {
         metadataForRequestor_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -339,9 +325,7 @@ class OtaSoftwareUpdateProviderCluster(
 
       if (tag == ContextSpecificTag(TAG_ACTION)) {
         action_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DELAYED_ACTION_TIME)) {
+      } else if (tag == ContextSpecificTag(TAG_DELAYED_ACTION_TIME)) {
         delayedActionTime_decoded = tlvReader.getUInt(tag)
       } else {
         tlvReader.skipElement()

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/OvenModeCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/OvenModeCluster.kt
@@ -120,9 +120,7 @@ class OvenModeCluster(private val controller: MatterController, private val endp
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
         statusText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/RefrigeratorAndTemperatureControlledCabinetModeCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/RefrigeratorAndTemperatureControlledCabinetModeCluster.kt
@@ -126,9 +126,7 @@ class RefrigeratorAndTemperatureControlledCabinetModeCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
         statusText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/RvcCleanModeCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/RvcCleanModeCluster.kt
@@ -123,9 +123,7 @@ class RvcCleanModeCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
         statusText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/RvcRunModeCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/RvcRunModeCluster.kt
@@ -120,9 +120,7 @@ class RvcRunModeCluster(private val controller: MatterController, private val en
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
         statusText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/ScenesManagementCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/ScenesManagementCluster.kt
@@ -173,13 +173,9 @@ class ScenesManagementCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
         groupID_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_SCENE_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_SCENE_ID)) {
         sceneID_decoded = tlvReader.getUByte(tag)
       } else {
         tlvReader.skipElement()
@@ -256,17 +252,11 @@ class ScenesManagementCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
         groupID_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_SCENE_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_SCENE_ID)) {
         sceneID_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_TRANSITION_TIME)) {
+      } else if (tag == ContextSpecificTag(TAG_TRANSITION_TIME)) {
         transitionTime_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -278,9 +268,7 @@ class ScenesManagementCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_SCENE_NAME)) {
+      } else if (tag == ContextSpecificTag(TAG_SCENE_NAME)) {
         sceneName_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -292,9 +280,7 @@ class ScenesManagementCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_EXTENSION_FIELD_SET_STRUCTS)) {
+      } else if (tag == ContextSpecificTag(TAG_EXTENSION_FIELD_SET_STRUCTS)) {
         extensionFieldSetStructs_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -386,13 +372,9 @@ class ScenesManagementCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
         groupID_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_SCENE_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_SCENE_ID)) {
         sceneID_decoded = tlvReader.getUByte(tag)
       } else {
         tlvReader.skipElement()
@@ -452,9 +434,7 @@ class ScenesManagementCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
         groupID_decoded = tlvReader.getUShort(tag)
       } else {
         tlvReader.skipElement()
@@ -517,13 +497,9 @@ class ScenesManagementCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
         groupID_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_SCENE_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_SCENE_ID)) {
         sceneID_decoded = tlvReader.getUByte(tag)
       } else {
         tlvReader.skipElement()
@@ -623,9 +599,7 @@ class ScenesManagementCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_CAPACITY)) {
+      } else if (tag == ContextSpecificTag(TAG_CAPACITY)) {
         capacity_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -638,13 +612,9 @@ class ScenesManagementCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_ID)) {
         groupID_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_SCENE_LIST)) {
+      } else if (tag == ContextSpecificTag(TAG_SCENE_LIST)) {
         sceneList_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -740,13 +710,9 @@ class ScenesManagementCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_GROUP_IDENTIFIER_FROM)) {
+      } else if (tag == ContextSpecificTag(TAG_GROUP_IDENTIFIER_FROM)) {
         groupIdentifierFrom_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_SCENE_IDENTIFIER_FROM)) {
+      } else if (tag == ContextSpecificTag(TAG_SCENE_IDENTIFIER_FROM)) {
         sceneIdentifierFrom_decoded = tlvReader.getUByte(tag)
       } else {
         tlvReader.skipElement()

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/ServiceAreaCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/ServiceAreaCluster.kt
@@ -177,9 +177,7 @@ class ServiceAreaCluster(private val controller: MatterController, private val e
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
         statusText_decoded = tlvReader.getString(tag)
       } else {
         tlvReader.skipElement()
@@ -232,9 +230,7 @@ class ServiceAreaCluster(private val controller: MatterController, private val e
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
         statusText_decoded = tlvReader.getString(tag)
       } else {
         tlvReader.skipElement()

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/TargetNavigatorCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/TargetNavigatorCluster.kt
@@ -127,9 +127,7 @@ class TargetNavigatorCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DATA)) {
+      } else if (tag == ContextSpecificTag(TAG_DATA)) {
         data_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/ThermostatCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/ThermostatCluster.kt
@@ -443,17 +443,11 @@ class ThermostatCluster(private val controller: MatterController, private val en
 
       if (tag == ContextSpecificTag(TAG_NUMBER_OF_TRANSITIONS_FOR_SEQUENCE)) {
         numberOfTransitionsForSequence_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DAY_OF_WEEK_FOR_SEQUENCE)) {
+      } else if (tag == ContextSpecificTag(TAG_DAY_OF_WEEK_FOR_SEQUENCE)) {
         dayOfWeekForSequence_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_MODE_FOR_SEQUENCE)) {
+      } else if (tag == ContextSpecificTag(TAG_MODE_FOR_SEQUENCE)) {
         modeForSequence_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_TRANSITIONS)) {
+      } else if (tag == ContextSpecificTag(TAG_TRANSITIONS)) {
         transitions_decoded =
           buildList<ThermostatClusterWeeklyScheduleTransitionStruct> {
             tlvReader.enterArray(tag)
@@ -686,9 +680,7 @@ class ThermostatCluster(private val controller: MatterController, private val en
 
       if (tag == ContextSpecificTag(TAG_STATUS_CODE)) {
         statusCode_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_ATTRIBUTE_STATUS)) {
+      } else if (tag == ContextSpecificTag(TAG_ATTRIBUTE_STATUS)) {
         attributeStatus_decoded =
           buildList<ThermostatClusterAtomicAttributeStatusStruct> {
             tlvReader.enterArray(tag)
@@ -697,9 +689,7 @@ class ThermostatCluster(private val controller: MatterController, private val en
             }
             tlvReader.exitContainer()
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_TIMEOUT)) {
+      } else if (tag == ContextSpecificTag(TAG_TIMEOUT)) {
         timeout_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/TlsCertificateManagementCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/TlsCertificateManagementCluster.kt
@@ -335,13 +335,9 @@ class TlsCertificateManagementCluster(
 
       if (tag == ContextSpecificTag(TAG_CCDID)) {
         ccdid_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_CSR)) {
+      } else if (tag == ContextSpecificTag(TAG_CSR)) {
         csr_decoded = tlvReader.getByteArray(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_NONCE_SIGNATURE)) {
+      } else if (tag == ContextSpecificTag(TAG_NONCE_SIGNATURE)) {
         nonceSignature_decoded = tlvReader.getByteArray(tag)
       } else {
         tlvReader.skipElement()

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/UnitTestingCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/UnitTestingCluster.kt
@@ -889,9 +889,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
             }
             tlvReader.exitContainer()
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_ARG2)) {
+      } else if (tag == ContextSpecificTag(TAG_ARG2)) {
         arg2_decoded =
           buildList<UnitTestingClusterSimpleStruct> {
             tlvReader.enterArray(tag)
@@ -900,9 +898,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
             }
             tlvReader.exitContainer()
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_ARG3)) {
+      } else if (tag == ContextSpecificTag(TAG_ARG3)) {
         arg3_decoded =
           buildList<UByte> {
             tlvReader.enterArray(tag)
@@ -911,9 +907,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
             }
             tlvReader.exitContainer()
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_ARG4)) {
+      } else if (tag == ContextSpecificTag(TAG_ARG4)) {
         arg4_decoded =
           buildList<Boolean> {
             tlvReader.enterArray(tag)
@@ -922,13 +916,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
             }
             tlvReader.exitContainer()
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_ARG5)) {
+      } else if (tag == ContextSpecificTag(TAG_ARG5)) {
         arg5_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_ARG6)) {
+      } else if (tag == ContextSpecificTag(TAG_ARG6)) {
         arg6_decoded = tlvReader.getBoolean(tag)
       } else {
         tlvReader.skipElement()
@@ -1363,9 +1353,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
 
       if (tag == ContextSpecificTag(TAG_ARG1)) {
         arg1_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_ARG2)) {
+      } else if (tag == ContextSpecificTag(TAG_ARG2)) {
         arg2_decoded = tlvReader.getUByte(tag)
       } else {
         tlvReader.skipElement()
@@ -1427,9 +1415,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
 
       if (tag == ContextSpecificTag(TAG_WAS_PRESENT)) {
         wasPresent_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_WAS_NULL)) {
+      } else if (tag == ContextSpecificTag(TAG_WAS_NULL)) {
         wasNull_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1441,9 +1427,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_VALUE)) {
         value_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1455,9 +1439,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_ORIGINAL_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_ORIGINAL_VALUE)) {
         originalValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1683,9 +1665,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
 
       if (tag == ContextSpecificTag(TAG_NULLABLE_INT_WAS_NULL)) {
         nullableIntWasNull_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_INT_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_INT_VALUE)) {
         nullableIntValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1697,13 +1677,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_OPTIONAL_INT_WAS_PRESENT)) {
+      } else if (tag == ContextSpecificTag(TAG_OPTIONAL_INT_WAS_PRESENT)) {
         optionalIntWasPresent_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_OPTIONAL_INT_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_OPTIONAL_INT_VALUE)) {
         optionalIntValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1715,13 +1691,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_INT_WAS_PRESENT)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_INT_WAS_PRESENT)) {
         nullableOptionalIntWasPresent_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_INT_WAS_NULL)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_INT_WAS_NULL)) {
         nullableOptionalIntWasNull_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1733,9 +1705,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_INT_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_INT_VALUE)) {
         nullableOptionalIntValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1747,13 +1717,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_STRING_WAS_NULL)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_STRING_WAS_NULL)) {
         nullableStringWasNull_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_STRING_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_STRING_VALUE)) {
         nullableStringValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1765,13 +1731,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_OPTIONAL_STRING_WAS_PRESENT)) {
+      } else if (tag == ContextSpecificTag(TAG_OPTIONAL_STRING_WAS_PRESENT)) {
         optionalStringWasPresent_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_OPTIONAL_STRING_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_OPTIONAL_STRING_VALUE)) {
         optionalStringValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1783,13 +1745,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRING_WAS_PRESENT)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRING_WAS_PRESENT)) {
         nullableOptionalStringWasPresent_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRING_WAS_NULL)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRING_WAS_NULL)) {
         nullableOptionalStringWasNull_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1801,9 +1759,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRING_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRING_VALUE)) {
         nullableOptionalStringValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1815,13 +1771,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_STRUCT_WAS_NULL)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_STRUCT_WAS_NULL)) {
         nullableStructWasNull_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_STRUCT_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_STRUCT_VALUE)) {
         nullableStructValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1833,13 +1785,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_OPTIONAL_STRUCT_WAS_PRESENT)) {
+      } else if (tag == ContextSpecificTag(TAG_OPTIONAL_STRUCT_WAS_PRESENT)) {
         optionalStructWasPresent_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_OPTIONAL_STRUCT_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_OPTIONAL_STRUCT_VALUE)) {
         optionalStructValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1851,13 +1799,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRUCT_WAS_PRESENT)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRUCT_WAS_PRESENT)) {
         nullableOptionalStructWasPresent_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRUCT_WAS_NULL)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRUCT_WAS_NULL)) {
         nullableOptionalStructWasNull_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1869,9 +1813,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRUCT_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_STRUCT_VALUE)) {
         nullableOptionalStructValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1883,13 +1825,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_LIST_WAS_NULL)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_LIST_WAS_NULL)) {
         nullableListWasNull_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_LIST_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_LIST_VALUE)) {
         nullableListValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1907,13 +1845,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_OPTIONAL_LIST_WAS_PRESENT)) {
+      } else if (tag == ContextSpecificTag(TAG_OPTIONAL_LIST_WAS_PRESENT)) {
         optionalListWasPresent_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_OPTIONAL_LIST_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_OPTIONAL_LIST_VALUE)) {
         optionalListValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1931,13 +1865,9 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_LIST_WAS_PRESENT)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_LIST_WAS_PRESENT)) {
         nullableOptionalListWasPresent_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_LIST_WAS_NULL)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_LIST_WAS_NULL)) {
         nullableOptionalListWasNull_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -1949,9 +1879,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_LIST_VALUE)) {
+      } else if (tag == ContextSpecificTag(TAG_NULLABLE_OPTIONAL_LIST_VALUE)) {
         nullableOptionalListValue_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -2450,9 +2378,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
 
       if (tag == ContextSpecificTag(TAG_FIELD1)) {
         field1_decoded = UnitTestingClusterTestGlobalStruct.fromTlv(tag, tlvReader)
-      }
-
-      if (tag == ContextSpecificTag(TAG_FIELD2)) {
+      } else if (tag == ContextSpecificTag(TAG_FIELD2)) {
         field2_decoded = tlvReader.getUByte(tag)
       } else {
         tlvReader.skipElement()
@@ -2526,9 +2452,7 @@ class UnitTestingCluster(private val controller: MatterController, private val e
 
       if (tag == ContextSpecificTag(TAG_ARG1)) {
         arg1_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_EVENT_NUMBER)) {
+      } else if (tag == ContextSpecificTag(TAG_EVENT_NUMBER)) {
         eventNumber_decoded = tlvReader.getULong(tag)
       } else {
         tlvReader.skipElement()

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/WaterHeaterModeCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/WaterHeaterModeCluster.kt
@@ -123,9 +123,7 @@ class WaterHeaterModeCluster(
 
       if (tag == ContextSpecificTag(TAG_STATUS)) {
         status_decoded = tlvReader.getUByte(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
+      } else if (tag == ContextSpecificTag(TAG_STATUS_TEXT)) {
         statusText_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/WebRTCTransportProviderCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/WebRTCTransportProviderCluster.kt
@@ -179,13 +179,9 @@ class WebRTCTransportProviderCluster(
 
       if (tag == ContextSpecificTag(TAG_WEB_RTC_SESSION_ID)) {
         webRTCSessionID_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_DEFERRED_OFFER)) {
+      } else if (tag == ContextSpecificTag(TAG_DEFERRED_OFFER)) {
         deferredOffer_decoded = tlvReader.getBoolean(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_VIDEO_STREAM_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_VIDEO_STREAM_ID)) {
         videoStreamID_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -202,9 +198,7 @@ class WebRTCTransportProviderCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_AUDIO_STREAM_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_AUDIO_STREAM_ID)) {
         audioStreamID_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -331,9 +325,7 @@ class WebRTCTransportProviderCluster(
 
       if (tag == ContextSpecificTag(TAG_WEB_RTC_SESSION_ID)) {
         webRTCSessionID_decoded = tlvReader.getUShort(tag)
-      }
-
-      if (tag == ContextSpecificTag(TAG_VIDEO_STREAM_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_VIDEO_STREAM_ID)) {
         videoStreamID_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)
@@ -350,9 +342,7 @@ class WebRTCTransportProviderCluster(
               null
             }
           }
-      }
-
-      if (tag == ContextSpecificTag(TAG_AUDIO_STREAM_ID)) {
+      } else if (tag == ContextSpecificTag(TAG_AUDIO_STREAM_ID)) {
         audioStreamID_decoded =
           if (tlvReader.isNull()) {
             tlvReader.getNull(tag)


### PR DESCRIPTION
#### Summary

This PR aim to fix the issue #42301

The issue is that Kotlin generated clusters are not able to get all tags from TLV messages due to wrong "if" chaining resulting `tlvReader.skipElement()` called too often.

#### Related issues

Fixes: #42301

The fix change a little part of the Kotlin generator in `MatterClusters.jinja`.
Basically, instead of generating code like following:
```kotlin
...
val tlvReader = TlvReader(response.payload)
...
// Define tags
val TAG_TOTO: Int = 0
val TAG_TATA: Int = 1
...
while (!tlvReader.isEndOfContainer()) {
      val tag = tlvReader.peekElement().tag

      if (tag == ContextSpecificTag(TAG_TOTO)) {
         // assigning data to a value here
      }

      // Issue in the next flow, calling skipElement() each time the tag is not the last one.
      if (tag == ContextSpecificTag(TAG_TATA)) {
        // assigning data to a value here
      } else {
        tlvReader.skipElement()
      }
}
...
```

If will generate code like following:
```kotlin
...
val tlvReader = TlvReader(response.payload)
...
// Define tags
val TAG_TOTO: Int = 0
val TAG_TATA: Int = 1
...
while (!tlvReader.isEndOfContainer()) {
      val tag = tlvReader.peekElement().tag

      if (tag == ContextSpecificTag(TAG_TOTO)) {
         // assigning data to a value here
      } else if (tag == ContextSpecificTag(TAG_TATA)) {
        // assigning data to a value here
      } else {
        tlvReader.skipElement()
      }
}
...
```

#### Testing
The generated Kotlin Clusters are in the second commit in this PR.
As the reviewers can see, the generated code is the expected behavior.