### PR TITLE
Move SFrame encryption into each transport's RTP packetization logic

### DIFF
--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -90,39 +90,9 @@ GstFlowReturn OnNewVideoSampleFromAppSink(GstAppSink * appsink, gpointer user_da
     GstMapInfo map;
     if (gst_buffer_map(buffer, &map, GST_MAP_READ))
     {
-        // Check if SFrame encryption is enabled for this stream
-        auto & mediaController = self->GetMediaController();
-        Transport * transport  = mediaController.GetTransportForVideoStream(videoStreamID);
-
-        if (transport != nullptr && transport->sFrameConfig.HasValue())
-        {
-            auto & sframeConfig = transport->sFrameConfig.Value();
-            ChipLogProgress(Camera, "SFrame encryption enabled for video stream %u: cipherSuite=0x%04X, keyLen=%u", videoStreamID,
-                            sframeConfig.cipherSuite, static_cast<unsigned int>(sframeConfig.baseKey.size()));
-
-            // TODO: Implement SFrame encryption (occurs AFTER H.264 encoding, BEFORE RTP packetization)
-            // Current state: map.data contains H.264 encoded frames from GStreamer
-            //
-            // SFrame encryption steps:
-            // 1. Take the H.264 compressed payload (map.data, map.size)
-            // 2. Select encryption algorithm based on cipherSuite:
-            //    - 0x0001: AES-128-GCM-SHA256 (16 byte key)
-            //    - 0x0002: AES-256-GCM-SHA512 (32 byte key)
-            // 3. Encrypt the H.264 payload using sframeConfig.baseKey
-            // 4. Build SFrame header containing:
-            //    - Key ID (kid) from sframeConfig.kid
-            //    - Frame counter (incremented per frame)
-            // 5. Prepend SFrame header to encrypted payload:
-            //    Result: [SFrame Header | Encrypted(H.264 Payload)]
-            // 6. This will later be packed into RTP as:
-            //    [RTP Header | SFrame Header | Encrypted(H.264 Payload)]
-            //    SFUs can inspect RTP headers but payload remains encrypted
-        }
-
-        // If SFrame is enabled above, this should be: [SFrame Header | Encrypted(H.264)]
-        // If SFrame is disabled, this is raw H.264 encoded frames
-
-        // Forward H.264 RTP data to media controller with the correct videoStreamID
+        // Forward raw H.264 encoded frames to media controller
+        // The PreRollBuffer will distribute to ALL transports registered for this videoStreamID
+        // Each transport will handle its own SFrame encryption (if configured) during RTP packetization
         self->GetMediaController().DistributeVideo(reinterpret_cast<const uint8_t *>(map.data), map.size, videoStreamID);
         gst_buffer_unmap(buffer, &map);
     }
@@ -164,39 +134,9 @@ static GstFlowReturn OnNewAudioSampleFromAppSink(GstAppSink * appsink, gpointer 
     GstMapInfo map;
     if (gst_buffer_map(buffer, &map, GST_MAP_READ))
     {
-        // Check if SFrame encryption is enabled for this stream
-        auto & mediaController = self->GetMediaController();
-        Transport * transport  = mediaController.GetTransportForAudioStream(audioStreamID);
-
-        if (transport != nullptr && transport->sFrameConfig.HasValue())
-        {
-            auto & sframeConfig = transport->sFrameConfig.Value();
-            ChipLogProgress(Camera, "SFrame encryption enabled for audio stream %u: cipherSuite=0x%04X, keyLen=%u", audioStreamID,
-                            sframeConfig.cipherSuite, static_cast<unsigned int>(sframeConfig.baseKey.size()));
-
-            // TODO: Implement SFrame encryption (occurs AFTER Opus encoding, BEFORE RTP packetization)
-            // Current state: map.data contains Opus encoded frames from GStreamer
-            //
-            // SFrame encryption steps:
-            // 1. Take the Opus compressed payload (map.data, map.size)
-            // 2. Select encryption algorithm based on cipherSuite:
-            //    - 0x0001: AES-128-GCM-SHA256 (16 byte key)
-            //    - 0x0002: AES-256-GCM-SHA512 (32 byte key)
-            // 3. Encrypt the Opus payload using sframeConfig.baseKey
-            // 4. Build SFrame header containing:
-            //    - Key ID (kid) from sframeConfig.kid
-            //    - Frame counter (incremented per frame)
-            // 5. Prepend SFrame header to encrypted payload:
-            //    Result: [SFrame Header | Encrypted(Opus Payload)]
-            // 6. This will later be packed into RTP as:
-            //    [RTP Header | SFrame Header | Encrypted(Opus Payload)]
-            //    SFUs can inspect RTP headers but payload remains encrypted
-        }
-
-        // If SFrame is enabled above, this should be: [SFrame Header | Encrypted(Opus)]
-        // If SFrame is disabled, this is raw Opus encoded frames
-
-        // Send raw Opus frames to the media controller
+        // Forward raw Opus encoded frames to media controller
+        // The PreRollBuffer will distribute to ALL transports registered for this audioStreamID
+        // Each transport will handle its own SFrame encryption (if configured) during RTP packetization
         self->GetMediaController().DistributeAudio(reinterpret_cast<const uint8_t *>(map.data), map.size, audioStreamID);
         gst_buffer_unmap(buffer, &map);
     }

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -71,6 +71,31 @@ void WebrtcTransport::SendVideo(const chip::ByteSpan & data, int64_t timestamp, 
 {
     if (mLocalVideoTrack)
     {
+        // TODO: Implement SFrame encryption HERE (per-transport, during RTP packetization)
+        // Current state: data contains raw H.264 encoded frames from GStreamer
+        //
+        // SFrame encryption should happen here because:
+        // 1. Each transport may have different sFrameConfig (different keys, cipher suites)
+        // 2. Multiple transports can share the same video stream
+        // 3. Encryption must be per-client, not per-stream
+        //
+        // Implementation steps:
+        // if (sFrameConfig.HasValue())
+        // {
+        //     auto& config = sFrameConfig.Value();
+        //     // 1. Encrypt H.264 payload using config.baseKey and config.cipherSuite:
+        //     //    - 0x0001: AES-128-GCM-SHA256 (16 byte key)
+        //     //    - 0x0002: AES-256-GCM-SHA512 (32 byte key)
+        //     // 2. Build SFrame header with config.kid and frame counter
+        //     // 3. Prepend SFrame header to encrypted payload
+        //     // 4. Pass encrypted data to RTP packetization
+        //     //    Result: [RTP Header | SFrame Header | Encrypted(H.264)]
+        // }
+        // else
+        // {
+        //     // No encryption - pass raw H.264 to RTP packetization
+        // }
+
         mLocalVideoTrack->SendFrame(data, timestamp);
     }
 }
@@ -80,6 +105,31 @@ void WebrtcTransport::SendAudio(const chip::ByteSpan & data, int64_t timestamp, 
 {
     if (mLocalAudioTrack)
     {
+        // TODO: Implement SFrame encryption HERE (per-transport, during RTP packetization)
+        // Current state: data contains raw Opus encoded frames from GStreamer
+        //
+        // SFrame encryption should happen here because:
+        // 1. Each transport may have different sFrameConfig (different keys, cipher suites)
+        // 2. Multiple transports can share the same audio stream
+        // 3. Encryption must be per-client, not per-stream
+        //
+        // Implementation steps:
+        // if (sFrameConfig.HasValue())
+        // {
+        //     auto& config = sFrameConfig.Value();
+        //     // 1. Encrypt Opus payload using config.baseKey and config.cipherSuite:
+        //     //    - 0x0001: AES-128-GCM-SHA256 (16 byte key)
+        //     //    - 0x0002: AES-256-GCM-SHA512 (32 byte key)
+        //     // 2. Build SFrame header with config.kid and frame counter
+        //     // 3. Prepend SFrame header to encrypted payload
+        //     // 4. Pass encrypted data to RTP packetization
+        //     //    Result: [RTP Header | SFrame Header | Encrypted(Opus)]
+        // }
+        // else
+        // {
+        //     // No encryption - pass raw Opus to RTP packetization
+        // }
+
         mLocalAudioTrack->SendFrame(data, timestamp);
     }
 }


### PR DESCRIPTION
#### Summary

**The Problem:**

GetTransportForVideoStream() and GetTransportForAudioStream() only return the first transport for a given stream ID
When multiple clients are viewing the same stream, the SFrame encryption check only looks at the first client's configuration
This is a fundamental architectural issue - SFrame encryption is being checked at the wrong layer

Scenario: Two clients (Alice and Bob) are both viewing video stream ID 1, but with different SFrame configurations:

Alice's transport: SFrame with AES-128-GCM (cipherSuite 0x0001, key "AliceKey123")
Bob's transport: SFrame with AES-256-GCM (cipherSuite 0x0002, key "BobSecretKey456")

GStreamer produces H.264 frame
          ↓
OnNewVideoSampleFromAppSink(videoStreamID=1)
          ↓
GetTransportForVideoStream(1) → Returns Alice's transport only!
          ↓
Check: Alice has SFrame enabled? Yes → Log message
          ↓
But then: DistributeVideo(raw H.264 data)  ← No encryption happens!
          ↓
PreRollBuffer distributes to BOTH Alice AND Bob
          ↓
Both get the SAME unencrypted H.264 data


**Solution:** 

Move SFrame encryption into each transport's RTP packetization logic, where each transport can use its own encryption keys

I'll remove the problematic SFrame check from the stream level in camera-device.cpp and add proper TODO comments in the transport layer where SFrame encryption should actually be implemented.


GStreamer produces H.264 frame
          ↓
DistributeVideo(raw H.264 data)  ← No encryption here!
          ↓
PreRollBuffer stores raw H.264
          ↓
    ┌─────────┴─────────┐
    ↓                   ↓
Alice's Transport    Bob's Transport
    ↓                   ↓
Each transport's RTP packetizer:
    ↓                   ↓
Encrypt with        Encrypt with
Alice's key         Bob's key
(AES-128)           (AES-256)
    ↓                   ↓
RTP packet with     RTP packet with
Alice's SFrame      Bob's SFrame
    ↓                   ↓
Send to Alice       Send to Bob

#### Related issues

N/A

#### Testing

Only fix the architecture issue, the actual encoding is TODO

