### PR TITLE
[WebRTC] Move CodegenIntegration to app specific build file

### DIFF
--- a/src/app/clusters/webrtc-transport-provider-server/BUILD.gn
+++ b/src/app/clusters/webrtc-transport-provider-server/BUILD.gn
@@ -17,7 +17,6 @@ import("//build_overrides/chip.gni")
 
 source_set("webrtc-transport-provider-server") {
   sources = [
-    "CodegenIntegration.cpp",
     "WebRTCTransportProviderCluster.cpp",
     "WebRTCTransportProviderCluster.h",
   ]

--- a/src/app/clusters/webrtc-transport-provider-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/webrtc-transport-provider-server/app_config_dependent_sources.gni
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-app_config_dependent_sources = []
+app_config_dependent_sources = [ "CodegenIntegration.cpp" ]


### PR DESCRIPTION
#### Summary

CodegenIntegration is ember specific. it should not be here and must be in the app specific files only

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
