### PR TITLE
[Push AV] Fix issue in Motion Zone based clip recording

### DIFF
--- a/examples/camera-app/linux/include/pushav-clip-recorder.h
+++ b/examples/camera-app/linux/include/pushav-clip-recorder.h
@@ -76,22 +76,22 @@ public:
      */
     struct ClipInfoStruct
     {
-        bool mHasVideo;                                       ///< Video recording enabled flag
-        bool mHasAudio;                                       ///< Audio recording enabled flag
-        uint64_t mSessionNumber;                              ///< Session number for unique clip identification
-        uint8_t mSessionGroup;                                ///< Session group for grouping multiple transports
-        uint32_t mMaxClipDurationS;                           ///< Maximum clip duration in seconds
-        uint16_t mInitialDurationS;                           ///< Initial clip duration in seconds
-        uint16_t mAugmentationDurationS;                      ///< Duration increment on motion detect
-        uint16_t mChunkDurationMs;                            ///< Chunk duration  milliseconds
-        uint16_t mSegmentDurationMs;                          ///< Segment duration in milliseconds
-        uint16_t mBlindDurationS;                             ///< Duration without recording after motion stop
-        uint16_t mPreRollLengthMs;                            ///< Pre-roll length in milliseconds
-        uint16_t mElapsedTimeS;                               ///< Elapsed time since recording start in seconds
-        std::string mOutputPath;                              ///< Base output directory path
-        std::string mTrackName;                               ///< Track name for segmented files
-        std::string mUrl;                                     ///< URL for uploading clips;
-        int mTriggerType;                                     ///< Recording trigger type
+        bool mHasVideo;                                        ///< Video recording enabled flag
+        bool mHasAudio;                                        ///< Audio recording enabled flag
+        uint64_t mSessionNumber;                               ///< Session number for unique clip identification
+        uint8_t mSessionGroup;                                 ///< Session group for grouping multiple transports
+        uint32_t mMaxClipDurationS;                            ///< Maximum clip duration in seconds
+        uint16_t mInitialDurationS;                            ///< Initial clip duration in seconds
+        uint16_t mAugmentationDurationS;                       ///< Duration increment on motion detect
+        uint16_t mChunkDurationMs;                             ///< Chunk duration  milliseconds
+        uint16_t mSegmentDurationMs;                           ///< Segment duration in milliseconds
+        uint16_t mBlindDurationS;                              ///< Duration without recording after motion stop
+        uint16_t mPreRollLengthMs;                             ///< Pre-roll length in milliseconds
+        uint16_t mElapsedTimeS;                                ///< Elapsed time since recording start in seconds
+        std::string mOutputPath;                               ///< Base output directory path
+        std::string mTrackName;                                ///< Track name for segmented files
+        std::string mUrl;                                      ///< URL for uploading clips;
+        int mTriggerType;                                      ///< Recording trigger type
         std::chrono::steady_clock::time_point activationTimeS; ///< Time when the recording started
     };
 

--- a/examples/camera-app/linux/include/pushav-clip-recorder.h
+++ b/examples/camera-app/linux/include/pushav-clip-recorder.h
@@ -92,7 +92,7 @@ public:
         std::string mTrackName;                                ///< Track name for segmented files
         std::string mUrl;                                      ///< URL for uploading clips;
         int mTriggerType;                                      ///< Recording trigger type
