### PR TITLE
[SU] TC_SUTestBase add a method to delete the provider KVS

### DIFF
--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -311,7 +311,7 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             attributes=[(0, acl_attribute)]
         )
 
-    def clear_kvs(self, kvs_path_prefix: str = None):
+    def clear_kvs(self, kvs_path_prefix: Optional[str] = "/tmp/chip_kvs"):
         """
         Remove all temporary KVS files created.
 
@@ -322,8 +322,9 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             kvs_path_prefix (str, optional): Prefix of KVS files/folders to remove.
             Defaults to "/tmp/chip_kvs", which removes all temporary chip KVS files.
         """
-
-        if kvs_path_prefix is None:
-            kvs_path_prefix = "/tmp/chip_kvs"
+        # Do not allow relative paths or paths outside of /tmp/
+        if not kvs_path_prefix.startswith('/tmp/'):
+            raise ValueError(
+                f"kvs_path_prefix must be an absolute path starting with /tmp/, but was: {kvs_path_prefix}")
         subprocess.run(f"rm -rf {kvs_path_prefix}*", shell=True)
         log.info(f"Removed all KVS files/folders with prefix: {kvs_path_prefix}")

--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -309,3 +309,21 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             nodeId=provider_node_id,
             attributes=[(0, acl_attribute)]
         )
+
+    def clear_kvs(self, kvs_path_prefix: str = None):
+        """
+        Remove all temporary KVS files matching a given prefix.
+
+        Args:
+            kvs_path_prefix (str, optional): Prefix of KVS files/folders to remove.
+            Defaults to "/tmp/chip_kvs", which removes all temporary chip KVS files
+
+        Returns:
+            None
+        """
+        import subprocess
+
+        if kvs_path_prefix is None:
+            kvs_path_prefix = "/tmp/chip_kvs"
+        subprocess.run(f"rm -rf {kvs_path_prefix}*", shell=True)
+        log.info(f"Removed all KVS files/folders with prefix: {kvs_path_prefix}")

--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -16,6 +16,7 @@
 
 
 import logging
+import subprocess
 import tempfile
 from os import path
 from typing import Optional
@@ -312,7 +313,10 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
 
     def clear_kvs(self, kvs_path_prefix: str = None):
         """
-        Remove all temporary KVS files matching a given prefix.
+        Remove all temporary KVS files created.
+
+        OTA Provider/Requestor use "/tmp/chip_kvs" as the default KVS location when no --KVS is provided. 
+        Tests may also specify custom prefixes such as "/tmp/chip_kvs_provider".
 
         Args:
             kvs_path_prefix (str, optional): Prefix of KVS files/folders to remove.
@@ -321,7 +325,6 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
         Returns:
             None
         """
-        import subprocess
 
         if kvs_path_prefix is None:
             kvs_path_prefix = "/tmp/chip_kvs"

--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -315,7 +315,7 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
         """
         Remove all temporary KVS files created.
 
-        OTA Provider/Requestor use "/tmp/chip_kvs" as the default KVS location when no --KVS is provided. 
+        OTA Provider/Requestor use "/tmp/chip_kvs" as the default KVS location when no --KVS is provided.
         Tests may also specify custom prefixes such as "/tmp/chip_kvs_provider".
 
         Args:

--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -326,5 +326,5 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
         if not kvs_path_prefix.startswith('/tmp/'):
             raise ValueError(
                 f"kvs_path_prefix must be an absolute path starting with /tmp/, but was: {kvs_path_prefix}")
-        subprocess.run(f"rm -rf {kvs_path_prefix}*", shell=True)
+        subprocess.run(['rm', '-rf', f'{kvs_path_prefix}*'])
         log.info(f"Removed all KVS files/folders with prefix: {kvs_path_prefix}")

--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -320,10 +320,7 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
 
         Args:
             kvs_path_prefix (str, optional): Prefix of KVS files/folders to remove.
-            Defaults to "/tmp/chip_kvs", which removes all temporary chip KVS files
-
-        Returns:
-            None
+            Defaults to "/tmp/chip_kvs", which removes all temporary chip KVS files.
         """
 
         if kvs_path_prefix is None:

--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -311,7 +311,7 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             attributes=[(0, acl_attribute)]
         )
 
