### PR TITLE
[Tizen] Replace TizenToChipError with MATTER_PLATFORM_ERROR

### DIFF
--- a/src/platform/Tizen/AppPreference.cpp
+++ b/src/platform/Tizen/AppPreference.cpp
@@ -32,6 +32,7 @@
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/PlatformError.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Tizen/AppPreference.cpp
+++ b/src/platform/Tizen/AppPreference.cpp
@@ -33,10 +33,6 @@
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
 
-#include "ErrorUtils.h"
-
-using chip::DeviceLayer::Internal::TizenToChipError;
-
 namespace chip {
 namespace DeviceLayer {
 namespace PersistedStorage {
@@ -62,9 +58,10 @@ CHIP_ERROR GetData(const char * key, void * data, size_t dataSize, size_t * getD
     int err = preference_get_string(key, &encodedData);
     if (err != PREFERENCE_ERROR_NONE)
     {
-        if (err != PREFERENCE_ERROR_NO_KEY)
-            ChipLogError(DeviceLayer, "Failed to get preference [%s]: %s", StringOrNullMarker(key), get_error_message(err));
-        return TizenToChipError(err);
+        if (err == PREFERENCE_ERROR_NO_KEY)
+            return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+        ChipLogError(DeviceLayer, "Failed to get preference [%s]: %s", StringOrNullMarker(key), get_error_message(err));
+        return MATTER_PLATFORM_ERROR(err);
     }
 
     size_t encodedDataSize = strlen(encodedData);
@@ -102,7 +99,7 @@ CHIP_ERROR SaveData(const char * key, const void * data, size_t dataSize)
 
     int err = preference_set_string(key, encodedData.Get());
     VerifyOrReturnError(
-        err == PREFERENCE_ERROR_NONE, TizenToChipError(err),
+        err == PREFERENCE_ERROR_NONE, MATTER_PLATFORM_ERROR(err),
         ChipLogError(DeviceLayer, "Failed to set preference [%s]: %s", StringOrNullMarker(key), get_error_message(err)));
 
     ChipLogDetail(DeviceLayer, "Save preference data: key=%s len=%u", key, static_cast<unsigned int>(dataSize));
@@ -116,9 +113,10 @@ CHIP_ERROR RemoveData(const char * key)
     int err = preference_remove(key);
     if (err != PREFERENCE_ERROR_NONE)
     {
-        if (err != PREFERENCE_ERROR_NO_KEY)
-            ChipLogError(DeviceLayer, "Failed to remove preference [%s]: %s", StringOrNullMarker(key), get_error_message(err));
-        return TizenToChipError(err);
+        if (err == PREFERENCE_ERROR_NO_KEY)
+            return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+        ChipLogError(DeviceLayer, "Failed to remove preference [%s]: %s", StringOrNullMarker(key), get_error_message(err));
+        return MATTER_PLATFORM_ERROR(err);
     }
 
     ChipLogProgress(DeviceLayer, "Remove preference data: key=%s", key);

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -65,7 +65,6 @@
 
 #include "CHIPDevicePlatformEvent.h"
 #include "ChipDeviceScanner.h"
-#include "ErrorUtils.h"
 #include "SystemInfo.h"
 
 namespace chip {
@@ -103,7 +102,7 @@ void BLEManagerImpl::GattConnectionStateChangedCb(int result, bool connected, co
     default:
         ChipLogError(DeviceLayer, "GATT %s failed: %s", connected ? "connection" : "disconnection", get_error_message(result));
         if (connected)
-            NotifyHandleConnectFailed(TizenToChipError(result));
+            NotifyHandleConnectFailed(MATTER_PLATFORM_ERROR(result));
     }
 }
 
@@ -136,7 +135,7 @@ CHIP_ERROR BLEManagerImpl::_InitImpl()
     return CHIP_NO_ERROR;
 
 exit:
-    return TizenToChipError(ret);
+    return MATTER_PLATFORM_ERROR(ret);
 }
 
 static int __GetAttInfo(bt_gatt_h gattHandle, char ** uuid, bt_gatt_type_e * type)
@@ -428,12 +427,12 @@ CHIP_ERROR BLEManagerImpl::ConnectChipThing(const char * address)
 
     ret = bt_gatt_client_create(address, &mGattClient);
     VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Failed to create GATT client: %s", get_error_message(ret));
-                 err = TizenToChipError(ret));
+                 err = MATTER_PLATFORM_ERROR(ret));
 
     ret = bt_gatt_connect(address, false);
     VerifyOrExit(ret == BT_ERROR_NONE,
                  ChipLogError(DeviceLayer, "Failed to issue GATT connect request: %s", get_error_message(ret));
-                 err = TizenToChipError(ret));
+                 err = MATTER_PLATFORM_ERROR(ret));
 
     ChipLogProgress(DeviceLayer, "GATT Connect Issued");
 
