### PR TITLE
Add support for the optional vendor defined info retrieval in the manufacturi…

### DIFF
--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -158,14 +158,15 @@ inline CHIP_ERROR ReadSoftwareVersionString(DeviceLayer::ConfigurationManager & 
 
 inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider * deviceInfoProvider, AttributeValueEncoder & aEncoder)
 {
-    constexpr size_t kMaxLen                  = DeviceLayer::ConfigurationManager::kMaxManufacturingDateLength;
-    constexpr size_t kMaxDateLength           = 8; // YYYYMMDD
+    constexpr size_t kMaxLen        = DeviceLayer::ConfigurationManager::kMaxManufacturingDateLength;
+    constexpr size_t kMaxDateLength = 8; // YYYYMMDD
+    static_assert(kMaxLen > kMaxDateLength, "kMaxLen must be greater than kMaxDateLength");
     char manufacturingDateString[kMaxLen + 1] = { 0 };
     uint16_t manufacturingYear;
     uint8_t manufacturingMonth;
     uint8_t manufacturingDayOfMonth;
     size_t totalManufacturingDateLen = 0;
-    MutableCharSpan vendorSuffixSpan(manufacturingDateString + kMaxDateLength, kMaxDateLength + 1);
+    MutableCharSpan vendorSuffixSpan(manufacturingDateString + kMaxDateLength, sizeof(manufacturingDateString) - kMaxDateLength);
     CHIP_ERROR status = deviceInfoProvider->GetManufacturingDate(manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
 
     // TODO: Remove defaulting once proper runtime defaulting of unimplemented factory data is done
@@ -184,14 +185,16 @@ inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider * deviceInfoP
              manufacturingDayOfMonth);
 
     totalManufacturingDateLen = strnlen(manufacturingDateString, kMaxLen);
-    status                    = deviceInfoProvider->GetManufacturingDateSuffix(vendorSuffixSpan);
-
-    if (status == CHIP_NO_ERROR && !vendorSuffixSpan.empty())
+    if (!vendorSuffixSpan.empty())
     {
-        memcpy(manufacturingDateString + totalManufacturingDateLen, vendorSuffixSpan.data(), vendorSuffixSpan.size());
-        totalManufacturingDateLen += vendorSuffixSpan.size();
+        status = deviceInfoProvider->GetManufacturingDateSuffix(vendorSuffixSpan);
+        if (status == CHIP_NO_ERROR)
+        {
+            totalManufacturingDateLen += vendorSuffixSpan.size();
+        }
     }
-    VerifyOrReturnError(totalManufacturingDateLen <= kMaxLen, CHIP_ERROR_INCORRECT_STATE);
+
+    VerifyOrDie(totalManufacturingDateLen <= kMaxLen);
 
     return aEncoder.Encode(CharSpan(manufacturingDateString, totalManufacturingDateLen));
 }

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -189,7 +189,7 @@ inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider * deviceInfoP
 
     if (status == CHIP_NO_ERROR && !vendorSuffixSpan.empty())
     {
-        memcpy(manufacturingDateString + kMaxDateLength, vendorSuffixSpan.data(), vendorSuffixSpan.size());
+        memcpy(manufacturingDateString + totalManufacturingDateLen, vendorSuffixSpan.data(), vendorSuffixSpan.size());
         totalManufacturingDateLen += vendorSuffixSpan.size();
     }
     VerifyOrReturnError(totalManufacturingDateLen <= kMaxLen, CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -158,16 +158,14 @@ inline CHIP_ERROR ReadSoftwareVersionString(DeviceLayer::ConfigurationManager & 
 
 inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider * deviceInfoProvider, AttributeValueEncoder & aEncoder)
 {
-    constexpr size_t kMaxLen                         = DeviceLayer::ConfigurationManager::kMaxManufacturingDateLength;
-    constexpr size_t kMaxDateLength                  = 8; // YYYYMMDD
-    constexpr size_t kMaxVendorSuffixLength          = kMaxLen - kMaxDateLength;
-    char manufacturingDateString[kMaxLen + 1]        = { 0 };
-    char vendorSuffixBuf[kMaxVendorSuffixLength + 1] = { 0 };
+    constexpr size_t kMaxLen                  = DeviceLayer::ConfigurationManager::kMaxManufacturingDateLength;
+    constexpr size_t kMaxDateLength           = 8; // YYYYMMDD
+    char manufacturingDateString[kMaxLen + 1] = { 0 };
     uint16_t manufacturingYear;
     uint8_t manufacturingMonth;
     uint8_t manufacturingDayOfMonth;
     size_t totalManufacturingDateLen = 0;
-    MutableCharSpan vendorSuffixSpan(vendorSuffixBuf);
+    MutableCharSpan vendorSuffixSpan(manufacturingDateString + kMaxDateLength, kMaxDateLength + 1);
     CHIP_ERROR status = deviceInfoProvider->GetManufacturingDate(manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
 
     // TODO: Remove defaulting once proper runtime defaulting of unimplemented factory data is done

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -184,14 +184,11 @@ inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider * deviceInfoP
     snprintf(manufacturingDateString, sizeof(manufacturingDateString), "%04u%02u%02u", manufacturingYear, manufacturingMonth,
              manufacturingDayOfMonth);
 
-    totalManufacturingDateLen = strnlen(manufacturingDateString, kMaxLen);
-    if (!vendorSuffixSpan.empty())
+    totalManufacturingDateLen = kMaxDateLength;
+    status                    = deviceInfoProvider->GetManufacturingDateSuffix(vendorSuffixSpan);
+    if (status == CHIP_NO_ERROR)
     {
-        status = deviceInfoProvider->GetManufacturingDateSuffix(vendorSuffixSpan);
-        if (status == CHIP_NO_ERROR)
-        {
-            totalManufacturingDateLen += vendorSuffixSpan.size();
-        }
+        totalManufacturingDateLen += vendorSuffixSpan.size();
     }
 
     VerifyOrDie(totalManufacturingDateLen <= kMaxLen);

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -174,7 +174,8 @@ inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider * deviceInfoP
         manufacturingYear       = 2020;
         manufacturingMonth      = 1;
         manufacturingDayOfMonth = 1;
-        status                  = CHIP_NO_ERROR;
+        vendorSuffixSpan.reduce_size(0);
+        status = CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(status);
 

--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -110,9 +110,7 @@ public:
             suffixBuffer.reduce_size(0);
             return CHIP_NO_ERROR;
         }
-        CHIP_ERROR err = SafeCopyString(suffixBuffer.data(), suffixBuffer.size(), mManufacturingDateSuffix);
-        suffixBuffer.reduce_size(strlen(mManufacturingDateSuffix));
-        return err;
+        return CopyCharSpanToMutableCharSpan(CharSpan::fromCharString(mManufacturingDateSuffix), suffixBuffer);
     }
 
     CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kPartNumber); }
