### PR TITLE
Add a documentation for cluster tester

### DIFF
--- a/docs/cluster_and_device_type_dev/cluster_tester.md
+++ b/docs/cluster_and_device_type_dev/cluster_tester.md
@@ -1,0 +1,219 @@
+# ClusterTester Helper Class
+
+The `ClusterTester` class is a C++ helper designed to simplify unit testing for
+Matter clusters implementing the `ServerClusterInterface`. It abstracts away the
+complexity of TLV encoding/decoding, path construction, and memory management
+for data views.
+
+**Header Location:** `src/app/server-cluster/testing/ClusterTester.h`
+
+## Why use ClusterTester?
+
+1. **Automatic TLV Handling**: Encodes C++ structures to TLV for writes/commands
+   and decodes TLV to C++ structures for reads/responses automatically.
+2. **Memory Safety**: For attributes that return views (like `CharSpan` or
+   `List`), `ClusterTester` maintains ownership of the underlying TLV data. This
+   allows you to inspect the data safely within the test scope without worrying
+   about dangling pointers.
+3. **Type Safety**: Leverages generated data model types (e.g.,
+   `Attributes::MyAttr::TypeInfo`) to ensure arguments match the spec.
+
+---
+
+## Basic Usage Example
+
+For simple clusters that do not require fabric context (like **Boolean State**),
+the setup is straightforward. You simply wrap your cluster instance with the
+tester.
+
+### Setup
+
+```cpp
+#include <app/server-cluster/testing/ClusterTester.h>
+#include <app/clusters/boolean-state-server/BooleanStateCluster.h>
+
+class TestBooleanStateCluster : public ::testing::Test
+{
+    // ... (Setup memory and context) ...
+
+    BooleanStateCluster booleanState{kRootEndpointId};
+
+    // Initialize the tester with the cluster instance
+    chip::Testing::ClusterTester tester{booleanState};
+
+    void SetUp() override {
+        booleanState.Startup(testContext.Get());
+    }
+};
+
+```
+
+### Reading Attributes
+
+The tester allows reading attributes directly into their `DecodableType`s.
+
+```cpp
+TEST_F(TestBooleanStateCluster, ReadAttributeTest)
+{
+    // 1. Read a simple integer attribute
+    uint16_t revision{};
+    ASSERT_EQ(tester.ReadAttribute(Globals::Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
+
+    // 2. Read a bitmap
+    uint32_t features{};
+    ASSERT_EQ(tester.ReadAttribute(FeatureMap::Id, features), CHIP_NO_ERROR);
+
+    // 3. Read a boolean
+    bool stateValue{};
+    ASSERT_EQ(tester.ReadAttribute(StateValue::Id, stateValue), CHIP_NO_ERROR);
+}
+
+```
+
+---
+
+## Advanced Usage: Fabric-Scoped Clusters
+
+For complex clusters involving Access Control or Fabric scoping (like **Group
+Key Management**), the `ClusterTester` integrates with `FabricTestFixture`.
+
+### Setup with Fabric Context
+
+When testing fabric-scoped clusters, pass the `FabricTestFixture` to the tester
+and set the active Fabric Index.
+
+```cpp
+class TestGroupKeyManagementCluster : public ::testing::Test
+{
+    TestServerClusterContext mTestContext;
+    FabricTestFixture fabricHelper{ &mTestContext.StorageDelegate() };
+    GroupKeyManagementCluster mCluster{ fabricHelper.GetFabricTable() };
+
+    // Initialize tester with both cluster and fabric helper
+    ClusterTester tester{ mCluster, &fabricHelper };
+
+    void SetUp() override
+    {
+        // ... (Startup cluster) ...
+
+        // Initialize the test fabric
+        fabricHelper.SetUpTestFabric(kTestFabricIndex);
+
+        // IMPORTANT: Set the fabric index for the tester.
+        // All subsequent writes/commands will appear to come from this fabric.
+        tester.SetFabricIndex(kTestFabricIndex);
+    }
+};
+
+```
+
+### Writing Attributes (Lists & Structs)
+
+The tester handles complex types like Lists and Structs automatically.
+
+```cpp
+TEST_F(TestGroupKeyManagementCluster, TestWriteGroupKeyMapAttribute)
+{
+    // Create a vector of Structs
+    std::vector<GroupKeyManagement::Structs::GroupKeyMapStruct::Type> keys;
+
+    GroupKeyManagement::Structs::GroupKeyMapStruct::Type key;
+    key.groupId = 0x1234;
+    key.groupKeySetID = 1;
+    key.fabricIndex = kTestFabricIndex;
+    keys.push_back(key);
+
+    // Wrap in DataModel::List
+    auto listToWrite = app::DataModel::List<const GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(keys.data(), keys.size());
+
+    // Write the attribute
+    // The tester automatically handles EncodeForWrite for fabric-scoped attributes
+    CHIP_ERROR err = tester.WriteAttribute(GroupKeyManagement::Attributes::GroupKeyMap::Id, listToWrite).GetUnderlyingError();
+
+    ASSERT_EQ(err, CHIP_NO_ERROR);
+}
+
+```
+
+### Invoking Commands
+
+Use the `Invoke` method with the generated Command Request structures.
+
+```cpp
+TEST_F(TestGroupKeyManagementCluster, TestKeySetWriteCommand)
+{
+    // 1. Prepare the Request Struct
+    GroupKeyManagement::Commands::KeySetWrite::Type requestData;
+    requestData.groupKeySet.groupKeySetID = kTestKeySetId;
+    requestData.groupKeySet.groupKeySecurityPolicy = GroupKeyManagement::GroupKeySecurityPolicyEnum::kTrustFirst;
+    requestData.groupKeySet.epochStartTime0 = kStartTime;
+    // ... populate other fields ...
+
+    // 2. Invoke the command
+    // The CommandId is deduced automatically from the request type,
+    // or can be passed explicitly: tester.Invoke(CommandId, request)
+    auto result = tester.Invoke(requestData);
+
+    // 3. Verify Result
+    EXPECT_TRUE(result.IsSuccess());
+}
+
+```
+
+---
+
+## API Reference
+
+### `ReadAttribute`
+
+Reads an attribute value from the cluster.
+
+-   **Signature**:
+    `ActionReturnStatus ReadAttribute(AttributeId attr_id, T & out)`
+-   **Behavior**:
+-   Constructs a read path.
+-   Reads and decodes the TLV.
+-   **Crucial**: If `T` contains views (e.g., `Span` or `List`), the internal
+    TLV buffer remains allocated within the `ClusterTester` instance. You can
+    safely iterate over the list immediately.
+
+### `WriteAttribute`
+
+Writes a value to the cluster.
+
+-   **Signature**:
+    `ActionReturnStatus WriteAttribute(AttributeId attr, const T & value)`
+-   **Behavior**:
+-   Detects if `T` is fabric-scoped.
+-   Uses `EncodeForWrite` if fabric-scoped, or standard `Encode` otherwise.
+-   Uses the subject descriptor from the current `SetFabricIndex`.
+
+### `Invoke`
+
+Invokes a command.
+
+-   **Signature**:
+    `InvokeResult<ResponseType> Invoke(const RequestType & request)`
+-   **Returns**: An `InvokeResult` struct containing:
+-   `status`: The `ActionReturnStatus` (success/failure).
+-   `response`: An `std::optional<ResponseType>` containing the decoded response
+    struct (if the command returns data).
+
+### `GetDirtyList` & `GetNextGeneratedEvent`
+
+Accessors for inspecting the `TestServerClusterContext`.
+
+-   **Usage**: Useful for verifying that a command or write caused a side effect
+    (like marking an attribute dirty for reporting or emitting an event).
+
+```cpp
+// Check if an attribute was marked dirty
+auto & dirtyList = tester.GetDirtyList();
+
+// Check if an event was generated
+auto event = tester.GetNextGeneratedEvent();
+if(event.has_value()) {
+   // Decode event data...
+}
+
+```

