### PR TITLE
fix: Add cross-compilation support for libdatachannel build

### DIFF
--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 import("//build_overrides/build.gni")
 import("${build_root}/config/compiler/compiler.gni")
+import("${build_root}/toolchain/custom/custom.gni")
 
 _compiler_subdir = "gcc"
 if (is_clang) {
@@ -27,10 +28,17 @@ action("build_libdatachannel") {
 
   if (is_clang) {
     args += [ "--clang" ]
+  }
 
-    # check for cross compilation
-    if (host_os == "linux" && host_cpu == "x64" && current_cpu == "arm64") {
-      args += [ "--cross-compile-cpu-type=arm64" ]
+  # check for cross compilation - use target_cc/target_cxx from args.gn if set
+  if (host_cpu != current_cpu) {
+    args += [ "--cross-compile-cpu-type=${current_cpu}" ]
+
+    if (target_cc != "" && target_cxx != "") {
+      args += [
+        "--target-cc=${target_cc}",
+        "--target-cxx=${target_cxx}",
+      ]
     }
   }
 }

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -10,7 +10,10 @@ import click
 @click.option("--clang", is_flag=True, default=False, help="If specified, use clang instead of gcc")
 @click.option("--output-dir", default="build", help="Output directory for libdatachannel build")
 @click.option("--cross-compile-cpu-type", default=None, help="CPU type for cross compilation if needed")
-def main(clang: bool, output_dir: str, cross_compile_cpu_type: str | None):
+@click.option("--target-cc", default=None, help="C compiler for cross compilation (from args.gn)")
+@click.option("--target-cxx", default=None, help="C++ compiler for cross compilation (from args.gn)")
+def main(clang: bool, output_dir: str, cross_compile_cpu_type: str | None,
+         target_cc: str | None, target_cxx: str | None):
     # figure out paths for building
     script_dir = os.path.dirname(os.path.abspath(__file__))
     repo_dir = os.path.join(script_dir, "..", "repo")
@@ -28,33 +31,65 @@ def main(clang: bool, output_dir: str, cross_compile_cpu_type: str | None):
         "-DBUILD_SHARED_LIBS=OFF",
     ]
 
-    if clang:
-        cmake_cmd.extend(
-            [
-                "-DCMAKE_C_COMPILER=clang",
-                "-DCMAKE_CXX_COMPILER=clang++",
-            ]
-        )
-    else:
-        cmake_cmd.extend(
-            [
-                "-DCMAKE_C_COMPILER=gcc",
-                "-DCMAKE_CXX_COMPILER=g++",
-            ]
-        )
+    # Handle cross compilation
+    if cross_compile_cpu_type:
+        # Map GN cpu type to CMake processor
+        cpu_to_processor = {
+            "arm": "arm",
+            "arm64": "aarch64",
+            "x64": "x86_64",
+            "x86": "i686",
+        }
+        processor = cpu_to_processor.get(cross_compile_cpu_type, cross_compile_cpu_type)
 
-    if cross_compile_cpu_type and cross_compile_cpu_type == "arm64":
-        sysroot_aarch64 = SysRootPath("SYSROOT_AARCH64")
         cmake_cmd.extend(
             [
                 "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
                 "-DCMAKE_SYSTEM_NAME=Linux",
-                "-DCMAKE_SYSTEM_PROCESSOR=aarch64",
-                "-DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu",
-                "-DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu",
-                f"-DCMAKE_SYSROOT={sysroot_aarch64}",
+                f"-DCMAKE_SYSTEM_PROCESSOR={processor}",
+                # Disable examples/tests during cross-compilation to avoid
+                # linking issues with host system libraries (e.g., OpenSSL)
+                "-DNO_EXAMPLES=ON",
+                "-DNO_TESTS=ON",
             ]
         )
+
+        if target_cc and target_cxx:
+            # Use explicit compilers from args.gn
+            cmake_cmd.extend(
+                [
+                    f"-DCMAKE_C_COMPILER={target_cc}",
+                    f"-DCMAKE_CXX_COMPILER={target_cxx}",
+                ]
+            )
+        elif cross_compile_cpu_type == "arm64":
+            # Fallback for arm64 clang cross compilation with sysroot
+            sysroot = SysRootPath("SYSROOT_AARCH64")
+            cmake_cmd.extend(
+                [
+                    "-DCMAKE_C_COMPILER=clang" if clang else "-DCMAKE_C_COMPILER=gcc",
+                    "-DCMAKE_CXX_COMPILER=clang++" if clang else "-DCMAKE_CXX_COMPILER=g++",
+                    "-DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu",
+                    "-DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu",
+                    f"-DCMAKE_SYSROOT={sysroot}",
+                ]
+            )
+    else:
+        # Native compilation
+        if clang:
+            cmake_cmd.extend(
+                [
+                    "-DCMAKE_C_COMPILER=clang",
+                    "-DCMAKE_CXX_COMPILER=clang++",
+                ]
+            )
+        else:
+            cmake_cmd.extend(
+                [
+                    "-DCMAKE_C_COMPILER=gcc",
+                    "-DCMAKE_CXX_COMPILER=g++",
+                ]
+            )
 
     print(f"Running: {' '.join(cmake_cmd)}")
     subprocess.run(cmake_cmd, cwd=repo_dir, check=True)

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -79,7 +79,7 @@ def main(clang: bool, output_dir: str, cross_compile_cpu_type: str | None,
                     ]
                 )
         else:
