### PR TITLE
[DO NOT REVIEW] Allow lambda to be non-trivial

### DIFF
--- a/examples/all-devices-app/esp32/CMakeLists.txt
+++ b/examples/all-devices-app/esp32/CMakeLists.txt
@@ -48,7 +48,4 @@ idf_build_set_property(COMPILE_OPTIONS "-Wno-format-nonliteral;-Wno-format-secur
 # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
 idf_build_set_property(COMPILE_OPTIONS "-Wno-error=maybe-uninitialized" APPEND)
 
-# -Werror=uninitialized will cause an error in "src/lib/support/LambdaBridge.h"
-idf_build_set_property(COMPILE_OPTIONS "-Wno-error=uninitialized" APPEND)
-
 flashing_script()

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include <cstdint>
 #include <string>
 
 #include <platform/CHIPDeviceLayer.h>
@@ -340,7 +341,8 @@ void StopMainEventLoop()
     else
     {
         Server::GetInstance().GenerateShutDownEvent();
-        TEMPORARY_RETURN_IGNORED SystemLayer().ScheduleLambda([]() { TEMPORARY_RETURN_IGNORED PlatformMgr().StopEventLoopTask(); });
+        TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(
+            [](intptr_t) { TEMPORARY_RETURN_IGNORED PlatformMgr().StopEventLoopTask(); });
     }
 }
 

--- a/src/platform/DeviceSafeQueue.cpp
+++ b/src/platform/DeviceSafeQueue.cpp
@@ -22,11 +22,29 @@
  *      and provides a specific set of member functions to access its elements wth thread safety.
  */
 
+#include <platform/CHIPDeviceEvent.h>
 #include <platform/DeviceSafeQueue.h>
 
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
+
+DeviceSafeQueue::~DeviceSafeQueue()
+{
+    std::unique_lock<std::mutex> lock(mEventQueueLock);
+
+    while (!mEventQueue.empty())
+    {
+        auto & event = mEventQueue.front();
+
+        if (event.Type == DeviceEventType::kChipLambdaEvent)
+        {
+            event.LambdaEvent.Destroy();
+        }
+
+        mEventQueue.pop();
+    }
+}
 
 void DeviceSafeQueue::Push(const ChipDeviceEvent & event)
 {

--- a/src/platform/DeviceSafeQueue.h
+++ b/src/platform/DeviceSafeQueue.h
@@ -47,8 +47,8 @@ namespace Internal {
 class DeviceSafeQueue
 {
 public:
-    DeviceSafeQueue()  = default;
-    ~DeviceSafeQueue() = default;
+    DeviceSafeQueue() = default;
+    ~DeviceSafeQueue();
 
     void Push(const ChipDeviceEvent & event);
     bool Empty();


### PR DESCRIPTION
#### Summary

This commit refactors the LambdaBridge to make it accept non-trivial captures. The lambda is expected to be called once. And if the scheduling failed, the resources are immediately released.

#### Related issues

This give the flexibility to allow capture non-trivial objects in lambda.

#### Testing

This is a refactor, and should be covered by existing tests, especially memory leak checks in the CI.