### PR TITLE
Use NullTerminated for CharSpan logging in LoggingChimeDevice

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/chime/impl/LoggingChimeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/chime/impl/LoggingChimeDevice.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 #include <devices/chime/impl/LoggingChimeDevice.h>
+#include <lib/support/StringBuilder.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip::app::Clusters;
@@ -68,7 +69,7 @@ Protocols::InteractionModel::Status LoggingChimeDevice::PlayChimeSound()
         }
     }
 
-    ChipLogProgress(AppServer, "LoggingChimeDevice: Playing sound %.*s", static_cast<int>(soundName.size()), soundName.data());
+    ChipLogProgress(AppServer, "LoggingChimeDevice: Playing sound %s", chip::NullTerminated(soundName).c_str());
     return Protocols::InteractionModel::Status::Success;
 }
 


### PR DESCRIPTION
#### Summary

This PR updates `LoggingChimeDevice.cpp` to use `chip::NullTerminated` when logging the chime sound name, replacing the  `%.*s` format specifier to align with the project logging patterns.

#### Testing

* Tested locally
* CI will validate further