### PR TITLE
Groupcast invoke does not need response

### DIFF
--- a/src/app/CommandHandlerImpl.cpp
+++ b/src/app/CommandHandlerImpl.cpp
@@ -335,12 +335,9 @@ void CommandHandlerImpl::Close()
                        static_cast<unsigned int>(mPendingWork));
     InvalidateHandles();
 
-    if (!IsGroupRequest())
+    if (mpCallback)
     {
-        if (mpCallback)
-        {
-            mpCallback->OnDone(*this);
-        }
+        mpCallback->OnDone(*this);
     }
 }
 

--- a/src/app/CommandHandlerImpl.cpp
+++ b/src/app/CommandHandlerImpl.cpp
@@ -335,9 +335,11 @@ void CommandHandlerImpl::Close()
                        static_cast<unsigned int>(mPendingWork));
     InvalidateHandles();
 
-    if (mpCallback)
-    {
-        mpCallback->OnDone(*this);
+    if (!IsGroupRequest()) {
+        if (mpCallback)
+        {
+            mpCallback->OnDone(*this);
+        }
     }
 }
 

--- a/src/app/CommandHandlerImpl.cpp
+++ b/src/app/CommandHandlerImpl.cpp
@@ -335,7 +335,8 @@ void CommandHandlerImpl::Close()
                        static_cast<unsigned int>(mPendingWork));
     InvalidateHandles();
 
-    if (!IsGroupRequest()) {
+    if (!IsGroupRequest())
+    {
         if (mpCallback)
         {
             mpCallback->OnDone(*this);

--- a/src/app/CommandHandlerImpl.h
+++ b/src/app/CommandHandlerImpl.h
@@ -256,6 +256,11 @@ public:
                                                         NlFaultInjectionType faultType);
 #endif // CHIP_WITH_NLFAULTINJECTION
 
+    /**
+     * Check whether the InvokeRequest we are handling is targeted to a group.
+     */
+    bool IsGroupRequest() { return mGroupRequest; }
+
 protected:
     // Lifetime management for CommandHandler::Handle
 
@@ -430,11 +435,6 @@ private:
                                   const DataModel::EncodableToTLV & aEncodable);
 
     void SetExchangeInterface(CommandHandlerExchangeInterface * commandResponder);
-
-    /**
-     * Check whether the InvokeRequest we are handling is targeted to a group.
-     */
-    bool IsGroupRequest() { return mGroupRequest; }
 
     bool ResponsesAccepted() { return mpResponder != nullptr && !mGroupRequest; }
 

--- a/src/app/CommandResponseSender.cpp
+++ b/src/app/CommandResponseSender.cpp
@@ -115,10 +115,10 @@ void CommandResponseSender::StartSendingCommandResponses()
 
 void CommandResponseSender::OnDone(CommandHandlerImpl & apCommandObj)
 {
-    if (mState == State::ErrorSentDelayCloseUntilOnDone)
+    if (mState == State::ErrorSentDelayCloseUntilOnDone || apCommandObj.IsGroupRequest())
     {
-        // We have already sent a message to the client indicating that we are not expecting
-        // a response.
+        // We either have already sent a message to the client indicating that we are not expecting
+        // a response, or do not need to send response to a groupcast.
         Close();
         return;
     }

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -1678,7 +1678,6 @@ TEST_F(TestCommandInteraction, TestCommandSenderGroupCommandNoResponseFlow)
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
-#if 0
 TEST_F(TestCommandInteraction, TestCommandSenderCommandAsyncSuccessResponseFlow)
 {
 
@@ -2146,7 +2145,6 @@ TEST_F_FROM_FIXTURE(TestCommandInteraction, TestCommandHandler_ReleaseWithExchan
     asyncCommandHandle.Get()->GetExchangeContext()->OnSessionReleased();
     asyncCommandHandle = nullptr;
 }
-#endif
 #endif
 
 } // namespace app

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -34,6 +34,7 @@
 #include <app/data-model/Encode.h>
 #include <app/tests/AppTestContext.h>
 #include <app/tests/test-interaction-model-api.h>
+#include <credentials/GroupDataProviderImpl.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/ErrorStr.h>
 #include <lib/core/Optional.h>
@@ -41,6 +42,7 @@
 #include <lib/core/TLV.h>
 #include <lib/core/TLVDebug.h>
 #include <lib/core/TLVUtilities.h>
+#include <lib/support/TestGroupData.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <lib/support/tests/ExtraPwTestMacros.h>
 #include <messaging/ExchangeContext.h>
@@ -459,18 +461,46 @@ public:
     }
 };
 
