### PR TITLE
Add more apps to local.py and fix some bugs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -953,35 +953,35 @@ jobs:
             - name: Generate an argument environment file
               run: |
                   echo -n "" >/tmp/test_env.yaml
+                  # keep-sorted: start
+                  echo "AIR_PURIFIER_APP: objdir-clone/linux-x64-air-purifier-${BUILD_VARIANT}-tsan-clang-test-unified/chip-air-purifier-app" >> /tmp/test_env.yaml
                   echo "ALL_CLUSTERS_APP: objdir-clone/linux-x64-all-clusters-${BUILD_VARIANT}-tsan-clang-test/chip-all-clusters-app" >> /tmp/test_env.yaml
                   echo "ALL_DEVICES_APP: objdir-clone/linux-x64-all-devices-app-tsan-clang-test/all-devices-app" >> /tmp/test_env.yaml
                   echo "BRIDGE_APP: objdir-clone/linux-x64-bridge-${BUILD_VARIANT}-tsan-clang-test-unified/chip-bridge-app" >> /tmp/test_env.yaml
-                  echo "CHIP_LOCK_APP: objdir-clone/linux-x64-lock-${BUILD_VARIANT}-tsan-clang-test-unified/chip-lock-app" >> /tmp/test_env.yaml
                   echo "CAMERA_APP: objdir-clone/linux-x64-camera/chip-camera-app" >> /tmp/test_env.yaml
                   echo "CAMERA_CONTROLLER_APP: objdir-clone/linux-x64-camera-controller/chip-camera-controller" >> /tmp/test_env.yaml
-                  echo "ENERGY_MANAGEMENT_APP: objdir-clone/linux-x64-energy-management-${BUILD_VARIANT}-tsan-clang-test/chip-energy-management-app" >> /tmp/test_env.yaml
-                  echo "ENERGY_GATEWAY_APP: objdir-clone/linux-x64-energy-gateway-${BUILD_VARIANT}-tsan-clang-test/chip-energy-gateway-app" >> /tmp/test_env.yaml
-                  echo "LIT_ICD_APP: objdir-clone/linux-x64-lit-icd-${BUILD_VARIANT}-tsan-clang-test/lit-icd-app" >> /tmp/test_env.yaml
-                  echo "AIR_PURIFIER_APP: objdir-clone/linux-x64-air-purifier-${BUILD_VARIANT}-tsan-clang-test-unified/chip-air-purifier-app" >> /tmp/test_env.yaml
+                  echo "CHIP_LOCK_APP: objdir-clone/linux-x64-lock-${BUILD_VARIANT}-tsan-clang-test-unified/chip-lock-app" >> /tmp/test_env.yaml
                   echo "CHIP_MICROWAVE_OVEN_APP: objdir-clone/linux-x64-microwave-oven-${BUILD_VARIANT}-tsan-clang-test-unified/chip-microwave-oven-app" >> /tmp/test_env.yaml
                   echo "CHIP_RVC_APP: objdir-clone/linux-x64-rvc-${BUILD_VARIANT}-tsan-clang-test-unified/chip-rvc-app" >> /tmp/test_env.yaml
-                  echo "NETWORK_MANAGEMENT_APP: objdir-clone/linux-x64-network-manager-${BUILD_VARIANT}-tsan-clang-test/matter-network-manager-app" >> /tmp/test_env.yaml
+                  echo "CLOSURE_APP: objdir-clone/linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test-unified/closure-app" >> /tmp/test_env.yaml
+                  echo "ENERGY_GATEWAY_APP: objdir-clone/linux-x64-energy-gateway-${BUILD_VARIANT}-tsan-clang-test/chip-energy-gateway-app" >> /tmp/test_env.yaml
+                  echo "ENERGY_MANAGEMENT_APP: objdir-clone/linux-x64-energy-management-${BUILD_VARIANT}-tsan-clang-test/chip-energy-management-app" >> /tmp/test_env.yaml
                   echo "FABRIC_ADMIN_APP: objdir-clone/linux-x64-fabric-admin-rpc-${BUILD_VARIANT}-clang/fabric-admin" >> /tmp/test_env.yaml
                   echo "FABRIC_BRIDGE_APP: objdir-clone/linux-x64-fabric-bridge-rpc-${BUILD_VARIANT}-clang/fabric-bridge-app" >> /tmp/test_env.yaml
                   echo "FABRIC_SYNC_APP: objdir-clone/linux-x64-fabric-sync-${BUILD_VARIANT}-clang/fabric-sync" >> /tmp/test_env.yaml