--- a/docs/cluster_and_device_type_dev/cluster_tester.md
+++ b/docs/cluster_and_device_type_dev/cluster_tester.md
@@ -181,8 +181,8 @@ TLV data for you.
     `ByteSpan`, or `DecodableList`), the tester buffers the TLV data internally.
 -   **Lifetime Safety**: This data remains valid for the lifetime of the
     `ClusterTester` instance, allowing you to safely iterate over lists or
-    inspect spans without worrying about the buffer being deallocated
-    immediately after the read call.
+    inspect spans without worrying about the buffer being freed immediately
+    after the read call.
 
 ### Fabric Scoping (Writes)
 

--- a/docs/cluster_and_device_type_dev/index.md
+++ b/docs/cluster_and_device_type_dev/index.md
@@ -15,3 +15,4 @@ types in the SDK.
 -   [Cluster and device type development](./cluster_and_device_type_dev.md)
 -   [How To Add New Device Types & Clusters](./how_to_add_new_dts_and_clusters.md)
 -   [Cluster Server design](./unit_testing_clusters.md)
+-   [Cluster Tester Helper Class](./cluster_tester.md)

--- a/docs/cluster_and_device_type_dev/unit_testing_clusters.md
+++ b/docs/cluster_and_device_type_dev/unit_testing_clusters.md
@@ -143,19 +143,17 @@ Important tests to consider:
     changed from the driver side.
 -   Others - very dependent on the cluster.
 
