### PR TITLE
Zone Management and Push AV Stream Transport clusters handle zone events independently

### DIFF
--- a/examples/camera-app/camera-common/include/camera-device-interface.h
+++ b/examples/camera-app/camera-common/include/camera-device-interface.h
@@ -148,8 +148,6 @@ public:
     // Getter for PushAVStreamTransport Delegate
     virtual chip::app::Clusters::PushAvStreamTransportDelegate & GetPushAVTransportDelegate() = 0;
 
-    virtual void HandlePushAvZoneTrigger(uint16_t zoneId) = 0;
-
     // Class defining the Camera HAL interface
     class CameraHALInterface
     {
@@ -391,7 +389,7 @@ public:
         UpdateZoneTrigger(const chip::app::Clusters::ZoneManagement::ZoneTriggerControlStruct & zoneTrigger) = 0;
 
         // Remove a zone trigger
-        virtual CameraError RemoveZoneTrigger(uint16_t zoneID) = 0;
+        virtual CameraError RemoveZoneTrigger(uint16_t zoneId) = 0;
 
         class ZoneEventCallback
         {

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -98,8 +98,6 @@ public:
 
     MediaController & GetMediaController() override;
 
-    void HandlePushAvZoneTrigger(uint16_t zoneId) override;
-
     CameraDevice();
     ~CameraDevice();
 
@@ -300,7 +298,7 @@ public:
 
     CameraError UpdateZoneTrigger(const chip::app::Clusters::ZoneManagement::ZoneTriggerControlStruct & zoneTrigger) override;
 
-    CameraError RemoveZoneTrigger(uint16_t zoneID) override;
+    CameraError RemoveZoneTrigger(uint16_t zoneId) override;
 
     CameraError SetPan(int16_t aPan) override;
     CameraError SetTilt(int16_t aTilt) override;
@@ -315,9 +313,9 @@ public:
 
     void SetVideoDevicePath(const std::string & path) { mVideoDevicePath = path; }
 
-    void HandleSimulatedZoneTriggeredEvent(uint16_t zoneID);
+    void HandleSimulatedZoneTriggeredEvent(uint16_t zoneId);
 
-    void HandleSimulatedZoneStoppedEvent(uint16_t zoneID);
+    void HandleSimulatedZoneStoppedEvent(uint16_t zoneId);
 
     // Audio playback pipeline methods
     CameraError StartAudioPlaybackStream();

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -1631,21 +1631,21 @@ CameraError CameraDevice::UpdateZoneTrigger(const ZoneTriggerControlStruct & zon
     return CameraError::SUCCESS;
 }
 
-CameraError CameraDevice::RemoveZoneTrigger(const uint16_t zoneID)
+CameraError CameraDevice::RemoveZoneTrigger(const uint16_t zoneId)
 {
 
     return CameraError::SUCCESS;
 }
 
-void CameraDevice::HandleSimulatedZoneTriggeredEvent(uint16_t zoneID)
+void CameraDevice::HandleSimulatedZoneTriggeredEvent(uint16_t zoneId)
 {
-    mZoneManager.OnZoneTriggeredEvent(zoneID, ZoneEventTriggeredReasonEnum::kMotion);
-    mPushAVTransportManager.HandleZoneTrigger(zoneID);
+    mZoneManager.OnZoneTriggeredEvent(zoneId, ZoneEventTriggeredReasonEnum::kMotion);
+    mPushAVTransportManager.HandleZoneTrigger(zoneId);
 }
 
-void CameraDevice::HandleSimulatedZoneStoppedEvent(uint16_t zoneID)
+void CameraDevice::HandleSimulatedZoneStoppedEvent(uint16_t zoneId)
 {
-    mZoneManager.OnZoneStoppedEvent(zoneID, ZoneEventStoppedReasonEnum::kActionStopped);
+    mZoneManager.OnZoneStoppedEvent(zoneId, ZoneEventStoppedReasonEnum::kActionStopped);
     // Note: PushAVTransportManager doesn't need zone stopped notification currently
 }
 
@@ -1870,11 +1870,6 @@ ZoneManagement::Delegate & CameraDevice::GetZoneManagementDelegate()
 MediaController & CameraDevice::GetMediaController()
 {
     return mMediaController;
-}
-
-void CameraDevice::HandlePushAvZoneTrigger(uint16_t zoneId)
-{
-    mPushAVTransportManager.HandleZoneTrigger(zoneId);
 }
 
 size_t CameraDevice::GetPreRollBufferSize()

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -1646,7 +1646,7 @@ void CameraDevice::HandleSimulatedZoneTriggeredEvent(uint16_t zoneId)
 void CameraDevice::HandleSimulatedZoneStoppedEvent(uint16_t zoneId)
 {
     mZoneManager.OnZoneStoppedEvent(zoneId, ZoneEventStoppedReasonEnum::kActionStopped);
-    // Note: PushAVTransportManager doesn't need zone stopped notification currently
+    // Note: PushAVTransportManager doesn't need zone stopped event currently
 }
 
 void CameraDevice::InitializeVideoStreams()

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -1640,11 +1640,13 @@ CameraError CameraDevice::RemoveZoneTrigger(const uint16_t zoneID)
 void CameraDevice::HandleSimulatedZoneTriggeredEvent(uint16_t zoneID)
 {
     mZoneManager.OnZoneTriggeredEvent(zoneID, ZoneEventTriggeredReasonEnum::kMotion);
+    mPushAVTransportManager.HandleZoneTrigger(zoneID);
 }
 
 void CameraDevice::HandleSimulatedZoneStoppedEvent(uint16_t zoneID)
 {
     mZoneManager.OnZoneStoppedEvent(zoneID, ZoneEventStoppedReasonEnum::kActionStopped);
+    // Note: PushAVTransportManager doesn't need zone stopped notification currently
 }
 
 void CameraDevice::InitializeVideoStreams()

--- a/examples/camera-app/linux/src/clusters/zone-mgmt/zone-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/zone-mgmt/zone-manager.cpp
@@ -272,11 +272,6 @@ void ZoneManager::OnZoneTriggeredEvent(uint16_t zoneId,
                             foundTrigCtxt->triggerCount);
         }
     }
