### PR TITLE
SystemLayer: rename LayerSocketsLoop to LayerSelectLoop

### DIFF
--- a/examples/network-manager-app/linux/UloopHandler.cpp
+++ b/examples/network-manager-app/linux/UloopHandler.cpp
@@ -35,9 +35,9 @@ namespace chip {
 namespace ubus {
 
 namespace {
-System::LayerSocketsLoop & SystemLayer()
+System::LayerSelectLoop & SystemLayer()
 {
-    return static_cast<System::LayerSocketsLoop &>(DeviceLayer::SystemLayer());
+    return static_cast<System::LayerSelectLoop &>(DeviceLayer::SystemLayer());
 }
 } // namespace
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_ZephyrSelect.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_ZephyrSelect.ipp
@@ -50,12 +50,12 @@ namespace Internal {
 
 namespace {
 
-System::LayerSocketsLoop & SystemLayerSocketsLoop()
+System::LayerSelectLoop & SystemLayerSelectLoop()
 {
-    return static_cast<System::LayerSocketsLoop &>(DeviceLayer::SystemLayer());
+    return static_cast<System::LayerSelectLoop &>(DeviceLayer::SystemLayer());
 }
 
-K_WORK_DEFINE(sSignalWork, [](k_work *) { SystemLayerSocketsLoop().Signal(); });
+K_WORK_DEFINE(sSignalWork, [](k_work *) { SystemLayerSelectLoop().Signal(); });
 
 } // anonymous namespace
 
@@ -151,7 +151,7 @@ CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_PostEvent(const ChipDe
     }
     else
     {
-        SystemLayerSocketsLoop().Signal();
+        SystemLayerSelectLoop().Signal();
     }
     return CHIP_NO_ERROR;
 }
@@ -180,20 +180,20 @@ void GenericPlatformManagerImpl_Zephyr<ImplClass>::_RunEventLoop(void)
     }
     mShouldRunEventLoop = true;
 
-    SystemLayerSocketsLoop().EventLoopBegins();
+    SystemLayerSelectLoop().EventLoopBegins();
     while (mShouldRunEventLoop)
     {
-        SystemLayerSocketsLoop().PrepareEvents();
+        SystemLayerSelectLoop().PrepareEvents();
 
         Impl()->UnlockChipStack();
-        SystemLayerSocketsLoop().WaitForEvents();
+        SystemLayerSelectLoop().WaitForEvents();
         Impl()->LockChipStack();
 
-        SystemLayerSocketsLoop().HandleEvents();
+        SystemLayerSelectLoop().HandleEvents();
 
         ProcessDeviceEvents();
     }
-    SystemLayerSocketsLoop().EventLoopEnds();
+    SystemLayerSelectLoop().EventLoopEnds();
 
     Impl()->UnlockChipStack();
 }

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -58,10 +58,12 @@ CriticalFailure LayerImplSelect::Init()
 
     RegisterPOSIXErrorFormatter();
 
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     for (auto & w : mSocketWatchPool)
     {
         w.Clear();
     }
+#endif
 
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
     mHandleSelectThread = PTHREAD_NULL;
@@ -91,10 +93,12 @@ void LayerImplSelect::Shutdown()
     }
     mTimerPool.ReleaseAll();
 
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     for (auto & w : mSocketWatchPool)
     {
         w.DisableAndClear();
     }
+#endif
 #else
     mTimerList.Clear();
     mTimerPool.ReleaseAll();
@@ -300,6 +304,7 @@ CriticalFailure LayerImplSelect::ScheduleWork(TimerCompleteCallback onComplete, 
     return CHIP_NO_ERROR;
 }
 
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 CHIP_ERROR LayerImplSelect::StartWatchingSocket(int fd, SocketWatchToken * tokenOut)
 {
     // Find a free slot.
@@ -488,6 +493,7 @@ SocketEvents LayerImplSelect::SocketEventsFromFDs(int socket, const fd_set & rea
 
     return res;
 }
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 enum : intptr_t
 {
@@ -560,6 +566,7 @@ void LayerImplSelect::PrepareEvents()
     mMaxFd = mWakeEvent.GetReadFD();
 #endif
 
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     for (auto & w : mSocketWatchPool)
     {
         if (w.mFD != kInvalidFd)
@@ -578,6 +585,7 @@ void LayerImplSelect::PrepareEvents()
             }
         }
     }
+#endif
 }
 
 void LayerImplSelect::WaitForEvents()
@@ -617,6 +625,7 @@ void LayerImplSelect::HandleEvents()
         mTimerPool.Invoke(timer);
     }
 
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     // Process socket events, if any
     if (mSelectResult > 0)
     {
@@ -632,6 +641,7 @@ void LayerImplSelect::HandleEvents()
             }
         }
     }
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
     // Call HandleEvents for active loop handlers
     auto loopIter = mLoopHandlers.begin();