@@ -613,8 +612,8 @@ CHIP_ERROR BLEManagerImpl::RegisterGATTServer()
     return CHIP_NO_ERROR;
 
 exit:
-    NotifyBLEPeripheralGATTServerRegisterComplete(TizenToChipError(ret));
-    return TizenToChipError(ret);
+    NotifyBLEPeripheralGATTServerRegisterComplete(MATTER_PLATFORM_ERROR(ret));
+    return MATTER_PLATFORM_ERROR(ret);
 }
 
 CHIP_ERROR BLEManagerImpl::StartBLEAdvertising()
@@ -697,7 +696,7 @@ CHIP_ERROR BLEManagerImpl::StartBLEAdvertising()
     return CHIP_NO_ERROR;
 
 exit:
-    err = ret != BT_ERROR_NONE ? TizenToChipError(ret) : err;
+    err = ret != BT_ERROR_NONE ? MATTER_PLATFORM_ERROR(ret) : err;
     NotifyBLEPeripheralAdvStartComplete(err);
     return err;
 }
@@ -714,8 +713,8 @@ CHIP_ERROR BLEManagerImpl::StopBLEAdvertising()
     return CHIP_NO_ERROR;
 
 exit:
-    NotifyBLEPeripheralAdvStopComplete(TizenToChipError(ret));
-    return TizenToChipError(ret);
+    NotifyBLEPeripheralAdvStopComplete(MATTER_PLATFORM_ERROR(ret));
+    return MATTER_PLATFORM_ERROR(ret);
 }
 
 static bool __GattClientForeachCharCb(int total, int index, bt_gatt_h charHandle, void * data)
@@ -934,7 +933,7 @@ void BLEManagerImpl::DriveBLEState()
         int ret = bt_adapter_le_destroy_advertiser(mAdvertiser);
         VerifyOrExit(ret == BT_ERROR_NONE,
                      ChipLogError(DeviceLayer, "bt_adapter_le_destroy_advertiser() failed: %s", get_error_message(ret));
-                     err = TizenToChipError(ret));
+                     err = MATTER_PLATFORM_ERROR(ret));
         mAdvertiser = nullptr;
     }
 
@@ -1009,7 +1008,7 @@ CHIP_ERROR BLEManagerImpl::_GetDeviceName(char * buf, size_t bufSize)
 
     GAutoPtr<char> deviceName;
     int ret = bt_adapter_get_name(&deviceName.GetReceiver());
-    VerifyOrReturnError(ret == BT_ERROR_NONE, TizenToChipError(ret),
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
                         ChipLogError(DeviceLayer, "bt_adapter_get_name() failed: %s", get_error_message(ret)));
 
     VerifyOrReturnError(deviceName, CHIP_ERROR_INTERNAL);
@@ -1026,7 +1025,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
     VerifyOrReturnError(deviceName != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     int ret = bt_adapter_set_name(deviceName);
-    VerifyOrReturnError(ret == BT_ERROR_NONE, TizenToChipError(ret),
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
                         ChipLogError(DeviceLayer, "bt_adapter_set_name() failed: %s", get_error_message(ret)));
 
     return CHIP_NO_ERROR;
@@ -1159,7 +1158,7 @@ CHIP_ERROR BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, 
     NotifySubscribeOpComplete(conId, true);
 
 exit:
-    return TizenToChipError(ret);
+    return MATTER_PLATFORM_ERROR(ret);
 }
 
 CHIP_ERROR BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId,
@@ -1183,7 +1182,7 @@ CHIP_ERROR BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId
     NotifySubscribeOpComplete(conId, false);
 
 exit:
-    return TizenToChipError(ret);
+    return MATTER_PLATFORM_ERROR(ret);
 }
 
 CHIP_ERROR BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
@@ -1194,7 +1193,7 @@ CHIP_ERROR BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
 
     ChipLogProgress(DeviceLayer, "Send GATT disconnect to [%s]", conId->peerAddr.c_str());
     int ret = bt_gatt_disconnect(conId->peerAddr.c_str());
-    VerifyOrReturnError(ret == BT_ERROR_NONE, TizenToChipError(ret),
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
                         ChipLogError(DeviceLayer, "bt_gatt_disconnect() failed: %s", get_error_message(ret)));
 
     return CHIP_NO_ERROR;
@@ -1226,7 +1225,7 @@ CHIP_ERROR BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const Ble
         ChipLogError(DeviceLayer, "bt_gatt_server_notify_characteristic_changed_value() failed: %s", get_error_message(ret)));
 
 exit:
-    return TizenToChipError(ret);
+    return MATTER_PLATFORM_ERROR(ret);
 }
 
 CHIP_ERROR BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId,
@@ -1252,7 +1251,7 @@ CHIP_ERROR BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const B
                  ChipLogError(DeviceLayer, "bt_gatt_client_write_value() failed: %s", get_error_message(ret)));
 
 exit:
-    return TizenToChipError(ret);
+    return MATTER_PLATFORM_ERROR(ret);
 }
 
 void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId) {}

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -58,6 +58,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/GLibTypeDeleter.h>
+#include <platform/PlatformError.h>
 #include <platform/PlatformManager.h>
 #include <system/SystemClock.h>
 #include <system/SystemLayer.h>
@@ -111,31 +112,30 @@ CHIP_ERROR BLEManagerImpl::_InitImpl()
     int ret;
 
     ret = bt_initialize();
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_initialize() failed: %s", get_error_message(ret)));
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
+                        ChipLogError(DeviceLayer, "bt_initialize() failed: %s", get_error_message(ret)));
 
     ret = bt_adapter_set_state_changed_cb(
         +[](int result, bt_adapter_state_e adapterState, void * self) {
             return reinterpret_cast<BLEManagerImpl *>(self)->AdapterStateChangedCb(result, adapterState);
         },
         this);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_adapter_set_state_changed_cb() failed: %s", get_error_message(ret)));
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
+                        ChipLogError(DeviceLayer, "bt_adapter_set_state_changed_cb() failed: %s", get_error_message(ret)));
 
     ret = bt_gatt_server_initialize();
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_initialize() failed: %s", get_error_message(ret)));
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
+                        ChipLogError(DeviceLayer, "bt_gatt_server_initialize() failed: %s", get_error_message(ret)));
 
     ret = bt_gatt_set_connection_state_changed_cb(
         +[](int result, bool connected, const char * remoteAddress, void * self) {
             return reinterpret_cast<BLEManagerImpl *>(self)->GattConnectionStateChangedCb(result, connected, remoteAddress);
         },
         this);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_adapter_set_state_changed_cb() failed: %s", get_error_message(ret)));
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
+                        ChipLogError(DeviceLayer, "bt_adapter_set_state_changed_cb() failed: %s", get_error_message(ret)));
 
     return CHIP_NO_ERROR;
-
-exit:
-    return MATTER_PLATFORM_ERROR(ret);
 }
 
 static int __GetAttInfo(bt_gatt_h gattHandle, char ** uuid, bt_gatt_type_e * type)
@@ -612,8 +612,9 @@ CHIP_ERROR BLEManagerImpl::RegisterGATTServer()
     return CHIP_NO_ERROR;
 
 exit:
-    NotifyBLEPeripheralGATTServerRegisterComplete(MATTER_PLATFORM_ERROR(ret));
-    return MATTER_PLATFORM_ERROR(ret);
+    auto err = MATTER_PLATFORM_ERROR(ret);
+    NotifyBLEPeripheralGATTServerRegisterComplete(err);
+    return err;
 }
 
 CHIP_ERROR BLEManagerImpl::StartBLEAdvertising()
@@ -713,8 +714,9 @@ CHIP_ERROR BLEManagerImpl::StopBLEAdvertising()
     return CHIP_NO_ERROR;
 
 exit:
