### PR TITLE
[Trivial] Documentation: Added Missing @file Doxygen Comment to Linux 'ConnectivityManagerImpl.h'

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -16,6 +16,12 @@
  *    limitations under the License.
  */
 
+/**
+ *    @file
+ *          Provides an implementation of the ConnectivityManager
+ *          object for Linux platforms.
+ */
+
 #pragma once
 
 #include <platform/ConnectivityManager.h>


### PR DESCRIPTION
#### Summary

This adds a missing `@file` Doxygen comment to _src/platform/Linux/ConnectivityManagerImpl.h_.

#### Related issues

Partially Fixes: #42516

#### Testing

This is a trivial documentation fix; no testing was performed beyond CI.