### PR TITLE
Add CriticalFailure Include in TimerDelegate

### DIFF
--- a/src/lib/support/TimerDelegate.h
+++ b/src/lib/support/TimerDelegate.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <lib/core/CHIPError.h>
+#include <lib/core/CriticalFailure.h>
 #include <system/SystemClock.h>
 
 namespace chip {


### PR DESCRIPTION
#### Summary

This PR adds an include statement in `TimerDelegate.h` to use `CriticalFailure` from the `CriticalFailure.h` file. The class is already in use here, just need to add the missing include statement.

#### Testing

- CI should still pass
