### PR TITLE
Validate attribute existence via `AttributeList` in `ClusterTester`

### DIFF
--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -177,7 +177,14 @@ struct TestBasicInformationReadWrite : public ::testing::Test
 
     TestBasicInformationReadWrite() {}
 
-    void SetUp() override { ASSERT_EQ(basicInformationClusterInstance.Startup(testContext.Get()), CHIP_NO_ERROR); }
+    void SetUp() override
+    {
+        // Enable optional attributes that are used in tests
+        basicInformationClusterInstance.OptionalAttributes()
+            .Set<Attributes::ManufacturingDate::Id>()
+            .Set<Attributes::LocalConfigDisabled::Id>();
+        ASSERT_EQ(basicInformationClusterInstance.Startup(testContext.Get()), CHIP_NO_ERROR);
+    }
 
     void TearDown() override { basicInformationClusterInstance.Shutdown(ClusterShutdownType::kClusterShutdown); }
 

--- a/src/app/clusters/electrical-power-measurement-server/ElectricalPowerMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-power-measurement-server/ElectricalPowerMeasurementCluster.cpp
@@ -156,19 +156,21 @@ CHIP_ERROR ElectricalPowerMeasurementCluster::Attributes(const ConcreteClusterPa
                                                          ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
 {
     DataModel::AttributeEntry optionalAttributes[] = {
-        Attributes::Ranges::kMetadataEntry,          //
-        Attributes::Voltage::kMetadataEntry,         //
-        Attributes::ActiveCurrent::kMetadataEntry,   //
-        Attributes::ReactiveCurrent::kMetadataEntry, //
-        Attributes::ApparentCurrent::kMetadataEntry, //
-        Attributes::ReactivePower::kMetadataEntry,   //
-        Attributes::ApparentPower::kMetadataEntry,   //
-        Attributes::RMSVoltage::kMetadataEntry,      //
-        Attributes::RMSCurrent::kMetadataEntry,      //
-        Attributes::RMSPower::kMetadataEntry,        //
-        Attributes::Frequency::kMetadataEntry,       //
-        Attributes::PowerFactor::kMetadataEntry,     //
-        Attributes::NeutralCurrent::kMetadataEntry,  //
+        Attributes::Ranges::kMetadataEntry,           //
+        Attributes::Voltage::kMetadataEntry,          //
+        Attributes::ActiveCurrent::kMetadataEntry,    //
+        Attributes::ReactiveCurrent::kMetadataEntry,  //
+        Attributes::ApparentCurrent::kMetadataEntry,  //
+        Attributes::ReactivePower::kMetadataEntry,    //
+        Attributes::ApparentPower::kMetadataEntry,    //
+        Attributes::RMSVoltage::kMetadataEntry,       //
+        Attributes::RMSCurrent::kMetadataEntry,       //
+        Attributes::RMSPower::kMetadataEntry,         //
+        Attributes::Frequency::kMetadataEntry,        //
+        Attributes::HarmonicCurrents::kMetadataEntry, // Derived from Harmonics feature
+        Attributes::HarmonicPhases::kMetadataEntry,   // Derived from PowerQuality feature
+        Attributes::PowerFactor::kMetadataEntry,      //
+        Attributes::NeutralCurrent::kMetadataEntry,   //
     };
 
     AttributeListBuilder listBuilder(builder);

--- a/src/app/clusters/electrical-power-measurement-server/ElectricalPowerMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-power-measurement-server/ElectricalPowerMeasurementCluster.cpp
@@ -167,8 +167,8 @@ CHIP_ERROR ElectricalPowerMeasurementCluster::Attributes(const ConcreteClusterPa
         Attributes::RMSCurrent::kMetadataEntry,       //
         Attributes::RMSPower::kMetadataEntry,         //
         Attributes::Frequency::kMetadataEntry,        //
-        Attributes::HarmonicCurrents::kMetadataEntry, // Derived from Harmonics feature
-        Attributes::HarmonicPhases::kMetadataEntry,   // Derived from PowerQuality feature
+        Attributes::HarmonicCurrents::kMetadataEntry, //
+        Attributes::HarmonicPhases::kMetadataEntry,   //
         Attributes::PowerFactor::kMetadataEntry,      //
         Attributes::NeutralCurrent::kMetadataEntry,   //
     };

--- a/src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp
+++ b/src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp
@@ -117,8 +117,11 @@ TEST_F(TestOccupancySensingCluster, TestHoldTimeAttribute)
     OccupancySensing::Structs::HoldTimeLimitsStruct::Type holdTimeLimitsConfig = { .holdTimeMin     = 10,
                                                                                    .holdTimeMax     = 200,
                                                                                    .holdTimeDefault = 100 };
-    OccupancySensingCluster cluster{ OccupancySensingCluster::Config{ kTestEndpointId }.WithHoldTime(100, holdTimeLimitsConfig,
-                                                                                                     mMockTimerDelegate) };
+    OccupancySensingCluster cluster{ OccupancySensingCluster::Config{ kTestEndpointId }
+                                         .WithHoldTime(100, holdTimeLimitsConfig, mMockTimerDelegate)
+                                         .WithFeatures(BitFlags<Feature>(Feature::kPassiveInfrared, Feature::kUltrasonic,
+                                                                         Feature::kPhysicalContact))
+                                         .WithDeprecatedAttributes(true) };
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
     EXPECT_TRUE(cluster.IsHoldTimeEnabled());
     chip::Testing::ClusterTester tester(cluster);
@@ -381,8 +384,11 @@ TEST_F(TestOccupancySensingCluster, TestReadOptionalHoldTimeAttributes)
     OccupancySensing::Structs::HoldTimeLimitsStruct::Type holdTimeLimitsConfig = { .holdTimeMin     = 10,
                                                                                    .holdTimeMax     = 200,
                                                                                    .holdTimeDefault = kHoldTime };
-    OccupancySensingCluster cluster{ OccupancySensingCluster::Config{ kTestEndpointId }.WithHoldTime(
-        kHoldTime, holdTimeLimitsConfig, mMockTimerDelegate) };
+    OccupancySensingCluster cluster{ OccupancySensingCluster::Config{ kTestEndpointId }
+                                         .WithHoldTime(kHoldTime, holdTimeLimitsConfig, mMockTimerDelegate)
+                                         .WithFeatures(BitFlags<Feature>(Feature::kPassiveInfrared, Feature::kUltrasonic,
+                                                                         Feature::kPhysicalContact))
+                                         .WithDeprecatedAttributes(true) };
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
     chip::Testing::ClusterTester tester(cluster);
 

--- a/src/app/clusters/resource-monitoring-server/tests/TestResourceMonitoringCluster.cpp
+++ b/src/app/clusters/resource-monitoring-server/tests/TestResourceMonitoringCluster.cpp
@@ -107,7 +107,10 @@ struct TestResourceMonitoringCluster : public ::testing::Test
 
     TestResourceMonitoringCluster() :
         activatedCarbonFilterMonitoring(kEndpointId, ActivatedCarbonFilterMonitoring::Id, kResourceMonitoringFeatureMap,
-                                        OptionalAttributeSet(), ResourceMonitoring::DegradationDirectionEnum::kDown, true)
+                                        ResourceMonitoringCluster::OptionalAttributeSet()
+                                            .Set<Attributes::InPlaceIndicator::Id>()
+                                            .Set<Attributes::LastChangedTime::Id>(),
+                                        ResourceMonitoring::DegradationDirectionEnum::kDown, true)
     {}
 };
 } // namespace