-# Unit testing ClusterServer
+## Simplified Unit Testing ClusterServer with ClusterTester
 
--   Best to have the lightest wrapping possible
-    -   If the wrapper is light, the code can be covered by integration or unit
-        tests, or a combination.
-    -   Correctness can mostly be validated by inspection if it’s trivial.
--   Important tests
-    -   Errors when ClusterLogic instances aren’t properly registered.
-    -   Flow through to ClusterLogic for all reads/writes/commands.
--   Can unit test this class by generating the TLV / path for input, parsing the
-    TLV output.
+For complex `ClusterServer` testing or existing cluster implementations, the
+`ClusterTester` helper class significantly reduces boilerplate code. It provides
+high-level, strongly-typed wrappers for reading/writing attributes and invoking
+commands without manually handling TLV encoding or path construction.
 
-# Unit testing existing clusters
+For detailed API usage and examples, please see the
+[ClusterTester Helper Class Guide](cluster_tester.md).
+
+## Unit testing existing clusters
 
 -   Important for clusters where there are multiple configurations that cannot
     easily be represented with example apps
@@ -167,6 +165,3 @@ Important tests to consider:
     -   Read / Write TLV and use TLV encode/decode functions to verify
         correctness.
     -   See TestPowerSourceCluster for an example of how to do this
--   Additional test coverage on clusters, especially for hard to trigger
-    conditions, is important. However, **don’t let perfection be the enemy of
-    progress** .


### PR DESCRIPTION
#### Summary

This PR adds dedicated documentation for the C++ `ClusterTester` helper class and reorganizes the "Cluster and Device Type Development" section to improve discoverability.

**Changes:**

* **Added `cluster_tester.md`:** A new guide detailing how to use the `ClusterTester` class for simplified unit testing (covering setup, reading/writing attributes, and fabric-scoped testing).

#### Related issues

N/A

#### Testing

* **Documentation Build:** Verified that the documentation builds locally without warnings.
* **Link Verification:** Checked that the new links in `index.md` and `unit_testing_clusters.md` correctly point to the new file locations.
* **Visual Check:** Verified markdown formatting for code blocks and headers in the new `cluster_tester.md` file.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

* [x] PR title is [[descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
* [x] Apply the *[[“When in Rome…”](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)* rule (coding style)
* [x] PR size is short
* [x] Try to avoid "squashing" and "force-update" in commit history
* [x] CI time didn't increase