### PR TITLE
[Telink] Add NDEF and overlay for NFC module & Update builds to docker version 177

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
 
         steps:
             - name: Checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -153,7 +153,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -326,7 +326,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -389,7 +389,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -515,7 +515,7 @@ jobs:
         runs-on: namespace-profile-4x8
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=0 net.ipv6.conf.all.forwarding=0"
 

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - "/:/runner-root-volume"
             options: --user root
@@ -60,7 +60,7 @@ jobs:
         timeout-minutes: 90
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             options: >-
                 --privileged
                 --sysctl net.ipv6.conf.all.disable_ipv6=0
@@ -98,7 +98,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:175
+            image: ghcr.io/project-chip/chip-build-esp32:177
             volumes:
                 - "/:/runner-root-volume"
             options: --user root
@@ -122,7 +122,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nrf-platform:175
+            image: ghcr.io/project-chip/chip-build-nrf-platform:177
             volumes:
                 - "/:/runner-root-volume"
             options: --user root
@@ -145,7 +145,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-telink:175
+            image: ghcr.io/project-chip/chip-build-telink:177
             volumes:
                 - "/:/runner-root-volume"
             options: --user root

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -84,7 +84,7 @@ jobs:
 
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/project-chip/chip-build-doxygen:175
+            image: ghcr.io/project-chip/chip-build-doxygen:177
 
         if: github.actor != 'restyled-io[bot]'
 

--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-ameba:175
+            image: ghcr.io/project-chip/chip-build-ameba:177
             options: --user root
 
         steps:

--- a/.github/workflows/examples-asr.yaml
+++ b/.github/workflows/examples-asr.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-asr:175
+            image: ghcr.io/project-chip/chip-build-asr:177
             options: --user root
 
         steps:

--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -38,7 +38,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build-bouffalolab:175
+      image: ghcr.io/project-chip/chip-build-bouffalolab:177
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
     steps:

--- a/.github/workflows/examples-cc13xx_26xx.yaml
+++ b/.github/workflows/examples-cc13xx_26xx.yaml
@@ -42,7 +42,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-ti:175
+            image: ghcr.io/project-chip/chip-build-ti:177
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/examples-cc32xx.yaml
+++ b/.github/workflows/examples-cc32xx.yaml
@@ -41,7 +41,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-ti:175
+            image: ghcr.io/project-chip/chip-build-ti:177
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -41,7 +41,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build-efr32:175
+      image: ghcr.io/project-chip/chip-build-efr32:177
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
     steps:

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:175
+            image: ghcr.io/project-chip/chip-build-esp32:177
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
@@ -178,7 +178,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]' &&  github.repository_owner == 'espressif'
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:175
+            image: ghcr.io/project-chip/chip-build-esp32:177
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-infineon:175
+            image: ghcr.io/project-chip/chip-build-infineon:177
             env:
                # TODO: this should probably be part of the dockerfile itself
                CY_TOOLS_PATHS: /opt/Tools/ModusToolbox/tools_3.2

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-crosscompile:175
+            image: ghcr.io/project-chip/chip-build-crosscompile:177
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-imx:175
+            image: ghcr.io/project-chip/chip-build-imx:177
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-linux-tv-casting-app.yaml
+++ b/.github/workflows/examples-linux-tv-casting-app.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nrf-platform:175
+            image: ghcr.io/project-chip/chip-build-nrf-platform:177
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/examples-nuttx.yaml
+++ b/.github/workflows/examples-nuttx.yaml
@@ -47,7 +47,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build-nuttx:175
+      image: ghcr.io/project-chip/chip-build-nuttx:177
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
     steps:

