### PR TITLE
[TC_AccessChecker] Add clearer logs when global attributes are missing.

### DIFF
--- a/src/python_testing/TC_AccessChecker.py
+++ b/src/python_testing/TC_AccessChecker.py
@@ -169,7 +169,7 @@ class AccessChecker(BasicCompositionTests):
                     cmds[cluster_id] = set()
 
                 if GlobalAttributeIds.ATTRIBUTE_LIST_ID not in device_cluster_data:
-                    location = ClusterPathLocation(endpoint_id=0, cluster_id=cluster_id)
+                    location = ClusterPathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id)
                     self.record_error(test_name="Access Checker", location=location,
                                       problem="Cluster does not have the AttributeList attribute")
                 else:
@@ -178,7 +178,7 @@ class AccessChecker(BasicCompositionTests):
                         {id for id in device_cluster_data[GlobalAttributeIds.ATTRIBUTE_LIST_ID] if is_standard_attribute_id(id)})
 
                 if GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID not in device_cluster_data:
-                    location = ClusterPathLocation(endpoint_id=0, cluster_id=cluster_id)
+                    location = ClusterPathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id)
                     self.record_error(test_name="Access Checker", location=location,
                                       problem="Cluster does not have the AcceptedCommandList attribute")
                 else:

--- a/src/python_testing/TC_AccessChecker.py
+++ b/src/python_testing/TC_AccessChecker.py
@@ -167,11 +167,23 @@ class AccessChecker(BasicCompositionTests):
                     attrs[cluster_id] = set()
                 if cluster_id not in cmds:
                     cmds[cluster_id] = set()
-                # discard MEI attributes as we do not have access information for them.
-                attrs[cluster_id].update(
-                    {id for id in device_cluster_data[GlobalAttributeIds.ATTRIBUTE_LIST_ID] if is_standard_attribute_id(id)})
-                cmds[cluster_id].update(
-                    {id for id in device_cluster_data[GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID] if is_standard_command_id(id)})
+
+                if GlobalAttributeIds.ATTRIBUTE_LIST_ID not in device_cluster_data:
+                    location = ClusterPathLocation(endpoint_id=0, cluster_id=cluster_id)
+                    self.record_error(test_name="Access Checker", location=location,
+                                      problem="Cluster does not have the AttributeList attribute")
+                else:
+                    # discard MEI attributes as we do not have access information for them.
+                    attrs[cluster_id].update(
+                        {id for id in device_cluster_data[GlobalAttributeIds.ATTRIBUTE_LIST_ID] if is_standard_attribute_id(id)})
+
+                if GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID not in device_cluster_data:
+                    location = ClusterPathLocation(endpoint_id=0, cluster_id=cluster_id)
+                    self.record_error(test_name="Access Checker", location=location,
+                                      problem="Cluster does not have the AcceptedCommandList attribute")
+                else:
+                    cmds[cluster_id].update(
+                        {id for id in device_cluster_data[GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID] if is_standard_command_id(id)})
 
         # Remove MEI clusters - we don't have information available to check these.
         all_clusters = [id for id in all_clusters if is_standard_cluster_id(id)]


### PR DESCRIPTION

#### Summary

This is a convenience change: if global attributes are missing, access checker errors are hard to read. this makes them easy to read.

Before this, if global attributes are missing, we get an exception of 'missing key' which is harder to understand.

#### Testing

Locally checked that the error messages look reasonable.
In CI we should see no behaviour changes.