### PR TITLE
SystemLayer: add external event source

### DIFF
--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -41,6 +41,7 @@
 #include <ev.h>
 #endif // CHIP_SYSTEM_CONFIG_USE_LIBEV
 
+#include <lib/support/IntrusiveList.h>
 #include <lib/support/ObjectLifeCycle.h>
 #include <system/SystemLayer.h>
 #include <system/SystemTimer.h>
@@ -99,7 +100,113 @@ public:
     // Expose the result of WaitForEvents() for non-blocking socket implementations.
     bool IsSelectResultValid() const { return mSelectResult >= 0; }
 
+    /**
+     * @brief Abstract interface for an event source compatible with a select()-based event loop.
+     *
+     * This interface defines the contract for objects that wish to register file descriptors
+     * and timeouts for monitoring. It is designed to be managed by a selection layer (e.g., LayerImplSelect).
+     */
+    struct EventSource : public IntrusiveListNodeBase<IntrusiveMode::Strict>
+    {
+        /**
+         * @brief Virtual destructor to ensure proper cleanup of derived classes.
+         */
+        virtual ~EventSource() = default;
+
+        /**
+         * @brief Prepares the file descriptor sets and timeout before the select() call.
+         *
+         * This method is called by the event loop to gather all file descriptors and the
+         * minimum required timeout from all registered sources.
+         *
+         * @param[in,out] maxfd      The highest-numbered file descriptor. Must be updated if
+         *                          this source adds a descriptor larger than the current value.
+         * @param[in,out] readfds   Set of file descriptors to be watched for read readiness.
+         * @param[in,out] writefds  Set of file descriptors to be watched for write readiness.
+         * @param[in,out] exceptfds Set of file descriptors to be watched for error conditions.
+         * @param[in,out] timeout   The maximum time to wait for an event.
+         *
+         * @warning **Timeout Modification Logic:**
+         * To ensure all sources are handled correctly, you must follow these rules:
+         * - **DO NOT** modify @p timeout if this source's desired timeout is **larger** than the current value.
+         * - **ONLY** modify @p timeout if this source's desired timeout is **smaller** than the current value.
+         *
+         * This ensures the event loop wakes up in time for the earliest pending event among all sources.
+         */
+        virtual void PrepareEvents(int & maxfd, fd_set & readfds, fd_set & writefds, fd_set & exceptfds,
+                                   struct timeval & timeout) = 0;
+
+        /**
+         * @brief Processes the results after the select() call returns.
+         *
+         * The event loop calls this method to allow the source to check if its descriptors
+         * are set in the resulting masks and perform the associated I/O or logic.
+         *
+         * @param[in] readfds   The set of descriptors ready for reading.
+         * @param[in] writefds  The set of descriptors ready for writing.
+         * @param[in] exceptfds The set of descriptors with pending error conditions.
+         */
+        virtual void ProcessEvents(const fd_set & readfds, const fd_set & writefds, const fd_set & exceptfds) = 0;
+    };
+
+    /**
+     * @brief Register an EventSource with this LayerImplSelect instance.
+     *
+     * Adds the given EventSource to the internal list of sources that will be
+     * consulted when preparing and handling events in the select()-based loop.
+     *
+     * Thread-safety: This method is not thread-safe and MUST be called with
+     * the ChipStack lock held.
+     *
+     * Ownership: LayerImplSelect does not take ownership of @p source.
+     * The caller is responsible for ensuring that the EventSource object
+     * remains valid for as long as it is registered.
+     *
+     * Lifecycle: The EventSource MUST either outlive its registration (i.e.,
+     * remain alive until after it is removed) or be explicitly removed using
+     * EventSourceRemove() before it is destroyed.
+     */
+    void EventSourceAdd(EventSource * source);
+
+    /**
+     * @brief Unregister a previously added EventSource.
+     *
+     * Removes the given EventSource from the internal list of sources that are
+     * monitored by the select()-based loop.
+     *
+     * Thread-safety: This method is not thread-safe and MUST be called with
+     * the ChipStack lock held.
+     *
+     * Ownership: This method does not delete or otherwise destroy @p source;
+     * ownership remains with the caller.
+     *
+     * Lifecycle: EventSourceRemove() MUST be called before destroying an
+     * EventSource that has been registered with EventSourceAdd(). It is safe
+     * to call EventSourceRemove() multiple times with the same pointer; calls
+     * after the source has been removed have no effect.
+     */
+    void EventSourceRemove(EventSource * source);
+
+    /**
+     * @brief Clear all registered EventSource instances.
+     *
+     * Removes all EventSource objects from the internal list maintained by
+     * LayerImplSelect.
+     *
+     * Thread-safety: This method is not thread-safe and MUST be called with
+     * the ChipStack lock held.
+     *
+     * Ownership: This method does not delete or destroy any EventSource
+     * instances; it only clears their registration with the loop.
+     *
+     * Lifecycle: After this call returns, all previously registered
+     * EventSource instances are no longer tracked by the event loop. The
+     * objects themselves remain the responsibility of the caller.
+     */
+    void EventSourceClear();
+
 protected:
