### PR TITLE
fix: Fix printf format specifiers for 32-bit ARM compilation

### DIFF
--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -635,7 +635,7 @@ void PushAvStreamTransportManager::SetTLSCerts(Tls::CertificateTable::BufferedCl
         }
         else
         {
-            ChipLogProgress(Camera, "Intermediate certificates fetched and stored. Size: %ld", mBufferIntermediateCerts.size());
+            ChipLogProgress(Camera, "Intermediate certificates fetched and stored. Size: %zu", mBufferIntermediateCerts.size());
         }
     }
     else
@@ -646,7 +646,7 @@ void PushAvStreamTransportManager::SetTLSCerts(Tls::CertificateTable::BufferedCl
     const ByteSpan rawKeySpan = clientCertEntry.mCertWithKey.key.Span();
     if (rawKeySpan.size() != Crypto::kP256_PublicKey_Length + Crypto::kP256_PrivateKey_Length)
     {
-        ChipLogError(Camera, "Raw key pair has incorrect size: %ld (expected %ld)", rawKeySpan.size(),
+        ChipLogError(Camera, "Raw key pair has incorrect size: %zu (expected %zu)", rawKeySpan.size(),
                      static_cast<size_t>(Crypto::kP256_PublicKey_Length + Crypto::kP256_PrivateKey_Length));
         return;
     }

--- a/examples/camera-app/linux/src/media-controller/default-media-controller.cpp
+++ b/examples/camera-app/linux/src/media-controller/default-media-controller.cpp
@@ -28,7 +28,7 @@ void DefaultMediaController::SetCameraDevice(Camera::CameraDevice * device)
     {
         size_t bufferSize = mCameraDevice->GetPreRollBufferSize();
         mPreRollBuffer.SetMaxTotalBytes(bufferSize * 1000);
-        ChipLogProgress(Camera, "PreRollBuffer size set to %ld bytes from CameraDevice.", bufferSize);
+        ChipLogProgress(Camera, "PreRollBuffer size set to %zu bytes from CameraDevice.", bufferSize);
     }
     else
     {

--- a/examples/camera-app/linux/src/pushav-prerollbuffer.cpp
+++ b/examples/camera-app/linux/src/pushav-prerollbuffer.cpp
@@ -25,7 +25,7 @@ PreRollBuffer::PreRollBuffer() : mMaxTotalBytes(4096), mContentBufferSize(0) {}
 
 void PreRollBuffer::SetMaxTotalBytes(size_t size)
 {
-    ChipLogProgress(Camera, "Setting max total bytes to %ld", size);
+    ChipLogProgress(Camera, "Setting max total bytes to %zu", size);
     mMaxTotalBytes = size;
     TrimBuffer();
 }

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -321,7 +321,7 @@ bool PushAVTransport::HandleTriggerDetected()
         elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - mClipInfo.mActivationTime).count();
     }
 
-    ChipLogDetail(Camera, "PushAVTransport HandleTriggerDetected elapsed: %ld", elapsed);
+    ChipLogDetail(Camera, "PushAVTransport HandleTriggerDetected elapsed: %" PRId64, elapsed);
 
     if (!mRecorder->GetRecorderStatus())
     {
@@ -705,7 +705,7 @@ uint16_t PushAVTransport::GetPreRollLength()
 void PushAVTransport::StartNewSession(uint64_t newSessionID)
 {
     mClipInfo.mSessionNumber = newSessionID;
-    ChipLogProgress(Camera, "Session completed, New session started with session number [%ld]", mClipInfo.mSessionNumber);
+    ChipLogProgress(Camera, "Session completed, New session started with session number [%" PRIu64 "]", mClipInfo.mSessionNumber);
     mStreaming    = false;
     mCanSendVideo = false;
     mCanSendAudio = false;

--- a/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
+++ b/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
@@ -66,7 +66,7 @@ std::string DerCertToPem(const std::vector<uint8_t> & derData)
     X509 * cert             = d2i_X509(nullptr, &p, derData.size());
     if (!cert)
     {
-        ChipLogError(Camera, "Failed to parse DER certificate of size: %ld", derData.size());
+        ChipLogError(Camera, "Failed to parse DER certificate of size: %zu", derData.size());
         return "";
     }
 
@@ -104,7 +104,7 @@ std::string ConvertECDSAPrivateKey_DER_to_PEM(const std::vector<uint8_t> & derDa
     EVP_PKEY * pkey = d2i_AutoPrivateKey(nullptr, &p, derData.size());
     if (!pkey)
     {
-        ChipLogError(Camera, "Failed to parse DER ECDSA private key of size: %ld", derData.size());
+        ChipLogError(Camera, "Failed to parse DER ECDSA private key of size: %zu", derData.size());
         return "";
     }
 
@@ -241,7 +241,7 @@ size_t PushAvUploadCb(void * ptr, size_t size, size_t nmemb, void * stream)
     }
     if ((size == 0) || (nmemb == 0) || ((size * nmemb) < 1))
     {
-        ChipLogError(Camera, "Zero buffer size = %ld nmemb = %ld %ld\n", size, nmemb, size * nmemb);
+        ChipLogError(Camera, "Zero buffer size = %zu nmemb = %zu %zu\n", size, nmemb, size * nmemb);
         return 0;
     }
     long remaining          = upload->mSize - upload->mBytesRead;
@@ -403,7 +403,7 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
     }
     else
     {
-        ChipLogDetail(Camera, "CURL uploaded file  %s size: %ld", data.first.c_str(), size);
+        ChipLogDetail(Camera, "CURL uploaded file  %s size: %zu", data.first.c_str(), static_cast<size_t>(size));
     }
 
     if (extension != ".mpd")

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -297,7 +297,7 @@ public:
 
             // Extract any candidates embedded in the SDP description
             std::vector<rtc::Candidate> candidates = desc.candidates();
-            ChipLogProgress(Camera, "Extracted %lu candidates from SDP description", candidates.size());
+            ChipLogProgress(Camera, "Extracted %zu candidates from SDP description", candidates.size());
 
             for (const auto & candidate : candidates)
             {

--- a/examples/camera-controller/commands/common/CHIPCommand.cpp
+++ b/examples/camera-controller/commands/common/CHIPCommand.cpp
@@ -326,7 +326,7 @@ std::string CHIPCommand::GetIdentity()
             // normalize name since it is used in persistent storage
 
             char s[24];
-            sprintf(s, "%lx", fabricId);
+            sprintf(s, "%" PRIx64, fabricId);
 
             name = s;
         }

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -281,7 +281,7 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
 
         // Extract any candidates embedded in the SDP description
         std::vector<rtc::Candidate> candidates = desc.candidates();
-        ChipLogProgress(Camera, "Extracted %lu candidates from SDP description", candidates.size());
+        ChipLogProgress(Camera, "Extracted %zu candidates from SDP description", candidates.size());
 
         for (const auto & candidate : candidates)
         {
@@ -496,7 +496,7 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
     }
     else
     {
-        ChipLogProgress(Camera, "Sent %lu ICE candidate(s)", candidateCount);
+        ChipLogProgress(Camera, "Sent %zu ICE candidate(s)", candidateCount);
 
         // Remove only the candidates that were successfully sent
         // New candidates may have arrived during transmission, so we remove from the front
@@ -505,13 +505,13 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
             mLocalCandidates.erase(mLocalCandidates.begin(), mLocalCandidates.begin() + candidateCount);
             if (!mLocalCandidates.empty())
             {
-                ChipLogProgress(Camera, "%lu new candidate(s) arrived during transmission, keeping for next batch",
+                ChipLogProgress(Camera, "%zu new candidate(s) arrived during transmission, keeping for next batch",
                                 mLocalCandidates.size());
             }
         }
         else
         {
-            ChipLogProgress(Camera, "Sent %lu ICE candidate(s), clearing list", mLocalCandidates.size());
+            ChipLogProgress(Camera, "Sent %zu ICE candidate(s), clearing list", mLocalCandidates.size());
             mLocalCandidates.clear();
         }
     }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -839,7 +839,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
     {
         if (DeviceLayer::ConnectivityMgr().GetWiFiPAF()->GetWiFiPAFState() != WiFiPAF::State::kConnected)
         {
-            ChipLogProgress(Controller, "WiFi-PAF: Subscribing to the NAN-USD devices, nodeId: %lu",
+            ChipLogProgress(Controller, "WiFi-PAF: Subscribing to the NAN-USD devices, nodeId: %" PRIu64,
                             params.GetPeerAddress().GetRemoteId());
             mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = params;
             auto nodeId                                         = params.GetPeerAddress().GetRemoteId();
@@ -934,7 +934,7 @@ void DeviceCommissioner::OnWiFiPAFSubscribeComplete(void * appState)
 
     if (nullptr != device && device->GetDeviceTransportType() == Transport::Type::kWiFiPAF)
     {
-        ChipLogProgress(Controller, "WiFi-PAF: Subscription Completed, dev_id = %lu", device->GetDeviceId());
+        ChipLogProgress(Controller, "WiFi-PAF: Subscription Completed, dev_id = %" PRIu64, device->GetDeviceId());
         auto remoteId = device->GetDeviceId();
         auto params   = self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF;
 
@@ -951,7 +951,7 @@ void DeviceCommissioner::OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err
 
     if (nullptr != device && device->GetDeviceTransportType() == Transport::Type::kWiFiPAF)
     {
-        ChipLogError(Controller, "WiFi-PAF: Subscription Error, id = %lu, err = %" CHIP_ERROR_FORMAT, device->GetDeviceId(),
+        ChipLogError(Controller, "WiFi-PAF: Subscription Error, id = %" PRIu64 ", err = %" CHIP_ERROR_FORMAT, device->GetDeviceId(),
                      err.Format());
         self->ReleaseCommissioneeDevice(device);
         self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = RendezvousParameters();

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -526,7 +526,7 @@ void SetUpCodePairer::OnBLEDiscoveryError(CHIP_ERROR err)
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 void SetUpCodePairer::OnDiscoveredDeviceOverWifiPAF()
 {
-    ChipLogProgress(Controller, "Discovered device to be commissioned over Wi-Fi PAF, RemoteId: %lu", mRemoteId);
+    ChipLogProgress(Controller, "Discovered device to be commissioned over Wi-Fi PAF, RemoteId: %" PRIu64, mRemoteId);
 
     mWaitingForDiscovery[kWiFiPAFTransport] = false;
     auto param                              = SetUpCodePairerParameters();

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1281,7 +1281,7 @@ void ConnectivityManagerImpl::OnDiscoveryResult(GVariant * discov_info)
     g_variant_get(dataValue.get(), "u", &srv_proto_type);
 
     // Read the ssi
-    size_t bufferLen;
+    gsize bufferLen;
     value = g_variant_lookup_value(discov_info, "ssi", G_VARIANT_TYPE_BYTESTRING);
     dataValue.reset(value);
     auto ssibuf      = g_variant_get_fixed_array(dataValue.get(), &bufferLen, sizeof(uint8_t));
@@ -1315,7 +1315,7 @@ void ConnectivityManagerImpl::OnDiscoveryResult(GVariant * discov_info)
     /*
         Set the PAF session information
     */
-    ChipLogProgress(DeviceLayer, "WiFi-PAF: DiscoveryResult, set PafInfo, whose nodeId: %lu", pPafInfo->nodeId);
+    ChipLogProgress(DeviceLayer, "WiFi-PAF: DiscoveryResult, set PafInfo, whose nodeId: %" PRIu64, pPafInfo->nodeId);
     ChipLogProgress(DeviceLayer, "\t (subscribe_id, peer_publish_id): (%u, %u)", subscribe_id, peer_publish_id);
     ChipLogProgress(DeviceLayer, "\t peer_addr: [%02x:%02x:%02x:%02x:%02x:%02x]", peer_addr[0], peer_addr[1], peer_addr[2],
                     peer_addr[3], peer_addr[4], peer_addr[5]);
@@ -1374,7 +1374,7 @@ void ConnectivityManagerImpl::OnReplied(GVariant * reply_info)
     g_variant_get(dataValue.get(), "u", &srv_proto_type);
 
     // Read the ssi
-    size_t bufferLen;
+    gsize bufferLen;
     value = g_variant_lookup_value(reply_info, "ssi", G_VARIANT_TYPE_BYTESTRING);
     dataValue.reset(value);
     auto ssibuf      = g_variant_get_fixed_array(dataValue.get(), &bufferLen, sizeof(uint8_t));
@@ -1408,7 +1408,7 @@ void ConnectivityManagerImpl::OnReplied(GVariant * reply_info)
     /*
         Set the PAF session information
     */
-    ChipLogProgress(DeviceLayer, "WiFi-PAF: OnReplied, set PafInfo, whose nodeId: %lu", pPafInfo->nodeId);
+    ChipLogProgress(DeviceLayer, "WiFi-PAF: OnReplied, set PafInfo, whose nodeId: %" PRIu64, pPafInfo->nodeId);
     ChipLogProgress(DeviceLayer, "\t (publish_id, peer_subscribe_id): (%u, %u)", publish_id, peer_subscribe_id);
     ChipLogProgress(DeviceLayer, "\t peer_addr: [%02x:%02x:%02x:%02x:%02x:%02x]", peer_addr[0], peer_addr[1], peer_addr[2],
                     peer_addr[3], peer_addr[4], peer_addr[5]);
@@ -1449,14 +1449,14 @@ void ConnectivityManagerImpl::OnNanReceive(GVariant * obj)
            &RxInfo.peer_addr[3], &RxInfo.peer_addr[4], &RxInfo.peer_addr[5]);
 
     // Read the rx_data
-    size_t bufferLen;
+    gsize bufferLen;
     System::PacketBufferHandle buf;
 
     value = g_variant_lookup_value(obj, "ssi", G_VARIANT_TYPE_BYTESTRING);
     dataValue.reset(value);
 
     auto rxbuf = g_variant_get_fixed_array(dataValue.get(), &bufferLen, sizeof(uint8_t));
-    ChipLogProgress(DeviceLayer, "WiFi-PAF: wpa_supplicant: nan-rx: [len: %lu]", bufferLen);
+    ChipLogProgress(DeviceLayer, "WiFi-PAF: wpa_supplicant: nan-rx: [len: %" G_GSIZE_FORMAT "]", bufferLen);
     buf = System::PacketBufferHandle::NewWithData(rxbuf, bufferLen);
 
     // Post an event to the Chip queue to deliver the data into the Chip stack.
@@ -1589,12 +1589,12 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFCancelIncompleteSubscribe()
 
 CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSend(const WiFiPAF::WiFiPAFSession & TxInfo, System::PacketBufferHandle && msgBuf)
 {
-    ChipLogProgress(Controller, "WiFi-PAF: sending PAF Follow-up packets, (%lu)", msgBuf->DataLength());
+    ChipLogProgress(Controller, "WiFi-PAF: sending PAF Follow-up packets, (%zu)", msgBuf->DataLength());
     CHIP_ERROR ret = CHIP_NO_ERROR;
 
     if (msgBuf.IsNull())
     {
-        ChipLogError(Controller, "WiFi-PAF: Invalid Packet (%lu)", msgBuf->DataLength());
+        ChipLogError(Controller, "WiFi-PAF: Invalid Packet (%zu)", msgBuf->DataLength());
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
@@ -1607,7 +1607,7 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSend(const WiFiPAF::WiFiPAFSession &
         if (msgBuf->HasChainedBuffer())
         {
             ret = CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG;
-            ChipLogError(Controller, "WiFi-PAF: Outbound message too big (%lu), skip temporally", msgBuf->DataLength());
+            ChipLogError(Controller, "WiFi-PAF: Outbound message too big (%zu), skip temporally", msgBuf->DataLength());
             return ret;
         }
     }
@@ -1641,7 +1641,7 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSend(const WiFiPAF::WiFiPAFSession &
     {
         ChipLogError(DeviceLayer, "WiFi-PAF: Failed to send message: %s", err == nullptr ? "unknown error" : err->message);
     }
-    ChipLogProgress(Controller, "WiFi-PAF: Outbound message (%lu) done", msgBuf->DataLength());
+    ChipLogProgress(Controller, "WiFi-PAF: Outbound message (%zu) done", msgBuf->DataLength());
 
     // Post an event to the Chip queue to deliver the data into the Chip stack.
     ChipDeviceEvent event{ .Type = DeviceEventType::kCHIPoWiFiPAFWriteDone };
@@ -2089,7 +2089,7 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
     }
     else
     {
-        ChipLogError(DeviceLayer, "WPA supplicant: Got a network with incorrect BSSID len: %zd != 6", bssidLen);
+        ChipLogError(DeviceLayer, "WPA supplicant: Got a network with incorrect BSSID len: %" G_GSIZE_FORMAT " != 6", bssidLen);
         bssidLen = 0;
     }
     ChipLogDetail(DeviceLayer, "Network Found: %s (%s) Signal:%d",

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -268,12 +268,12 @@ void BluezConnection::SetupNotifyHandler(int aSocketFd, bool aAdditionalAdvertis
 CHIP_ERROR BluezConnection::SendIndicationImpl(ConnectionDataBundle * data)
 {
     GAutoPtr<GError> error;
-    size_t len, written;
+    gsize len, written;
 
     if (bluez_gatt_characteristic1_get_notify_acquired(data->mConn.mC2.get()) == TRUE)
     {
         auto * buf = static_cast<const char *>(g_variant_get_fixed_array(data->mData.get(), &len, sizeof(uint8_t)));
-        VerifyOrExit(len <= static_cast<size_t>(std::numeric_limits<gssize>::max()),
+        VerifyOrExit(len <= std::numeric_limits<gssize>::max(),
                      ChipLogError(DeviceLayer, "FAIL: buffer too large in %s", __func__));
         auto status = g_io_channel_write_chars(data->mConn.mC2Channel.mChannel.get(), buf, static_cast<gssize>(len), &written,
                                                &error.GetReceiver());
@@ -341,7 +341,7 @@ void BluezConnection::OnCharacteristicChanged(GDBusProxy * aInterface, GVariant 
     GAutoPtr<GVariant> dataValue(g_variant_lookup_value(aChangedProperties, "Value", G_VARIANT_TYPE_BYTESTRING));
     VerifyOrReturn(dataValue != nullptr);
 
-    size_t bufferLen;
+    gsize bufferLen;
     auto buffer = g_variant_get_fixed_array(dataValue.get(), &bufferLen, sizeof(uint8_t));
     VerifyOrReturn(buffer != nullptr, ChipLogError(DeviceLayer, "Characteristic value has unexpected type"));
 

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -45,7 +45,7 @@ bool BluezGetChipDeviceInfo(BluezDevice1 & aDevice, chip::Ble::ChipBLEDeviceIden
     GAutoPtr<GVariant> dataValue(g_variant_lookup_value(serviceData, Ble::CHIP_BLE_SERVICE_LONG_UUID_STR, nullptr));
     VerifyOrReturnError(dataValue != nullptr, false);
 
-    size_t dataLen         = 0;
+    gsize dataLen          = 0;
     const void * dataBytes = g_variant_get_fixed_array(dataValue.get(), &dataLen, sizeof(uint8_t));
     VerifyOrReturnError(dataBytes != nullptr && dataLen >= sizeof(aDeviceInfo), false);
 

--- a/src/transport/raw/WiFiPAF.cpp
+++ b/src/transport/raw/WiFiPAF.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR WiFiPAFBase::SendMessage(const Transport::PeerAddress & address, Pack
         /*
             The session does not exist
         */
-        ChipLogError(Inet, "WiFi-PAF: No valid session whose nodeId: %lu", address.GetRemoteId());
+        ChipLogError(Inet, "WiFi-PAF: No valid session whose nodeId: %" PRIu64, address.GetRemoteId());
         return CHIP_ERROR_INCORRECT_STATE;
     }
     return mWiFiPAFLayer->SendMessage(*pTxInfo, std::move(msgBuf));

--- a/src/wifipaf/WiFiPAFLayer.cpp
+++ b/src/wifipaf/WiFiPAFLayer.cpp
@@ -73,7 +73,7 @@ public:
                 (elem->mSessionInfo.peer_id == pInInfo->peer_id) &&
                 !memcmp(elem->mSessionInfo.peer_addr, pInInfo->peer_addr, sizeof(uint8_t) * 6))
             {
-                ChipLogProgress(WiFiPAF, "Find: Found WiFiPAFEndPoint[%lu]", i);
+                ChipLogProgress(WiFiPAF, "Find: Found WiFiPAFEndPoint[%zu]", i);
                 return elem;
             }
 #ifdef CHIP_WIFIPAF_LAYER_DEBUG_LOGGING_ENABLED
@@ -454,7 +454,7 @@ CHIP_ERROR WiFiPAFLayer::AddPafSession(PafInfoAccess accType, WiFiPAFSession & S
         case PafInfoAccess::kAccNodeInfo:
             pPafSession->nodeId        = SessionInfo.nodeId;
             pPafSession->discriminator = SessionInfo.discriminator;
-            ChipLogProgress(WiFiPAF, "WiFiPAF: Add session with nodeId: %lu, disc: %x, sessions", SessionInfo.nodeId,
+            ChipLogProgress(WiFiPAF, "WiFiPAF: Add session with nodeId: %" PRIu64 ", disc: %x, sessions", SessionInfo.nodeId,
                             SessionInfo.discriminator);
             return CHIP_NO_ERROR;
         case PafInfoAccess::kAccSessionId:


### PR DESCRIPTION
#### Summary

Fix printf format specifier warnings when cross-compiling for 32-bit ARM targets.

**Root cause:** On 32-bit ARM, `long` is 32 bits, but `uint64_t`/`int64_t` are 64 bits. Using `%lu/%ld` format specifiers causes `-Werror=format` compilation failures.

**Solution:**
- `%lu/%ld` → `PRIu64/PRId64` for 64-bit integers
- `%lx` → `PRIx64` for hex formatting  
- `%ld/%lu` → `%zu` for `size_t`
- `size_t` → `gsize` for GLib API returns (e.g., `g_variant_get_fixed_array`)
- `%zd` → `G_GSIZE_FORMAT` for `gsize`

#### Related issues

N/A

#### Testing

- Cross-compiled for ARMv7 (32-bit) using arm-linux-gnueabihf-gcc
- Verified no format warnings with `-Werror=format`
- Native x86_64 build unaffected