### PR TITLE
fix: camera-app improvements

### DIFF
--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -413,6 +413,11 @@ CameraError CameraDevice::InitializeCameraDevice()
         gstreamerInitialized = true;
     }
 
+    if (LinuxDeviceOptions::GetInstance().cameraTestVideosrc)
+    {
+        return CameraError::SUCCESS;
+    }
+
     ChipLogDetail(Camera, "InitializeCameraDevice: %s", mVideoDevicePath.c_str());
 
     videoDeviceFd = open(mVideoDevicePath.c_str(), O_RDWR);

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -150,8 +150,11 @@ void PushAvStreamTransportServerLogic::RemoveTimerAppState(const uint16_t connec
 void PushAvStreamTransportServerLogic::LoadPersistentAttributes()
 {
     // Load currentConnections
-    ChipLogFailure(mDelegate->LoadCurrentConnections(mCurrentConnections), Zcl,
-                   "PushAVStreamTransport: Unable to load allocated connections from the KVS.");
+    auto err = mDelegate->LoadCurrentConnections(mCurrentConnections);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "PushAVStreamTransport: Unable to load connections: %s", ErrorStr(err));
+    }
 
     // Signal delegate that all persistent configuration attributes have been loaded.
     TEMPORARY_RETURN_IGNORED mDelegate->PersistentAttributesLoadedCallback();


### PR DESCRIPTION
- camera-device: Skip real camera init when using test video source
- PushAVStreamTransportLogic: Fix misleading log, only print error on failure

#### Summary

This PR includes two small fixes for the camera-app:

1. **camera-device.cpp**: When `--camera-test-videosrc` flag is enabled, skip the real camera device initialization. This prevents errors when running on systems without a physical camera (e.g., CI environments or development machines).

2. **PushAVStreamTransportLogic.cpp**: Fixed a misleading log message. The original code used `ChipLogFailure()` which unconditionally prints an error log with the message "Unable to load allocated connections from the KVS" - even when the operation succeeds (showing `: Success` at the end). Changed to only print the error message when `LoadCurrentConnections()` actually fails.

   Before: `[ZCL] PushAVStreamTransport: Unable to load allocated connections from the KVS.: Success`
   After: No log on success, error log only on failure.

#### Related issues

N/A

#### Testing

- Manually tested camera-app with `--camera-test-videosrc` flag on Linux without physical camera
- Verified that the misleading "Unable to load... Success" log no longer appears on startup

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_"When in Rome…"_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)