### PR TITLE
Decouple FabricTableImpl from ember.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -389,7 +389,10 @@ void TlsClientManagementCommandDelegate::RemoveFabric(FabricIndex fabric)
 {
     VerifyOrReturn(mStorage != nullptr);
 
-    ReturnAndLogOnFailure(mProvisioned.RemoveFabric(*InteractionModelEngine::GetInstance()->GetDataModelProvider(), fabric), Zcl,
+    DataModel::Provider * provider = InteractionModelEngine::GetInstance()->GetDataModelProvider();
+    VerifyOrReturn(provider != nullptr, ChipLogError(Zcl, "No data model provider on fabric removal."));
+
+    ReturnAndLogOnFailure(mProvisioned.RemoveFabric(*provider, fabric), Zcl,
                           "Failure clearing TLS endpoints for fabric");
 
     UniquePtr<GlobalEndpointData> globalData(New<GlobalEndpointData>(EndpointId(1)));

--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -17,6 +17,7 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/InteractionModelEngine.h>
 #include <app/clusters/tls-certificate-management-server/CertificateTableImpl.h>
 #include <app/clusters/tls-certificate-management-server/IncrementingIdHelper.h>
 #include <app/clusters/tls-client-management-server/TlsClientManagementCluster.h>
@@ -388,7 +389,8 @@ void TlsClientManagementCommandDelegate::RemoveFabric(FabricIndex fabric)
 {
     VerifyOrReturn(mStorage != nullptr);
 
-    ReturnAndLogOnFailure(mProvisioned.RemoveFabric(fabric), Zcl, "Failure clearing TLS endpoints for fabric");
+    ReturnAndLogOnFailure(mProvisioned.RemoveFabric(*InteractionModelEngine::GetInstance()->GetDataModelProvider(), fabric), Zcl,
+                          "Failure clearing TLS endpoints for fabric");
 
     UniquePtr<GlobalEndpointData> globalData(New<GlobalEndpointData>(EndpointId(1)));
     VerifyOrReturn(globalData);

--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -392,8 +392,7 @@ void TlsClientManagementCommandDelegate::RemoveFabric(FabricIndex fabric)
     DataModel::Provider * provider = InteractionModelEngine::GetInstance()->GetDataModelProvider();
     VerifyOrReturn(provider != nullptr, ChipLogError(Zcl, "No data model provider on fabric removal."));
 
-    ReturnAndLogOnFailure(mProvisioned.RemoveFabric(*provider, fabric), Zcl,
-                          "Failure clearing TLS endpoints for fabric");
+    ReturnAndLogOnFailure(mProvisioned.RemoveFabric(*provider, fabric), Zcl, "Failure clearing TLS endpoints for fabric");
 
     UniquePtr<GlobalEndpointData> globalData(New<GlobalEndpointData>(EndpointId(1)));
     VerifyOrReturn(globalData);

--- a/scripts/ember_exclusions.txt
+++ b/scripts/ember_exclusions.txt
@@ -8,4 +8,3 @@ src/controller/tests/TestServerCommandDispatch.cpp
 src/controller/tests/TestWriteChunking.cpp
 src/darwin/Framework/CHIP/ServerEndpoint/MTRIMDispatch.mm
 src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint.mm
-src/app/storage/FabricTableImpl.ipp

--- a/src/app/clusters/scenes-server/SceneTableImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneTableImpl.cpp
@@ -307,7 +307,9 @@ CHIP_ERROR DefaultSceneTableImpl::SceneApplyEFS(const SceneTableEntry & scene)
 
 CHIP_ERROR DefaultSceneTableImpl::RemoveFabric(FabricIndex fabric_index)
 {
-    return FabricTableImpl::RemoveFabric(*app::InteractionModelEngine::GetInstance()->GetDataModelProvider(), fabric_index);
+    app::DataModel::Provider * provider = app::InteractionModelEngine::GetInstance()->GetDataModelProvider();
+    VerifyOrReturnError(provider != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    return FabricTableImpl::RemoveFabric(*provider, fabric_index);
 }
 
 CHIP_ERROR DefaultSceneTableImpl::RemoveEndpoint()

--- a/src/app/clusters/scenes-server/SceneTableImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneTableImpl.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <app/InteractionModelEngine.h>
 #include <app/clusters/scenes-server/SceneTableImpl.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 
@@ -306,7 +307,7 @@ CHIP_ERROR DefaultSceneTableImpl::SceneApplyEFS(const SceneTableEntry & scene)
 
 CHIP_ERROR DefaultSceneTableImpl::RemoveFabric(FabricIndex fabric_index)
 {
-    return FabricTableImpl::RemoveFabric(fabric_index);
+    return FabricTableImpl::RemoveFabric(*app::InteractionModelEngine::GetInstance()->GetDataModelProvider(), fabric_index);
 }
 
 CHIP_ERROR DefaultSceneTableImpl::RemoveEndpoint()

--- a/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
+++ b/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/tls-certificate-management-server/CertificateTableImpl.h>
 #include <app/clusters/tls-certificate-management-server/IncrementingIdHelper.h>
@@ -575,6 +574,7 @@ CHIP_ERROR CertificateTableImpl::RemoveFabric(FabricIndex fabric)
     // We want to release as many resources as possible; if anything fails,
     // hold on to the error until we've had a chance to try to free other resources
     DataModel::Provider * provider = InteractionModelEngine::GetInstance()->GetDataModelProvider();
+    VerifyOrReturnError(provider != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     CHIP_ERROR clientResult = mClientCertificates.RemoveFabric(*provider, fabric).NoErrorIf(CHIP_ERROR_NOT_FOUND);
     CHIP_ERROR rootResult   = mRootCertificates.RemoveFabric(*provider, fabric).NoErrorIf(CHIP_ERROR_NOT_FOUND);

--- a/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
+++ b/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
@@ -15,8 +15,10 @@
  *    limitations under the License.
  */
 
+#include <app/InteractionModelEngine.h>
 #include <app/clusters/tls-certificate-management-server/CertificateTableImpl.h>
 #include <app/clusters/tls-certificate-management-server/IncrementingIdHelper.h>
+#include <app/data-model-provider/Provider.h>
 #include <app/storage/FabricTableImpl.ipp>
 #include <app/storage/TableEntry.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
@@ -572,8 +574,10 @@ CHIP_ERROR CertificateTableImpl::RemoveFabric(FabricIndex fabric)
 {
     // We want to release as many resources as possible; if anything fails,
     // hold on to the error until we've had a chance to try to free other resources
-    CHIP_ERROR clientResult = mClientCertificates.RemoveFabric(fabric).NoErrorIf(CHIP_ERROR_NOT_FOUND);
-    CHIP_ERROR rootResult   = mRootCertificates.RemoveFabric(fabric).NoErrorIf(CHIP_ERROR_NOT_FOUND);
+    DataModel::Provider * provider = InteractionModelEngine::GetInstance()->GetDataModelProvider();
+
+    CHIP_ERROR clientResult = mClientCertificates.RemoveFabric(*provider, fabric).NoErrorIf(CHIP_ERROR_NOT_FOUND);
+    CHIP_ERROR rootResult   = mRootCertificates.RemoveFabric(*provider, fabric).NoErrorIf(CHIP_ERROR_NOT_FOUND);
 
     GlobalCertificateData globalData(mEndpointId);
     CHIP_ERROR globalDataResult = globalData.Load(mStorage);

--- a/src/app/storage/FabricTableImpl.h
+++ b/src/app/storage/FabricTableImpl.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <app/data-model-provider/ProviderMetadataTree.h>
 #include <app/storage/TableEntry.h>
 #include <lib/support/CommonIterator.h>
 #include <lib/support/PersistentData.h>
@@ -142,7 +143,7 @@ public:
     CHIP_ERROR RemoveTableEntryAtPosition(EndpointId endpoint, FabricIndex fabric_index, EntryIndex entry_idx);
 
     // Fabrics
-    CHIP_ERROR RemoveFabric(FabricIndex fabric_index);
+    CHIP_ERROR RemoveFabric(DataModel::ProviderMetadataTree & provider, FabricIndex fabric_index);
     CHIP_ERROR RemoveEndpoint();
 
     /**

--- a/src/app/tests/TestCertificateTableImpl.cpp
+++ b/src/app/tests/TestCertificateTableImpl.cpp
@@ -17,8 +17,11 @@
  */
 
 #include <app/clusters/tls-certificate-management-server/CertificateTableImpl.h>
+
+#include <app/InteractionModelEngine.h>
 #include <app/util/mock/Constants.h>
 #include <app/util/mock/MockNodeConfig.h>
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 
 #include <lib/core/StringBuilderAdapters.h>
@@ -63,9 +66,11 @@ public:
     static void SetUpTestSuite()
     {
         mpTestStorage = new chip::TestPersistentStorageDelegate;
+        ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR);
         ASSERT_NE(mpTestStorage, nullptr);
         ASSERT_EQ(sCertificateTable.Init(*mpTestStorage), CHIP_NO_ERROR);
         ASSERT_EQ(sCertificateTable.SetEndpoint(kMockEndpoint1), CHIP_NO_ERROR);
+        app::InteractionModelEngine::GetInstance()->SetDataModelProvider(&app::CodegenDataModelProvider::Instance());
     }
 
     static void TearDownTestSuite()
@@ -73,6 +78,7 @@ public:
         sCertificateTable.Finish();
         delete mpTestStorage;
         mpTestStorage = nullptr;
+        Platform::MemoryShutdown();
     }
 
     static void ResetCertificateTable()

--- a/src/app/tests/TestSceneTable.cpp
+++ b/src/app/tests/TestSceneTable.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include <app/InteractionModelEngine.h>
 #include <app/clusters/scenes-server/CodegenAttributeValuePairValidator.h>
 #include <app/clusters/scenes-server/SceneTableImpl.h>
 #include <app/util/attribute-metadata.h>
@@ -639,6 +640,7 @@ public:
         ASSERT_NE(sceneTable, nullptr);
         ASSERT_EQ(sceneTable->Init(*mpTestStorage, app::CodegenDataModelProvider::Instance()), CHIP_NO_ERROR);
         SetMockNodeConfig(SceneMockNodeConfig);
+        app::InteractionModelEngine::GetInstance()->SetDataModelProvider(&app::CodegenDataModelProvider::Instance());
     }
 
     static void TearDownTestSuite()

--- a/src/protocols/BUILD.gn
+++ b/src/protocols/BUILD.gn
@@ -14,6 +14,10 @@
 
 import("//build_overrides/chip.gni")
 
+# TODO: this is NOT valid: we need Protocols.cpp for actual implementation here
+#       otherwise link will fail. This indicates a layering problem in our code
+# In particular, SessionManager.cpp will use GetProtocolName which requires .cpp.
+# This code is MORE than just type definitions.
 source_set("type_definitions") {
   sources = [ "Protocols.h" ]
 }


### PR DESCRIPTION
#### Summary

FabricTableImpl was using emberAf calls, making all fabric tables depend on codegen implementations.

Move this to be ember agnostic. The only place ember calls were done were at fabric removal (to list all endpoints), so changed that to add a metadata tree argument. That seemed to result in a smaller change than changing `::Init` of the table to maintain a data model provider delegate.

#### Testing

No functionality changed in code: I tested compile and adjusted unit tests to call the right initializers. Unit tests should still pass.