### PR TITLE
Refactor FailSafeContext command-tracking bools to use bitflags

### DIFF
--- a/src/app/FailSafeContext.cpp
+++ b/src/app/FailSafeContext.cpp
@@ -73,7 +73,7 @@ void FailSafeContext::FailSafeTimerExpired()
     }
 
     ChipLogProgress(FailSafe, "Fail-safe timer expired");
-    ScheduleFailSafeCleanup(mFabricIndex, mAddNocCommandHasBeenInvoked, mUpdateNocCommandHasBeenInvoked);
+    ScheduleFailSafeCleanup(mFabricIndex, AddNocCommandHasBeenInvoked(), UpdateNocCommandHasBeenInvoked());
 }
 
 void FailSafeContext::ScheduleFailSafeCleanup(FabricIndex fabricIndex, bool addNocCommandInvoked, bool updateNocCommandInvoked)
@@ -90,8 +90,8 @@ void FailSafeContext::ScheduleFailSafeCleanup(FabricIndex fabricIndex, bool addN
                                .fabricIndex                               = fabricIndex,
                                .addNocCommandHasBeenInvoked               = addNocCommandInvoked,
                                .updateNocCommandHasBeenInvoked            = updateNocCommandInvoked,
-                               .updateTermsAndConditionsHasBeenInvoked    = mUpdateTermsAndConditionsHasBeenInvoked,
-                               .setVidVerificationStatementHasBeenInvoked = mSetVidVerificationStatementHasBeenInvoked,
+                               .updateTermsAndConditionsHasBeenInvoked    = UpdateTermsAndConditionsHasBeenInvoked(),
+                               .setVidVerificationStatementHasBeenInvoked = HasSetVidVerificationStatementHasBeenInvoked(),
                            } };
     CHIP_ERROR status = PlatformMgr().PostEvent(&event);
 

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -55,7 +55,10 @@ public:
     }
     void SetUpdateNocCommandInvoked() { mContextFlags.Set(ContextFlags::kUpdateNocCommandInvoked); }
     void SetAddTrustedRootCertInvoked() { mContextFlags.Set(ContextFlags::kAddTrustedRootCertInvoked); }
-    void SetCsrRequestForUpdateNoc(bool isForUpdateNoc) { mContextFlags.Set(ContextFlags::kIsCsrRequestForUpdateNoc); }
+    void SetCsrRequestForUpdateNoc(bool isForUpdateNoc)
+    {
+        mContextFlags.Set(ContextFlags::kIsCsrRequestForUpdateNoc, isForUpdateNoc);
+    }
     void SetUpdateTermsAndConditionsHasBeenInvoked() { mContextFlags.Set(ContextFlags::kUpdateTermsAndConditionsInvoked); }
     void RecordSetVidVerificationStatementHasBeenInvoked() { mContextFlags.Set(ContextFlags::kSetVidVerificationStatementInvoked); }
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
@@ -109,9 +112,6 @@ public:
     }
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     bool AddICACCommandHasBeenInvoked() const { return mContextFlags.Has(ContextFlags::kAddICACInvoked); }
-    {
-        return mContextFlags.Has(ContextFlags::kAddICACInvoked);
-    }
 #endif
 
     FabricIndex GetFabricIndex() const
@@ -125,15 +125,12 @@ public:
     void ForceFailSafeTimerExpiry();
 
 private:
-    bool mFailSafeArmed = false;
-    bool mFailSafeBusy  = false;
-
     enum class ContextFlags : uint8_t
     {
         kAddNocCommandInvoked               = 0x01,
         kUpdateNocCommandInvoked            = 0x02,
         kAddTrustedRootCertInvoked          = 0x04,
-        kIsCsrRequestForUpdateNoc           = 0x08,
+        kIsCsrRequestForUpdateNoc           = 0x08, /* The fact of whether a CSR occurred at all is stored elsewhere. */
         kUpdateTermsAndConditionsInvoked    = 0x10,
         kSetVidVerificationStatementInvoked = 0x20,
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
@@ -142,8 +139,10 @@ private:
     };
 
     BitFlags<ContextFlags> mContextFlags;
-
     FabricIndex mFabricIndex = kUndefinedFabricIndex;
