### PR TITLE
[mock-server] Add optional HTTP mode for reverse tunnel scenarios

### DIFF
--- a/integrations/mock_server/src/server.py
+++ b/integrations/mock_server/src/server.py
@@ -24,20 +24,28 @@ from route_configuration import Configuration, load_configurations
 log = logging.getLogger(__name__)
 
 
-def run_server(port: int, config_path: Path, routing_config_dir: Path, cert_path: Path, key_path: Path) -> None:
+def run_server(
+    port: int,
+    config_path: Path,
+    routing_config_dir: Path,
+    cert_path: Path | None,
+    key_path: Path | None,
+    use_https: bool = True
+) -> None:
     """
-    Starts a secure HTTPS server with mock endpoints defined by configuration files.
+    Starts an HTTP or HTTPS server with mock endpoints defined by configuration files.
 
-    Initializes and runs a threaded HTTPS server that handles requests according to
-    configured routes. The server uses TLS for secure communication and supports
-    multiple concurrent connections.
+    Initializes and runs a threaded server that handles requests according to
+    configured routes. The server can use TLS for secure communication (HTTPS)
+    or run in plain HTTP mode for reverse tunnel scenarios.
 
     Args:
         port (int): Port number on which the server will listen
         config_path (Path): Path to the main configuration file
         routing_config_dir (Path): Directory containing additional routing configuration files
-        cert_path (Path): Path to the SSL/TLS certificate file
-        key_path (Path): Path to the SSL/TLS private key file
+        cert_path (Path | None): Path to the SSL/TLS certificate file (required for HTTPS)
+        key_path (Path | None): Path to the SSL/TLS private key file (required for HTTPS)
+        use_https (bool): Whether to use HTTPS (True) or HTTP (False). Defaults to True.
 
     Returns:
         None
@@ -49,12 +57,24 @@ def run_server(port: int, config_path: Path, routing_config_dir: Path, cert_path
         KeyboardInterrupt: When the server is stopped using Ctrl+C
 
     Example:
+        # HTTPS mode
         run_server(
             port=8443,
             config_path=Path("config/main.json"),
             routing_config_dir=Path("config/routes"),
             cert_path=Path("certs/server.crt"),
-            key_path=Path("certs/server.key")
+            key_path=Path("certs/server.key"),
+            use_https=True
+        )
+
+        # HTTP mode (for reverse tunnel)
+        run_server(
+            port=8080,
+            config_path=Path("config/main.json"),
+            routing_config_dir=Path("config/routes"),
+            cert_path=None,
+            key_path=None,
+            use_https=False
         )
 
     Note:
@@ -62,8 +82,7 @@ def run_server(port: int, config_path: Path, routing_config_dir: Path, cert_path
         - Logs are written to stdout with DEBUG level
         - Server binds to all available network interfaces ("")
         - Uses ThreadingHTTPServer for concurrent request handling
-        - TLS configuration uses server's default security settings
-        - All endpoints are HTTPS-only
+        - HTTP mode is useful for Android reverse tunnel access via adb
     """
 
     logging.basicConfig(level=logging.DEBUG, format="[%(levelname)s] %(message)s")
@@ -74,24 +93,35 @@ def run_server(port: int, config_path: Path, routing_config_dir: Path, cert_path
     if not routing_config_dir.is_dir():
         raise ValueError(f"'{routing_config_dir}' is not a directory")
 
-    if not cert_path.is_file():
-        raise ValueError(f"'{cert_path}' is not a file")
+    if use_https:
+        if cert_path is None or not cert_path.is_file():
+            raise ValueError(f"'{cert_path}' is not a file")
 
-    if not key_path.is_file():
-        raise ValueError(f"'{key_path}' is not a file")
+        if key_path is None or not key_path.is_file():
+            raise ValueError(f"'{key_path}' is not a file")
 
     config: Configuration = load_configurations(config_path, routing_config_dir)
     server_address: socketserver._AfInetAddress = ("", port)
-    context: ssl.SSLContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-    context.load_cert_chain(certfile=cert_path, keyfile=key_path)
 
     theMockServerHandler = createMockServerHandler(config)
     httpd = http.server.ThreadingHTTPServer(server_address, theMockServerHandler)
 
     log.info("Server starting on port %s", port)
-    with context.wrap_socket(httpd.socket, server_side=True) as httpd.socket:
-        log.info("Server started on port %s", port)
-        log.info("HTTPS enabled with cert: %s and key: %s", cert_path, key_path)
+
+    if use_https:
+        context: ssl.SSLContext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(certfile=cert_path, keyfile=key_path)
+        with context.wrap_socket(httpd.socket, server_side=True) as httpd.socket:
+            log.info("Server started on port %s (HTTPS)", port)
+            log.info("HTTPS enabled with cert: %s and key: %s", cert_path, key_path)
+            try:
+                httpd.serve_forever()
+            except KeyboardInterrupt:
+                log.info("Server is shutting down due to keyboard interrupt.")
+                httpd.server_close()
+    else:
+        log.info("Server started on port %s (HTTP)", port)
+        log.warning("Running in HTTP mode - no TLS encryption")
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:


### PR DESCRIPTION
#### Summary

Added optional HTTP mode to the mock server to support reverse tunnel scenarios, particularly for Android testing via adb port forwarding. The mock server previously 
only supported HTTPS, which creates complications when TLS termination occurs at a reverse proxy or when using adb reverse tunneling.

Changes:
• Added --http flag to disable TLS and run in plain HTTP mode
• Updated server.py to handle both HTTP and HTTPS modes
• Enhanced documentation with HTTP mode usage examples
• Maintained full backward compatibility with existing HTTPS-only usage

This enables testing scenarios where TLS is handled upstream or when direct HTTP access is needed for development/testing workflows.

#### Related issues

N/A

#### Testing

• Manually tested HTTP mode with --http flag
• Verified HTTPS mode still works without flag (backward compatibility)
• Tested adb port forwarding scenario with Android apps
• Confirmed server starts correctly in both modes
• Validated documentation examples work as described
