### PR TITLE
[Documentation] Initial revision of markdown glossary.

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -826,6 +826,7 @@ WARN_LOGFILE           =
 INPUT                  = README.md \
                          CODE_OF_CONDUCT.md \
                          CONTRIBUTING.md \
+                         docs/GLOSSARY.md \
                          docs/README.md \
                          docs/guides/BUILDING.md \
                          docs/VSCODE_DEVELOPMENT.md \

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,66 @@
+## Matter Glossary
+
+This defines acronyms and terminology frequently mentioned and used throughout
+the Matter project repository that are not otherwise well defined before their
+use and introduction absent the Matter specification.
+
+**BCM** :Basic Commissioning Method
+
+**Check-In Protocol** :A specific protocol used by a Long Interval Time (LIT)
+Intermittently Connected Device (ICD) to notify the client device that they are
+temporarily available for communication.
+
+**CIP** :Check-In Protocol
+
+**ECM** :Enhanced Commissioning Method
+
+**Electric Vehicle Supply Equipment** :The hardware and software that safely
+delivers electricity from the grid to an electric vehicle's battery, essentially
+the "charging station" with its connectors, cables, and communication systems
+that manage power flow and ensure safety during the charging process.
+
+**EVSE** :Electric Vehicle Supply Equipment
+
+**ICD** :Intermittently Connected Device
+
+**Intermittently Connected Device** :A device that enters a low-power sleep mode
+for periods of time to conserve battery life, and thus is not always reachable
+on the network.
+
+**LIT** :Long Interval Time
+
+**Long Interval Time** :A configuration for an Intermittently Connected Device
+(ICD) where the device sleeps for much longer intervals (that is, minutes or
+even hours).
+
+**MEI** :Manufacturer Extensible Identifier
+
+**PAF** :Public Action Frame
+
+**PCC** :Pump Configuration and Control
+
+**PDC** :Per-device Credentials
+
+**Public Action Frames** :Wi-Fi Public Action Frames (PAFs) are IEEE 802.11
+management frames (Category 4) used for unencrypted, public communication
+between stations (STAs) and Access Points (APs) without requiring prior
+association.
+
+**RVC** :Robotic Vacuum Cleaner
+
+**Short Interval Time** :A configuration for an Intermittently Connected Device
+(ICD) where the device's polling interval is relatively short (that is, several
+seconds).
+
+**SIT** :Short Interval Time
+
+**SMCO** :Smoke and Carbon Monoxide
+
+**TCC** :Temperature-controlled Cabinet
+
+**UAT** :User Active Mode Trigger
+
+**User Active Mode Trigger** :A feature used by an Intermittently Connected
+Device (ICD) that allows a user interaction (like pressing a button on a device)
+to immediately switch the ICD from Idle mode to Active mode, making it instantly
+responsive for a short period of time.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 :caption: Contents
 :hidden:
 
+GLOSSARY
 PROJECT_FLOW
 VSCODE_DEVELOPMENT
 contributing/index


### PR DESCRIPTION
#### Summary

There are a number of acronyms and terms that a product or platform integrator new to Matter is likely to encounter that are difficult to determine the meaning of without access to the specification.

While the specification is available, it should not be strictly necessary to work effectively with the Matter project repository source code.

This adds an initial mark down glossary with some acronyms frequently encountered in the Matter repository for which a `git grep -i` does not easily and quickly reveal an answer to: "What does \<_term_\> mean?" or "What is \<_term_\>?".

#### Related issues

Fixes: #42357 

#### Testing

None; documentation-only.