@@ -124,6 +127,8 @@ TEST_F(TestResourceMonitoringCluster, AttributeTest)
         { ActivatedCarbonFilterMonitoring::Attributes::ChangeIndication::kMetadataEntry,
           ActivatedCarbonFilterMonitoring::Attributes::Condition::kMetadataEntry,
           ActivatedCarbonFilterMonitoring::Attributes::DegradationDirection::kMetadataEntry,
+          ActivatedCarbonFilterMonitoring::Attributes::InPlaceIndicator::kMetadataEntry,
+          ActivatedCarbonFilterMonitoring::Attributes::LastChangedTime::kMetadataEntry,
           ActivatedCarbonFilterMonitoring::Attributes::ReplacementProductList::kMetadataEntry }));
 }
 

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -49,298 +49,312 @@
 
 namespace chip {
 namespace Testing {
-    // Helper class for testing clusters.
-    //
-    // This class ensures that data read by attribute is referencing valid memory for all
-    // read requests until the ClusterTester object goes out of scope. (for the case where the underlying read references a list or
-    // string that points to TLV data).
-    //
-    // Read/Write of all attribute types should work, but make sure to use ::Type for encoding
-    // and ::DecodableType for decoding structure types.
-    //
-    // Example of usage:
-    //
-    // ExampleCluster cluster(someEndpointId);
-    //
-    // // Possibly steps to setup the cluster
-    //
-    // ClusterTester tester(cluster);
-    // app::Clusters::ExampleCluster::Attributes::FeatureMap::TypeInfo::DecodableType features;
-    // ASSERT_EQ(tester.ReadAttribute(FeatureMap::Id, features), CHIP_NO_ERROR);
-    //
-    // app::Clusters::ExampleCluster::Attributes::ExampleListAttribute::TypeInfo::DecodableType list;
-    // ASSERT_EQ(tester.ReadAttribute(LabelList::Id, list), CHIP_NO_ERROR);
-    // auto it = list.begin();
-    // while (it.Next())
-    // {
-    //     ASSERT_GT(it.GetValue().label.size(), 0u);
-    // }
-    //
-    class ClusterTester {
-    public:
-        ClusterTester(app::ServerClusterInterface & cluster)
-            : mCluster(cluster)
-            , mFabricTestFixture(nullptr)
+// Helper class for testing clusters.
+//
+// This class ensures that data read by attribute is referencing valid memory for all
+// read requests until the ClusterTester object goes out of scope. (for the case where the underlying read references a list or
+// string that points to TLV data).
+//
+// Read/Write of all attribute types should work, but make sure to use ::Type for encoding
+// and ::DecodableType for decoding structure types.
+//
+// Example of usage:
+//
+// ExampleCluster cluster(someEndpointId);
+//
+// // Possibly steps to setup the cluster
+//
+// ClusterTester tester(cluster);
+// app::Clusters::ExampleCluster::Attributes::FeatureMap::TypeInfo::DecodableType features;
+// ASSERT_EQ(tester.ReadAttribute(FeatureMap::Id, features), CHIP_NO_ERROR);
+//
+// app::Clusters::ExampleCluster::Attributes::ExampleListAttribute::TypeInfo::DecodableType list;
+// ASSERT_EQ(tester.ReadAttribute(LabelList::Id, list), CHIP_NO_ERROR);
+// auto it = list.begin();
+// while (it.Next())
+// {
+//     ASSERT_GT(it.GetValue().label.size(), 0u);
+// }
+//
+class ClusterTester
+{
+public:
+    ClusterTester(app::ServerClusterInterface & cluster) : mCluster(cluster), mFabricTestFixture(nullptr) {}
+
+    // Constructor with FabricHelper
+    ClusterTester(app::ServerClusterInterface & cluster, FabricTestFixture * fabricHelper) :
+        mCluster(cluster), mFabricTestFixture(fabricHelper)
+    {}
+
+    app::ServerClusterContext & GetServerClusterContext() { return mTestServerClusterContext.Get(); }
+
+    // Read attribute into `out` parameter.
+    // The `out` parameter must be of the correct type for the attribute being read.
+    // Use `app::Clusters::<ClusterName>::Attributes::<AttributeName>::TypeInfo::DecodableType` for the `out` parameter to be spec
+    // compliant (see the comment of the class for usage example).
+    // Will construct the attribute path using the first path returned by `GetPaths()` on the cluster.
+    // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
+    // @returns `CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute)` if the attribute is not present in AttributeList.
+    template <typename T>
+    app::DataModel::ActionReturnStatus ReadAttribute(AttributeId attr_id, T & out)
+    {
+        VerifyOrReturnError(VerifyClusterPathsValid(), CHIP_ERROR_INCORRECT_STATE);
+
+        // Verify that the attribute is present in AttributeList before attempting to read it.
+        // This ensures tests match real-world behavior where the Interaction Model checks AttributeList first.
+        auto checkStatus = VerifyAttributeInAttributeList(attr_id);
+        VerifyOrReturnError(checkStatus.IsSuccess(), checkStatus);
+
+        auto path = mCluster.GetPaths()[0];
+
+        // Store the read operation in a vector<std::unique_ptr<...>> to ensure its lifetime
+        // using std::unique_ptr because ReadOperation is non-copyable and non-movable
+        // vector reallocation is not an issue since we store unique_ptrs
+        std::unique_ptr<chip::Testing::ReadOperation> readOperation =
+            std::make_unique<chip::Testing::ReadOperation>(path.mEndpointId, path.mClusterId, attr_id);
+
+        mReadOperations.push_back(std::move(readOperation));
+        chip::Testing::ReadOperation & readOperationRef = *mReadOperations.back().get();
+
+        std::unique_ptr<app::AttributeValueEncoder> encoder = readOperationRef.StartEncoding();
+        app::DataModel::ActionReturnStatus status           = mCluster.ReadAttribute(readOperationRef.GetRequest(), *encoder);
+        VerifyOrReturnError(status.IsSuccess(), status);
+        ReturnErrorOnFailure(readOperationRef.FinishEncoding());
+
+        std::vector<chip::Testing::DecodedAttributeData> attributeData;
+        ReturnErrorOnFailure(readOperationRef.GetEncodedIBs().Decode(attributeData));
+        VerifyOrReturnError(attributeData.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
+
+        return app::DataModel::Decode(attributeData[0].dataReader, out);
+    }
+
+    // Write attribute from `value` parameter.
+    // The `value` parameter must be of the correct type for the attribute being written.
+    // Use `app::Clusters::<ClusterName>::Attributes::<AttributeName>::TypeInfo::Type` for the `value` parameter to be spec
+    // compliant (see the comment of the class for usage example).
+    // Will construct the attribute path using the first path returned by `GetPaths()` on the cluster.
+    // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
+    // @returns `CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute)` if the attribute is not present in AttributeList.
+    template <typename T>
+    app::DataModel::ActionReturnStatus WriteAttribute(AttributeId attr, const T & value)
+    {
+        const auto & paths = mCluster.GetPaths();
+
+        VerifyOrReturnError(paths.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
+
+        // Verify that the attribute is present in AttributeList before attempting to write it.
+        // This ensures tests match real-world behavior where the Interaction Model checks AttributeList first.
+        auto checkStatus = VerifyAttributeInAttributeList(attr);
+        VerifyOrReturnError(checkStatus.IsSuccess(), checkStatus);
+
+        app::ConcreteAttributePath path(paths[0].mEndpointId, paths[0].mClusterId, attr);
+        chip::Testing::WriteOperation writeOp(path);
+
+        // Create a stable object on the stack
+        Access::SubjectDescriptor subjectDescriptor{ mHandler.GetAccessingFabricIndex() };
+        writeOp.SetSubjectDescriptor(subjectDescriptor);
+
+        uint8_t buffer[1024];
+        TLV::TLVWriter writer;
+        writer.Init(buffer);
+
+        // - DataModel::Encode(integral, enum, etc.) for simple types.
+        // - DataModel::Encode(List<X>) for lists (which iterates and calls Encode on elements).
+        // - DataModel::Encode(Struct) for non-fabric-scoped structs.
+        // - Note: For attribute writes, DataModel::EncodeForWrite is usually preferred for fabric-scoped types,
+        //         but the generic DataModel::Encode often works as a top-level function.
+        //         If you use EncodeForWrite, you ensure fabric-scoped list items are handled correctly:
+
+        if constexpr (app::DataModel::IsFabricScoped<T>::value)
         {
+            ReturnErrorOnFailure(chip::app::DataModel::EncodeForWrite(writer, TLV::AnonymousTag(), value));
+        }
+        else
+        {
+            ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, TLV::AnonymousTag(), value));
         }
 
-        // Constructor with FabricHelper
-        ClusterTester(app::ServerClusterInterface & cluster, FabricTestFixture * fabricHelper)
-            : mCluster(cluster)
-            , mFabricTestFixture(fabricHelper)
+        TLV::TLVReader reader;
+        reader.Init(buffer, writer.GetLengthWritten());
+        ReturnErrorOnFailure(reader.Next());
+
+        app::AttributeValueDecoder decoder(reader, *writeOp.GetRequest().subjectDescriptor);
+
+        return mCluster.WriteAttribute(writeOp.GetRequest(), decoder);
+    }
+
+    // Result structure for Invoke operations, containing both status and decoded response.
+    template <typename ResponseType>
+    struct InvokeResult
+    {
+        std::optional<app::DataModel::ActionReturnStatus> status;
+        std::optional<ResponseType> response;
+
+        // Returns true if the command was successful and response is available
+        bool IsSuccess() const
         {
+            if constexpr (std::is_same_v<ResponseType, app::DataModel::NullObjectType>)
+                return status.has_value() && status->IsSuccess();
+            else
+                return status.has_value() && status->IsSuccess() && response.has_value();
         }
-
-        app::ServerClusterContext & GetServerClusterContext() { return mTestServerClusterContext.Get(); }
-
-        // Read attribute into `out` parameter.
-        // The `out` parameter must be of the correct type for the attribute being read.
-        // Use `app::Clusters::<ClusterName>::Attributes::<AttributeName>::TypeInfo::DecodableType` for the `out` parameter to be spec
-        // compliant (see the comment of the class for usage example).
-        // Will construct the attribute path using the first path returned by `GetPaths()` on the cluster.
-        // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
-        // @returns `CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute)` if the attribute is not present in AttributeList.
-        template <typename T>
-        app::DataModel::ActionReturnStatus ReadAttribute(AttributeId attr_id, T & out)
-        {
-            VerifyOrReturnError(VerifyClusterPathsValid(), CHIP_ERROR_INCORRECT_STATE);
-
-            // Verify that the attribute is present in AttributeList before attempting to read it.
-            // This ensures tests match real-world behavior where the Interaction Model checks AttributeList first.
-            auto checkStatus = VerifyAttributeInAttributeList(attr_id);
-            VerifyOrReturnError(checkStatus.IsSuccess(), checkStatus);
-
-            auto path = mCluster.GetPaths()[0];
-
-            // Store the read operation in a vector<std::unique_ptr<...>> to ensure its lifetime
-            // using std::unique_ptr because ReadOperation is non-copyable and non-movable
-            // vector reallocation is not an issue since we store unique_ptrs
-            std::unique_ptr<chip::Testing::ReadOperation> readOperation = std::make_unique<chip::Testing::ReadOperation>(path.mEndpointId, path.mClusterId, attr_id);
-
-            mReadOperations.push_back(std::move(readOperation));
-            chip::Testing::ReadOperation & readOperationRef = *mReadOperations.back().get();
-
-            std::unique_ptr<app::AttributeValueEncoder> encoder = readOperationRef.StartEncoding();
-            app::DataModel::ActionReturnStatus status = mCluster.ReadAttribute(readOperationRef.GetRequest(), *encoder);
-            VerifyOrReturnError(status.IsSuccess(), status);
-            ReturnErrorOnFailure(readOperationRef.FinishEncoding());
-
-            std::vector<chip::Testing::DecodedAttributeData> attributeData;
-            ReturnErrorOnFailure(readOperationRef.GetEncodedIBs().Decode(attributeData));
-            VerifyOrReturnError(attributeData.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
-
-            return app::DataModel::Decode(attributeData[0].dataReader, out);
-        }
-
-        // Write attribute from `value` parameter.
-        // The `value` parameter must be of the correct type for the attribute being written.
-        // Use `app::Clusters::<ClusterName>::Attributes::<AttributeName>::TypeInfo::Type` for the `value` parameter to be spec
-        // compliant (see the comment of the class for usage example).
-        // Will construct the attribute path using the first path returned by `GetPaths()` on the cluster.
-        // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
-        // @returns `CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute)` if the attribute is not present in AttributeList.
-        template <typename T>
-        app::DataModel::ActionReturnStatus WriteAttribute(AttributeId attr, const T & value)
-        {
-            const auto & paths = mCluster.GetPaths();
-
-            VerifyOrReturnError(paths.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
-
-            // Verify that the attribute is present in AttributeList before attempting to write it.
-            // This ensures tests match real-world behavior where the Interaction Model checks AttributeList first.
-            auto checkStatus = VerifyAttributeInAttributeList(attr);
-            VerifyOrReturnError(checkStatus.IsSuccess(), checkStatus);
-
-            app::ConcreteAttributePath path(paths[0].mEndpointId, paths[0].mClusterId, attr);
-            chip::Testing::WriteOperation writeOp(path);
-
-            // Create a stable object on the stack
-            Access::SubjectDescriptor subjectDescriptor { mHandler.GetAccessingFabricIndex() };
-            writeOp.SetSubjectDescriptor(subjectDescriptor);
-
-            uint8_t buffer[1024];
-            TLV::TLVWriter writer;
-            writer.Init(buffer);
-
-            // - DataModel::Encode(integral, enum, etc.) for simple types.
-            // - DataModel::Encode(List<X>) for lists (which iterates and calls Encode on elements).
-            // - DataModel::Encode(Struct) for non-fabric-scoped structs.
-            // - Note: For attribute writes, DataModel::EncodeForWrite is usually preferred for fabric-scoped types,
-            //         but the generic DataModel::Encode often works as a top-level function.
-            //         If you use EncodeForWrite, you ensure fabric-scoped list items are handled correctly:
-
-            if constexpr (app::DataModel::IsFabricScoped<T>::value) {
-                ReturnErrorOnFailure(chip::app::DataModel::EncodeForWrite(writer, TLV::AnonymousTag(), value));
-            } else {
-                ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, TLV::AnonymousTag(), value));
-            }
-
-            TLV::TLVReader reader;
-            reader.Init(buffer, writer.GetLengthWritten());
-            ReturnErrorOnFailure(reader.Next());
-
-            app::AttributeValueDecoder decoder(reader, *writeOp.GetRequest().subjectDescriptor);
-
-            return mCluster.WriteAttribute(writeOp.GetRequest(), decoder);
-        }
-
-        // Result structure for Invoke operations, containing both status and decoded response.
-        template <typename ResponseType>
-        struct InvokeResult {
-            std::optional<app::DataModel::ActionReturnStatus> status;
-            std::optional<ResponseType> response;
-
-            // Returns true if the command was successful and response is available
-            bool IsSuccess() const
-            {
-                if constexpr (std::is_same_v<ResponseType, app::DataModel::NullObjectType>)
-                    return status.has_value() && status->IsSuccess();
-                else
-                    return status.has_value() && status->IsSuccess() && response.has_value();
-            }
-        };
-
-        // Invoke a command and return the decoded result.
-        // The `request` parameter must be of the correct type for the command being invoked.
-        // Use `app::Clusters::<ClusterName>::Commands::<CommandName>::Type` for the `request` parameter to be spec compliant
-        // Will construct the command path using the first path returned by `GetPaths()` on the cluster.
-        // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
-        template <typename RequestType, typename ResponseType = typename RequestType::ResponseType>
-        [[nodiscard]] InvokeResult<ResponseType> Invoke(chip::CommandId commandId, const RequestType & request)
-        {
-            InvokeResult<ResponseType> result;
-
-            const auto & paths = mCluster.GetPaths();
-            VerifyOrReturnValue(paths.size() == 1u, result);
-
-            mHandler.ClearResponses();
-            mHandler.ClearStatuses();
-
-            const app::DataModel::InvokeRequest invokeRequest = { .path = { paths[0].mEndpointId, paths[0].mClusterId, commandId } };
-
-            TLV::TLVWriter writer;
-            writer.Init(mTlvBuffer);
-
-            TLV::TLVReader reader;
-
-            VerifyOrReturnValue(request.Encode(writer, TLV::AnonymousTag()) == CHIP_NO_ERROR, result);
-            VerifyOrReturnValue(writer.Finalize() == CHIP_NO_ERROR, result);
-
-            reader.Init(mTlvBuffer, writer.GetLengthWritten());
-            VerifyOrReturnValue(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()) == CHIP_NO_ERROR, result);
-
-            result.status = mCluster.InvokeCommand(invokeRequest, reader, &mHandler);
-
-            // If InvokeCommand returned nullopt, it means the command implementation handled the response.
-            // We need to check the mock handler for a data response or a status response.
-            if (!result.status.has_value()) {
-                if (mHandler.HasResponse()) {
-                    // A data response was added, so the command is successful.
-                    result.status = app::DataModel::ActionReturnStatus(CHIP_NO_ERROR);
-                } else if (mHandler.HasStatus()) {
-                    // A status response was added. Use the last one.
-                    result.status = app::DataModel::ActionReturnStatus(mHandler.GetLastStatus().status);
-                } else {
-                    // Neither response nor status was provided; this is unexpected.
-                    // This would happen either in error (as mentioned here) or if the command is supposed
-                    // to be handled asynchronously. ClusterTester does not support such asynchronous processing.
-                    result.status = app::DataModel::ActionReturnStatus(CHIP_ERROR_INCORRECT_STATE);
-                    ChipLogError(
-                        Test, "InvokeCommand returned nullopt, but neither HasResponse nor HasStatus is true. Setting error status.");
-                }
-            }
-
-            // If command was successful and there's a response, decode it (skip for NullObjectType)
-            if constexpr (!std::is_same_v<ResponseType, app::DataModel::NullObjectType>) {
-                if (result.status.has_value() && result.status->IsSuccess() && mHandler.HasResponse()) {
-                    ResponseType decodedResponse;
-                    CHIP_ERROR decodeError = mHandler.DecodeResponse(decodedResponse);
-                    if (decodeError == CHIP_NO_ERROR) {
-                        result.response = std::move(decodedResponse);
-                    } else {
-                        // Decode failed; reflect error in status and log
-                        result.status = app::DataModel::ActionReturnStatus(decodeError);
-                        ChipLogError(Test, "DecodeResponse failed: %s", decodeError.AsString());
-                    }
-                }
-            }
-
-            return result;
-        }
-
-        // convenience method: most requests have a `GetCommandId` (and GetClusterId() as well).
-        template <typename RequestType, typename ResponseType = typename RequestType::ResponseType>
-        [[nodiscard]] InvokeResult<ResponseType> Invoke(const RequestType & request)
-        {
-            return Invoke(RequestType::GetCommandId(), request);
-        }
-
-        // Returns the next generated event from the event generator in the test server cluster context
-        std::optional<LogOnlyEvents::EventInformation> GetNextGeneratedEvent()
-        {
-            return mTestServerClusterContext.EventsGenerator().GetNextEvent();
-        }
-
-        std::vector<app::AttributePathParams> & GetDirtyList() { return mTestServerClusterContext.ChangeListener().DirtyList(); }
-
-        void SetFabricIndex(FabricIndex fabricIndex) { mHandler.SetFabricIndex(fabricIndex); }
-
-        FabricTestFixture * GetFabricHelper() { return mFabricTestFixture; }
-
-    private:
-        bool VerifyClusterPathsValid()
-        {
-            auto paths = mCluster.GetPaths();
-            if (paths.size() != 1) {
-                ChipLogError(Test, "cluster.GetPaths() did not return exactly one path");
-                return false;
-            }
-            return true;
-        }
-
-        // Verifies that an attribute is present in the cluster's AttributeList.
-        // This mimics the real-world Interaction Model behavior where AttributeList is checked first.
-        // @returns CHIP_NO_ERROR if the attribute is found in AttributeList.
-        // @returns CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute) if the attribute is not found in AttributeList.
-        // @returns error status if Attributes cannot be retrieved (indicates a problem with cluster implementation).
-        app::DataModel::ActionReturnStatus VerifyAttributeInAttributeList(AttributeId attr_id)
-        {
-            auto path = mCluster.GetPaths()[0];
-
-            // Get the list of attributes from the cluster's metadata
-            // This is more efficient than reading AttributeList attribute, and matches how IM works internally
-            ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> builder;
-            CHIP_ERROR err = mCluster.Attributes(path, builder);
-            ReturnErrorOnFailure(err);
-
-            ReadOnlyBuffer<app::DataModel::AttributeEntry> attributeEntries = builder.TakeBuffer();
-
-            // Check if the requested attribute ID is present in the attribute list
-            for (const auto & entry : attributeEntries) {
-                if (entry.attributeId == attr_id) {
-                    return CHIP_NO_ERROR; // Attribute found in AttributeList
-                }
-            }
-
-            // Attribute not found in AttributeList - this matches real-world IM behavior
-            return CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute);
-        }
-
-        TestServerClusterContext mTestServerClusterContext {};
-        app::ServerClusterInterface & mCluster;
-
-        // Buffer size for TLV encoding/decoding of command payloads.
-        // 256 bytes was chosen as a conservative upper bound for typical command payloads in tests.
-        // All command payloads used in tests must fit within this buffer; tests with larger payloads will fail.
-        // If protocol or test requirements change, this value may need to be increased.
-        static constexpr size_t kTlvBufferSize = 256;
-
-        chip::Testing::MockCommandHandler mHandler;
-        uint8_t mTlvBuffer[kTlvBufferSize];
-        std::vector<std::unique_ptr<ReadOperation>> mReadOperations;
-
-        FabricTestFixture * mFabricTestFixture;
     };
+
+    // Invoke a command and return the decoded result.
+    // The `request` parameter must be of the correct type for the command being invoked.
+    // Use `app::Clusters::<ClusterName>::Commands::<CommandName>::Type` for the `request` parameter to be spec compliant
+    // Will construct the command path using the first path returned by `GetPaths()` on the cluster.
+    // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
+    template <typename RequestType, typename ResponseType = typename RequestType::ResponseType>
+    [[nodiscard]] InvokeResult<ResponseType> Invoke(chip::CommandId commandId, const RequestType & request)
+    {
+        InvokeResult<ResponseType> result;
+
+        const auto & paths = mCluster.GetPaths();
+        VerifyOrReturnValue(paths.size() == 1u, result);
+
+        mHandler.ClearResponses();
+        mHandler.ClearStatuses();
+
+        const app::DataModel::InvokeRequest invokeRequest = { .path = { paths[0].mEndpointId, paths[0].mClusterId, commandId } };
+
+        TLV::TLVWriter writer;
+        writer.Init(mTlvBuffer);
+
+        TLV::TLVReader reader;
+
+        VerifyOrReturnValue(request.Encode(writer, TLV::AnonymousTag()) == CHIP_NO_ERROR, result);
+        VerifyOrReturnValue(writer.Finalize() == CHIP_NO_ERROR, result);
+
+        reader.Init(mTlvBuffer, writer.GetLengthWritten());
+        VerifyOrReturnValue(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()) == CHIP_NO_ERROR, result);
+
+        result.status = mCluster.InvokeCommand(invokeRequest, reader, &mHandler);
+
+        // If InvokeCommand returned nullopt, it means the command implementation handled the response.
+        // We need to check the mock handler for a data response or a status response.
+        if (!result.status.has_value())
+        {
+            if (mHandler.HasResponse())
+            {
+                // A data response was added, so the command is successful.
+                result.status = app::DataModel::ActionReturnStatus(CHIP_NO_ERROR);
+            }
+            else if (mHandler.HasStatus())
+            {
+                // A status response was added. Use the last one.
+                result.status = app::DataModel::ActionReturnStatus(mHandler.GetLastStatus().status);
+            }
+            else
+            {
+                // Neither response nor status was provided; this is unexpected.
+                // This would happen either in error (as mentioned here) or if the command is supposed
+                // to be handled asynchronously. ClusterTester does not support such asynchronous processing.
+                result.status = app::DataModel::ActionReturnStatus(CHIP_ERROR_INCORRECT_STATE);
+                ChipLogError(
+                    Test, "InvokeCommand returned nullopt, but neither HasResponse nor HasStatus is true. Setting error status.");
+            }
+        }
+
+        // If command was successful and there's a response, decode it (skip for NullObjectType)
+        if constexpr (!std::is_same_v<ResponseType, app::DataModel::NullObjectType>)
+        {
+            if (result.status.has_value() && result.status->IsSuccess() && mHandler.HasResponse())
+            {
+                ResponseType decodedResponse;
+                CHIP_ERROR decodeError = mHandler.DecodeResponse(decodedResponse);
+                if (decodeError == CHIP_NO_ERROR)
+                {
+                    result.response = std::move(decodedResponse);
+                }
+                else
+                {
+                    // Decode failed; reflect error in status and log
+                    result.status = app::DataModel::ActionReturnStatus(decodeError);
+                    ChipLogError(Test, "DecodeResponse failed: %s", decodeError.AsString());
+                }
+            }
+        }
+
+        return result;
+    }
+
+    // convenience method: most requests have a `GetCommandId` (and GetClusterId() as well).
+    template <typename RequestType, typename ResponseType = typename RequestType::ResponseType>
+    [[nodiscard]] InvokeResult<ResponseType> Invoke(const RequestType & request)
+    {
+        return Invoke(RequestType::GetCommandId(), request);
+    }
+
+    // Returns the next generated event from the event generator in the test server cluster context
+    std::optional<LogOnlyEvents::EventInformation> GetNextGeneratedEvent()
+    {
+        return mTestServerClusterContext.EventsGenerator().GetNextEvent();
+    }
+
+    std::vector<app::AttributePathParams> & GetDirtyList() { return mTestServerClusterContext.ChangeListener().DirtyList(); }
+
+    void SetFabricIndex(FabricIndex fabricIndex) { mHandler.SetFabricIndex(fabricIndex); }
+
+    FabricTestFixture * GetFabricHelper() { return mFabricTestFixture; }
+
+private:
+    bool VerifyClusterPathsValid()
+    {
+        auto paths = mCluster.GetPaths();
+        if (paths.size() != 1)
+        {
+            ChipLogError(Test, "cluster.GetPaths() did not return exactly one path");
+            return false;
+        }
+        return true;
+    }
+
+    // Verifies that an attribute is present in the cluster's AttributeList.
+    // This mimics the real-world Interaction Model behavior where AttributeList is checked first.
+    // @returns CHIP_NO_ERROR if the attribute is found in AttributeList.
+    // @returns CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute) if the attribute is not found in AttributeList.
+    // @returns error status if Attributes cannot be retrieved (indicates a problem with cluster implementation).
+    app::DataModel::ActionReturnStatus VerifyAttributeInAttributeList(AttributeId attr_id)
+    {
+        auto path = mCluster.GetPaths()[0];
+
+        // Get the list of attributes from the cluster's metadata
+        // This is more efficient than reading AttributeList attribute, and matches how IM works internally
+        ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> builder;
+        CHIP_ERROR err = mCluster.Attributes(path, builder);
+        ReturnErrorOnFailure(err);
+
+        ReadOnlyBuffer<app::DataModel::AttributeEntry> attributeEntries = builder.TakeBuffer();
+
+        // Check if the requested attribute ID is present in the attribute list
+        for (const auto & entry : attributeEntries)
+        {
+            if (entry.attributeId == attr_id)
+            {
+                return CHIP_NO_ERROR; // Attribute found in AttributeList
+            }
+        }
+
+        // Attribute not found in AttributeList - this matches real-world IM behavior
+        return CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute);
+    }
+
+    TestServerClusterContext mTestServerClusterContext{};
+    app::ServerClusterInterface & mCluster;
+
+    // Buffer size for TLV encoding/decoding of command payloads.
+    // 256 bytes was chosen as a conservative upper bound for typical command payloads in tests.
+    // All command payloads used in tests must fit within this buffer; tests with larger payloads will fail.
+    // If protocol or test requirements change, this value may need to be increased.
+    static constexpr size_t kTlvBufferSize = 256;
+
+    chip::Testing::MockCommandHandler mHandler;
+    uint8_t mTlvBuffer[kTlvBufferSize];
+    std::vector<std::unique_ptr<ReadOperation>> mReadOperations;
+
+    FabricTestFixture * mFabricTestFixture;
+};
 
 } // namespace Testing
 } // namespace chip

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -311,16 +311,14 @@ private:
     }
 
     // Verifies that an attribute is present in the cluster's AttributeList.
