### PR TITLE
Fix window app tc_rc_1_1 testcase failure

### DIFF
--- a/examples/window-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/window-app/silabs/include/CHIPProjectConfig.h
@@ -28,6 +28,10 @@
 
 #pragma once
 
+// Window-app has 2 endpoints with Groups cluster (endpoint 1 and 2).
+// This needs to be defined so that CHIP_CONFIG_MAX_GROUPS_PER_FABRIC is properly configured.
+#define CHIP_CONFIG_MAX_GROUP_ENDPOINTS_PER_FABRIC 2
+
 // Use a default pairing code if one hasn't been provisioned in flash.
 #ifndef CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021


### PR DESCRIPTION
#### Summary

Test case failure on window app ->

Test test_TC_RR_1_1 failed for the following reason:
Details=Failed Step 11: MaxGroupsPerFabric < 4 * counted_groups_clusters, Extras=None
File "/home/pi/matter_sdk/src/python_testing/TC_RR_1_1.py", line 535, in test_TC_RR_1_1
asserts.fail("Failed Step 11: MaxGroupsPerFabric < 4 * counted_groups_clusters")

Solution:
Test Case validates if MaxGroupsPerFabric ≥ 4 × (number of endpoints with Groups cluster)
This ensures each endpoint with a Groups cluster can be a member of at least 4 groups per fabric.

Window-app has had 2 endpoints with Groups cluster , but the CHIPProjectConfig.h has never had the required override
so using the default value CHIP_CONFIG_MAX_GROUP_ENDPOINTS_PER_FABRIC = 1
Resulted in MaxGroupsPerFabric = 4 × 1 = 4, but test-case expects 4 × 2 = 8

so added the config override for the window-app
#define CHIP_CONFIG_MAX_GROUP_ENDPOINTS_PER_FABRIC 2

#### Related issues

N/A

#### Testing

Run successful  test TC_RC_1_1 on windows app.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