+
+    bool mFailSafeArmed = false;
+    bool mFailSafeBusy  = false;
 
     /**
      * @brief

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -25,6 +25,7 @@
 
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
+#include <lib/support/BitFlags.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <system/SystemClock.h>
 

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -50,16 +50,16 @@ public:
     void DisarmFailSafe();
     void SetAddNocCommandInvoked(FabricIndex nocFabricIndex)
     {
-        mAddNocCommandHasBeenInvoked = true;
-        mFabricIndex                 = nocFabricIndex;
+        mContextFlags.Set(ContextFlags::kAddNocCommandInvoked);
+        mFabricIndex = nocFabricIndex;
     }
-    void SetUpdateNocCommandInvoked() { mUpdateNocCommandHasBeenInvoked = true; }
-    void SetAddTrustedRootCertInvoked() { mAddTrustedRootCertHasBeenInvoked = true; }
-    void SetCsrRequestForUpdateNoc(bool isForUpdateNoc) { mIsCsrRequestForUpdateNoc = isForUpdateNoc; }
-    void SetUpdateTermsAndConditionsHasBeenInvoked() { mUpdateTermsAndConditionsHasBeenInvoked = true; }
-    void RecordSetVidVerificationStatementHasBeenInvoked() { mSetVidVerificationStatementHasBeenInvoked = true; }
+    void SetUpdateNocCommandInvoked() { mContextFlags.Set(ContextFlags::kUpdateNocCommandInvoked); }
+    void SetAddTrustedRootCertInvoked() { mContextFlags.Set(ContextFlags::kAddTrustedRootCertInvoked); }
+    void SetCsrRequestForUpdateNoc(bool isForUpdateNoc) { mContextFlags.Set(ContextFlags::kIsCsrRequestForUpdateNoc); }
+    void SetUpdateTermsAndConditionsHasBeenInvoked() { mContextFlags.Set(ContextFlags::kUpdateTermsAndConditionsInvoked); }
+    void RecordSetVidVerificationStatementHasBeenInvoked() { mContextFlags.Set(ContextFlags::kSetVidVerificationStatementInvoked); }
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-    void SetAddICACHasBeenInvoked() { mAddICACHasBeenInvoked = true; }
+    void SetAddICACHasBeenInvoked() { mContextFlags.Set(ContextFlags::kAddICACInvoked); }
 #endif
 
     /**
@@ -91,15 +91,27 @@ public:
         return (accessingFabricIndex == mFabricIndex);
     }
 
-    bool NocCommandHasBeenInvoked() const { return mAddNocCommandHasBeenInvoked || mUpdateNocCommandHasBeenInvoked; }
-    bool AddNocCommandHasBeenInvoked() const { return mAddNocCommandHasBeenInvoked; }
-    bool UpdateNocCommandHasBeenInvoked() const { return mUpdateNocCommandHasBeenInvoked; }
-    bool AddTrustedRootCertHasBeenInvoked() const { return mAddTrustedRootCertHasBeenInvoked; }
-    bool IsCsrRequestForUpdateNoc() const { return mIsCsrRequestForUpdateNoc; }
-    bool UpdateTermsAndConditionsHasBeenInvoked() const { return mUpdateTermsAndConditionsHasBeenInvoked; }
-    bool HasSetVidVerificationStatementHasBeenInvoked() const { return mSetVidVerificationStatementHasBeenInvoked; }
+    bool NocCommandHasBeenInvoked() const
+    {
+        return mContextFlags.Has(ContextFlags::kAddNocCommandInvoked) || mContextFlags.Has(ContextFlags::kUpdateNocCommandInvoked);
+    }
+    bool AddNocCommandHasBeenInvoked() const { return mContextFlags.Has(ContextFlags::kAddNocCommandInvoked); }
+    bool UpdateNocCommandHasBeenInvoked() const { return mContextFlags.Has(ContextFlags::kUpdateNocCommandInvoked); }
+    bool AddTrustedRootCertHasBeenInvoked() const { return mContextFlags.Has(ContextFlags::kAddTrustedRootCertInvoked); }
+    bool IsCsrRequestForUpdateNoc() const { return mContextFlags.Has(ContextFlags::kIsCsrRequestForUpdateNoc); }
+    bool UpdateTermsAndConditionsHasBeenInvoked() const
+    {
+        return mContextFlags.Has(ContextFlags::kUpdateTermsAndConditionsInvoked);
+    }
+    bool HasSetVidVerificationStatementHasBeenInvoked() const
+    {
+        return mContextFlags.Has(ContextFlags::kSetVidVerificationStatementInvoked);
+    }
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-    bool AddICACCommandHasBeenInvoked() const { return mAddICACHasBeenInvoked; }
+    bool AddICACCommandHasBeenInvoked() const { return mContextFlags.Has(ContextFlags::kAddICACInvoked); }
+    {
+        return mContextFlags.Has(ContextFlags::kAddICACInvoked);
+    }
 #endif
 
     FabricIndex GetFabricIndex() const
@@ -113,19 +125,25 @@ public:
     void ForceFailSafeTimerExpiry();
 
 private:
-    bool mFailSafeArmed                    = false;
-    bool mFailSafeBusy                     = false;
-    bool mAddNocCommandHasBeenInvoked      = false;
-    bool mUpdateNocCommandHasBeenInvoked   = false;
-    bool mAddTrustedRootCertHasBeenInvoked = false;
-    // The fact of whether a CSR occurred at all is stored elsewhere.
-    bool mIsCsrRequestForUpdateNoc                  = false;
-    FabricIndex mFabricIndex                        = kUndefinedFabricIndex;
-    bool mUpdateTermsAndConditionsHasBeenInvoked    = false;
-    bool mSetVidVerificationStatementHasBeenInvoked = false;
+    bool mFailSafeArmed = false;
+    bool mFailSafeBusy  = false;
+
+    enum class ContextFlags : uint8_t
+    {
+        kAddNocCommandInvoked               = 0x01,
+        kUpdateNocCommandInvoked            = 0x02,
+        kAddTrustedRootCertInvoked          = 0x04,
+        kIsCsrRequestForUpdateNoc           = 0x08,
+        kUpdateTermsAndConditionsInvoked    = 0x10,
+        kSetVidVerificationStatementInvoked = 0x20,
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-    bool mAddICACHasBeenInvoked = false;
+        kAddICACInvoked = 0x40,
 #endif
+    };
+
+    BitFlags<ContextFlags> mContextFlags;
+
+    FabricIndex mFabricIndex = kUndefinedFabricIndex;
 
     /**
      * @brief
@@ -155,16 +173,8 @@ private:
     {
         SetFailSafeArmed(false);
 
-        mAddNocCommandHasBeenInvoked               = false;
-        mUpdateNocCommandHasBeenInvoked            = false;
-        mAddTrustedRootCertHasBeenInvoked          = false;
-        mFailSafeBusy                              = false;
-        mIsCsrRequestForUpdateNoc                  = false;
-        mUpdateTermsAndConditionsHasBeenInvoked    = false;
-        mSetVidVerificationStatementHasBeenInvoked = false;
-#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-        mAddICACHasBeenInvoked = false;
-#endif
+        mFailSafeBusy = false;
+        mContextFlags.ClearAll();
     }
 
     void FailSafeTimerExpired();

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -94,10 +94,7 @@ public:
         return (accessingFabricIndex == mFabricIndex);
     }
 
-    bool NocCommandHasBeenInvoked() const
-    {
-        return mContextFlags.Has(ContextFlags::kAddNocCommandInvoked) || mContextFlags.Has(ContextFlags::kUpdateNocCommandInvoked);
-    }
+    bool NocCommandHasBeenInvoked() const { return AddNocCommandHasBeenInvoked() || UpdateNocCommandHasBeenInvoked(); }
     bool AddNocCommandHasBeenInvoked() const { return mContextFlags.Has(ContextFlags::kAddNocCommandInvoked); }
     bool UpdateNocCommandHasBeenInvoked() const { return mContextFlags.Has(ContextFlags::kUpdateNocCommandInvoked); }
     bool AddTrustedRootCertHasBeenInvoked() const { return mContextFlags.Has(ContextFlags::kAddTrustedRootCertInvoked); }

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -128,17 +128,17 @@ private:
         kAddNocCommandInvoked               = 0x01,
         kUpdateNocCommandInvoked            = 0x02,
         kAddTrustedRootCertInvoked          = 0x04,
-        kIsCsrRequestForUpdateNoc           = 0x08, /* The fact of whether a CSR occurred at all is stored elsewhere. */
+        kIsCsrRequestForUpdateNoc           = 0x08, /* Whether a CSR request occurred at all is stored elsewhere. */
         kUpdateTermsAndConditionsInvoked    = 0x10,
         kSetVidVerificationStatementInvoked = 0x20,
