### PR TITLE
Make TimeUtils constants ints instead of enums and fix Darwin warnings

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -1931,13 +1931,9 @@ NSTimeInterval MTRTimeIntervalForEventTimestampValue(uint64_t timeValue)
 
     // First convert the event timestamp value (in milliseconds) to NSTimeInterval - to minimize potential loss of precision
     // of uint64 => NSTimeInterval (double), convert whole seconds and remainder separately and then combine
-    uint64_t eventTimestampValueSeconds = timeValue / chip::kMillisecondsPerSecond;
-    uint64_t eventTimestampValueRemainderMilliseconds = timeValue % chip::kMillisecondsPerSecond;
-    NSTimeInterval eventTimestampValueRemainder
-        = NSTimeInterval(eventTimestampValueRemainderMilliseconds) / static_cast<double>(chip::kMillisecondsPerSecond);
-    NSTimeInterval eventTimestampValue = eventTimestampValueSeconds + eventTimestampValueRemainder;
-
-    return eventTimestampValue;
+    NSTimeInterval eventTimestampValueSeconds = static_cast<NSTimeInterval>(timeValue / chip::kMillisecondsPerSecond);
+    NSTimeInterval eventTimestampValueRemainder = static_cast<NSTimeInterval>(timeValue % chip::kMillisecondsPerSecond) / chip::kMillisecondsPerSecond;
+    return eventTimestampValueSeconds + eventTimestampValueRemainder;
 }
 
 #pragma mark - Utility for event priority conversion

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -1924,16 +1924,10 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
 #pragma mark - Utility for time conversion
 NSTimeInterval MTRTimeIntervalForEventTimestampValue(uint64_t timeValue)
 {
-    // Note: The event timestamp value as written in the spec is in microseconds, but the released 1.0 SDK implemented it in
-    // milliseconds. The following issue was filed to address the inconsistency:
-    //    https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/6236
-    // For consistency with the released behavior, calculations here will be done in milliseconds.
-
-    // First convert the event timestamp value (in milliseconds) to NSTimeInterval - to minimize potential loss of precision
-    // of uint64 => NSTimeInterval (double), convert whole seconds and remainder separately and then combine
-    NSTimeInterval eventTimestampValueSeconds = static_cast<NSTimeInterval>(timeValue / chip::kMillisecondsPerSecond);
-    NSTimeInterval eventTimestampValueRemainder = static_cast<NSTimeInterval>(timeValue % chip::kMillisecondsPerSecond) / chip::kMillisecondsPerSecond;
-    return eventTimestampValueSeconds + eventTimestampValueRemainder;
+    // Note: The event timestamp value was originally specified to be in microseconds, but the released 1.0 SDK
+    // implemented it as milliseconds. As of Matter 1.1 the specification has been updated to match.
+    // Implementation note: 2^53 ms =~ 285000 years, so NSTimeInterval (double) can store these without loss of precision.
+    return static_cast<NSTimeInterval>(timeValue) / chip::kMillisecondsPerSecond;
 }
 
 #pragma mark - Utility for event priority conversion

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1226,7 +1226,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         using TimeZoneType = chip::app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type;
         TimeZoneType timeZone;
         timeZone.validAt = 0;
-        timeZone.offset = static_cast<int32_t>(tz.secondsFromGMT - tz.daylightSavingTimeOffset);
+        timeZone.offset = static_cast<int32_t>(tz.secondsFromGMT) - static_cast<int32_t>(tz.daylightSavingTimeOffset);
         timeZone.name.Emplace(AsCharSpan(tz.name));
 
         params.SetTimeZone(chip::app::DataModel::List<TimeZoneType>(&timeZone, 1));

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -741,7 +741,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         return YES;
     }
 
-    __block uint64_t cadence = MTR_DEVICE_TIME_SYNCHRONIZATION_LOSS_CHECK_CADENCE;
+    __block NSTimeInterval cadence = MTR_DEVICE_TIME_SYNCHRONIZATION_LOSS_CHECK_CADENCE;
 
 #ifdef DEBUG
     [self _callFirstDelegateSynchronouslyWithBlock:^(id testDelegate) {
@@ -2149,7 +2149,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
                 cumulativeIntervals += intervalSinceLastReport;
             }
         }