--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -43,7 +43,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp:175
+            image: ghcr.io/project-chip/chip-build-nxp:177
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:
@@ -153,7 +153,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp-zephyr:175
+            image: ghcr.io/project-chip/chip-build-nxp-zephyr:177
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-realtek.yaml
+++ b/.github/workflows/examples-realtek.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-stm32.yaml
+++ b/.github/workflows/examples-stm32.yaml
@@ -41,7 +41,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-telink:175
+            image: ghcr.io/project-chip/chip-build-telink:177
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
@@ -386,7 +386,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-telink-zephyr_3_3:175
+            image: ghcr.io/project-chip/chip-build-telink-zephyr_3_3:177
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-tizen:175
+            image: ghcr.io/project-chip/chip-build-tizen:177
             options: --user root
 
         steps:

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-android:175
+            image: ghcr.io/project-chip/chip-build-android:177
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -33,7 +33,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-java:175
+            image: ghcr.io/project-chip/chip-build-java:177
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=0 net.ipv6.conf.all.forwarding=0"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
 
         steps:
             - name: Checkout

--- a/.github/workflows/minimal-build.yaml
+++ b/.github/workflows/minimal-build.yaml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-minimal:175
+            image: ghcr.io/project-chip/chip-build-minimal:177
 
         steps:
             - name: Checkout
@@ -56,7 +56,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-minimal:175
+            image: ghcr.io/project-chip/chip-build-minimal:177
 
         steps:
             - name: Checkout

--- a/.github/workflows/mypy-validation.yml
+++ b/.github/workflows/mypy-validation.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build:175
+      image: ghcr.io/project-chip/chip-build:177
       options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
 
     steps:

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -79,7 +79,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-tizen-qemu:175
+            image: ghcr.io/project-chip/chip-build-tizen-qemu:177
             options: --user root
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:175
+            image: ghcr.io/project-chip/chip-build-esp32:177
 
         steps:
             - name: Checkout
@@ -64,7 +64,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-efr32:175
+            image: ghcr.io/project-chip/chip-build-efr32:177
         steps:
             - name: Checkout
               uses: actions/checkout@v5

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-android:175
+            image: ghcr.io/project-chip/chip-build-android:177
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             options: >-
                 --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
@@ -626,7 +626,7 @@ jobs:
         runs-on: namespace-profile-16x32
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - /var/run/nsc/:/var/run/nsc/
             env:
@@ -887,7 +887,7 @@ jobs:
         runs-on: namespace-profile-1x2
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - /var/run/nsc/:/var/run/nsc/
             env:

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -40,7 +40,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -30,7 +30,7 @@ jobs:
 
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
         defaults:
             run:
                 shell: sh

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -35,7 +35,7 @@ jobs:
 
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/project-chip/chip-build:175
+            image: ghcr.io/project-chip/chip-build:177
         defaults:
             run:
                 shell: sh

--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -35,12 +35,7 @@ config CHIP_NFC_ONBOARDING_PAYLOAD
 	default n
 	imply I2C
 	imply ST25DVXXKC
-	imply NFC		
-	imply NFC_NDEF
-	imply NFC_NDEF_MSG
-	imply NFC_NDEF_RECORD
-	imply NFC_NDEF_URI_REC
-	imply NFC_NDEF_URI_MSG
+	imply NFC
 	help
 	  Enables sharing the onboarding payload in the NFC tag.
 

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -171,7 +171,7 @@ config BT_GATT_CACHING
 
 config BT_RX_STACK_SIZE
     default 1352 if BT_B9X || BT_TLX
-    default 896 if BT_W91
+    default 1024 if BT_W91
 
 config BT_HCI_TX_STACK_SIZE
     default 664 if BT_B9X || BT_TLX

--- a/examples/all-clusters-app/ameba/README.md
+++ b/examples/all-clusters-app/ameba/README.md
@@ -27,11 +27,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:175
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:177
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:175
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:177
 
 -   Setup build environment:
 

--- a/examples/all-clusters-minimal-app/ameba/README.md
+++ b/examples/all-clusters-minimal-app/ameba/README.md
@@ -27,13 +27,13 @@ The CHIP demo application is supported on
 -   Pull docker image:
 
           ```
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:175
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:177
           ```
 
 -   Run docker container:
 
           ```
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:175
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:177
           ```
 
 -   Setup build environment:

