### PR TITLE
Fix Camera app crash on multiple start and stop sessions.

### DIFF
--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -23,6 +23,7 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/ScopedNodeId.h>
 
+#include <mutex>
 #include <string>
 
 using OnTransportLocalDescriptionCallback = std::function<void(const std::string & sdp, SDPType type, const int16_t sessionId)>;
@@ -143,4 +144,6 @@ private:
     RequestArgs mRequestArgs;
     OnTransportLocalDescriptionCallback mOnLocalDescription = nullptr;
     OnTransportConnectionStateCallback mOnConnectionState   = nullptr;
+
+    std::mutex trackStatusLock;
 };

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -145,5 +145,5 @@ private:
     OnTransportLocalDescriptionCallback mOnLocalDescription = nullptr;
     OnTransportConnectionStateCallback mOnConnectionState   = nullptr;
 
-    std::mutex trackStatusLock;
+    std::mutex mTrackStatusLock;
 };

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -69,7 +69,7 @@ WebrtcTransport::RequestArgs & WebrtcTransport::GetRequestArgs()
 
 void WebrtcTransport::SendVideo(const chip::ByteSpan & data, int64_t timestamp, uint16_t videoStreamID)
 {
-    std::lock_guard<std::mutex> lock(trackStatusLock);
+    std::lock_guard<std::mutex> lock(mTrackStatusLock);
     if (mLocalVideoTrack)
     {
         // TODO: Implement SFrame encryption HERE (per-transport, during RTP packetization)
@@ -104,7 +104,7 @@ void WebrtcTransport::SendVideo(const chip::ByteSpan & data, int64_t timestamp, 
 // Implementation of SendAudio method
 void WebrtcTransport::SendAudio(const chip::ByteSpan & data, int64_t timestamp, uint16_t audioStreamID)
 {
-    std::lock_guard<std::mutex> lock(trackStatusLock);
+    std::lock_guard<std::mutex> lock(mTrackStatusLock);
     if (mLocalAudioTrack)
     {
         // TODO: Implement SFrame encryption HERE (per-transport, during RTP packetization)
@@ -205,7 +205,7 @@ void WebrtcTransport::Start()
 
 void WebrtcTransport::Stop()
 {
-    std::lock_guard<std::mutex> lock(trackStatusLock);
+    std::lock_guard<std::mutex> lock(mTrackStatusLock);
     if (mPeerConnection != nullptr)
     {
         mPeerConnection->Close();
@@ -251,7 +251,7 @@ void WebrtcTransport::OnLocalDescription(const std::string & sdp, SDPType type)
 
 bool WebrtcTransport::ClosePeerConnection()
 {
-    std::lock_guard<std::mutex> lock(trackStatusLock);
+    std::lock_guard<std::mutex> lock(mTrackStatusLock);
     if (mPeerConnection == nullptr)
     {
         return false;

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -96,6 +96,7 @@ void WebrtcTransport::SendVideo(const chip::ByteSpan & data, int64_t timestamp, 
         //     // No encryption - pass raw H.264 to RTP packetization
         // }
 
+        std::lock_guard<std::mutex> lock(trackStatusLock);
         mLocalVideoTrack->SendFrame(data, timestamp);
     }
 }
@@ -130,6 +131,7 @@ void WebrtcTransport::SendAudio(const chip::ByteSpan & data, int64_t timestamp, 
         //     // No encryption - pass raw Opus to RTP packetization
         // }
 
+        std::lock_guard<std::mutex> lock(trackStatusLock);
         mLocalAudioTrack->SendFrame(data, timestamp);
     }
 }
@@ -252,7 +254,10 @@ bool WebrtcTransport::ClosePeerConnection()
     {
         return false;
     }
-    mPeerConnection->Close();
+    {
+        std::lock_guard<std::mutex> lock(trackStatusLock);
+        mPeerConnection->Close();
+    }
     mPeerConnection.reset();
 
     return true;

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -131,7 +131,7 @@ void WebrtcTransport::SendAudio(const chip::ByteSpan & data, int64_t timestamp, 
         // {
         //     // No encryption - pass raw Opus to RTP packetization
         // }
-    
+
         mLocalAudioTrack->SendFrame(data, timestamp);
     }
 }


### PR DESCRIPTION
#### Summary
Random crash happens during repeated execution of start and stop commands for live stream
This PR fixes the issue by adding a mutex.


#### Related issues
Fixes #41880 

#### Testing

1. Build and run camera application
```
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debu/chip-camera-app
```
2. Build and run camera controller
```
./scripts/examples/gn_build_example.sh examples/camera-controller/ out/debug/
./out/debug/chip-camera-controller
```
3. Pair camera and test the webrtc live streaming multiple times