### PR TITLE
Rename WebRTCTransportRequestorServer to WebRTCTransportRequestorCluster

### DIFF
--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -84,7 +84,7 @@ private:
     WebRTCManager();
     ~WebRTCManager();
 
-    chip::app::LazyRegisteredServerCluster<chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorServer>
+    chip::app::LazyRegisteredServerCluster<chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorCluster>
         mWebRTCRegisteredServerCluster;
 
     WebRTCProviderClient mWebRTCProviderClient;

--- a/examples/camera-controller/webrtc-manager/WebRTCProviderClient.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCProviderClient.cpp
@@ -32,7 +32,7 @@ constexpr uint32_t kDeferredOfferTimeoutSeconds = 30;
 } // namespace
 
 void WebRTCProviderClient::Init(const ScopedNodeId & peerId, EndpointId endpointId,
-                                Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorServer * requestorServer)
+                                Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorCluster * requestorServer)
 {
     mPeerId          = peerId;
     mEndpointId      = endpointId;

--- a/examples/camera-controller/webrtc-manager/WebRTCProviderClient.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCProviderClient.h
@@ -50,14 +50,14 @@ public:
 
     /**
      * @brief Initializes the WebRTCProviderClient with a ScopedNodeId, an EndpointId, and an optional
-     *        pointer to the WebRTCTransportRequestorServer.
+     *        pointer to the WebRTCTransportRequestorCluster.
      *
      * @param peerId              The PeerId (fabric + nodeId) for the remote device.
      * @param endpointId          The Matter endpoint on the remote device for WebRTCTransportProvider cluster.
-     * @param requestorServer     Pointer to a WebRTCTransportRequestorServer instance.
+     * @param requestorServer     Pointer to a WebRTCTransportRequestorCluster instance.
      */
     void Init(const chip::ScopedNodeId & peerId, chip::EndpointId endpointId,
-              chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorServer * requestorServer);
+              chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorCluster * requestorServer);
 
     /**
      * @brief Sends a SolicitOffer command to the remote device.
@@ -221,7 +221,7 @@ private:
 
     State mState = State::Idle;
 
-    chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorServer * mRequestorServer = nullptr;
+    chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorCluster * mRequestorServer = nullptr;
 
     // Data needed to send the WebRTCTransportProvider commands
     chip::app::Clusters::WebRTCTransportProvider::Commands::SolicitOffer::Type mSolicitOfferData;

--- a/src/app/clusters/webrtc-transport-requestor-server/WebRTCTransportRequestorCluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/WebRTCTransportRequestorCluster.cpp
@@ -55,12 +55,12 @@ namespace app {
 namespace Clusters {
 namespace WebRTCTransportRequestor {
 
-WebRTCTransportRequestorServer::WebRTCTransportRequestorServer(EndpointId endpointId, Delegate & delegate) :
+WebRTCTransportRequestorCluster::WebRTCTransportRequestorCluster(EndpointId endpointId, Delegate & delegate) :
     DefaultServerCluster({ endpointId, Id }), mDelegate(delegate)
 {}
 
-DataModel::ActionReturnStatus WebRTCTransportRequestorServer::ReadAttribute(const DataModel::ReadAttributeRequest & request,
-                                                                            AttributeValueEncoder & encoder)
+DataModel::ActionReturnStatus WebRTCTransportRequestorCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
+                                                                             AttributeValueEncoder & encoder)
 {
     switch (request.path.mAttributeId)
     {
@@ -84,9 +84,9 @@ DataModel::ActionReturnStatus WebRTCTransportRequestorServer::ReadAttribute(cons
     }
 }
 
-std::optional<DataModel::ActionReturnStatus> WebRTCTransportRequestorServer::InvokeCommand(const DataModel::InvokeRequest & request,
-                                                                                           TLV::TLVReader & input_arguments,
-                                                                                           CommandHandler * handler)
+std::optional<DataModel::ActionReturnStatus>
+WebRTCTransportRequestorCluster::InvokeCommand(const DataModel::InvokeRequest & request, TLV::TLVReader & input_arguments,
+                                               CommandHandler * handler)
 {
     switch (request.path.mCommandId)
     {
@@ -127,21 +127,21 @@ std::optional<DataModel::ActionReturnStatus> WebRTCTransportRequestorServer::Inv
     }
 }
 
-CHIP_ERROR WebRTCTransportRequestorServer::AcceptedCommands(const ConcreteClusterPath & path,
-                                                            ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder)
+CHIP_ERROR WebRTCTransportRequestorCluster::AcceptedCommands(const ConcreteClusterPath & path,
+                                                             ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder)
 {
     return builder.ReferenceExisting(kAcceptedCommands);
 }
 
-CHIP_ERROR WebRTCTransportRequestorServer::Attributes(const ConcreteClusterPath & path,
-                                                      ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
+CHIP_ERROR WebRTCTransportRequestorCluster::Attributes(const ConcreteClusterPath & path,
+                                                       ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
 {
     AttributeListBuilder listBuilder(builder);
     return listBuilder.Append(Span(kMandatoryMetadata), {}, {});
 }
 
-DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleOffer(const CommandHandler & commandHandler,
-                                                                          const Commands::Offer::DecodableType & req)
+DataModel::ActionReturnStatus WebRTCTransportRequestorCluster::HandleOffer(const CommandHandler & commandHandler,
+                                                                           const Commands::Offer::DecodableType & req)
 {
     uint16_t sessionId = req.webRTCSessionID;
 
@@ -184,8 +184,8 @@ DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleOffer(const 
     return mDelegate.HandleOffer(*session, args);
 }
 
-DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleAnswer(const CommandHandler & commandHandler,
-                                                                           const Commands::Answer::DecodableType & req)
+DataModel::ActionReturnStatus WebRTCTransportRequestorCluster::HandleAnswer(const CommandHandler & commandHandler,
+                                                                            const Commands::Answer::DecodableType & req)
 {
     uint16_t sessionId = req.webRTCSessionID;
     auto sdpSpan       = req.sdp;
@@ -204,8 +204,8 @@ DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleAnswer(const
 }
 
 DataModel::ActionReturnStatus
-WebRTCTransportRequestorServer::HandleICECandidates(const CommandHandler & commandHandler,
-                                                    const Commands::ICECandidates::DecodableType & req)
+WebRTCTransportRequestorCluster::HandleICECandidates(const CommandHandler & commandHandler,
+                                                     const Commands::ICECandidates::DecodableType & req)
 {
     uint16_t sessionId = req.webRTCSessionID;
 
@@ -252,8 +252,8 @@ WebRTCTransportRequestorServer::HandleICECandidates(const CommandHandler & comma
     return mDelegate.HandleICECandidates(*session, candidates);
 }
 
-DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleEnd(const CommandHandler & commandHandler,
-                                                                        const Commands::End::DecodableType & req)
+DataModel::ActionReturnStatus WebRTCTransportRequestorCluster::HandleEnd(const CommandHandler & commandHandler,
+                                                                         const Commands::End::DecodableType & req)
 {
     uint16_t sessionId = req.webRTCSessionID;
     auto reason        = req.reason;
@@ -280,7 +280,7 @@ DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleEnd(const Co
 }
 
 // Helper functions
-WebRTCSessionStruct * WebRTCTransportRequestorServer::FindSession(uint16_t sessionId, NodeId peerNodeId, FabricIndex fabricIndex)
+WebRTCSessionStruct * WebRTCTransportRequestorCluster::FindSession(uint16_t sessionId, NodeId peerNodeId, FabricIndex fabricIndex)
 {
     for (auto & session : mCurrentSessions)
     {
@@ -293,7 +293,8 @@ WebRTCSessionStruct * WebRTCTransportRequestorServer::FindSession(uint16_t sessi
     return nullptr;
 }
 
-WebRTCTransportRequestorServer::UpsertResultEnum WebRTCTransportRequestorServer::UpsertSession(const WebRTCSessionStruct & session)
+WebRTCTransportRequestorCluster::UpsertResultEnum
+WebRTCTransportRequestorCluster::UpsertSession(const WebRTCSessionStruct & session)
 {
     // Search for a session in the current sessions using the full tuple <id, peerNodeID, fabricIndex>
     // This is critical because different cameras can allocate the same sessionId
@@ -319,7 +320,7 @@ WebRTCTransportRequestorServer::UpsertResultEnum WebRTCTransportRequestorServer:
     return result;
 }
 
-void WebRTCTransportRequestorServer::RemoveSession(uint16_t sessionId, NodeId peerNodeId, FabricIndex fabricIndex)
+void WebRTCTransportRequestorCluster::RemoveSession(uint16_t sessionId, NodeId peerNodeId, FabricIndex fabricIndex)
 {
     size_t originalSize = mCurrentSessions.size();
     // Remove the session if the full tuple <sessionId, peerNodeId, fabricIndex> matches

--- a/src/app/clusters/webrtc-transport-requestor-server/WebRTCTransportRequestorCluster.h
+++ b/src/app/clusters/webrtc-transport-requestor-server/WebRTCTransportRequestorCluster.h
@@ -106,7 +106,7 @@ public:
     virtual CHIP_ERROR HandleEnd(const WebRTCSessionStruct & session, WebRTCEndReasonEnum reasonCode) = 0;
 };
 
-class WebRTCTransportRequestorServer : public DefaultServerCluster
+class WebRTCTransportRequestorCluster : public DefaultServerCluster
 {
 public:
     enum class UpsertResultEnum : uint8_t
@@ -117,13 +117,13 @@ public:
 
     /**
      * @brief
-     *  Creates a WebRTCTransportRequestorServer instance with a given endpoint and delegate.
+     *  Creates a WebRTCTransportRequestorCluster instance with a given endpoint and delegate.
      *
      * @param endpointId The endpoint on which this cluster exists. This must match the zap configuration.
      * @param delegate A reference to the delegate to be used by this server.
      *                 The caller must ensure that the delegate lives throughout the instance's lifetime.
      */