-#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-        kAddICACInvoked = 0x40,
-#endif
+        kAddICACInvoked                     = 0x40, /* Used only by Joint Fabric*/
     };
 
     BitFlags<ContextFlags> mContextFlags;
     FabricIndex mFabricIndex = kUndefinedFabricIndex;
 
+    // These bools track the state of the fail-safe and are intentionally separate from mContextFlags, which records command/context
+    // history.
     bool mFailSafeArmed = false;
     bool mFailSafeBusy  = false;
 

--- a/src/app/tests/TestFailSafeContext.cpp
+++ b/src/app/tests/TestFailSafeContext.cpp
@@ -111,23 +111,77 @@ TEST_F(TestFailSafeContext, TestFailSafeContext_MiscellaneousElementFlagsWork)
 
     EXPECT_EQ(failSafeContext.ArmFailSafe(kTestAccessingFabricIndex1, System::Clock::Seconds16(1)), CHIP_NO_ERROR);
 
-    EXPECT_FALSE(failSafeContext.UpdateTermsAndConditionsHasBeenInvoked());
-    EXPECT_FALSE(failSafeContext.HasSetVidVerificationStatementHasBeenInvoked());
+    {
+        EXPECT_FALSE(failSafeContext.UpdateTermsAndConditionsHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.HasSetVidVerificationStatementHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.AddTrustedRootCertHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.IsCsrRequestForUpdateNoc());
+    }
 
     failSafeContext.SetUpdateTermsAndConditionsHasBeenInvoked();
 
