### PR TITLE
[NXP] Bug fix: Allow val is nullptr in TLV commands

### DIFF
--- a/src/crypto/EleManagerImpl.cpp
+++ b/src/crypto/EleManagerImpl.cpp
@@ -38,12 +38,18 @@ namespace ele {
 
 static bool add_tlv(uint8_t * buf, size_t buf_size, size_t buf_index, uint8_t tag, size_t len, uint8_t * val)
 {
-    if (buf == nullptr || val == nullptr || (buf_index + 2 + len) > buf_size)
+    if (buf == nullptr || (buf_index + kTlvHeader + len) > buf_size)
+    {
         return false;
+    }
 
     buf[buf_index++] = (uint8_t) tag;
     buf[buf_index++] = (uint8_t) len;
-    memcpy(&buf[buf_index], val, len);
+
+    if (len > 0 && val != nullptr)
+    {
+        memcpy(&buf[buf_index], val, len);
+    }
 
     return true;
 }


### PR DESCRIPTION
For ELE HSM command, we use TLV(tag, length, value) as standard format. In some conditions, a command with no value is useful(length = 0, value = nullptr).
This patch fix the add_tlv function to allow this stituation.

Change-Id: I62649344fd5ba7e2c4502a6df474667b8e73400b

#### Testing
Testing passed on i.MX 91 frdm and i.MX 93 evk with lighting-app pairing with controller with manual testing.