-    WebRTCTransportRequestorServer(EndpointId endpointId, Delegate & delegate);
+    WebRTCTransportRequestorCluster(EndpointId endpointId, Delegate & delegate);
 
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                 AttributeValueEncoder & encoder) override;

--- a/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
@@ -74,7 +74,7 @@ struct TestWebRTCTransportRequestorCluster : public ::testing::Test
 TEST_F(TestWebRTCTransportRequestorCluster, TestAttributes)
 {
     MockWebRTCTransportRequestorDelegate mockDelegate;
-    WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
+    WebRTCTransportRequestorCluster server(kTestEndpointId, mockDelegate);
 
     ASSERT_TRUE(IsAttributesListEqualTo(server, { WebRTCTransportRequestor::Attributes::CurrentSessions::kMetadataEntry }));
 }
@@ -82,7 +82,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestAttributes)
 TEST_F(TestWebRTCTransportRequestorCluster, TestCommands)
 {
     MockWebRTCTransportRequestorDelegate mockDelegate;
-    WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
+    WebRTCTransportRequestorCluster server(kTestEndpointId, mockDelegate);
 
     ASSERT_TRUE(IsAcceptedCommandsListEqualTo(server,
                                               {
@@ -96,7 +96,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestCommands)
 TEST_F(TestWebRTCTransportRequestorCluster, TestCurrentSessionsAttribute)
 {
     MockWebRTCTransportRequestorDelegate mockDelegate;
-    WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
+    WebRTCTransportRequestorCluster server(kTestEndpointId, mockDelegate);
 
     // Initially, no sessions should exist
     auto sessions = server.GetCurrentSessions();
@@ -110,7 +110,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestCurrentSessionsAttribute)
     testSession.streamUsage = StreamUsageEnum::kLiveView;
 
     auto result = server.UpsertSession(testSession);
-    EXPECT_EQ(result, WebRTCTransportRequestorServer::UpsertResultEnum::kInserted);
+    EXPECT_EQ(result, WebRTCTransportRequestorCluster::UpsertResultEnum::kInserted);
 
     // Verify session was added
     sessions = server.GetCurrentSessions();
@@ -120,7 +120,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestCurrentSessionsAttribute)
     // Update the same session
     testSession.streamUsage = StreamUsageEnum::kRecording;
     result                  = server.UpsertSession(testSession);
-    EXPECT_EQ(result, WebRTCTransportRequestorServer::UpsertResultEnum::kUpdated);
+    EXPECT_EQ(result, WebRTCTransportRequestorCluster::UpsertResultEnum::kUpdated);
 
     // Verify session was updated, not duplicated
     sessions = server.GetCurrentSessions();
@@ -136,7 +136,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestCurrentSessionsAttribute)
 TEST_F(TestWebRTCTransportRequestorCluster, TestSessionManagement)
 {
     MockWebRTCTransportRequestorDelegate mockDelegate;
-    WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
+    WebRTCTransportRequestorCluster server(kTestEndpointId, mockDelegate);
 
     // Test adding multiple sessions
     WebRTCSessionStruct session1;
@@ -170,7 +170,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestSessionManagement)
 TEST_F(TestWebRTCTransportRequestorCluster, TestReadCurrentSessionsAttribute)
 {
     MockWebRTCTransportRequestorDelegate mockDelegate;
-    WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
+    WebRTCTransportRequestorCluster server(kTestEndpointId, mockDelegate);
 
     // Create a mock attribute request for CurrentSessions
     chip::app::DataModel::ReadAttributeRequest request;
@@ -202,7 +202,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestReadCurrentSessionsAttribute)
 TEST_F(TestWebRTCTransportRequestorCluster, TestReadClusterRevisionAttribute)
 {
     MockWebRTCTransportRequestorDelegate mockDelegate;
-    WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
+    WebRTCTransportRequestorCluster server(kTestEndpointId, mockDelegate);
 
     // Create a mock attribute request for ClusterRevision
     chip::app::DataModel::ReadAttributeRequest request;
@@ -232,7 +232,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestReadClusterRevisionAttribute)
 TEST_F(TestWebRTCTransportRequestorCluster, TestReadUnsupportedAttribute)
 {
     MockWebRTCTransportRequestorDelegate mockDelegate;
-    WebRTCTransportRequestorServer server(kTestEndpointId, mockDelegate);
+    WebRTCTransportRequestorCluster server(kTestEndpointId, mockDelegate);
 
     // Create a mock attribute request for an unsupported attribute
     chip::app::DataModel::ReadAttributeRequest request;

--- a/src/controller/webrtc/WebRTCTransportRequestorManager.h
+++ b/src/controller/webrtc/WebRTCTransportRequestorManager.h
@@ -83,6 +83,6 @@ private:
     WebRTCTransportRequestorManager()  = default;
     ~WebRTCTransportRequestorManager() = default;
 
-    chip::app::LazyRegisteredServerCluster<chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorServer>
+    chip::app::LazyRegisteredServerCluster<chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorCluster>
         mWebRTCRegisteredServerCluster;
 };


### PR DESCRIPTION
#### Summary

Rename WebRTCTransportRequestorServer to WebRTCTransportRequestorCluster to align with other code-driven clusters

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
