### PR TITLE
[Push AV 1.5.1] Update upload sequence of the record clip files

### DIFF
--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-crosscompile:181
+            image: ghcr.io/project-chip/chip-build-crosscompile:182
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:181
+            image: ghcr.io/project-chip/chip-build:182
 
         steps:
             - name: Checkout

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-java:181
+            image: ghcr.io/project-chip/chip-build-java:182
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=0 net.ipv6.conf.all.forwarding=0"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -971,7 +971,7 @@ jobs:
         runs-on: namespace-profile-1x2
 
         container:
-            image: ghcr.io/project-chip/chip-build:181
+            image: ghcr.io/project-chip/chip-build:182
             volumes:
                 - /var/run/nsc/:/var/run/nsc/
             env:

--- a/examples/camera-app/camera-common/include/media-controller/media-controller.h
+++ b/examples/camera-app/camera-common/include/media-controller/media-controller.h
@@ -48,7 +48,7 @@ public:
     virtual Transport * GetTransportForAudioStream(uint16_t audioStreamID) = 0;
     // Media controller goes through registered transports and dispatches media
     // if the transport is ready.
-    virtual void DistributeVideo(const uint8_t * data, size_t size, uint16_t videoStreamID) = 0;
-    virtual void DistributeAudio(const uint8_t * data, size_t size, uint16_t audioStreamID) = 0;
-    virtual void SetPreRollLength(Transport * transport, uint16_t PreRollBufferLength)      = 0;
+    virtual void DistributeVideo(const uint8_t * data, size_t size, uint16_t videoStreamID, int64_t timestamp) = 0;
+    virtual void DistributeAudio(const uint8_t * data, size_t size, uint16_t audioStreamID, int64_t timestamp) = 0;
+    virtual void SetPreRollLength(Transport * transport, uint16_t PreRollBufferLength)                         = 0;
 };

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -320,6 +320,12 @@ public:
     CameraError StartAudioPlaybackStream();
     CameraError StopAudioPlaybackStream();
 
+    // Timestamp handling for video and audio streams
+    std::map<uint16_t, int64_t> mVideoStreamStartEpochs;
+    std::map<uint16_t, GstClockTime> mVideoStreamFirstPts;
+    std::map<uint16_t, int64_t> mAudioStreamStartEpochs;
+    std::map<uint16_t, GstClockTime> mAudioStreamFirstPts;
+
 private:
     int videoDeviceFd            = -1;
     std::string mVideoDevicePath = kDefaultVideoDevicePath;

--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -21,16 +21,13 @@
 #include <app/clusters/push-av-stream-transport-server/PushAVStreamTransportCluster.h>
 #include <app/clusters/tls-certificate-management-server/TLSCertificateManagementCluster.h>
 #include <camera-device-interface.h>
-#include <chrono>
 #include <credentials/CHIPCert.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <functional>
 #include <iomanip>
 #include <media-controller.h>
-#include <mutex>
 #include <pushav-transport.h>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 namespace chip {
@@ -38,28 +35,12 @@ namespace app {
 namespace Clusters {
 namespace PushAvStreamTransport {
 
-static constexpr int kMaxSessionDuration     = 5; // in minutes
-static constexpr int kSessionMonitorInterval = 1; // in seconds
-
-// Helper function to combine FabricIndex and sessionGroup into a single key
-inline uint32_t CreateSessionKey(FabricIndex fabricIdx, uint8_t sessionGroup)
-{
-    return (static_cast<uint32_t>(fabricIdx) << 8) | sessionGroup;
-}
-
 struct PushAvStream
 {
     uint16_t id;
     TransportOptionsStruct transportOptions;
     TransportStatusEnum transportStatus;
     PushAvStreamTransportStatusEnum connectionStatus;
-};
-
-struct SessionInfo
-{
-    uint64_t sessionNumber = 0;
-    std::chrono::system_clock::time_point sessionStartedTimestamp;
-    std::unordered_set<uint16_t> activeConnectionIDs;
 };
 
 /**
@@ -138,10 +119,6 @@ public:
 
     void RecordingStreamPrivacyModeChanged(bool privacyModeEnabled);
 
-    uint64_t OnTriggerActivated(uint8_t fabricIdx, uint8_t sessionGroup, uint16_t connectionID);
-
-    void OnTriggerDeactivated(uint8_t fabricIdx, uint8_t sessionGroup, uint16_t connectionID);
-
 private:
     MediaController * mMediaController                         = nullptr;
     CameraDeviceInterface * mCameraDevice                      = nullptr;
@@ -150,13 +127,8 @@ private:
     AudioStreamStruct mAudioStreamParams;
     VideoStreamStruct mVideoStreamParams;
 
-    std::atomic<bool> mStopMonitoring{ false };
-    std::mutex mSessionMapMutex;
-    std::thread mSessionMonitorThread;
-
     std::unordered_map<uint16_t, std::unique_ptr<PushAVTransport>> mTransportMap; // map for the transport objects
     std::unordered_map<uint16_t, TransportOptionsStruct> mTransportOptionsMap;    // map for the transport options
-    std::unordered_map<uint32_t, SessionInfo> mSessionMap;                        // map for the session info
     uint32_t mTotalUsedBandwidthbps = 0; // Tracks the total bandwidth used by all active transports
 
     std::vector<uint8_t> mBufferRootCert;
@@ -182,10 +154,6 @@ private:
      */
     void GetBandwidthForStreams(const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
                                 const Optional<DataModel::Nullable<uint16_t>> & audioStreamId, uint32_t & outBandwidthbps);
-
-    void StartSessionMonitor();
-    void StopSessionMonitor();
-    void SessionMonitor();
 };
 
 } // namespace PushAvStreamTransport

--- a/examples/camera-app/linux/include/media-controller/default-media-controller.h
+++ b/examples/camera-app/linux/include/media-controller/default-media-controller.h
@@ -39,8 +39,8 @@ public:
     // getting destroyed.
     void UnregisterTransport(Transport * transport) override;
     // DistributeVideo and DistributeAudio are called when data is ready to be sent out
-    void DistributeVideo(const uint8_t * data, size_t size, uint16_t videoStreamID) override;
-    void DistributeAudio(const uint8_t * data, size_t size, uint16_t audioStreamID) override;
+    void DistributeVideo(const uint8_t * data, size_t size, uint16_t videoStreamID, int64_t timestamp) override;
+    void DistributeAudio(const uint8_t * data, size_t size, uint16_t audioStreamID, int64_t timestamp) override;
     // Sets the desired preroll buffer length in milliseconds for the given transport
     void SetPreRollLength(Transport * transport, uint16_t preRollBufferLength) override;
     void SetCameraDevice(Camera::CameraDevice * device);

--- a/examples/camera-app/linux/include/pushav-clip-recorder.h
+++ b/examples/camera-app/linux/include/pushav-clip-recorder.h
@@ -278,6 +278,7 @@ private:
     int64_t mLastAudioPts        = 0;
     bool mMetadataSet            = false;
     bool mUploadMPD              = false;
+    bool firstSegmentReady       = false;
 
     std::vector<int> mUploadSegmentID;
     std::vector<bool> mUploadedInitSegment;

--- a/examples/camera-app/linux/include/pushav-prerollbuffer.h
+++ b/examples/camera-app/linux/include/pushav-prerollbuffer.h
@@ -47,7 +47,7 @@ class PreRollBuffer
 {
 public:
     PreRollBuffer();
-    void PushFrameToBuffer(const std::string & streamKey, const uint8_t * data, size_t size);
+    void PushFrameToBuffer(const std::string & streamKey, const uint8_t * data, size_t size, int64_t timestampMs);
     void RegisterTransportToBuffer(BufferSink * sink, const std::unordered_set<std::string> & streamKeys);
     void DeregisterTransportFromBuffer(BufferSink * sink);
     void SetMaxTotalBytes(size_t size);

--- a/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
+++ b/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
@@ -37,18 +37,9 @@
 #include <thread>
 #include <vector>
 
-namespace chip {
-namespace app {
-namespace Clusters {
-namespace PushAvStreamTransport {
-class PushAvStreamTransportManager; // Forward declaration
-} // namespace PushAvStreamTransport
-} // namespace Clusters
-} // namespace app
-} // namespace chip
-
-static constexpr int kInvalidZoneId      = -1;
-static constexpr int kDefaultSensitivity = 5;
+static constexpr int kInvalidZoneId             = -1; // Invalid zone id value for trigger detection
+static constexpr int kDefaultSensitivity        = 5;  // Default motion sensitivity level
+static constexpr int kMaxSessionDurationMinutes = 5;  // Maximum session duration in minutes
 
 class PushAVTransport : public Transport
 {
@@ -59,10 +50,10 @@ public:
     ~PushAVTransport() override;
 
     // Send video data for a given stream ID
-    void SendVideo(const chip::ByteSpan & data, int64_t timestamp, uint16_t videoStreamID) override;
+    void SendVideo(const chip::ByteSpan & data, int64_t timestampMs, uint16_t videoStreamID) override;
 
     // Send audio data for a given stream ID
-    void SendAudio(const chip::ByteSpan & data, int64_t timestamp, uint16_t audioStreamID) override;
+    void SendAudio(const chip::ByteSpan & data, int64_t timestampMs, uint16_t audioStreamID) override;
 
     // Send synchronized audio/video data for given audio and video stream IDs
     void SendAudioVideo(const chip::ByteSpan & data, uint16_t videoStreamID, uint16_t audioStreamID) override;
@@ -73,8 +64,11 @@ public:
     // Indicates that the transport is ready to send audio data
     bool CanSendAudio() override;
 
-    // Dummy implementation to indicate whether the transport is streaming or not
-    bool IsStreaming();
+    // Update send flags based on current streaming state
+    void UpdateSendFlags();
+
+    // Indicates whether the transport is streaming or not
+    bool IsStreaming() const;
 
     bool GetBusyStatus();
 
@@ -84,7 +78,7 @@ public:
     void SetTransportStatus(chip::app::Clusters::PushAvStreamTransport::TransportStatusEnum status);
 
     void TriggerTransport(chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum activationReason,
-                          int zoneId = kInvalidZoneId, int sensitivity = kDefaultSensitivity, bool isZoneBasedTrigger = false);
+                          int zoneId = kInvalidZoneId, int sensitivity = kDefaultSensitivity);
     // Get Transport status
     bool GetTransportStatus()
     {
@@ -128,27 +122,30 @@ public:
         mPushAvStreamTransportServer = server;
     }
 
-    void SetPushAvStreamTransportManager(chip::app::Clusters::PushAvStreamTransport::PushAvStreamTransportManager * manager)
-    {
-        mPushAvStreamTransportManager = manager;
-    }
-
     void ConfigureRecorderTimeSetting(
         const chip::app::Clusters::PushAvStreamTransport::Structs::TransportMotionTriggerTimeControlStruct::DecodableType &
             timeControl);
 
     void SetFabricIndex(chip::FabricIndex accessingFabricIndex) { mFabricIndex = accessingFabricIndex; }
 
-    void StartNewSession(uint64_t newSessionID);
-
 private:
-    bool mHasAugmented                                                                                       = false;
-    bool mStreaming                                                                                          = false;
-    std::unique_ptr<PushAVClipRecorder> mRecorder                                                            = nullptr;
-    std::unique_ptr<PushAVUploader> mUploader                                                                = nullptr;
-    chip::FabricIndex mFabricIndex                                                                           = 0;
-    chip::app::Clusters::PushAvStreamTransportServer * mPushAvStreamTransportServer                          = nullptr;
-    chip::app::Clusters::PushAvStreamTransport::PushAvStreamTransportManager * mPushAvStreamTransportManager = nullptr;
+    void CheckAndUpdateSession();
+    void GeneratePushTransportBeginEvent();
+    void StartRecordingAndStreaming();
+    bool ValidateZoneAndSensitivity(
+        const std::vector<std::pair<chip::app::DataModel::Nullable<uint16_t>, uint8_t>> & zoneSensitivityList, int zoneId,
+        int sensitivity);
+
+    bool mHasAugmented                                                              = false;
+    bool mStreaming                                                                 = false;
+    uint64_t mSessionNumber                                                         = 1;
+    std::unique_ptr<PushAVClipRecorder> mRecorder                                   = nullptr;
+    std::unique_ptr<PushAVUploader> mUploader                                       = nullptr;
+    chip::FabricIndex mFabricIndex                                                  = 0;
+    chip::app::Clusters::PushAvStreamTransportServer * mPushAvStreamTransportServer = nullptr;
+    chip::Optional<chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum> mActivationReason =
+        chip::Optional<chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum>();
+    std::chrono::system_clock::time_point mSessionStartedTimestamp;
     std::chrono::steady_clock::time_point mBlindStartTime;
     PushAVClipRecorder::ClipInfoStruct mClipInfo;
     PushAVClipRecorder::AudioInfoStruct mAudioInfo;
@@ -170,7 +167,7 @@ private:
     chip::app::Clusters::PushAvStreamTransport::TransportStatusEnum mTransportStatus;
     chip::app::Clusters::PushAvStreamTransport::TransportTriggerTypeEnum mTransportTriggerType;
     uint16_t mConnectionID;
-    uint32_t mCurrentlyUsedBandwidthbps    = 0;
-    bool mActivationTimeSetByManualTrigger = false;
-    bool mIsZoneBasedTrigger               = false;
+    uint32_t mCurrentlyUsedBandwidthbps     = 0;
+    bool mCurrentActivationByManualTrigger  = false;
+    bool mPreviousActivationByManualTrigger = false;
 };

--- a/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
+++ b/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
@@ -128,6 +128,8 @@ public:
 
     void SetFabricIndex(chip::FabricIndex accessingFabricIndex) { mFabricIndex = accessingFabricIndex; }
 
+    uint64_t GetSessionNumber() const { return mSessionNumber; }
+
 private:
     void CheckAndUpdateSession();
     void GeneratePushTransportBeginEvent();

--- a/examples/camera-app/linux/include/uploader/pushav-uploader.h
+++ b/examples/camera-app/linux/include/uploader/pushav-uploader.h
@@ -78,6 +78,5 @@ private:
     std::mutex mQueueMutex;
     std::atomic<bool> mIsRunning;
     std::thread mUploaderThread;
-    std::pair<std::string, std::string> mMPDPath;
     std::vector<std::string> mStreamIdNameMap;
 };

--- a/examples/camera-app/linux/include/uploader/pushav-uploader.h
+++ b/examples/camera-app/linux/include/uploader/pushav-uploader.h
@@ -19,11 +19,14 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <curl/curl.h>
+#include <filesystem>
 #include <mutex>
 #include <queue>
 #include <string>
 #include <thread>
+#include <unordered_map>
 
 typedef struct UploadDataInfo
 {
@@ -55,7 +58,7 @@ public:
 
     void Start();
     void Stop();
-    void AddUploadData(std::string & filename, std::string & url);
+    void AddUploadData(const std::string & filename, const std::string & url);
     size_t GetUploadQueueSize()
     {
         std::lock_guard<std::mutex> lock(mQueueMutex);
@@ -64,9 +67,7 @@ public:
 
     void setCertificateBuffer(const PushAVCertBuffer & certBuffer) { mCertBuffer = certBuffer; }
     void setCertificatePath(const PushAVCertPath & certPath) { mCertPath = certPath; }
-
-    void setMPDPath(const std::pair<std::string, std::string> & path) { mMPDPath = path; }
-    std::pair<std::string, std::string> getMPDPath() const { return mMPDPath; }
+    void setStreamIdNameMap(const std::vector<std::string> & streamIdNameMap) { mStreamIdNameMap = streamIdNameMap; }
 
 private:
     void ProcessQueue();
@@ -78,4 +79,5 @@ private:
     std::atomic<bool> mIsRunning;
     std::thread mUploaderThread;
     std::pair<std::string, std::string> mMPDPath;
+    std::vector<std::string> mStreamIdNameMap;
 };

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -119,8 +119,8 @@ GstFlowReturn OnNewVideoSampleFromAppSink(GstAppSink * appsink, gpointer user_da
         else
         {
             ChipLogError(Camera,
-                        "Dropping video frame with PTS %" G_GUINT64_FORMAT " <= first PTS %" G_GUINT64_FORMAT " for stream %u",
-                        rawPts, self->mVideoStreamFirstPts[videoStreamID], videoStreamID);
+                         "Dropping video frame with PTS %" G_GUINT64_FORMAT " <= first PTS %" G_GUINT64_FORMAT " for stream %u",
+                         rawPts, self->mVideoStreamFirstPts[videoStreamID], videoStreamID);
         }
         gst_buffer_unmap(buffer, &map);
     }
