### PR TITLE
[NXP][platform][zephyr] Move Factory Data Provider files to be added on application level

### DIFF
--- a/config/nxp/chip-module/CMakeLists.txt
+++ b/config/nxp/chip-module/CMakeLists.txt
@@ -106,10 +106,7 @@ matter_add_gn_arg_string("zephyr_ar"                              ${CMAKE_AR})
 matter_add_gn_arg_string("zephyr_cc"                              ${CMAKE_C_COMPILER})
 matter_add_gn_arg_string("zephyr_cxx"                             ${CMAKE_CXX_COMPILER})
 
-if (CONFIG_CHIP_FACTORY_DATA)
-    matter_add_gn_arg_bool("chip_use_transitional_commissionable_data_provider" FALSE)
-    matter_add_gn_arg_bool("chip_enable_factory_data"                           TRUE)
-elseif (CONFIG_CHIP_FACTORY_DATA_CUSTOM_BACKEND)
+if (CONFIG_CHIP_FACTORY_DATA OR CONFIG_CHIP_FACTORY_DATA_CUSTOM_BACKEND)
     matter_add_gn_arg_bool("chip_use_transitional_commissionable_data_provider" FALSE)
 endif()
 

--- a/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
@@ -88,6 +88,17 @@ if(CONFIG_CHIP_OTA_REQUESTOR)
     )
 endif()
 
+if (CONFIG_CHIP_FACTORY_DATA)
+    target_sources(app PRIVATE
+        ${CHIP_ROOT}/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
+        ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
+    )
+    target_include_directories(app PRIVATE
+        ${CHIP_ROOT}/src/platform/nxp/zephyr
+        ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy
+    )
+endif()
+
 chip_configure_data_model(app
     ZAP_FILE ${ALL_CLUSTERS_COMMON_DIR}/all-clusters-app.zap
 )

--- a/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
@@ -93,10 +93,6 @@ if (CONFIG_CHIP_FACTORY_DATA)
         ${CHIP_ROOT}/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
         ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
     )
-    target_include_directories(app PRIVATE
-        ${CHIP_ROOT}/src/platform/nxp/zephyr
-        ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy
-    )
 endif()
 
 chip_configure_data_model(app

--- a/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
@@ -95,10 +95,6 @@ if (CONFIG_CHIP_FACTORY_DATA)
         ${CHIP_ROOT}/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
         ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
     )
-    target_include_directories(app PRIVATE
-        ${CHIP_ROOT}/src/platform/nxp/zephyr
-        ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy
-    )
 endif()
 
 chip_configure_data_model(app

--- a/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
@@ -90,6 +90,17 @@ if(CONFIG_CHIP_OTA_REQUESTOR)
     )
 endif()
 
+if (CONFIG_CHIP_FACTORY_DATA)
+    target_sources(app PRIVATE
+        ${CHIP_ROOT}/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
+        ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
+    )
+    target_include_directories(app PRIVATE
+        ${CHIP_ROOT}/src/platform/nxp/zephyr
+        ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy
+    )
+endif()
+
 chip_configure_data_model(app
     ZAP_FILE ${ALL_CLUSTERS_COMMON_DIR}/../../laundry-washer-app/nxp/zap/laundry-washer-app.zap
 )

--- a/examples/thermostat/nxp/zephyr/CMakeLists.txt
+++ b/examples/thermostat/nxp/zephyr/CMakeLists.txt
@@ -95,10 +95,6 @@ if (CONFIG_CHIP_FACTORY_DATA)
         ${CHIP_ROOT}/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
         ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
     )
-    target_include_directories(app PRIVATE
-        ${CHIP_ROOT}/src/platform/nxp/zephyr
-        ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy
-    )
 endif()
 
 chip_configure_data_model(app

--- a/examples/thermostat/nxp/zephyr/CMakeLists.txt
+++ b/examples/thermostat/nxp/zephyr/CMakeLists.txt
@@ -90,6 +90,17 @@ if(CONFIG_CHIP_OTA_REQUESTOR)
     )
 endif()
 
+if (CONFIG_CHIP_FACTORY_DATA)
+    target_sources(app PRIVATE
+        ${CHIP_ROOT}/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
+        ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
+    )
+    target_include_directories(app PRIVATE
+        ${CHIP_ROOT}/src/platform/nxp/zephyr
+        ${CHIP_ROOT}/src/platform/nxp/common/factory_data/legacy
+    )
+endif()
+
 chip_configure_data_model(app
     ZAP_FILE ${ALL_CLUSTERS_COMMON_DIR}/../../thermostat/nxp/zap/thermostat_matter_wifi.zap
 )

--- a/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
@@ -101,8 +101,8 @@ CHIP_ERROR FactoryDataProviderImpl::SignWithDacKey(const ByteSpan & digestToSign
     Crypto::P256ECDSASignature signature;
     Crypto::P256Keypair keypair;
 
-    VerifyOrReturnError(IsSpanUsable(outSignBuffer), CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(IsSpanUsable(digestToSign), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!outSignBuffer.empty(), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!digestToSign.empty(), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(outSignBuffer.size() >= signature.Capacity(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // In a non-exemplary implementation, the public key is not needed here. It is used here merely because

--- a/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
@@ -19,7 +19,7 @@
 /*                                  Includes                                  */
 /* -------------------------------------------------------------------------- */
 
-#include "FactoryDataProviderImpl.h"
+#include <platform/nxp/zephyr/FactoryDataProviderImpl.h>
 
 /* mbedtls */
 #include "mbedtls/aes.h"


### PR DESCRIPTION
#### Summary

The aim of this PR is to move the Factory Data Provider build to be done on application level instead of platform level. The primary motive behind this change is to migrate to src/platform/Zephyr instead of src/platform/nxp/zephyr (see dedicated PR #42391 )

#### Testing

Tested with manual build command:
- west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr/ -DFILE_SUFFIX=fdata
