### PR TITLE
Make nrfconnect builds work in devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,6 +60,7 @@ RUN mkdir -p /opt/android/sdk \
     && chown -R $USERNAME:$USERNAME \
     $ANDROID_HOME \
     $IDF_TOOLS_PATH \
+    $ZEPHYR_BASE/.. `# Assume $ZEPHYR_BASE is inside the west workspace` \
     && find $AMEBA_PATH \
     -name "inc_lp" -print0      -or \
     -name "inc_hp" -print0      -or \


### PR DESCRIPTION
#### Summary

nrfconnect builds require that the `/opt/NordicSemiconductor/nrfconnect` directory is writable. This is not the case when running in a devcontainer:

```shell
vscode@AMDC4865:/workspaces/connectedhomeip$ scripts/build/build_examples.py --target nrf-nrf52840dongle-all-clusters build
2025-12-09 15:55:13 INFO    Preparing builder 'nrf-nrf52840dongle-all-clusters'
2025-12-09 15:55:13 INFO    Generating /workspaces/connectedhomeip/out/nrf-nrf52840dongle-all-clusters
2025-12-09 15:55:13 INFO    Checking current nRF Connect SDK revision...
2025-12-09 15:55:13 INFO    Your current version is up to date with the recommended one.
2025-12-09 15:55:13 INFO    Command ['python3', 'scripts/setup/nrfconnect/update_ncs.py', '--check'] completed
Traceback (most recent call last):
  File "/workspaces/connectedhomeip/scripts/build/build_examples.py", line 255, in <module>
    main(auto_envvar_prefix='CHIP')
  File "/opt/NordicSemiconductor/nRF5_tools/zephyr-sdk/toolchains/c5be9c56c7/usr/local/lib/python3.12/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/NordicSemiconductor/nRF5_tools/zephyr-sdk/toolchains/c5be9c56c7/usr/local/lib/python3.12/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/opt/NordicSemiconductor/nRF5_tools/zephyr-sdk/toolchains/c5be9c56c7/usr/local/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    rv.append(sub_ctx.command.invoke(sub_ctx))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/NordicSemiconductor/nRF5_tools/zephyr-sdk/toolchains/c5be9c56c7/usr/local/lib/python3.12/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/NordicSemiconductor/nRF5_tools/zephyr-sdk/toolchains/c5be9c56c7/usr/local/lib/python3.12/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/NordicSemiconductor/nRF5_tools/zephyr-sdk/toolchains/c5be9c56c7/usr/local/lib/python3.12/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/connectedhomeip/scripts/build/build_examples.py", line 245, in cmd_build
    context.obj.Build()
  File "/workspaces/connectedhomeip/scripts/build/build/__init__.py", line 116, in Build
    self.Generate()
  File "/workspaces/connectedhomeip/scripts/build/build/__init__.py", line 111, in Generate
    builder.generate()
  File "/workspaces/connectedhomeip/scripts/build/builders/nrf.py", line 185, in generate
    raise Exception(
Exception: Directory /opt/NordicSemiconductor/nrfconnect not writable. NRFConnect builds require updates to this directory.
```

After the change:

```shell
vscode@AMDC4865:/workspaces/connectedhomeip$ scripts/build/build_examples.py --target nrf-nrf52840dongle-all-clusters build
2025-12-09 15:56:38 INFO    Preparing builder 'nrf-nrf52840dongle-all-clusters'
2025-12-09 15:56:38 INFO    Generating /workspaces/connectedhomeip/out/nrf-nrf52840dongle-all-clusters
2025-12-09 15:56:38 INFO    Checking current nRF Connect SDK revision...
2025-12-09 15:56:38 INFO    Your current version is up to date with the recommended one.
2025-12-09 15:56:38 INFO    Command ['python3', 'scripts/setup/nrfconnect/update_ncs.py', '--check'] completed
2025-12-09 15:56:38 INFO    Generating nrf-nrf52840dongle-all-clusters
2025-12-09 15:56:38 WARNING 2025-12-09 15:56:38,968 Loading extra packages for 'linux'
2025-12-09 15:56:38 WARNING 2025-12-09 15:56:38,968 Skipping: 'darwin' (i.e. /workspaces/connectedhomeip/third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/cipd_setup/python311.json)
2025-12-09 15:56:38 WARNING 2025-12-09 15:56:38,968 Skipping: 'windows' (i.e. /workspaces/connectedhomeip/third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/cipd_setup/python311.json)
2025-12-09 15:56:38 INFO    
2025-12-09 15:56:38 INFO      WELCOME TO...
[...]
2025-12-09 15:58:34 INFO    [184/184] Linking C executable zephyr/zephyr.elf
2025-12-09 15:58:34 INFO    Memory region         Used Size  Region Size  %age Used
2025-12-09 15:58:34 INFO               FLASH:       24152 B        48 KB     49.14%
2025-12-09 15:58:34 INFO                 RAM:       18304 B       256 KB      6.98%
2025-12-09 15:58:34 INFO            IDT_LIST:          0 GB        32 KB      0.00%
2025-12-09 15:58:34 INFO    Generating files from /workspaces/connectedhomeip/out/nrf-nrf52840dongle-all-clusters/mcuboot/zephyr/zephyr.elf for board: nrf52840dk
2025-12-09 15:58:34 INFO    [16/21] Generating ../dfu_application.zip
2025-12-09 15:58:34 INFO    [18/21] No install step for 'mcuboot'
2025-12-09 15:58:34 INFO    [19/21] Completed 'mcuboot'
2025-12-09 15:58:34 INFO    [20/21] cd /workspaces/connectedhomeip/out/nrf-nrf52840dongle-all-clusters/_sysbuild && /opt/NordicSemiconductor/nRF5_tools/zephyr-sdk/toolchains/c5be9c56c7/usr/local/bin/cmake -E true
2025-12-09 15:58:34 INFO    [21/21] Generating ../merged.hex
2025-12-09 15:58:34 INFO    Command ['bash', '-c', 'source "$ZEPHYR_BASE/zephyr-env.sh";\nsource scripts/activate.sh;\nninja -C /workspaces/connectedhomeip/out/nrf-nrf52840dongle-all-clusters'] completed
2025-12-09 15:58:34 INFO    Build Time Summary:
2025-12-09 15:58:34 INFO      - nrf-nrf52840dongle-all-clusters: 1m34s
2025-12-09 15:58:34 INFO    Total build time: 1m34s
vscode@AMDC4865:/workspaces/connectedhomeip$ 

```

#### Testing

Successfully building nrfconnect examples in the dev container.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