@@ -137,6 +135,7 @@ public:
 
     CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override { return CHIP_NO_ERROR; }
 
+    // NOTE: suffix lifetime MUST be longer than this object lifetime as just a pointer is kept.
     void SetManufacturingDateSuffix(const char * suffix) { mManufacturingDateSuffix = suffix; }
 
 private:

--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -38,21 +38,22 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::BasicInformation;
 
-static constexpr const char * kVendorName            = "TestVendor";
-static constexpr const char * kProductName           = "TestProduct";
-static constexpr const char * kHardwareVersionString = "HW1.0";
-static constexpr const char * kPartNumber            = "PART123";
-static constexpr const char * kProductURL            = "http://example.com";
-static constexpr const char * kProductLabel          = "Label123";
-static constexpr const char * kSerialNumber          = "SN123456";
-static constexpr uint16_t kVendorId                  = static_cast<uint16_t>(VendorId::TestVendor1);
-static constexpr uint16_t kProductId                 = 0x5678;
-static constexpr uint16_t kHardwareVersion           = 1;
-static constexpr uint16_t kManufacturingYear         = 2023;
-static constexpr uint8_t kManufacturingMonth         = 6;
-static constexpr uint8_t kManufacturingDay           = 15;
-static constexpr ProductFinishEnum kProductFinish    = ProductFinishEnum::kMatte;
-static constexpr ColorEnum kProductPrimaryColor      = ColorEnum::kBlack;
+static constexpr const char * kVendorName              = "TestVendor";
+static constexpr const char * kProductName             = "TestProduct";
+static constexpr const char * kHardwareVersionString   = "HW1.0";
+static constexpr const char * kPartNumber              = "PART123";
+static constexpr const char * kProductURL              = "http://example.com";
+static constexpr const char * kProductLabel            = "Label123";
+static constexpr const char * kSerialNumber            = "SN123456";
+static constexpr uint16_t kVendorId                    = static_cast<uint16_t>(VendorId::TestVendor1);
+static constexpr uint16_t kProductId                   = 0x5678;
+static constexpr uint16_t kHardwareVersion             = 1;
+static constexpr uint16_t kManufacturingYear           = 2023;
+static constexpr uint8_t kManufacturingMonth           = 6;
+static constexpr uint8_t kManufacturingDay             = 15;
+static constexpr const char * kManufacturingDateSuffix = "ABCDEFGH";
+static constexpr ProductFinishEnum kProductFinish      = ProductFinishEnum::kMatte;
+static constexpr ColorEnum kProductPrimaryColor        = ColorEnum::kBlack;
 
 // Helper function to safely copy strings and check for buffer size
 CHIP_ERROR SafeCopyString(char * buf, size_t bufSize, const char * source)