+    IntrusiveList<EventSource> mSources;
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     static SocketEvents SocketEventsFromFDs(int socket, const fd_set & readfds, const fd_set & writefds, const fd_set & exceptfds);
 

--- a/src/system/tests/BUILD.gn
+++ b/src/system/tests/BUILD.gn
@@ -43,7 +43,10 @@ chip_test_suite("tests") {
   }
 
   if (chip_system_config_event_loop == "Select") {
-    test_sources += [ "TestSystemWakeEvent.cpp" ]
+    test_sources += [
+      "TestSystemEventSource.cpp",
+      "TestSystemWakeEvent.cpp",
+    ]
   }
 
   cflags = [ "-Wconversion" ]

--- a/src/system/tests/TestSystemEventSource.cpp
+++ b/src/system/tests/TestSystemEventSource.cpp
@@ -1,0 +1,220 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This is a unit test suite for <tt>chip::System::SystemLayerImplSelect</tt>
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <lib/support/CodeUtils.h>
+#include <pw_unit_test/framework.h>
+#include <system/SystemClock.h>
+#include <system/SystemConfig.h>
+#include <system/SystemError.h>
+#include <system/SystemLayer.h>
+#include <system/SystemLayerImpl.h>
+
+#include <platform/CHIPDeviceLayer.h>
+
+using namespace chip;
+using namespace chip::System;
+using namespace chip::System::Clock::Literals;
+
+// EventSources are only supported by a select-based LayerSelectLoop
+#if !CHIP_SYSTEM_CONFIG_USE_DISPATCH
+// The fake PlatformManagerImpl does not drive the system layer event loop
+#if !CHIP_DEVICE_LAYER_TARGET_FAKE
+
+struct TestSource : public LayerImplSelect::EventSource
+{
+    TestSource() { EXPECT_EQ(wakeEvent.Open(), CHIP_NO_ERROR); }
+    ~TestSource() { wakeEvent.Close(); }
+
+    void PrepareEvents(int & maxfd, fd_set & readfds, fd_set & writefds, fd_set & exceptfds, struct timeval & timeout) override
+    {
+        maxfd = std::max(maxfd, wakeEvent.GetReadFD());
+        FD_SET(wakeEvent.GetReadFD(), &readfds);
+
+        if (timeout.tv_sec > delaySeconds)
+        {
+            timeout.tv_sec  = delaySeconds;
+            timeout.tv_usec = 0;
+        }
+        else if (timeout.tv_sec == delaySeconds)
+        {
+            timeout.tv_usec = 0;
+        }
+        prepareCalled++;
+    }
+
+    void ProcessEvents(const fd_set & readfds, const fd_set & writefds, const fd_set & exceptfds) override
+    {
+        if (FD_ISSET(wakeEvent.GetReadFD(), &readfds))
+        {
+            wakeEvent.Confirm();
+            handlerCalled++;
+        }
+    }
+
+    CHIP_ERROR Notify() { return wakeEvent.Notify(); }
+
+    int prepareCalled = 0;
+    int handlerCalled = 0;
+    int delaySeconds  = 0;
+    WakeEvent wakeEvent;
+};
+
+struct TestSystemEventSource : public ::testing::Test
+{
+    static void SetUpTestSuite()
+    {
+        ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR);
+        ASSERT_EQ(DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
+    }
+
+    static void TearDownTestSuite()
+    {
+        DeviceLayer::PlatformMgr().Shutdown();
+        Platform::MemoryShutdown();
+    }
+};
+
+TEST_F(TestSystemEventSource, OneEventSource)
+{
+    auto & impl = static_cast<LayerImplSelect &>(chip::DeviceLayer::SystemLayer());
+
+    TestSource source1;
+
+    // Add for the first time
+    impl.EventSourceAdd(&source1);
+    impl.PrepareEvents();
+    impl.WaitForEvents();
+    impl.HandleEvents();
+
+    ASSERT_EQ(source1.prepareCalled, 1);
+    ASSERT_EQ(source1.handlerCalled, 0);
+
+    // Add the same source for the second time
+    impl.EventSourceAdd(&source1);
+    impl.PrepareEvents();
+    impl.WaitForEvents();
+    impl.HandleEvents();
+
+    ASSERT_EQ(source1.prepareCalled, 2);
+    ASSERT_EQ(source1.handlerCalled, 0);
+
+    // Notify the source
+    ASSERT_EQ(source1.Notify(), CHIP_NO_ERROR);
+    impl.PrepareEvents();
+    impl.WaitForEvents();
+    impl.HandleEvents();
+    ASSERT_EQ(source1.prepareCalled, 3);
+    ASSERT_EQ(source1.handlerCalled, 1);
+
+    impl.EventSourceClear();
+}
+
+TEST_F(TestSystemEventSource, MultipleEventSources)
+{
+    auto & impl = static_cast<LayerImplSelect &>(chip::DeviceLayer::SystemLayer());
+
+    TestSource source1;
+    TestSource source2;
+
+    ASSERT_EQ(source1.Notify(), CHIP_NO_ERROR);
+    impl.EventSourceAdd(&source1);
+    impl.PrepareEvents();
+    impl.WaitForEvents();
+    impl.HandleEvents();
+    ASSERT_EQ(source1.handlerCalled, 1);
+
+    ASSERT_EQ(source2.Notify(), CHIP_NO_ERROR);
+    impl.EventSourceAdd(&source2);
+    impl.PrepareEvents();
+    impl.WaitForEvents();
+    impl.HandleEvents();
+    ASSERT_EQ(source2.handlerCalled, 1);
+
+    ASSERT_EQ(source1.Notify(), CHIP_NO_ERROR);
+    ASSERT_EQ(source2.Notify(), CHIP_NO_ERROR);
+
+    impl.PrepareEvents();
+    impl.WaitForEvents();
+    impl.HandleEvents();
+    ASSERT_EQ(source1.handlerCalled, 2);
+    ASSERT_EQ(source2.handlerCalled, 2);
+
+    impl.EventSourceClear();
+}
+
+TEST_F(TestSystemEventSource, RemoveSomeEventSource)
+{
+    auto & impl = static_cast<LayerImplSelect &>(chip::DeviceLayer::SystemLayer());
+
+    TestSource source1;
+    TestSource source2;
+
+    ASSERT_EQ(source1.Notify(), CHIP_NO_ERROR);
+    impl.EventSourceAdd(&source1);
+    impl.PrepareEvents();
+    impl.WaitForEvents();
+    impl.HandleEvents();
+
+    ASSERT_EQ(source2.Notify(), CHIP_NO_ERROR);
+    impl.EventSourceAdd(&source2);
+    impl.PrepareEvents();
+    impl.WaitForEvents();
+    impl.HandleEvents();
+
+    ASSERT_EQ(source2.Notify(), CHIP_NO_ERROR);
+    impl.EventSourceRemove(&source1);
+    impl.PrepareEvents();
+    impl.WaitForEvents();
+    impl.HandleEvents();
+    ASSERT_EQ(source1.handlerCalled, 1);
+    ASSERT_EQ(source2.handlerCalled, 2);
+
+    impl.EventSourceClear();
+}
+
+TEST_F(TestSystemEventSource, MultipleEventSourcesOfDifferentTimeout)
+{
+    auto & impl = static_cast<LayerImplSelect &>(chip::DeviceLayer::SystemLayer());
+
+    TestSource source1;
+    TestSource source2;
+
+    source1.delaySeconds = 2;
+    source2.delaySeconds = 3;
+    impl.EventSourceAdd(&source1);
+    impl.EventSourceAdd(&source2);
+    impl.PrepareEvents();
+    auto start = System::SystemClock().GetMonotonicTimestamp();
+    impl.WaitForEvents();
+    auto end = System::SystemClock().GetMonotonicTimestamp();
+    impl.HandleEvents();
+    auto duration = end - start;
+    ASSERT_GE(duration, 2000_ms);
+    ASSERT_LT(duration, 3000_ms);
+
+    impl.EventSourceClear();
+}
+#endif // !CHIP_DEVICE_LAYER_TARGET_FAKE
+#endif // !CHIP_SYSTEM_CONFIG_USE_DISPATCH


### PR DESCRIPTION
#### Summary

This commit adds external source support in SystemLayerImplSelect for integrating other select based event loops. This is for integrating OpenThread's event loop on Linux, which is also `select()` based.

#### Related issues

This is split from https://github.com/project-chip/connectedhomeip/pull/42336 as suggested in review comments.

#### Testing

Added unittest for this functionality.
