### PR TITLE
Add support for parsing comments in ConstantEntry, Struct, Event, Enum, Bitmap, and Field types.

### DIFF
--- a/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
@@ -367,7 +367,6 @@ class MatterIdlTransformer(Transformer):
         meta = None if self.skip_meta else ParseMetaData(meta)
         return Event(qualities=args[0], priority=args[1], code=args[3], fields=args[4:], parse_meta=meta, **args[2])
 
-
     def view_privilege(self, args):
         return AccessPrivilege.VIEW
 
@@ -452,7 +451,7 @@ class MatterIdlTransformer(Transformer):
 
         return Attribute(definition=definition, qualities=qualities, **acl)
 
-    @v_args(meta=True,inline=True)
+    @v_args(meta=True, inline=True)
     def struct(self, meta, shared, qualities, id, *fields):
         if shared is None:
             shared = False

--- a/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
@@ -65,9 +65,26 @@ class PrefixCppDocComment:
         """List all types supported by doc comments."""
         for cluster in idl.clusters:
             yield cluster
-
+            for attribute in cluster.attributes:
+                yield attribute.definition
             for command in cluster.commands:
                 yield command
+            for struct in cluster.structs:
+                yield struct
+                for field in struct.fields:
+                    yield field
+            for event in cluster.events:
+                yield event
+                for field in event.fields:
+                    yield field
+            for enum in cluster.enums:
+                yield enum
+                for entry in enum.entries:
+                    yield entry
+            for bitmap in cluster.bitmaps:
+                yield bitmap
+                for entry in bitmap.entries:
+                    yield entry
 
     def __repr__(self):
         return ("PREFIXDoc: %r at %r" % (self.value, self.start_pos))
@@ -200,30 +217,34 @@ class MatterIdlTransformer(Transformer):
             return DataType(name=tokens[0], max_length=tokens[1])
         raise Exception("Unexpected size for data type")
 
-    @v_args(inline=True)
-    def constant_entry(self, api_maturity, id, number, spec_name):
+    @v_args(meta=True, inline=True)
+    def constant_entry(self, meta, api_maturity, id, number, spec_name):
         if api_maturity is None:
             api_maturity = ApiMaturity.STABLE
-        return ConstantEntry(name=id, code=number, api_maturity=api_maturity, specification_name=spec_name)
+        meta = None if self.skip_meta else ParseMetaData(meta)
+        return ConstantEntry(name=id, code=number, api_maturity=api_maturity, specification_name=spec_name, parse_meta=meta)
 
-    @v_args(inline=True)
-    def enum(self, shared, id, type, *entries):
+    @v_args(meta=True, inline=True)
+    def enum(self, meta, shared, id, type, *entries):
         if shared is None:
             shared = False
-        return Enum(name=id, base_type=type, entries=list(entries), is_shared=shared)
+        meta = None if self.skip_meta else ParseMetaData(meta)
+        return Enum(name=id, base_type=type, entries=list(entries), is_shared=shared, parse_meta=meta)
 
-    @v_args(inline=True)
-    def bitmap(self, shared, id, type, *entries):
+    @v_args(meta=True, inline=True)
+    def bitmap(self, meta, shared, id, type, *entries):
         if shared is None:
             shared = False
-        return Bitmap(name=id, base_type=type, entries=list(entries), is_shared=shared)
+        meta = None if self.skip_meta else ParseMetaData(meta)
+        return Bitmap(name=id, base_type=type, entries=list(entries), is_shared=shared, parse_meta=meta)
 
-    def field(self, args):
+    @v_args(meta=True)
+    def field(self, meta, args):
         data_type, name = args[0], args[1]
         is_list = (len(args) == 4)
         code = args[-1]
-
-        return Field(data_type=data_type, name=name, code=code, is_list=is_list)
+        meta = None if self.skip_meta else ParseMetaData(meta)
+        return Field(data_type=data_type, name=name, code=code, is_list=is_list, parse_meta=meta)
 
     def optional(self, _):
         return FieldQuality.OPTIONAL
@@ -341,8 +362,11 @@ class MatterIdlTransformer(Transformer):
     def cluster_revision(self, revision):
         return revision
 
-    def event(self, args):
-        return Event(qualities=args[0], priority=args[1], code=args[3], fields=args[4:], **args[2])
+    @v_args(meta=True)
+    def event(self, meta, args):
+        meta = None if self.skip_meta else ParseMetaData(meta)
+        return Event(qualities=args[0], priority=args[1], code=args[3], fields=args[4:], parse_meta=meta, **args[2])
+
 
     def view_privilege(self, args):
         return AccessPrivilege.VIEW
@@ -415,8 +439,8 @@ class MatterIdlTransformer(Transformer):
         # handle escapes, skip the start and end quotes
         return s.value[1:-1].encode('utf-8').decode('unicode-escape')
 