-    NotifyBLEPeripheralAdvStopComplete(MATTER_PLATFORM_ERROR(ret));
-    return MATTER_PLATFORM_ERROR(ret);
+    auto err = MATTER_PLATFORM_ERROR(ret);
+    NotifyBLEPeripheralAdvStopComplete(err);
+    return err;
 }
 
 static bool __GattClientForeachCharCb(int total, int index, bt_gatt_h charHandle, void * data)
@@ -1151,14 +1153,12 @@ CHIP_ERROR BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, 
 
     ChipLogProgress(DeviceLayer, "Sending Notification Enable Request to CHIP Peripheral: %s", conId->peerAddr.c_str());
     int ret = bt_gatt_client_set_characteristic_value_changed_cb(conId->gattCharC2Handle, CharacteristicIndicationCb, conId);
-    VerifyOrExit(
-        ret == BT_ERROR_NONE,
+    VerifyOrReturnError(
+        ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
         ChipLogError(DeviceLayer, "bt_gatt_client_set_characteristic_value_changed_cb() failed: %s", get_error_message(ret)));
 
     NotifySubscribeOpComplete(conId, true);
-
-exit:
-    return MATTER_PLATFORM_ERROR(ret);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId,
@@ -1175,14 +1175,12 @@ CHIP_ERROR BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId
 
     ChipLogProgress(DeviceLayer, "Disable Notification Request to CHIP Peripheral: %s", conId->peerAddr.c_str());
     int ret = bt_gatt_client_unset_characteristic_value_changed_cb(conId->gattCharC2Handle);
-    VerifyOrExit(
-        ret == BT_ERROR_NONE,
+    VerifyOrReturnError(
+        ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
         ChipLogError(DeviceLayer, "bt_gatt_client_unset_characteristic_value_changed_cb() failed: %s", get_error_message(ret)));
 
     NotifySubscribeOpComplete(conId, false);
-
-exit:
-    return MATTER_PLATFORM_ERROR(ret);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
@@ -1207,7 +1205,8 @@ CHIP_ERROR BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const Ble
     VerifyOrReturnError(CanCastTo<int>(pBuf->DataLength()), CHIP_ERROR_INTERNAL);
 
     int ret = bt_gatt_set_value(mGattCharC2Handle, Uint8::to_const_char(pBuf->Start()), static_cast<int>(pBuf->DataLength()));
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_set_value() failed: %s", get_error_message(ret)));
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
+                        ChipLogError(DeviceLayer, "bt_gatt_set_value() failed: %s", get_error_message(ret)));
 
     ChipLogProgress(DeviceLayer, "Sending indication for CHIPoBLE RX characteristic (con %s, len %u)", conId->peerAddr.c_str(),
                     static_cast<int>(pBuf->DataLength()));
@@ -1220,12 +1219,11 @@ CHIP_ERROR BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const Ble
                                                                                       completed);
         },
         conId->peerAddr.c_str(), this);
-    VerifyOrExit(
-        ret == BT_ERROR_NONE,
+    VerifyOrReturnError(
+        ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
         ChipLogError(DeviceLayer, "bt_gatt_server_notify_characteristic_changed_value() failed: %s", get_error_message(ret)));
 
-exit:
-    return MATTER_PLATFORM_ERROR(ret);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId,
@@ -1241,17 +1239,17 @@ CHIP_ERROR BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const B
     VerifyOrReturnError(CanCastTo<int>(pBuf->DataLength()), CHIP_ERROR_INTERNAL);
 
     int ret = bt_gatt_set_value(conId->gattCharC1Handle, Uint8::to_const_char(pBuf->Start()), static_cast<int>(pBuf->DataLength()));
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_set_value() failed: %s", get_error_message(ret)));
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
+                        ChipLogError(DeviceLayer, "bt_gatt_set_value() failed: %s", get_error_message(ret)));
 
     ChipLogProgress(DeviceLayer, "Sending Write Request for CHIPoBLE TX characteristic (con %s, len %u)", conId->peerAddr.c_str(),
                     static_cast<int>(pBuf->DataLength()));
 
     ret = bt_gatt_client_write_value(conId->gattCharC1Handle, WriteCompletedCb, conId);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_gatt_client_write_value() failed: %s", get_error_message(ret)));
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
+                        ChipLogError(DeviceLayer, "bt_gatt_client_write_value() failed: %s", get_error_message(ret)));
 
