### PR TITLE
[TLSCLIENT] Initial PR for conversion to Code Driven - Rename of cluster and associated classes

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/tls-client-management-instance.h
+++ b/examples/all-clusters-app/all-clusters-common/include/tls-client-management-instance.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <app/clusters/tls-client-management-server/tls-client-management-server.h>
+#include <app/clusters/tls-client-management-server/TlsClientManagementCluster.h>
 #include <app/storage/FabricTableImpl.h>
 #include <app/util/config.h>
 #include <vector>

--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -19,7 +19,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/clusters/tls-certificate-management-server/CertificateTableImpl.h>
 #include <app/clusters/tls-certificate-management-server/IncrementingIdHelper.h>
-#include <app/clusters/tls-client-management-server/tls-client-management-server.h>
+#include <app/clusters/tls-client-management-server/TlsClientManagementCluster.h>
 #include <app/storage/FabricTableImpl.ipp>
 #include <clusters/TlsClientManagement/Commands.h>
 #include <lib/support/CHIPMem.h>
@@ -289,7 +289,7 @@ ClusterStatusCode TlsClientManagementCommandDelegate::ProvisionEndpoint(
 
     if (provisionReq.endpointID.IsNull())
     {
-        VerifyOrReturnError(numInFabric < mTlsClientManagementServer->GetMaxProvisioned(),
+        VerifyOrReturnError(numInFabric < mTlsClientManagementCluster->GetMaxProvisioned(),
                             ClusterStatusCode(Status::ResourceExhausted));
         EndpointSerializer::Clear(endpoint.mEndpoint);
         auto & endpointStruct = endpoint.mEndpoint;
@@ -421,16 +421,16 @@ CHIP_ERROR TlsClientManagementCommandDelegate::MutateEndpointReferenceCount(Endp
 
 static CertificateTableImpl gCertificateTableInstance;
 TlsClientManagementCommandDelegate TlsClientManagementCommandDelegate::instance;
-static TlsClientManagementServer gTlsClientManagementClusterServerInstance = TlsClientManagementServer(
+static TlsClientManagementCluster gTlsClientManagementClusterInstance = TlsClientManagementCluster(
     EndpointId(1), TlsClientManagementCommandDelegate::GetInstance(), gCertificateTableInstance, kMaxProvisionedEndpoints);
 
 void emberAfTlsClientManagementClusterInitCallback(EndpointId matterEndpoint)
 {
     TEMPORARY_RETURN_IGNORED gCertificateTableInstance.SetEndpoint(EndpointId(1));
-    TEMPORARY_RETURN_IGNORED gTlsClientManagementClusterServerInstance.Init();
+    TEMPORARY_RETURN_IGNORED gTlsClientManagementClusterInstance.Init();
 }
 
 void emberAfTlsClientManagementClusterShutdownCallback(EndpointId matterEndpoint)
 {
-    TEMPORARY_RETURN_IGNORED gTlsClientManagementClusterServerInstance.Finish();
+    TEMPORARY_RETURN_IGNORED gTlsClientManagementClusterInstance.Finish();
 }

--- a/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.h
+++ b/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.h
@@ -20,7 +20,7 @@
 
 #include "push-av-stream-transport-delegate.h"
 #include <app/clusters/tls-certificate-management-server/tls-certificate-management-server.h>
-#include <app/clusters/tls-client-management-server/tls-client-management-server.h>
+#include <app/clusters/tls-client-management-server/TlsClientManagementCluster.h>
 
 namespace chip {
 namespace app {

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.h
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.h
@@ -7,7 +7,7 @@
 #include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h>
 #include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h>
 #include <app/clusters/tls-certificate-management-server/tls-certificate-management-server.h>
-#include <app/clusters/tls-client-management-server/tls-client-management-server.h>
+#include <app/clusters/tls-client-management-server/TlsClientManagementCluster.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <functional>
 #include <protocols/interaction_model/StatusCode.h>

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -22,7 +22,7 @@
 #include <app/clusters/push-av-stream-transport-server/constants.h>
 #include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h>
 #include <app/clusters/tls-certificate-management-server/tls-certificate-management-server.h>
-#include <app/clusters/tls-client-management-server/tls-client-management-server.h>
+#include <app/clusters/tls-client-management-server/TlsClientManagementCluster.h>
 #include <functional>
 #include <protocols/interaction_model/StatusCode.h>
 #include <vector>

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -26,7 +26,7 @@
 #include <app/MessageDef/CommandDataIB.h>
 #include <app/clusters/push-av-stream-transport-server/PushAVStreamTransportCluster.h>
 #include <app/clusters/testing/MockCommandHandler.h>
-#include <app/clusters/tls-client-management-server/tls-client-management-server.h>
+#include <app/clusters/tls-client-management-server/TlsClientManagementCluster.h>
 #include <app/tests/AppTestContext.h>
 #include <lib/core/Optional.h>
 #include <lib/core/StringBuilderAdapters.h>

--- a/src/app/clusters/tls-client-management-server/BUILD.gn
+++ b/src/app/clusters/tls-client-management-server/BUILD.gn
@@ -14,7 +14,7 @@
 import("//build_overrides/chip.gni")
 
 source_set("tls-client-management-server") {
-  sources = [ "tls-client-management-server.h" ]
+  sources = [ "TlsClientManagementCluster.h" ]
 
   public_deps = [
     "${chip_root}/src/app/",

--- a/src/app/clusters/tls-client-management-server/TlsClientManagementCluster.h
+++ b/src/app/clusters/tls-client-management-server/TlsClientManagementCluster.h
@@ -35,9 +35,9 @@ static constexpr uint16_t kSpecMaxHostname = 253;
 
 class TlsClientManagementDelegate;
 
-class TlsClientManagementServer : private AttributeAccessInterface,
-                                  private CommandHandlerInterface,
-                                  private chip::FabricTable::Delegate
+class TlsClientManagementCluster : private AttributeAccessInterface,
+                                   private CommandHandlerInterface,
+                                   private chip::FabricTable::Delegate
 {
 public:
     /**
@@ -49,9 +49,9 @@ public:
      * @param maxProvisioned The maximum number of endpoints which can be provisioned
      * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
      */
-    TlsClientManagementServer(EndpointId endpointId, TlsClientManagementDelegate & delegate,
-                              Tls::CertificateTable & certificateTable, uint8_t maxProvisioned);
-    ~TlsClientManagementServer();
+    TlsClientManagementCluster(EndpointId endpointId, TlsClientManagementDelegate & delegate,
+                               Tls::CertificateTable & certificateTable, uint8_t maxProvisioned);
+    ~TlsClientManagementCluster();
 
     /**
      * Initialise the TLS Client Management server instance.
@@ -184,16 +184,16 @@ public:
                                                     int8_t delta) = 0;
 
 protected:
-    friend class TlsClientManagementServer;
+    friend class TlsClientManagementCluster;
 
-    TlsClientManagementServer * mTlsClientManagementServer = nullptr;
+    TlsClientManagementCluster * mTlsClientManagementCluster = nullptr;
 
-    // sets the TlsClientManagement Server pointer
-    void SetTlsClientManagementServer(TlsClientManagementServer * tlsClientManagementServer)
+    // sets the TlsClientManagement Cluster pointer
+    void SetTlsClientManagementCluster(TlsClientManagementCluster * tlsClientManagementServer)
     {
-        mTlsClientManagementServer = tlsClientManagementServer;
+        mTlsClientManagementCluster = tlsClientManagementServer;
     }
-    TlsClientManagementServer * GetTlsClientManagementServer() const { return mTlsClientManagementServer; }
+    TlsClientManagementCluster * GetTlsClientManagementCluster() const { return mTlsClientManagementCluster; }
 };
 
 } // namespace Clusters

--- a/src/app/clusters/tls-client-management-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/tls-client-management-server/app_config_dependent_sources.cmake
@@ -18,6 +18,6 @@ TARGET_SOURCES(
         PRIVATE
         "${CHIP_APP_BASE_DIR}/clusters/tls-certificate-management-server/CertificateTableImpl.cpp"
         "${CHIP_APP_BASE_DIR}/clusters/tls-certificate-management-server/CertificateTableImpl.h"
-        "${CLUSTER_DIR}/tls-client-management-server.cpp"
-        "${CLUSTER_DIR}/tls-client-management-server.h"
+        "${CLUSTER_DIR}/TlsClientManagementCluster.cpp"
+        "${CLUSTER_DIR}/TlsClientManagementCluster.h"
 )

--- a/src/app/clusters/tls-client-management-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/tls-client-management-server/app_config_dependent_sources.gni
@@ -14,6 +14,6 @@
 import("//build_overrides/chip.gni")
 
 app_config_dependent_sources = [
-  "tls-client-management-server.cpp",
-  "tls-client-management-server.h",
+  "TlsClientManagementCluster.cpp",
+  "TlsClientManagementCluster.h",
 ]


### PR DESCRIPTION
#### Summary

Initial PR in converting the TLSClient cluster to using the Code Driven pattern; this PR just renames the existing clusters and the handles. This will help the review of the actual changes of Code Driven migration in the follow-up PR.


#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
