### PR TITLE
Making Restyle-diff script use Restyle CLI instead of the deprecated Restyler Docker image

### DIFF
--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -48,7 +48,7 @@ restyle-paths() {
 
     echo
     echo "[restyle-diff.sh] Restoring file ownership to current user (sudo required)"
-    sudo chown "$uid:$gid" "$@"
+    sudo chown -h "$uid:$gid" "$@"
 }
 
 if ! command -v restyle >/dev/null 2>&1; then

--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -82,10 +82,6 @@ if [[ -z "$ref" ]]; then
     git remote | grep -qxF upstream && ref="upstream/master"
 fi
 
-if [[ $pull_image -eq 1 ]]; then
-    docker pull restyled/restyler:edge
-fi
-
 paths=$(git diff --ignore-submodules --name-only --merge-base "$ref")
 
 echo "$paths" | xargs -n "$MAX_ARGS" "$BASH" -c 'restyle-paths "$@"' -

--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -73,7 +73,6 @@ ensure_restyle_installed() {
     tmpdir=$(mktemp -d)
     trap 'rm -rf "$tmpdir"' EXIT
 
-
     if ! curl -sSfL "https://github.com/restyled-io/restyler/releases/latest/download/$asset.tar.gz" | tar xz -C "$tmpdir"; then
         echo "[restyle-diff.sh] Failed to download restyle for $(uname -s)-$(uname -m)"
         echo "[restyle-diff.sh] Check available binaries at: https://github.com/restyled-io/restyler/releases"

--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -27,8 +27,8 @@
 # -d enables debug logging for Restyle CLI
 #
 # Note: This script requires sudo to restore file ownership after restyle
-#  (which uses Docker and changes ownership of restyled files to root); You can either run the
-#  script directly and be prompted for sudo, or run it with sudo.
+#  (which uses Docker and changes ownership of restyled files to root). Run this script as a regular user;
+#  it will prompt for sudo only when needed to restore file ownership.
 
 here=${0%/*}
 
@@ -49,7 +49,7 @@ restyle-paths() {
 
     echo
     echo "[restyle-diff.sh] Restoring file ownership to current user (sudo required)"
-    sudo chown -h "$uid:$gid" "$@"
+    sudo chown -h "$uid:$gid" -- "$@"
 }
 
 ensure_restyle_installed() {
@@ -79,10 +79,10 @@ ensure_restyle_installed() {
         exit 1
     fi
 
-    echo "[restyle-diff.sh] Installing restyle to ""$HOME/.local/bin"
+    echo "[restyle-diff.sh] Installing restyle to $HOME/.local/bin"
     mkdir -p "$HOME/.local/bin"
     install "$tmpdir/$asset/restyle" "$HOME/.local/bin"
-    rm -rf "$tmpdir"
+    export PATH="$HOME/.local/bin:$PATH"
 
 }
 

--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -44,7 +44,7 @@ restyle-paths() {
     local uid="${SUDO_UID:-$(id -u)}"
     local gid="${SUDO_GID:-$(id -g)}"
 
-    echo "[restyle-diff.sh] Please wait, Restyling files (and Pulling restyler docker images if needed)"
+    echo "[restyle-diff.sh] Please wait, Restyling files (and Pulling restyler Docker images if needed)"
     restyle --config-file=.restyled.yaml "$@"
 
     echo
@@ -71,6 +71,8 @@ ensure_restyle_installed() {
     esac
 
     tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
 
     if ! curl -sSfL "https://github.com/restyled-io/restyler/releases/latest/download/$asset.tar.gz" | tar xz -C "$tmpdir"; then
         echo "[restyle-diff.sh] Failed to download restyle for $(uname -s)-$(uname -m)"
@@ -78,13 +80,14 @@ ensure_restyle_installed() {
         exit 1
     fi
 
-    echo "[restyle-diff.sh] Installing restyle to /usr/local/bin (sudo required)..."
-    sudo install "$tmpdir/$asset/restyle" /usr/local/bin/restyle
+    echo "[restyle-diff.sh] Installing restyle to ""$HOME/.local/bin"
+    mkdir -p "$HOME/.local/bin"
+    install "$tmpdir/$asset/restyle" "$HOME/.local/bin"
     rm -rf "$tmpdir"
 
 }
 
-#This was added to be able to use xargs to call the function restyle-paths
+# This was added to be able to use xargs to call the function restyle-paths
 export -f restyle-paths
 while [[ $# -gt 0 ]]; do
     case "$1" in


### PR DESCRIPTION

#### Summary

- After Updating locally to Docker V29, `restyler-diff.sh` started failing locally  since  the `restyler` docker image is outdated and uses Docker API version 1.27 which was deprecated by Docker V29.


##### Fix

- Making Restyle-diff script use Restyle CLI instead of the deprecated "global" `restyler` docker image

- Making script restore file ownership after restyling which was always a pain

#### Related issues

- https://github.com/restyled-io/restyler/issues/308

#### Testing

Tested Locally 


