### PR TITLE
[shell] Fixed NFC shell command to not ignore error code

### DIFF
--- a/src/lib/shell/commands/NFC.cpp
+++ b/src/lib/shell/commands/NFC.cpp
@@ -55,8 +55,16 @@ static CHIP_ERROR NFCHandler(int argc, char ** argv)
     {
         if (nfcEnabled)
         {
-            chip::DeviceLayer::NFCOnboardingPayloadMgr().StopTagEmulation();
-            streamer_printf(sout, "NFC tag emulation stopped\r\n");
+            error = chip::DeviceLayer::NFCOnboardingPayloadMgr().StopTagEmulation();
+
+            if (error != CHIP_NO_ERROR)
+            {
+                streamer_printf(sout, "Failed to stop NFC tag emulation: %s\r\n", ErrorStr(error));
+            }
+            else
+            {
+                streamer_printf(sout, "NFC tag emulation stopped\r\n");
+            }
         }
         else
         {


### PR DESCRIPTION

#### Summary
NFC stop command ignores returned error code, what is incorrect due to nodiscard label.

#### Related issues
https://github.com/project-chip/connectedhomeip/issues/42194

#### Testing
Tested locally that compilation passes.