@@ -684,6 +694,7 @@ void LayerImplSelect::HandleLibEvIoWatcher(EV_P_ struct ev_io * i, int revents)
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LIBEV
 
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 void LayerImplSelect::SocketWatch::Clear()
 {
     mFD = kInvalidFd;
@@ -705,6 +716,7 @@ void LayerImplSelect::SocketWatch::DisableAndClear()
     Clear();
 }
 #endif // CHIP_SYSTEM_CONFIG_USE_LIBEV
+#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 } // namespace System
 } // namespace chip

--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -49,7 +49,7 @@
 namespace chip {
 namespace System {
 
-class LayerImplSelect : public LayerSocketsLoop
+class LayerImplSelect : public LayerSelectLoop
 {
 public:
     LayerImplSelect() = default;
@@ -66,6 +66,7 @@ public:
     void CancelTimer(TimerCompleteCallback onComplete, void * appState) override;
     CriticalFailure ScheduleWork(TimerCompleteCallback onComplete, void * appState) override;
 
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     // LayerSocket overrides.
     CHIP_ERROR StartWatchingSocket(int fd, SocketWatchToken * tokenOut) override;
     CHIP_ERROR SetCallback(SocketWatchToken token, SocketWatchCallback callback, intptr_t data) override;
@@ -75,8 +76,9 @@ public:
     CHIP_ERROR ClearCallbackOnPendingWrite(SocketWatchToken token) override;
     CHIP_ERROR StopWatchingSocket(SocketWatchToken * tokenInOut) override;
     SocketWatchToken InvalidSocketWatchToken() override { return reinterpret_cast<SocketWatchToken>(nullptr); }
+#endif
 
-    // LayerSocketLoop overrides.
+    // LayerSelectLoop overrides.
     void Signal() override;
     void EventLoopBegins() override {}
     void PrepareEvents() override;
@@ -98,6 +100,7 @@ public:
     bool IsSelectResultValid() const { return mSelectResult >= 0; }
 
 protected:
+#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     static SocketEvents SocketEventsFromFDs(int socket, const fd_set & readfds, const fd_set & writefds, const fd_set & exceptfds);
 
     static constexpr int kSocketWatchMax = (INET_CONFIG_ENABLE_TCP_ENDPOINT ? INET_CONFIG_NUM_TCP_ENDPOINTS : 0) +
@@ -118,6 +121,7 @@ protected:
         intptr_t mCallbackData;
     };
     SocketWatch mSocketWatchPool[kSocketWatchMax];
+#endif
 
     TimerPool<TimerList::Node> mTimerPool;
     TimerList mTimerList;

--- a/src/system/tests/TestEventLoopHandler.cpp
+++ b/src/system/tests/TestEventLoopHandler.cpp
@@ -21,7 +21,7 @@
 #include <pw_unit_test/framework.h>
 #include <system/SystemConfig.h>
 
-// EventLoopHandlers are only supported by a select-based LayerSocketsLoop
+// EventLoopHandlers are only supported by a select-based LayerSelectLoop
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && !CHIP_SYSTEM_CONFIG_USE_DISPATCH
 // The fake PlatformManagerImpl does not drive the system layer event loop
 #if !CHIP_DEVICE_LAYER_TARGET_FAKE
@@ -49,7 +49,7 @@ public:
         Platform::MemoryShutdown();
     }
 
-    static System::LayerSocketsLoop & SystemLayer() { return static_cast<System::LayerSocketsLoop &>(DeviceLayer::SystemLayer()); }
+    static System::LayerSelectLoop & SystemLayer() { return static_cast<System::LayerSelectLoop &>(DeviceLayer::SystemLayer()); }
 
     // Schedules a call to the provided lambda and returns a cancel function.
     template <class Lambda>

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -69,13 +69,13 @@ public:
 };
 #elif CHIP_SYSTEM_CONFIG_USE_SOCKETS
 template <class LayerImpl>
-class LayerEvents<LayerImpl, typename std::enable_if<std::is_base_of<LayerSocketsLoop, LayerImpl>::value>::type>
+class LayerEvents<LayerImpl, typename std::enable_if<std::is_base_of<LayerSelectLoop, LayerImpl>::value>::type>
 {
 public:
     static bool HasServiceEvents() { return true; }
     static void ServiceEvents(Layer & aLayer)
     {
-        LayerSocketsLoop & layer = static_cast<LayerSocketsLoop &>(aLayer);
+        LayerSelectLoop & layer = static_cast<LayerSelectLoop &>(aLayer);
         layer.PrepareEvents();
         layer.WaitForEvents();
         layer.HandleEvents();


### PR DESCRIPTION
#### Summary

This commit renames `LayerSocketsLoop` to `LayerSelectLoop` reflecting that it doesn't depend on sockets. This commit also guards the sockets related operation in the `SystemLayerImplSelect` by `CHIP_SYSTEM_CONFIG_USE_SOCKETS`.

#### Related issues

This is split from #42336 as suggested in review comments.

#### Testing

The change is refactoring of the current implementation. No new function is added, so It should be covered by existing tests.