### PR TITLE
[Trivial] Documentation: Fix a Comment Typo in 'ConnectivityManager.h'

### DIFF
--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -329,7 +329,7 @@ extern ConnectivityManagerImpl & ConnectivityMgrImpl();
 } // namespace DeviceLayer
 } // namespace chip
 
-/* Include a header file containing the implementation of the ConfigurationManager
+/* Include a header file containing the implementation of the ConnectivityManager
  * object for the selected platform.
  */
 #ifdef EXTERNAL_CONNECTIVITYMANAGERIMPL_HEADER


### PR DESCRIPTION
#### Summary

This addresses a copy-and-paste typo in _src/include/platform/ConnectivityManager.h_ that ostensibly came from _src/include/platform/ConfigurationManager.h_.

#### Related issues

Partially Fixes: #42516

#### Testing

Trivial documentation typo fix; no testing performed outside of CI.