### PR TITLE
[TLSCERT] Initial PR for conversion to Code Driven - Rename of cluster and associated classes

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/tls-certificate-management-instance.h
+++ b/examples/all-clusters-app/all-clusters-common/include/tls-certificate-management-instance.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <app/clusters/tls-certificate-management-server/tls-certificate-management-server.h>
+#include <app/clusters/tls-certificate-management-server/TlsCertificateManagementCluster.h>
 
 namespace chip {
 namespace app {

--- a/examples/all-clusters-app/all-clusters-common/src/tls-certificate-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-certificate-management-instance.cpp
@@ -18,7 +18,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/clusters/tls-certificate-management-server/CertificateTableImpl.h>
-#include <app/clusters/tls-certificate-management-server/tls-certificate-management-server.h>
+#include <app/clusters/tls-certificate-management-server/TlsCertificateManagementCluster.h>
 #include <clusters/TlsCertificateManagement/Commands.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <tls-certificate-management-instance.h>
@@ -443,17 +443,17 @@ Status TlsCertificateManagementCommandDelegate::RemoveClientCert(EndpointId matt
 
 static CertificateTableImpl gCertificateTableInstance;
 TlsCertificateManagementCommandDelegate TlsCertificateManagementCommandDelegate::instance(gCertificateTableInstance);
-static TlsCertificateManagementServer gTlsCertificateManagementClusterServerInstance = TlsCertificateManagementServer(
+static TlsCertificateManagementCluster gTlsCertificateManagementClusterInstance = TlsCertificateManagementCluster(
     EndpointId(1), TlsCertificateManagementCommandDelegate::GetInstance(), TlsClientManagementCommandDelegate::GetInstance(),
     gCertificateTableInstance, kMaxRootCerts, kMaxClientCerts);
 
 void emberAfTlsCertificateManagementClusterInitCallback(EndpointId matterEndpoint)
 {
     TEMPORARY_RETURN_IGNORED gCertificateTableInstance.SetEndpoint(EndpointId(1));
-    TEMPORARY_RETURN_IGNORED gTlsCertificateManagementClusterServerInstance.Init();
+    TEMPORARY_RETURN_IGNORED gTlsCertificateManagementClusterInstance.Init();
 }
 
 void emberAfTlsCertificateManagementClusterShutdownCallback(EndpointId matterEndpoint)
 {
-    TEMPORARY_RETURN_IGNORED gTlsCertificateManagementClusterServerInstance.Finish();
+    TEMPORARY_RETURN_IGNORED gTlsCertificateManagementClusterInstance.Finish();
 }

--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -19,7 +19,7 @@
 #pragma once
 #include <app-common/zap-generated/cluster-enums.h>
 #include <app/clusters/push-av-stream-transport-server/PushAVStreamTransportCluster.h>
-#include <app/clusters/tls-certificate-management-server/tls-certificate-management-server.h>
+#include <app/clusters/tls-certificate-management-server/TlsCertificateManagementCluster.h>
 #include <camera-device-interface.h>
 #include <chrono>
 #include <credentials/CHIPCert.h>

--- a/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.h
+++ b/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "push-av-stream-transport-delegate.h"
-#include <app/clusters/tls-certificate-management-server/tls-certificate-management-server.h>
+#include <app/clusters/tls-certificate-management-server/TlsCertificateManagementCluster.h>
 #include <app/clusters/tls-client-management-server/TlsClientManagementCluster.h>
 
 namespace chip {

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.h
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.h
@@ -6,7 +6,7 @@
 #include <app/clusters/push-av-stream-transport-server/constants.h>
 #include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h>
 #include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h>
-#include <app/clusters/tls-certificate-management-server/tls-certificate-management-server.h>
+#include <app/clusters/tls-certificate-management-server/TlsCertificateManagementCluster.h>
 #include <app/clusters/tls-client-management-server/TlsClientManagementCluster.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <functional>

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -21,7 +21,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/clusters/push-av-stream-transport-server/constants.h>
 #include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-storage.h>
-#include <app/clusters/tls-certificate-management-server/tls-certificate-management-server.h>
+#include <app/clusters/tls-certificate-management-server/TlsCertificateManagementCluster.h>
 #include <app/clusters/tls-client-management-server/TlsClientManagementCluster.h>
 #include <functional>
 #include <protocols/interaction_model/StatusCode.h>

--- a/src/app/clusters/tls-certificate-management-server/BUILD.gn
+++ b/src/app/clusters/tls-certificate-management-server/BUILD.gn
@@ -28,7 +28,7 @@ source_set("certificate-table") {
 }
 
 source_set("tls-certificate-management-server") {
-  public = [ "tls-certificate-management-server.h" ]
+  public = [ "TlsCertificateManagementCluster.h" ]
 
   deps = [
     ":certificate-table",
@@ -38,5 +38,5 @@ source_set("tls-certificate-management-server") {
     "${chip_root}/zzz_generated/app-common/clusters:all-metadata",
   ]
 
-  sources = [ "tls-certificate-management-server.cpp" ]
+  sources = [ "TlsCertificateManagementCluster.cpp" ]
 }

--- a/src/app/clusters/tls-certificate-management-server/TlsCertificateManagementCluster.h
+++ b/src/app/clusters/tls-certificate-management-server/TlsCertificateManagementCluster.h
@@ -34,9 +34,9 @@ namespace Clusters {
 
 class TlsCertificateManagementDelegate;
 
-class TlsCertificateManagementServer : private AttributeAccessInterface,
-                                       private CommandHandlerInterface,
-                                       private FabricTable::Delegate
+class TlsCertificateManagementCluster : private AttributeAccessInterface,
+                                        private CommandHandlerInterface,
+                                        private FabricTable::Delegate
 {
 public:
     /**
@@ -50,10 +50,10 @@ public:
      * @param maxClientCertificates The maximum number of client certificates which can be provisioned
      * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
      */
-    TlsCertificateManagementServer(EndpointId endpointId, TlsCertificateManagementDelegate & delegate,
-                                   Tls::CertificateDependencyChecker & dependencyChecker, Tls::CertificateTable & certificateTable,
-                                   uint8_t maxRootCertificates, uint8_t maxClientCertificates);
-    ~TlsCertificateManagementServer();
+    TlsCertificateManagementCluster(EndpointId endpointId, TlsCertificateManagementDelegate & delegate,
+                                    Tls::CertificateDependencyChecker & dependencyChecker, Tls::CertificateTable & certificateTable,
+                                    uint8_t maxRootCertificates, uint8_t maxClientCertificates);
+    ~TlsCertificateManagementCluster();
 
     /**
      * Initializes the TLS Certificate Management server instance.
@@ -337,19 +337,19 @@ public:
     virtual Protocols::InteractionModel::Status RemoveClientCert(EndpointId matterEndpoint, FabricIndex fabric,
                                                                  Tls::TLSCCDID id) = 0;
 
-    Tls::CertificateTable & GetCertificateTable() { return mTlsCertificateManagementServer->GetCertificateTable(); }
+    Tls::CertificateTable & GetCertificateTable() { return mTlsCertificateManagementCluster->GetCertificateTable(); }
 
 protected:
-    friend class TlsCertificateManagementServer;
+    friend class TlsCertificateManagementCluster;
 
-    TlsCertificateManagementServer * mTlsCertificateManagementServer = nullptr;
+    TlsCertificateManagementCluster * mTlsCertificateManagementCluster = nullptr;
 
-    // sets the TlsCertificateManagement Server pointer
-    void SetTlsCertificateManagementServer(TlsCertificateManagementServer * tlsCertificateManagementServer)
+    // sets the TlsCertificateManagement Cluster pointer
+    void SetTlsCertificateManagementCluster(TlsCertificateManagementCluster * tlsCertificateManagementServer)
     {
-        mTlsCertificateManagementServer = tlsCertificateManagementServer;
+        mTlsCertificateManagementCluster = tlsCertificateManagementServer;
     }
-    TlsCertificateManagementServer * GetTlsCertificateManagementServer() const { return mTlsCertificateManagementServer; }
+    TlsCertificateManagementCluster * GetTlsCertificateManagementCluster() const { return mTlsCertificateManagementCluster; }
 };
 
 } // namespace Clusters

--- a/src/app/clusters/tls-certificate-management-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/tls-certificate-management-server/app_config_dependent_sources.cmake
@@ -18,6 +18,6 @@ TARGET_SOURCES(
         PRIVATE
         "${CLUSTER_DIR}/CertificateTableImpl.cpp"
         "${CLUSTER_DIR}/CertificateTableImpl.h"
-        "${CLUSTER_DIR}/TlsCertificateManagementServer.cpp"
-        "${CLUSTER_DIR}/TlsCertificateManagementServer.h"
+        "${CLUSTER_DIR}/TlsCertificateManagementCluster.cpp"
+        "${CLUSTER_DIR}/TlsCertificateManagementCluster.h"
 )

--- a/src/app/clusters/tls-certificate-management-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/tls-certificate-management-server/app_config_dependent_sources.cmake
@@ -18,6 +18,6 @@ TARGET_SOURCES(
         PRIVATE
         "${CLUSTER_DIR}/CertificateTableImpl.cpp"
         "${CLUSTER_DIR}/CertificateTableImpl.h"
-        "${CLUSTER_DIR}/tls-certificate-management-server.cpp"
-        "${CLUSTER_DIR}/tls-certificate-management-server.h"
+        "${CLUSTER_DIR}/TlsCertificateManagementServer.cpp"
+        "${CLUSTER_DIR}/TlsCertificateManagementServer.h"
 )


### PR DESCRIPTION
#### Summary

Initial PR in converting the TLSCertManagement cluster to using the Code Driven pattern; this PR just renames the existing clusters and the handles. This will help the review of the actual changes of Code Driven migration in the follow-up PR.

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
