### PR TITLE
Fix ESP32 Windows build: normalize paths in create_args_gn.py

### DIFF
--- a/config/esp32/components/chip/create_args_gn.py
+++ b/config/esp32/components/chip/create_args_gn.py
@@ -45,7 +45,7 @@ with open(compile_commands_path) as compile_commands_json:
 
     def get_compile_flags(src_file):
         compile_command = [
-            res["command"] for res in compile_commands if res["file"] == src_file
+            res["command"] for res in compile_commands if os.path.normpath(res["file"]) == os.path.normpath(src_file)
         ]
 
         if len(compile_command) != 1:


### PR DESCRIPTION
## Problem

Building ESP32 examples on Windows via esp-matter fails with:

```
Exception: Failed to resolve compile flags for C:/Espressif/esp-matter/connectedhomeip/connectedhomeip/config/esp32/components/chip/chip.c
```

This issue was first reported in June 2022: https://github.com/espressif/esp-matter/issues/1

## Root Cause

On Windows, `compile_commands.json` contains backslash-escaped paths:
```json
"file": "C:\Espressif\esp-matter\...\chip.c"
```

But CMake passes forward-slash paths to `create_args_gn.py`:
```
C:/Espressif/esp-matter/.../chip.c
```

The direct string comparison on line 49 fails because the path separators don't match.

## Solution

Use `os.path.normpath()` on both paths before comparison. This normalizes path separators to the platform convention, making the comparison work correctly.

### Testing

- Tested on Windows 11 with ESP-IDF 5.5.1, ESP32-C6 target, esp-matter SDK
- Build completes successfully after this fix
- No impact on Linux/macOS builds (`os.path.normpath()` is a no-op when paths already use consistent separators)

## Change

One-line fix in `config/esp32/components/chip/create_args_gn.py`:

\`\`\`diff
- res["command"] for res in compile_commands if res["file"] == src_file
+ res["command"] for res in compile_commands if os.path.normpath(res["file"]) == os.path.normpath(src_file)
\`\`\`