-
-    if (mCameraDevice)
-    {
-        mCameraDevice->HandlePushAvZoneTrigger(zoneId);
-    }
 }
 
 void ZoneManager::OnZoneStoppedEvent(uint16_t zoneId, chip::app::Clusters::ZoneManagement::ZoneEventStoppedReasonEnum stopReason)


### PR DESCRIPTION

#### Summary

The Issue:

https://github.com/project-chip/connectedhomeip/pull/40840#discussion_r2345077390 -

Zone Management and Push AV Stream Transport clusters handle zone events independently. The current implementation creates an unnecessary dependency where:

1. Zone event goes UP to ZoneManager
2. ZoneManager calls DOWN through CameraDevice interface
3. CameraDevice calls UP to PushAVTransportManager

This is architecturally awkward and creates tight coupling.

CameraDevice::HandleSimulatedZoneTriggeredEvent(zoneId)
    ↓
ZoneManager::OnZoneTriggeredEvent(zoneId, reason)
    ↓ (generates Zone Mgmt cluster event)
    ↓ (then goes back down through interface)
mCameraDevice->HandlePushAvZoneTrigger(zoneId)
    ↓
CameraDevice::HandlePushAvZoneTrigger(zoneId)
    ↓
PushAVTransportManager::HandleZoneTrigger(zoneId)



The Better Solution:

CameraDevice::HandleSimulatedZoneTriggeredEvent(zoneId)
    ↓
    ├─→ mZoneManager.OnZoneTriggeredEvent(zoneId, reason)
    │   (handles Zone Mgmt cluster independently)
    │
    └─→ mPushAVTransportManager.HandleZoneTrigger(zoneId)
        (handles Push AV cluster independently)

1. Both clusters handle the zone event independently as per spec
2. CameraDevice acts as the coordinator
3. No unnecessary down-and-up call chain
4. Each cluster manager is independent

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
