### PR TITLE
Make Fail Safe Expiry Timeout that is triggered post PASE Completion a non-configurable constant

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -43,9 +43,9 @@ namespace {
 // As per specifications (Section 13.3), Nodes SHALL exit commissioning mode after 20 failed commission attempts.
 constexpr uint8_t kMaxFailedCommissioningAttempts = 20;
 
-// As per specifications (5.5. Commissioning Flows), Upon completion of PASE session establishment, the Commissionee SHALL
+// As per specifications (Section 5.5: Commissioning Flows), Upon completion of PASE session establishment, the Commissionee SHALL
 // autonomously arm the Fail-safe timer for a timeout of 60 seconds.
-constexpr uint8_t kFailSafeTimeoutPostPaseCompletion = 60;
+constexpr Seconds16 kFailSafeTimeoutPostPaseCompletion(60);
 
 void HandleSessionEstablishmentTimeout(chip::System::Layer * aSystemLayer, void * aAppState)
 {
@@ -226,7 +226,7 @@ void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & sess
     }
     else
     {
-        err = failSafeContext.ArmFailSafe(kUndefinedFabricIndex, System::Clock::Seconds16(kFailSafeTimeoutPostPaseCompletion));
+        err = failSafeContext.ArmFailSafe(kUndefinedFabricIndex, kFailSafeTimeoutPostPaseCompletion);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "Error arming failsafe on PASE session establishment completion");

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -43,6 +43,10 @@ namespace {
 // As per specifications (Section 13.3), Nodes SHALL exit commissioning mode after 20 failed commission attempts.
 constexpr uint8_t kMaxFailedCommissioningAttempts = 20;
 
+// As per specifications (5.5. Commissioning Flows), Upon completion of PASE session establishment, the Commissionee SHALL
+// autonomously arm the Fail-safe timer for a timeout of 60 seconds.
+constexpr uint8_t kFailSafeTimeoutPostPaseCompletion = 60;
+
 void HandleSessionEstablishmentTimeout(chip::System::Layer * aSystemLayer, void * aAppState)
 {
     chip::CommissioningWindowManager * commissionMgr = static_cast<chip::CommissioningWindowManager *>(aAppState);
@@ -222,8 +226,7 @@ void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & sess
     }
     else
     {
-        err = failSafeContext.ArmFailSafe(kUndefinedFabricIndex,
-                                          System::Clock::Seconds16(CHIP_DEVICE_CONFIG_FAILSAFE_EXPIRY_LENGTH_SEC));
+        err = failSafeContext.ArmFailSafe(kUndefinedFabricIndex, System::Clock::Seconds16(kFailSafeTimeoutPostPaseCompletion));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "Error arming failsafe on PASE session establishment completion");


### PR DESCRIPTION
#### Summary

- After PASE Session Establishment is completed, the Spec mandates that we arm the Fail Safe with 60 seconds.
- However, in the spec, this is a constant and is not configurable (5.5. Commissioning Flows):

>Upon completion of PASE session establishment, the Commissionee SHALL autonomously arm the Fail-safe timer for a timeout of 60 seconds.

-  However, the macro `CHIP_DEVICE_CONFIG_FAILSAFE_EXPIRY_LENGTH_SEC` was used for that timeout, which is not correct. Since that is used for the  configurable `ExpiryLengthSeconds` within the `ArmFailSafe` Command in the General Commissioning Cluster; which is different.


#### Testing

- Unit and Integration Tests of CI should suffice