### PR TITLE
Simplify scheduling sync task

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -291,14 +291,17 @@ void PlatformManagerImpl::_Shutdown()
 }
 
 #if CHIP_DEVICE_CONFIG_WITH_GLIB_MAIN_LOOP
-void PlatformManagerImpl::_GLibMatterContextInvokeSync(LambdaBridge && bridge)
+void PlatformManagerImpl::_GLibMatterContextInvokeSync(void (*callback)(void * context), void * context)
 {
     // Because of TSAN false positives, we need to use a mutex to synchronize access to all members of
     // the GLibMatterContextInvokeData object (including constructor and destructor). This is a temporary
     // workaround until TSAN-enabled GLib will be used in our CI.
     std::unique_lock<std::mutex> lock(mGLibMainLoopCallbackIndirectionMutex);
 
-    GLibMatterContextInvokeData invokeData{ std::move(bridge) };
+    GLibMatterContextInvokeData invokeData{
+        callback,
+        context,
+    };
 
     lock.unlock();
 
@@ -311,7 +314,7 @@ void PlatformManagerImpl::_GLibMatterContextInvokeSync(LambdaBridge && bridge)
             std::unique_lock<std::mutex> lock_(PlatformMgrImpl().mGLibMainLoopCallbackIndirectionMutex);
 
             lock_.unlock();
-            data->bridge();
+            data->mCallback(data->mContext);
             lock_.lock();
 
             data->mDone = true;

--- a/src/platform/NuttX/PlatformManagerImpl.cpp
+++ b/src/platform/NuttX/PlatformManagerImpl.cpp
@@ -282,14 +282,17 @@ void PlatformManagerImpl::_Shutdown()
 }
 
 #if CHIP_DEVICE_CONFIG_WITH_GLIB_MAIN_LOOP
-void PlatformManagerImpl::_GLibMatterContextInvokeSync(LambdaBridge && bridge)
+void PlatformManagerImpl::_GLibMatterContextInvokeSync(void (*callback)(void * context), void * context)
 {
     // Because of TSAN false positives, we need to use a mutex to synchronize access to all members of
     // the GLibMatterContextInvokeData object (including constructor and destructor). This is a temporary
     // workaround until TSAN-enabled GLib will be used in our CI.
     std::unique_lock<std::mutex> lock(mGLibMainLoopCallbackIndirectionMutex);
 
-    GLibMatterContextInvokeData invokeData{ std::move(bridge) };
+    GLibMatterContextInvokeData invokeData{
+        callback,
+        context,
+    };
 
     lock.unlock();
 
@@ -302,7 +305,7 @@ void PlatformManagerImpl::_GLibMatterContextInvokeSync(LambdaBridge && bridge)
             std::unique_lock<std::mutex> lock_(PlatformMgrImpl().mGLibMainLoopCallbackIndirectionMutex);
 
             lock_.unlock();
-            data->bridge();
+            data->mCallback(data->mContext);
             lock_.lock();
 
             data->mDone = true;

--- a/src/platform/NuttX/PlatformManagerImpl.h
+++ b/src/platform/NuttX/PlatformManagerImpl.h
@@ -69,21 +69,24 @@ public:
     template <typename T>
     CHIP_ERROR GLibMatterContextInvokeSync(CHIP_ERROR (*func)(T *), T * userData)
     {
-        struct
+        struct Invoke
         {
             CHIP_ERROR returnValue = CHIP_NO_ERROR;
             CHIP_ERROR (*functionToCall)(T *);
             T * userData;
-        } context;
+        } invoke;
 
-        context.functionToCall = func;
-        context.userData       = userData;
+        invoke.functionToCall = func;
+        invoke.userData       = userData;
 
-        LambdaBridge bridge;
-        bridge.Initialize([&context]() { context.returnValue = context.functionToCall(context.userData); });
+        _GLibMatterContextInvokeSync(
+            [](void * context) {
+                auto & invoke_      = *static_cast<Invoke *>(context);
+                invoke_.returnValue = invoke_.functionToCall(invoke_.userData);
+            },
+            &invoke);
 
-        _GLibMatterContextInvokeSync(std::move(bridge));
-        return context.returnValue;
+        return invoke.returnValue;
     }
 
     unsigned int GLibMatterContextAttachSource(GSource * source)