-exit:
-    return MATTER_PLATFORM_ERROR(ret);
+    return CHIP_NO_ERROR;
 }
 
 void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId) {}

--- a/src/platform/Tizen/CHIPPlatformConfig.h
+++ b/src/platform/Tizen/CHIPPlatformConfig.h
@@ -28,6 +28,9 @@
 
 #define CHIP_CONFIG_ABORT() abort()
 
+#define CHIP_CONFIG_ERROR_FORMAT_AS_STRING 1
+#define CHIP_CONFIG_ERROR_SOURCE 1
+
 // ==================== Security Adaptations ====================
 
 // ==================== General Configuration Overrides ====================

--- a/src/platform/Tizen/CHIPPlatformConfig.h
+++ b/src/platform/Tizen/CHIPPlatformConfig.h
@@ -28,9 +28,6 @@
 
 #define CHIP_CONFIG_ABORT() abort()
 
-#define CHIP_CONFIG_ERROR_FORMAT_AS_STRING 1
-#define CHIP_CONFIG_ERROR_SOURCE 1
-
 // ==================== Security Adaptations ====================
 
 // ==================== General Configuration Overrides ====================

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -38,8 +38,6 @@
 #include <platform/GLibTypeDeleter.h>
 #include <platform/PlatformManager.h>
 