-    @v_args(inline=True)
-    def attribute(self, qualities, definition_tuple):
+    @v_args(meta=True, inline=True)
+    def attribute(self, meta, qualities, definition_tuple):
         (definition, acl) = definition_tuple
 
         # If the attribute is neither "readonly" nor "writeonly", then it must be Read/Write
@@ -424,22 +448,26 @@ class MatterIdlTransformer(Transformer):
             qualities |= AttributeQuality.READABLE
             qualities |= AttributeQuality.WRITABLE
 
+        definition.parse_meta = None if self.skip_meta else ParseMetaData(meta)
+
         return Attribute(definition=definition, qualities=qualities, **acl)
 
-    @v_args(inline=True)
-    def struct(self, shared, qualities, id, *fields):
+    @v_args(meta=True,inline=True)
+    def struct(self, meta, shared, qualities, id, *fields):
         if shared is None:
             shared = False
-        return Struct(name=id, qualities=qualities, fields=list(fields), is_shared=shared)
+        meta = None if self.skip_meta else ParseMetaData(meta)
+        return Struct(name=id, qualities=qualities, fields=list(fields), is_shared=shared, parse_meta=meta)
 
     @v_args(inline=True)
     def request_struct(self, value):
         value.tag = StructTag.REQUEST
         return value
 
-    @v_args(inline=True)
-    def response_struct(self, id, code, *fields):
-        return Struct(name=id, tag=StructTag.RESPONSE, code=code, fields=list(fields))
+    @v_args(meta=True, inline=True)
+    def response_struct(self, meta, id, code, *fields):
+        meta = None if self.skip_meta else ParseMetaData(meta)
+        return Struct(name=id, tag=StructTag.RESPONSE, code=code, fields=list(fields), parse_meta=meta)
 
     @v_args(inline=True)
     def endpoint(self, number, *transforms):

--- a/scripts/py_matter_idl/matter/idl/matter_idl_types.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_types.py
@@ -132,6 +132,10 @@ class Field:
     is_list: bool = False
     qualities: FieldQuality = FieldQuality.NONE
     api_maturity: ApiMaturity = ApiMaturity.STABLE
+    description: Optional[str] = None
+
+    # Parsing meta data missing only when skip meta data is requested
+    parse_meta: Optional[ParseMetaData] = field(default=None, compare=False)
 
     @property
     def is_optional(self) -> bool:
@@ -178,6 +182,10 @@ class Struct:
     api_maturity: ApiMaturity = ApiMaturity.STABLE
     is_global: bool = False
     is_shared: bool = False  # shared across multiple clusters (shared by name)
+    description: Optional[str] = None
+
+    # Parsing meta data missing only when skip meta data is requested
+    parse_meta: Optional[ParseMetaData] = field(default=None, compare=False)
 
 
 @dataclass
@@ -191,6 +199,9 @@ class Event:
     description: Optional[str] = None
     api_maturity: ApiMaturity = ApiMaturity.STABLE
 
+    # Parsing meta data missing only when skip meta data is requested
+    parse_meta: Optional[ParseMetaData] = field(default=None, compare=False)
+
     @property
     def is_fabric_sensitive(self) -> bool:
         return EventQuality.FABRIC_SENSITIVE in self.qualities
@@ -203,6 +214,10 @@ class ConstantEntry:
     api_maturity: ApiMaturity = ApiMaturity.STABLE
     # If set, shows the specification name including spaces and special characters.
     specification_name: Optional[str] = None
+    description: Optional[str] = None
+
+    # Parsing meta data missing only when skip meta data is requested
+    parse_meta: Optional[ParseMetaData] = field(default=None, compare=False)
 
 
 @dataclass
@@ -213,6 +228,10 @@ class Enum:
     api_maturity: ApiMaturity = ApiMaturity.STABLE
     is_global: bool = False
     is_shared: bool = False  # shared across multiple clusters (shared by name)
+    description: Optional[str] = None
+
+    # Parsing meta data missing only when skip meta data is requested
+    parse_meta: Optional[ParseMetaData] = field(default=None, compare=False)
 
 
 @dataclass
@@ -223,6 +242,9 @@ class Bitmap:
     api_maturity: ApiMaturity = ApiMaturity.STABLE
     is_global: bool = False
     is_shared: bool = False  # shared across multiple clusters (shared by name)
+    description: Optional[str] = None
+
+    parse_meta: Optional[ParseMetaData] = field(default=None, compare=False)
 
 
 @dataclass

--- a/scripts/py_matter_idl/matter/idl/matter_idl_types.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_types.py
@@ -244,6 +244,7 @@ class Bitmap:
     is_shared: bool = False  # shared across multiple clusters (shared by name)
     description: Optional[str] = None
 