+namespace {
+constexpr uint16_t kMaxGroupsPerFabric    = 5;
+constexpr uint16_t kMaxGroupKeysPerFabric = 8;
+
+chip::TestPersistentStorageDelegate gTestStorage;
+chip::Crypto::DefaultSessionKeystore gSessionKeystore;
+chip::Credentials::GroupDataProviderImpl gGroupsProvider(kMaxGroupsPerFabric, kMaxGroupKeysPerFabric);
+} // namespace
+
 class TestCommandInteraction : public chip::Testing::AppContext
 {
 public:
     void SetUp() override
     {
         AppContext::SetUp();
+
+        gTestStorage.ClearStorage();
+        gGroupsProvider.SetStorageDelegate(&gTestStorage);
+        gGroupsProvider.SetSessionKeystore(&gSessionKeystore);
+        ASSERT_EQ(gGroupsProvider.Init(), CHIP_NO_ERROR);
+        chip::Credentials::SetGroupDataProvider(&gGroupsProvider);
+
+        uint8_t buf[sizeof(chip::CompressedFabricId)];
+        chip::MutableByteSpan span(buf);
+        ASSERT_EQ(GetBobFabric()->GetCompressedFabricIdBytes(span), CHIP_NO_ERROR);
+        ASSERT_EQ(chip::GroupTesting::InitData(&gGroupsProvider, GetBobFabricIndex(), span), CHIP_NO_ERROR);
+
         mOldProvider = InteractionModelEngine::GetInstance()->SetDataModelProvider(TestCommandInteractionModel::Instance());
         chip::Testing::SetMockNodeConfig(TestMockNodeConfig());
     }
 
     void TearDown() override
     {
+        chip::Credentials::GroupDataProvider * provider = chip::Credentials::GetGroupDataProvider();
+        if (provider != nullptr)
+        {
+            provider->Finish();
+        }
+        chip::Credentials::SetGroupDataProvider(nullptr);
+
         chip::Testing::ResetMockNodeConfig();
         InteractionModelEngine::GetInstance()->SetDataModelProvider(mOldProvider);
         AppContext::TearDown();
@@ -1625,6 +1655,30 @@ TEST_F(TestCommandInteraction, TestCommandSenderCommandSuccessResponseFlow)
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
+TEST_F(TestCommandInteraction, TestCommandSenderGroupCommandNoResponseFlow)
+{
+    mockCommandSenderDelegate.ResetCounter();
+    app::CommandSender commandSender(&mockCommandSenderDelegate, &GetExchangeManager());
+
+    AddInvokeRequestData(&commandSender);
+    SessionHandle groupSession = GetSessionBobToFriends();
+    EXPECT_TRUE(groupSession->IsGroupSession());
+    EXPECT_EQ(commandSender.SendGroupCommandRequest(groupSession), CHIP_NO_ERROR);
+
+    DrainAndServiceIO();
+
+    EXPECT_EQ(mockCommandSenderDelegate.onFinalCalledTimes, 1);
+    // No response is expected for a group command, so OnResponse and OnError should not be called.
+    EXPECT_EQ(mockCommandSenderDelegate.onResponseCalledTimes, 0);
+    EXPECT_EQ(mockCommandSenderDelegate.onErrorCalledTimes, 0);
+    // There should be no invoke response messages.
+    EXPECT_EQ(commandSender.GetInvokeResponseMessageCount(), 0u);
+
+    EXPECT_EQ(GetNumActiveCommandResponderObjects(), 0u);
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+}
+
+#if 0
 TEST_F(TestCommandInteraction, TestCommandSenderCommandAsyncSuccessResponseFlow)
 {
 
@@ -2092,6 +2146,7 @@ TEST_F_FROM_FIXTURE(TestCommandInteraction, TestCommandHandler_ReleaseWithExchan
     asyncCommandHandle.Get()->GetExchangeContext()->OnSessionReleased();
     asyncCommandHandle = nullptr;
 }
+#endif
 #endif
 
 } // namespace app


### PR DESCRIPTION
#### Summary

Stop sending response to groupcast invoke commands

#### Related issues

#42330

#### Testing

Set up a groupcast test by following https://project-chip.github.io/connectedhomeip-doc/examples/chip-tool/README.html#
Send a group cast "chip-tool onoff on 0xffffffffffff4141 1" on client side
Server does not try to send response and the error log "[DMG] Failed to send InvokeResponseMessage" is gone.