-#include "ErrorUtils.h"
-
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -85,7 +83,7 @@ static bool __IsChipThingDevice(const bt_adapter_le_device_scan_result_info_s & 
 
 void ChipDeviceScanner::LeScanResultCb(int result, bt_adapter_le_device_scan_result_info_s * scanInfo)
 {
-    VerifyOrReturn(result == BT_ERROR_NONE, mDelegate->OnScanError(TizenToChipError(result)));
+    VerifyOrReturn(result == BT_ERROR_NONE, mDelegate->OnScanError(MATTER_PLATFORM_ERROR(result)));
     VerifyOrReturn(scanInfo != nullptr, mDelegate->OnScanError(CHIP_ERROR_INTERNAL));
 
     ChipLogProgress(DeviceLayer, "LE device reported: %s", scanInfo->remote_address);

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -36,6 +36,7 @@
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/GLibTypeDeleter.h>
+#include <platform/PlatformError.h>
 #include <platform/PlatformManager.h>
 
 namespace chip {

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -40,6 +40,7 @@
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/GLibTypeDeleter.h>
+#include <platform/PlatformError.h>
 #include <platform/PlatformManager.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/Tizen/ErrorUtils.cpp
+++ b/src/platform/Tizen/ErrorUtils.cpp
@@ -17,12 +17,46 @@
 
 #include "ErrorUtils.h"
 
+#include <lib/core/CHIPError.h>
+#include <lib/core/ErrorStr.h>
+#include <platform/PlatformError.h>
+
 #include <app_preference.h>
 #include <dns-sd.h>
+#include <tizen.h>
 
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
+
+namespace {
+
+bool FormatTizenPlatformError(char * buf, uint16_t bufSize, CHIP_ERROR err)
+{
+    if (!err.IsRange(ChipError::Range::kPlatformExtended))
+    {
+        return false;
+    }
+
+    const char * desc = nullptr;
+#if !CHIP_CONFIG_SHORT_ERROR_STR
+    // The get_error_message() returns a pointer to a thread local storage. Subsequent
+    // call will override it, however, FormatError() should consume it before the next
+    // call to FormatTizenPlatformError() on the same thread.
+    desc = get_error_message(err.GetValue());
+#endif
+
+    FormatError(buf, bufSize, "Platform", err, desc);
+    return true;
+}
+
+}; // namespace
+
+void RegisterTizenPlatformErrorFormatter()
+{
+    static ErrorFormatter sTizenPlatformErrorFormatter = { FormatTizenPlatformError, nullptr };
+    RegisterErrorFormatter(&sTizenPlatformErrorFormatter);
+}
 
 CHIP_ERROR TizenToChipError(int tizenError)
 {
@@ -33,7 +67,7 @@ CHIP_ERROR TizenToChipError(int tizenError)
     case TIZEN_ERROR_OUT_OF_MEMORY:
         return CHIP_ERROR_NO_MEMORY;
     default:
-        return CHIP_ERROR_INTERNAL;
+        return MATTER_PLATFORM_ERROR(tizenError);
 
     // Tizen DNSSD API errors
     case DNSSD_ERROR_NAME_CONFLICT:

--- a/src/platform/Tizen/ErrorUtils.cpp
+++ b/src/platform/Tizen/ErrorUtils.cpp
@@ -21,8 +21,6 @@
 #include <lib/core/ErrorStr.h>
 #include <platform/PlatformError.h>
 
-#include <app_preference.h>
-#include <dns-sd.h>
 #include <tizen.h>
 
 namespace chip {
@@ -56,27 +54,6 @@ void RegisterTizenPlatformErrorFormatter()
 {
     static ErrorFormatter sTizenPlatformErrorFormatter = { FormatTizenPlatformError, nullptr };
     RegisterErrorFormatter(&sTizenPlatformErrorFormatter);
-}
-
-CHIP_ERROR TizenToChipError(int tizenError)
-{
-    switch (tizenError)
-    {
-    case TIZEN_ERROR_NONE:
-        return CHIP_NO_ERROR;
-    case TIZEN_ERROR_OUT_OF_MEMORY:
-        return CHIP_ERROR_NO_MEMORY;
-    default:
-        return MATTER_PLATFORM_ERROR(tizenError);
-
-    // Tizen DNSSD API errors
-    case DNSSD_ERROR_NAME_CONFLICT:
-        return CHIP_ERROR_MDNS_COLLISION;
-
-    // Tizen Preference API errors
-    case PREFERENCE_ERROR_NO_KEY:
-        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
-    }
 }
 
 } // namespace Internal

--- a/src/platform/Tizen/ErrorUtils.h
+++ b/src/platform/Tizen/ErrorUtils.h
@@ -23,6 +23,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
+void RegisterTizenPlatformErrorFormatter();
 CHIP_ERROR TizenToChipError(int tizenError);
 
 } // namespace Internal

--- a/src/platform/Tizen/ErrorUtils.h
+++ b/src/platform/Tizen/ErrorUtils.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include <lib/core/CHIPError.h>
-
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {

--- a/src/platform/Tizen/ErrorUtils.h
+++ b/src/platform/Tizen/ErrorUtils.h
@@ -24,7 +24,6 @@ namespace DeviceLayer {
 namespace Internal {
 
 void RegisterTizenPlatformErrorFormatter();
-CHIP_ERROR TizenToChipError(int tizenError);
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/Tizen/PlatformManagerImpl.cpp
+++ b/src/platform/Tizen/PlatformManagerImpl.cpp
@@ -40,6 +40,7 @@
 #include <platform/GLibTypeDeleter.h>
 #include <platform/Tizen/DeviceInstanceInfoProviderImpl.h>
 
+#include "ErrorUtils.h"
 #include "PosixConfig.h"
 #include "SystemInfo.h"
 #include "platform/internal/GenericPlatformManagerImpl.h"
@@ -107,6 +108,8 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
         std::unique_lock<std::mutex> lock(invokeData.mDoneMutex);
         invokeData.mDoneCond.wait(lock, [&invokeData]() { return invokeData.mDone; });
     }
+
+    Internal::RegisterTizenPlatformErrorFormatter();
 
     ReturnErrorOnFailure(Internal::PosixConfig::Init());
 

--- a/src/platform/Tizen/SystemInfo.cpp
+++ b/src/platform/Tizen/SystemInfo.cpp
@@ -24,8 +24,6 @@
 
 #include <lib/support/logging/CHIPLogging.h>
 
-#include "ErrorUtils.h"
-
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -48,7 +46,7 @@ CHIP_ERROR SystemInfo::GetPlatformVersion(PlatformVersion & version)
     if (ret != SYSTEM_INFO_ERROR_NONE)
     {
         ChipLogError(DeviceLayer, "system_info_get_platform_string() failed: %s", get_error_message(ret));
-        return TizenToChipError(ret);
+        return MATTER_PLATFORM_ERROR(ret);
     }
 
     sInstance.mMajor = version.mMajor = (uint8_t) (platformVersion[0] - '0');

--- a/src/platform/Tizen/SystemInfo.cpp
+++ b/src/platform/Tizen/SystemInfo.cpp
@@ -23,6 +23,7 @@
 #include <tizen.h>
 
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/PlatformError.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -54,11 +54,8 @@
 #include <platform/NetworkCommissioning.h>
 #include <platform/PlatformManager.h>
 
-#include <platform/Tizen/ErrorUtils.h>
 #include <platform/Tizen/ThreadStackManagerImpl.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-
-using chip::DeviceLayer::Internal::TizenToChipError;
 
 namespace chip {
 namespace DeviceLayer {
@@ -495,7 +492,7 @@ CHIP_ERROR ThreadStackManagerImpl::_GetThreadVersion(uint16_t & version)
 
 #if defined(TIZEN_NETWORK_THREAD_VERSION) && TIZEN_NETWORK_THREAD_VERSION >= 0x000900
     int threadErr = thread_get_version(mThreadInstance, &version);
-    VerifyOrReturnError(threadErr == THREAD_ERROR_NONE, TizenToChipError(threadErr),
+    VerifyOrReturnError(threadErr == THREAD_ERROR_NONE, MATTER_PLATFORM_ERROR(threadErr),
                         ChipLogError(DeviceLayer, "FAIL: Get thread version: %s", get_error_message(threadErr)));
     ChipLogProgress(DeviceLayer, "Thread version [%u]", version);
     return CHIP_NO_ERROR;

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -52,6 +52,7 @@
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/CHIPDeviceEvent.h>
 #include <platform/NetworkCommissioning.h>
+#include <platform/PlatformError.h>
 #include <platform/PlatformManager.h>
 
 #include <platform/Tizen/ThreadStackManagerImpl.h>

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -30,6 +30,7 @@
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/GLibTypeDeleter.h>
+#include <platform/PlatformError.h>
 #include <platform/PlatformManager.h>
 
 #include "NetworkCommissioningDriver.h"

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -32,7 +32,6 @@
 #include <platform/GLibTypeDeleter.h>
 #include <platform/PlatformManager.h>
 
-#include "ErrorUtils.h"
 #include "NetworkCommissioningDriver.h"
 
 using namespace ::chip::DeviceLayer::NetworkCommissioning;
@@ -1107,7 +1106,7 @@ CHIP_ERROR WiFiManager::GetBssId(MutableByteSpan & value)
 
     GAutoPtr<char> bssIdStr;
     int wifiErr = wifi_manager_ap_get_bssid(connectedAp, &bssIdStr.GetReceiver());
-    VerifyOrReturnError(wifiErr == WIFI_MANAGER_ERROR_NONE, TizenToChipError(wifiErr),
+    VerifyOrReturnError(wifiErr == WIFI_MANAGER_ERROR_NONE, MATTER_PLATFORM_ERROR(wifiErr),
                         ChipLogError(DeviceLayer, "FAIL: Get AP BSSID: %s", get_error_message(wifiErr)));
 
     uint8_t * data = value.data();


### PR DESCRIPTION
#### Summary

Since https://github.com/project-chip/connectedhomeip/pull/40444 and https://github.com/project-chip/connectedhomeip/pull/42364 got merged, now it is possible to define platform errors in an easy way. This PR converts `TizenToChipError()` usage to `MATTER_PLATFORM_ERROR` which stores error location correctly. Also, it enables formatting errors as strings on Tizen.

#### Testing

CI will verify for potential breaks.

Manually tested on Tizen that `MATTER_PLATFORM_ERROR` on Tizen is printed correctly:
```
INFO    [1770289359.898] [697:736] [DL] DNSsd ResolveAsync
INFO    [1770289359.916] [697:736] [DL] DNSsd OnResolve
INFO    [1770289359.917] [697:736] [DL] dnssd_service_get_ip() failed: Service not found
INFO    [1770289359.917] [697:736] [DL] DNSsd Finalize
INFO    [1770289359.917] [697:736] [DIS] Failed to resolve DNS-SD node: src/platform/Tizen/DnssdImpl.cpp:358: Platform Error 0xFE360005: Service not found
```