--- a/examples/camera-app/linux/README.md
+++ b/examples/camera-app/linux/README.md
@@ -78,7 +78,7 @@ environment to ensure all dependencies are correct.
 1. Pull the Cross-Compilation Docker Image
 
 ```
-docker pull ghcr.io/project-chip/chip-build-crosscompile:175
+docker pull ghcr.io/project-chip/chip-build-crosscompile:177
 ```
 
 2. Run the Docker Container This command starts an interactive shell inside the
@@ -86,7 +86,7 @@ docker pull ghcr.io/project-chip/chip-build-crosscompile:175
    container's /var/connectedhomeip directory.
 
 ```
-docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:175 /bin/bash
+docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:177 /bin/bash
 ```
 
 3. Build Inside the Container From within the Docker container's shell, execute

--- a/examples/camera-controller/README.md
+++ b/examples/camera-controller/README.md
@@ -95,7 +95,7 @@ environment to ensure all dependencies are correct.
 1. Pull the Cross-Compilation Docker Image
 
 ```
-docker pull ghcr.io/project-chip/chip-build-crosscompile:175
+docker pull ghcr.io/project-chip/chip-build-crosscompile:177
 ```
 
 2. Run the Docker Container This command starts an interactive shell inside the
@@ -103,7 +103,7 @@ docker pull ghcr.io/project-chip/chip-build-crosscompile:175
    container's /var/connectedhomeip directory.
 
 ```
-docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:175 /bin/bash
+docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:177 /bin/bash
 ```
 
 3. Build Inside the Container From within the Docker container's shell, execute

--- a/examples/chef/tests/README.md
+++ b/examples/chef/tests/README.md
@@ -22,7 +22,7 @@ shows all chef tests run in CI.
    container.
 
 ```
-docker run -it --rm ghcr.io/project-chip/chip-build:175 /bin/bash
+docker run -it --rm ghcr.io/project-chip/chip-build:177 /bin/bash
 ```
 
 Run the remaining commands inside the container.

--- a/examples/fabric-admin/README.md
+++ b/examples/fabric-admin/README.md
@@ -23,13 +23,13 @@ For Raspberry Pi 4 example:
 ### Pull Docker Images
 
 ```
-docker pull ghcr.io/project-chip/chip-build-crosscompile:175
+docker pull ghcr.io/project-chip/chip-build-crosscompile:177
 ```
 
 ### Run docker
 
 ```
-docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:175 /bin/bash
+docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:177 /bin/bash
 ```
 
 ### Build

--- a/examples/fabric-bridge-app/linux/README.md
+++ b/examples/fabric-bridge-app/linux/README.md
@@ -100,13 +100,13 @@ defined:
     Pull Docker Images
 
     ```
-    docker pull ghcr.io/project-chip/chip-build-crosscompile:175
+    docker pull ghcr.io/project-chip/chip-build-crosscompile:177
     ```
 
     Run docker
 
     ```
-    docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:175 /bin/bash
+    docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:177 /bin/bash
     ```
 
     Build

--- a/examples/fabric-sync/README.md
+++ b/examples/fabric-sync/README.md
@@ -92,13 +92,13 @@ defined:
     Pull Docker Images
 
     ```sh
-    docker pull ghcr.io/project-chip/chip-build-crosscompile:175
+    docker pull ghcr.io/project-chip/chip-build-crosscompile:177
     ```
 
     Run docker
 
     ```sh
-    docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:175 /bin/bash
+    docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:177 /bin/bash
     ```
 
     Build

--- a/examples/light-switch-app/ameba/README.md
+++ b/examples/light-switch-app/ameba/README.md
@@ -26,11 +26,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:175
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:177
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:175
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:177
 
 -   Setup build environment:
 

--- a/examples/lighting-app/ameba/README.md
+++ b/examples/lighting-app/ameba/README.md
@@ -23,11 +23,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:175
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:177
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:175
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:177
 
 -   Setup build environment:
 