@@ -100,6 +101,13 @@ public:
         year  = kManufacturingYear;
         month = kManufacturingMonth;
         day   = kManufacturingDay;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer) override
+    {
+        ReturnErrorOnFailure(SafeCopyString(suffixBuffer.data(), suffixBuffer.size(), kManufacturingDateSuffix));
+        suffixBuffer.reduce_size(strlen(kManufacturingDateSuffix));
         return CHIP_NO_ERROR;
     }
 
@@ -309,7 +317,7 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
         char buf[32];
         CharSpan val(buf);
         ASSERT_EQ(tester.ReadAttribute(Attributes::ManufacturingDate::Id, val), CHIP_NO_ERROR);
-        EXPECT_TRUE(val.data_equal("20230615"_span));
+        EXPECT_TRUE(val.data_equal("20230615ABCDEFGH"_span));
     }
 
     // UniqueID (Mandatory in Rev 4+, so if it fails, cluster rev must be < 4)

--- a/src/include/platform/DeviceInstanceInfoProvider.h
+++ b/src/include/platform/DeviceInstanceInfoProvider.h
@@ -132,6 +132,28 @@ public:
     virtual CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) = 0;
 
     /**
+     * @brief Retrieve the optional vendor-specific suffix of the manufacturing date
+     *        from the device's factory data.
+     *
+     * Per Matter spec 11.1.5.12:
+     *   - The first 8 characters of the ManufacturingDate SHALL be the ISO 8601 date (YYYYMMDD).
+     *   - The final 8 characters MAY contain optional vendor-specific information.
+     *
+     * @param[in,out] suffixBuffer A buffer to receive the vendor-defined suffix (up to 8 characters).
+     *                             On input, the span size indicates the available capacity.
+     *                             On success, the span is reduced to the actual suffix length (0..8).
+     *
+     * @returns CHIP_NO_ERROR if the vendor suffix was retrieved successfully (or is empty / not supported),
+     *          CHIP_ERROR_BUFFER_TOO_SMALL if the provided span is too small, or another CHIP_ERROR from the underlying
+     *          implementation if access fails.
+     */
+    virtual CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer)
+    {
+        suffixBuffer.reduce_size(0);
+        return CHIP_NO_ERROR;
+    }
+
+    /**
      * @brief Obtain a Hardware Version from the device's factory data.
      *
      * @param[out] hardwareVersion Reference to location where the hardware version integer will be copied


### PR DESCRIPTION
#### Summary

The `Manufacturing Date` attribute in the `Basic Information cluster` is a 16-byte string where:

The first 8 bytes represent the date in `YYYYMMDD` format

The remaining bytes are vendor-defined information

[Specification reference](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/7426ff7f7dd256532c45611762cae3a3b81cda32/src/service_device_management/BasicInformationCluster.adoc#512-manufacturingdate-attribute)

Currently, SDK only supports retrieving the year, month, and day portion of the manufacturing date via `DeviceInstanceInfoProvider::GetManufacturingDate()`.

### Changes Overview

Provided a new AP  `GetManufacturingDateSuffix()`  to support retrieval of the optional vendor-defined information:

Existing implementations remain unaffected

#### Related issues
Fixes https://github.com/project-chip/connectedhomeip/issues/42533

#### Testing
Basic Information test passes.
CI passes.
Manually verified retrieval of the optional vendor info using esp32 platform through chip-tool.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
