### PR TITLE
Use a templated helper approach that reduces the boilerplate

### DIFF
--- a/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.cpp
+++ b/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.cpp
@@ -246,31 +246,21 @@ std::optional<DataModel::ActionReturnStatus> WebRTCTransportProviderCluster::Inv
 
     switch (request.path.mCommandId)
     {
-    case Commands::SolicitOffer::Id: {
-        Commands::SolicitOffer::DecodableType req;
-        ReturnErrorOnFailure(req.Decode(input_arguments, accessingFabricIndex));
-        return HandleSolicitOffer(*handler, req);
-    }
-    case Commands::ProvideOffer::Id: {
-        Commands::ProvideOffer::DecodableType req;
-        ReturnErrorOnFailure(req.Decode(input_arguments, accessingFabricIndex));
-        return HandleProvideOffer(*handler, req);
-    }
-    case Commands::ProvideAnswer::Id: {
-        Commands::ProvideAnswer::DecodableType req;
-        ReturnErrorOnFailure(req.Decode(input_arguments, accessingFabricIndex));
-        return HandleProvideAnswer(*handler, req);
-    }
-    case Commands::ProvideICECandidates::Id: {
-        Commands::ProvideICECandidates::DecodableType req;
-        ReturnErrorOnFailure(req.Decode(input_arguments, accessingFabricIndex));
-        return HandleProvideICECandidates(*handler, req);
-    }
-    case Commands::EndSession::Id: {
-        Commands::EndSession::DecodableType req;
-        ReturnErrorOnFailure(req.Decode(input_arguments, accessingFabricIndex));
-        return HandleEndSession(*handler, req);
-    }
+    case Commands::SolicitOffer::Id:
+        return HandleCommand<Commands::SolicitOffer::DecodableType>(input_arguments, accessingFabricIndex, *handler,
+                                                                    &WebRTCTransportProviderCluster::HandleSolicitOffer);
+    case Commands::ProvideOffer::Id:
+        return HandleCommand<Commands::ProvideOffer::DecodableType>(input_arguments, accessingFabricIndex, *handler,
+                                                                    &WebRTCTransportProviderCluster::HandleProvideOffer);
+    case Commands::ProvideAnswer::Id:
+        return HandleCommand<Commands::ProvideAnswer::DecodableType>(input_arguments, accessingFabricIndex, *handler,
+                                                                     &WebRTCTransportProviderCluster::HandleProvideAnswer);
+    case Commands::ProvideICECandidates::Id:
+        return HandleCommand<Commands::ProvideICECandidates::DecodableType>(
+            input_arguments, accessingFabricIndex, *handler, &WebRTCTransportProviderCluster::HandleProvideICECandidates);
+    case Commands::EndSession::Id:
+        return HandleCommand<Commands::EndSession::DecodableType>(input_arguments, accessingFabricIndex, *handler,
+                                                                  &WebRTCTransportProviderCluster::HandleEndSession);
     default:
         return Status::UnsupportedCommand;
     }

--- a/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.h
+++ b/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.h
@@ -408,6 +408,16 @@ private:
     CheckTurnsOrStunsRequiresUTCTime(const char * commandName,
                                      const Optional<DataModel::DecodableList<ICEServerDecodableStruct>> & iceServers);
 
+    // Templated helper to decode and dispatch commands
+    template <typename DecodableType, typename HandlerFunc>
+    __attribute__((always_inline)) std::optional<DataModel::ActionReturnStatus>
+    HandleCommand(TLV::TLVReader & input_arguments, FabricIndex fabricIndex, CommandHandler & handler, HandlerFunc handlerFunc)
+    {
+        DecodableType req;
+        ReturnErrorOnFailure(req.Decode(input_arguments, fabricIndex));
+        return (this->*handlerFunc)(handler, req);
+    }
+
     // Command Handlers
     std::optional<DataModel::ActionReturnStatus> HandleSolicitOffer(CommandHandler & commandHandler,
                                                                     const Commands::SolicitOffer::DecodableType & req);


### PR DESCRIPTION
#### Summary

Use a templated helper approach that reduces the boilerplate from 3 lines per command to 1 line.

Benefits:

1. Reduced boilerplate: Each command case went from 3 lines to 1 line
2. No code bloat: 
3. Improved maintainability: New commands can be added with just one line in the switch statement
4. Type safety: The template ensures type-safe decoding and handler invocation
5. The pattern follows Marcos's suggestion from PR #39749, to ensure zero flash/RAM impact while reducing repetition.

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