-    // This mimics the real-world Interaction Model behavior where AttributeList is checked first.
     // @returns CHIP_NO_ERROR if the attribute is found in AttributeList.
     // @returns CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute) if the attribute is not found in AttributeList.
-    // @returns error status if Attributes cannot be retrieved (indicates a problem with cluster implementation).
+    // @returns error status if Attributes cannot be retrieved.
     app::DataModel::ActionReturnStatus VerifyAttributeInAttributeList(AttributeId attr_id)
     {
         auto path = mCluster.GetPaths()[0];
 
         // Get the list of attributes from the cluster's metadata
-        // This is more efficient than reading AttributeList attribute, and matches how IM works internally
         ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> builder;
         CHIP_ERROR err = mCluster.Attributes(path, builder);
         ReturnErrorOnFailure(err);
@@ -332,11 +330,11 @@ private:
         {
             if (entry.attributeId == attr_id)
             {
-                return CHIP_NO_ERROR; // Attribute found in AttributeList
+                return CHIP_NO_ERROR;
             }
         }
 
-        // Attribute not found in AttributeList - this matches real-world IM behavior
+        // Attribute not found in AttributeList
         return CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute);
     }
 

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -31,6 +31,7 @@
 #include <app/server-cluster/ServerClusterInterface.h>
 #include <app/server-cluster/testing/MockCommandHandler.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
