### PR TITLE
Add support for parsing comments for cluster revision

### DIFF
--- a/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
@@ -26,8 +26,8 @@ from lark.visitors import Transformer, v_args
 from matter.idl.matter_idl_types import (AccessPrivilege, ApiMaturity, Attribute, AttributeInstantiation, AttributeOperation,
                                          AttributeQuality, AttributeStorage, Bitmap, Cluster, Command, CommandInstantiation,
                                          CommandQuality, ConstantEntry, DataType, DeviceType, Endpoint, Enum, Event, EventPriority,
-                                         EventQuality, Field, FieldQuality, Idl, ParseMetaData, ServerClusterInstantiation, Struct,
-                                         StructQuality, StructTag, Revision)
+                                         EventQuality, Field, FieldQuality, Idl, ParseMetaData, Revision,
+                                         ServerClusterInstantiation, Struct, StructQuality, StructTag)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
@@ -27,7 +27,7 @@ from matter.idl.matter_idl_types import (AccessPrivilege, ApiMaturity, Attribute
                                          AttributeQuality, AttributeStorage, Bitmap, Cluster, Command, CommandInstantiation,
                                          CommandQuality, ConstantEntry, DataType, DeviceType, Endpoint, Enum, Event, EventPriority,
                                          EventQuality, Field, FieldQuality, Idl, ParseMetaData, ServerClusterInstantiation, Struct,
-                                         StructQuality, StructTag)
+                                         StructQuality, StructTag, Revision)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -65,6 +65,7 @@ class PrefixCppDocComment:
         """List all types supported by doc comments."""
         for cluster in idl.clusters:
             yield cluster
+            yield cluster.revision
             for attribute in cluster.attributes:
                 yield attribute.definition
             for command in cluster.commands:
@@ -358,9 +359,10 @@ class MatterIdlTransformer(Transformer):
 
         return init_args
 
-    @v_args(inline=True)
-    def cluster_revision(self, revision):
-        return revision
+    @v_args(meta=True, inline=True)
+    def cluster_revision(self, meta, revision):
+        meta = None if self.skip_meta else ParseMetaData(meta)
+        return Revision(parse_meta=meta, number=revision)
 
     @v_args(meta=True)
     def event(self, meta, args):
@@ -517,7 +519,7 @@ class MatterIdlTransformer(Transformer):
             api_maturity = ApiMaturity.STABLE
 
         if not revision:
-            revision = 1
+            revision = Revision(number=1)
 
         result = Cluster(parse_meta=meta, name=name, code=code,
                          revision=revision, api_maturity=api_maturity)

--- a/scripts/py_matter_idl/matter/idl/matter_idl_types.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_types.py
@@ -268,10 +268,19 @@ class Command:
 
 
 @dataclass
+class Revision:
+    number: int
+    description: Optional[str] = None
+
+    # Parsing meta data missing only when skip meta data is requested
+    parse_meta: Optional[ParseMetaData] = field(default=None, compare=False)
+
+
+@dataclass
 class Cluster:
     name: str
     code: int
-    revision: int = 1
+    revision: Revision = field(default_factory=lambda: Revision(number=1))
     enums: List[Enum] = field(default_factory=list)
     bitmaps: List[Bitmap] = field(default_factory=list)
     events: List[Event] = field(default_factory=list)

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -176,33 +176,33 @@ class TestParser(unittest.TestCase):
         # meta_data may not match but is required for doc comments. Clean it up
 
         # Metadata parsing varies line/column, so only check doc comments
