### PR TITLE
[Telink] Add BLE layer re-initialization if BLE was previously shut down

### DIFF
--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -335,6 +335,12 @@ CHIP_ERROR BLEManagerImpl::StartAdvertisingProcess(void)
         ThreadStackMgrImpl().SetRadioBlocked(true);
 #endif
 
+        if (!BleLayer::IsInitialized())
+        {
+            // Re-initializing the BLE layer after shutdown
+            ReturnErrorOnFailure(BleLayer::Init(this, this, &DeviceLayer::SystemLayer()));
+        }
+
         // Init BLE
         err = bt_enable(NULL);
         VerifyOrReturnError(err == 0, MapErrorZephyr(err));


### PR DESCRIPTION
### Change overview:

- Add BLE layer initialization if BLE was previously shut down

### Related issues:
[[Telink]: Shut down BLE after commissioning window closes #26786](https://github.com/project-chip/connectedhomeip/pull/26786)

### Testing:

1. Run any Telink board.
2. Wait 15 minutes for the commissioning window to close (performing BLE layer deinitialization).
3. Push the start BLE advertising button (opening the commissioning window andperforming BLE layer initialization).
4. Execute the commissioning.