### PR TITLE
[Tests] Perform Linux unshare check early

### DIFF
--- a/scripts/tests/chiptest/linux.py
+++ b/scripts/tests/chiptest/linux.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 test_environ = os.environ.copy()
 
 
-def EnsureNetworkNamespaceAvailability():
+def ensure_network_namespace_availability():
     if os.getuid() == 0:
         log.debug("Current user is root")
         log.warning("Running as root and this will change global namespaces.")
@@ -48,7 +48,7 @@ def EnsureNetworkNamespaceAvailability():
         test_environ)
 
 
-def EnsurePrivateState():
+def ensure_private_state():
     log.info("Ensuring /run is privately accessible")
 
     log.debug("Making / private")
@@ -137,16 +137,7 @@ class IsolatedNetworkNamespace:
     ]
 
     def __init__(self, index=0, setup_app_link_up=True, setup_tool_link_up=True,
-                 app_link_name='eth-app', tool_link_name='eth-tool',
-                 unshared=False):
-
-        if not unshared:
-            # If not running in an unshared network namespace yet, try
-            # to rerun the script with the 'unshare' command.
-            EnsureNetworkNamespaceAvailability()
-        else:
-            EnsurePrivateState()
-
+                 app_link_name='eth-app', tool_link_name='eth-tool'):
         self.index = index
         self.app_link_name = app_link_name
         self.tool_link_name = tool_link_name

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 import chiptest
 import click
 import coloredlogs
+from chiptest import linux
 from chiptest.accessories import AppsRegister
 from chiptest.glob_matcher import GlobMatcher
 from chiptest.runner import Executor, SubprocessInfo
@@ -59,7 +60,6 @@ __LOG_LEVELS__ = logging.getLevelNamesMapping()
 class RunContext:
     root: str
     tests: typing.List[chiptest.TestDefinition]
-    in_unshare: bool
     chip_tool: str
     dry_run: bool
     runtime: TestRunTime
@@ -149,6 +149,13 @@ def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
         log_fmt = '%(levelname)-7s %(message)s'
     coloredlogs.install(level=__LOG_LEVELS__[log_level], fmt=log_fmt)
 
+    if sys.platform == "linux":
+        if not internal_inside_unshare:
+            # If not running in an unshared network namespace yet, try to rerun the script with the 'unshare' command.
+            linux.ensure_network_namespace_availability()
+        else:
+            linux.ensure_private_state()
+
     runtime = TestRunTime.CHIP_TOOL_PYTHON
     if runner == 'matter_repl_python':
         runtime = TestRunTime.MATTER_REPL_PYTHON
@@ -224,7 +231,6 @@ def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
     tests.sort(key=lambda x: x.name)
 
     context.obj = RunContext(root=root, tests=tests,
-                             in_unshare=internal_inside_unshare,
                              chip_tool=chip_tool, dry_run=dry_run,
                              runtime=runtime,
                              find_path=find_path,
@@ -404,8 +410,7 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, o
             setup_app_link_up=not ble_wifi,
             # Change the app link name so the interface will be recognized as WiFi or Ethernet
             # depending on the commissioning method used.
-            app_link_name='wlx-app' if ble_wifi else 'eth-app',
-            unshared=context.obj.in_unshare)
+            app_link_name='wlx-app' if ble_wifi else 'eth-app')
 
         if ble_wifi:
             bus = chiptest.linux.DBusTestSystemBus()
@@ -488,9 +493,8 @@ if sys.platform == 'linux':
         'shell',
         help=('Execute a bash shell in the environment (useful to test '
               'network namespaces)'))
-    @click.pass_context
-    def cmd_shell(context):
-        chiptest.linux.IsolatedNetworkNamespace(unshared=context.obj.in_unshare)
+    def cmd_shell():
+        chiptest.linux.IsolatedNetworkNamespace()
         os.execvpe("bash", ["bash"], os.environ.copy())
 
 

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -25,7 +25,6 @@ from dataclasses import dataclass, field
 import chiptest
 import click
 import coloredlogs
-from chiptest import linux
 from chiptest.accessories import AppsRegister
 from chiptest.glob_matcher import GlobMatcher
 from chiptest.runner import Executor, SubprocessInfo
@@ -152,9 +151,9 @@ def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
     if sys.platform == "linux":
         if not internal_inside_unshare:
             # If not running in an unshared network namespace yet, try to rerun the script with the 'unshare' command.
-            linux.ensure_network_namespace_availability()
+            chiptest.linux.ensure_network_namespace_availability()
         else:
-            linux.ensure_private_state()
+            chiptest.linux.ensure_private_state()
 
     runtime = TestRunTime.CHIP_TOOL_PYTHON
     if runner == 'matter_repl_python':


### PR DESCRIPTION
#### Summary

This PR moves Linux-specific check if the script is running in unshare to the beginning of main. It greatly reduces initialization time, as the test structure doesn't need to be calculated, discarded and calculated again.

Also, renamed relevant functions to use snake_case convention.

#### Related issues

Continuation of work on concurrent tests (#42004) – related to:
- #42204
- #42261
- #42264
- #42378
- #42379
- #42380
- #42392
- #42393

#### Testing

Tested locally using run_test_suite.py

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