+                  echo "JF_ADMIN_APP: objdir-clone/linux-x64-jf-admin-app/jfa-app" >> /tmp/test_env.yaml
+                  echo "JF_CONTROL_APP: objdir-clone/linux-x64-jf-control-app/jfc-app" >> /tmp/test_env.yaml
                   echo "LIGHTING_APP_NO_UNIQUE_ID: objdir-clone/linux-x64-light-data-model-no-unique-id-${BUILD_VARIANT}-clang/chip-lighting-app" >> /tmp/test_env.yaml
-                  echo "TERMS_AND_CONDITIONS_APP: objdir-clone/linux-x64-terms-and-conditions/chip-terms-and-conditions-app" >> /tmp/test_env.yaml
+                  echo "LIT_ICD_APP: objdir-clone/linux-x64-lit-icd-${BUILD_VARIANT}-tsan-clang-test/lit-icd-app" >> /tmp/test_env.yaml
+                  echo "NETWORK_MANAGEMENT_APP: objdir-clone/linux-x64-network-manager-${BUILD_VARIANT}-tsan-clang-test/matter-network-manager-app" >> /tmp/test_env.yaml
                   echo "OTA_PROVIDER_APP: objdir-clone/linux-x64-ota-provider-${BUILD_VARIANT}-tsan-clang-test/chip-ota-provider-app" >> /tmp/test_env.yaml
                   echo "OTA_REQUESTOR_APP: objdir-clone/linux-x64-ota-requestor-${BUILD_VARIANT}-tsan-clang-test/chip-ota-requestor-app" >> /tmp/test_env.yaml
-                  echo "TRACE_APP: out/trace_data/app-{SCRIPT_BASE_NAME}" >> /tmp/test_env.yaml
-                  echo "JF_CONTROL_APP: objdir-clone/linux-x64-jf-control-app/jfc-app" >> /tmp/test_env.yaml
-                  echo "JF_ADMIN_APP: objdir-clone/linux-x64-jf-admin-app/jfa-app" >> /tmp/test_env.yaml
-                  echo "CLOSURE_APP: objdir-clone/linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test-unified/closure-app" >> /tmp/test_env.yaml
-                  echo "WATER_LEAK_DETECTOR_APP: objdir-clone/linux-x64-water-leak-detector-${BUILD_VARIANT}-tsan-clang-test-unified/water-leak-detector-app" >> /tmp/test_env.yaml
                   echo "PUSH_AV_SERVER: src/tools/push_av_server/server.py" >> /tmp/test_env.yaml
-
-                  # SU OTA Images
                   echo "SU_OTA_REQUESTOR_V2: objdir-clone/chip-ota-requestor-app_v2.min.ota" >> /tmp/test_env.yaml
+                  echo "TERMS_AND_CONDITIONS_APP: objdir-clone/linux-x64-terms-and-conditions/chip-terms-and-conditions-app" >> /tmp/test_env.yaml
+                  echo "TRACE_APP: out/trace_data/app-{SCRIPT_BASE_NAME}" >> /tmp/test_env.yaml
+                  echo "WATER_LEAK_DETECTOR_APP: objdir-clone/linux-x64-water-leak-detector-${BUILD_VARIANT}-tsan-clang-test-unified/water-leak-detector-app" >> /tmp/test_env.yaml
+                  # keep-sorted: end
 
                   # Generic trace setups after applications
                   echo "TRACE_TEST_JSON: out/trace_data/test-{SCRIPT_BASE_NAME}" >> /tmp/test_env.yaml

--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -313,6 +313,14 @@ def _get_targets(coverage: Optional[bool]) -> list[ApplicationTarget]:
         )
     )
 