-        std::chrono::steady_clock::time_point activationTimeS; ///< Time when the recording started
+        std::chrono::steady_clock::time_point mActivationTime; ///< Time when the recording started
     };
 
     /**

--- a/examples/camera-app/linux/include/pushav-clip-recorder.h
+++ b/examples/camera-app/linux/include/pushav-clip-recorder.h
@@ -92,7 +92,7 @@ public:
         std::string mTrackName;                               ///< Track name for segmented files
         std::string mUrl;                                     ///< URL for uploading clips;
         int mTriggerType;                                     ///< Recording trigger type
-        std::chrono::steady_clock::time_point activationTime; ///< Time when the recording started
+        std::chrono::steady_clock::time_point activationTimeS; ///< Time when the recording started
     };
 
     /**

--- a/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
+++ b/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
@@ -83,7 +83,7 @@ public:
     void SetTransportStatus(chip::app::Clusters::PushAvStreamTransport::TransportStatusEnum status);
 
     void TriggerTransport(chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum activationReason,
-                          int zoneId = kInvalidZoneId, int sensitivity = kDefaultSensitivity);
+                          int zoneId = kInvalidZoneId, int sensitivity = kDefaultSensitivity, bool isZoneBasedTrigger = false);
     // Get Transport status
     bool GetTransportStatus()
     {
@@ -169,4 +169,5 @@ private:
     chip::app::Clusters::PushAvStreamTransport::TransportTriggerTypeEnum mTransportTriggerType;
     uint16_t mConnectionID;
     uint32_t mCurrentlyUsedBandwidthbps = 0;
+    bool mActivationTimeSetByManualTrigger = false;
 };

--- a/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
+++ b/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
@@ -170,6 +170,5 @@ private:
     uint16_t mConnectionID;
     uint32_t mCurrentlyUsedBandwidthbps    = 0;
     bool mActivationTimeSetByManualTrigger = false;
-    bool mRecordingTriggerByManual         = false;
     bool mIsZoneBasedTrigger               = false;
 };

--- a/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
+++ b/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
@@ -170,4 +170,6 @@ private:
     uint16_t mConnectionID;
     uint32_t mCurrentlyUsedBandwidthbps = 0;
     bool mActivationTimeSetByManualTrigger = false;
+    bool mRecordingTriggerByManual = false;
+    bool mIsZoneBasedTrigger = false;
 };

--- a/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
+++ b/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
@@ -168,8 +168,8 @@ private:
     chip::app::Clusters::PushAvStreamTransport::TransportStatusEnum mTransportStatus;
     chip::app::Clusters::PushAvStreamTransport::TransportTriggerTypeEnum mTransportTriggerType;
     uint16_t mConnectionID;
-    uint32_t mCurrentlyUsedBandwidthbps = 0;
+    uint32_t mCurrentlyUsedBandwidthbps    = 0;
     bool mActivationTimeSetByManualTrigger = false;
-    bool mRecordingTriggerByManual = false;
-    bool mIsZoneBasedTrigger = false;
+    bool mRecordingTriggerByManual         = false;
+    bool mIsZoneBasedTrigger               = false;
 };

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -602,7 +602,7 @@ void PushAvStreamTransportManager::HandleZoneTrigger(uint16_t zoneId)
 
         if (mTransportOptionsMap[connectionId].triggerOptions.triggerType == TransportTriggerTypeEnum::kMotion)
         {
-            pavst.second->TriggerTransport(TriggerActivationReasonEnum::kAutomation, zoneId, 10);
+            pavst.second->TriggerTransport(TriggerActivationReasonEnum::kAutomation, zoneId, 10, true);
         }
     }
 }

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -384,8 +384,8 @@ void PushAVTransport::TriggerTransport(TriggerActivationReasonEnum activationRea
             mUploader = std::make_unique<PushAVUploader>();
             mUploader->Start();
             InitializeRecorder();
-            mClipInfo.activationTime            = std::chrono::steady_clock::now();
-            mRecorder->mClipInfo.activationTime = mClipInfo.activationTime;
+            mClipInfo.activationTimeS            = std::chrono::steady_clock::now();
+            mRecorder->mClipInfo.activationTimeS = mClipInfo.activationTimeS;
             return;
         }
         bool zoneFound = false; // Zone found flag
@@ -565,9 +565,9 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
         // Clear activationTime for manual triggers when setting status to inactive
         if (mActivationTimeSetByManualTrigger)
         {
-            mClipInfo.activationTime = std::chrono::steady_clock::time_point();
+            mClipInfo.activationTimeS = std::chrono::steady_clock::time_point();
             mActivationTimeSetByManualTrigger = false;
-            ChipLogProgress(Camera, "PushAVTransport, cleared activationTime for manual trigger");
+            ChipLogProgress(Camera, "PushAVTransport, cleared activationTimeS for manual trigger");
         }
         mRecorder.reset();
         ChipLogProgress(Camera, "Recorder destruction done");

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -30,11 +30,11 @@ PushAVTransport::PushAVTransport(const TransportOptionsStruct & transportOptions
     mVideoStreamParams(videoStreamParams)
 {
     ConfigureRecorderSettings(transportOptions, audioStreamParams, videoStreamParams);
-    mConnectionID    = connectionID;
-    mTransportStatus = TransportStatusEnum::kInactive;
+    mConnectionID                     = connectionID;
+    mTransportStatus                  = TransportStatusEnum::kInactive;
     mActivationTimeSetByManualTrigger = false;
-    mRecordingTriggerByManual = false;
-    mIsZoneBasedTrigger = false;
+    mRecordingTriggerByManual         = false;
+    mIsZoneBasedTrigger               = false;
 
     auto now               = std::chrono::system_clock::now();
     std::time_t time_t_now = std::chrono::system_clock::to_time_t(now);
@@ -311,7 +311,8 @@ bool PushAVTransport::HandleTriggerDetected()
     int64_t elapsed = 0;
     auto now        = std::chrono::steady_clock::now();
 
-    if (!mRecordingTriggerByManual && mIsZoneBasedTrigger && mTransportTriggerType != TransportTriggerTypeEnum::kCommand && InBlindPeriod(mBlindStartTime, mClipInfo.mBlindDurationS))
+    if (!mRecordingTriggerByManual && mIsZoneBasedTrigger && mTransportTriggerType != TransportTriggerTypeEnum::kCommand &&
+        InBlindPeriod(mBlindStartTime, mClipInfo.mBlindDurationS))
     {
         return false;
     }
@@ -327,9 +328,9 @@ bool PushAVTransport::HandleTriggerDetected()
     {
         // Start new recording
         ChipLogError(Camera, "PushAVTransport starting new recording");
-        mHasAugmented                       = false;
-        mClipInfo.activationTimeS           = std::chrono::steady_clock::now();
-        mRecorder->mClipInfo.activationTimeS= mClipInfo.activationTimeS;
+        mHasAugmented                        = false;
+        mClipInfo.activationTimeS            = std::chrono::steady_clock::now();
+        mRecorder->mClipInfo.activationTimeS = mClipInfo.activationTimeS;
         mRecorder->mClipInfo.mSessionNumber =
             mPushAvStreamTransportManager->OnTriggerActivated(mFabricIndex, mClipInfo.mSessionGroup, mConnectionID);
 
@@ -362,11 +363,13 @@ bool PushAVTransport::HandleTriggerDetected()
             mStreaming                             = true;
         }
     }
-    mBlindStartTime = mRecorder->mClipInfo.activationTimeS + std::chrono::seconds(mRecorder->mClipInfo.mInitialDurationS) + std::chrono::seconds((mRecorder->mClipInfo.mPreRollLengthMs / 1000));
+    mBlindStartTime = mRecorder->mClipInfo.activationTimeS + std::chrono::seconds(mRecorder->mClipInfo.mInitialDurationS) +
+        std::chrono::seconds((mRecorder->mClipInfo.mPreRollLengthMs / 1000));
     return true;
 }
 
-void PushAVTransport::TriggerTransport(TriggerActivationReasonEnum activationReason, int zoneId, int sensitivity, bool isZoneBasedTrigger)
+void PushAVTransport::TriggerTransport(TriggerActivationReasonEnum activationReason, int zoneId, int sensitivity,
+                                       bool isZoneBasedTrigger)
 {
     ChipLogProgress(Camera, "PushAVTransport trigger transport, activation reason: [%u], ZoneId: [%d], Sensitivity: [%d]",
                     (uint16_t) activationReason, zoneId, sensitivity);
@@ -390,7 +393,8 @@ void PushAVTransport::TriggerTransport(TriggerActivationReasonEnum activationRea
     }
     else if (mTransportTriggerType == TransportTriggerTypeEnum::kMotion)
     {
-        if (mTransportStatus == TransportStatusEnum::kInactive) {
+        if (mTransportStatus == TransportStatusEnum::kInactive)
+        {
             ChipLogProgress(Camera, "PushAVTransport Inactive transport status received. No action needed");
             mUploader = std::make_unique<PushAVUploader>();
             mUploader->Start();
@@ -546,7 +550,8 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
                     mRecorder->mClipInfo.mElapsedTimeS = static_cast<uint16_t>(elapsedSeconds);
                     ChipLogProgress(Camera, "Active trigger is present. Recording will start for [%d seconds]",
                                     mRecorder->mClipInfo.mInitialDurationS);
-                    if (HandleTriggerDetected()) {
+                    if (HandleTriggerDetected())
+                    {
                         if (mPushAvStreamTransportServer != nullptr)
                         {
                             mPushAvStreamTransportServer->NotifyTransportStarted(
@@ -558,10 +563,13 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
                             ChipLogError(Camera, "PushAvStreamTransportServer is null for connection %u", mConnectionID);
                         }
                     }
-                    else {
-                         ChipLogError(Camera,
-                         "PushAVTransport command/motion transport trigger received but ignored due to blind period. Clip duration "
-                         "[%d seconds]",mRecorder->mClipInfo.mInitialDurationS);
+                    else
+                    {
+                        ChipLogError(Camera,
+                                     "PushAVTransport command/motion transport trigger received but ignored due to blind period. "
+                                     "Clip duration "
+                                     "[%d seconds]",
+                                     mRecorder->mClipInfo.mInitialDurationS);
                     }
                 }
             }
@@ -576,7 +584,7 @@ void PushAVTransport::SetTransportStatus(TransportStatusEnum status)
         // Clear activationTime for manual triggers when setting status to inactive
         if (mActivationTimeSetByManualTrigger)
         {
-            mClipInfo.activationTimeS = std::chrono::steady_clock::time_point();
+            mClipInfo.activationTimeS         = std::chrono::steady_clock::time_point();
             mActivationTimeSetByManualTrigger = false;
             ChipLogProgress(Camera, "PushAVTransport, cleared activationTimeS for manual trigger");
         }

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -33,7 +33,6 @@ PushAVTransport::PushAVTransport(const TransportOptionsStruct & transportOptions
     mConnectionID                     = connectionID;
     mTransportStatus                  = TransportStatusEnum::kInactive;
     mActivationTimeSetByManualTrigger = false;
-    mRecordingTriggerByManual         = false;
     mIsZoneBasedTrigger               = false;
 
     auto now               = std::chrono::system_clock::now();
@@ -311,7 +310,7 @@ bool PushAVTransport::HandleTriggerDetected()
     int64_t elapsed = 0;
     auto now        = std::chrono::steady_clock::now();
 
-    if (!mRecordingTriggerByManual && mIsZoneBasedTrigger && mTransportTriggerType != TransportTriggerTypeEnum::kCommand &&
+    if (mIsZoneBasedTrigger && mTransportTriggerType != TransportTriggerTypeEnum::kCommand &&
         InBlindPeriod(mBlindStartTime, mClipInfo.mBlindDurationS))
     {
         return false;
@@ -336,14 +335,6 @@ bool PushAVTransport::HandleTriggerDetected()
 
         mRecorder->Start();
         mStreaming = true;
-        if (mIsZoneBasedTrigger)
-        {
-            mRecordingTriggerByManual = false;
-        }
-        else
-        {
-            mRecordingTriggerByManual = true;
-        }
     }
     else
     {


### PR DESCRIPTION
#### Summary
Follow issues are addressed in this PR:

1. Camera app crash on a reactivated transport
2. Clip record doesn't start when the transport becomes active, after motion zone trigger occurs
```
Example:
(Motion Trigger Type) Transport Status Active (t = -1) -> Motion event trigger (duration 20 sec) t=0 -> Transport Inactive at t = 5 sec -> Transport Active at t = 10 -> For second time when status change to active, clip recording not started.
```
3. Ignore blind period for Manual trigger type

#### Related issues

Fixes #41800

#### Testing

```
#Build and run camera application
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debu/chip-camera-app

#Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate
```