### PR TITLE
[NXP] Sync the imx-secure-enclave third part lib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -331,7 +331,7 @@
 [submodule "third_party/imx-secure-enclave/repo"]
 	path = third_party/imx-secure-enclave/repo
 	url = https://github.com/nxp-imx/imx-secure-enclave.git
-	branch = lf-6.12.34_2.1.0
+	branch = lf-6.12.49_2.2.0
 	platforms = linux
 [submodule "third_party/amazon-kinesis-video-streams-webrtc-sdk-c/repo"]
 	path = third_party/amazon-kinesis-video-streams-webrtc-sdk-c/repo

--- a/third_party/imx-secure-enclave/BUILD.gn
+++ b/third_party/imx-secure-enclave/BUILD.gn
@@ -63,7 +63,6 @@ config("libele_config") {
     "MT_SAB_STORAGE_CHUNK_EXPORT_REQ=${ELE_FMW}",
     "MT_SAB_STORAGE_OPEN=${ELE_FMW}",
     "MT_SAB_STORAGE_CLOSE=${ELE_FMW}",
-    "MT_SAB_STORAGE_KEY_DB_REQ=${ELE_FMW}",
     "MT_SAB_ENC_DATA_STORAGE=${ELE_FMW}",
 
     "HSM_SIGN_GEN=1",
@@ -162,7 +161,6 @@ source_set("libelematter") {
     "repo/${ELE_PLAT_COMMON_PATH}/sab_msg/sab_storage_export_finish.c",
     "repo/${ELE_PLAT_COMMON_PATH}/sab_msg/sab_storage_get_chunk.c",
     "repo/${ELE_PLAT_COMMON_PATH}/sab_msg/sab_storage_get_chunk_done.c",
-    "repo/${ELE_PLAT_COMMON_PATH}/sab_msg/sab_storage_key_db.c",
     "repo/${ELE_PLAT_COMMON_PATH}/sab_msg/sab_storage_master_export.c",
     "repo/${ELE_PLAT_COMMON_PATH}/sab_msg/sab_storage_master_import.c",
     "repo/${ELE_PLAT_COMMON_PATH}/sab_msg/sab_storage_open.c",


### PR DESCRIPTION
Sync the imx-secure-enclave lib with yocto 2025q4-rc2 github release.

Change-Id: I79b44898554bfbd0922f371bad6af9d8863f28f5

#### Testing

Testing passed on i.MX 91 frdm, i.MX 91 qsb, i.MX 91 evk and i.MX 93 evk:
lighting-app pairing with controller with manual testing via onnetwork and ble-wifi.
otbr testing(iw612 WIFI card)
ot-daemon with IW612 /  IW610
and soon...