-    def clear_kvs(self, kvs_path_prefix: Optional[str] = "/tmp/chip_kvs"):
+    def clear_kvs(self, kvs_path_prefix: str = "/tmp/chip_kvs"):
         """
         Remove all temporary KVS files created.
 
@@ -323,8 +323,9 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             Defaults to "/tmp/chip_kvs", which removes all temporary chip KVS files.
         """
         # Do not allow relative paths or paths outside of /tmp/
-        if not kvs_path_prefix.startswith('/tmp/'):
+        real_kvs_path_prefix = path.realpath(kvs_path_prefix)
+        if not real_kvs_path_prefix.startswith('/tmp/'):
             raise ValueError(
                 f"kvs_path_prefix must be an absolute path starting with /tmp/, but was: {kvs_path_prefix}")
-        subprocess.run(['rm', '-rf', f'{kvs_path_prefix}*'])
-        log.info(f"Removed all KVS files/folders with prefix: {kvs_path_prefix}")
+        subprocess.run(['rm', '-rf', f'{real_kvs_path_prefix}*'])
+        log.info(f"Removed all KVS files/folders with prefix: {real_kvs_path_prefix}")

--- a/src/python_testing/TC_SUTestBase.py
+++ b/src/python_testing/TC_SUTestBase.py
@@ -156,7 +156,7 @@ class SoftwareUpdateBaseTest(MatterBaseTest):
             controller (ChipDeviceCtrl): Controller to write the providers.
             provider_node_id (int): Node where the provider is located.
             requestor_node_id (int): Node of the requestor to write the providers.
-            endpoint (int, optional): Endpoint to write the providerss. Defaults to 0.
+            endpoint (int, optional): Endpoint to write the providers. Defaults to 0.
         """
 
         current_otap_info = await self.read_single_attribute_check_success(


### PR DESCRIPTION
### Summary

This PR is focused on following the feedback from https://github.com/project-chip/connectedhomeip/pull/40366, the following generic logic should be moved out of TC-SU-2.2 and centralized into the base class so it can be reused by SU 2.3, 2.5, 2.7 and/or others:

Fixes: https://github.com/project-chip/matter-test-scripts/issues/741

### Scope
Add `clear_kvs()` function to clean the provider KVS at the end of the test (`teardown_test`). This ensures the test can run multiple times without leftover KVS affecting results.

Feedback link https://github.com/project-chip/connectedhomeip/pull/40366/files#r2566109730

Should be self.KVS_PATH
Feedback link https://github.com/project-chip/connectedhomeip/pull/40366#discussion_r2578968523

### Related Issues & PRs
[TC-SU-all: Consolidate updates #654](https://github.com/project-chip/matter-test-scripts/issues/654)
[TC-SU-2.2 python test #40366](https://github.com/project-chip/connectedhomeip/pull/40366)

#### Testing
To run the automated TC-SU-2.2 test, keep in mind to setup the prerequisites fro SU OTA and the ota file

#### Run Test
**Option 1**
```bash
# Launch OTA Requestor from Terminal 1:
./out/debug/chip-ota-requestor-app --discriminator 1234 --passcode 20202021 --KVS /tmp/chip_kvs_requestor

# Launch Python test from Terminal 2:
python3 src/python_testing/TC_SU_2_2.py \
  --commissioning-method on-network \
  --discriminator 1234 \
  --passcode 20202021 \
  --string-arg provider_app_path:out/debug/chip-ota-provider-app \
  --string-arg ota_image:firmware_requestor_v2.ota
```

**Option 2**
```bash
# Launch OTA Requestor from Terminal 1:
./out/debug/chip-ota-requestor-app --discriminator 1234 --passcode 20202021 --KVS /tmp/chip_kvs_requestor

# Launch Python test from Terminal 2:
python3 scripts/tests/run_python_test.py \
  --load-from-env /tmp/test_env.yaml \
  --script src/python_testing/TC_SU_2_2.py

# Create file ../tmp/test_env.yaml
OTA_REQUESTOR_APP: out/debug/chip-ota-requestor-app
OTA_PROVIDER_APP: out/debug/chip-ota-provider-app
SU_OTA_REQUESTOR_V2: firmware_requestor_v2min.ota
TRACE_APP: out/trace_data/app_TC_SU_2_2
TRACE_TEST_JSON: out/trace_data/test_TC_SU_2_2.json
TRACE_TEST_PERFETTO: out/trace_data/test_TC_SU_2_2.perfetto
BUILD_VARIANT: debug
KVS_PATH: /tmp/chip_kvs_requestor

```