@@ -116,7 +119,8 @@ private:
 
     struct GLibMatterContextInvokeData
     {
-        LambdaBridge bridge;
+        void (*mCallback)(void * context);
+        void * mContext;
         // Sync primitives to wait for the function to be executed
         std::condition_variable mDoneCond;
         bool mDone = false;
@@ -125,13 +129,11 @@ private:
     /**
      * @brief Invoke a function on the Matter GLib context.
      *
-     * @param[in] bridge a LambdaBridge object that holds the lambda to be invoked within the GLib context.
+     * @param[in] callback  A callback to be invoked within the GLib context.
+     * @param[in] context   The context for the callback.
      *
-     * @note This function moves the LambdaBridge into the GLib context for invocation.
-     *       The LambdaBridge is created and initialised in GLibMatterContextInvokeSync().
-     *       use the GLibMatterContextInvokeSync() template function instead of this one.
      */
-    void _GLibMatterContextInvokeSync(LambdaBridge && bridge);
+    void _GLibMatterContextInvokeSync(void (*callback)(void * context), void * context);
 
     // XXX: Mutex for guarding access to glib main event loop callback indirection
     //      synchronization primitives. This is a workaround to suppress TSAN warnings.

--- a/src/platform/Tizen/PlatformManagerImpl.h
+++ b/src/platform/Tizen/PlatformManagerImpl.h
@@ -64,21 +64,24 @@ public:
     template <typename T>
     CHIP_ERROR GLibMatterContextInvokeSync(CHIP_ERROR (*func)(T *), T * userData)
     {
-        struct
+        struct Invoke
         {
             CHIP_ERROR returnValue = CHIP_NO_ERROR;
             CHIP_ERROR (*functionToCall)(T *);
             T * userData;
-        } context;
+        } invoke;
 
-        context.functionToCall = func;
-        context.userData       = userData;
+        invoke.functionToCall = func;
+        invoke.userData       = userData;
 
-        LambdaBridge bridge;
-        bridge.Initialize([&context]() { context.returnValue = context.functionToCall(context.userData); });
+        _GLibMatterContextInvokeSync(
+            [](void * context) {
+                auto & invoke_      = *static_cast<Invoke *>(context);
+                invoke_.returnValue = invoke_.functionToCall(invoke_.userData);
+            },
+            &invoke);
 
-        _GLibMatterContextInvokeSync(std::move(bridge));
-        return context.returnValue;
+        return invoke.returnValue;
     }
     System::Clock::Timestamp GetStartTime() { return mStartTime; }
 
@@ -101,13 +104,11 @@ private:
     /**
      * @brief Invoke a function on the Matter GLib context.
      *
-     * @param[in] bridge a LambdaBridge object that holds the lambda to be invoked within the GLib context.
+     * @param[in] callback  A callback to be invoked within the GLib context.
+     * @param[in] context   The context for the callback.
      *
-     * @note This function moves the LambdaBridge into the GLib context for invocation.
-     *       The LambdaBridge is created and initialised in GLibMatterContextInvokeSync().
-     *       use the GLibMatterContextInvokeSync() template function instead of this one.
      */
-    void _GLibMatterContextInvokeSync(LambdaBridge && bridge);
+    void _GLibMatterContextInvokeSync(void (*callback)(void * context), void * context);
 
     GMainLoop * mGLibMainLoop;
     GThread * mGLibMainLoopThread;

--- a/src/platform/webos/PlatformManagerImpl.cpp
+++ b/src/platform/webos/PlatformManagerImpl.cpp
@@ -290,14 +290,17 @@ void PlatformManagerImpl::_Shutdown()
 }
 
 #if CHIP_DEVICE_CONFIG_WITH_GLIB_MAIN_LOOP
-void PlatformManagerImpl::_GLibMatterContextInvokeSync(LambdaBridge && bridge)
+void PlatformManagerImpl::_GLibMatterContextInvokeSync(void (*callback)(void * context), void * context)
 {
     // Because of TSAN false positives, we need to use a mutex to synchronize access to all members of
     // the GLibMatterContextInvokeData object (including constructor and destructor). This is a temporary
     // workaround until TSAN-enabled GLib will be used in our CI.
     std::unique_lock<std::mutex> lock(mGLibMainLoopCallbackIndirectionMutex);
 
-    GLibMatterContextInvokeData invokeData{ std::move(bridge) };
+    GLibMatterContextInvokeData invokeData{
+        callback,
+        context,
+    };
 
     lock.unlock();
 
@@ -310,7 +313,7 @@ void PlatformManagerImpl::_GLibMatterContextInvokeSync(LambdaBridge && bridge)
             std::unique_lock<std::mutex> lock_(PlatformMgrImpl().mGLibMainLoopCallbackIndirectionMutex);
 
             lock_.unlock();
-            data->bridge();
+            data->mCallback(data->mContext);
             lock_.lock();
 
             data->mDone = true;


### PR DESCRIPTION
#### Summary

This commit aims simplifying scheduling sync task with glib support. The LambdaBridge is expensive and should be avoided when possible. 

#### Related issues

This is pure refactoring to reduce unnecessary complexity.

#### Testing

This change should be covered by existing tests.