+    targets.append(ApplicationTarget(key="ALL_DEVICES_APP", target=f"{target_prefix}-all-devices-app", binary="all-devices-app"))
+
+    targets.append(ApplicationTarget(key="CAMERA_CONTROLLER_APP",
+                   target=f"{target_prefix}-camera-controller", binary="chip-camera-controller"))
+
+    targets.append(ApplicationTarget(key="WATER_LEAK_DETECTOR_APP",
+                   target=f"{target_prefix}-water-leak-detector-{suffix}", binary="water-leak-detector-app"))
+
     return targets
 
 
@@ -861,6 +869,18 @@ def python_tests(
             else:
                 run_path = as_runner(f"out/{target.target}/{target.binary}")
             f.write(f"{target.key}: {run_path}\n")
+
+        # PushAV is special
+        f.write("PUSH_AV_SERVER: src/tools/push_av_server/server.py\n")
+
+        # refuse OTA requestor v2 for now
+        # This would be built by a shell script like this:
+        #
+        #    ./scripts/run_in_build_env.sh "./scripts/build/build_ota_images.sh --out-prefix out/su_ota_images_min --max-range 2
+        #
+        # Which is not currently integrated in our build logic (we always use build_examples.py)
+        f.write("SU_OTA_REQUESTOR_V2: /usr/bin/false\n")
+
         f.write("TRACE_APP: out/trace_data/app-{SCRIPT_BASE_NAME}\n")
         f.write("TRACE_TEST_JSON: out/trace_data/test-{SCRIPT_BASE_NAME}\n")
         f.write("TRACE_TEST_PERFETTO: out/trace_data/test-{SCRIPT_BASE_NAME}\n")

--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -873,7 +873,7 @@ def python_tests(
         # PushAV is special
         f.write("PUSH_AV_SERVER: src/tools/push_av_server/server.py\n")
 
-        # refuse OTA requestor v2 for now
+        # Disable OTA requestor v2 for now
         # This would be built by a shell script like this:
         #
         #    ./scripts/run_in_build_env.sh "./scripts/build/build_ota_images.sh --out-prefix out/su_ota_images_min --max-range 2"

--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -876,7 +876,7 @@ def python_tests(
         # refuse OTA requestor v2 for now
         # This would be built by a shell script like this:
         #
-        #    ./scripts/run_in_build_env.sh "./scripts/build/build_ota_images.sh --out-prefix out/su_ota_images_min --max-range 2
+        #    ./scripts/run_in_build_env.sh "./scripts/build/build_ota_images.sh --out-prefix out/su_ota_images_min --max-range 2"
         #
         # Which is not currently integrated in our build logic (we always use build_examples.py)
         f.write("SU_OTA_REQUESTOR_V2: /usr/bin/false\n")

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
@@ -117,7 +117,7 @@ class Subprocess(threading.Thread):
             if not self.event_started.is_set():
                 self.event_started.set()
 
-            LOGGER.exception("Failed to execute suprocess `%s`", self.program, exc_info=sys.exc_info())
+            LOGGER.exception("Failed to execute subprocess `%s`", self.program, exc_info=sys.exc_info())
         finally:
             # Wait for the process to finish.
             if self.p is not None:

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
@@ -117,7 +117,7 @@ class Subprocess(threading.Thread):
             if not self.event_started.is_set():
                 self.event_started.set()
 
-            LOGGER.exception("Failed to execute subprocess `%s`", self.program, exc_info=sys.exc_info())
+            LOGGER.exception("Failed to execute subprocess `%s`", self.program)
         finally:
             # Wait for the process to finish.
             if self.p is not None:


### PR DESCRIPTION
#### Summary

We had a few issues in local.py:
  - not all applications were built. This makes a lot of tests fail
  - in particular, BasicComposition was hanging forever due to an exception thrown because ALL_DEVICES_APP path was not found

Changes:
  - keep the list of apps sorted in tests.yaml (easier to view)
  - add logic to not allow infinite hang on subprocess start
  - add local.py extra application settings (all except OTA tests)

#### Testing

Local run of `./scripts/tests/local.py python-tests --fail-log-dir out/faillogs --test-filter 'BasicCom'`

Observed:
  - with bad config the test stops hanging
  - with updated local.py build this test passes