### PR TITLE
Add Common Connectivity Manager Singleton Accessor Function

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -121,6 +121,7 @@ jobs:
                      --known-failure platform/DeviceSafeQueue.h \
                      --known-failure platform/GLibTypeDeleter.h \
                      --known-failure platform/SingletonConfigurationManager.cpp \
+                     --known-failure platform/SingletonConnectivityManager.cpp \
                      src
                   scripts/tools/not_known_to_gn.py \
                      -e py -e matter -e lark -e yaml -e cpp -e java -e kt -e jinja -e proto \

--- a/src/platform/SingletonConnectivityManager.cpp
+++ b/src/platform/SingletonConnectivityManager.cpp
@@ -1,0 +1,35 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Implements a getter for a singleton ConnectivityManager object.
+ */
+
+#include <lib/support/CodeUtils.h>
+#include <platform/ConnectivityManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+ConnectivityManager & ConnectivityMgr()
+{
+    return ConnectivityMgrImpl();
+}
+
+} // namespace DeviceLayer
+} // namespace chip


### PR DESCRIPTION
#### Summary

This works towards aligning the singleton implementation of `ConnectivityManager` with that of its peer `ConfigurationManager` by adding a _src/platform/SingletonConnectivityManager.cpp_ peer to _src/platform/SingletonConfigurationManager.cpp_.

#### Related issues

#42516

#### Testing

Successfully paired / commissioned an armvl-unknown-linux-gnu device using the iOS 26.2 Apple "Home" app.