--- a/examples/lighting-app/realtek/zephyr/README.md
+++ b/examples/lighting-app/realtek/zephyr/README.md
@@ -49,13 +49,13 @@ sudo apt-get install git gcc g++ pkg-config libssl-dev libdbus-1-dev libglib2.0-
 -   Step 1: Pull docker image
 
     ```bash
-    $ docker pull ghcr.io/project-chip/chip-build-realtek-zephyr:175
+    $ docker pull ghcr.io/project-chip/chip-build-realtek-zephyr:177
     ```
 
 -   Step 2: Run docker container:
 
     ```bash
-    $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-realtek-zephyr:175
+    $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-realtek-zephyr:177
     ```
 
 -   Step 3: Activate build environment

--- a/examples/ota-requestor-app/ameba/README.md
+++ b/examples/ota-requestor-app/ameba/README.md
@@ -6,11 +6,11 @@ A prototype application that demonstrates OTA Requestor capabilities.
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:175
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:177
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:175
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:177
 
 -   Setup build environment:
 

--- a/examples/pigweed-app/ameba/README.md
+++ b/examples/pigweed-app/ameba/README.md
@@ -31,11 +31,11 @@ following features are available:
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:175
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:177
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:175
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:177
 
 -   Setup build environment:
 

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -23,7 +23,7 @@ steps:
           - name: pwenv
             path: /pwenv
       timeout: 900s
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -39,7 +39,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       # ICD device is currently not supported for ESP32 and NRF targets. New rule to compile only ICD
       # linux binary.
       env:
@@ -54,7 +54,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
       #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
@@ -24,7 +24,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -45,7 +45,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -66,7 +66,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -87,7 +87,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -140,7 +140,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:175"
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv

--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -1199,7 +1199,7 @@ def chip_tool_tests(
     # This likely should be run in docker to not allow breaking things
     # run as:
     #
-    # docker run --rm -it -v ~/devel/connectedhomeip:/workspace --privileged ghcr.io/project-chip/chip-build-vscode:175
+    # docker run --rm -it -v ~/devel/connectedhomeip:/workspace --privileged ghcr.io/project-chip/chip-build-vscode:177
     runner = __RUNNERS__[runner]
 
     # make sure we are fully aware if running with or without coverage

--- a/src/platform/telink/NFCOnboardingPayloadManagerImpl.cpp
+++ b/src/platform/telink/NFCOnboardingPayloadManagerImpl.cpp
@@ -21,8 +21,8 @@
 
 #include <lib/support/logging/CHIPLogging.h>
 
-#include <zephyr/kernel.h>
 #include <zephyr/drivers/nfc/nfc_tag.h>
+#include <zephyr/kernel.h>
 
 void nfc_callback(const struct device * dev, enum nfc_tag_event event, const uint8_t * data, size_t data_len)
 {
@@ -114,23 +114,24 @@ CHIP_ERROR NFCOnboardingPayloadManagerImpl::_StopTagEmulation()
     return CHIP_NO_ERROR;
 }
 
-size_t NFCOnboardingPayloadManagerImpl::_EncodeNDEFURI(const uint8_t* uri, size_t uri_len, uint8_t* out_buf)
+size_t NFCOnboardingPayloadManagerImpl::_EncodeNDEFURI(const uint8_t * uri, size_t uri_len, uint8_t * out_buf)
 {
     size_t max_len = 128;
     // NDEF Record Header for short record, TNF = Well Known, Type = 'U'
-    const uint8_t type_field = 'U';
-    const uint8_t tnf = 0xD1; // MB=1, ME=1, SR=1, TNF=1
+    const uint8_t type_field     = 'U';
+    const uint8_t tnf            = 0xD1; // MB=1, ME=1, SR=1, TNF=1
     const uint8_t payload_prefix = 0x00; // No prefix, full URI follows
 
-    if (max_len < 5 + uri_len) {
+    if (max_len < 5 + uri_len)
+    {
         ChipLogError(DeviceLayer, "NDEF message is too long, (5 + uri_len) required for TNF URI NDEF record");
         return 0;
     }
 
-    size_t offset = 0;
+    size_t offset     = 0;
     out_buf[offset++] = tnf;
-    out_buf[offset++] = 1;               // Type length
-    out_buf[offset++] = uri_len + 1;     // Payload length (1 prefix + uri)
+    out_buf[offset++] = 1;           // Type length
+    out_buf[offset++] = uri_len + 1; // Payload length (1 prefix + uri)
     out_buf[offset++] = type_field;
     out_buf[offset++] = payload_prefix;
     memcpy(out_buf + offset, uri, uri_len);

--- a/src/platform/telink/NFCOnboardingPayloadManagerImpl.h
+++ b/src/platform/telink/NFCOnboardingPayloadManagerImpl.h
@@ -37,6 +37,7 @@ private:
     CHIP_ERROR _StartTagEmulation(const char * payload, size_t payloadLength);
     CHIP_ERROR _StopTagEmulation();
     bool _IsTagEmulationStarted() const { return mIsStarted; };
+    size_t _EncodeNDEFURI(const uint8_t* uri, size_t uri_len, uint8_t* out_buf);
 
     // ===== Members for internal use by this class.
     bool mIsStarted;

--- a/src/platform/telink/NFCOnboardingPayloadManagerImpl.h
+++ b/src/platform/telink/NFCOnboardingPayloadManagerImpl.h
@@ -37,7 +37,7 @@ private:
     CHIP_ERROR _StartTagEmulation(const char * payload, size_t payloadLength);
     CHIP_ERROR _StopTagEmulation();
     bool _IsTagEmulationStarted() const { return mIsStarted; };
-    size_t _EncodeNDEFURI(const uint8_t* uri, size_t uri_len, uint8_t* out_buf);
+    size_t _EncodeNDEFURI(const uint8_t * uri, size_t uri_len, uint8_t * out_buf);
 
     // ===== Members for internal use by this class.
     bool mIsStarted;

--- a/src/platform/telink/st25dvxxkc.overlay
+++ b/src/platform/telink/st25dvxxkc.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		i2c = &i2c;
+	};
+};
+
+&i2c {
+	status = "okay";
+	/* in datasheet it's 0x53, 0x57 but addresses shift so here's what works with module */
+	st25dvxxkc: st25dvxxkc@a6 {
+		compatible = "st,st25dvxxkc";
+		zephyr,deferred-init;
+		status = "okay";
+		reg = <0xa6>, <0xae>;
+	};
+};

--- a/src/test_driver/tizen/README.md
+++ b/src/test_driver/tizen/README.md
@@ -12,7 +12,7 @@ image from hub.docker.com or build it locally using the provided Dockerfile in
 
 ```sh
 # Pull the image from hub.docker.com
-docker pull ghcr.io/project-chip/chip-build-tizen-qemu:175
+docker pull ghcr.io/project-chip/chip-build-tizen-qemu:177
 ```
 
 ## Building and Running Tests on QEMU
@@ -21,7 +21,7 @@ All steps described below should be done inside the docker container.
 
 ```sh
 docker run -it --rm --name chip-tizen-qemu \
-    ghcr.io/project-chip/chip-build-tizen-qemu:175 /bin/bash
+    ghcr.io/project-chip/chip-build-tizen-qemu:177 /bin/bash
 ```
 
 ### Clone the connectedhomeip repository


### PR DESCRIPTION
#### Summary

- Update compatible Docker builds version 175->177  #42345 


NDEF now in form of single function.
Removed all license-issue code from Zephyr already.

Introduced NFC module overlay.
Now NFC config can be built with:
```
west build -b tlsr9528a -- -DDTC_OVERLAY_FILE="./../../../src/platform/telink/st25dvxxkc.overlay"
```
Of course with CONFIG_CHIP_NFC_ONBOARDING_PAYLOAD set to `=Y`

As APPLICATION init priority of Zephyr drivers is now deprecated in v4.1, deffered-init introduced instead for init from app(src/platform/telink/NFCOnboardingPayloadManagerImpl.cpp). This commit fixes NFC usage for onboarding payload on Telink platform.

**NOTE**: using ST25DV module you should take care about external 4k7 Ohm pullups for SDA/SCL.

**Minors:**
- Increased default BT_RX_STACK_SIZE for W91

#### Testing

- Tested NFC manually with Apple Home on B92
- BT_RX_STACK_SIZE change tested manually with W91