-        self.assertIdlEqual(
+        self.assertEqual(
             actual.clusters[0].description, "Documentation for MyCluster")
-        self.assertIdlEqual(
+        self.assertEqual(
             actual.clusters[1].description, "Documentation for MyCluster #2")
         self.assertIsNone(actual.clusters[1].commands[0].description)
-        self.assertIdlEqual(
+        self.assertEqual(
             actual.clusters[1].commands[1].description, "Some command doc comment")
 
-        self.assertIdlEqual(
+        self.assertEqual(
             actual.clusters[1].attributes[0].definition.description, "Attribute comment")
-        self.assertIdlEqual(
+        self.assertEqual(
             actual.clusters[1].enums[0].description, "Multi line\n                Enum comment")
-        self.assertIdlEqual(
+        self.assertEqual(
             actual.clusters[1].enums[0].entries[0].description, "Enum field comment")
-        self.assertIdlEqual(
+        self.assertEqual(
             actual.clusters[1].structs[0].description, "Multi line\n                Struct comment")
-        self.assertIdlEqual(
+        self.assertEqual(
             actual.clusters[1].structs[0].fields[0].description, "Struct field comment")
-        self.assertIdlEqual(
+        self.assertEqual(
             actual.clusters[1].bitmaps[0].description, "Multi line\n                Bitmap comment")
-        self.assertIdlEqual(actual.clusters[1].bitmaps[0].entries[0].description,
+        self.assertEqual(actual.clusters[1].bitmaps[0].entries[0].description,
                             "Multi line\n                    Bitmap field comment")
-        self.assertIdlEqual(
+        self.assertEqual(
             actual.clusters[1].events[0].description, "Multi line\n                Event comment")
-        self.assertIdlEqual(
+        self.assertEqual(
             actual.clusters[1].events[0].fields[0].description, "Event field comment")
-        self.assertIdlEqual(actual.clusters[1].revision.description, "Revision comment")
+        self.assertEqual(actual.clusters[1].revision.description, "Revision comment")
 
     def test_sized_attribute(self):
         actual = parseText("""

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -197,12 +197,13 @@ class TestParser(unittest.TestCase):
         self.assertEqual(
             actual.clusters[1].bitmaps[0].description, "Multi line\n                Bitmap comment")
         self.assertEqual(actual.clusters[1].bitmaps[0].entries[0].description,
-                            "Multi line\n                    Bitmap field comment")
+                         "Multi line\n                    Bitmap field comment")
         self.assertEqual(
             actual.clusters[1].events[0].description, "Multi line\n                Event comment")
         self.assertEqual(
             actual.clusters[1].events[0].fields[0].description, "Event field comment")
-        self.assertEqual(actual.clusters[1].revision.description, "Revision comment")
+        self.assertEqual(
+            actual.clusters[1].revision.description, "Revision comment")
 
     def test_sized_attribute(self):
         actual = parseText("""

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -32,8 +32,8 @@ from matter.idl.generators.storage import GeneratorStorage
 from matter.idl.matter_idl_types import (AccessPrivilege, ApiMaturity, Attribute, AttributeInstantiation, AttributeQuality,
                                          AttributeStorage, Bitmap, Cluster, Command, CommandInstantiation, CommandQuality,
                                          ConstantEntry, DataType, DeviceType, Endpoint, Enum, Event, EventPriority, EventQuality,
-                                         Field, FieldQuality, Idl, ParseMetaData, ServerClusterInstantiation, Struct, StructTag,
-                                         Revision)
+                                         Field, FieldQuality, Idl, ParseMetaData, Revision, ServerClusterInstantiation, Struct,
+                                         StructTag)
 
 
 class GeneratorContentStorage(GeneratorStorage):

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -32,7 +32,8 @@ from matter.idl.generators.storage import GeneratorStorage
 from matter.idl.matter_idl_types import (AccessPrivilege, ApiMaturity, Attribute, AttributeInstantiation, AttributeQuality,
                                          AttributeStorage, Bitmap, Cluster, Command, CommandInstantiation, CommandQuality,
                                          ConstantEntry, DataType, DeviceType, Endpoint, Enum, Event, EventPriority, EventQuality,
-                                         Field, FieldQuality, Idl, ParseMetaData, ServerClusterInstantiation, Struct, StructTag)
+                                         Field, FieldQuality, Idl, ParseMetaData, ServerClusterInstantiation, Struct, StructTag,
+                                         Revision)
 
 
 class GeneratorContentStorage(GeneratorStorage):
@@ -128,6 +129,9 @@ class TestParser(unittest.TestCase):
 
             /** Documentation for MyCluster #2 */
             client cluster MyCluster2 = 0x322 {
+                /** Revision comment */
+                revision 1;
+
                 /** Attribute comment */
                 attribute boolean value = 0;
 
@@ -198,6 +202,7 @@ class TestParser(unittest.TestCase):
             actual.clusters[1].events[0].description, "Multi line\n                Event comment")
         self.assertIdlEqual(
             actual.clusters[1].events[0].fields[0].description, "Event field comment")
+        self.assertIdlEqual(actual.clusters[1].revision.description, "Revision comment")
 
     def test_sized_attribute(self):
         actual = parseText("""
@@ -1084,7 +1089,7 @@ server cluster A = 1 { /* Test comment */ }
                      entries=[ConstantEntry(name="A", code=1234)],
                      is_global=True)],
             clusters=[
-                Cluster(name="A", code=1, revision=1, enums=[
+                Cluster(name="A", code=1, revision=Revision(number=1), enums=[
                     Enum(name="FooEnum", base_type="ENUM32",
                          entries=[ConstantEntry(name="B", code=234)])],
                         structs=[
@@ -1104,10 +1109,10 @@ server cluster A = 1 { /* Test comment */ }
         """)
 
         expected = Idl(clusters=[
-            Cluster(name="A", code=1, revision=1),
-            Cluster(name="B", code=2, revision=1),
-            Cluster(name="C", code=3, revision=2),
-            Cluster(name="D", code=4, revision=123),
+            Cluster(name="A", code=1, revision=Revision(number=1)),
+            Cluster(name="B", code=2, revision=Revision(number=1)),
+            Cluster(name="C", code=3, revision=Revision(number=2)),
+            Cluster(name="D", code=4, revision=Revision(number=123)),
         ])
         self.assertIdlEqual(actual, expected)
 


### PR DESCRIPTION
#### Summary

The matter IDL parser now stores comments attached to revisions. This change replaces revision with a `Revision` type to store the revision number and optionally documentation, similar to how documentation is currently parsed and stored for other types.

#### Related issues

None that I am aware of.

#### Testing

Modified unit tests in `test_matter_idl_parser.py`.
