### PR TITLE
Place Linux Connectivity Manager Singleton Behind Static Getter Method

### DIFF
--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -47,6 +47,7 @@ static_library("Linux") {
     "../DeviceSafeQueue.h",
     "../GLibTypeDeleter.h",
     "../SingletonConfigurationManager.cpp",
+    "../SingletonConnectivityManager.cpp",
     "CHIPDevicePlatformConfig.h",
     "CHIPDevicePlatformEvent.h",
     "CHIPLinuxStorage.cpp",

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -2294,5 +2294,10 @@ CHIP_ERROR ConnectivityManagerImpl::_StartWiFiManagement()
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 
+ConnectivityManagerImpl & ConnectivityMgrImpl(void)
+{
+    return ConnectivityManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -94,7 +94,13 @@ static constexpr char kWpaSupplicantBlobUnknown[] = "fi.w1.wpa_supplicant1.BlobU
 
 } // namespace
 
-ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
+// MARK: Singleton
+
+ConnectivityManagerImpl & ConnectivityManagerImpl::GetDefaultInstance()
+{
+    static ConnectivityManagerImpl sInstance;
+    return sInstance;
+}
 
 void ConnectivityManagerImpl::UpdateEthernetNetworkingStatus()
 {

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -130,8 +130,12 @@ class ConnectivityManagerImpl final : public ConnectivityManager,
     // the implementation methods provided by this class.
     friend class ConnectivityManager;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
 public:
+    // Singleton
+
+    static ConnectivityManagerImpl & GetDefaultInstance(void);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
     CHIP_ERROR ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credentials,
                                        NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback);
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
@@ -173,13 +177,6 @@ private:
                                         NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback)
         CHIP_REQUIRES(mWpaSupplicantMutex);
 #endif
-
-    // ===== Members for internal use by the following friends.
-
-    friend ConnectivityManager & ConnectivityMgr();
-    friend ConnectivityManagerImpl & ConnectivityMgrImpl();
-
-    static ConnectivityManagerImpl & GetDefaultInstance(void);
 
 public:
     const char * GetEthernetIfName() { return (mEthIfName[0] == '\0') ? nullptr : mEthIfName; }

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -174,6 +174,13 @@ private:
         CHIP_REQUIRES(mWpaSupplicantMutex);
 #endif
 
+    // ===== Members for internal use by the following friends.
+
+    friend ConnectivityManager & ConnectivityMgr();
+    friend ConnectivityManagerImpl & ConnectivityMgrImpl();
+
+    static ConnectivityManagerImpl & GetDefaultInstance(void);
+
 public:
     const char * GetEthernetIfName() { return (mEthIfName[0] == '\0') ? nullptr : mEthIfName; }
     void UpdateEthernetNetworkingStatus();
@@ -273,13 +280,6 @@ private:
     static void DriveAPState(::chip::System::Layer * aLayer, void * aAppState);
 #endif
 
-    // ===== Members for internal use by the following friends.
-
-    friend ConnectivityManager & ConnectivityMgr();
-    friend ConnectivityManagerImpl & ConnectivityMgrImpl();
-
-    static ConnectivityManagerImpl sInstance;
-
     // ===== Private members reserved for use by this class only.
 
     char mEthIfName[Inet::InterfaceId::kMaxIfNameLength];
@@ -336,7 +336,7 @@ inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout()
  */
 inline ConnectivityManager & ConnectivityMgr()
 {
-    return ConnectivityManagerImpl::sInstance;
+    return ConnectivityManagerImpl::GetDefaultInstance();
 }
 
 /**
@@ -347,7 +347,7 @@ inline ConnectivityManager & ConnectivityMgr()
  */
 inline ConnectivityManagerImpl & ConnectivityMgrImpl()
 {
-    return ConnectivityManagerImpl::sInstance;
+    return ConnectivityManagerImpl::GetDefaultInstance();
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -328,16 +328,5 @@ inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout()
 
 #endif
 
-/**
- * Returns the platform-specific implementation of the ConnectivityManager singleton object.
- *
- * chip applications can use this to gain access to features of the ConnectivityManager
- * that are specific to the ESP32 platform.
- */
-inline ConnectivityManagerImpl & ConnectivityMgrImpl()
-{
-    return ConnectivityManagerImpl::GetDefaultInstance();
-}
-
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -329,17 +329,6 @@ inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout()
 #endif
 
 /**
- * Returns the public interface of the ConnectivityManager singleton object.
- *
- * chip applications should use this to access features of the ConnectivityManager object
- * that are common to all platforms.
- */
-inline ConnectivityManager & ConnectivityMgr()
-{
-    return ConnectivityManagerImpl::GetDefaultInstance();
-}
-
-/**
  * Returns the platform-specific implementation of the ConnectivityManager singleton object.
  *
  * chip applications can use this to gain access to features of the ConnectivityManager

--- a/src/platform/SingletonConfigurationManager.cpp
+++ b/src/platform/SingletonConfigurationManager.cpp
@@ -26,8 +26,6 @@
 namespace chip {
 namespace DeviceLayer {
 
-class ConfigurationManager;
-
 namespace {
 
 /** Singleton pointer to the ConfigurationManager implementation.


### PR DESCRIPTION
#### Summary

This:

1. Leverages the singleton implementation of ConnectivityManager in _src/platform/SingletonConnectivityManager.cpp_ for the Matter Linux platform.
2. Eliding the inline singleton getter in lieu of the common implementation in (1).

In addition, this mirrors the pattern used by the Linux `ConfigurationManager`, placing the singleton instance behind a static getter method, `GetDefaultInstance`.

The eventual goal here is to evolve towards having a peer _src/platform/SingletonConnectivityManager.cpp_ to _src/platform/SingletonConfigurationManager.cpp_ and a singular:

```c++
ConnectivityManager & ConnectivityManager()
{
    return ConnectivityMgrImpl();
}
```

and, eventually from there:

```c++
ConnectivityManager & ConnectivityManager()
{
    if (gInstance != nullptr)
    {
        return *gInstance;
    }

    return ConnectivityMgrImpl();
}
```

rather than:

```c++
inline ConnectivityManager & ConnectivityMgr()
{
    return ConnectivityManagerImpl::GetDefaultInstance();
}
```

for each platform connectivity manager implementation.

#### Related issues

#42516

#### Testing

Successfully paired / commissioned an armvl-unknown-linux-gnu device using the iOS 26.2 Apple "Home" app.