-            raise NotImplementedError(f"No sysroot and compiler targets defined for target_cpu '{cross_compile_cpu_type}'")
+            raise click.UsageError(f"No sysroot and compiler targets defined for target_cpu '{cross_compile_cpu_type}'")
 
     # Set compilers for CMake
     cmake_cmd.extend(

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 import os
-import subprocess
 import shlex
+import subprocess
 
 import click
 

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -62,7 +62,10 @@ def main(clang: bool, output_dir: str, cross_compile_cpu_type: str | None,
             ]
         )
 
-        if target_cc and target_cxx:
+        if target_cc or target_cxx:
+            if not (target_cc and target_cxx):
+                raise click.UsageError("--target-cc and --target-cxx options need to be used together")
+
             # Use explicit compilers from args.gn
             c_compiler = target_cc
             cxx_compiler = target_cxx

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+import shlex
 
 import click
 
@@ -31,6 +32,13 @@ def main(clang: bool, output_dir: str, cross_compile_cpu_type: str | None,
         "-DBUILD_SHARED_LIBS=OFF",
     ]
 
+    # Default compilers
+    c_compiler = 'gcc'
+    cxx_compiler = 'g++'
+    if clang:
+        c_compiler = 'clang'
+        cxx_compiler = 'clang++'
+
     # Handle cross compilation
     if cross_compile_cpu_type:
         # Map GN cpu type to CMake processor
@@ -56,47 +64,37 @@ def main(clang: bool, output_dir: str, cross_compile_cpu_type: str | None,
 
         if target_cc and target_cxx:
             # Use explicit compilers from args.gn
-            cmake_cmd.extend(
-                [
-                    f"-DCMAKE_C_COMPILER={target_cc}",
-                    f"-DCMAKE_CXX_COMPILER={target_cxx}",
-                ]
-            )
+            c_compiler = target_cc
+            cxx_compiler = target_cxx
         elif cross_compile_cpu_type == "arm64":
-            # Fallback for arm64 clang cross compilation with sysroot
             sysroot = SysRootPath("SYSROOT_AARCH64")
-            cmake_cmd.extend(
-                [
-                    "-DCMAKE_C_COMPILER=clang" if clang else "-DCMAKE_C_COMPILER=gcc",
-                    "-DCMAKE_CXX_COMPILER=clang++" if clang else "-DCMAKE_CXX_COMPILER=g++",
-                    "-DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu",
-                    "-DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu",
-                    f"-DCMAKE_SYSROOT={sysroot}",
-                ]
-            )
-    else:
-        # Native compilation
-        if clang:
-            cmake_cmd.extend(
-                [
-                    "-DCMAKE_C_COMPILER=clang",
-                    "-DCMAKE_CXX_COMPILER=clang++",
-                ]
-            )
-        else:
-            cmake_cmd.extend(
-                [
-                    "-DCMAKE_C_COMPILER=gcc",
-                    "-DCMAKE_CXX_COMPILER=g++",
-                ]
-            )
+            cmake_cmd.append(f"-DCMAKE_SYSROOT={sysroot}")
 
-    print(f"Running: {' '.join(cmake_cmd)}")
+            if clang:
+                # These defines are not used by gcc
+                cmake_cmd.extend(
+                    [
+                        "-DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu",
+                        "-DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu",
+                    ]
+                )
+        else:
+            raise NotImplementedError(f"No sysroot and compiler targets defined for target_cpu '{cross_compile_cpu_type}'")
+
+    # Set compilers for CMake
+    cmake_cmd.extend(
+        [
+            f"-DCMAKE_C_COMPILER={c_compiler}",
+            f"-DCMAKE_CXX_COMPILER={cxx_compiler}",
+        ]
+    )
+
+    print(f"Running: {shlex.join(cmake_cmd)}")
     subprocess.run(cmake_cmd, cwd=repo_dir, check=True)
 
     # Build with Make
     make_cmd = ["make", "-j%d" % os.cpu_count()]
-    print(f"Running: {' '.join(make_cmd)}")
+    print(f"Running: {shlex.join(make_cmd)}")
     subprocess.run(make_cmd, cwd=build_dir, check=True)
 
     print("libdatachannel build complete.")


### PR DESCRIPTION
#### Summary

Generalize libdatachannel cross-compilation support beyond arm64.

**Problem:** The existing build script only supported arm64 cross-compilation with hardcoded clang/sysroot paths, making it impossible to cross-compile for other architectures like ARMv7.

**Solution:**

`BUILD.gn` changes:
- Detect cross-compilation via `host_cpu != current_cpu` (not just arm64)
- Pass `--target-cc` and `--target-cxx` from `args.gn` to the build script

`build_libdatachannel.py` changes:
- Add `--target-cc` and `--target-cxx` CLI options
- Add CPU type mapping: `arm`→`arm`, `arm64`→`aarch64`, `x64`→`x86_64`
- Add `-DNO_EXAMPLES=ON -DNO_TESTS=ON` to avoid host library linking issues
- Maintain backward compatibility with existing arm64 sysroot workflow

#### Related issues

N/A

#### Testing

- Cross-compiled libdatachannel for ARMv7 using custom gcc cross-compiler
- Verified existing arm64 cross-compilation path still works
- Native x86_64 build unaffected