### PR TITLE
[Trivial] Address '-Wconversion' Error

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
@@ -234,7 +234,7 @@ Protocols::InteractionModel::Status CameraAVStreamManager::CaptureSnapshot(const
         return Status::Failure;
     }
 
-    std::streamsize size = file.tellg();
+    std::streamsize size = static_cast<std::streamsize>(file.tellg());
     file.seekg(0, std::ios::beg);
 
     // Ensure space for image snapshot data in outImageSnapshot


### PR DESCRIPTION
#### Summary

This fully addresses and closes #42499 by applying a `static_cast` in _examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp_ to avoid a compiler implicit conversion error when converting the result of `file.tellg()` to the `std::streamsize` stack variable.

#### Related issues

Fixes: #42499

#### Testing

Successfully completed on-network provisioning of a custom product/platform integration using the equivalent of the chip-all-clusters-app with the Apple Home app on iOS 26.2.