### PR TITLE
[TC_EEVSE_2_3] Fix flaky test failure around midnight UTC

### DIFF
--- a/src/python_testing/TC_EEVSE_2_3.py
+++ b/src/python_testing/TC_EEVSE_2_3.py
@@ -41,6 +41,7 @@
 # === END CI TEST ARGUMENTS ===
 
 import logging
+from datetime import datetime
 
 from mobly import asserts
 from TC_EEVSE_Utils import EEVSEBaseTestHelper
@@ -283,8 +284,10 @@ class TC_EEVSE_2_3(MatterBaseTest, EEVSEBaseTestHelper):
                                  f"Unexpected 'GetTargets' response value - expected {targets}, was {get_targets_response}")
 
         self.step("11")
-        # This should be all days Sun-Sat (0x7F) with an TargetTime 1 and SoC of 100%, AddedEnergy= NullValue
-        minutes_past_midnight = 1
+        # This should be all days Sun-Sat (0x7F) with a TargetTime in the future and SoC of 100%, AddedEnergy= NullValue
+        # Use a time that's always at least 1 hour in the future to avoid flaky test failures around midnight
+        now = datetime.now()
+        minutes_past_midnight = ((now.hour * 60 + now.minute + 61) % 1440)  # Current time + 61 minutes, wrapped to valid range
         daily_targets_step_11 = [Clusters.EnergyEvse.Structs.ChargingTargetStruct(targetTimeMinutesPastMidnight=minutes_past_midnight,
                                                                                   targetSoC=100)]
         targets_step_11 = [Clusters.EnergyEvse.Structs.ChargingTargetScheduleStruct(


### PR DESCRIPTION
#### Summary

TC_EEVSE_2_3 step 11 was flaky when CI ran around midnight UTC.

**Example failure:** https://github.com/project-chip/connectedhomeip/actions/runs/20320700736/job/58376256158?pr=42440 (CI ran at 00:01:07 UTC)

**Root cause:** The test used `minutes_past_midnight = 1` (00:01 AM). When the test executed at 00:01:07 UTC, the target time was either in the past or imminent, causing a race condition where `NextChargeStartTime` ended up 9 seconds *after* `NextChargeTargetTime`, failing the `assert_less` check.

**Fix:** Dynamically compute a target time ~61 minutes in the future:
```python
now = datetime.now()
minutes_past_midnight = ((now.hour * 60 + now.minute + 61) % 1440)
```

This ensures the target is always safely in the future regardless of when CI runs.

#### Testing

- Verified no syntax/lint errors in modified file
- Minimal isolated change to step 11's target time calculation
- Logic validated: modulo operation correctly wraps times past 23:59 (1439 minutes)
