### PR TITLE
[Trivial] Address '-Wuninitialized' Error in Test Cluster Server Implementation

### DIFF
--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -898,7 +898,7 @@ bool emberAfUnitTestingClusterTestEmitTestEventRequestCallback(
     const Commands::TestEmitTestEventRequest::DecodableType & commandData)
 {
     Commands::TestEmitTestEventResponse::Type responseData;
-    Structs::SimpleStruct::Type arg4;
+    Structs::SimpleStruct::Type arg4 = {};
     DataModel::List<const Structs::SimpleStruct::Type> arg5;
     DataModel::List<const SimpleEnum> arg6;
 


### PR DESCRIPTION
#### Summary

This fully addresses and closes #42510 by applying an empty brace initializer to the previously-uninitialized `Structs::SimpleStruct::Type arg4` stack variable in the test cluster server implementation.

#### Related issues

Fixes: #42510

#### Testing

Successfully completed on-network provisioning of a custom product/platform integration using the equivalent of the `chip-all-clusters-app` with the Apple Home app on iOS 26.2.