### PR TITLE
Remove overarching ifdef in favour of conditional usage through BUILD.gn

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -231,8 +231,6 @@ static_library("support") {
     "BytesCircularBuffer.h",
     "BytesToHex.cpp",
     "BytesToHex.h",
-    "CHIPArgParser.cpp",
-    "CHIPArgParser.hpp",
     "CHIPCounter.h",
     "CHIPMemString.h",
     "CommonIterator.h",
@@ -297,6 +295,13 @@ static_library("support") {
     "verhoeff/Verhoeff.h",
     "verhoeff/Verhoeff10.cpp",
   ]
+
+  if (chip_config_enable_arg_parser) {
+    sources += [
+      "CHIPArgParser.cpp",
+      "CHIPArgParser.hpp",
+    ]
+  }
 
   if (chip_device_platform == "android" || matter_enable_java_compilation) {
     if (matter_enable_java_compilation) {

--- a/src/lib/support/CHIPArgParser.cpp
+++ b/src/lib/support/CHIPArgParser.cpp
@@ -25,8 +25,6 @@
 
 #include "CHIPArgParser.hpp"
 
-#if CHIP_CONFIG_ENABLE_ARG_PARSER
-
 #include <climits>
 #include <ctype.h>
 #include <errno.h>
@@ -1575,5 +1573,3 @@ static bool SanityCheckOptions(OptionSet * optSets[])
 
 } // namespace ArgParser
 } // namespace chip
-
-#endif // CHIP_CONFIG_ENABLE_ARG_PARSER

--- a/src/lib/support/CHIPArgParser.hpp
+++ b/src/lib/support/CHIPArgParser.hpp
@@ -27,8 +27,6 @@
 
 #include <lib/core/CHIPCore.h>
 
-#if CHIP_CONFIG_ENABLE_ARG_PARSER
-
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -163,5 +161,3 @@ public:
 
 } // namespace ArgParser
 } // namespace chip
-
-#endif // CHIP_CONFIG_ENABLE_ARG_PARSER


### PR DESCRIPTION
#### Summary

By removing the `#ifdef` that wrapped up all the implementation in `CHIPArgParser.cpp` as well as larger parts of `CHIPArgParser.hpp`, we are able to make it clearer and easier to navigate, as well as not including it unless we use the appropriate flag through `BUILD.gn`.

There are some other parts that could be reworked but might fall outside the scope of this PR, such as:
* Inlining the `ParseInt` functions where appropriate and either provide correct declarations (there is one missing for the `int16_t` case) OR remove the unused ones, if possible
* Making the args parsing from environment or strings conditional according to a new flag, if possible.

#### Related issues

[Issue #40021](https://github.com/project-chip/connectedhomeip/issues/40021)

#### Testing

Tested by running `ninja -C out/host check` in macOS, locally.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
