### PR TITLE
Update README for closure-app path correction

### DIFF
--- a/examples/closure-app/silabs/README.md
+++ b/examples/closure-app/silabs/README.md
@@ -177,7 +177,7 @@ passed to the build scripts.
 
 show_qr_code
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/closure-app/silabs ./out/closure-app BRD4164A "show_qr_code=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/closure-app/silabs ./out/closure-app BRD4338A "show_qr_code=false"
 
 ### KVS maximum entry count
 

--- a/examples/closure-app/silabs/README.md
+++ b/examples/closure-app/silabs/README.md
@@ -177,7 +177,7 @@ passed to the build scripts.
 
 show_qr_code
 
-    $ ./scripts/examples/gn_silabs_example.sh ./examples/window-app/silabs ./out/window-app BRD4164A "show_qr_code=false"
+    $ ./scripts/examples/gn_silabs_example.sh ./examples/closure-app/silabs ./out/closure-app BRD4164A "show_qr_code=false"
 
 ### KVS maximum entry count
 


### PR DESCRIPTION
#### Summary

- Update README for closure-app path correction referring to `window-app`. 
- Replace the wrong `BRD4164A` board in a command to be consistant

#### Related issues

N/A

### Testing

Render Markdown page

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
