### PR TITLE
[NXP] Removing APP_BT_DEVICE_NAME flag as it can be configured with a dedicated KCONFIG when application is built with cmake

### DIFF
--- a/examples/all-clusters-app/nxp/common/main/AppTask.cpp
+++ b/examples/all-clusters-app/nxp/common/main/AppTask.cpp
@@ -40,9 +40,6 @@ void AllClustersApp::AppTask::PostInitMatterStack()
 
 void AllClustersApp::AppTask::PostInitMatterServerInstance()
 {
-#ifdef APP_BT_DEVICE_NAME
-    chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(APP_BT_DEVICE_NAME);
-#endif
     // Disable last fixed endpoint, which is used as a placeholder for all of the
     // supported clusters so that ZAP will generated the requisite code.
     emberAfEndpointEnableDisable(emberAfEndpointFromIndex(static_cast<uint16_t>(emberAfFixedEndpointCount() - 1)), false);

--- a/examples/thermostat/nxp/common/main/AppTask.cpp
+++ b/examples/thermostat/nxp/common/main/AppTask.cpp
@@ -38,9 +38,6 @@ void ThermostatApp::AppTask::PreInitMatterStack()
 void ThermostatApp::AppTask::PostInitMatterStack()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-#ifdef APP_BT_DEVICE_NAME
-    chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(APP_BT_DEVICE_NAME);
-#endif
     /* BLEApplicationManager implemented per platform or left blank */
     chip::NXP::App::BleAppMgr().Init();
 #endif

--- a/examples/thermostat/nxp/rt/rw61x/BUILD.gn
+++ b/examples/thermostat/nxp/rt/rw61x/BUILD.gn
@@ -154,7 +154,6 @@ rt_executable("thermostat") {
   ]
 
   if (chip_enable_ble) {
-    defines += [ "APP_BT_DEVICE_NAME=\"NXP-ThermostatApp\"" ]
     include_dirs += [ "${common_example_dir}/app_ble/include" ]
     if (ble_adv_data_custom) {
       # to customize BLE advertising data


### PR DESCRIPTION

#### Summary

The flag APP_BT_DEVICE_NAME  has been removed to prevent confusion. When building the application with CMake, it is recommended to use the CONFIG_BT_DEVICE_NAME flag. For application still built with GN a call to ConnectivityMgr().SetBLEDeviceName could be added in application layer.

#### Testing

No specific tests were performed as the change is minimal.

