### PR TITLE
[Documentation] Add missing Debian/Ubuntu package requirement.

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -94,8 +94,8 @@ satisfied with the following command:
 ```
 sudo apt-get install git gcc g++ pkg-config cmake libssl-dev libdbus-1-dev \
      libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev \
-     python3-pip unzip libgirepository1.0-dev libcairo2-dev libreadline-dev \
-     default-jre
+     python3-pip unzip libgirepository1.0-dev libglib2.0-dev-bin
+     libcairo2-dev libreadline-dev default-jre
 ```
 
 #### NFC builds


### PR DESCRIPTION
#### Summary

'libglib2.0-dev-bin' is required as a Debian / Ubuntu package dependency necessary to build the Matter on Ubuntu 20.04 "Focal Fossa" and later. This change explicitly enumerates it.

#### Related issues

Fixes: #42433 

#### Testing

Validated that a clean Ubuntu 20.04 with this package added can build a Linux standalone configuration of Matter.