### PR TITLE
Update logic for shorten-64-to-32 errors.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -325,15 +325,6 @@ config("strict_warnings") {
     ]
 
     configs += [ "$dir_pw_build:clang_thread_safety_warnings" ]
-
-    # TODO: can make this back fatal in once pigweed updates can be taken again.
-    #       See https://github.com/project-chip/connectedhomeip/pull/22079
-    #
-    # Currently `./scripts/build/build_examples.py --target linux-arm64-light-rpc-ipv6only-clang build`
-    # fails in third_party/pigweed/repo/pw_protobuf
-    if (current_cpu == "arm64" && current_os == "linux") {
-      cflags += [ "-Wno-error=shorten-64-to-32" ]
-    }
   }
 
   if (!is_asan && (current_os == "linux" || current_os == "android")) {

--- a/third_party/perfetto/BUILD.gn
+++ b/third_party/perfetto/BUILD.gn
@@ -32,6 +32,12 @@ config("sdk_private_config") {
     #   Based on comments from perfetto/repo/gn/standalone/BUILD.gn:
     #   Use return std::move(...) for compatibility with old GCC compilers.
     #
+    cflags += [
+      "-Wno-redundant-move",
+    ]
+  }
+
+  if (current_cpu == "arm" && current_os == "android") {
     # no-error=shorten-64-to-32:
     #
     #   Failure in android for android-arm-chip-tool:
@@ -42,10 +48,7 @@ config("sdk_private_config") {
     #     50363 |     const size_t key_hash = Hasher{}(key);
     #           |                  ~~~~~~~~   ^~~~~~~~~~~~~
     #
-    cflags += [
-      "-Wno-redundant-move",
-      "-Wno-error=shorten-64-to-32",
-    ]
+    cflags += [ "-Wno-error=shorten-64-to-32" ]
   }
 }
 

--- a/third_party/perfetto/BUILD.gn
+++ b/third_party/perfetto/BUILD.gn
@@ -32,9 +32,7 @@ config("sdk_private_config") {
     #   Based on comments from perfetto/repo/gn/standalone/BUILD.gn:
     #   Use return std::move(...) for compatibility with old GCC compilers.
     #
-    cflags += [
-      "-Wno-redundant-move",
-    ]
+    cflags += [ "-Wno-redundant-move" ]
   }
 
   if (current_cpu == "arm" && current_os == "android") {

--- a/third_party/perfetto/BUILD.gn
+++ b/third_party/perfetto/BUILD.gn
@@ -35,7 +35,7 @@ config("sdk_private_config") {
     cflags += [ "-Wno-redundant-move" ]
   }
 
-  if (current_cpu == "arm" && current_os == "android") {
+  if (is_clang) {
     # no-error=shorten-64-to-32:
     #
     #   Failure in android for android-arm-chip-tool:
@@ -46,7 +46,7 @@ config("sdk_private_config") {
     #     50363 |     const size_t key_hash = Hasher{}(key);
     #           |                  ~~~~~~~~   ^~~~~~~~~~~~~
     #
-    cflags += [ "-Wno-error=shorten-64-to-32" ]
+    cflags += [ "-Wno-shorten-64-to-32" ]
   }
 }
 

--- a/third_party/perfetto/BUILD.gn
+++ b/third_party/perfetto/BUILD.gn
@@ -27,9 +27,25 @@ config("sdk_private_config") {
   cflags = [ "-Wno-shadow" ]
 
   if (!is_clang) {
-    # Based on comments from perfetto/repo/gn/standalone/BUILD.gn:
-    # Use return std::move(...) for compatibility with old GCC compilers.
-    cflags += [ "-Wno-redundant-move" ]
+    # no-redundant-move:
+    #
+    #   Based on comments from perfetto/repo/gn/standalone/BUILD.gn:
+    #   Use return std::move(...) for compatibility with old GCC compilers.
+    #
+    # no-error=shorten-64-to-32:
+    #
+    #   Failure in android for android-arm-chip-tool:
+    #
+    #     implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long')
+    #     to 'const size_t' (aka 'const unsigned int')
+    #
+    #     50363 |     const size_t key_hash = Hasher{}(key);
+    #           |                  ~~~~~~~~   ^~~~~~~~~~~~~
+    #
+    cflags += [
+      "-Wno-redundant-move",
+      "-Wno-error=shorten-64-to-32",
+    ]
   }
 }
 


### PR DESCRIPTION
#### Summary

Android full builds broken after #42398

This PR:
- adds a `no-shorten-64-to-32` to perfetto builds (this supperssion is needed)
- removes it from general config: pigweed is fine now, this setting does no longer apply

#### Testing

Locally tested that `android-arm-chip-tool` and `linux-arm64-light-rpc-ipv6only-clang` targets compile fine.