@@ -183,7 +183,7 @@ static GstFlowReturn OnNewAudioSampleFromAppSink(GstAppSink * appsink, gpointer 
         {
             offsetNs = rawPts - self->mAudioStreamFirstPts[audioStreamID];
             ts       = startEpoch + (offsetNs / 1000000); // Convert ns to ms
-                                                        // Forward raw Opus encoded frames to media controller with timestamp
+            // Forward raw Opus encoded frames to media controller with timestamp
             // The PreRollBuffer will distribute to ALL transports registered for this audioStreamID
             // Each transport will handle its own SFrame encryption (if configured) during RTP packetization
             self->GetMediaController().DistributeAudio(reinterpret_cast<const uint8_t *>(map.data), map.size, audioStreamID, ts);
@@ -191,8 +191,8 @@ static GstFlowReturn OnNewAudioSampleFromAppSink(GstAppSink * appsink, gpointer 
         else
         {
             ChipLogError(Camera,
-                        "Dropping audio frame with PTS %" G_GUINT64_FORMAT " <= first PTS %" G_GUINT64_FORMAT " for stream %u",
-                        rawPts, self->mAudioStreamFirstPts[audioStreamID], audioStreamID);
+                         "Dropping audio frame with PTS %" G_GUINT64_FORMAT " <= first PTS %" G_GUINT64_FORMAT " for stream %u",
+                         rawPts, self->mAudioStreamFirstPts[audioStreamID], audioStreamID);
         }
         gst_buffer_unmap(buffer, &map);
     }

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -90,10 +90,38 @@ GstFlowReturn OnNewVideoSampleFromAppSink(GstAppSink * appsink, gpointer user_da
     GstMapInfo map;
     if (gst_buffer_map(buffer, &map, GST_MAP_READ))
     {
-        // Forward raw H.264 encoded frames to media controller
-        // The PreRollBuffer will distribute to ALL transports registered for this videoStreamID
-        // Each transport will handle its own SFrame encryption (if configured) during RTP packetization
-        self->GetMediaController().DistributeVideo(reinterpret_cast<const uint8_t *>(map.data), map.size, videoStreamID);
+        GstClockTime rawPts = GST_BUFFER_PTS(buffer);
+        if (rawPts == GST_CLOCK_TIME_NONE)
+        {
+            rawPts = GST_BUFFER_DTS(buffer);
+            if (rawPts == GST_CLOCK_TIME_NONE)
+            {
+                rawPts = 0;
+            }
+        }
+        auto firstPtsIt = self->mVideoStreamFirstPts.find(videoStreamID);
+        if (firstPtsIt == self->mVideoStreamFirstPts.end())
+        {
+            self->mVideoStreamFirstPts[videoStreamID] = rawPts;
+        }
+        GstClockTime offsetNs = 0;
+        int64_t startEpoch    = self->mVideoStreamStartEpochs[videoStreamID];
+        int64_t ts            = 0;
+        if (rawPts >= self->mVideoStreamFirstPts[videoStreamID])
+        {
+            offsetNs = rawPts - self->mVideoStreamFirstPts[videoStreamID];
+            ts       = startEpoch + (offsetNs / 1000000); // Convert ns to ms
+            // Forward raw H.264 encoded frames to media controller with timestamp
+            // The PreRollBuffer will distribute to ALL transports registered for this videoStreamID
+            // Each transport will handle its own SFrame encryption (if configured) during RTP packetization
+            self->GetMediaController().DistributeVideo(reinterpret_cast<const uint8_t *>(map.data), map.size, videoStreamID, ts);
+        }
+        else
+        {
+            ChipLogError(Camera,
+                        "Dropping video frame with PTS %" G_GUINT64_FORMAT " <= first PTS %" G_GUINT64_FORMAT " for stream %u",
+                        rawPts, self->mVideoStreamFirstPts[videoStreamID], videoStreamID);
+        }
         gst_buffer_unmap(buffer, &map);
     }
 
@@ -134,10 +162,38 @@ static GstFlowReturn OnNewAudioSampleFromAppSink(GstAppSink * appsink, gpointer 
     GstMapInfo map;
     if (gst_buffer_map(buffer, &map, GST_MAP_READ))
     {
-        // Forward raw Opus encoded frames to media controller
-        // The PreRollBuffer will distribute to ALL transports registered for this audioStreamID
-        // Each transport will handle its own SFrame encryption (if configured) during RTP packetization
-        self->GetMediaController().DistributeAudio(reinterpret_cast<const uint8_t *>(map.data), map.size, audioStreamID);
+        GstClockTime rawPts = GST_BUFFER_PTS(buffer);
+        if (rawPts == GST_CLOCK_TIME_NONE)
+        {
+            rawPts = GST_BUFFER_DTS(buffer);
+            if (rawPts == GST_CLOCK_TIME_NONE)
+            {
+                rawPts = 0;
+            }
+        }
+        auto firstPtsIt = self->mAudioStreamFirstPts.find(audioStreamID);
+        if (firstPtsIt == self->mAudioStreamFirstPts.end())
+        {
+            self->mAudioStreamFirstPts[audioStreamID] = rawPts;
+        }
+        GstClockTime offsetNs = 0;
+        int64_t startEpoch    = self->mAudioStreamStartEpochs[audioStreamID];
+        int64_t ts            = 0;
+        if (rawPts >= self->mAudioStreamFirstPts[audioStreamID])
+        {
+            offsetNs = rawPts - self->mAudioStreamFirstPts[audioStreamID];
+            ts       = startEpoch + (offsetNs / 1000000); // Convert ns to ms
+                                                        // Forward raw Opus encoded frames to media controller with timestamp
+            // The PreRollBuffer will distribute to ALL transports registered for this audioStreamID
+            // Each transport will handle its own SFrame encryption (if configured) during RTP packetization
+            self->GetMediaController().DistributeAudio(reinterpret_cast<const uint8_t *>(map.data), map.size, audioStreamID, ts);
+        }
+        else
+        {
+            ChipLogError(Camera,
+                        "Dropping audio frame with PTS %" G_GUINT64_FORMAT " <= first PTS %" G_GUINT64_FORMAT " for stream %u",
+                        rawPts, self->mAudioStreamFirstPts[audioStreamID], audioStreamID);
+        }
         gst_buffer_unmap(buffer, &map);
     }
 
@@ -907,6 +963,10 @@ CameraError CameraDevice::StartVideoStream(const VideoStreamStruct & allocatedSt
         return CameraError::ERROR_VIDEO_STREAM_START_FAILED;
     }
 
+    mVideoStreamFirstPts.erase(streamID);
+    auto now                          = std::chrono::steady_clock::now().time_since_epoch();
+    mVideoStreamStartEpochs[streamID] = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+
     // Store in stream context
     it->videoContext = videoPipeline;
 
@@ -1005,6 +1065,10 @@ CameraError CameraDevice::StartAudioStream(uint16_t streamID)
         it->audioContext = nullptr;
         return CameraError::ERROR_AUDIO_STREAM_START_FAILED;
     }
+
+    mAudioStreamFirstPts.erase(streamID);
+    auto now                          = std::chrono::steady_clock::now().time_since_epoch();
+    mAudioStreamStartEpochs[streamID] = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
 
     // Store in stream context
     it->audioContext = audioPipeline;

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -803,7 +803,7 @@ bool PushAvStreamTransportManager::GetCMAFSessionNumber(const uint16_t connectio
         return false;
     }
     else
-    {   
+    {
         sessionNumber = transportIt->second->GetSessionNumber();
     }
 

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -794,26 +794,17 @@ CHIP_ERROR PushAvStreamTransportManager::IsAnyPrivacyModeActive(bool & isActive)
 
 bool PushAvStreamTransportManager::GetCMAFSessionNumber(const uint16_t connectionID, uint64_t & sessionNumber)
 {
-    std::lock_guard<std::mutex> lock(mSessionMapMutex);
-
-    // Look for the connection in any session
-    for (const auto & sessionPair : mSessionMap)
+    sessionNumber = 0;
+    // find the transport for the given connection id and return its session number
+    auto transportIt = mTransportMap.find(connectionID);
+    if (transportIt == mTransportMap.end())
     {
-        const auto & sessionInfo = sessionPair.second;
-        if (sessionInfo.activeConnectionIDs.find(connectionID) != sessionInfo.activeConnectionIDs.end())
-        {
-            sessionNumber = sessionInfo.sessionNumber;
-            return true;
-        }
+        ChipLogError(Camera, "PushAvStreamTransportManager, failed to find Connection :[%u]", connectionID);
+        return false;
     }
-
-    // If not found in active sessions, check if we have transport options for this connection
-    auto transportIt = mTransportOptionsMap.find(connectionID);
-    if (transportIt != mTransportOptionsMap.end())
-    {
-        // For connections not in active sessions, return a default session number
-        sessionNumber = 0;
-        return true;
+    else
+    {   
+        sessionNumber = transportIt->second->GetSessionNumber();
     }
 
     return false;

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -802,10 +802,7 @@ bool PushAvStreamTransportManager::GetCMAFSessionNumber(const uint16_t connectio
         ChipLogError(Camera, "PushAvStreamTransportManager, failed to find Connection :[%u]", connectionID);
         return false;
     }
-    else
-    {
-        sessionNumber = transportIt->second->GetSessionNumber();
-    }
 
-    return false;
+    sessionNumber = transportIt->second->GetSessionNumber();
+    return true;
 }

--- a/examples/camera-app/linux/src/media-controller/default-media-controller.cpp
+++ b/examples/camera-app/linux/src/media-controller/default-media-controller.cpp
@@ -89,16 +89,16 @@ void DefaultMediaController::UnregisterTransport(Transport * transport)
     }
 }
 
-void DefaultMediaController::DistributeVideo(const uint8_t * data, size_t size, uint16_t videoStreamID)
+void DefaultMediaController::DistributeVideo(const uint8_t * data, size_t size, uint16_t videoStreamID, int64_t timestamp)
 {
     std::string streamKey = "v" + std::to_string(videoStreamID);
-    mPreRollBuffer.PushFrameToBuffer(streamKey, data, size);
+    mPreRollBuffer.PushFrameToBuffer(streamKey, data, size, timestamp);
 }
 
-void DefaultMediaController::DistributeAudio(const uint8_t * data, size_t size, uint16_t audioStreamID)
+void DefaultMediaController::DistributeAudio(const uint8_t * data, size_t size, uint16_t audioStreamID, int64_t timestamp)
 {
     std::string streamKey = "a" + std::to_string(audioStreamID);
-    mPreRollBuffer.PushFrameToBuffer(streamKey, data, size);
+    mPreRollBuffer.PushFrameToBuffer(streamKey, data, size, timestamp);
 }
 
 void DefaultMediaController::SetPreRollLength(Transport * transport, uint16_t preRollBufferLength)

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -23,12 +23,12 @@
 #include <iomanip>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/PlatformManager.h>
-#include <push-av-stream-manager.h>
 #include <regex>
 #include <sys/stat.h>
 
 constexpr int kSegmentIdOffset       = 1000;
 constexpr int kMPDDefaultStartNumber = 1001;
+constexpr int kInitialSegmentId      = 1;
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -51,45 +51,42 @@ AVDictionary * options = NULL;
 
 PushAVClipRecorder::PushAVClipRecorder(ClipInfoStruct & aClipInfo, AudioInfoStruct & aAudioInfo, VideoInfoStruct & aVideoInfo,
                                        PushAVUploader * aUploader) :
-    mClipInfo(aClipInfo),
-    mAudioInfo(aAudioInfo), mVideoInfo(aVideoInfo), mUploader(aUploader)
+    mClipInfo(aClipInfo), mAudioInfo(aAudioInfo), mVideoInfo(aVideoInfo), mUploader(aUploader)
 {
-    mFormatContext        = nullptr;
-    mInputFormatContext   = nullptr;
-    mVideoStream          = nullptr;
-    mAudioStream          = nullptr;
-    mAudioEncoderContext  = nullptr;
-    mVideoInfo.mVideoPts  = 0;
-    mVideoInfo.mVideoDts  = 0;
-    mAudioInfo.mAudioPts  = 0;
-    mAudioInfo.mAudioDts  = 0;
-    int streamIndex       = 0;
-    mMetadataSet          = false;
-    mDeinitializeRecorder = false;
-    mUploadedInitSegment  = false;
-    mUploadMPD            = false;
-    mUploadSegmentID      = 0001;
-    mCurrentClipStartPts  = AV_NOPTS_VALUE;
-    mFoundFirstIFramePts  = -1;
-    currentPts            = AV_NOPTS_VALUE;
+    mFormatContext          = nullptr;
+    mInputFormatContext     = nullptr;
+    mVideoStream            = nullptr;
+    mAudioStream            = nullptr;
+    mAudioEncoderContext    = nullptr;
+    int streamIndex         = 0;
+    mLastVideoPts           = 0;
+    mLastAudioPts           = 0;
+    mClipInfo.mClipStartPTS = 0;
+    mMetadataSet            = false;
+    mDeinitializeRecorder   = false;
+    mUploadMPD              = true;
+    mCurrentClipStartPts    = AV_NOPTS_VALUE;
+    currentPts              = AV_NOPTS_VALUE;
 
-    mVideoInfo.mVideoStreamIndex = -1;
-    mAudioInfo.mAudioStreamIndex = -1;
+    mVideoInfo.mVideoOutputStreamId = -1;
+    mAudioInfo.mAudioOutputStreamId = -1;
 
-    if (mClipInfo.mHasAudio && mClipInfo.mHasVideo)
-    {
-        ChipLogDetail(Camera, "Both audio and video streams are active. Only one stream at a time is supported currently.");
-        mClipInfo.mHasAudio = false;
-    }
     if (mClipInfo.mHasVideo)
     {
-        mVideoInfo.mVideoStreamIndex = streamIndex++;
+        mUploadSegmentID.push_back(kInitialSegmentId);
+        mUploadedInitSegment.push_back(false);
+        mStreamIdNameMap.push_back(mVideoInfo.mVideoStreamName);
+        mVideoInfo.mVideoOutputStreamId = streamIndex++;
     }
     if (mClipInfo.mHasAudio)
     {
-        mAudioInfo.mAudioStreamIndex = streamIndex++;
+        mUploadSegmentID.push_back(kInitialSegmentId);
+        mUploadedInitSegment.push_back(false);
+        mStreamIdNameMap.push_back(mAudioInfo.mAudioStreamName);
+        mAudioInfo.mAudioOutputStreamId = streamIndex++;
     }
     SetRecorderStatus(false); // Start off as not running
+    mUploader->setStreamIdNameMap(mStreamIdNameMap);
     ChipLogProgress(Camera, "PushAVClipRecorder initialized for Track name: %s, output path: %s", mClipInfo.mTrackName.c_str(),
                     mClipInfo.mOutputPath.c_str());
 }
@@ -103,14 +100,22 @@ PushAVClipRecorder::~PushAVClipRecorder()
     {
         mWorkerThread.join();
     }
+
+    std::filesystem::path mpdPath = mUploadFileBasePath / "index.mpd";
+    if (IsFileReadyForUpload(mpdPath))
+    {
+        UpdateMPDParams(mpdPath);
+        ChipLogProgress(Camera, "Uploading final MPD: %s for track: %s, sessionID: %lu, connectionID: %u", mpdPath.c_str(),
+                        mClipInfo.mTrackName.c_str(), mClipInfo.mSessionNumber, mConnectionID);
+        CheckAndUploadFile(mpdPath.string());
+    }
 }
 
 bool PushAVClipRecorder::EnsureDirectoryExists(const std::string & path)
 {
     // Base output path
     std::filesystem::path basePath(path);
-    std::filesystem::path sessionDir = basePath / ("session_" + std::to_string(mClipInfo.mSessionNumber));
-    std::filesystem::path trackDir   = sessionDir / mClipInfo.mTrackName;
+    mUploadFileBasePath = basePath / ("session_" + std::to_string(mClipInfo.mSessionNumber));
 
     // Helper lambda to ensure a directory exists and is writable, creating it with mode 0755
     auto ensure = [&](const std::filesystem::path & p) -> bool {
@@ -138,50 +143,27 @@ bool PushAVClipRecorder::EnsureDirectoryExists(const std::string & path)
         auto perms = std::filesystem::status(p, ec).permissions();
         if ((perms & std::filesystem::perms::owner_write) == std::filesystem::perms::none)
         {
-            ChipLogError(Camera, "Directory is not writable: %s, error code: %d (%s)", p.c_str(), ec.value(), ec.message().c_str());
+            ChipLogError(Camera, "Directory is not writable: %s (permissions: %o)", p.c_str(), static_cast<unsigned int>(perms));
             return false;
         }
+
         return true;
     };
 
     // Ensure base directory exists
-
-    std::string basePathStr = basePath.string();
-    std::string pathExists;
-    pathExists.reserve(basePathStr.length());
-
-    size_t startIndex = (basePathStr[0] == '/') ? 1 : 0;
-
-    for (size_t i = startIndex; i < basePathStr.length(); ++i)
+    if (!ensure(basePath))
     {
-        if (basePathStr[i] == '/' || i == basePathStr.length() - 1)
-        {
-            // Include the current character if it's the last character and not a slash
-            size_t endPos = (basePathStr[i] == '/' && i != basePathStr.length() - 1) ? i : i + 1;
-
-            // Build the path incrementally
-            pathExists = basePathStr.substr(0, endPos);
-
-            // Skip empty paths (can happen with consecutive slashes)
-            if (pathExists.empty() || pathExists.back() == '/')
-            {
-                continue;
-            }
-
-            if (!ensure(pathExists))
-            {
-                ChipLogError(Camera, "Failed to ensure directory exists: %s", pathExists.c_str());
-                return false;
-            }
-        }
+        ChipLogError(Camera, "Failed to ensure base directory exists: %s", basePath.c_str());
+        return false;
     }
 
     // Clean up previous session directory if it exists
-    std::filesystem::remove_all(sessionDir);
+    std::filesystem::remove_all(mUploadFileBasePath);
 
     // Create session and track directories
-    if (!ensure(sessionDir) || !ensure(trackDir))
+    if (!ensure(mUploadFileBasePath))
     {
+        ChipLogError(Camera, "Failed to ensure session directory exists: %s", mUploadFileBasePath.c_str());
         return false;
     }
 
@@ -256,7 +238,7 @@ bool PushAVClipRecorder::IsH264IFrame(const uint8_t * data, unsigned int length)
     return ret;
 }
 
-AVPacket * PushAVClipRecorder::CreatePacket(const uint8_t * data, int size, bool isVideo)
+AVPacket * PushAVClipRecorder::CreatePacket(const uint8_t * data, int size, int64_t timestampMs, bool isVideo)
 {
     AVPacket * packet = av_packet_alloc();
     if (!packet)
@@ -264,7 +246,6 @@ AVPacket * PushAVClipRecorder::CreatePacket(const uint8_t * data, int size, bool
         ChipLogError(Camera, "ERROR: AVPacket allocation failed!");
         return nullptr;
     }
-
     packet->data = static_cast<uint8_t *>(av_malloc(static_cast<size_t>(size)));
     if (!packet->data)
     {
@@ -272,7 +253,6 @@ AVPacket * PushAVClipRecorder::CreatePacket(const uint8_t * data, int size, bool
         av_packet_free(&packet);
         return nullptr;
     }
-
     memcpy(packet->data, data, static_cast<size_t>(size));
     packet->size = size;
 
@@ -280,42 +260,70 @@ AVPacket * PushAVClipRecorder::CreatePacket(const uint8_t * data, int size, bool
     {
         if (IsH264IFrame(data, static_cast<unsigned int>(size)))
         {
-            mFoundFirstIFramePts = mVideoInfo.mVideoPts;
-            packet->flags        = AV_PKT_FLAG_KEY;
-            ChipLogProgress(Camera, "Found I-frame at PTS: %" PRId64, mVideoInfo.mVideoPts);
+            if (mClipInfo.mClipStartPTS == 0)
+                mClipInfo.mClipStartPTS = timestampMs;
+            packet->flags = AV_PKT_FLAG_KEY;
+
+            ChipLogProgress(Camera, "Found I-frame at timestamp: %ld ms", timestampMs);
         }
 
-        if (mClipInfo.mHasVideo && mFoundFirstIFramePts < 0)
+        if (mClipInfo.mHasVideo && mClipInfo.mClipStartPTS == 0)
         {
             ChipLogError(Camera, "ERROR: First frame is not an I-frame. Dropping packet.");
             av_packet_free(&packet);
             return nullptr;
         }
 
-        packet->pts          = mVideoInfo.mVideoPts;
-        packet->dts          = mVideoInfo.mVideoDts;
-        packet->stream_index = mVideoInfo.mVideoStreamIndex;
-        packet->duration     = mVideoInfo.mVideoFrameDuration;
-        mVideoInfo.mVideoDts += mVideoInfo.mVideoFrameDuration;
-        mVideoInfo.mVideoPts += mVideoInfo.mVideoFrameDuration;
-    }
-    else
-    {
-        if (mClipInfo.mHasVideo && mFoundFirstIFramePts < 0 && mFoundFirstIFramePts <= mAudioInfo.mAudioPts)
+        if (mVideoInfo.mVideoTimeBase.num != 0)
         {
-            ChipLogError(Camera, "ERROR: frames will be dropped till an Iframe is recived");
+            mLastVideoPts = timestampMs;
+
+            // Normalize timestamp relative to clip start
+            int64_t normalizedTimestampMs = timestampMs - mClipInfo.mClipStartPTS;
+            packet->pts                   = av_rescale_q(normalizedTimestampMs, (AVRational){ 1, 1000 }, mVideoInfo.mVideoTimeBase);
+            packet->dts                   = packet->pts;
+        }
+        else
+        {
+            ChipLogError(Camera, "ERROR: Invalid video timebase (num=0)");
             av_packet_free(&packet);
             return nullptr;
         }
-        packet->pts          = mAudioInfo.mAudioPts;
-        packet->dts          = mAudioInfo.mAudioDts;
-        packet->stream_index = mAudioInfo.mAudioStreamIndex;
-        packet->duration     = mAudioInfo.mAudioFrameDuration;
-        mAudioInfo.mAudioDts += mAudioInfo.mAudioFrameDuration;
-        mAudioInfo.mAudioPts += mAudioInfo.mAudioFrameDuration;
+
+        packet->stream_index = mVideoInfo.mVideoOutputStreamId;
+    }
+    else
+    {
+        if (mClipInfo.mHasVideo && mClipInfo.mClipStartPTS == 0)
+        {
+            av_packet_free(&packet);
+            return nullptr;
+        }
+
+        if (!mClipInfo.mHasVideo && mClipInfo.mClipStartPTS == 0)
+        {
+            mClipInfo.mClipStartPTS = timestampMs;
+        }
+        if (mAudioInfo.mAudioTimeBase.num != 0)
+        {
+            mLastAudioPts = timestampMs;
+
+            // Normalize timestamp relative to clip start
+            int64_t normalizedTimestampMs = timestampMs - mClipInfo.mClipStartPTS;
+            packet->pts                   = av_rescale_q(normalizedTimestampMs, (AVRational){ 1, 1000 }, mAudioInfo.mAudioTimeBase);
+            packet->dts                   = packet->pts;
+        }
+        else
+        {
+            ChipLogError(Camera, "ERROR: Invalid audio timebase (num=0)");
+            av_packet_free(&packet);
+            return nullptr;
+        }
+
+        packet->stream_index = mAudioInfo.mAudioOutputStreamId;
     }
 
-    return (mClipInfo.mHasVideo && mFoundFirstIFramePts < 0) ? nullptr : packet;
+    return packet;
 }
 
 void PushAVClipRecorder::Start()
@@ -332,6 +340,11 @@ void PushAVClipRecorder::Start()
         mDeinitializeRecorder = true;
     }
 
+    if (mWorkerThread.joinable())
+    {
+        mWorkerThread.join();
+    }
+
     SetRecorderStatus(true);
     mWorkerThread = std::thread(&PushAVClipRecorder::StartClipRecording, this);
     ChipLogProgress(Camera, "Recording started for sessionID: %" PRIu64 " Track name: %s", mClipInfo.mSessionNumber,
@@ -342,8 +355,6 @@ void PushAVClipRecorder::Stop()
 {
     if (GetRecorderStatus())
     {
-        mPushAvStreamTransportManager->OnTriggerDeactivated(mFabricIndex, mClipInfo.mSessionGroup, mConnectionID);
-
         // Call the cluster server's NotifyTransportStopped method asynchronously to prevent blocking
         if (mPushAvStreamTransportServer != nullptr)
         {
@@ -389,7 +400,7 @@ void PushAVClipRecorder::Stop()
                     mClipInfo.mTrackName.c_str());
 }
 
-void PushAVClipRecorder::PushPacket(const uint8_t * data, size_t size, bool isVideo)
+void PushAVClipRecorder::PushPacket(const uint8_t * data, size_t size, int64_t timestampMs, bool isVideo)
 {
     if (!GetRecorderStatus())
     {
@@ -397,7 +408,7 @@ void PushAVClipRecorder::PushPacket(const uint8_t * data, size_t size, bool isVi
         return;
     }
 
-    AVPacket * packet = CreatePacket(data, static_cast<int>(size), isVideo);
+    AVPacket * packet = CreatePacket(data, static_cast<int>(size), timestampMs, isVideo);
     if (!packet)
     {
         ChipLogError(Camera, "ERROR: PACKET DROPPED!");
@@ -420,7 +431,7 @@ void PushAVClipRecorder::PushPacket(const uint8_t * data, size_t size, bool isVi
 RecorderStatus PushAVClipRecorder::SetupOutput(const std::string & outputPrefix, const std::string & initSegPattern,
                                                const std::string & mediaSegPattern)
 {
-    const std::string mpdFilename = outputPrefix + ".mpd";
+    const std::string mpdFilename = outputPrefix + "/index.mpd";
     if (avformat_alloc_output_context2(&mFormatContext, nullptr, nullptr, mpdFilename.c_str()) < 0)
     {
         ChipLogError(Camera, "ERROR: Failed to allocate output context");
@@ -627,14 +638,11 @@ RecorderStatus PushAVClipRecorder::ProcessBuffersAndWrite()
 
     if (mMetadataSet == false)
     {
-        std::string initSegName =
-            mClipInfo.mTrackName + std::filesystem::path::preferred_separator + mClipInfo.mTrackName + ".init";
-        std::string mediaSegName = mClipInfo.mTrackName + std::filesystem::path::preferred_separator + "segment_$Number%04d$.m4s";
-        std::string mpdPrefix = "session_" + std::to_string(mClipInfo.mSessionNumber) + std::filesystem::path::preferred_separator +
-            mClipInfo.mTrackName;
-
-        mInputFormatContext          = avformat_alloc_context();
-        int64_t avioCtxBufferSize    = (static_cast<int64_t>(mVideoInfo.mBitRate) * mClipInfo.mSegmentDurationMs) / (8 * 1000);
+        std::string initSegName  = "#__$RepresentationID$__#.init";
+        std::string mediaSegName = "#__$RepresentationID$__#segment_$Number%04d$.m4s";
+        mInputFormatContext      = avformat_alloc_context();
+        int64_t avioCtxBufferSize =
+            (static_cast<int64_t>(mVideoInfo.mBitRate + mAudioInfo.mBitRate) * mClipInfo.mSegmentDurationMs) / (8 * 1000);
         uint8_t * mAvioContextBuffer = static_cast<uint8_t *>(av_malloc(static_cast<size_t>(avioCtxBufferSize)));
         struct BufferData data       = { 0 };
         data.mPtr                    = static_cast<uint8_t *>(pkt->data);
@@ -664,7 +672,7 @@ RecorderStatus PushAVClipRecorder::ProcessBuffersAndWrite()
             ChipLogProgress(Camera, "Setting up audio-only stream, skipping input format initialization");
         }
 
-        if (SetupOutput(mClipInfo.mOutputPath + mpdPrefix, initSegName, mediaSegName) == RecorderStatus::kFail)
+        if (SetupOutput(mUploadFileBasePath, initSegName, mediaSegName) == RecorderStatus::kFail)
         {
             ChipLogError(Camera, "Error: setting up output");
             return RecorderStatus::kFail;
@@ -750,87 +758,84 @@ void PushAVClipRecorder::CleanupOutput()
     ChipLogProgress(Camera, "Cleanup completed");
 }
 
-std::string RenameSegmentFile(const std::string & originalPath)
+void PushAVClipRecorder::UpdateMPDParams(const std::string & mpdPath)
 {
-    std::regex segment_regex(R"((.*/segment_)(\d+)(\.m4s))");
-    std::smatch match;
-
-    if (std::regex_match(originalPath, match, segment_regex) && match.size() == 4)
-    {
-        std::string pathPrefix = match[1].str();
-        std::string numberStr  = match[2].str();
-        std::string pathSuffix = match[3].str();
-
-        char * endPtr;
-        long originalNumber = std::strtol(numberStr.c_str(), &endPtr, 10);
-
-        // Check for conversion errors: no digits were converted, or extra characters remain.
-        if (endPtr == numberStr.c_str() || *endPtr != '\0' || originalNumber > INT_MAX || originalNumber < INT_MIN)
-        {
-            ChipLogDetail(Camera, "Invalid segment number format in path %s, not renaming.", originalPath.c_str());
-            return originalPath;
-        }
-
-        int newNumber = static_cast<int>(originalNumber) + kSegmentIdOffset;
-
-        if (newNumber > 9999)
-        {
-            ChipLogDetail(Camera, "Segment %s (new number %d) exceeds 9999, stopping clip recording", originalPath.c_str(),
-                          newNumber);
-            return originalPath;
-        }
-
-        char newPathBuffer[1024];
-        snprintf(newPathBuffer, sizeof(newPathBuffer), "%s%04d%s", pathPrefix.c_str(), newNumber, pathSuffix.c_str());
-        std::string newPath = newPathBuffer;
-
-        std::error_code error;
-        std::filesystem::rename(originalPath.c_str(), newPath.c_str(), error);
-        if (error.value() == 0)
-        {
-            ChipLogDetail(Camera, "Renamed segment %s to %s", originalPath.c_str(), newPath.c_str());
-            return newPath;
-        }
-        else
-        {
-            ChipLogDetail(Camera, "Failed to rename segment %s to %s, error: %d", originalPath.c_str(), newPath.c_str(),
-                          error.value());
-            return originalPath;
-        }
-    }
-
-    ChipLogDetail(Camera, "Path %s does not match expected segment format, not renaming.", originalPath.c_str());
-    return originalPath;
-}
-
-void UpdateMPDStartNumber(const std::string & mpdPath)
-{
-    std::ifstream file(mpdPath);
-    if (!file)
+    std::ifstream inFile(mpdPath);
+    if (!inFile)
     {
         ChipLogError(Camera, "ERROR: Failed to open MPD file for reading: %s", mpdPath.c_str());
         return;
     }
 
-    std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-    file.close();
+    // Define the exact pattern to find
+    const std::string searchPattern =
+        R"(initialization="#__$RepresentationID$__#.init" media="#__$RepresentationID$__#segment_$Number%04d$.m4s" startNumber=")";
 
-    // Replace startNumber="<digits>" with startNumber="kMPDDefaultStartNumber"
-    std::regex startNumberRegex(R"(startNumber="\d+")");
-    int newStartNumber      = kMPDDefaultStartNumber;
-    std::string replacement = "startNumber=\"" + std::to_string(newStartNumber) + "\"";
-    std::string newContent  = std::regex_replace(content, startNumberRegex, replacement);
+    std::vector<std::string> lines;
+    std::string line;
+    size_t streamIndex    = 0;
+    bool foundAndReplaced = false;
 
-    std::ofstream outFile(mpdPath);
-    if (!outFile)
+    // Read file line by line
+    while (std::getline(inFile, line))
     {
-        ChipLogError(Camera, "ERROR: Failed to open MPD file for writing: %s", mpdPath.c_str());
-        return;
-    }
-    outFile << newContent;
-    outFile.close();
+        size_t pos = line.find(searchPattern);
+        while (pos != std::string::npos && streamIndex < mStreamIdNameMap.size())
+        {
+            const std::string & streamName = mStreamIdNameMap[static_cast<int>(streamIndex)];
 
-    ChipLogProgress(Camera, "Successfully updated startNumber to 1001 in MPD file: %s", mpdPath.c_str());
+            // Find the startNumber value
+            size_t startNumberStart = line.find("startNumber=\"", pos);
+            size_t startNumberEnd   = line.find("\"", startNumberStart + 13);
+
+            std::string replacement;
+
+            if (startNumberStart != std::string::npos && startNumberEnd != std::string::npos)
+            {
+                // Replace the entire pattern
+                replacement = "initialization=\"" + streamName + "/" + streamName + ".init\" media=\"" + streamName +
+                    "/segment_$Number%04d$.m4s\" startNumber=\"" + std::to_string(kMPDDefaultStartNumber) + "\"";
+
+                line.replace(pos, startNumberEnd - pos + 1, replacement);
+                foundAndReplaced = true;
+                streamIndex++;
+            }
+
+            // Look for next occurrence in the same line
+            pos = line.find(searchPattern, pos + replacement.length());
+        }
+        lines.push_back(line);
+    }
+    inFile.close();
+
+    // Write the modified lines back to the file
+    if (foundAndReplaced)
+    {
+        std::ofstream outFile(mpdPath);
+        if (!outFile)
+        {
+            ChipLogError(Camera, "ERROR: Failed to open MPD file for writing: %s", mpdPath.c_str());
+            return;
+        }
+
+        for (size_t i = 0; i < lines.size(); ++i)
+        {
+            outFile << lines[i];
+            if (i < lines.size() - 1) // Don't add newline after last line
+                outFile << "\n";
+        }
+        outFile.close();
+        ChipLogProgress(Camera, "Successfully updated stream info in MPD file: %s", mpdPath.c_str());
+    }
+    else
+    {
+        ChipLogProgress(Camera, "Pattern not found in MPD file, no changes made: %s", mpdPath.c_str());
+    }
+}
+
+bool PushAVClipRecorder::IsFileReadyForUpload(const std::filesystem::path & path) const
+{
+    return std::filesystem::exists(path) && !std::filesystem::exists(path.string() + ".tmp");
 }
 
 /**
@@ -843,8 +848,9 @@ void PushAVClipRecorder::FinalizeCurrentClip(ClipFinalizationReason reason)
 {
     int64_t clipLengthInPTS = currentPts - mCurrentClipStartPts;
     // Final duration has to be (clipDuration + preRollLen) seconds
-    const int64_t remainingDuration = mClipInfo.mInitialDurationS - mClipInfo.mElapsedTimeS + (mClipInfo.mPreRollLengthMs / 1000);
-    int64_t clipDuration            = 0;
+    const int64_t remainingDuration =
+        mClipInfo.mMotionDetectedDurationS - mClipInfo.mElapsedTimeS + (mClipInfo.mPreRollLengthMs / 1000);
+    int64_t clipDuration = 0;
 
     if (remainingDuration <= 0)
     {
@@ -896,47 +902,83 @@ void PushAVClipRecorder::FinalizeCurrentClip(ClipFinalizationReason reason)
         mCurrentClipStartPts = AV_NOPTS_VALUE;
     }
 
-    // Helper function for safe path formatting using std::filesystem
-    auto make_segment_path = [&](int number) -> std::filesystem::path {
+    //  Helper function for safe path formatting using std::filesystem
+    auto make_segment_path = [&](int stream, int number) -> std::filesystem::path {
         std::ostringstream oss;
-        oss << "segment_" << std::setw(4) << std::setfill('0') << number << ".m4s";
-        return basePath / oss.str();
+        oss << "#__" << stream << "__#segment_" << std::setw(4) << std::setfill('0') << number << ".m4s";
+        return mUploadFileBasePath / oss.str();
     };
 
-    std::filesystem::path segment_path = make_segment_path(mUploadSegmentID);
-    while (std::filesystem::exists(segment_path) && !std::filesystem::exists(segment_path.string() + ".tmp"))
-    {
-        mUploadMPD                       = true;
-        std::string renamed_segment_path = RenameSegmentFile(segment_path.string());
-        CheckAndUploadFile(renamed_segment_path);
-        mUploadSegmentID++;
-        segment_path = make_segment_path(mUploadSegmentID);
-    }
+    std::filesystem::path mpdPath = mUploadFileBasePath / "index.mpd";
 
-    // Handle MPD and init file upload
+    // Wait for the first segment (segment_0001.m4s) for any stream to be created before starting any uploads
+    bool first_segment_ready = false;
+    for (size_t i = 0; i < mUploadSegmentID.size(); i++)
+    {
+        if (mUploadSegmentID[i] == 1 && IsFileReadyForUpload(make_segment_path(i, 1)))
+        {
+            first_segment_ready = true;
+            break;
+        }
+    }
+    if (!first_segment_ready)
+        return;
+
     if (mUploadMPD)
     {
-        std::filesystem::path mpd_path = basePath;
-        mpd_path += ".mpd";
-        if (std::filesystem::exists(mpd_path) && !std::filesystem::exists(mpd_path.string() + ".tmp"))
+        if (IsFileReadyForUpload(mpdPath))
         {
-            mUploader->setMPDPath(std::make_pair(mpd_path.string(), mClipInfo.mUrl));
-            UpdateMPDStartNumber(mpd_path.string());
-            CheckAndUploadFile(mpd_path.string());
+            UpdateMPDParams(mpdPath.string());
+            CheckAndUploadFile(mpdPath.string());
             mUploadMPD = false; // Reset flag after successful upload
         }
-
-        // Handle init segment upload if needed
-        if (!mUploadedInitSegment)
+        else
         {
-            std::filesystem::path init_path = basePath / (mClipInfo.mTrackName + ".init");
-            if (std::filesystem::exists(init_path) && !std::filesystem::exists(init_path.string() + ".tmp"))
-            {
-                CheckAndUploadFile(init_path.string());
-            }
-            mUploadedInitSegment = true;
+            return; // Wait for MPD to be ready before proceeding
         }
     }
+
+    for (size_t i = 0; i < mUploadSegmentID.size(); i++)
+    {
+        if (!mUploadedInitSegment[i])
+        {
+            const std::filesystem::path init_path = mUploadFileBasePath / ("#__" + std::to_string(i) + "__#" + ".init");
+            if (IsFileReadyForUpload(init_path))
+            {
+                CheckAndUploadFile(init_path.string());
+                mUploadedInitSegment[i] = true;
+            }
+            else
+            {
+                return; // Wait for init segment to be ready before proceeding
+            }
+        }
+    }
+    for (size_t i = 0; i < mUploadSegmentID.size(); i++)
+    {
+        std::filesystem::path segment_path = make_segment_path(i, mUploadSegmentID[i]);
+        while (IsFileReadyForUpload(segment_path))
+        {
+            // std::string renamed_segment_path = RenameSegmentFile(segment_path.string());
+            CheckAndUploadFile(segment_path.string());
+            mUploadSegmentID[i]++;
+            // For testing purpose
+#ifdef TEST_UPLOAD_MPD_AFTER_EVERY_SEGMENT
+            mUploadMPD = true;
+#endif
+            segment_path = make_segment_path(i, mUploadSegmentID[i]);
+        }
+    }
+
+    // For testing purpose
+#ifdef TEST_UPLOAD_MPD_AFTER_EVERY_SEGMENT
+    if (IsFileReadyForUpload(mpdPath) && mUploadMPD)
+    {
+        UpdateMPDParams(mpdPath.string());
+        CheckAndUploadFile(mpdPath.string());
+        mUploadMPD = false;
+    }
+#endif
 }
 
 bool PushAVClipRecorder::CheckAndUploadFile(std::string filename)

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -51,7 +51,8 @@ AVDictionary * options = NULL;
 
 PushAVClipRecorder::PushAVClipRecorder(ClipInfoStruct & aClipInfo, AudioInfoStruct & aAudioInfo, VideoInfoStruct & aVideoInfo,
                                        PushAVUploader * aUploader) :
-    mClipInfo(aClipInfo), mAudioInfo(aAudioInfo), mVideoInfo(aVideoInfo), mUploader(aUploader)
+    mClipInfo(aClipInfo),
+    mAudioInfo(aAudioInfo), mVideoInfo(aVideoInfo), mUploader(aUploader)
 {
     mFormatContext          = nullptr;
     mInputFormatContext     = nullptr;

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -918,12 +918,15 @@ void PushAVClipRecorder::FinalizeCurrentClip(ClipFinalizationReason reason)
     std::filesystem::path mpdPath = mUploadFileBasePath / "index.mpd";
 
     // Wait for the first segment (segment_0001.m4s) for any stream to be created before starting any uploads
-    for (size_t i = 0; i < mUploadSegmentID.size(); i++)
+    if (!firstSegmentReady)
     {
-        if (mUploadSegmentID[i] == 1 && IsFileReadyForUpload(make_segment_path(i, 1)))
+        for (size_t i = 0; i < mUploadSegmentID.size(); i++)
         {
-            firstSegmentReady = true;
-            break;
+            if (mUploadSegmentID[i] == 1 && IsFileReadyForUpload(make_segment_path(i, 1)))
+            {
+                firstSegmentReady = true;
+                break;
+            }
         }
     }
     if (!firstSegmentReady)

--- a/examples/camera-app/linux/src/pushav-prerollbuffer.cpp
+++ b/examples/camera-app/linux/src/pushav-prerollbuffer.cpp
@@ -29,7 +29,7 @@ void PreRollBuffer::SetMaxTotalBytes(size_t size)
     mMaxTotalBytes = size;
     TrimBuffer();
 }
-void PreRollBuffer::PushFrameToBuffer(const std::string & streamKey, const uint8_t * data, size_t size)
+void PreRollBuffer::PushFrameToBuffer(const std::string & streamKey, const uint8_t * data, size_t size, int64_t timestampMs)
 {
     TrimBuffer();
     std::lock_guard<std::mutex> lock(mBufferMutex);
@@ -38,7 +38,7 @@ void PreRollBuffer::PushFrameToBuffer(const std::string & streamKey, const uint8
     frame->data      = std::make_unique<uint8_t[]>(size);
     memcpy(frame->data.get(), data, size);
     frame->size  = size;
-    frame->ptsMs = NowMs();
+    frame->ptsMs = timestampMs;
     auto & queue = mBuffers[streamKey]; // Get or create the queue for this stream key
     queue.push_back(frame);
     mContentBufferSize += size; // Track total bytes in buffer for all streams

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -548,7 +548,8 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
 
         if (mTransportTriggerType == TransportTriggerTypeEnum::kContinuous)
         {
-            mClipInfo.mMotionDetectedDurationS =0; mClipInfo.mElapsedTimeS = 0;
+            mClipInfo.mMotionDetectedDurationS = 0;
+            mClipInfo.mElapsedTimeS            = 0;
             StartRecordingAndStreaming();
         }
         else if (mTransportTriggerType == TransportTriggerTypeEnum::kMotion)

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -168,7 +168,7 @@ CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStru
 
     mClipInfo.mMotionDetectedDurationS         = 0;
     mClipInfo.mPreviousMotionDetectedDurationS = 0;
-    mClipInfo.mElapsedTimeS = 0;
+    mClipInfo.mElapsedTimeS                    = 0;
 
     if (transportOptions.triggerOptions.motionTimeControl.HasValue())
     {
@@ -276,7 +276,7 @@ void PushAVTransport::InitializeRecorder()
         mRecorder->SetConnectionInfo(mConnectionID, mTransportTriggerType,
                                      chip::Optional<chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum>());
         ChipLogProgress(Camera, "PushAVTransport, Initialize Recorder done !!! FabricIdx: %u Session Id: %ld", mFabricIndex,
-                        mSessionNumber-1);
+                        mSessionNumber - 1);
     }
     else
     {

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -25,7 +25,8 @@ using namespace chip::app::Clusters::PushAvStreamTransport;
 
 PushAVTransport::PushAVTransport(const TransportOptionsStruct & transportOptions, const uint16_t connectionID,
                                  AudioStreamStruct & audioStreamParams, VideoStreamStruct & videoStreamParams) :
-    mAudioStreamParams(audioStreamParams), mVideoStreamParams(videoStreamParams)
+    mAudioStreamParams(audioStreamParams),
+    mVideoStreamParams(videoStreamParams)
 {
     mConnectionID                      = connectionID;
     mTransportStatus                   = TransportStatusEnum::kInactive;

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -323,8 +323,7 @@ bool InBlindPeriod(std::chrono::steady_clock::time_point blindStartTime, uint16_
     }
 
     const auto elapsedSeconds = std::chrono::duration_cast<std::chrono::seconds>(now - blindStartTime).count();
-    ChipLogProgress(Camera, "PushAVTransport blind period elapsed: %" PRId64 " seconds (duration: %u seconds)", elapsedSeconds,
-                    blindDuration);
+    ChipLogProgress(Camera, "PushAVTransport blind period, blindDuration: %u seconds", blindDuration);
     return ((elapsedSeconds >= 0) && (elapsedSeconds < blindDuration));
 }
 
@@ -534,10 +533,6 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
     {
         ChipLogProgress(Camera, "PushAVTransport transport status changed to active");
 
-        mUploader = std::make_unique<PushAVUploader>();
-        mUploader->setCertificateBuffer(mCertBuffer);
-        mUploader->setCertificatePath(mCertPath);
-        mUploader->Start();
         if (mUploader.get() == nullptr)
         {
             mUploader = std::make_unique<PushAVUploader>();

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -212,10 +212,11 @@ CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStru
     mAudioInfo.mBitRate = audioStreamParams.bitRate;
     if (mClipInfo.mHasAudio)
     {
-        if (transportOptions.audioStreams.HasValue())
+        if (transportOptions.audioStreams.HasValue() && !transportOptions.audioStreams.Value().empty())
         {
             // Recoder module currently only supports one audio and one video stream
-            mAudioInfo.mAudioStreamName = transportOptions.audioStreams.Value().begin()->audioStreamName.data();
+            auto audioStreamName        = transportOptions.audioStreams.Value().begin()->audioStreamName;
+            mAudioInfo.mAudioStreamName = std::string(audioStreamName.data(), audioStreamName.size());
         }
         else
         {
@@ -245,10 +246,11 @@ CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStru
     mVideoInfo.mBitRate   = videoStreamParams.minBitRate;
     if (mClipInfo.mHasVideo)
     {
-        if (transportOptions.videoStreams.HasValue())
+        if (transportOptions.videoStreams.HasValue() && !transportOptions.videoStreams.Value().empty())
         {
             // Recoder module currently only supports one audio and one video stream
-            mVideoInfo.mVideoStreamName = transportOptions.videoStreams.Value().begin()->videoStreamName.data();
+            auto videoStreamName        = transportOptions.videoStreams.Value().begin()->videoStreamName;
+            mVideoInfo.mVideoStreamName = std::string(videoStreamName.data(), videoStreamName.size());
         }
         else
         {

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -168,6 +168,7 @@ CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStru
 
     mClipInfo.mMotionDetectedDurationS         = 0;
     mClipInfo.mPreviousMotionDetectedDurationS = 0;
+    mClipInfo.mElapsedTimeS = 0;
 
     if (transportOptions.triggerOptions.motionTimeControl.HasValue())
     {
@@ -268,20 +269,19 @@ void PushAVTransport::InitializeRecorder()
 {
     if (mRecorder.get() == nullptr)
     {
-        mClipInfo.mSessionNumber = mSessionNumber;
+        mClipInfo.mSessionNumber = mSessionNumber++;
         mRecorder                = std::make_unique<PushAVClipRecorder>(mClipInfo, mAudioInfo, mVideoInfo, mUploader.get());
         mRecorder->SetFabricIndex(mFabricIndex);
         mRecorder->SetPushAvStreamTransportServer(mPushAvStreamTransportServer);
         mRecorder->SetConnectionInfo(mConnectionID, mTransportTriggerType,
                                      chip::Optional<chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum>());
         ChipLogProgress(Camera, "PushAVTransport, Initialize Recorder done !!! FabricIdx: %u Session Id: %ld", mFabricIndex,
-                        mSessionNumber);
+                        mSessionNumber-1);
     }
     else
     {
         ChipLogError(Camera, "Recorder already initialized");
     }
-    mSessionNumber++;
 }
 
 PushAVTransport::~PushAVTransport()
@@ -355,6 +355,7 @@ bool PushAVTransport::HandleTriggerDetected()
         mPreviousActivationByManualTrigger         = mCurrentActivationByManualTrigger;
         mClipInfo.mMotionDetectedDurationS         = mClipInfo.mInitialDurationS;
         mClipInfo.mPreviousMotionDetectedDurationS = 0;
+        mClipInfo.mElapsedTimeS                    = 0;
     }
     else
     {

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -18,7 +18,6 @@
 
 #include <ctime>
 #include <filesystem>
-#include <push-av-stream-manager.h>
 #include <pushav-transport.h>
 #include <time.h>
 
@@ -26,13 +25,13 @@ using namespace chip::app::Clusters::PushAvStreamTransport;
 
 PushAVTransport::PushAVTransport(const TransportOptionsStruct & transportOptions, const uint16_t connectionID,
                                  AudioStreamStruct & audioStreamParams, VideoStreamStruct & videoStreamParams) :
-    mAudioStreamParams(audioStreamParams),
-    mVideoStreamParams(videoStreamParams)
+    mAudioStreamParams(audioStreamParams), mVideoStreamParams(videoStreamParams)
 {
-    mConnectionID                     = connectionID;
-    mTransportStatus                  = TransportStatusEnum::kInactive;
-    mActivationTimeSetByManualTrigger = false;
-    mIsZoneBasedTrigger               = false;
+    mConnectionID                      = connectionID;
+    mTransportStatus                   = TransportStatusEnum::kInactive;
+    mBlindStartTime                    = std::chrono::steady_clock::time_point();
+    mCurrentActivationByManualTrigger  = false;
+    mPreviousActivationByManualTrigger = false;
 
     auto now               = std::chrono::system_clock::now();
     std::time_t time_t_now = std::chrono::system_clock::to_time_t(now);
@@ -46,7 +45,7 @@ PushAVTransport::PushAVTransport(const TransportOptionsStruct & transportOptions
     std::string uniqueDirName =
         "FabricIdx" + std::to_string(mFabricIndex) + "_ConnectionId" + std::to_string(connectionID) + "_" + datetime_str;
 
-    std::filesystem::path outputPath = std::filesystem::path("/tmp") / uniqueDirName / "";
+    std::filesystem::path outputPath = std::filesystem::path("/tmp") / uniqueDirName;
     mClipInfo.mOutputPath            = outputPath.string();
 }
 
@@ -72,13 +71,21 @@ const char * GetVideoCodecName(int codecId)
     }
 }
 
+void PrintRecorderTimeSetting(const PushAVClipRecorder::ClipInfoStruct & clipInfo)
+{
+    ChipLogDetail(Camera, "=== PushAVTransport ConfigureRecorderTimeSetting ===");
+    ChipLogDetail(Camera, "Initial Duration: %d sec", clipInfo.mInitialDurationS);
+    ChipLogDetail(Camera, "Augmentation Duration: %d sec", clipInfo.mAugmentationDurationS);
+    ChipLogDetail(Camera, "Max Clip Duration: %d sec", clipInfo.mMaxClipDurationS);
+    ChipLogDetail(Camera, "Blind Duration: %d sec", clipInfo.mBlindDurationS);
+}
+
 void PrintTransportSettings(PushAVClipRecorder::ClipInfoStruct clipInfo, PushAVClipRecorder::AudioInfoStruct audioInfo,
                             PushAVClipRecorder::VideoInfoStruct videoInfo)
 {
     ChipLogProgress(Camera, "=== Clip Configuration ===");
     ChipLogProgress(Camera, "Has Audio: %s", clipInfo.mHasAudio ? "true" : "false");
     ChipLogProgress(Camera, "Has Video: %s", clipInfo.mHasVideo ? "true" : "false");
-    ChipLogProgress(Camera, "Session Group: %d", clipInfo.mSessionGroup);
     ChipLogProgress(Camera, "Chunk Duration: %d ms", clipInfo.mChunkDurationMs);
     ChipLogProgress(Camera, "Segment Duration: %d ms", clipInfo.mSegmentDurationMs);
     ChipLogProgress(Camera, "PreRoll Length: %d ms", clipInfo.mPreRollLengthMs);
@@ -86,14 +93,6 @@ void PrintTransportSettings(PushAVClipRecorder::ClipInfoStruct clipInfo, PushAVC
     ChipLogProgress(Camera, "Trigger Type: %d", clipInfo.mTriggerType);
     ChipLogProgress(Camera, "Output Path: %s", clipInfo.mOutputPath.c_str());
     ChipLogProgress(Camera, "Track Name: %s", clipInfo.mTrackName.c_str());
-    // Time control parameters are only passed during transport allocation for motion triggers.
-    if (clipInfo.mTriggerType == 1)
-    {
-        ChipLogProgress(Camera, "Initial Duration: %d sec", clipInfo.mInitialDurationS);
-        ChipLogProgress(Camera, "Augmentation Duration: %d sec", clipInfo.mAugmentationDurationS);
-        ChipLogProgress(Camera, "Max Clip Duration: %d sec", clipInfo.mMaxClipDurationS);
-        ChipLogProgress(Camera, "Blind Duration: %d sec", clipInfo.mBlindDurationS);
-    }
 
     ChipLogProgress(Camera, "=== Audio Configuration ===");
     ChipLogProgress(Camera, "Codec: %s", GetAudioCodecName(audioInfo.mAudioCodecId));
@@ -101,30 +100,28 @@ void PrintTransportSettings(PushAVClipRecorder::ClipInfoStruct clipInfo, PushAVC
     ChipLogProgress(Camera, "Sample Rate: %d Hz", audioInfo.mSampleRate);
     ChipLogProgress(Camera, "Bit Rate: %d bps", audioInfo.mBitRate);
     ChipLogProgress(Camera, "Audio Time Base: %d/%d", audioInfo.mAudioTimeBase.num, audioInfo.mAudioTimeBase.den);
-    ChipLogProgress(Camera, "Frame Duration: %d samples", audioInfo.mAudioFrameDuration);
+    ChipLogProgress(Camera, "Audio Stream Name: %s", audioInfo.mAudioStreamName.c_str());
 
     ChipLogProgress(Camera, "=== Video Configuration ===");
     ChipLogProgress(Camera, "Codec: %s", GetVideoCodecName(videoInfo.mVideoCodecId));
     ChipLogProgress(Camera, "Resolution: %dx%d", videoInfo.mWidth, videoInfo.mHeight);
     ChipLogProgress(Camera, "Frame Rate: %d fps", videoInfo.mFrameRate);
     ChipLogProgress(Camera, "Video Time Base: %d/%d", videoInfo.mVideoTimeBase.num, videoInfo.mVideoTimeBase.den);
-    ChipLogProgress(Camera, "Frame Duration: %d ticks", videoInfo.mVideoFrameDuration);
     ChipLogProgress(Camera, "Bit Rate: %d bps", videoInfo.mBitRate);
+    ChipLogProgress(Camera, "Video Stream Name: %s", videoInfo.mVideoStreamName.c_str());
 }
 
 void PushAVTransport::ConfigureRecorderTimeSetting(
     const chip::app::Clusters::PushAvStreamTransport::Structs::TransportMotionTriggerTimeControlStruct::DecodableType & timeControl)
 {
-    mClipInfo.mInitialDurationS      = timeControl.initialDuration;
+    mClipInfo.mInitialDurationS      = std::min(static_cast<uint32_t>(timeControl.initialDuration), timeControl.maxDuration);
     mClipInfo.mAugmentationDurationS = timeControl.augmentationDuration;
     mClipInfo.mMaxClipDurationS      = timeControl.maxDuration;
     mClipInfo.mBlindDurationS        = timeControl.blindDuration;
     mClipInfo.mElapsedTimeS          = 0;
-    ChipLogDetail(Camera, "=== PushAVTransport ConfigureRecorderTimeSetting ===");
-    ChipLogDetail(Camera, "Initial Duration: %d sec", mClipInfo.mInitialDurationS);
-    ChipLogDetail(Camera, "Augmentation Duration: %d sec", mClipInfo.mAugmentationDurationS);
-    ChipLogDetail(Camera, "Max Clip Duration: %d sec", mClipInfo.mMaxClipDurationS);
-    ChipLogDetail(Camera, "Blind Duration: %d sec", mClipInfo.mBlindDurationS);
+    mClipInfo.mClipStartPTS          = 0;
+
+    PrintRecorderTimeSetting(mClipInfo);
     if (mRecorder.get() != nullptr)
     {
         mRecorder->mClipInfo = mClipInfo;
@@ -159,12 +156,10 @@ CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStru
     }
 
     // Codecs are valid, proceed with configuration
-    mClipInfo.mHasAudio = transportOptions.audioStreamID.HasValue();
-    mClipInfo.mHasVideo = transportOptions.videoStreamID.HasValue();
-    if (mClipInfo.mHasAudio && mClipInfo.mHasVideo)
-    {
-        mClipInfo.mHasAudio = false;
-    }
+    mClipInfo.mHasAudio      = transportOptions.audioStreams.HasValue();
+    mClipInfo.mHasVideo      = transportOptions.videoStreams.HasValue();
+    mSessionStartedTimestamp = std::chrono::system_clock::time_point();
+
     mClipInfo.mUrl         = std::string(transportOptions.url.data(), transportOptions.url.size());
     mClipInfo.mTriggerType = static_cast<int>(transportOptions.triggerOptions.triggerType);
     if (transportOptions.triggerOptions.maxPreRollLen.HasValue())
@@ -181,7 +176,6 @@ CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStru
     }
     if (transportOptions.containerOptions.CMAFContainerOptions.HasValue())
     {
-        mClipInfo.mSessionGroup      = transportOptions.containerOptions.CMAFContainerOptions.Value().sessionGroup;
         mClipInfo.mTrackName         = std::string(transportOptions.containerOptions.CMAFContainerOptions.Value().trackName.data(),
                                                    transportOptions.containerOptions.CMAFContainerOptions.Value().trackName.size());
         mClipInfo.mChunkDurationMs   = transportOptions.containerOptions.CMAFContainerOptions.Value().chunkDuration;
@@ -205,9 +199,8 @@ CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStru
             ChipLogError(Camera, "Invalid sample rate: 0. Using fallback 48000 Hz.");
             audioStreamParams.sampleRate = 48000; // Fallback value for invalid sample rate
         }
-        mAudioInfo.mAudioCodecId       = AV_CODEC_ID_OPUS;
-        mAudioInfo.mAudioTimeBase      = { 1, static_cast<int>(audioStreamParams.sampleRate) };
-        mAudioInfo.mAudioFrameDuration = 20000; // Default OPUS frame duration
+        mAudioInfo.mAudioCodecId  = AV_CODEC_ID_OPUS;
+        mAudioInfo.mAudioTimeBase = { 1, static_cast<int>(audioStreamParams.sampleRate) };
     }
 
     mAudioInfo.mSampleRate = audioStreamParams.sampleRate;
@@ -216,10 +209,19 @@ CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStru
         ChipLogError(Camera, "Invalid audio bit rate: 0. Using fallback 96000 bps.");
         audioStreamParams.bitRate = 96000;
     }
-    mAudioInfo.mBitRate          = audioStreamParams.bitRate;
-    mAudioInfo.mAudioPts         = 0;
-    mAudioInfo.mAudioDts         = 0;
-    mAudioInfo.mAudioStreamIndex = -1;
+    mAudioInfo.mBitRate = audioStreamParams.bitRate;
+    if (mClipInfo.mHasAudio)
+    {
+        if (transportOptions.audioStreams.HasValue())
+        {
+            // Recoder module currently only supports one audio and one video stream
+            mAudioInfo.mAudioStreamName = transportOptions.audioStreams.Value().begin()->audioStreamName.data();
+        }
+        else
+        {
+            mAudioInfo.mAudioStreamName = "audio";
+        }
+    }
 
     // Configure video settings
     if (videoCodec == 0)
@@ -227,8 +229,6 @@ CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStru
         mVideoInfo.mVideoCodecId  = AV_CODEC_ID_H264;
         mVideoInfo.mVideoTimeBase = { 1, 90000 };
     }
-    mVideoInfo.mVideoPts = 0;
-    mVideoInfo.mVideoDts = 0;
     if (videoStreamParams.maxResolution.width == 0 || videoStreamParams.maxResolution.height == 0)
     {
         videoStreamParams.maxResolution.width  = 640;
@@ -242,13 +242,13 @@ CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStru
         videoStreamParams.minFrameRate = 30;
     }
     mVideoInfo.mFrameRate = videoStreamParams.minFrameRate;
-
-    mVideoInfo.mVideoFrameDuration = mVideoInfo.mVideoTimeBase.den / (mVideoInfo.mFrameRate * mVideoInfo.mVideoTimeBase.num);
-    mVideoInfo.mVideoStreamIndex   = -1;
-    mVideoInfo.mBitRate            = videoStreamParams.minBitRate;
+    mVideoInfo.mBitRate   = videoStreamParams.minBitRate;
 
     PrintTransportSettings(mClipInfo, mAudioInfo, mVideoInfo);
-    ChipLogProgress(Camera, "PushAvStreamTransportManager, Configure Recorder Settings done !!!");
+    UpdateSendFlags();
+    ChipLogProgress(Camera, "Transport[%u] Session[%lu] ConfigureRecorderSettings success - Track=%s HasVideo=%s HasAudio=%s",
+                    mConnectionID, mSessionNumber, mClipInfo.mTrackName.c_str(), mClipInfo.mHasVideo ? "true" : "false",
+                    mClipInfo.mHasAudio ? "true" : "false");
 
     return CHIP_NO_ERROR;
 }
@@ -257,12 +257,14 @@ void PushAVTransport::InitializeRecorder()
 {
     if (mRecorder.get() == nullptr)
     {
-        mRecorder = std::make_unique<PushAVClipRecorder>(mClipInfo, mAudioInfo, mVideoInfo, mUploader.get());
+        mClipInfo.mSessionNumber = mSessionNumber++;
+        mRecorder                = std::make_unique<PushAVClipRecorder>(mClipInfo, mAudioInfo, mVideoInfo, mUploader.get());
         mRecorder->SetFabricIndex(mFabricIndex);
         mRecorder->SetPushAvStreamTransportServer(mPushAvStreamTransportServer);
-        mRecorder->SetPushAvStreamTransportManager(mPushAvStreamTransportManager);
         mRecorder->SetConnectionInfo(mConnectionID, mTransportTriggerType,
                                      chip::Optional<chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum>());
+        ChipLogProgress(Camera, "PushAVTransport, Initialize Recorder done !!! FabricIdx: %u Session Id: %ld", mFabricIndex,
+                        mSessionNumber);
     }
     else
     {
@@ -299,173 +301,193 @@ PushAVTransport::~PushAVTransport()
     }
 }
 
-bool InBlindPeriod(std::chrono::steady_clock::time_point blindStartTime, uint16_t blindDuration)
+bool InBlindPeriod(std::chrono::steady_clock::time_point blindStartTime, uint16_t blindDuration,
+                   std::chrono::steady_clock::time_point now)
 {
-    if (blindStartTime == std::chrono::steady_clock::time_point())
+    if (blindDuration == 0 || blindStartTime == std::chrono::steady_clock::time_point())
     {
-        ChipLogProgress(Camera, "PushAVTransport no blind period");
+        ChipLogProgress(Camera, "PushAVTransport: No active blind period");
         return false;
     }
-    else
-    {
-        auto now     = std::chrono::steady_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - blindStartTime).count();
-        ChipLogProgress(Camera, "PushAVTransport blind period elapsed: %lld", static_cast<long long int>(elapsed));
-        return ((elapsed >= 0) && (elapsed < blindDuration));
-    }
+
+    const auto elapsedSeconds = std::chrono::duration_cast<std::chrono::seconds>(now - blindStartTime).count();
+    ChipLogProgress(Camera, "PushAVTransport blind period elapsed: %" PRId64 " seconds (duration: %u seconds)", elapsedSeconds,
+                    blindDuration);
+    return ((elapsedSeconds >= 0) && (elapsedSeconds < blindDuration));
 }
 
 bool PushAVTransport::HandleTriggerDetected()
 {
-    int64_t elapsed = 0;
-    auto now        = std::chrono::steady_clock::now();
+    auto now = std::chrono::steady_clock::now();
 
-    if (mIsZoneBasedTrigger && mTransportTriggerType != TransportTriggerTypeEnum::kCommand &&
-        InBlindPeriod(mBlindStartTime, mClipInfo.mBlindDurationS))
+    // Blind duration is considered in case of motion event only
+    if (!mPreviousActivationByManualTrigger && !mCurrentActivationByManualTrigger &&
+        InBlindPeriod(mBlindStartTime, mClipInfo.mBlindDurationS, now))
     {
+        ChipLogError(Camera,
+                     "PushAVTransport command/motion transport trigger received but ignored due to blind period. Clip duration "
+                     "[%d seconds]",
+                     mRecorder->mClipInfo.mMotionDetectedDurationS);
         return false;
     }
 
-    if (mClipInfo.mActivationTime != std::chrono::steady_clock::time_point())
-    {
-        elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - mClipInfo.mActivationTime).count();
-    }
-
-    ChipLogDetail(Camera, "PushAVTransport HandleTriggerDetected elapsed: %" PRId64, elapsed);
-
-    if (!mRecorder->GetRecorderStatus())
+    int64_t elapsedClipDurationS = std::chrono::duration_cast<std::chrono::seconds>(now - mClipInfo.mActivationTime).count();
+    if (mClipInfo.mActivationTime == std::chrono::steady_clock::time_point() ||
+        elapsedClipDurationS >= mClipInfo.mMotionDetectedDurationS)
     {
         // Start new recording
-        ChipLogError(Camera, "PushAVTransport starting new recording");
-        mHasAugmented                        = false;
-        mClipInfo.mActivationTime            = std::chrono::steady_clock::now();
-        mRecorder->mClipInfo.mActivationTime = mClipInfo.mActivationTime;
-        mRecorder->mClipInfo.mSessionNumber =
-            mPushAvStreamTransportManager->OnTriggerActivated(mFabricIndex, mClipInfo.mSessionGroup, mConnectionID);
+        ChipLogDetail(Camera, "PushAVTransport starting new recording");
+        mHasAugmented             = false;
+        mClipInfo.mActivationTime = now;
 
-        mRecorder->Start();
-        mStreaming = true;
+        mPreviousActivationByManualTrigger         = mCurrentActivationByManualTrigger;
+        mClipInfo.mMotionDetectedDurationS         = mClipInfo.mInitialDurationS;
+        mClipInfo.mPreviousMotionDetectedDurationS = 0;
     }
     else
     {
-        // Extend existing recording
-        uint16_t previousDuration = mRecorder->mClipInfo.mInitialDurationS - mRecorder->mClipInfo.mAugmentationDurationS;
+        // Handle augmentation for ongoing recording
+        ChipLogDetail(Camera, "PushAVTransport HandleTriggerDetected time since last trigger: %" PRId64, elapsedClipDurationS);
 
-        if ((elapsed < mRecorder->mClipInfo.mInitialDurationS) && (!mHasAugmented || elapsed >= previousDuration))
+        if (!mHasAugmented || (mHasAugmented && (elapsedClipDurationS >= mClipInfo.mPreviousMotionDetectedDurationS)))
         {
-            ChipLogError(Camera, "PushAVTransport extending recording %d -> %d", mRecorder->mClipInfo.mInitialDurationS,
-                         static_cast<uint16_t>(std::min(static_cast<uint32_t>(mRecorder->mClipInfo.mInitialDurationS +
-                                                                              mRecorder->mClipInfo.mAugmentationDurationS),
-                                                        static_cast<uint32_t>(mRecorder->mClipInfo.mMaxClipDurationS))));
-            mRecorder->mClipInfo.mInitialDurationS = static_cast<uint16_t>(std::min(
-                static_cast<uint32_t>(mRecorder->mClipInfo.mInitialDurationS + mRecorder->mClipInfo.mAugmentationDurationS),
-                static_cast<uint32_t>(mRecorder->mClipInfo.mMaxClipDurationS)));
-            mHasAugmented                          = true;
-            mStreaming                             = true;
+            uint16_t newDuration = static_cast<uint16_t>(
+                std::min(static_cast<uint32_t>(mClipInfo.mMotionDetectedDurationS + mClipInfo.mAugmentationDurationS),
+                         static_cast<uint32_t>(mClipInfo.mMaxClipDurationS)));
+
+            ChipLogDetail(Camera, "PushAVTransport extending recording %d -> %d", mClipInfo.mMotionDetectedDurationS, newDuration);
+
+            // Update tracking variables
+            mClipInfo.mPreviousMotionDetectedDurationS = mClipInfo.mMotionDetectedDurationS;
+            mClipInfo.mMotionDetectedDurationS         = newDuration;
+            mHasAugmented                              = true;
         }
     }
-    mBlindStartTime = mRecorder->mClipInfo.mActivationTime + std::chrono::seconds(mRecorder->mClipInfo.mInitialDurationS) +
-        std::chrono::seconds(mRecorder->mClipInfo.mPreRollLengthMs / 1000);
+
+    // Calculate blind start time based on when the current recording will actually end
+    // Use the current motion detected duration which represents when this recording session will end
+    mBlindStartTime = mClipInfo.mActivationTime + std::chrono::seconds(mClipInfo.mMotionDetectedDurationS);
+
+    if (mRecorder.get() != nullptr)
+    {
+        mRecorder->mClipInfo = mClipInfo;
+        if (!mRecorder->GetRecorderStatus())
+        {
+            mRecorder->SetConnectionInfo(mConnectionID, mTransportTriggerType, mActivationReason);
+            // Initiate recording if the recorder is not currently recording
+            StartRecordingAndStreaming();
+        }
+    }
     return true;
 }
 
-void PushAVTransport::TriggerTransport(TriggerActivationReasonEnum activationReason, int zoneId, int sensitivity,
-                                       bool isZoneBasedTrigger)
+void PushAVTransport::StartRecordingAndStreaming()
 {
-    ChipLogProgress(Camera, "PushAVTransport trigger transport, activation reason: [%u], ZoneId: [%d], Sensitivity: [%d]",
-                    (uint16_t) activationReason, zoneId, sensitivity);
-    mIsZoneBasedTrigger = isZoneBasedTrigger;
-    if (mTransportTriggerType == TransportTriggerTypeEnum::kCommand)
+    mRecorder->mClipInfo.mSessionNumber = mClipInfo.mSessionNumber;
+    mRecorder->Start();
+    mStreaming = true;
+    UpdateSendFlags();
+    if (IsStreaming() && (mTransportTriggerType != TransportTriggerTypeEnum::kCommand))
     {
-        mRecorder->SetConnectionInfo(mConnectionID, mTransportTriggerType, chip::MakeOptional(activationReason));
-        if (HandleTriggerDetected())
-        {
-            ChipLogError(Camera, "PushAVTransport command/motion transport trigger received. Clip duration [%d seconds]",
-                         mRecorder->mClipInfo.mInitialDurationS);
-            // Begin event already generated at cluster server
-        }
-        else
-        {
-            ChipLogError(Camera,
-                         "PushAVTransport command/motion transport trigger received but ignored due to blind period. Clip duration "
-                         "[%d seconds]",
-                         mRecorder->mClipInfo.mInitialDurationS);
-        }
+        ChipLogDetail(Camera, "Ready to stream");
+        GeneratePushTransportBeginEvent();
     }
-    else if (mTransportTriggerType == TransportTriggerTypeEnum::kMotion)
+}
+
+void PushAVTransport::GeneratePushTransportBeginEvent()
+{
+    if (mPushAvStreamTransportServer != nullptr)
     {
-        if (mTransportStatus == TransportStatusEnum::kInactive)
+        // mActivationReason is optional - if not set, it defaults to empty value
+        mPushAvStreamTransportServer->NotifyTransportStarted(mConnectionID, mTransportTriggerType, mActivationReason);
+    }
+    else
+    {
+        ChipLogError(Camera, "PushAvStreamTransportServer is null or activation reason not set for connection %u", mConnectionID);
+    }
+}
+
+bool PushAVTransport::ValidateZoneAndSensitivity(
+    const std::vector<std::pair<chip::app::DataModel::Nullable<uint16_t>, uint8_t>> & zoneSensitivityList, int zoneId,
+    int sensitivity)
+{
+    // Validate input parameters
+
+    if (sensitivity < 0 || sensitivity > 10)
+    {
+        ChipLogError(Camera, "PushAVTransport invalid sensitivity value: %d (must be 0-10)", sensitivity);
+        return false;
+    }
+
+    if (zoneSensitivityList.empty())
+    {
+        ChipLogProgress(Camera, "PushAVTransport zoneSensitivityList NOT set, accepting all zones");
+        return true;
+    }
+
+    // Check for specific zone match
+    for (const auto & zone : zoneSensitivityList)
+    {
+        if (zone.first.IsNull() || (zone.first.Value() == static_cast<uint16_t>(zoneId)))
         {
-            ChipLogProgress(Camera, "PushAVTransport Inactive transport status received. No action needed");
-            mUploader = std::make_unique<PushAVUploader>();
-            mUploader->Start();
-            InitializeRecorder();
-            mClipInfo.mActivationTime            = std::chrono::steady_clock::now();
-            mRecorder->mClipInfo.mActivationTime = mClipInfo.mActivationTime;
-            return;
-        }
-        bool zoneFound = false; // Zone found flag
-        for (auto zone : mZoneSensitivityList)
-        {
-            // A Null ZoneId means all zones
-            if (zone.first.IsNull())
+            if (zone.second <= static_cast<uint8_t>(sensitivity))
             {
-                zoneFound = true;
+                ChipLogDetail(Camera, "PushAVTransport zone %d accepted (sensitivity %d >= threshold %u)", zoneId, sensitivity,
+                              zone.second);
+                return true;
             }
             else
             {
-                zoneFound = (zone.first.Value() = zoneId);
+                ChipLogProgress(Camera,
+                                "PushAVTransport motion transport trigger ignored - zone %d sensitivity %d exceeds threshold %u",
+                                zoneId, sensitivity, zone.second);
+                return false;
             }
+        }
+    }
 
-            if (zoneFound)
-            {
-                if (zone.second > sensitivity)
-                {
-                    ChipLogProgress(Camera, "PushAVTransport motion transport trigger received but ignored due to sensitivity");
-                }
-                else
-                {
-                    if (HandleTriggerDetected())
-                    {
-                        if (!isZoneBasedTrigger)
-                        {
-                            mActivationTimeSetByManualTrigger = true;
-                        }
-                        ChipLogError(Camera,
-                                     "PushAVTransport command/motion transport trigger received. Clip duration [%d seconds]",
-                                     mRecorder->mClipInfo.mInitialDurationS);
-                        if (mPushAvStreamTransportServer != nullptr)
-                        {
-                            mPushAvStreamTransportServer->NotifyTransportStarted(
-                                mConnectionID, mTransportTriggerType,
-                                chip::Optional<chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum>());
-                        }
-                        else
-                        {
-                            ChipLogError(Camera, "PushAvStreamTransportServer is null for connection %u", mConnectionID);
-                        }
-                    }
-                    else
-                    {
-                        ChipLogError(Camera,
-                                     "PushAVTransport command/motion transport trigger received but ignored due to blind period. "
-                                     "Clip duration. "
-                                     "Clip duration [%d seconds]",
-                                     mRecorder->mClipInfo.mInitialDurationS);
-                    }
-                }
-                break;
-            }
-        }
-        if (!zoneFound)
-        {
-            ChipLogProgress(Camera, "PushAVTransport motion transport trigger received but ignored due to unknown zone id");
-        }
+    ChipLogProgress(Camera, "PushAVTransport motion transport trigger ignored - zone %d not found in configuration", zoneId);
+    return false;
+}
+
+void PushAVTransport::TriggerTransport(TriggerActivationReasonEnum activationReason, int zoneId, int sensitivity)
+{
+    ChipLogProgress(Camera, "PushAVTransport trigger transport, activation reason: [%u], ZoneId: [%d], Sensitivity: [%d]",
+                    (uint16_t) activationReason, zoneId, sensitivity);
+
+    mCurrentActivationByManualTrigger = (zoneId == kInvalidZoneId) ? true : false;
+    mActivationReason                 = chip::MakeOptional(activationReason);
+
+    // Check if trigger should be processed based on transport type
+    bool shouldProcessTrigger = false;
+
+    if (mTransportTriggerType == TransportTriggerTypeEnum::kCommand)
+    {
+        shouldProcessTrigger = true;
+    }
+    else if (mTransportTriggerType == TransportTriggerTypeEnum::kMotion)
+    {
+        shouldProcessTrigger =
+            mCurrentActivationByManualTrigger || ValidateZoneAndSensitivity(mZoneSensitivityList, zoneId, sensitivity);
     }
     else if (mTransportTriggerType == TransportTriggerTypeEnum::kContinuous)
     {
         ChipLogProgress(Camera, "PushAVTransport continuous transport trigger received. No action needed");
         return;
+    }
+    // Process the trigger if conditions are met
+    if (shouldProcessTrigger)
+    {
+        if (HandleTriggerDetected())
+        {
+            // Event generation is handled differently based on trigger type:
+            // - Command: Begin event already generated at cluster server
+            // - Motion: GeneratePushTransportBeginEvent() would be called inside `HandleTriggerDetected` API if needed
+        }
+        else
+        {
+            ChipLogError(Camera, "PushAVTransport trigger detection ignored or failed for connection %u", mConnectionID);
+        }
     }
 }
 
@@ -505,27 +527,9 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
         mUploader->Start();
         InitializeRecorder();
 
-        mRecorder->mClipInfo.mElapsedTimeS = 0;
         if (mTransportTriggerType == TransportTriggerTypeEnum::kContinuous)
         {
-            mRecorder->mClipInfo.mSessionNumber =
-                mPushAvStreamTransportManager->OnTriggerActivated(mFabricIndex, mClipInfo.mSessionGroup, mConnectionID);
-            mRecorder->Start();
-            mStreaming = true;
-            if (IsStreaming())
-            {
-                ChipLogProgress(Camera, "Ready to stream");
-                if (mPushAvStreamTransportServer != nullptr)
-                {
-                    mPushAvStreamTransportServer->NotifyTransportStarted(
-                        mConnectionID, mTransportTriggerType,
-                        chip::Optional<chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum>());
-                }
-                else
-                {
-                    ChipLogError(Camera, "PushAvStreamTransportServer is null for connection %u", mConnectionID);
-                }
-            }
+            StartRecordingAndStreaming();
         }
         else if (mTransportTriggerType == TransportTriggerTypeEnum::kMotion)
         {
@@ -541,37 +545,16 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
                     std::chrono::duration_cast<std::chrono::seconds>(now - mRecorder->mClipInfo.mActivationTime).count();
 
                 // Check if recording duration has expired
-                if (elapsedSeconds >= mRecorder->mClipInfo.mInitialDurationS)
+                if (elapsedSeconds >= mRecorder->mClipInfo.mMotionDetectedDurationS)
                 {
                     ChipLogProgress(Camera, "No active trigger (time expired) to start recording");
                 }
                 else
                 {
-                    // Calculate remaining duration safely
                     mRecorder->mClipInfo.mElapsedTimeS = static_cast<uint16_t>(elapsedSeconds);
                     ChipLogProgress(Camera, "Active trigger is present. Recording will start for [%d seconds]",
-                                    mRecorder->mClipInfo.mInitialDurationS);
-                    if (HandleTriggerDetected())
-                    {
-                        if (mPushAvStreamTransportServer != nullptr)
-                        {
-                            mPushAvStreamTransportServer->NotifyTransportStarted(
-                                mConnectionID, mTransportTriggerType,
-                                chip::Optional<chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum>());
-                        }
-                        else
-                        {
-                            ChipLogError(Camera, "PushAvStreamTransportServer is null for connection %u", mConnectionID);
-                        }
-                    }
-                    else
-                    {
-                        ChipLogError(Camera,
-                                     "PushAVTransport command/motion transport trigger received but ignored due to blind period. "
-                                     "Clip duration "
-                                     "[%d seconds]",
-                                     mRecorder->mClipInfo.mInitialDurationS);
-                    }
+                                    mRecorder->mClipInfo.mMotionDetectedDurationS);
+                    StartRecordingAndStreaming();
                 }
             }
         }
@@ -579,38 +562,32 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
     else if (status == TransportStatusEnum::kInactive)
     {
         ChipLogProgress(Camera, "PushAVTransport transport status change requested to inactive");
-        mStreaming    = false; // Stop streaming
-        mCanSendVideo = false;
-        mCanSendAudio = false;
-        // Clear activationTime for manual triggers when setting status to inactive
-        if (mActivationTimeSetByManualTrigger)
-        {
-            mClipInfo.mActivationTime         = std::chrono::steady_clock::time_point();
-            mActivationTimeSetByManualTrigger = false;
-            ChipLogDetail(Camera, "PushAVTransport, cleared mActivationTime for manual trigger");
-        }
+        mStreaming = false; // Stop streaming
+        UpdateSendFlags();
         mRecorder.reset();
         ChipLogProgress(Camera, "Recorder destruction done");
+        // Clear activationTime for manual triggers when setting status to inactive
+        if (mCurrentActivationByManualTrigger)
+        {
+            mClipInfo.mActivationTime = std::chrono::steady_clock::time_point();
+            ChipLogDetail(Camera, "PushAVTransport, cleared mActivationTime for manual trigger");
+        }
         mUploader.reset();
         ChipLogProgress(Camera, "Uploader destruction done");
         ChipLogProgress(Camera, "PushAVTransport transport status changed to inactive");
     }
 }
 
-bool PushAVTransport::IsStreaming()
+void PushAVTransport::UpdateSendFlags()
 {
-    if (mStreaming && (mTransportStatus == TransportStatusEnum::kActive))
-    {
-        mCanSendVideo = true;
-        mCanSendAudio = true;
-        return true;
-    }
-    else
-    {
-        mCanSendVideo = false;
-        mCanSendAudio = false;
-        return false;
-    }
+    bool canSend  = mStreaming && (mTransportStatus == TransportStatusEnum::kActive);
+    mCanSendVideo = canSend && mClipInfo.mHasVideo;
+    mCanSendAudio = canSend && mClipInfo.mHasAudio;
+}
+
+bool PushAVTransport::IsStreaming() const
+{
+    return mStreaming && (mTransportStatus == TransportStatusEnum::kActive);
 }
 
 bool PushAVTransport::CanSendPacketsToRecorder()
@@ -619,30 +596,34 @@ bool PushAVTransport::CanSendPacketsToRecorder()
     {
         return false;
     }
+
+    CheckAndUpdateSession();
+
     if (mRecorder->mDeinitializeRecorder.load())
     {
         ChipLogProgress(Camera, "Current clip is completed, Next clip will start on trigger");
         mRecorder.reset(); // Redundant cleanup to make sure no dangling pointer left
         InitializeRecorder();
         mStreaming = false;
+        UpdateSendFlags();
         return false;
     }
     return true;
 }
 
-void PushAVTransport::SendVideo(const chip::ByteSpan & data, int64_t timestamp, uint16_t videoStreamID)
+void PushAVTransport::SendVideo(const chip::ByteSpan & data, int64_t timestampMs, uint16_t videoStreamID)
 {
     if (CanSendPacketsToRecorder())
     {
-        mRecorder->PushPacket(data.data(), data.size(), 1);
+        mRecorder->PushPacket(data.data(), data.size(), timestampMs, 1);
     }
 }
 
-void PushAVTransport::SendAudio(const chip::ByteSpan & data, int64_t timestamp, uint16_t audioStreamID)
+void PushAVTransport::SendAudio(const chip::ByteSpan & data, int64_t timestampMs, uint16_t audioStreamID)
 {
     if (CanSendPacketsToRecorder())
     {
-        mRecorder->PushPacket(data.data(), data.size(), 0);
+        mRecorder->PushPacket(data.data(), data.size(), timestampMs, 0);
     }
 }
 
@@ -718,20 +699,39 @@ uint16_t PushAVTransport::GetPreRollLength()
     return mClipInfo.mPreRollLengthMs;
 }
 
-void PushAVTransport::StartNewSession(uint64_t newSessionID)
+void PushAVTransport::CheckAndUpdateSession()
 {
-    mClipInfo.mSessionNumber = newSessionID;
-    ChipLogProgress(Camera, "Session completed, New session started with session number [%" PRIu64 "]", mClipInfo.mSessionNumber);
-    mStreaming    = false;
-    mCanSendVideo = false;
-    mCanSendAudio = false;
-    mRecorder.reset();
+    auto now = std::chrono::system_clock::now();
 
-    InitializeRecorder();
-    auto now            = std::chrono::steady_clock::now();
-    auto elapsedSeconds = std::chrono::duration_cast<std::chrono::seconds>(now - mRecorder->mClipInfo.mActivationTime).count();
-    mRecorder->mClipInfo.mElapsedTimeS = static_cast<uint16_t>(elapsedSeconds);
+    if (mSessionStartedTimestamp == std::chrono::system_clock::time_point())
+    {
+        mSessionStartedTimestamp = now;
+        ChipLogProgress(Camera, "Transport[%u] Session[%lu] SESSION_STARTED: First session initialized for Track=%s", mConnectionID,
+                        mSessionNumber, mClipInfo.mTrackName.c_str());
+        return;
+    }
 
-    mRecorder->Start();
-    mStreaming = true;
+    auto elapsed = std::chrono::duration_cast<std::chrono::minutes>(now - mSessionStartedTimestamp).count();
+    if (elapsed >= kMaxSessionDurationMinutes)
+    {
+        mSessionStartedTimestamp = now;
+
+        ChipLogProgress(Camera,
+                        "Transport[%u] Session[%lu] SESSION_INCREMENTED: Session duration limit reached (%d min). New session "
+                        "started. Track=%s",
+                        mConnectionID, mSessionNumber, kMaxSessionDurationMinutes, mClipInfo.mTrackName.c_str());
+        mStreaming = false;
+        UpdateSendFlags();
+        mRecorder.reset();
+
+        InitializeRecorder();
+        auto elapsedSeconds = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() -
+                                                                               mRecorder->mClipInfo.mActivationTime)
+                                  .count();
+        mRecorder->mClipInfo.mElapsedTimeS = static_cast<uint16_t>(elapsedSeconds);
+
+        mRecorder->Start();
+        mStreaming = true;
+        UpdateSendFlags();
+    }
 }

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -637,12 +637,14 @@ Status PushAvStreamTransportServerLogic::ValidateIncomingTransportOptions(
     return Status::Success;
 }
 
-std::optional<DataModel::ActionReturnStatus>
-PushAvStreamTransportServerLogic::ValidateStreamParameters(CommandHandler & handler, const ConcreteCommandPath & commandPath, const PushAvStreamTransport::Structs::TransportOptionsStruct::DecodableType & transportOptions,
-                             const std::shared_ptr<PushAvStreamTransport::TransportOptionsStorage> transportOptionsPtr)
+std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServerLogic::ValidateStreamParameters(
+    CommandHandler & handler, const ConcreteCommandPath & commandPath,
+    const PushAvStreamTransport::Structs::TransportOptionsStruct::DecodableType & transportOptions,
+    const std::shared_ptr<PushAvStreamTransport::TransportOptionsStorage> transportOptionsPtr)
 {
 
-    // Check mutual exclusivity and presence of stream fieldsconst PushAvStreamTransport::Structs::TransportOptionsStruct::DecodableType
+    // Check mutual exclusivity and presence of stream fieldsconst
+    // PushAvStreamTransport::Structs::TransportOptionsStruct::DecodableType
     bool hasNewStreamFields = transportOptions.videoStreams.HasValue() || transportOptions.audioStreams.HasValue();
     bool hasOldStreamFields = transportOptions.videoStreamID.HasValue() || transportOptions.audioStreamID.HasValue();
 

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -638,6 +638,211 @@ Status PushAvStreamTransportServerLogic::ValidateIncomingTransportOptions(
 }
 
 std::optional<DataModel::ActionReturnStatus>
+PushAvStreamTransportServerLogic::ValidateStreamParameters(CommandHandler & handler, const ConcreteCommandPath & commandPath, const PushAvStreamTransport::Structs::TransportOptionsStruct::DecodableType & transportOptions,
+                             const std::shared_ptr<PushAvStreamTransport::TransportOptionsStorage> transportOptionsPtr)
+{
+
+    // Check mutual exclusivity and presence of stream fieldsconst PushAvStreamTransport::Structs::TransportOptionsStruct::DecodableType
+    bool hasNewStreamFields = transportOptions.videoStreams.HasValue() || transportOptions.audioStreams.HasValue();
+    bool hasOldStreamFields = transportOptions.videoStreamID.HasValue() || transportOptions.audioStreamID.HasValue();
+
+    VerifyOrReturnValue(!(hasNewStreamFields && hasOldStreamFields), Status::InvalidCommand,
+                        ChipLogError(Zcl, "Transport Options[ep=%d]: Both new and old stream fields are present", mEndpointId));
+
+    VerifyOrReturnValue(hasNewStreamFields || hasOldStreamFields, Status::InvalidCommand,
+                        ChipLogError(Zcl, "Transport Options[ep=%d]: Missing stream fields", mEndpointId));
+
+    // Validate new multistream fields
+    if (hasNewStreamFields)
+    {
+        std::set<std::string> videoStreamNames;
+
+        // Validate videoStreams
+        uint16_t videoStreamsCount = 0;
+        if (transportOptions.videoStreams.HasValue())
+        {
+            std::set<uint16_t> videoStreamIDs;
+
+            for (auto iter = transportOptions.videoStreams.Value().begin(); iter.Next();)
+            {
+                auto & videoStream = iter.GetValue();
+
+                videoStreamsCount++;
+                videoStreamNames.insert(std::string(videoStream.videoStreamName.data(), videoStream.videoStreamName.size()));
+                videoStreamIDs.insert(videoStream.videoStreamID);
+            }
+
+            // Check for duplicates within video streams
+            if ((videoStreamNames.size() != videoStreamsCount) || (videoStreamIDs.size() != videoStreamsCount))
+            {
+                auto status = to_underlying(StatusCodeEnum::kDuplicateStreamValues);
+                ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Duplicate videoStreamName or videoStreamID found",
+                             mEndpointId);
+                TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, status);
+                return std::nullopt;
+            }
+
+            for (auto iter = transportOptions.videoStreams.Value().begin(); iter.Next();)
+            {
+                auto & videoStream = iter.GetValue();
+                // Validate videoStreamID
+                auto status = Protocols::InteractionModel::ClusterStatusCode(mDelegate->SetVideoStream(videoStream.videoStreamID));
+                VerifyOrReturnValue(status.IsSuccess(), Status::InvalidCommand,
+                                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Invalid Video Stream ID", mEndpointId));
+            }
+        }
+
+        // Validate audioStreams
+        uint16_t audioStreamsCount = 0;
+        if (transportOptions.audioStreams.HasValue())
+        {
+            std::set<std::string> audioStreamNames;
+            std::set<uint16_t> audioStreamIDs;
+
+            // Check against video stream names
+            for (auto iter = transportOptions.audioStreams.Value().begin(); iter.Next();)
+            {
+                auto & audioStream = iter.GetValue();
+
+                audioStreamsCount++;
+                audioStreamNames.insert(std::string(audioStream.audioStreamName.data(), audioStream.audioStreamName.size()));
+                audioStreamIDs.insert(audioStream.audioStreamID);
+            }
+
+            // Check for duplicates within audio streams
+            if ((audioStreamNames.size() != audioStreamsCount) || (audioStreamIDs.size() != audioStreamsCount))
+            {
+                auto status = to_underlying(StatusCodeEnum::kDuplicateStreamValues);
+                ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Duplicate audioStreamName or audioStreamID found",
+                             mEndpointId);
+                TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, status);
+                return std::nullopt;
+            }
+
+            for (auto iter = transportOptions.audioStreams.Value().begin(); iter.Next();)
+            {
+                auto & audioStream = iter.GetValue();
+                // Check for duplicate with video streams
+                if (videoStreamNames.find(std::string(audioStream.audioStreamName.data(), audioStream.audioStreamName.size())) !=
+                    videoStreamNames.end())
+                {
+                    auto status = to_underlying(StatusCodeEnum::kInvalidStream);
+                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: AudioStreamName conflicts with video stream",
+                                 mEndpointId);
+                    TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, status);
+                    return std::nullopt;
+                }
+
+                // Validate audioStreamID
+                auto status = Protocols::InteractionModel::ClusterStatusCode(mDelegate->SetAudioStream(audioStream.audioStreamID));
+                VerifyOrReturnValue(status.IsSuccess(), Status::InvalidCommand,
+                                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Invalid Audio Stream ID", mEndpointId));
+            }
+        }
+
+        // Check if both videoStreams and audioStreams are empty
+        if (videoStreamsCount == 0 && audioStreamsCount == 0)
+        {
+            auto status = to_underlying(StatusCodeEnum::kInvalidStream);
+            ChipLogError(Zcl, "Transport Options[ep=%d]: Both VideoStreams and AudioStreams empty", mEndpointId);
+            TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, status);
+            return std::nullopt;
+        }
+    }
+
+    // Validate old format single stream fields
+    if (hasOldStreamFields)
+    {
+
+        if (transportOptions.videoStreamID.HasValue())
+        {
+            uint16_t finalVideoStreamID;
+
+            if (transportOptions.videoStreamID.Value().IsNull())
+            {
+                auto delegateStatus = Protocols::InteractionModel::ClusterStatusCode(
+                    mDelegate->SelectVideoStream(transportOptions.streamUsage, finalVideoStreamID));
+                if (!delegateStatus.IsSuccess())
+                {
+                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: AllocatedVideoStreamsAttribute is empty", mEndpointId);
+                    handler.AddStatus(commandPath, Status::InvalidInState);
+                    return std::nullopt;
+                }
+
+                transportOptionsPtr->videoStreamID.SetValue(finalVideoStreamID);
+            }
+            else
+            {
+                auto delegateStatus = Protocols::InteractionModel::ClusterStatusCode(
+                    mDelegate->SetVideoStream(transportOptions.videoStreamID.Value().Value()));
+
+                if (!delegateStatus.IsSuccess())
+                {
+                    auto cluster_status = to_underlying(StatusCodeEnum::kInvalidStream);
+                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Invalid Video Stream ", mEndpointId);
+                    TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, cluster_status);
+                    return std::nullopt;
+                }
+
+                finalVideoStreamID = transportOptions.videoStreamID.Value().Value();
+            }
+
+            // Create new video stream entry with name 'video' and the provided or selected VideoStreamID i.e; finalVideoStreamID
+            Structs::VideoStreamStruct::Type newVideoStream;
+            newVideoStream.videoStreamName = CharSpan::fromCharString("video");
+            newVideoStream.videoStreamID   = finalVideoStreamID;
+
+            // Add to storage and update the list
+            transportOptionsPtr->AddVideoStream(newVideoStream);
+        }
+
+        if (transportOptions.audioStreamID.HasValue())
+        {
+            uint16_t finalAudioStreamID;
+
+            if (transportOptions.audioStreamID.Value().IsNull())
+            {
+                auto delegateStatus = Protocols::InteractionModel::ClusterStatusCode(
+                    mDelegate->SelectAudioStream(transportOptions.streamUsage, finalAudioStreamID));
+                if (!delegateStatus.IsSuccess())
+                {
+                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: AllocatedAudioStreamsAttribute is empty", mEndpointId);
+                    handler.AddStatus(commandPath, Status::InvalidInState);
+                    return std::nullopt;
+                }
+
+                transportOptionsPtr->audioStreamID.SetValue(finalAudioStreamID);
+            }
+            else
+            {
+                auto delegateStatus = Protocols::InteractionModel::ClusterStatusCode(
+                    mDelegate->SetAudioStream(transportOptions.audioStreamID.Value().Value()));
+
+                if (!delegateStatus.IsSuccess())
+                {
+                    auto cluster_status = to_underlying(StatusCodeEnum::kInvalidStream);
+                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Invalid Audio Stream ", mEndpointId);
+                    TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, cluster_status);
+                    return std::nullopt;
+                }
+
+                finalAudioStreamID = transportOptions.audioStreamID.Value().Value();
+            }
+
+            // Create new audio stream entry with name 'audio' and the provided or selected AudioStreamID i.e; finalAudioStreamID
+            Structs::AudioStreamStruct::Type newAudioStream;
+            newAudioStream.audioStreamName = CharSpan::fromCharString("audio");
+            newAudioStream.audioStreamID   = finalAudioStreamID;
+
+            // Add to storage and update the list
+            transportOptionsPtr->AddAudioStream(newAudioStream);
+        }
+    }
+
+    return Status::Success;
+}
+
+std::optional<DataModel::ActionReturnStatus>
 PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & handler, const ConcreteCommandPath & commandPath,
                                                               const Commands::AllocatePushTransport::DecodableType & commandData)
 {
@@ -840,202 +1045,7 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
         return std::nullopt;
     }
 
-    // Check mutual exclusivity and presence of stream fields
-    bool hasNewStreamFields = transportOptions.videoStreams.HasValue() || transportOptions.audioStreams.HasValue();
-    bool hasOldStreamFields = transportOptions.videoStreamID.HasValue() || transportOptions.audioStreamID.HasValue();
-
-    VerifyOrReturnValue(!(hasNewStreamFields && hasOldStreamFields), Status::InvalidCommand,
-                        ChipLogError(Zcl, "Transport Options[ep=%d]: Both new and old stream fields are present", mEndpointId));
-
-    VerifyOrReturnValue(hasNewStreamFields || hasOldStreamFields, Status::InvalidCommand,
-                        ChipLogError(Zcl, "Transport Options[ep=%d]: Missing stream fields", mEndpointId));
-
-    // Validate new multistream fields
-    if (hasNewStreamFields)
-    {
-        std::set<std::string> videoStreamNames;
-
-        // Validate videoStreams
-        uint16_t videoStreamsCount = 0;
-        if (transportOptions.videoStreams.HasValue())
-        {
-            std::set<uint16_t> videoStreamIDs;
-
-            for (auto iter = transportOptions.videoStreams.Value().begin(); iter.Next();)
-            {
-                auto & videoStream = iter.GetValue();
-
-                videoStreamsCount++;
-                videoStreamNames.insert(std::string(videoStream.videoStreamName.data(), videoStream.videoStreamName.size()));
-                videoStreamIDs.insert(videoStream.videoStreamID);
-            }
-
-            // Check for duplicates within video streams
-            if ((videoStreamNames.size() != videoStreamsCount) || (videoStreamIDs.size() != videoStreamsCount))
-            {
-                auto status = to_underlying(StatusCodeEnum::kDuplicateStreamValues);
-                ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Duplicate videoStreamName or videoStreamID found",
-                             mEndpointId);
-                TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, status);
-                return std::nullopt;
-            }
-
-            for (auto iter = transportOptions.videoStreams.Value().begin(); iter.Next();)
-            {
-                auto & videoStream = iter.GetValue();
-                // Validate videoStreamID
-                auto status = Protocols::InteractionModel::ClusterStatusCode(mDelegate->SetVideoStream(videoStream.videoStreamID));
-                VerifyOrReturnValue(status.IsSuccess(), Status::InvalidCommand,
-                                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Invalid Video Stream ID", mEndpointId));
-            }
-        }
-
-        // Validate audioStreams
-        uint16_t audioStreamsCount = 0;
-        if (transportOptions.audioStreams.HasValue())
-        {
-            std::set<std::string> audioStreamNames;
-            std::set<uint16_t> audioStreamIDs;
-
-            // Check against video stream names
-            for (auto iter = transportOptions.audioStreams.Value().begin(); iter.Next();)
-            {
-                auto & audioStream = iter.GetValue();
-
-                audioStreamsCount++;
-                audioStreamNames.insert(std::string(audioStream.audioStreamName.data(), audioStream.audioStreamName.size()));
-                audioStreamIDs.insert(audioStream.audioStreamID);
-            }
-
-            // Check for duplicates within audio streams
-            if ((audioStreamNames.size() != audioStreamsCount) || (audioStreamIDs.size() != audioStreamsCount))
-            {
-                auto status = to_underlying(StatusCodeEnum::kDuplicateStreamValues);
-                ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Duplicate audioStreamName or audioStreamID found",
-                             mEndpointId);
-                TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, status);
-                return std::nullopt;
-            }
-
-            for (auto iter = transportOptions.audioStreams.Value().begin(); iter.Next();)
-            {
-                auto & audioStream = iter.GetValue();
-                // Check for duplicate with video streams
-                if (videoStreamNames.find(std::string(audioStream.audioStreamName.data(), audioStream.audioStreamName.size())) !=
-                    videoStreamNames.end())
-                {
-                    auto status = to_underlying(StatusCodeEnum::kInvalidStream);
-                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: AudioStreamName conflicts with video stream",
-                                 mEndpointId);
-                    TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, status);
-                    return std::nullopt;
-                }
-
-                // Validate audioStreamID
-                auto status = Protocols::InteractionModel::ClusterStatusCode(mDelegate->SetAudioStream(audioStream.audioStreamID));
-                VerifyOrReturnValue(status.IsSuccess(), Status::InvalidCommand,
-                                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Invalid Audio Stream ID", mEndpointId));
-            }
-        }
-
-        // Check if both videoStreams and audioStreams are empty
-        if (videoStreamsCount == 0 && audioStreamsCount == 0)
-        {
-            auto status = to_underlying(StatusCodeEnum::kInvalidStream);
-            ChipLogError(Zcl, "Transport Options[ep=%d]: Both VideoStreams and AudioStreams empty", mEndpointId);
-            TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, status);
-            return std::nullopt;
-        }
-    }
-
-    // Validate old format single stream fields
-    if (hasOldStreamFields)
-    {
-
-        if (transportOptions.videoStreamID.HasValue())
-        {
-            uint16_t finalVideoStreamID;
-
-            if (transportOptions.videoStreamID.Value().IsNull())
-            {
-                auto delegateStatus = Protocols::InteractionModel::ClusterStatusCode(
-                    mDelegate->SelectVideoStream(transportOptions.streamUsage, finalVideoStreamID));
-                if (!delegateStatus.IsSuccess())
-                {
-                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: AllocatedVideoStreamsAttribute is empty", mEndpointId);
-                    handler.AddStatus(commandPath, Status::InvalidInState);
-                    return std::nullopt;
-                }
-
-                transportOptionsPtr->videoStreamID.SetValue(finalVideoStreamID);
-            }
-            else
-            {
-                auto delegateStatus = Protocols::InteractionModel::ClusterStatusCode(
-                    mDelegate->SetVideoStream(transportOptions.videoStreamID.Value().Value()));
-
-                if (!delegateStatus.IsSuccess())
-                {
-                    auto cluster_status = to_underlying(StatusCodeEnum::kInvalidStream);
-                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Invalid Video Stream ", mEndpointId);
-                    TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, cluster_status);
-                    return std::nullopt;
-                }
-
-                finalVideoStreamID = transportOptions.videoStreamID.Value().Value();
-            }
-
-            // Create new video stream entry with name 'video' and the provided or selected VideoStreamID i.e; finalVideoStreamID
-            Structs::VideoStreamStruct::Type newVideoStream;
-            newVideoStream.videoStreamName = CharSpan::fromCharString("video");
-            newVideoStream.videoStreamID   = finalVideoStreamID;
-
-            // Add to storage and update the list
-            transportOptionsPtr->AddVideoStream(newVideoStream);
-        }
-
-        if (transportOptions.audioStreamID.HasValue())
-        {
-            uint16_t finalAudioStreamID;
-
-            if (transportOptions.audioStreamID.Value().IsNull())
-            {
-                auto delegateStatus = Protocols::InteractionModel::ClusterStatusCode(
-                    mDelegate->SelectAudioStream(transportOptions.streamUsage, finalAudioStreamID));
-                if (!delegateStatus.IsSuccess())
-                {
-                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: AllocatedAudioStreamsAttribute is empty", mEndpointId);
-                    handler.AddStatus(commandPath, Status::InvalidInState);
-                    return std::nullopt;
-                }
-
-                transportOptionsPtr->audioStreamID.SetValue(finalAudioStreamID);
-            }
-            else
-            {
-                auto delegateStatus = Protocols::InteractionModel::ClusterStatusCode(
-                    mDelegate->SetAudioStream(transportOptions.audioStreamID.Value().Value()));
-
-                if (!delegateStatus.IsSuccess())
-                {
-                    auto cluster_status = to_underlying(StatusCodeEnum::kInvalidStream);
-                    ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: Invalid Audio Stream ", mEndpointId);
-                    TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, cluster_status);
-                    return std::nullopt;
-                }
-
-                finalAudioStreamID = transportOptions.audioStreamID.Value().Value();
-            }
-
-            // Create new audio stream entry with name 'audio' and the provided or selected AudioStreamID i.e; finalAudioStreamID
-            Structs::AudioStreamStruct::Type newAudioStream;
-            newAudioStream.audioStreamName = CharSpan::fromCharString("audio");
-            newAudioStream.audioStreamID   = finalAudioStreamID;
-
-            // Add to storage and update the list
-            transportOptionsPtr->AddAudioStream(newAudioStream);
-        }
-    }
+    ValidateStreamParameters(handler, commandPath, transportOptions, transportOptionsPtr);
 
     if (transportOptions.containerOptions.containerType == ContainerFormatEnum::kCmaf &&
         transportOptions.containerOptions.CMAFContainerOptions.HasValue())
@@ -1236,6 +1246,8 @@ PushAvStreamTransportServerLogic::HandleModifyPushTransport(CommandHandler & han
         handler.AddStatus(commandPath, Status::ResourceExhausted);
         return std::nullopt;
     }
+
+    ValidateStreamParameters(handler, commandPath, transportOptions, transportOptionsPtr);
 
     // Call the delegate
     status = mDelegate->ModifyPushTransport(connectionID, *transportOptionsPtr);

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.h
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.h
@@ -103,7 +103,8 @@ public:
         const PushAvStreamTransport::Structs::TransportOptionsStruct::DecodableType & transportOptions);
 
     std::optional<DataModel::ActionReturnStatus>
-    ValidateStreamParameters(CommandHandler & handler, const ConcreteCommandPath & commandPath, const PushAvStreamTransport::Structs::TransportOptionsStruct::DecodableType & transportOptions,
+    ValidateStreamParameters(CommandHandler & handler, const ConcreteCommandPath & commandPath,
+                             const PushAvStreamTransport::Structs::TransportOptionsStruct::DecodableType & transportOptions,
                              const std::shared_ptr<PushAvStreamTransport::TransportOptionsStorage> transportOptionsPtr);
 
     std::optional<DataModel::ActionReturnStatus>

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.h
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.h
@@ -103,6 +103,10 @@ public:
         const PushAvStreamTransport::Structs::TransportOptionsStruct::DecodableType & transportOptions);
 
     std::optional<DataModel::ActionReturnStatus>
+    ValidateStreamParameters(CommandHandler & handler, const ConcreteCommandPath & commandPath, const PushAvStreamTransport::Structs::TransportOptionsStruct::DecodableType & transportOptions,
+                             const std::shared_ptr<PushAvStreamTransport::TransportOptionsStorage> transportOptionsPtr);
+
+    std::optional<DataModel::ActionReturnStatus>
     HandleAllocatePushTransport(CommandHandler & handler, const ConcreteCommandPath & commandPath,
                                 const PushAvStreamTransport::Commands::AllocatePushTransport::DecodableType & commandData);
 

--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 
 
 class PAVSTTestBase:
-    DEFAULT_AV_TRANSPORT_EXPIRY_TIME_SEC = 30  # 30 seconds
+    DEFAULT_AV_TRANSPORT_EXPIRY_TIME_SEC = 100  # 100 seconds
 
     async def read_pavst_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.PushAvStreamTransport

--- a/src/python_testing/TC_PAVST_2_11.py
+++ b/src/python_testing/TC_PAVST_2_11.py
@@ -21,7 +21,7 @@
 # test-runner-runs:
 #   run1:
 #     app: ${CAMERA_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/pavst_2_11_fifo
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --string-arg th_server_app_path:${PUSH_AV_SERVER}
@@ -33,6 +33,7 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #       --endpoint 1
+#       --app-pipe /tmp/pavst_2_11_fifo
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_PAVST_2_11.py
+++ b/src/python_testing/TC_PAVST_2_11.py
@@ -284,7 +284,7 @@ class TC_PAVST_2_11(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         self.step(10)
         if self.pics_guard(self.check_pics("PAVST.S")):
             aProvisionedEndpoints = await self.read_single_attribute_check_success(
-                endpoint=endpoint, cluster=tlscluster, attribute=tlsattr
+                endpoint=endpoint, cluster=tlscluster, attribute=tlsattr.ProvisionedEndpoints
             )
             log.info(f"aProvisionedEndpoints: {aProvisionedEndpoints}")
 

--- a/src/python_testing/TC_PAVST_2_12.py
+++ b/src/python_testing/TC_PAVST_2_12.py
@@ -378,7 +378,7 @@ class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID2, "Unexpected value for ConnectionID returned")
 
-        await asyncio.to_thread(time.sleep, 5) # Wait for 5 seconds before sending DeallocatePushTransport command
+        await asyncio.to_thread(time.sleep, 5)  # Wait for 5 seconds before sending DeallocatePushTransport command
         cmd = pvcluster.Commands.DeallocatePushTransport(
             connectionID=aConnectionID2
         )

--- a/src/python_testing/TC_PAVST_2_12.py
+++ b/src/python_testing/TC_PAVST_2_12.py
@@ -352,7 +352,7 @@ class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         await self._trigger_motion_event(aZones, prompt_msg=f"Press enter and immediately start motion activity in zone {aZones} and stop any motion after {initDuration} seconds of pressing enter.")
 
         self.step(14)
-        event = event_callback.wait_for_event_expect_no_report(timeout_sec=5)
+        event_data = event_callback.wait_for_event_expect_no_report(timeout_sec=5)
         logger.info(f"Successfully timed out without receiving any PushTransportBegin event for zone: {aZones}")
 
         self.step(15)

--- a/src/python_testing/TC_PAVST_2_12.py
+++ b/src/python_testing/TC_PAVST_2_12.py
@@ -377,7 +377,7 @@ class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID2, "Unexpected value for ConnectionID returned")
 
-        asyncio.sleep(5) # Wait for 5 seconds before sending DelocatePushTransport command
+        asyncio.sleep(5)  # Wait for 5 seconds before sending DelocatePushTransport command
         cmd = pvcluster.Commands.DelocatePushTransport(
             connectionID=aConnectionID2
         )

--- a/src/python_testing/TC_PAVST_2_12.py
+++ b/src/python_testing/TC_PAVST_2_12.py
@@ -1,0 +1,384 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/pavst_2_12_fifo
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --string-arg th_server_app_path:${PUSH_AV_SERVER}
+#       --string-arg host_ip:localhost
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#       --app-pipe /tmp/pavst_2_12_fifo
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import logging
+
+from mobly import asserts
+from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
+from TC_PAVSTTestBase import PAVSTTestBase
+
+import matter.clusters as Clusters
+from matter.interaction_model import InteractionModelError, Status
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.testing.runner import default_matter_test_main
+from matter.testing.decorators import has_cluster, run_if_endpoint_matches, async_test_body
+from matter.testing.matter_testing import (MatterBaseTest, TestStep)
+
+logger = logging.getLogger(__name__)
+
+
+class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
+    def desc_TC_PAVST_2_12(self) -> str:
+        return "[TC-PAVST-2.12] Validate PushAV Clip record for Motion Trigger"
+
+    def pics_TC_PAVST_2_12(self):
+        return ["PAVST.S", "AVSM.S", "ZONEMGMT.S"]
+
+    @async_test_body
+    async def setup_class(self):
+        th_server_app = self.user_params.get("th_server_app_path", None)
+        self.server = PushAvServerProcess(server_path=th_server_app)
+        self.server.start(
+            expected_output="Running on https://0.0.0.0:1234",
+            timeout=30,
+        )
+        super().setup_class()
+
+    def teardown_class(self):
+        if self.server is not None:
+            self.server.terminate()
+        super().teardown_class()
+
+    def steps_TC_PAVST_2_12(self) -> list[TestStep]:
+        return [
+            TestStep("precondition", "Commissioning, already done", is_commissioning=True),
+            TestStep(
+                1,
+                "TH Reads CurrentConnections attribute from PushAV Stream Transport Cluster on DUT",
+                "Verify the number of PushAV Connections is 0. If not 0, deallocate any existing connections.",
+            ),
+            TestStep(
+                2,
+                "TH Reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Store as aAllocatedVideoStreams.",
+            ),
+            TestStep(
+                3,
+                "TH Reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Store as aAllocatedAudioStreams.",
+            ),
+            TestStep(
+                4,
+                "TH Reads Zones attribute from Zones Management Cluster on DUT",
+                "Store as aZones.",
+            ),
+            TestStep(
+                5,
+                "If DUT supports TwoDCartesianZone and User defined zones, TH sends CreateTwoDCartesianZone command.",
+                "Verify that the DUT response contains a new zoneId, store in aZoneID"),
+            TestStep(
+                6,
+                "TH sends AllocatePushTransport command with TriggerType = Motion, MotionZones = [aZoneID]",
+                "DUT responds with AllocatePushTransportResponse containing the allocated ConnectionID, TransportOptions, and TransportStatus in the TransportConfigurationStruct. Store ConnectionID as aConnectionID1."),
+            TestStep(
+                7,
+                "TH sends SetTransportStatus command with ConnectionID = aConnectionID1 and TransportStatus = Active",
+                "DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                8,
+                "Motion Event triggers the DUT to generate PushAV Event",
+                "Successful completion of steps"
+            ),
+            TestStep(
+                9,
+                "DUT generates a PushTransportBegin event with ConnectionID = aConnectionID1",
+                "TH waits for the events from DUT with timeout of 5 sec, Verifies that the PushTransportBegin event is triggered.",
+            ),
+            TestStep(
+                10,
+                "TH sends DeallocatePushTransport command with ConnectionID = aConnectionID1",
+                "DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                11,
+                "TH Reads CurrentConnections attribute from PushAV Stream Transport Cluster on DUT",
+                "Verify the number of PushAV Connections is 0. If not 0, deallocate any existing connections.",
+            ),
+            TestStep(
+                12,
+                "TH sends AllocatePushTransport command with TriggerType = Motion, MotionZones = [aZoneID]",
+                "DUT responds with AllocatePushTransportResponse containing the allocated ConnectionID, TransportOptions, and TransportStatus in the TransportConfigurationStruct. Store ConnectionID as aConnectionID2.",
+            ),
+            TestStep(
+                13,
+                "Motion Event triggers the DUT to generate PushAV Event",
+                "Successful completion of steps."
+            ),
+            TestStep(
+                14,
+                "TH waits for the events from DUT with timeout of 5 sec",
+                "Verifies that no PushTransportBegin event is triggered."
+            ),
+            TestStep(
+                15,
+                "TH sends SetTransportStatus command with ConnectionID = aConnectionID2 and TransportStatus = Active",
+                "DUT responds with SUCCESS status code."
+            ),
+            TestStep(
+                16,
+                "TH waits for the events from DUT with timeout of 5 sec",
+                "Verifies that the PushTransportBegin event with ConnectionID = aConnectionID2 is triggered.",
+            ),
+            TestStep(
+                17,
+                "TH sends DeallocatePushTransport command with ConnectionID = aConnectionID2",
+                "DUT responds with SUCCESS status code.",
+            ),
+        ]
+
+    async def _trigger_motion_event(self, zone_id, prompt_msg=None):
+        # CI: Use app pipe to trigger zone event.
+        # Manual: User should trigger a motion event from the defined zone.
+        if self.is_pics_sdk_ci_only:
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zone_id})
+        else:
+            if prompt_msg is None:
+                prompt_msg = f"Press enter and immediately start motion activity in zone {zone_id}."
+            self.wait_for_user_input(prompt_msg=prompt_msg)
+
+    @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport) and has_cluster(Clusters.ZoneManagement) and has_cluster(Clusters.CameraAvStreamManagement))
+    async def test_TC_PAVST_2_12(self):
+        endpoint = self.get_endpoint()
+        self.endpoint = endpoint
+        self.node_id = self.dut_node_id
+        pvcluster = Clusters.PushAvStreamTransport
+        pvattr = Clusters.PushAvStreamTransport.Attributes
+        zmcluster = Clusters.ZoneManagement
+        zmattr = Clusters.ZoneManagement.Attributes
+        aAllocatedVideoStreams = []
+        aAllocatedAudioStreams = []
+
+        aConnectionID1 = ""
+
+        self.step("precondition")
+        host_ip = self.user_params.get("host_ip", None)
+        tlsEndpointId, host_ip = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server, host_ip=host_ip)
+        uploadStreamId = self.server.create_stream()
+
+        self.step(1)
+        # Commission DUT - already done
+        status = await self.check_and_delete_all_push_av_transports(endpoint, pvattr)
+        asserts.assert_equal(
+            status, Status.Success, "Status must be SUCCESS!"
+        )
+
+        self.step(2)
+        aAllocatedVideoStreams = await self.allocate_one_video_stream()
+        asserts.assert_greater_equal(
+            len(aAllocatedVideoStreams),
+            1,
+            "AllocatedVideoStreams must not be empty",
+        )
+
+        self.step(3)
+        aAllocatedAudioStreams = await self.allocate_one_audio_stream()
+        asserts.assert_greater_equal(
+            len(aAllocatedAudioStreams),
+            1,
+            "AllocatedAudioStreams must not be empty",
+        )
+
+        self.step(4)
+        aZones = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=zmcluster, attribute=zmattr.Zones
+        )
+        logger.info(f"aZones: {aZones}")
+
+        self.step(5)
+        aFeatureMap = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=zmcluster, attribute=zmattr.FeatureMap)
+        logger.info(f"Rx'd FeatureMap: {aFeatureMap}")
+        self.twoDCartSupported = aFeatureMap & zmcluster.Bitmaps.Feature.kTwoDimensionalCartesianZone
+        self.userDefinedSupported = aFeatureMap & zmcluster.Bitmaps.Feature.kUserDefined
+        self.perZoneSensSupported = aFeatureMap & zmcluster.Bitmaps.Feature.kPerZoneSensitivity
+
+        if self.twoDCartSupported and self.userDefinedSupported:
+
+            # Form the Create request and send
+            zoneVertices = [
+                zmcluster.Structs.TwoDCartesianVertexStruct(10, 10),
+                zmcluster.Structs.TwoDCartesianVertexStruct(20, 10),
+                zmcluster.Structs.TwoDCartesianVertexStruct(20, 20),
+                zmcluster.Structs.TwoDCartesianVertexStruct(10, 20)
+            ]
+            zoneToCreate = zmcluster.Structs.TwoDCartesianZoneStruct(
+                name="Zone1", use=zmcluster.Enums.ZoneUseEnum.kMotion, vertices=zoneVertices,
+                color="#00FFFF")
+            createTwoDCartesianCmd = zmcluster.Commands.CreateTwoDCartesianZone(
+                zone=zoneToCreate
+            )
+            cmdResponse = await self.send_single_cmd(endpoint=endpoint, cmd=createTwoDCartesianCmd)
+            logger.info(f"Rx'd CreateTwoDCartesianZoneResponse : {cmdResponse}")
+            asserts.assert_equal(type(cmdResponse), zmcluster.Commands.CreateTwoDCartesianZoneResponse,
+                                 "Incorrect response type")
+            asserts.assert_is_not_none(
+                cmdResponse.zoneID, "CreateTwoDCartesianCmdResponse does not contain ZoneID")
+
+            # Check that created zoneID did not exist before
+            matchingZone = next(
+                (z for z in aZones if z.zoneID == cmdResponse.zoneID), None)
+            asserts.assert_is_none(matchingZone, "fZone with {cmdResponse.zoneID} already existed in Zones")
+            aZones = cmdResponse.zoneID
+
+        self.step(6)
+        initDuration = 10
+        augDuration = 5
+        maxDuration = 20
+        blindDuration = 1
+        try:
+            zoneList = [{"zone": aZones, "sensitivity": 4}]
+            triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                              "maxPreRollLen": 4000,
+                              "motionZones": zoneList,
+                              "motionTimeControl": {"initialDuration": initDuration, "augmentationDuration": augDuration, "maxDuration": maxDuration, "blindDuration": blindDuration}}
+            status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions,
+                                                              tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}/")
+            asserts.assert_equal(status, Status.Success,
+                                 "DUT must respond with Status Code Success.")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.clusterStatus, Status.Success,
+                                 "Unexpected error: DUT must respond with Status Code Success.")
+        
+        transportConfigs = await self.read_pavst_attribute_expect_success(endpoint,
+                                                                          pvattr.CurrentConnections,
+                                                                          )
+        asserts.assert_greater_equal(
+            len(transportConfigs), 1, "TransportConfigurations must not be empty!"
+        )
+        aConnectionID1 = transportConfigs[0].connectionID
+        
+        self.step(7)
+        cmd = pvcluster.Commands.SetTransportStatus(
+            connectionID=aConnectionID1,
+            transportStatus=pvcluster.Enums.TransportStatusEnum.kActive
+        )
+        status = await self.psvt_set_transport_status(cmd)
+        asserts.assert_true(
+            status == Status.Success,
+            "DUT responds with SUCCESS status code.")
+
+        self.step(8)
+        event_callback = EventSubscriptionHandler(expected_cluster=pvcluster)
+        await event_callback.start(self.default_controller,
+                                   self.dut_node_id,
+                                   self.get_endpoint())
+        await self._trigger_motion_event(aZones, prompt_msg=f"Press enter and immediately start motion activity in zone {aZones} and stop any motion after {initDuration} seconds of pressing enter.")
+
+        self.step(9)
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID1, "Unexpected value for ConnectionID returned")
+        
+        self.step(10)
+        cmd = pvcluster.Commands.DeallocatePushTransport(
+            connectionID=aConnectionID1
+        )
+        status = await self.psvt_deallocate_push_transport(cmd)
+        asserts.assert_true(
+            status == Status.Success,
+            "DUT responds with SUCCESS status code.")
+        
+        self.step(11)
+        status = await self.check_and_delete_all_push_av_transports(endpoint, pvattr)
+        asserts.assert_equal(
+            status, Status.Success, "Status must be SUCCESS!"
+        )
+        
+        self.step(12)
+        try:
+            zoneList = [{"zone": aZones, "sensitivity": 4}]
+            triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                              "maxPreRollLen": 4000,
+                              "motionZones": zoneList,
+                              "motionTimeControl": {"initialDuration": initDuration, "augmentationDuration": augDuration, "maxDuration": maxDuration, "blindDuration": blindDuration}}
+            status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions,
+                                                              tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}/")
+            asserts.assert_equal(status, Status.Success,
+                                 "DUT must respond with Status Code Success.")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.clusterStatus, Status.Success,
+                                 "Unexpected error: DUT must respond with Status Code Success.")
+        
+        transportConfigs = await self.read_pavst_attribute_expect_success(endpoint,
+                                                                          pvattr.CurrentConnections,
+                                                                          )
+        asserts.assert_greater_equal(
+            len(transportConfigs), 1, "TransportConfigurations must not be empty!"
+        )
+        aConnectionID2 = transportConfigs[0].connectionID
+        
+        self.step(13)
+        event_callback = EventSubscriptionHandler(expected_cluster=pvcluster)
+        await event_callback.start(self.default_controller,
+                                   self.dut_node_id,
+                                   self.get_endpoint())
+        await self._trigger_motion_event(aZones, prompt_msg=f"Press enter and immediately start motion activity in zone {aZones} and stop any motion after {initDuration} seconds of pressing enter.")
+        
+        self.step(14)
+        event = event_callback.wait_for_event_expect_no_report(timeout_sec=5)
+        logger.info(f"Successfully timed out without receiving any PushTransportBegin event for zone: {aZones}")
+        
+        self.step(15)
+        cmd = pvcluster.Commands.SetTransportStatus(
+            connectionID=aConnectionID2,
+            transportStatus=pvcluster.Enums.TransportStatusEnum.kActive
+        )
+        status = await self.psvt_set_transport_status(cmd)
+        asserts.assert_true(
+            status == Status.Success,
+            "DUT responds with SUCCESS status code.")
+        
+        self.step(16)
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID2, "Unexpected value for ConnectionID returned")
+        
+        self.step(17)
+        cmd = pvcluster.Commands.DeallocatePushTransport(
+            connectionID=aConnectionID2
+        )
+        status = await self.psvt_deallocate_push_transport(cmd)
+        asserts.assert_true(
+            status == Status.Success,
+            "DUT responds with SUCCESS status code.")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_PAVST_2_12.py
+++ b/src/python_testing/TC_PAVST_2_12.py
@@ -46,10 +46,10 @@ from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
+from matter.testing.decorators import async_test_body, has_cluster, run_if_endpoint_matches
 from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.testing.matter_testing import MatterBaseTest, TestStep
 from matter.testing.runner import default_matter_test_main
-from matter.testing.decorators import has_cluster, run_if_endpoint_matches, async_test_body
-from matter.testing.matter_testing import (MatterBaseTest, TestStep)
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_12.py
+++ b/src/python_testing/TC_PAVST_2_12.py
@@ -275,7 +275,7 @@ class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         except InteractionModelError as e:
             asserts.assert_equal(e.clusterStatus, Status.Success,
                                  "Unexpected error: DUT must respond with Status Code Success.")
-        
+
         transportConfigs = await self.read_pavst_attribute_expect_success(endpoint,
                                                                           pvattr.CurrentConnections,
                                                                           )
@@ -283,7 +283,7 @@ class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             len(transportConfigs), 1, "TransportConfigurations must not be empty!"
         )
         aConnectionID1 = transportConfigs[0].connectionID
-        
+
         self.step(7)
         cmd = pvcluster.Commands.SetTransportStatus(
             connectionID=aConnectionID1,
@@ -305,7 +305,7 @@ class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID1, "Unexpected value for ConnectionID returned")
-        
+
         self.step(10)
         cmd = pvcluster.Commands.DeallocatePushTransport(
             connectionID=aConnectionID1
@@ -314,13 +314,13 @@ class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_true(
             status == Status.Success,
             "DUT responds with SUCCESS status code.")
-        
+
         self.step(11)
         status = await self.check_and_delete_all_push_av_transports(endpoint, pvattr)
         asserts.assert_equal(
             status, Status.Success, "Status must be SUCCESS!"
         )
-        
+
         self.step(12)
         try:
             zoneList = [{"zone": aZones, "sensitivity": 4}]
@@ -335,7 +335,7 @@ class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         except InteractionModelError as e:
             asserts.assert_equal(e.clusterStatus, Status.Success,
                                  "Unexpected error: DUT must respond with Status Code Success.")
-        
+
         transportConfigs = await self.read_pavst_attribute_expect_success(endpoint,
                                                                           pvattr.CurrentConnections,
                                                                           )
@@ -343,18 +343,18 @@ class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             len(transportConfigs), 1, "TransportConfigurations must not be empty!"
         )
         aConnectionID2 = transportConfigs[0].connectionID
-        
+
         self.step(13)
         event_callback = EventSubscriptionHandler(expected_cluster=pvcluster)
         await event_callback.start(self.default_controller,
                                    self.dut_node_id,
                                    self.get_endpoint())
         await self._trigger_motion_event(aZones, prompt_msg=f"Press enter and immediately start motion activity in zone {aZones} and stop any motion after {initDuration} seconds of pressing enter.")
-        
+
         self.step(14)
         event = event_callback.wait_for_event_expect_no_report(timeout_sec=5)
         logger.info(f"Successfully timed out without receiving any PushTransportBegin event for zone: {aZones}")
-        
+
         self.step(15)
         cmd = pvcluster.Commands.SetTransportStatus(
             connectionID=aConnectionID2,
@@ -364,12 +364,12 @@ class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_true(
             status == Status.Success,
             "DUT responds with SUCCESS status code.")
-        
+
         self.step(16)
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID2, "Unexpected value for ConnectionID returned")
-        
+
         self.step(17)
         cmd = pvcluster.Commands.DeallocatePushTransport(
             connectionID=aConnectionID2

--- a/src/python_testing/TC_PAVST_2_12.py
+++ b/src/python_testing/TC_PAVST_2_12.py
@@ -21,7 +21,7 @@
 # test-runner-runs:
 #   run1:
 #     app: ${CAMERA_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/pavst_2_12_fifo
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/pavst_2_12_fifo --camera-test-videosrc --camera-test-audiosrc
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --string-arg th_server_app_path:${PUSH_AV_SERVER}

--- a/src/python_testing/TC_PAVST_2_12.py
+++ b/src/python_testing/TC_PAVST_2_12.py
@@ -40,6 +40,7 @@
 
 import asyncio
 import logging
+import time
 
 from mobly import asserts
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
@@ -377,8 +378,8 @@ class TC_PAVST_2_12(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID2, "Unexpected value for ConnectionID returned")
 
-        asyncio.sleep(5)  # Wait for 5 seconds before sending DelocatePushTransport command
-        cmd = pvcluster.Commands.DelocatePushTransport(
+        await asyncio.to_thread(time.sleep, 5) # Wait for 5 seconds before sending DeallocatePushTransport command
+        cmd = pvcluster.Commands.DeallocatePushTransport(
             connectionID=aConnectionID2
         )
         status = await self.psvt_deallocate_push_transport(cmd)

--- a/src/python_testing/TC_PAVST_2_13.py
+++ b/src/python_testing/TC_PAVST_2_13.py
@@ -21,7 +21,7 @@
 # test-runner-runs:
 #   run1:
 #     app: ${CAMERA_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/pavst_2_13_fifo
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/pavst_2_13_fifo --camera-test-videosrc --camera-test-audiosrc
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --string-arg th_server_app_path:${PUSH_AV_SERVER}

--- a/src/python_testing/TC_PAVST_2_13.py
+++ b/src/python_testing/TC_PAVST_2_13.py
@@ -21,7 +21,7 @@
 # test-runner-runs:
 #   run1:
 #     app: ${CAMERA_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/app_pipe_pavstmgmt
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/pavst_2_13_fifo
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --string-arg th_server_app_path:${PUSH_AV_SERVER}
@@ -33,7 +33,7 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #       --endpoint 1
-#       --app-pipe /tmp/app_pipe_pavstmgmt
+#       --app-pipe /tmp/pavst_2_13_fifo
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -175,7 +175,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         # CI: Use app pipe to trigger zone event.
         # Manual: User should trigger a motion event from the defined zone.
         if self.is_pics_sdk_ci_only:
-            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zone_id}, app_pipe="/tmp/app_pipe_pavstmgmt")
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zone_id})
         else:
             if prompt_msg is None:
                 prompt_msg = f"Press enter and immediately start motion activity in zone {zone_id}."

--- a/src/python_testing/TC_PAVST_2_13.py
+++ b/src/python_testing/TC_PAVST_2_13.py
@@ -322,7 +322,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         await event_callback.start(self.default_controller,
                                    self.dut_node_id,
                                    self.get_endpoint())
-        
+
         timeControl = {"initialDuration": 5, "augmentationDuration": 2, "maxDuration": 15, "blindDuration": 3}
         cmd = pvcluster.Commands.ManuallyTriggerTransport(
             connectionID=aConnectionID,
@@ -343,7 +343,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
         # Clip duration is augmented
         await asyncio.to_thread(time.sleep, initDuration + augDuration + 1)
-        
+
         event_callback = EventSubscriptionHandler(expected_cluster=pvcluster)
         await event_callback.start(self.default_controller,
                                    self.dut_node_id,

--- a/src/python_testing/TC_PAVST_2_13.py
+++ b/src/python_testing/TC_PAVST_2_13.py
@@ -1,0 +1,493 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/app_pipe_pavstmgmt
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --string-arg th_server_app_path:${PUSH_AV_SERVER}
+#       --string-arg host_ip:localhost
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#       --app-pipe /tmp/app_pipe_pavstmgmt
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import logging
+import time
+import asyncio
+
+from mobly import asserts
+from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
+from TC_PAVSTTestBase import PAVSTTestBase
+
+import matter.clusters as Clusters
+from matter.interaction_model import InteractionModelError, Status
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.testing.runner import default_matter_test_main
+from matter.testing.decorators import has_cluster, run_if_endpoint_matches, async_test_body
+from matter.testing.matter_testing import (MatterBaseTest, TestStep)
+
+logger = logging.getLogger(__name__)
+
+
+class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
+    def desc_TC_PAVST_2_13(self) -> str:
+        return "[TC-PAVST-2.13] Verify time control fields with Manual and Motion Trigger"
+
+    def pics_TC_PAVST_2_13(self):
+        return ["PAVST.S", "AVSM.S", "ZONEMGMT.S"]
+
+    @async_test_body
+    async def setup_class(self):
+        th_server_app = self.user_params.get("th_server_app_path", None)
+        self.server = PushAvServerProcess(server_path=th_server_app)
+        self.server.start(
+            expected_output="Running on https://0.0.0.0:1234",
+            timeout=30,
+        )
+        super().setup_class()
+
+    def teardown_class(self):
+        if self.server is not None:
+            self.server.terminate()
+        super().teardown_class()
+
+    def steps_TC_PAVST_2_13(self) -> list[TestStep]:
+        return [
+            TestStep("precondition", "Commissioning, already done", is_commissioning=True),
+            TestStep(
+                1,
+                "TH Reads CurrentConnections attribute from PushAV Stream Transport Cluster on DUT",
+                "Verify the number of PushAV Connections is 0. If not 0, deallocate any existing connections.",
+            ),
+            TestStep(
+                2,
+                "TH Reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Store as aAllocatedVideoStreams.",
+            ),
+            TestStep(
+                3,
+                "TH Reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Store as aAllocatedAudioStreams.",
+            ),
+            TestStep(
+                4,
+                "TH Reads Zones attribute from Zones Management Cluster on DUT",
+                "Store as aZones.",
+            ),
+            TestStep(
+                5,
+                "If DUT supports TwoDCartesianZone and User defined zones, TH sends CreateTwoDCartesianZone command.",
+                "Verify that the DUT response contains a new zoneId."),
+            TestStep(
+                6,
+                "TH sends AllocatePushTransport command with TriggerType = Motion, MotionZones = [aZoneID]",
+                "DUT responds with AllocatePushTransportResponse containing the allocated ConnectionID, TransportOptions, and TransportStatus in the TransportConfigurationStruct. Store ConnectionID as aConnectionID1."),
+            TestStep(
+                7,
+                "TH sends SetTransportStatus command with ConnectionID = aConnectionID1 and TransportStatus = Active",
+                "DUT responds with SUCCESS status code."
+            ),
+            TestStep(
+                8,
+                "TH sends the ManuallyTriggerTransport command with ConnectionID = aConnectionID1",
+                "DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                9,
+                "Motion Event triggers the DUT to generate PushAV Event to increment the Clip duration by the AugmentationDuration - AUGMENTATION DURATION Check",
+                "Verify that the TH receives the PushTransportEnd event after (InitialDuration + AugmentationDuration) and the connectionID matches aConnectionID1.",
+            ),
+            TestStep(
+                10,
+                "Motion Event triggers the DUT to generate PushAV Event during BlindDuration after PushTransportEnd event was received - BLIND DURATION Check",
+                "Verify that the TH receives the PushTransportBegin event.",
+            ),
+            TestStep(
+                11,
+                "After Blind duration of previous recording passes, Motion Event triggers the DUT to generate PushAV Event and then TH waits for the events from DUT",
+                "Verify that the TH receives the PushTransportBegin event.",
+            ),
+            TestStep(
+                12,
+                "Again Motion Event triggers the DUT to generate PushAV Event to increment the Clip duration by the AugmentationDuration - AUGMENTATION DURATION Check",
+                "Verify that the TH receives the PushTransportEnd event after (InitialDuration + AugmentationDuration) and the connectionID matches aConnectionID1.",
+            ),
+            TestStep(
+                13,
+                "Motion Event triggers the DUT to generate PushAV Event during BlindDuration after PushTransportEnd event was received - BLIND DURATION check, no recording should start for trigger during blind duration",
+                "Verify that the TH receives no PushAV event.",
+            ),
+            TestStep(
+                14,
+                "Motion Event triggers the DUT to generate PushAV Event - BLIND DURATION check, recording should start for trigger after blind duration",
+                "Verify that the TH receives the PushTransportBegin event and after InitialDuration it should receive PushTransportEnd event.",
+            ),
+            TestStep(
+                15,
+                "Motion Event triggers the DUT to generate PushAV Event after BlindDuration of previous recording passes",
+                "Verify that PushTransportBegin event is triggered.",
+            ),
+            TestStep(
+                16,
+                "TH sends DeallocatePushTransport command with ConnectionID = aConnectionID1",
+                "DUT responds with SUCCESS status code."
+            ),
+            TestStep(
+                17,
+                "Repeat step-6 and step-7. Store ConnectionID as aConnectionID2",
+                "Successful completion of step."
+            ),
+            TestStep(
+                18,
+                "Two consecutive Motion Event triggers the DUT to generate PushAV Events (InitialDuration + AugmentationDuration > MaxDuration).",
+                "Verify that the TH receives the PushTransportEnd event after MaxDuration and the connectionID matches aConnectionID2."
+            ),
+
+        ]
+
+    async def _trigger_motion_event(self, zone_id, prompt_msg=None):
+        # CI: Use app pipe to trigger zone event.
+        # Manual: User should trigger a motion event from the defined zone.
+        if self.is_pics_sdk_ci_only:
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zone_id},app_pipe="/tmp/app_pipe_pavstmgmt")
+        else:
+            if prompt_msg is None:
+                prompt_msg = f"Press enter and immediately start motion activity in zone {zone_id}."
+            self.wait_for_user_input(prompt_msg=prompt_msg)
+
+    async def ensure_session_active(self):
+        """Ensure Matter session is active, reconnect if needed"""
+        try:
+            # Test session with a simple read from PushAvStreamTransport (we know this cluster exists)
+            await self.read_single_attribute_check_success(
+                endpoint=self.get_endpoint(),
+                cluster=Clusters.PushAvStreamTransport,
+                attribute=Clusters.PushAvStreamTransport.Attributes.FeatureMap
+            )
+        except (TimeoutError, asyncio.CancelledError):
+            # Session timed out, re-establish
+            logger.info("Session timed out, re-establishing...")
+            await self.default_controller.EstablishSession(self.dut_node_id)
+
+    @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport)and has_cluster(Clusters.ZoneManagement) and has_cluster(Clusters.CameraAvStreamManagement)) 
+    async def test_TC_PAVST_2_13(self):
+        endpoint = self.get_endpoint()
+        self.endpoint = endpoint
+        self.node_id = self.dut_node_id
+        pvcluster = Clusters.PushAvStreamTransport
+        pvattr = Clusters.PushAvStreamTransport.Attributes
+        zmcluster = Clusters.ZoneManagement
+        zmattr = Clusters.ZoneManagement.Attributes
+        aAllocatedVideoStreams = []
+        aAllocatedAudioStreams = []
+        aConnectionID = ""
+        zoneID1 = 1  # Default zone ID for testing
+
+        self.step("precondition")
+        host_ip = self.user_params.get("host_ip", None)
+        tlsEndpointId, host_ip = await self.precondition_provision_tls_endpoint(endpoint=endpoint, server=self.server, host_ip=host_ip)
+        uploadStreamId = self.server.create_stream()
+
+        self.step(1)
+        # Commission DUT - already done
+        status = await self.check_and_delete_all_push_av_transports(endpoint, pvattr)
+        asserts.assert_equal(
+            status, Status.Success, "Status must be SUCCESS!"
+        )
+
+        self.step(2)
+        aAllocatedVideoStreams = await self.allocate_one_video_stream()
+        asserts.assert_greater_equal(
+            len(aAllocatedVideoStreams),
+            1,
+            "AllocatedVideoStreams must not be empty",
+        )
+
+        self.step(3)
+        aAllocatedAudioStreams = await self.allocate_one_audio_stream()
+        asserts.assert_greater_equal(
+            len(aAllocatedAudioStreams),
+            1,
+            "AllocatedAudioStreams must not be empty",
+        )
+
+        self.step(4)
+        aZones = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=zmcluster, attribute=zmattr.Zones
+        )
+        logger.info(f"aZones: {aZones}")
+
+        self.step(5)
+        aFeatureMap = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=zmcluster, attribute=zmattr.FeatureMap)
+        logger.info(f"Rx'd FeatureMap: {aFeatureMap}")
+        self.twoDCartSupported = aFeatureMap & zmcluster.Bitmaps.Feature.kTwoDimensionalCartesianZone
+        self.userDefinedSupported = aFeatureMap & zmcluster.Bitmaps.Feature.kUserDefined
+
+        if self.twoDCartSupported and self.userDefinedSupported:
+            # Form the Create request and send
+            zoneVertices = [
+                zmcluster.Structs.TwoDCartesianVertexStruct(10, 10),
+                zmcluster.Structs.TwoDCartesianVertexStruct(20, 10),
+                zmcluster.Structs.TwoDCartesianVertexStruct(20, 20),
+                zmcluster.Structs.TwoDCartesianVertexStruct(10, 20)
+            ]
+            zoneToCreate = zmcluster.Structs.TwoDCartesianZoneStruct(
+                name="Zone1", use=zmcluster.Enums.ZoneUseEnum.kMotion, vertices=zoneVertices,
+                color="#00FFFF")
+            createTwoDCartesianCmd = zmcluster.Commands.CreateTwoDCartesianZone(
+                zone=zoneToCreate
+            )
+            cmdResponse = await self.send_single_cmd(endpoint=endpoint, cmd=createTwoDCartesianCmd)
+            logger.info(f"Rx'd CreateTwoDCartesianZoneResponse : {cmdResponse}")
+            asserts.assert_equal(type(cmdResponse), zmcluster.Commands.CreateTwoDCartesianZoneResponse,
+                                 "Incorrect response type")
+            asserts.assert_is_not_none(
+                cmdResponse.zoneID, "CreateTwoDCartesianCmdResponse does not contain ZoneID")
+
+            # Check that zoneID1 did not exist before
+            matchingZone = next(
+                (z for z in aZones if z.zoneID == cmdResponse.zoneID), None)
+            asserts.assert_is_none(matchingZone, "fZone with {cmdResponse.zoneID} already existed in Zones")
+            zoneID1 = cmdResponse.zoneID
+
+        self.step(6)
+        initDuration = 5
+        augDuration = 2
+        maxDuration = 15
+        blindDuration = 3
+        maxPreRollLen = 4
+        try:
+            zoneList = [{"zone": zoneID1, "sensitivity": 4}]
+            triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                              "maxPreRollLen": 4000,
+                              "motionZones": zoneList,
+                              "motionTimeControl": {"initialDuration": 5, "augmentationDuration": 2, "maxDuration": 15, "blindDuration": 3}}
+            status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions,
+                                                              tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}/")
+            asserts.assert_equal(status, Status.Success,
+                                 "DUT must responds with Status Code Success.")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.clusterStatus, Status.Success,
+                                 "DUT must responds with Status Code Success.")
+
+        transportConfigs = await self.read_pavst_attribute_expect_success(endpoint,
+                                                                          pvattr.CurrentConnections,
+                                                                          )
+        asserts.assert_greater_equal(
+            len(transportConfigs), 1, "TransportConfigurations must not be empty!"
+        )
+        aConnectionID = transportConfigs[0].connectionID
+
+        self.step(7)
+        cmd = pvcluster.Commands.SetTransportStatus(
+            connectionID=aConnectionID,
+            transportStatus=pvcluster.Enums.TransportStatusEnum.kActive
+        )
+        status = await self.psvt_set_transport_status(cmd)
+        asserts.assert_true(
+            status == Status.Success,
+            "DUT responds with SUCCESS status code.")
+
+        # Manual trigger + Motion trigger case -> Step handle Augmentation and blind duration
+        # Manual Trigger -> Recording start -> Motion trigger -> Clip Duration extended -> Recording stop -> Trigger motion event without waiting for blind period -> Recording should start
+        self.step(8)
+        timeControl = {"initialDuration": 5, "augmentationDuration": 2, "maxDuration": 15, "blindDuration": 3}
+        cmd = pvcluster.Commands.ManuallyTriggerTransport(
+            connectionID=aConnectionID,
+            activationReason=pvcluster.Enums.TriggerActivationReasonEnum.kEmergency,
+            timeControl=timeControl
+        )
+        status = await self.psvt_manually_trigger_transport(cmd)
+        asserts.assert_true(
+            status == Status.Success,
+            "DUT responds with Success status code.",
+        )
+ 
+        self.step(9)
+        event_callback = EventSubscriptionHandler(expected_cluster=pvcluster)
+        await event_callback.start(self.default_controller,
+                                   self.dut_node_id,
+                                   self.get_endpoint())
+
+        await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
+        # Clip duration is augmented
+        time.sleep(initDuration + augDuration + 1)
+
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
+
+        # Previous Recording stops and now new trigger came for which blind period is ignored and new recording should start because previous recording started due to manual trigger
+        self.step(10)
+        await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
+        # Since previous recording was started by manual trigger, blind period should be ignored and new recording should start
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
+        time.sleep(initDuration + 1)
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
+        time.sleep(blindDuration + 1)
+
+        # Motion Trigger - Motion Trigger case (Check Augment duration and blind duration)
+        # Motion Trigger -> Recording Start -> Motion Trigger -> Clip Duration extended -> Recording stop -> Trigger motion event without waiting for blind period -> Recording should not start
+        self.step(11)
+        event_callback = EventSubscriptionHandler(expected_cluster=pvcluster)
+        await event_callback.start(self.default_controller,
+                                   self.dut_node_id,
+                                   self.get_endpoint())
+
+        await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
+
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
+
+        self.step(12)
+        await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
+        # Motion trigger during ongoing recording should NOT generate PushTransportBegin, only extend duration
+        # Clip duration augmented
+        time.sleep(initDuration + augDuration + 1)
+
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
+
+        # Previous recording stops, didn't waited for blind period-> sended another motion trigger -> new recording should not start -> Because previous Recording started due to motion trigger
+        self.step(13)
+        await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
+        event = event_callback.wait_for_event_expect_no_report(timeout_sec=blindDuration+1)
+
+        # Motion Trigger - Motion Trigger case (Check blind duration)
+        # Trigger motion event-> wait for recording to stop. Wait for blind period to finish before sending another trigger -> Recording should start.
+        self.step(14)
+        await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
+
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
+        
+        time.sleep(initDuration + 1)
+
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
+ 
+        self.step(15)
+        # Recording stopped and now waiting for blind period to finish
+        time.sleep(blindDuration + 1)
+        # Previous recording stops and also waited for blind period before triggering another motion event -> Recording starts
+        await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
+        
+        time.sleep(initDuration + maxPreRollLen + 1)
+        
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
+        time.sleep(blindDuration + 1)
+
+        # Max Duration
+        # Deallocating all active connection -> Allocate one pushav with time control such that max duration is tested
+        self.step(16)
+        await self.ensure_session_active()
+        cmd = pvcluster.Commands.DeallocatePushTransport(
+            connectionID=aConnectionID
+        )
+        status = await self.psvt_deallocate_push_transport(cmd)
+        asserts.assert_true(
+            status == Status.Success,
+            "DUT responds with SUCCESS status code.")
+        
+        status = await self.check_and_delete_all_push_av_transports(endpoint, pvattr)
+        asserts.assert_equal(
+            status, Status.Success, "Status must be SUCCESS!"
+        )
+   
+        self.step(17)
+        maxDuration=10
+        try:
+            zoneList = [{"zone": zoneID1, "sensitivity": 4}]
+            triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
+                              "maxPreRollLen": 4000,
+                              "motionZones": zoneList,
+                              "motionTimeControl": {"initialDuration": 5, "augmentationDuration": 15, "maxDuration": 10, "blindDuration": 3}}
+            status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions,
+                                                              tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}/")
+            asserts.assert_equal(status, Status.Success,
+                                 "DUT must responds with Status Code Success.")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.clusterStatus, Status.Success,
+                                 "DUT must responds with Status Code Success.")
+            
+        transportConfigs = await self.read_pavst_attribute_expect_success(endpoint,
+                                                                          pvattr.CurrentConnections,
+                                                                          )
+        asserts.assert_greater_equal(
+            len(transportConfigs), 1, "TransportConfigurations must not be empty!"
+        )
+        aConnectionID2 = transportConfigs[0].connectionID
+        
+        cmd = pvcluster.Commands.SetTransportStatus(
+            connectionID=aConnectionID2,
+            transportStatus=pvcluster.Enums.TransportStatusEnum.kActive
+        )
+        status = await self.psvt_set_transport_status(cmd)
+        asserts.assert_true(
+            status == Status.Success,
+            "DUT responds with SUCCESS status code.")
+   
+        # MAX DURATION Check
+        #  Triggering 2 motion event -> recording starts -> wait for max duration -> recording stops
+        self.step(18)
+        event_callback = EventSubscriptionHandler(expected_cluster=pvcluster)
+        await event_callback.start(self.default_controller,
+                                   self.dut_node_id,
+                                   self.get_endpoint())
+        
+        await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID2, "Unexpected value for ConnectionID returned")
+        
+        await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
+        # Second motion trigger during ongoing recording should NOT generate PushTransportBegin, only extend duration
+
+        time.sleep(maxDuration + 1)
+        event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
+        logger.info(f"Event data {event_data}")
+        asserts.assert_equal(event_data.connectionID, aConnectionID2, "Unexpected value for ConnectionID returned")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_PAVST_2_13.py
+++ b/src/python_testing/TC_PAVST_2_13.py
@@ -38,9 +38,9 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import asyncio
 import logging
 import time
-import asyncio
 
 from mobly import asserts
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
@@ -48,10 +48,10 @@ from TC_PAVSTTestBase import PAVSTTestBase
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
+from matter.testing.decorators import async_test_body, has_cluster, run_if_endpoint_matches
 from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.testing.matter_testing import MatterBaseTest, TestStep
 from matter.testing.runner import default_matter_test_main
-from matter.testing.decorators import has_cluster, run_if_endpoint_matches, async_test_body
-from matter.testing.matter_testing import (MatterBaseTest, TestStep)
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_PAVST_2_13.py
+++ b/src/python_testing/TC_PAVST_2_13.py
@@ -176,7 +176,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         # CI: Use app pipe to trigger zone event.
         # Manual: User should trigger a motion event from the defined zone.
         if self.is_pics_sdk_ci_only:
-            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zone_id},app_pipe="/tmp/app_pipe_pavstmgmt")
+            self.write_to_app_pipe({"Name": "ZoneTriggered", "ZoneId": zone_id}, app_pipe="/tmp/app_pipe_pavstmgmt")
         else:
             if prompt_msg is None:
                 prompt_msg = f"Press enter and immediately start motion activity in zone {zone_id}."
@@ -196,7 +196,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             logger.info("Session timed out, re-establishing...")
             await self.default_controller.EstablishSession(self.dut_node_id)
 
-    @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport)and has_cluster(Clusters.ZoneManagement) and has_cluster(Clusters.CameraAvStreamManagement))
+    @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport) and has_cluster(Clusters.ZoneManagement) and has_cluster(Clusters.CameraAvStreamManagement))
     async def test_TC_PAVST_2_13(self):
         endpoint = self.get_endpoint()
         self.endpoint = endpoint
@@ -435,7 +435,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         )
 
         self.step(17)
-        maxDuration=10
+        maxDuration = 10
         try:
             zoneList = [{"zone": zoneID1, "sensitivity": 4}]
             triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,

--- a/src/python_testing/TC_PAVST_2_13.py
+++ b/src/python_testing/TC_PAVST_2_13.py
@@ -40,7 +40,6 @@
 
 import asyncio
 import logging
-import time
 
 from mobly import asserts
 from TC_PAVSTI_Utils import PAVSTIUtils, PushAvServerProcess
@@ -338,7 +337,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
 
         await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
         # Clip duration is augmented
-        time.sleep(initDuration + augDuration + 1)
+        await asyncio.sleep(initDuration + augDuration + 1)
 
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
         logger.info(f"Event data {event_data}")
@@ -351,11 +350,11 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
-        time.sleep(initDuration + 1)
+        await asyncio.sleep(initDuration + 1)
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
-        time.sleep(blindDuration + 1)
+        await asyncio.sleep(blindDuration + 1)
 
         # Motion Trigger - Motion Trigger case (Check Augment duration and blind duration)
         # Motion Trigger -> Recording Start -> Motion Trigger -> Clip Duration extended -> Recording stop -> Trigger motion event without waiting for blind period -> Recording should not start
@@ -375,7 +374,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
         # Motion trigger during ongoing recording should NOT generate PushTransportBegin, only extend duration
         # Clip duration augmented
-        time.sleep(initDuration + augDuration + 1)
+        await asyncio.sleep(initDuration + augDuration + 1)
 
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
         logger.info(f"Event data {event_data}")
@@ -384,7 +383,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         # Previous recording stops, didn't waited for blind period-> sended another motion trigger -> new recording should not start -> Because previous Recording started due to motion trigger
         self.step(13)
         await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
-        event = event_callback.wait_for_event_expect_no_report(timeout_sec=blindDuration+1)
+        event_data = event_callback.wait_for_event_expect_no_report(timeout_sec=blindDuration+1)
 
         # Motion Trigger - Motion Trigger case (Check blind duration)
         # Trigger motion event-> wait for recording to stop. Wait for blind period to finish before sending another trigger -> Recording should start.
@@ -395,7 +394,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
 
-        time.sleep(initDuration + 1)
+        await asyncio.sleep(initDuration + 1)
 
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
         logger.info(f"Event data {event_data}")
@@ -403,19 +402,19 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
 
         self.step(15)
         # Recording stopped and now waiting for blind period to finish
-        time.sleep(blindDuration + 1)
+        await asyncio.sleep(blindDuration + 1)
         # Previous recording stops and also waited for blind period before triggering another motion event -> Recording starts
         await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
 
-        time.sleep(initDuration + maxPreRollLen + 1)
+        await asyncio.sleep(initDuration + maxPreRollLen + 1)
 
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
-        time.sleep(blindDuration + 1)
+        await asyncio.sleep(blindDuration + 1)
 
         # Max Duration
         # Deallocating all active connection -> Allocate one pushav with time control such that max duration is tested
@@ -483,7 +482,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
         # Second motion trigger during ongoing recording should NOT generate PushTransportBegin, only extend duration
 
-        time.sleep(maxDuration + 1)
+        await asyncio.sleep(maxDuration + 1)
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID2, "Unexpected value for ConnectionID returned")

--- a/src/python_testing/TC_PAVST_2_13.py
+++ b/src/python_testing/TC_PAVST_2_13.py
@@ -196,7 +196,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             logger.info("Session timed out, re-establishing...")
             await self.default_controller.EstablishSession(self.dut_node_id)
 
-    @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport)and has_cluster(Clusters.ZoneManagement) and has_cluster(Clusters.CameraAvStreamManagement)) 
+    @run_if_endpoint_matches(has_cluster(Clusters.PushAvStreamTransport)and has_cluster(Clusters.ZoneManagement) and has_cluster(Clusters.CameraAvStreamManagement))
     async def test_TC_PAVST_2_13(self):
         endpoint = self.get_endpoint()
         self.endpoint = endpoint
@@ -329,7 +329,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             status == Status.Success,
             "DUT responds with Success status code.",
         )
- 
+
         self.step(9)
         event_callback = EventSubscriptionHandler(expected_cluster=pvcluster)
         await event_callback.start(self.default_controller,
@@ -394,13 +394,13 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
-        
+
         time.sleep(initDuration + 1)
 
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
- 
+
         self.step(15)
         # Recording stopped and now waiting for blind period to finish
         time.sleep(blindDuration + 1)
@@ -409,9 +409,9 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
-        
+
         time.sleep(initDuration + maxPreRollLen + 1)
-        
+
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportEnd, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID, "Unexpected value for ConnectionID returned")
@@ -428,12 +428,12 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_true(
             status == Status.Success,
             "DUT responds with SUCCESS status code.")
-        
+
         status = await self.check_and_delete_all_push_av_transports(endpoint, pvattr)
         asserts.assert_equal(
             status, Status.Success, "Status must be SUCCESS!"
         )
-   
+
         self.step(17)
         maxDuration=10
         try:
@@ -449,7 +449,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         except InteractionModelError as e:
             asserts.assert_equal(e.clusterStatus, Status.Success,
                                  "DUT must responds with Status Code Success.")
-            
+
         transportConfigs = await self.read_pavst_attribute_expect_success(endpoint,
                                                                           pvattr.CurrentConnections,
                                                                           )
@@ -457,7 +457,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             len(transportConfigs), 1, "TransportConfigurations must not be empty!"
         )
         aConnectionID2 = transportConfigs[0].connectionID
-        
+
         cmd = pvcluster.Commands.SetTransportStatus(
             connectionID=aConnectionID2,
             transportStatus=pvcluster.Enums.TransportStatusEnum.kActive
@@ -466,7 +466,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         asserts.assert_true(
             status == Status.Success,
             "DUT responds with SUCCESS status code.")
-   
+
         # MAX DURATION Check
         #  Triggering 2 motion event -> recording starts -> wait for max duration -> recording stops
         self.step(18)
@@ -474,12 +474,12 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         await event_callback.start(self.default_controller,
                                    self.dut_node_id,
                                    self.get_endpoint())
-        
+
         await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
         event_data = event_callback.wait_for_event_report(pvcluster.Events.PushTransportBegin, timeout_sec=5)
         logger.info(f"Event data {event_data}")
         asserts.assert_equal(event_data.connectionID, aConnectionID2, "Unexpected value for ConnectionID returned")
-        
+
         await self._trigger_motion_event(zoneID1, prompt_msg=f"Press enter and immediately start motion activity in zone {zoneID1} and stop any motion after {initDuration} seconds of pressing enter.")
         # Second motion trigger during ongoing recording should NOT generate PushTransportBegin, only extend duration
 

--- a/src/python_testing/TC_PAVST_2_4.py
+++ b/src/python_testing/TC_PAVST_2_4.py
@@ -197,7 +197,7 @@ class TC_PAVST_2_4(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         aTransportOptions.expiryTime = aModifiedTransportOptions
         aTransportOptions.videoStreams = []
         aTransportOptions.audioStreams = []
-       
+
         cmd = pvcluster.Commands.ModifyPushTransport(
             connectionID=aConnectionID,
             transportOptions=aTransportOptions,

--- a/src/python_testing/TC_PAVST_2_4.py
+++ b/src/python_testing/TC_PAVST_2_4.py
@@ -195,6 +195,9 @@ class TC_PAVST_2_4(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         aModifiedTransportOptions = aTransportOptions.expiryTime
         aModifiedTransportOptions = aModifiedTransportOptions + 120
         aTransportOptions.expiryTime = aModifiedTransportOptions
+        aTransportOptions.videoStreams = []
+        aTransportOptions.audioStreams = []
+       
         cmd = pvcluster.Commands.ModifyPushTransport(
             connectionID=aConnectionID,
             transportOptions=aTransportOptions,

--- a/src/python_testing/TC_PAVST_2_6.py
+++ b/src/python_testing/TC_PAVST_2_6.py
@@ -275,6 +275,8 @@ class TC_PAVST_2_6(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             connectionID=Nullable(),
             transportStatus=Clusters.PushAvStreamTransport.Enums.TransportStatusEnum.kInactive
         )
+        aTransportOptions.videoStreams = []
+        aTransportOptions.audioStreams = []
         status = await self.psvt_set_transport_status(cmd)
         asserts.assert_true(
             status == Status.Success,


### PR DESCRIPTION
#### Summary
This is to modify the upload sequence of the recorded clip files in the camera application in the following order:

1. Manifest file
2. Init media
3. First media segment

ex:  `.mpd ->  .init -> .m4s`


#### Related issues
Fixes #41808
Fixes https://github.com/project-chip/connectedhomeip/issues/41613

#### Testing
```
[1]
# Build and run camera application
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debug/chip-camera-app

# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run Push AV TC
Example:
python3 src/python_testing/TC_PAVSTI_1_1.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1

[2] Verify the order the clip files in the push av server
```