+#include <clusters/shared/Attributes.h>
 #include <credentials/FabricTable.h>
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <crypto/CHIPCryptoPAL.h>
@@ -47,269 +48,324 @@
 
 namespace chip {
 namespace Testing {
-// Helper class for testing clusters.
-//
-// This class ensures that data read by attribute is referencing valid memory for all
-// read requests until the ClusterTester object goes out of scope. (for the case where the underlying read references a list or
-// string that points to TLV data).
-//
-// Read/Write of all attribute types should work, but make sure to use ::Type for encoding
-// and ::DecodableType for decoding structure types.
-//
-// Example of usage:
-//
-// ExampleCluster cluster(someEndpointId);
-//
-// // Possibly steps to setup the cluster
-//
-// ClusterTester tester(cluster);
-// app::Clusters::ExampleCluster::Attributes::FeatureMap::TypeInfo::DecodableType features;
-// ASSERT_EQ(tester.ReadAttribute(FeatureMap::Id, features), CHIP_NO_ERROR);
-//
-// app::Clusters::ExampleCluster::Attributes::ExampleListAttribute::TypeInfo::DecodableType list;
-// ASSERT_EQ(tester.ReadAttribute(LabelList::Id, list), CHIP_NO_ERROR);
-// auto it = list.begin();
-// while (it.Next())
-// {
-//     ASSERT_GT(it.GetValue().label.size(), 0u);
-// }
-//
-class ClusterTester
-{
-public:
-    ClusterTester(app::ServerClusterInterface & cluster) : mCluster(cluster), mFabricTestFixture(nullptr) {}
-
-    // Constructor with FabricHelper
-    ClusterTester(app::ServerClusterInterface & cluster, FabricTestFixture * fabricHelper) :
-        mCluster(cluster), mFabricTestFixture(fabricHelper)
-    {}
-
-    app::ServerClusterContext & GetServerClusterContext() { return mTestServerClusterContext.Get(); }
-
-    // Read attribute into `out` parameter.
-    // The `out` parameter must be of the correct type for the attribute being read.
-    // Use `app::Clusters::<ClusterName>::Attributes::<AttributeName>::TypeInfo::DecodableType` for the `out` parameter to be spec
-    // compliant (see the comment of the class for usage example).
-    // Will construct the attribute path using the first path returned by `GetPaths()` on the cluster.
-    // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
-    template <typename T>
-    app::DataModel::ActionReturnStatus ReadAttribute(AttributeId attr_id, T & out)
-    {
-        VerifyOrReturnError(VerifyClusterPathsValid(), CHIP_ERROR_INCORRECT_STATE);
-        auto path = mCluster.GetPaths()[0];
-
-        // Store the read operation in a vector<std::unique_ptr<...>> to ensure its lifetime
-        // using std::unique_ptr because ReadOperation is non-copyable and non-movable
-        // vector reallocation is not an issue since we store unique_ptrs
-        std::unique_ptr<chip::Testing::ReadOperation> readOperation =
-            std::make_unique<chip::Testing::ReadOperation>(path.mEndpointId, path.mClusterId, attr_id);
-
-        mReadOperations.push_back(std::move(readOperation));
-        chip::Testing::ReadOperation & readOperationRef = *mReadOperations.back().get();
-
-        std::unique_ptr<app::AttributeValueEncoder> encoder = readOperationRef.StartEncoding();
-        app::DataModel::ActionReturnStatus status           = mCluster.ReadAttribute(readOperationRef.GetRequest(), *encoder);
-        VerifyOrReturnError(status.IsSuccess(), status);
-        ReturnErrorOnFailure(readOperationRef.FinishEncoding());
-
-        std::vector<chip::Testing::DecodedAttributeData> attributeData;
-        ReturnErrorOnFailure(readOperationRef.GetEncodedIBs().Decode(attributeData));
-        VerifyOrReturnError(attributeData.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
-
-        return app::DataModel::Decode(attributeData[0].dataReader, out);
-    }
-
-    // Write attribute from `value` parameter.
-    // The `value` parameter must be of the correct type for the attribute being written.
-    // Use `app::Clusters::<ClusterName>::Attributes::<AttributeName>::TypeInfo::Type` for the `value` parameter to be spec
-    // compliant (see the comment of the class for usage example).
-    // Will construct the attribute path using the first path returned by `GetPaths()` on the cluster.
-    // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
-    template <typename T>
-    app::DataModel::ActionReturnStatus WriteAttribute(AttributeId attr, const T & value)
-    {
-        const auto & paths = mCluster.GetPaths();
-
-        VerifyOrReturnError(paths.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
-
-        app::ConcreteAttributePath path(paths[0].mEndpointId, paths[0].mClusterId, attr);
-        chip::Testing::WriteOperation writeOp(path);
-
-        // Create a stable object on the stack
-        Access::SubjectDescriptor subjectDescriptor{ mHandler.GetAccessingFabricIndex() };
-        writeOp.SetSubjectDescriptor(subjectDescriptor);
-
-        uint8_t buffer[1024];
-        TLV::TLVWriter writer;
-        writer.Init(buffer);
-
-        // - DataModel::Encode(integral, enum, etc.) for simple types.
-        // - DataModel::Encode(List<X>) for lists (which iterates and calls Encode on elements).
-        // - DataModel::Encode(Struct) for non-fabric-scoped structs.
-        // - Note: For attribute writes, DataModel::EncodeForWrite is usually preferred for fabric-scoped types,
-        //         but the generic DataModel::Encode often works as a top-level function.
-        //         If you use EncodeForWrite, you ensure fabric-scoped list items are handled correctly:
-
-        if constexpr (app::DataModel::IsFabricScoped<T>::value)
+    // Helper class for testing clusters.
+    //
+    // This class ensures that data read by attribute is referencing valid memory for all
+    // read requests until the ClusterTester object goes out of scope. (for the case where the underlying read references a list or
+    // string that points to TLV data).
+    //
+    // Read/Write of all attribute types should work, but make sure to use ::Type for encoding
+    // and ::DecodableType for decoding structure types.
+    //
+    // Example of usage:
+    //
+    // ExampleCluster cluster(someEndpointId);
+    //
+    // // Possibly steps to setup the cluster
+    //
+    // ClusterTester tester(cluster);
+    // app::Clusters::ExampleCluster::Attributes::FeatureMap::TypeInfo::DecodableType features;
+    // ASSERT_EQ(tester.ReadAttribute(FeatureMap::Id, features), CHIP_NO_ERROR);
+    //
+    // app::Clusters::ExampleCluster::Attributes::ExampleListAttribute::TypeInfo::DecodableType list;
+    // ASSERT_EQ(tester.ReadAttribute(LabelList::Id, list), CHIP_NO_ERROR);
+    // auto it = list.begin();
+    // while (it.Next())
+    // {
+    //     ASSERT_GT(it.GetValue().label.size(), 0u);
+    // }
+    //
+    class ClusterTester {
+    public:
+        ClusterTester(app::ServerClusterInterface & cluster)
+            : mCluster(cluster)
+            , mFabricTestFixture(nullptr)
         {
-            ReturnErrorOnFailure(chip::app::DataModel::EncodeForWrite(writer, TLV::AnonymousTag(), value));
-        }
-        else
-        {
-            ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, TLV::AnonymousTag(), value));
         }
 
-        TLV::TLVReader reader;
-        reader.Init(buffer, writer.GetLengthWritten());
-        ReturnErrorOnFailure(reader.Next());
-
-        app::AttributeValueDecoder decoder(reader, *writeOp.GetRequest().subjectDescriptor);
-
-        return mCluster.WriteAttribute(writeOp.GetRequest(), decoder);
-    }
-
-    // Result structure for Invoke operations, containing both status and decoded response.
-    template <typename ResponseType>
-    struct InvokeResult
-    {
-        std::optional<app::DataModel::ActionReturnStatus> status;
-        std::optional<ResponseType> response;
-
-        // Returns true if the command was successful and response is available
-        bool IsSuccess() const
+        // Constructor with FabricHelper
+        ClusterTester(app::ServerClusterInterface & cluster, FabricTestFixture * fabricHelper)
+            : mCluster(cluster)
+            , mFabricTestFixture(fabricHelper)
         {
-            if constexpr (std::is_same_v<ResponseType, app::DataModel::NullObjectType>)
-                return status.has_value() && status->IsSuccess();
-            else
-                return status.has_value() && status->IsSuccess() && response.has_value();
         }
-    };
 
-    // Invoke a command and return the decoded result.
-    // The `request` parameter must be of the correct type for the command being invoked.
-    // Use `app::Clusters::<ClusterName>::Commands::<CommandName>::Type` for the `request` parameter to be spec compliant
-    // Will construct the command path using the first path returned by `GetPaths()` on the cluster.
-    // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
-    template <typename RequestType, typename ResponseType = typename RequestType::ResponseType>
-    [[nodiscard]] InvokeResult<ResponseType> Invoke(chip::CommandId commandId, const RequestType & request)
-    {
-        InvokeResult<ResponseType> result;
+        app::ServerClusterContext & GetServerClusterContext() { return mTestServerClusterContext.Get(); }
 
-        const auto & paths = mCluster.GetPaths();
-        VerifyOrReturnValue(paths.size() == 1u, result);
-
-        mHandler.ClearResponses();
-        mHandler.ClearStatuses();
-
-        const app::DataModel::InvokeRequest invokeRequest = { .path = { paths[0].mEndpointId, paths[0].mClusterId, commandId } };
-
-        TLV::TLVWriter writer;
-        writer.Init(mTlvBuffer);
-
-        TLV::TLVReader reader;
-
-        VerifyOrReturnValue(request.Encode(writer, TLV::AnonymousTag()) == CHIP_NO_ERROR, result);
-        VerifyOrReturnValue(writer.Finalize() == CHIP_NO_ERROR, result);
-
-        reader.Init(mTlvBuffer, writer.GetLengthWritten());
-        VerifyOrReturnValue(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()) == CHIP_NO_ERROR, result);
-
-        result.status = mCluster.InvokeCommand(invokeRequest, reader, &mHandler);
-
-        // If InvokeCommand returned nullopt, it means the command implementation handled the response.
-        // We need to check the mock handler for a data response or a status response.
-        if (!result.status.has_value())
+        // Read attribute into `out` parameter.
+        // The `out` parameter must be of the correct type for the attribute being read.
+        // Use `app::Clusters::<ClusterName>::Attributes::<AttributeName>::TypeInfo::DecodableType` for the `out` parameter to be spec
+        // compliant (see the comment of the class for usage example).
+        // Will construct the attribute path using the first path returned by `GetPaths()` on the cluster.
+        // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
+        // @returns `CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute)` if the attribute is not present in AttributeList.
+        template <typename T>
+        app::DataModel::ActionReturnStatus ReadAttribute(AttributeId attr_id, T & out)
         {
-            if (mHandler.HasResponse())
-            {
-                // A data response was added, so the command is successful.
-                result.status = app::DataModel::ActionReturnStatus(CHIP_NO_ERROR);
+            VerifyOrReturnError(VerifyClusterPathsValid(), CHIP_ERROR_INCORRECT_STATE);
+
+            // Verify that the attribute is present in AttributeList before attempting to read it.
+            // This ensures tests match real-world behavior where the Interaction Model checks AttributeList first.
+            // Skip this check for AttributeList itself to avoid infinite recursion.
+            if (attr_id != app::Clusters::Globals::Attributes::AttributeList::Id) {
+                auto checkStatus = VerifyAttributeInAttributeList(attr_id);
+                VerifyOrReturnError(checkStatus.IsSuccess(), checkStatus);
             }
-            else if (mHandler.HasStatus())
-            {
-                // A status response was added. Use the last one.
-                result.status = app::DataModel::ActionReturnStatus(mHandler.GetLastStatus().status);
-            }
-            else
-            {
-                // Neither response nor status was provided; this is unexpected.
-                // This would happen either in error (as mentioned here) or if the command is supposed
-                // to be handled asynchronously. ClusterTester does not support such asynchronous processing.
-                result.status = app::DataModel::ActionReturnStatus(CHIP_ERROR_INCORRECT_STATE);
-                ChipLogError(
-                    Test, "InvokeCommand returned nullopt, but neither HasResponse nor HasStatus is true. Setting error status.");
-            }
+
+            auto path = mCluster.GetPaths()[0];
+
+            // Store the read operation in a vector<std::unique_ptr<...>> to ensure its lifetime
+            // using std::unique_ptr because ReadOperation is non-copyable and non-movable
+            // vector reallocation is not an issue since we store unique_ptrs
+            std::unique_ptr<chip::Testing::ReadOperation> readOperation = std::make_unique<chip::Testing::ReadOperation>(path.mEndpointId, path.mClusterId, attr_id);
+
+            mReadOperations.push_back(std::move(readOperation));
+            chip::Testing::ReadOperation & readOperationRef = *mReadOperations.back().get();
+
+            std::unique_ptr<app::AttributeValueEncoder> encoder = readOperationRef.StartEncoding();
+            app::DataModel::ActionReturnStatus status = mCluster.ReadAttribute(readOperationRef.GetRequest(), *encoder);
+            VerifyOrReturnError(status.IsSuccess(), status);
+            ReturnErrorOnFailure(readOperationRef.FinishEncoding());
+
+            std::vector<chip::Testing::DecodedAttributeData> attributeData;
+            ReturnErrorOnFailure(readOperationRef.GetEncodedIBs().Decode(attributeData));
+            VerifyOrReturnError(attributeData.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
+
+            return app::DataModel::Decode(attributeData[0].dataReader, out);
         }
 
-        // If command was successful and there's a response, decode it (skip for NullObjectType)
-        if constexpr (!std::is_same_v<ResponseType, app::DataModel::NullObjectType>)
+        // Write attribute from `value` parameter.
+        // The `value` parameter must be of the correct type for the attribute being written.
+        // Use `app::Clusters::<ClusterName>::Attributes::<AttributeName>::TypeInfo::Type` for the `value` parameter to be spec
+        // compliant (see the comment of the class for usage example).
+        // Will construct the attribute path using the first path returned by `GetPaths()` on the cluster.
+        // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
+        // @returns `CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute)` if the attribute is not present in AttributeList.
+        template <typename T>
+        app::DataModel::ActionReturnStatus WriteAttribute(AttributeId attr, const T & value)
         {
-            if (result.status.has_value() && result.status->IsSuccess() && mHandler.HasResponse())
+            const auto & paths = mCluster.GetPaths();
+
+            VerifyOrReturnError(paths.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
+
+            // Verify that the attribute is present in AttributeList before attempting to write it.
+            // This ensures tests match real-world behavior where the Interaction Model checks AttributeList first.
+            // Skip this check for AttributeList itself to avoid infinite recursion.
+            if (attr != app::Clusters::Globals::Attributes::AttributeList::Id) {
+                auto checkStatus = VerifyAttributeInAttributeList(attr);
+                VerifyOrReturnError(checkStatus.IsSuccess(), checkStatus);
+            }
+
+            app::ConcreteAttributePath path(paths[0].mEndpointId, paths[0].mClusterId, attr);
+            chip::Testing::WriteOperation writeOp(path);
+
+            // Create a stable object on the stack
+            Access::SubjectDescriptor subjectDescriptor { mHandler.GetAccessingFabricIndex() };
+            writeOp.SetSubjectDescriptor(subjectDescriptor);
+
+            uint8_t buffer[1024];
+            TLV::TLVWriter writer;
+            writer.Init(buffer);
+
+            // - DataModel::Encode(integral, enum, etc.) for simple types.
+            // - DataModel::Encode(List<X>) for lists (which iterates and calls Encode on elements).
+            // - DataModel::Encode(Struct) for non-fabric-scoped structs.
+            // - Note: For attribute writes, DataModel::EncodeForWrite is usually preferred for fabric-scoped types,
+            //         but the generic DataModel::Encode often works as a top-level function.
+            //         If you use EncodeForWrite, you ensure fabric-scoped list items are handled correctly:
+
+            if constexpr (app::DataModel::IsFabricScoped<T>::value) {
+                ReturnErrorOnFailure(chip::app::DataModel::EncodeForWrite(writer, TLV::AnonymousTag(), value));
+            } else {
+                ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, TLV::AnonymousTag(), value));
+            }
+
+            TLV::TLVReader reader;
+            reader.Init(buffer, writer.GetLengthWritten());
+            ReturnErrorOnFailure(reader.Next());
+
+            app::AttributeValueDecoder decoder(reader, *writeOp.GetRequest().subjectDescriptor);
+
+            return mCluster.WriteAttribute(writeOp.GetRequest(), decoder);
+        }
+
+        // Result structure for Invoke operations, containing both status and decoded response.
+        template <typename ResponseType>
+        struct InvokeResult {
+            std::optional<app::DataModel::ActionReturnStatus> status;
+            std::optional<ResponseType> response;
+
+            // Returns true if the command was successful and response is available
+            bool IsSuccess() const
             {
-                ResponseType decodedResponse;
-                CHIP_ERROR decodeError = mHandler.DecodeResponse(decodedResponse);
-                if (decodeError == CHIP_NO_ERROR)
-                {
-                    result.response = std::move(decodedResponse);
-                }
+                if constexpr (std::is_same_v<ResponseType, app::DataModel::NullObjectType>)
+                    return status.has_value() && status->IsSuccess();
                 else
-                {
-                    // Decode failed; reflect error in status and log
-                    result.status = app::DataModel::ActionReturnStatus(decodeError);
-                    ChipLogError(Test, "DecodeResponse failed: %s", decodeError.AsString());
+                    return status.has_value() && status->IsSuccess() && response.has_value();
+            }
+        };
+
+        // Invoke a command and return the decoded result.
+        // The `request` parameter must be of the correct type for the command being invoked.
+        // Use `app::Clusters::<ClusterName>::Commands::<CommandName>::Type` for the `request` parameter to be spec compliant
+        // Will construct the command path using the first path returned by `GetPaths()` on the cluster.
+        // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
+        template <typename RequestType, typename ResponseType = typename RequestType::ResponseType>
+        [[nodiscard]] InvokeResult<ResponseType> Invoke(chip::CommandId commandId, const RequestType & request)
+        {
+            InvokeResult<ResponseType> result;
+
+            const auto & paths = mCluster.GetPaths();
+            VerifyOrReturnValue(paths.size() == 1u, result);
+
+            mHandler.ClearResponses();
+            mHandler.ClearStatuses();
+
+            const app::DataModel::InvokeRequest invokeRequest = { .path = { paths[0].mEndpointId, paths[0].mClusterId, commandId } };
+
+            TLV::TLVWriter writer;
+            writer.Init(mTlvBuffer);
+
+            TLV::TLVReader reader;
+
+            VerifyOrReturnValue(request.Encode(writer, TLV::AnonymousTag()) == CHIP_NO_ERROR, result);
+            VerifyOrReturnValue(writer.Finalize() == CHIP_NO_ERROR, result);
+
+            reader.Init(mTlvBuffer, writer.GetLengthWritten());
+            VerifyOrReturnValue(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()) == CHIP_NO_ERROR, result);
+
+            result.status = mCluster.InvokeCommand(invokeRequest, reader, &mHandler);
+
+            // If InvokeCommand returned nullopt, it means the command implementation handled the response.
+            // We need to check the mock handler for a data response or a status response.
+            if (!result.status.has_value()) {
+                if (mHandler.HasResponse()) {
+                    // A data response was added, so the command is successful.
+                    result.status = app::DataModel::ActionReturnStatus(CHIP_NO_ERROR);
+                } else if (mHandler.HasStatus()) {
+                    // A status response was added. Use the last one.
+                    result.status = app::DataModel::ActionReturnStatus(mHandler.GetLastStatus().status);
+                } else {
+                    // Neither response nor status was provided; this is unexpected.
+                    // This would happen either in error (as mentioned here) or if the command is supposed
+                    // to be handled asynchronously. ClusterTester does not support such asynchronous processing.
+                    result.status = app::DataModel::ActionReturnStatus(CHIP_ERROR_INCORRECT_STATE);
+                    ChipLogError(
+                        Test, "InvokeCommand returned nullopt, but neither HasResponse nor HasStatus is true. Setting error status.");
                 }
             }
+
+            // If command was successful and there's a response, decode it (skip for NullObjectType)
+            if constexpr (!std::is_same_v<ResponseType, app::DataModel::NullObjectType>) {
+                if (result.status.has_value() && result.status->IsSuccess() && mHandler.HasResponse()) {
+                    ResponseType decodedResponse;
+                    CHIP_ERROR decodeError = mHandler.DecodeResponse(decodedResponse);
+                    if (decodeError == CHIP_NO_ERROR) {
+                        result.response = std::move(decodedResponse);
+                    } else {
+                        // Decode failed; reflect error in status and log
+                        result.status = app::DataModel::ActionReturnStatus(decodeError);
+                        ChipLogError(Test, "DecodeResponse failed: %s", decodeError.AsString());
+                    }
+                }
+            }
+
+            return result;
         }
 
-        return result;
-    }
-
-    // convenience method: most requests have a `GetCommandId` (and GetClusterId() as well).
-    template <typename RequestType, typename ResponseType = typename RequestType::ResponseType>
-    [[nodiscard]] InvokeResult<ResponseType> Invoke(const RequestType & request)
-    {
-        return Invoke(RequestType::GetCommandId(), request);
-    }
-
-    // Returns the next generated event from the event generator in the test server cluster context
-    std::optional<LogOnlyEvents::EventInformation> GetNextGeneratedEvent()
-    {
-        return mTestServerClusterContext.EventsGenerator().GetNextEvent();
-    }
-
-    std::vector<app::AttributePathParams> & GetDirtyList() { return mTestServerClusterContext.ChangeListener().DirtyList(); }
-
-    void SetFabricIndex(FabricIndex fabricIndex) { mHandler.SetFabricIndex(fabricIndex); }
-
-    FabricTestFixture * GetFabricHelper() { return mFabricTestFixture; }
-
-private:
-    bool VerifyClusterPathsValid()
-    {
-        auto paths = mCluster.GetPaths();
-        if (paths.size() != 1)
+        // convenience method: most requests have a `GetCommandId` (and GetClusterId() as well).
+        template <typename RequestType, typename ResponseType = typename RequestType::ResponseType>
+        [[nodiscard]] InvokeResult<ResponseType> Invoke(const RequestType & request)
         {
-            ChipLogError(Test, "cluster.GetPaths() did not return exactly one path");
-            return false;
+            return Invoke(RequestType::GetCommandId(), request);
         }
-        return true;
-    }
 
-    TestServerClusterContext mTestServerClusterContext{};
-    app::ServerClusterInterface & mCluster;
+        // Returns the next generated event from the event generator in the test server cluster context
+        std::optional<LogOnlyEvents::EventInformation> GetNextGeneratedEvent()
+        {
+            return mTestServerClusterContext.EventsGenerator().GetNextEvent();
+        }
 
-    // Buffer size for TLV encoding/decoding of command payloads.
-    // 256 bytes was chosen as a conservative upper bound for typical command payloads in tests.
-    // All command payloads used in tests must fit within this buffer; tests with larger payloads will fail.
-    // If protocol or test requirements change, this value may need to be increased.
-    static constexpr size_t kTlvBufferSize = 256;
+        std::vector<app::AttributePathParams> & GetDirtyList() { return mTestServerClusterContext.ChangeListener().DirtyList(); }
 
-    chip::Testing::MockCommandHandler mHandler;
-    uint8_t mTlvBuffer[kTlvBufferSize];
-    std::vector<std::unique_ptr<ReadOperation>> mReadOperations;
+        void SetFabricIndex(FabricIndex fabricIndex) { mHandler.SetFabricIndex(fabricIndex); }
 
-    FabricTestFixture * mFabricTestFixture;
-};
+        FabricTestFixture * GetFabricHelper() { return mFabricTestFixture; }
+
+    private:
+        bool VerifyClusterPathsValid()
+        {
+            auto paths = mCluster.GetPaths();
+            if (paths.size() != 1) {
+                ChipLogError(Test, "cluster.GetPaths() did not return exactly one path");
+                return false;
+            }
+            return true;
+        }
+
+        // Verifies that an attribute is present in the cluster's AttributeList.
+        // This mimics the real-world Interaction Model behavior where AttributeList is checked first.
+        // @returns CHIP_NO_ERROR if the attribute is found in AttributeList.
+        // @returns CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute) if the attribute is not found in AttributeList.
+        // @returns error status if AttributeList cannot be read or decoded (indicates a problem with cluster implementation).
+        app::DataModel::ActionReturnStatus VerifyAttributeInAttributeList(AttributeId attr_id)
+        {
+            auto path = mCluster.GetPaths()[0];
+
+            // Read the AttributeList attribute
+            std::unique_ptr<chip::Testing::ReadOperation> readOperation = std::make_unique<chip::Testing::ReadOperation>(
+                path.mEndpointId, path.mClusterId, app::Clusters::Globals::Attributes::AttributeList::Id);
+
+            mReadOperations.push_back(std::move(readOperation));
+            chip::Testing::ReadOperation & readOperationRef = *mReadOperations.back().get();
+
+            std::unique_ptr<app::AttributeValueEncoder> encoder = readOperationRef.StartEncoding();
+            app::DataModel::ActionReturnStatus status = mCluster.ReadAttribute(readOperationRef.GetRequest(), *encoder);
+
+            // If we cannot read AttributeList, return the error - this indicates a problem with cluster implementation
+            VerifyOrReturnError(status.IsSuccess(), status);
+
+            ReturnErrorOnFailure(readOperationRef.FinishEncoding());
+
+            std::vector<chip::Testing::DecodedAttributeData> attributeData;
+            ReturnErrorOnFailure(readOperationRef.GetEncodedIBs().Decode(attributeData));
+
+            VerifyOrReturnError(attributeData.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
+
+            // Decode the AttributeList
+            app::Clusters::Globals::Attributes::AttributeList::TypeInfo::DecodableType attributeList;
+            CHIP_ERROR decodeError = app::DataModel::Decode(attributeData[0].dataReader, attributeList);
+
+            // If decoding failed, return the error - this indicates a problem with cluster implementation
+            ReturnErrorOnFailure(decodeError);
+
+            // Check if the requested attribute ID is present in the AttributeList
+            auto it = attributeList.begin();
+            while (it.Next()) {
+                if (it.GetValue() == attr_id) {
+                    return CHIP_NO_ERROR; // Attribute found in AttributeList
+                }
+            }
+
+            // Attribute not found in AttributeList - this matches real-world IM behavior
+            return CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute);
+        }
+
+        TestServerClusterContext mTestServerClusterContext {};
+        app::ServerClusterInterface & mCluster;
+
+        // Buffer size for TLV encoding/decoding of command payloads.
+        // 256 bytes was chosen as a conservative upper bound for typical command payloads in tests.
+        // All command payloads used in tests must fit within this buffer; tests with larger payloads will fail.
+        // If protocol or test requirements change, this value may need to be increased.
+        static constexpr size_t kTlvBufferSize = 256;
+
+        chip::Testing::MockCommandHandler mHandler;
+        uint8_t mTlvBuffer[kTlvBufferSize];
+        std::vector<std::unique_ptr<ReadOperation>> mReadOperations;
+
+        FabricTestFixture * mFabricTestFixture;
+    };
 
 } // namespace Testing
 } // namespace chip