-        NSTimeInterval averageTimeBetweenReports = cumulativeIntervals / (_mostRecentReportTimes.count - 1);
+        NSTimeInterval averageTimeBetweenReports = cumulativeIntervals / static_cast<double>(_mostRecentReportTimes.count - 1);
 
         if (averageTimeBetweenReports < _storageBehaviorConfiguration.timeBetweenReportsTooShortThreshold) {
             // Multiplier goes from 1 to _reportToPersistenceDelayMaxMultiplier uniformly, as
@@ -4585,7 +4585,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                 // verify that the uptime is indeed the data type we want
                 if ([attributeDataValue[MTRTypeKey] isEqual:MTRUnsignedIntegerValueType]) {
                     NSNumber * upTimeNumber = attributeDataValue[MTRValueKey];
-                    NSTimeInterval upTime = upTimeNumber.unsignedLongLongValue; // UpTime unit is defined as seconds in the spec
+                    NSTimeInterval upTime = static_cast<NSTimeInterval>(upTimeNumber.unsignedLongLongValue); // UpTime unit is defined as seconds in the spec
                     NSDate * potentialSystemStartTime = [NSDate dateWithTimeIntervalSinceNow:-upTime];
                     NSDate * oldSystemStartTime = _estimatedStartTime;
                     if (!_estimatedStartTime || ([potentialSystemStartTime compare:_estimatedStartTime] == NSOrderedAscending)) {

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -1655,7 +1655,7 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
 
     // Only test that 90% of attributes are the same because there are some changing attributes each time (UTC time, for example)
     //   * With all-clusters-app as of 2024-02-10, about 1.476% of attributes change.
-    double storedAttributeDifferFromMTRDevicePercentage = storedAttributeDifferFromMTRDeviceCount * 100.0 / dataStoreValuesCount;
+    double storedAttributeDifferFromMTRDevicePercentage = (double) storedAttributeDifferFromMTRDeviceCount * 100.0 / (double) dataStoreValuesCount;
     XCTAssertTrue(storedAttributeDifferFromMTRDevicePercentage < 10.0);
 
     // Check that the new device is already primed.
@@ -2957,7 +2957,7 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
 
     // Make the wait time depend on device count
     NSArray * expectationsToWait = [subscriptionExpectations.allValues arrayByAddingObject:baseDeviceReadExpectation];
-    [self waitForExpectations:expectationsToWait timeout:(kSubscriptionPoolBaseTimeoutInSeconds * orderedDeviceIDs.count)];
+    [self waitForExpectations:expectationsToWait timeout:(NSTimeInterval) (kSubscriptionPoolBaseTimeoutInSeconds * orderedDeviceIDs.count)];
 
     XCTAssertEqual(subscriptionDequeueCount, orderedDeviceIDs.count);
 

--- a/src/lib/support/TimeUtils.h
+++ b/src/lib/support/TimeUtils.h
@@ -29,40 +29,37 @@
 
 namespace chip {
 
-enum
-{
-    kYearsPerCentury  = 100,
-    kLeapYearInterval = 4,
+inline constexpr int kYearsPerCentury  = 100;
+inline constexpr int kLeapYearInterval = 4;
 
-    kMonthsPerYear = 12,
+inline constexpr int kMonthsPerYear = 12;
 
-    kMaxDaysPerMonth = 31,
+inline constexpr int kMaxDaysPerMonth = 31;
 
-    kDaysPerWeek         = 7,
-    kDaysPerStandardYear = 365,
-    kDaysPerLeapYear     = kDaysPerStandardYear + 1,
+inline constexpr int kDaysPerWeek         = 7;
+inline constexpr int kDaysPerStandardYear = 365;
+inline constexpr int kDaysPerLeapYear     = kDaysPerStandardYear + 1;
 
-    kHoursPerDay  = 24,
-    kHoursPerWeek = kDaysPerWeek * kHoursPerDay,
+inline constexpr int kHoursPerDay  = 24;
+inline constexpr int kHoursPerWeek = kDaysPerWeek * kHoursPerDay;
 
-    kMinutesPerHour = 60,
-    kMinutesPerDay  = kHoursPerDay * kMinutesPerHour,
+inline constexpr int kMinutesPerHour = 60;
+inline constexpr int kMinutesPerDay  = kHoursPerDay * kMinutesPerHour;
 
-    kSecondsPerMinute       = 60,
-    kSecondsPerHour         = kSecondsPerMinute * kMinutesPerHour,
-    kSecondsPerDay          = kSecondsPerHour * kHoursPerDay,
-    kSecondsPerWeek         = kSecondsPerDay * kDaysPerWeek,
-    kSecondsPerStandardYear = kSecondsPerDay * kDaysPerStandardYear,
+inline constexpr int kSecondsPerMinute       = 60;
+inline constexpr int kSecondsPerHour         = kSecondsPerMinute * kMinutesPerHour;
+inline constexpr int kSecondsPerDay          = kSecondsPerHour * kHoursPerDay;
+inline constexpr int kSecondsPerWeek         = kSecondsPerDay * kDaysPerWeek;
+inline constexpr int kSecondsPerStandardYear = kSecondsPerDay * kDaysPerStandardYear;
 
-    kMillisecondsPerSecond = 1000,
+inline constexpr int kMillisecondsPerSecond = 1000;
 
-    kMicrosecondsPerSecond      = 1000000,
-    kMicrosecondsPerMillisecond = 1000,
+inline constexpr int kMicrosecondsPerSecond      = 1000000;
+inline constexpr int kMicrosecondsPerMillisecond = 1000;
 
-    kNanosecondsPerSecond      = 1000000000,
-    kNanosecondsPerMillisecond = 1000000,
-    kNanosecondsPerMicrosecond = 1000,
-};
+inline constexpr int kNanosecondsPerSecond      = 1000000000;
+inline constexpr int kNanosecondsPerMillisecond = 1000000;
+inline constexpr int kNanosecondsPerMicrosecond = 1000;
 
 enum
 {


### PR DESCRIPTION
#### Summary

It seems Darwin clang has gotten more fussy about unsigned long -> double conversions.  The TimeUtil constants were implicitly ints anyway, but disallowing implicit conversion to double even when there is no possible overflow.

#### Testing

Existing tests. Verified manually that the Darwin framework now compiles cleanly on recent Apple clang.