### PR TITLE
Log consistency All Devices App

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.cpp
@@ -39,12 +39,12 @@ void BooleanStateSensorDevice::UnRegister(CodeDrivenDataModelProvider & provider
     SingleEndpointUnregistration(provider);
     if (mBooleanStateCluster.IsConstructed())
     {
-        TEMPORARY_RETURN_IGNORED provider.RemoveCluster(&mBooleanStateCluster.Cluster());
+        LogErrorOnFailure(provider.RemoveCluster(&mBooleanStateCluster.Cluster()));
         mBooleanStateCluster.Destroy();
     }
     if (mIdentifyCluster.IsConstructed())
     {
-        TEMPORARY_RETURN_IGNORED provider.RemoveCluster(&mIdentifyCluster.Cluster());
+        LogErrorOnFailure(provider.RemoveCluster(&mIdentifyCluster.Cluster()));
         mIdentifyCluster.Destroy();
     }
 }

--- a/examples/all-devices-app/all-devices-common/devices/interface/SingleEndpointDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/interface/SingleEndpointDevice.cpp
@@ -42,10 +42,10 @@ CHIP_ERROR SingleEndpointDevice::SingleEndpointRegistration(EndpointId endpoint,
 
 void SingleEndpointDevice::SingleEndpointUnregistration(CodeDrivenDataModelProvider & provider)
 {
-    TEMPORARY_RETURN_IGNORED provider.RemoveEndpoint(mEndpointId);
+    LogErrorOnFailure(provider.RemoveEndpoint(mEndpointId));
     if (mDescriptorCluster.IsConstructed())
     {
-        TEMPORARY_RETURN_IGNORED provider.RemoveCluster(&mDescriptorCluster.Cluster());
+        LogErrorOnFailure(provider.RemoveCluster(&mDescriptorCluster.Cluster()));
         mDescriptorCluster.Destroy();
     }
 }

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -52,15 +52,15 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
     ReturnErrorOnFailure(provider.AddCluster(mBasicInformationCluster.Registration()));
 
     mGeneralCommissioningCluster.Create(
-        GeneralCommissioningCluster::Context {
+        GeneralCommissioningCluster::Context{
             .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
-                .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
-                .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-                .fabricTable            = Server::GetInstance().GetFabricTable(),                //
-                .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
-                .platformManager        = DeviceLayer::PlatformMgr(),                            //
+            .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
+            .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+            .fabricTable                = Server::GetInstance().GetFabricTable(),                //
+            .failsafeContext            = Server::GetInstance().GetFailSafeContext(),            //
+            .platformManager            = DeviceLayer::PlatformMgr(),                            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         GeneralCommissioningCluster::OptionalAttributes());
@@ -161,12 +161,12 @@ void WifiRootNodeDevice::UnRegister(CodeDrivenDataModelProvider & provider)
     RootNodeDevice::UnRegister(provider);
     if (mNetworkCommissioningCluster.IsConstructed())
     {
-        TEMPORARY_RETURN_IGNORED provider.RemoveCluster(&mNetworkCommissioningCluster.Cluster());
+        LogErrorOnFailure(provider.RemoveCluster(&mNetworkCommissioningCluster.Cluster()));
         mNetworkCommissioningCluster.Destroy();
     }
     if (mWifiDiagnosticsCluster.IsConstructed())
     {
-        TEMPORARY_RETURN_IGNORED provider.RemoveCluster(&mWifiDiagnosticsCluster.Cluster());
+        LogErrorOnFailure(provider.RemoveCluster(&mWifiDiagnosticsCluster.Cluster()));
         mWifiDiagnosticsCluster.Destroy();
     }
 }

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -52,15 +52,15 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
     ReturnErrorOnFailure(provider.AddCluster(mBasicInformationCluster.Registration()));
 
     mGeneralCommissioningCluster.Create(
-        GeneralCommissioningCluster::Context{
+        GeneralCommissioningCluster::Context {
             .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
-            .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
-            .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-            .fabricTable                = Server::GetInstance().GetFabricTable(),                //
-            .failsafeContext            = Server::GetInstance().GetFailSafeContext(),            //
-            .platformManager            = DeviceLayer::PlatformMgr(),                            //
+                .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
+                .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                .fabricTable            = Server::GetInstance().GetFabricTable(),                //
+                .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
+                .platformManager        = DeviceLayer::PlatformMgr(),                            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         GeneralCommissioningCluster::OptionalAttributes());


### PR DESCRIPTION
Added LogErrorOnFailure on all failure points of unregistration for consistency

#### Summary

From the conversation here: https://github.com/project-chip/connectedhomeip/pull/42404#discussion_r2631943782

It seems that we prefer logging the failures during the unregistering of devices, this PR makes the behavior consistent accross all devices types in the all-devices-app.

#### Related issues

na

#### Testing

Built locally, no behavior change outside of the logs.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