### PR DESCRIPTION
#### Summary

Aligned cluster tests and testing utilities with real Interaction Model behavior by explicitly enabling optional attributes and features where required, and by tightening test helpers to validate AttributeList membership before read/write operations. This improves correctness of tests and prevents false positives when optional or feature-gated attributes are accessed.

The changes include:

* **ClusterTester improvements**

  * Added AttributeList verification before attribute read/write operations, returning `UnsupportedAttribute` when an attribute is not present, mirroring real IM behavior.

* **Basic Information cluster tests**

  * Explicitly enabled optional attributes (`ManufacturingDate`, `LocalConfigDisabled`) during test setup to match expected AttributeList contents.

* **Electrical Power Measurement cluster**

  * Extended the optional attribute metadata to include feature-derived attributes (`HarmonicCurrents`, `HarmonicPhases`) so the AttributeList accurately reflects enabled features.

* **Occupancy Sensing cluster tests**

  * Enabled relevant features (PIR, Ultrasonic, Physical Contact) and deprecated attributes in test configurations to ensure optional HoldTime-related attributes are exposed and testable.

* **Resource Monitoring cluster tests**

  * Explicitly enabled optional attributes (`InPlaceIndicator`, `LastChangedTime`) and updated expectations to include them in the AttributeList.


#### Related issues

#42503

#### Testing

* Existing and updated unit tests pass
* No production behavior changes. Test correctness and coverage improved