### PR TITLE
[Trivial] Address '-Wuse-after-free' Error

### DIFF
--- a/examples/all-clusters-app/linux/diagnostic-logs-provider-delegate-impl.cpp
+++ b/examples/all-clusters-app/linux/diagnostic-logs-provider-delegate-impl.cpp
@@ -60,7 +60,7 @@ LogProvider::~LogProvider()
         auto rv = fclose(f.second);
         if (rv != 0)
         {
-            ChipLogError(NotSpecified, "Error when closing file pointer: %p (%d)", f.second, errno);
+            ChipLogError(NotSpecified, "Error when closing file pointer: %d", errno);
         }
     }
     mFiles.clear();


### PR DESCRIPTION
#### Summary

This fully addresses and closes #42500 by not referencing the `f.second` map data member after invoking `fclose`, in _examples/all-clusters-app/linux/diagnostic-logs-provider-delegate-impl.cpp_ avoiding the otherwise-trigged `-Wuse-after-free` compiler error / warning.

This is arguably harmless and, unfortunately, workarounds such as assigning the value to a `const void *` before calling `fclose` and then using that value did not avoid the compiler error / warning.

The formerly-printed pointer does not seem to provide much forensic value; consequently, this avoids the error / warning, but simply eliding printing the value on failure.

#### Related issues

Fixes: #42500

#### Testing

Successfully completed on-network provisioning of a custom product/platform integration using the equivalent of the chip-all-clusters-app with the Apple Home app on iOS 26.2.