### PR TITLE
Make cluster deps public in chip_data_model

### DIFF
--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -255,7 +255,9 @@ template("chip_data_model") {
 
     _app_config_dependent_sources = []
     foreach(cluster, _cluster_sources) {
-      deps += [ "${_app_root}/clusters/${cluster}" ]
+      # Clusters are public deps to allow applications to depend on cluster APIs, (e.g. delegates / providers)
+      # without having to manually re-state the dependencies computed here from the zap file.
+      public_deps += [ "${_app_root}/clusters/${cluster}" ]
 
       # app_config_dependent_sources paths are relative to the target
       # accumulate them here so that we can "rebase_path" later on


### PR DESCRIPTION
#### Summary

Make cluster deps public in chip_data_model to allow applications to depend on cluster APIs, (e.g. delegates / providers) without having to manually re-state the dependencies computed from the zap file.

#### Testing

Tested manually during example app development.