+    # Parsing meta data missing only when skip meta data is requested
     parse_meta: Optional[ParseMetaData] = field(default=None, compare=False)
 
 

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -128,6 +128,39 @@ class TestParser(unittest.TestCase):
 
             /** Documentation for MyCluster #2 */
             client cluster MyCluster2 = 0x322 {
+                /** Attribute comment */
+                attribute boolean value = 0;
+
+                /** Multi line
+                Enum comment */
+                enum SimpleEnum : enum8 {
+                    /** Enum field comment */
+                    test_enum_value = 1;
+                }
+
+                /** Multi line
+                Struct comment
+                */
+                struct TestStruct {
+                    /** Struct field comment */
+                    int8u returnValue = 0;
+                }
+
+                /** Multi line
+                Bitmap comment */
+                bitmap Bitmap16MaskMap : bitmap16 {
+                    /** Multi line
+                    Bitmap field comment */
+                    kMaskVal1 = 0x1;
+                }
+
+                /** Multi line
+                Event comment */
+                info event TestEvent = 1 {
+                    /** Event field comment */
+                    int8u returnValue = 0;
+                }
+
                 /* NOT a doc comment */
                 command WithoutArg(): DefaultSuccess = 123;
 
@@ -146,6 +179,16 @@ class TestParser(unittest.TestCase):
         self.assertIsNone(actual.clusters[1].commands[0].description)
         self.assertIdlEqual(
             actual.clusters[1].commands[1].description, "Some command doc comment")
+
+        self.assertIdlEqual(actual.clusters[1].attributes[0].definition.description, "Attribute comment")
+        self.assertIdlEqual(actual.clusters[1].enums[0].description, "Multi line\n                Enum comment")
+        self.assertIdlEqual(actual.clusters[1].enums[0].entries[0].description, "Enum field comment")
+        self.assertIdlEqual(actual.clusters[1].structs[0].description, "Multi line\n                Struct comment")
+        self.assertIdlEqual(actual.clusters[1].structs[0].fields[0].description, "Struct field comment")
+        self.assertIdlEqual(actual.clusters[1].bitmaps[0].description, "Multi line\n                Bitmap comment")
+        self.assertIdlEqual(actual.clusters[1].bitmaps[0].entries[0].description, "Multi line\n                    Bitmap field comment")
+        self.assertIdlEqual(actual.clusters[1].events[0].description, "Multi line\n                Event comment")
+        self.assertIdlEqual(actual.clusters[1].events[0].fields[0].description, "Event field comment")
 
     def test_sized_attribute(self):
         actual = parseText("""

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -180,15 +180,24 @@ class TestParser(unittest.TestCase):
         self.assertIdlEqual(
             actual.clusters[1].commands[1].description, "Some command doc comment")
 
-        self.assertIdlEqual(actual.clusters[1].attributes[0].definition.description, "Attribute comment")
-        self.assertIdlEqual(actual.clusters[1].enums[0].description, "Multi line\n                Enum comment")
-        self.assertIdlEqual(actual.clusters[1].enums[0].entries[0].description, "Enum field comment")
-        self.assertIdlEqual(actual.clusters[1].structs[0].description, "Multi line\n                Struct comment")
-        self.assertIdlEqual(actual.clusters[1].structs[0].fields[0].description, "Struct field comment")
-        self.assertIdlEqual(actual.clusters[1].bitmaps[0].description, "Multi line\n                Bitmap comment")
-        self.assertIdlEqual(actual.clusters[1].bitmaps[0].entries[0].description, "Multi line\n                    Bitmap field comment")
-        self.assertIdlEqual(actual.clusters[1].events[0].description, "Multi line\n                Event comment")
-        self.assertIdlEqual(actual.clusters[1].events[0].fields[0].description, "Event field comment")
+        self.assertIdlEqual(
+            actual.clusters[1].attributes[0].definition.description, "Attribute comment")
+        self.assertIdlEqual(
+            actual.clusters[1].enums[0].description, "Multi line\n                Enum comment")
+        self.assertIdlEqual(
+            actual.clusters[1].enums[0].entries[0].description, "Enum field comment")
+        self.assertIdlEqual(
+            actual.clusters[1].structs[0].description, "Multi line\n                Struct comment")
+        self.assertIdlEqual(
+            actual.clusters[1].structs[0].fields[0].description, "Struct field comment")
+        self.assertIdlEqual(
+            actual.clusters[1].bitmaps[0].description, "Multi line\n                Bitmap comment")
+        self.assertIdlEqual(actual.clusters[1].bitmaps[0].entries[0].description,
+                            "Multi line\n                    Bitmap field comment")
+        self.assertIdlEqual(
+            actual.clusters[1].events[0].description, "Multi line\n                Event comment")
+        self.assertIdlEqual(
+            actual.clusters[1].events[0].fields[0].description, "Event field comment")
 
     def test_sized_attribute(self):
         actual = parseText("""


### PR DESCRIPTION
#### Summary

Update ConstantEntry, Struct, Event, Enum, Bitmap, and Field types to store documentation. Also updated the matter idl parser to store documentation for these types when parse_meta=True.

#### Related issues

No related issues that I am aware of.

#### Testing

Updated unit tests in matter_idl_parser.py.