-    EXPECT_TRUE(failSafeContext.UpdateTermsAndConditionsHasBeenInvoked());
-    EXPECT_FALSE(failSafeContext.HasSetVidVerificationStatementHasBeenInvoked());
+    {
+        EXPECT_TRUE(failSafeContext.UpdateTermsAndConditionsHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.HasSetVidVerificationStatementHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.AddTrustedRootCertHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.IsCsrRequestForUpdateNoc());
+    }
 
     failSafeContext.RecordSetVidVerificationStatementHasBeenInvoked();
 
-    EXPECT_TRUE(failSafeContext.UpdateTermsAndConditionsHasBeenInvoked());
-    EXPECT_TRUE(failSafeContext.HasSetVidVerificationStatementHasBeenInvoked());
+    {
+        EXPECT_TRUE(failSafeContext.UpdateTermsAndConditionsHasBeenInvoked());
+        EXPECT_TRUE(failSafeContext.HasSetVidVerificationStatementHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.AddTrustedRootCertHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.IsCsrRequestForUpdateNoc());
+    }
+
+    failSafeContext.SetAddTrustedRootCertInvoked();
+
+    {
+        EXPECT_TRUE(failSafeContext.UpdateTermsAndConditionsHasBeenInvoked());
+        EXPECT_TRUE(failSafeContext.HasSetVidVerificationStatementHasBeenInvoked());
+        EXPECT_TRUE(failSafeContext.AddTrustedRootCertHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.IsCsrRequestForUpdateNoc());
+    }
+
+    failSafeContext.SetCsrRequestForUpdateNoc(true);
+
+    {
+        EXPECT_TRUE(failSafeContext.UpdateTermsAndConditionsHasBeenInvoked());
+        EXPECT_TRUE(failSafeContext.HasSetVidVerificationStatementHasBeenInvoked());
+        EXPECT_TRUE(failSafeContext.AddTrustedRootCertHasBeenInvoked());
+        EXPECT_TRUE(failSafeContext.IsCsrRequestForUpdateNoc());
+    }
+
+    failSafeContext.SetCsrRequestForUpdateNoc(false);
+
+    {
+        EXPECT_TRUE(failSafeContext.UpdateTermsAndConditionsHasBeenInvoked());
+        EXPECT_TRUE(failSafeContext.HasSetVidVerificationStatementHasBeenInvoked());
+        EXPECT_TRUE(failSafeContext.AddTrustedRootCertHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.IsCsrRequestForUpdateNoc());
+        failSafeContext.SetCsrRequestForUpdateNoc(true);
+    }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    EXPECT_FALSE(failSafeContext.AddICACCommandHasBeenInvoked());
+
+    failSafeContext.SetAddICACHasBeenInvoked();
+    EXPECT_TRUE(failSafeContext.AddICACCommandHasBeenInvoked());
+
+#endif
 
     failSafeContext.DisarmFailSafe();
 
-    EXPECT_FALSE(failSafeContext.UpdateTermsAndConditionsHasBeenInvoked());
-    EXPECT_FALSE(failSafeContext.HasSetVidVerificationStatementHasBeenInvoked());
+    {
+        EXPECT_FALSE(failSafeContext.UpdateTermsAndConditionsHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.HasSetVidVerificationStatementHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.AddTrustedRootCertHasBeenInvoked());
+        EXPECT_FALSE(failSafeContext.IsCsrRequestForUpdateNoc());
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+        EXPECT_FALSE(failSafeContext.AddICACCommandHasBeenInvoked());
+#endif
+    }
 }
-
 } // namespace


### PR DESCRIPTION
#### Summary

- This PR refactors `FailSafeContext` to replace command-tracking booleans with a BitFlags member for the fail-safe context.
- managing multiple independent booleans is more error prone and requires clearing each of them individually.


#### Testing

More Unit Tests added to test the fail safe context Flags behaviour 
