### PR TITLE
[Trivial] Documentation: Align Singleton-related Comments in Both {Configuration,Connectivity}Manager

### DIFF
--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -191,7 +191,7 @@ protected:
 };
 
 /**
- * Returns a reference to a ConfigurationManager object.
+ * Returns a reference to a ConfigurationManager singleton object.
  *
  * Applications should use this to access features of the ConfigurationManager object
  * that are common to all platforms.
@@ -199,7 +199,7 @@ protected:
 ConfigurationManager & ConfigurationMgr();
 
 /**
- * Returns the platform-specific implementation of the ConfigurationManager object.
+ * Returns the platform-specific implementation of the ConfigurationManager singleton object.
  *
  * Applications can use this to gain access to features of the ConfigurationManager
  * that are specific to the selected platform.

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -313,7 +313,7 @@ struct ConnectivityManager::WiFiPAFAdvertiseParam
 /**
  * Returns a reference to the public interface of the ConnectivityManager singleton object.
  *
- * chip applications should use this to access features of the ConnectivityManager object
+ * Applications should use this to access features of the ConnectivityManager object
  * that are common to all platforms.
  */
 extern ConnectivityManager & ConnectivityMgr();
@@ -321,7 +321,7 @@ extern ConnectivityManager & ConnectivityMgr();
 /**
  * Returns the platform-specific implementation of the ConnectivityManager singleton object.
  *
- * chip applications can use this to gain access to features of the ConnectivityManager
+ * Applications can use this to gain access to features of the ConnectivityManager
  * that are specific to the selected platform.
  */
 extern ConnectivityManagerImpl & ConnectivityMgrImpl();


### PR DESCRIPTION
#### Summary

In an effort, per #42516, to more architecturally-align `ConnectivityManager` with `ConfigurationManager`, particularly in a side-by-side graphical diff, this aligns the comments with several singleton-related methods between the two implementations.

#### Related issues

Partially Fixes #42516

#### Testing

This is a trivial documentation-only change; no testing beyond CI.