### PR TITLE
Handling no_discard of CHIP_ERROR in fuzztests

### DIFF
--- a/examples/all-clusters-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-app/linux/fuzzing-main.cpp
@@ -56,7 +56,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
 
         // ChipLinuxAppMainLoop blocks, and we don't want that here.
         static chip::CommonCaseDeviceServerInitParams initParams;
-        (void) initParams.InitializeStaticResourcesBeforeServerInit();
+        RETURN_SAFELY_IGNORED initParams.InitializeStaticResourcesBeforeServerInit();
         initParams.dataModelProvider = app::CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
         VerifyOrDie(Server::GetInstance().Init(initParams) == CHIP_NO_ERROR);
 
@@ -109,8 +109,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
         Server::GetInstance().GetSecureSessionManager().OnMessageReceived(peerAddr, std::move(buf));
     }
     // Now process pending events until our sentinel is reached.
-    TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(
-        [](intptr_t) { TEMPORARY_RETURN_IGNORED PlatformMgr().StopEventLoopTask(); });
+    RETURN_SAFELY_IGNORED PlatformMgr().ScheduleWork([](intptr_t) { RETURN_SAFELY_IGNORED PlatformMgr().StopEventLoopTask(); });
     PlatformMgr().RunEventLoop();
     return 0;
 }

--- a/examples/all-clusters-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-app/linux/fuzzing-main.cpp
@@ -109,7 +109,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
         Server::GetInstance().GetSecureSessionManager().OnMessageReceived(peerAddr, std::move(buf));
     }
     // Now process pending events until our sentinel is reached.
-    PlatformMgr().ScheduleWork([](intptr_t) { PlatformMgr().StopEventLoopTask(); });
+    TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(
+        [](intptr_t) { TEMPORARY_RETURN_IGNORED PlatformMgr().StopEventLoopTask(); });
     PlatformMgr().RunEventLoop();
     return 0;
 }

--- a/examples/all-clusters-minimal-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-minimal-app/linux/fuzzing-main.cpp
@@ -43,7 +43,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
 
         // ChipLinuxAppMainLoop blocks, and we don't want that here.
         static chip::CommonCaseDeviceServerInitParams initParams;
-        (void) initParams.InitializeStaticResourcesBeforeServerInit();
+        RETURN_SAFELY_IGNORED initParams.InitializeStaticResourcesBeforeServerInit();
         initParams.dataModelProvider = app::CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
         VerifyOrDie(Server::GetInstance().Init(initParams) == CHIP_NO_ERROR);
 
@@ -76,8 +76,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
     Server::GetInstance().GetSecureSessionManager().OnMessageReceived(peerAddr, std::move(buf));
 
     // Now process pending events until our sentinel is reached.
-    TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(
-        [](intptr_t) { TEMPORARY_RETURN_IGNORED PlatformMgr().StopEventLoopTask(); });
+    RETURN_SAFELY_IGNORED PlatformMgr().ScheduleWork([](intptr_t) { RETURN_SAFELY_IGNORED PlatformMgr().StopEventLoopTask(); });
     PlatformMgr().RunEventLoop();
     return 0;
 }

--- a/examples/all-clusters-minimal-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-minimal-app/linux/fuzzing-main.cpp
@@ -76,7 +76,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
     Server::GetInstance().GetSecureSessionManager().OnMessageReceived(peerAddr, std::move(buf));
 
     // Now process pending events until our sentinel is reached.
-    PlatformMgr().ScheduleWork([](intptr_t) { PlatformMgr().StopEventLoopTask(); });
+    TEMPORARY_RETURN_IGNORED PlatformMgr().ScheduleWork(
+        [](intptr_t) { TEMPORARY_RETURN_IGNORED PlatformMgr().StopEventLoopTask(); });
     PlatformMgr().RunEventLoop();
     return 0;
 }

--- a/src/credentials/tests/FuzzChipCert.cpp
+++ b/src/credentials/tests/FuzzChipCert.cpp
@@ -14,22 +14,22 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t len)
 
     ByteSpan span(data, len);
 
-    (void) ExtractFabricIdFromCert(span, &fabricId);
-    (void) ExtractNodeIdFabricIdFromOpCert(span, &nodeId, &fabricId);
+    RETURN_SAFELY_IGNORED ExtractFabricIdFromCert(span, &fabricId);
+    RETURN_SAFELY_IGNORED ExtractNodeIdFabricIdFromOpCert(span, &nodeId, &fabricId);
 
     {
         ChipDN dn;
-        (void) ExtractSubjectDNFromX509Cert(span, dn);
+        RETURN_SAFELY_IGNORED ExtractSubjectDNFromX509Cert(span, dn);
     }
 
     {
         Credentials::P256PublicKeySpan key;
-        (void) ExtractPublicKeyFromChipCert(span, key);
+        RETURN_SAFELY_IGNORED ExtractPublicKeyFromChipCert(span, key);
     }
 
     {
         ChipCertificateData certData;
-        (void) DecodeChipCert(span, certData);
+        RETURN_SAFELY_IGNORED DecodeChipCert(span, certData);
     }
 
     return 0;

--- a/src/credentials/tests/FuzzChipCertPW.cpp
+++ b/src/credentials/tests/FuzzChipCertPW.cpp
@@ -110,7 +110,7 @@ void ValidateChipRCACFuzz(const std::string & fuzzRcacCerts)
     ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
     {
         ByteSpan span(reinterpret_cast<const uint8_t *>(fuzzRcacCerts.data()), fuzzRcacCerts.size());
-        ValidateChipRCAC(span);
+        (void) ValidateChipRCAC(span);
     }
     chip::Platform::MemoryShutdown();
 }
@@ -127,7 +127,7 @@ void ConvertX509CertToChipCertFuzz(const std::string & fuzzDerCerts)
     uint8_t outCertBuf[kMaxDERCertLength];
     MutableByteSpan outCert(outCertBuf);
 
-    ConvertX509CertToChipCert(span, outCert);
+    (void) ConvertX509CertToChipCert(span, outCert);
 }
 FUZZ_TEST(FuzzChipCert, ConvertX509CertToChipCertFuzz).WithDomains(Arbitrary<std::string>().WithSeeds(seedProvider(isDerFile)));
 
@@ -138,7 +138,7 @@ void ExtractSubjectDNFromX509CertFuzz(const std::string & fuzzDerCerts)
 {
     ByteSpan span(reinterpret_cast<const uint8_t *>(fuzzDerCerts.data()), fuzzDerCerts.size());
     ChipDN subjectDN;
-    ExtractSubjectDNFromX509Cert(span, subjectDN);
+    (void) ExtractSubjectDNFromX509Cert(span, subjectDN);
 }
 FUZZ_TEST(FuzzChipCert, ExtractSubjectDNFromX509CertFuzz).WithDomains(Arbitrary<std::string>().WithSeeds(seedProvider(isDerFile)));
 

--- a/src/credentials/tests/FuzzChipCertPW.cpp
+++ b/src/credentials/tests/FuzzChipCertPW.cpp
@@ -46,13 +46,13 @@ void ChipCertFuzzer(const std::string & fuzzChipCerts)
     {
         NodeId nodeId;
         FabricId fabricId;
-        (void) ExtractFabricIdFromCert(span, &fabricId);
-        (void) ExtractNodeIdFabricIdFromOpCert(span, &nodeId, &fabricId);
+        RETURN_SAFELY_IGNORED ExtractFabricIdFromCert(span, &fabricId);
+        RETURN_SAFELY_IGNORED ExtractNodeIdFabricIdFromOpCert(span, &nodeId, &fabricId);
     }
 
     {
         CATValues cats;
-        (void) ExtractCATsFromOpCert(span, cats);
+        RETURN_SAFELY_IGNORED ExtractCATsFromOpCert(span, cats);
     }
 }
 FUZZ_TEST(FuzzChipCert, ChipCertFuzzer).WithDomains(Arbitrary<std::string>().WithSeeds(seedProvider(isChipFile)));
@@ -69,7 +69,7 @@ void DecodeChipCertFuzzer(const std::string & fuzzChipCerts, BitFlags<CertDecode
         ByteSpan span(reinterpret_cast<const uint8_t *>(fuzzChipCerts.data()), fuzzChipCerts.size());
 
         ChipCertificateData certData;
-        (void) DecodeChipCert(span, certData, aDecodeFlag);
+        RETURN_SAFELY_IGNORED DecodeChipCert(span, certData, aDecodeFlag);
     }
     chip::Platform::MemoryShutdown();
 }
@@ -97,7 +97,7 @@ void ConvertChipCertToX509CertFuzz(const std::string & fuzzChipCerts)
 
     uint8_t outCertBuf[kMaxDERCertLength];
     MutableByteSpan outCert(outCertBuf);
-    (void) ConvertChipCertToX509Cert(span, outCert);
+    RETURN_SAFELY_IGNORED ConvertChipCertToX509Cert(span, outCert);
 }
 FUZZ_TEST(FuzzChipCert, ConvertChipCertToX509CertFuzz).WithDomains(Arbitrary<std::string>().WithSeeds(seedProvider(isChipFile)));
 
@@ -110,7 +110,7 @@ void ValidateChipRCACFuzz(const std::string & fuzzRcacCerts)
     ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
     {
         ByteSpan span(reinterpret_cast<const uint8_t *>(fuzzRcacCerts.data()), fuzzRcacCerts.size());
-        (void) ValidateChipRCAC(span);
+        RETURN_SAFELY_IGNORED ValidateChipRCAC(span);
     }
     chip::Platform::MemoryShutdown();
 }
@@ -127,7 +127,7 @@ void ConvertX509CertToChipCertFuzz(const std::string & fuzzDerCerts)
     uint8_t outCertBuf[kMaxDERCertLength];
     MutableByteSpan outCert(outCertBuf);
 
-    (void) ConvertX509CertToChipCert(span, outCert);
+    RETURN_SAFELY_IGNORED ConvertX509CertToChipCert(span, outCert);
 }
 FUZZ_TEST(FuzzChipCert, ConvertX509CertToChipCertFuzz).WithDomains(Arbitrary<std::string>().WithSeeds(seedProvider(isDerFile)));
 
@@ -138,7 +138,7 @@ void ExtractSubjectDNFromX509CertFuzz(const std::string & fuzzDerCerts)
 {
     ByteSpan span(reinterpret_cast<const uint8_t *>(fuzzDerCerts.data()), fuzzDerCerts.size());
     ChipDN subjectDN;
-    (void) ExtractSubjectDNFromX509Cert(span, subjectDN);
+    RETURN_SAFELY_IGNORED ExtractSubjectDNFromX509Cert(span, subjectDN);
 }
 FUZZ_TEST(FuzzChipCert, ExtractSubjectDNFromX509CertFuzz).WithDomains(Arbitrary<std::string>().WithSeeds(seedProvider(isDerFile)));
 

--- a/src/lib/core/tests/FuzzTlvReader.cpp
+++ b/src/lib/core/tests/FuzzTlvReader.cpp
@@ -15,7 +15,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t len)
 {
     TLVReader reader;
     reader.Init(data, len);
-    chip::TLV::Utilities::Iterate(reader, FuzzIterator, nullptr);
+    TEMPORARY_RETURN_IGNORED chip::TLV::Utilities::Iterate(reader, FuzzIterator, nullptr);
 
     return 0;
 }

--- a/src/lib/core/tests/FuzzTlvReader.cpp
+++ b/src/lib/core/tests/FuzzTlvReader.cpp
@@ -15,7 +15,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t len)
 {
     TLVReader reader;
     reader.Init(data, len);
-    TEMPORARY_RETURN_IGNORED chip::TLV::Utilities::Iterate(reader, FuzzIterator, nullptr);
+    RETURN_SAFELY_IGNORED chip::TLV::Utilities::Iterate(reader, FuzzIterator, nullptr);
 
     return 0;
 }

--- a/src/lib/core/tests/FuzzTlvReaderPW.cpp
+++ b/src/lib/core/tests/FuzzTlvReaderPW.cpp
@@ -27,7 +27,7 @@ void FuzzTlvReader(const std::vector<std::uint8_t> & bytes)
 {
     TLVReader reader;
     reader.Init(bytes.data(), bytes.size());
-    (void) chip::TLV::Utilities::Iterate(reader, FuzzIterator, nullptr);
+    RETURN_SAFELY_IGNORED chip::TLV::Utilities::Iterate(reader, FuzzIterator, nullptr);
 }
 // Fuzz tests are instantiated with the FUZZ_TEST macro
 FUZZ_TEST(TLVReader, FuzzTlvReader).WithDomains(Arbitrary<std::vector<std::uint8_t>>());

--- a/src/lib/core/tests/FuzzTlvReaderPW.cpp
+++ b/src/lib/core/tests/FuzzTlvReaderPW.cpp
@@ -27,7 +27,7 @@ void FuzzTlvReader(const std::vector<std::uint8_t> & bytes)
 {
     TLVReader reader;
     reader.Init(bytes.data(), bytes.size());
-    chip::TLV::Utilities::Iterate(reader, FuzzIterator, nullptr);
+    (void) chip::TLV::Utilities::Iterate(reader, FuzzIterator, nullptr);
 }
 // Fuzz tests are instantiated with the FUZZ_TEST macro
 FUZZ_TEST(TLVReader, FuzzTlvReader).WithDomains(Arbitrary<std::vector<std::uint8_t>>());

--- a/src/protocols/secure_channel/tests/FuzzCASE_PW.cpp
+++ b/src/protocols/secure_channel/tests/FuzzCASE_PW.cpp
@@ -84,7 +84,7 @@ void ParseSigma1_RawPayload(const vector<uint8_t> & fuzzEncodedSigma1)
         tlvReaderEncodedSigma1.Init(std::move(EncodedSigma1));
 
         FuzzCASESession::ParsedSigma1 unused;
-        FuzzCASESession::ParseSigma1(tlvReaderEncodedSigma1, unused);
+        (void) FuzzCASESession::ParseSigma1(tlvReaderEncodedSigma1, unused);
     }
 
     Platform::MemoryShutdown();
@@ -212,14 +212,14 @@ void ParseSigma1_StructuredPayload(const vector<uint8_t> & fuzzInitiatorRandom, 
 
         /********************************* Encode Sigma1 *********************************/
         PacketBufferHandle encodedSigma1Msg;
-        EncodeSigma1Helper(encodedSigma1Msg, encodeParams, initiatorEphPubKey);
+        (void) EncodeSigma1Helper(encodedSigma1Msg, encodeParams, initiatorEphPubKey);
 
         /********************************* Fuzz the Encoded Sigma1 Payload *********************************/
         PacketBufferTLVReader tlvReader;
         tlvReader.Init(std::move(encodedSigma1Msg));
         FuzzCASESession::ParsedSigma1 unused;
 
-        FuzzCASESession::ParseSigma1(tlvReader, unused);
+        (void) FuzzCASESession::ParseSigma1(tlvReader, unused);
         // std::cout << "ParseSigma1: " << err.Format() << std::endl;
     }
 
@@ -362,7 +362,7 @@ void ParseSigma2_RawPayload(const vector<uint8_t> & seededEncodedSigma2)
         tlvReaderEncodedSigma2.Init(std::move(EncodedSigma2));
 
         FuzzCASESession::ParsedSigma2 unused;
-        FuzzCASESession::ParseSigma2(tlvReaderEncodedSigma2, unused);
+        (void) FuzzCASESession::ParseSigma2(tlvReaderEncodedSigma2, unused);
     }
 
     Platform::MemoryShutdown();
@@ -493,7 +493,7 @@ void ParseSigma2_StructuredPayload(const vector<uint8_t> & fuzzResponderRandom, 
         tlvReader.Init(encodedSpan);
 
         FuzzCASESession::ParsedSigma2 unused;
-        FuzzCASESession::ParseSigma2(tlvReader, unused);
+        (void) FuzzCASESession::ParseSigma2(tlvReader, unused);
         // std::cout << err.Format() << std::endl;
 
         mem.Free();
@@ -614,7 +614,7 @@ void ParseSigma2TBEData_RawPayload(const vector<uint8_t> & fuzzEncodedSigma2TBED
         PacketBufferTLVReader tlvReaderFuzzed;
         tlvReaderFuzzed.Init(std::move(fuzzedMsg));
 
-        FuzzCASESession::ParseSigma2TBEData(tlvReaderFuzzed, parsedSigma2TBEDataFuzzed);
+        (void) FuzzCASESession::ParseSigma2TBEData(tlvReaderFuzzed, parsedSigma2TBEDataFuzzed);
     }
     Platform::MemoryShutdown();
 }
@@ -732,7 +732,7 @@ void ParseSigma2TBEData_StructuredPayload(const vector<uint8_t> & fuzzResponderN
         tlvReader.Init(encodedSpan);
         FuzzCASESession::ParsedSigma2TBEData parsedSigma2TBEData;
 
-        FuzzCASESession::ParseSigma2TBEData(tlvReader, parsedSigma2TBEData);
+        (void) FuzzCASESession::ParseSigma2TBEData(tlvReader, parsedSigma2TBEData);
         // std::cout << "ParseSigma2TBEData: " << err.Format() << std::endl;
     }
 
@@ -774,7 +774,7 @@ void ParseSigma2Resume_RawPayload(const vector<uint8_t> & seededEncodedSigma2Res
         tlvReaderSeeded.Init(std::move(encodedSigma2Resume));
 
         FuzzCASESession::ParsedSigma2Resume unused;
-        FuzzCASESession::ParseSigma2Resume(tlvReaderSeeded, unused);
+        (void) FuzzCASESession::ParseSigma2Resume(tlvReaderSeeded, unused);
     }
     Platform::MemoryShutdown();
 }
@@ -867,7 +867,7 @@ void ParseSigma2Resume_StructuredPayload(const vector<uint8_t> & fuzzResumptionI
         tlvReader.Init(std::move(encodedSigma2Resume));
 
         FuzzCASESession::ParsedSigma2Resume unused;
-        FuzzCASESession::ParseSigma2Resume(tlvReader, unused);
+        (void) FuzzCASESession::ParseSigma2Resume(tlvReader, unused);
     }
 
     Platform::MemoryShutdown();
@@ -975,7 +975,7 @@ void ParseSigma3_RawPayload(const vector<uint8_t> & fuzzEncodedSigma3)
         MutableByteSpan outMsgR3EncryptedPayload;
         ByteSpan outMsgR3MIC;
 
-        FuzzCASESession::ParseSigma3(tlvReader2, outMsgR3Encrypted, outMsgR3EncryptedPayload, outMsgR3MIC);
+        (void) FuzzCASESession::ParseSigma3(tlvReader2, outMsgR3Encrypted, outMsgR3EncryptedPayload, outMsgR3MIC);
     }
     Platform::MemoryShutdown();
 }
@@ -1083,7 +1083,7 @@ void ParseSigma3_StructuredPayload(const vector<uint8_t> & fuzzEncrypted3)
         ByteSpan outMsgR3MIC;
 
         // Parse Sigma3
-        FuzzCASESession::ParseSigma3(tlvReader, outMsgR3Encrypted, outMsgR3EncryptedPayload, outMsgR3MIC);
+        (void) FuzzCASESession::ParseSigma3(tlvReader, outMsgR3Encrypted, outMsgR3EncryptedPayload, outMsgR3MIC);
 
         mem.Free();
     }
@@ -1120,7 +1120,7 @@ void ParseSigma3TBEData_RawPayload(const vector<uint8_t> & fuzzEncodedSigma3TBED
         tlvReader2.Init(std::move(EncodedSigma3));
 
         FuzzCASESession::HandleSigma3Data unused;
-        FuzzCASESession::ParseSigma3TBEData(tlvReader2, unused);
+        (void) FuzzCASESession::ParseSigma3TBEData(tlvReader2, unused);
         // std::cout << "Seeded Encoded Sigma3TBEData:" << err.Format() << std::endl;
     }
 
@@ -1230,7 +1230,7 @@ void ParseSigma3TBEData_StructuredPayload(const vector<uint8_t> & fuzzInitiatorN
         tlvReader.Init(encodedSpan);
 
         FuzzCASESession::HandleSigma3Data unused;
-        FuzzCASESession::ParseSigma3TBEData(tlvReader, unused);
+        (void) FuzzCASESession::ParseSigma3TBEData(tlvReader, unused);
         // std::cout << err.Format() << std::endl;
 
         mem.Free();
@@ -1285,12 +1285,12 @@ void HandleSigma3b(const vector<uint8_t> & fuzzInitiatorNOC, const vector<uint8_
         data.msgR3SignedSpan = MutableByteSpan{ data.msgR3Signed.Get(), fuzzMsg3Signed.size() };
 
         // prepare the fuzzed signature
-        data.tbsData3Signature.SetLength(fuzzTbs3Signature.size());
+        (void) data.tbsData3Signature.SetLength(fuzzTbs3Signature.size());
         memcpy(data.tbsData3Signature.Bytes(), fuzzTbs3Signature.data(), fuzzTbs3Signature.size());
 
         /************ Fuzz CASESession::HandleSigma3b *************/
         bool unused = false;
-        FuzzCASESession::HandleSigma3b(data, unused);
+        (void) FuzzCASESession::HandleSigma3b(data, unused);
         // std::cout << "fuzzed HandleSigma3b: " << err.Format() << std::endl;
     }
 

--- a/src/protocols/secure_channel/tests/FuzzCASE_PW.cpp
+++ b/src/protocols/secure_channel/tests/FuzzCASE_PW.cpp
@@ -84,7 +84,7 @@ void ParseSigma1_RawPayload(const vector<uint8_t> & fuzzEncodedSigma1)
         tlvReaderEncodedSigma1.Init(std::move(EncodedSigma1));
 
         FuzzCASESession::ParsedSigma1 unused;
-        (void) FuzzCASESession::ParseSigma1(tlvReaderEncodedSigma1, unused);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma1(tlvReaderEncodedSigma1, unused);
     }
 
     Platform::MemoryShutdown();
@@ -212,14 +212,14 @@ void ParseSigma1_StructuredPayload(const vector<uint8_t> & fuzzInitiatorRandom, 
 
         /********************************* Encode Sigma1 *********************************/
         PacketBufferHandle encodedSigma1Msg;
-        (void) EncodeSigma1Helper(encodedSigma1Msg, encodeParams, initiatorEphPubKey);
+        RETURN_SAFELY_IGNORED EncodeSigma1Helper(encodedSigma1Msg, encodeParams, initiatorEphPubKey);
 
         /********************************* Fuzz the Encoded Sigma1 Payload *********************************/
         PacketBufferTLVReader tlvReader;
         tlvReader.Init(std::move(encodedSigma1Msg));
         FuzzCASESession::ParsedSigma1 unused;
 
-        (void) FuzzCASESession::ParseSigma1(tlvReader, unused);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma1(tlvReader, unused);
         // std::cout << "ParseSigma1: " << err.Format() << std::endl;
     }
 
@@ -362,7 +362,7 @@ void ParseSigma2_RawPayload(const vector<uint8_t> & seededEncodedSigma2)
         tlvReaderEncodedSigma2.Init(std::move(EncodedSigma2));
 
         FuzzCASESession::ParsedSigma2 unused;
-        (void) FuzzCASESession::ParseSigma2(tlvReaderEncodedSigma2, unused);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma2(tlvReaderEncodedSigma2, unused);
     }
 
     Platform::MemoryShutdown();
@@ -493,7 +493,7 @@ void ParseSigma2_StructuredPayload(const vector<uint8_t> & fuzzResponderRandom, 
         tlvReader.Init(encodedSpan);
 
         FuzzCASESession::ParsedSigma2 unused;
-        (void) FuzzCASESession::ParseSigma2(tlvReader, unused);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma2(tlvReader, unused);
         // std::cout << err.Format() << std::endl;
 
         mem.Free();
@@ -614,7 +614,7 @@ void ParseSigma2TBEData_RawPayload(const vector<uint8_t> & fuzzEncodedSigma2TBED
         PacketBufferTLVReader tlvReaderFuzzed;
         tlvReaderFuzzed.Init(std::move(fuzzedMsg));
 
-        (void) FuzzCASESession::ParseSigma2TBEData(tlvReaderFuzzed, parsedSigma2TBEDataFuzzed);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma2TBEData(tlvReaderFuzzed, parsedSigma2TBEDataFuzzed);
     }
     Platform::MemoryShutdown();
 }
@@ -732,7 +732,7 @@ void ParseSigma2TBEData_StructuredPayload(const vector<uint8_t> & fuzzResponderN
         tlvReader.Init(encodedSpan);
         FuzzCASESession::ParsedSigma2TBEData parsedSigma2TBEData;
 
-        (void) FuzzCASESession::ParseSigma2TBEData(tlvReader, parsedSigma2TBEData);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma2TBEData(tlvReader, parsedSigma2TBEData);
         // std::cout << "ParseSigma2TBEData: " << err.Format() << std::endl;
     }
 
@@ -774,7 +774,7 @@ void ParseSigma2Resume_RawPayload(const vector<uint8_t> & seededEncodedSigma2Res
         tlvReaderSeeded.Init(std::move(encodedSigma2Resume));
 
         FuzzCASESession::ParsedSigma2Resume unused;
-        (void) FuzzCASESession::ParseSigma2Resume(tlvReaderSeeded, unused);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma2Resume(tlvReaderSeeded, unused);
     }
     Platform::MemoryShutdown();
 }
@@ -867,7 +867,7 @@ void ParseSigma2Resume_StructuredPayload(const vector<uint8_t> & fuzzResumptionI
         tlvReader.Init(std::move(encodedSigma2Resume));
 
         FuzzCASESession::ParsedSigma2Resume unused;
-        (void) FuzzCASESession::ParseSigma2Resume(tlvReader, unused);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma2Resume(tlvReader, unused);
     }
 
     Platform::MemoryShutdown();
@@ -975,7 +975,7 @@ void ParseSigma3_RawPayload(const vector<uint8_t> & fuzzEncodedSigma3)
         MutableByteSpan outMsgR3EncryptedPayload;
         ByteSpan outMsgR3MIC;
 
-        (void) FuzzCASESession::ParseSigma3(tlvReader2, outMsgR3Encrypted, outMsgR3EncryptedPayload, outMsgR3MIC);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma3(tlvReader2, outMsgR3Encrypted, outMsgR3EncryptedPayload, outMsgR3MIC);
     }
     Platform::MemoryShutdown();
 }
@@ -1083,7 +1083,7 @@ void ParseSigma3_StructuredPayload(const vector<uint8_t> & fuzzEncrypted3)
         ByteSpan outMsgR3MIC;
 
         // Parse Sigma3
-        (void) FuzzCASESession::ParseSigma3(tlvReader, outMsgR3Encrypted, outMsgR3EncryptedPayload, outMsgR3MIC);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma3(tlvReader, outMsgR3Encrypted, outMsgR3EncryptedPayload, outMsgR3MIC);
 
         mem.Free();
     }
@@ -1120,7 +1120,7 @@ void ParseSigma3TBEData_RawPayload(const vector<uint8_t> & fuzzEncodedSigma3TBED
         tlvReader2.Init(std::move(EncodedSigma3));
 
         FuzzCASESession::HandleSigma3Data unused;
-        (void) FuzzCASESession::ParseSigma3TBEData(tlvReader2, unused);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma3TBEData(tlvReader2, unused);
         // std::cout << "Seeded Encoded Sigma3TBEData:" << err.Format() << std::endl;
     }
 
@@ -1230,7 +1230,7 @@ void ParseSigma3TBEData_StructuredPayload(const vector<uint8_t> & fuzzInitiatorN
         tlvReader.Init(encodedSpan);
 
         FuzzCASESession::HandleSigma3Data unused;
-        (void) FuzzCASESession::ParseSigma3TBEData(tlvReader, unused);
+        RETURN_SAFELY_IGNORED FuzzCASESession::ParseSigma3TBEData(tlvReader, unused);
         // std::cout << err.Format() << std::endl;
 
         mem.Free();
@@ -1285,12 +1285,12 @@ void HandleSigma3b(const vector<uint8_t> & fuzzInitiatorNOC, const vector<uint8_
         data.msgR3SignedSpan = MutableByteSpan{ data.msgR3Signed.Get(), fuzzMsg3Signed.size() };
 
         // prepare the fuzzed signature
-        (void) data.tbsData3Signature.SetLength(fuzzTbs3Signature.size());
+        RETURN_SAFELY_IGNORED data.tbsData3Signature.SetLength(fuzzTbs3Signature.size());
         memcpy(data.tbsData3Signature.Bytes(), fuzzTbs3Signature.data(), fuzzTbs3Signature.size());
 
         /************ Fuzz CASESession::HandleSigma3b *************/
         bool unused = false;
-        (void) FuzzCASESession::HandleSigma3b(data, unused);
+        RETURN_SAFELY_IGNORED FuzzCASESession::HandleSigma3b(data, unused);
         // std::cout << "fuzzed HandleSigma3b: " << err.Format() << std::endl;
     }
 

--- a/src/protocols/secure_channel/tests/FuzzPASE_PW.cpp
+++ b/src/protocols/secure_channel/tests/FuzzPASE_PW.cpp
@@ -195,12 +195,12 @@ void TestPASESession::SecurePairingHandshake(SessionManager & sessionManager, PA
                                                                             &pairingAccessory),
               CHIP_NO_ERROR);
 
-    pairingAccessory.WaitForPairing(sessionManager, verifier, pbkdf2IterCount, salt,
-                                    Optional<ReliableMessageProtocolConfig>::Missing(), &delegateAccessory);
+    (void) pairingAccessory.WaitForPairing(sessionManager, verifier, pbkdf2IterCount, salt,
+                                           Optional<ReliableMessageProtocolConfig>::Missing(), &delegateAccessory);
     DrainAndServiceIO();
 
-    pairingCommissioner.Pair(sessionManager, SetUpPINCode, Optional<ReliableMessageProtocolConfig>::Missing(), contextCommissioner,
-                             &delegateCommissioner);
+    (void) pairingCommissioner.Pair(sessionManager, SetUpPINCode, Optional<ReliableMessageProtocolConfig>::Missing(),
+                                    contextCommissioner, &delegateCommissioner);
 
     DrainAndServiceIO();
 }
@@ -255,7 +255,7 @@ void PASESession_Unbounded(const uint32_t fuzzedSetupPasscode, const vector<uint
     ByteSpan fuzzedSaltSpan{ fuzzedSalt.data(), fuzzedSalt.size() };
 
     // Generating the Spake2+ verifier from fuzzed inputs
-    fuzzedSpake2pVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
+    (void) fuzzedSpake2pVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
 
     TestPASESession PASELoopBack;
     TemporarySessionManager sessionManager(PASELoopBack);
@@ -355,7 +355,7 @@ void TestPASESession::FuzzHandlePBKDFParamRequest(vector<uint8_t> fuzzPBKDFLocal
 
     /*************************** Preparing Commissioner ***************************/
 
-    CallAllocateSecureSession(sessionManager, pairingCommissioner);
+    (void) CallAllocateSecureSession(sessionManager, pairingCommissioner);
 
     ReliableMessageProtocolConfig LocalMRPConfig(System::Clock::Milliseconds32(100), System::Clock::Milliseconds32(200),
                                                  System::Clock::Milliseconds16(4000));
@@ -412,7 +412,7 @@ void TestPASESession::FuzzHandlePBKDFParamRequest(vector<uint8_t> fuzzPBKDFLocal
               CHIP_NO_ERROR);
 
     // Adding PASESession::Init in order to AllocateSecureSession and have a localsessionID generated for pairingAccessory
-    pairingAccessory.Init(sessionManager, 0, &delegateAccessory);
+    (void) pairingAccessory.Init(sessionManager, 0, &delegateAccessory);
 
     // This was done to have an exchange context
     pairingAccessory.mExchangeCtxt.Emplace(*contextAccessory);
@@ -422,7 +422,8 @@ void TestPASESession::FuzzHandlePBKDFParamRequest(vector<uint8_t> fuzzPBKDFLocal
     payloadHeaderAccessory.SetMessageType(Protocols::SecureChannel::MsgType::PBKDFParamRequest);
     pairingAccessory.mNextExpectedMsg.SetValue(Protocols::SecureChannel::MsgType::PBKDFParamRequest);
 
-    pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory, std::move(req));
+    (void) pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory,
+                                              std::move(req));
 
     DrainAndServiceIO();
 }
@@ -461,7 +462,7 @@ void TestPASESession::FuzzHandlePBKDFParamResponse(vector<uint8_t> fuzzPBKDFLoca
 
     /*************************** Preparing Commissioner ***************************/
 
-    CallAllocateSecureSession(sessionManager, pairingCommissioner);
+    (void) CallAllocateSecureSession(sessionManager, pairingCommissioner);
 
     ExchangeContext * contextCommissioner = NewUnauthenticatedExchangeToBob(&pairingCommissioner);
 
@@ -474,8 +475,8 @@ void TestPASESession::FuzzHandlePBKDFParamResponse(vector<uint8_t> fuzzPBKDFLoca
     pairingCommissioner.mLocalMRPConfig = MakeOptional(LocalMRPConfig);
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    pairingCommissioner.mCommissioningHash.Begin();
-    pairingCommissioner.mCommissioningHash.AddData(ByteSpan(fuzzedSalt.data(), fuzzedSalt.size()));
+    (void) pairingCommissioner.mCommissioningHash.Begin();
+    (void) pairingCommissioner.mCommissioningHash.AddData(ByteSpan(fuzzedSalt.data(), fuzzedSalt.size()));
 
     // The Commissioner will check if the PBKDFLocalRandomData it received in TLV is same as the stored mPBKDFLocalRandomData. So we
     // inject it here to be able to pass that check
@@ -534,8 +535,8 @@ void TestPASESession::FuzzHandlePBKDFParamResponse(vector<uint8_t> fuzzPBKDFLoca
     payloadHeaderCommissioner.SetMessageType(Protocols::SecureChannel::MsgType::PBKDFParamResponse);
     pairingCommissioner.mNextExpectedMsg.SetValue(Protocols::SecureChannel::MsgType::PBKDFParamResponse);
 
-    pairingCommissioner.OnMessageReceived(&pairingCommissioner.mExchangeCtxt.Value().Get(), payloadHeaderCommissioner,
-                                          std::move(resp));
+    (void) pairingCommissioner.OnMessageReceived(&pairingCommissioner.mExchangeCtxt.Value().Get(), payloadHeaderCommissioner,
+                                                 std::move(resp));
 
     DrainAndServiceIO();
 }
@@ -585,15 +586,15 @@ void TestPASESession::FuzzHandlePake1(const uint32_t fuzzedSetupPasscode, const 
     /*************************** Preparing Commissioner ***************************/
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    pairingCommissioner.mCommissioningHash.Begin();
-    pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
+    (void) pairingCommissioner.mCommissioningHash.Begin();
+    (void) pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingCommissioner.SetupSpake2p());
 
     uint8_t serializedWS[kSpake2p_WS_Length * 2] = { 0 };
 
     // Compute serializedWS, to be used in BeginProver()
 
-    Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS, sizeof(serializedWS));
+    (void) Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS, sizeof(serializedWS));
 
     EXPECT_EQ(CHIP_NO_ERROR,
               pairingCommissioner.mSpake2p.BeginProver(nullptr, 0, nullptr, 0, &serializedWS[0], kSpake2p_WS_Length,
@@ -628,13 +629,13 @@ void TestPASESession::FuzzHandlePake1(const uint32_t fuzzedSetupPasscode, const 
         System::Clock::Milliseconds32(100), System::Clock::Milliseconds32(200), System::Clock::Milliseconds16(4000)));
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    pairingAccessory.mCommissioningHash.Begin();
-    pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
+    (void) pairingAccessory.mCommissioningHash.Begin();
+    (void) pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingAccessory.SetupSpake2p());
 
     //  Compute mPASEVerifier (in order for mSpake2p.BeginVerifier() to use it, once it is called by the pairingAccessory through
     //  HandleMsg1_and_SendMsg2)
-    pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
+    (void) pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
 
     /************************Injecting Fuzzed Pake1 Message into PaseSession::OnMessageReceived*************************/
 
@@ -644,7 +645,8 @@ void TestPASESession::FuzzHandlePake1(const uint32_t fuzzedSetupPasscode, const 
     payloadHeaderAccessory.SetMessageType(Protocols::SecureChannel::MsgType::PASE_Pake1);
     pairingAccessory.mNextExpectedMsg.SetValue(Protocols::SecureChannel::MsgType::PASE_Pake1);
 
-    pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory, std::move(msg));
+    (void) pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory,
+                                              std::move(msg));
 
     DrainAndServiceIO();
 }
@@ -695,7 +697,7 @@ void TestPASESession::FuzzHandlePake2(const uint32_t fuzzedSetupPasscode, const 
 
     /*************************** Preparing Commissioner ***************************/
 
-    CallAllocateSecureSession(sessionManager, pairingCommissioner);
+    (void) CallAllocateSecureSession(sessionManager, pairingCommissioner);
 
     ExchangeContext * contextCommissioner = NewUnauthenticatedExchangeToBob(&pairingCommissioner);
 
@@ -706,14 +708,14 @@ void TestPASESession::FuzzHandlePake2(const uint32_t fuzzedSetupPasscode, const 
         System::Clock::Milliseconds32(100), System::Clock::Milliseconds32(200), System::Clock::Milliseconds16(4000)));
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    pairingCommissioner.mCommissioningHash.Begin();
-    pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
+    (void) pairingCommissioner.mCommissioningHash.Begin();
+    (void) pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingCommissioner.SetupSpake2p());
 
     uint8_t serializedWS[kSpake2p_WS_Length * 2] = { 0 };
 
     // Compute serializedWS, to be used in BeginProver()
-    Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS, sizeof(serializedWS));
+    (void) Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS, sizeof(serializedWS));
 
     EXPECT_EQ(CHIP_NO_ERROR,
               pairingCommissioner.mSpake2p.BeginProver(nullptr, 0, nullptr, 0, &serializedWS[0], kSpake2p_WS_Length,
@@ -723,21 +725,21 @@ void TestPASESession::FuzzHandlePake2(const uint32_t fuzzedSetupPasscode, const 
     // mSpake2p.state = CHIP_SPAKE2P_STATE::R1), the computed values are not used in the test.
     uint8_t X[kMAX_Point_Length];
     size_t X_len = sizeof(X);
-    pairingCommissioner.mSpake2p.ComputeRoundOne(nullptr, 0, X, &X_len);
+    (void) pairingCommissioner.mSpake2p.ComputeRoundOne(nullptr, 0, X, &X_len);
 
     /*************************** Preparing Accessory  ***************************/
 
     // Init mCommissioningHash; needed for SetupSpake2p()
-    pairingAccessory.mCommissioningHash.Begin();
-    pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
+    (void) pairingAccessory.mCommissioningHash.Begin();
+    (void) pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingAccessory.SetupSpake2p());
 
     // Below Steps take place in HandleMsg1
     // Compute mPASEVerifier to be able to pass it to BeginVerifier()
-    pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
+    (void) pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
 
-    pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0, kP256_FE_Length,
-                                            pairingAccessory.mPASEVerifier.mL, kP256_Point_Length);
+    (void) pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0, kP256_FE_Length,
+                                                   pairingAccessory.mPASEVerifier.mL, kP256_Point_Length);
 
     /*********************** Constructing Fuzzed PAKE2 Message, to later inject it into PASE Session *********************/
 
@@ -769,8 +771,8 @@ void TestPASESession::FuzzHandlePake2(const uint32_t fuzzedSetupPasscode, const 
     payloadHeaderCommissioner.SetMessageType(Protocols::SecureChannel::MsgType::PASE_Pake2);
     pairingCommissioner.mNextExpectedMsg.SetValue(Protocols::SecureChannel::MsgType::PASE_Pake2);
 
-    pairingCommissioner.OnMessageReceived(&pairingCommissioner.mExchangeCtxt.Value().Get(), payloadHeaderCommissioner,
-                                          std::move(msg2));
+    (void) pairingCommissioner.OnMessageReceived(&pairingCommissioner.mExchangeCtxt.Value().Get(), payloadHeaderCommissioner,
+                                                 std::move(msg2));
 
     DrainAndServiceIO();
 }
@@ -821,15 +823,15 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
     /*************************** Preparing Commissioner  ***************************/
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    pairingCommissioner.mCommissioningHash.Begin();
-    pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
+    (void) pairingCommissioner.mCommissioningHash.Begin();
+    (void) pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingCommissioner.SetupSpake2p());
 
     uint8_t serializedWS[kSpake2p_WS_Length * 2] = { 0 };
 
     // Compute serializedWS, to be used in BeginProver()
 
-    Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS, sizeof(serializedWS));
+    (void) Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS, sizeof(serializedWS));
 
     EXPECT_EQ(CHIP_NO_ERROR,
               pairingCommissioner.mSpake2p.BeginProver(nullptr, 0, nullptr, 0, &serializedWS[0], kSpake2p_WS_Length,
@@ -839,11 +841,11 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
     // CHIP_SPAKE2P_STATE::R1), the computed values are not used.
     uint8_t X[kMAX_Point_Length];
     size_t X_len = sizeof(X);
-    pairingCommissioner.mSpake2p.ComputeRoundOne(nullptr, 0, X, &X_len);
+    (void) pairingCommissioner.mSpake2p.ComputeRoundOne(nullptr, 0, X, &X_len);
 
     /*************************** Preparing Accessory ***************************/
 
-    CallAllocateSecureSession(sessionManager, pairingAccessory);
+    (void) CallAllocateSecureSession(sessionManager, pairingAccessory);
 
     // One Limitation of using this is that contextAccessory will automatically be an Initiator, while in real-life it should be a
     // responder.
@@ -856,16 +858,16 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
         System::Clock::Milliseconds32(100), System::Clock::Milliseconds32(200), System::Clock::Milliseconds16(4000)));
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    pairingAccessory.mCommissioningHash.Begin();
-    pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
+    (void) pairingAccessory.mCommissioningHash.Begin();
+    (void) pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingAccessory.SetupSpake2p());
 
     // Below Steps take place in HandleMsg1
     //  compute mPASEVerifier to be able to pass it to BeginVerifier()
-    pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
+    (void) pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
 
-    pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0, kP256_FE_Length,
-                                            pairingAccessory.mPASEVerifier.mL, kP256_Point_Length);
+    (void) pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0, kP256_FE_Length,
+                                                   pairingAccessory.mPASEVerifier.mL, kP256_Point_Length);
 
     /*************************** Preparing Accessory for Receiving PAKE3 Message ***************************/
 
@@ -877,8 +879,8 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
 
     // These calls are usually done on the Accessory before sending Pake2. They are needed to make sure that the Accessory is at the
     // correct Spake2p state (CHIP_SPAKE2P_STATE::R2) to handle Pake3 Messages.
-    pairingAccessory.mSpake2p.ComputeRoundOne(X, X_len, Y, &Y_len);
-    pairingAccessory.mSpake2p.ComputeRoundTwo(X, X_len, verifier, &verifier_len);
+    (void) pairingAccessory.mSpake2p.ComputeRoundOne(X, X_len, Y, &Y_len);
+    (void) pairingAccessory.mSpake2p.ComputeRoundTwo(X, X_len, verifier, &verifier_len);
 
     /*********************** Constructing Fuzzed PAKE3 Message, to later inject it into PASE Session *********************/
 
@@ -908,7 +910,8 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
     payloadHeaderAccessory.SetMessageType(Protocols::SecureChannel::MsgType::PASE_Pake3);
     pairingAccessory.mNextExpectedMsg.SetValue(Protocols::SecureChannel::MsgType::PASE_Pake3);
 
-    pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory, std::move(msg3));
+    (void) pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory,
+                                              std::move(msg3));
 
     DrainAndServiceIO();
 }

--- a/src/protocols/secure_channel/tests/FuzzPASE_PW.cpp
+++ b/src/protocols/secure_channel/tests/FuzzPASE_PW.cpp
@@ -195,12 +195,12 @@ void TestPASESession::SecurePairingHandshake(SessionManager & sessionManager, PA
                                                                             &pairingAccessory),
               CHIP_NO_ERROR);
 
-    (void) pairingAccessory.WaitForPairing(sessionManager, verifier, pbkdf2IterCount, salt,
-                                           Optional<ReliableMessageProtocolConfig>::Missing(), &delegateAccessory);
+    RETURN_SAFELY_IGNORED pairingAccessory.WaitForPairing(sessionManager, verifier, pbkdf2IterCount, salt,
+                                                          Optional<ReliableMessageProtocolConfig>::Missing(), &delegateAccessory);
     DrainAndServiceIO();
 
-    (void) pairingCommissioner.Pair(sessionManager, SetUpPINCode, Optional<ReliableMessageProtocolConfig>::Missing(),
-                                    contextCommissioner, &delegateCommissioner);
+    RETURN_SAFELY_IGNORED pairingCommissioner.Pair(sessionManager, SetUpPINCode, Optional<ReliableMessageProtocolConfig>::Missing(),
+                                                   contextCommissioner, &delegateCommissioner);
 
     DrainAndServiceIO();
 }
@@ -255,7 +255,7 @@ void PASESession_Unbounded(const uint32_t fuzzedSetupPasscode, const vector<uint
     ByteSpan fuzzedSaltSpan{ fuzzedSalt.data(), fuzzedSalt.size() };
 
     // Generating the Spake2+ verifier from fuzzed inputs
-    (void) fuzzedSpake2pVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
+    RETURN_SAFELY_IGNORED fuzzedSpake2pVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
 
     TestPASESession PASELoopBack;
     TemporarySessionManager sessionManager(PASELoopBack);
@@ -355,7 +355,7 @@ void TestPASESession::FuzzHandlePBKDFParamRequest(vector<uint8_t> fuzzPBKDFLocal
 
     /*************************** Preparing Commissioner ***************************/
 
-    (void) CallAllocateSecureSession(sessionManager, pairingCommissioner);
+    RETURN_SAFELY_IGNORED CallAllocateSecureSession(sessionManager, pairingCommissioner);
 
     ReliableMessageProtocolConfig LocalMRPConfig(System::Clock::Milliseconds32(100), System::Clock::Milliseconds32(200),
                                                  System::Clock::Milliseconds16(4000));
@@ -412,7 +412,7 @@ void TestPASESession::FuzzHandlePBKDFParamRequest(vector<uint8_t> fuzzPBKDFLocal
               CHIP_NO_ERROR);
 
     // Adding PASESession::Init in order to AllocateSecureSession and have a localsessionID generated for pairingAccessory
-    (void) pairingAccessory.Init(sessionManager, 0, &delegateAccessory);
+    RETURN_SAFELY_IGNORED pairingAccessory.Init(sessionManager, 0, &delegateAccessory);
 
     // This was done to have an exchange context
     pairingAccessory.mExchangeCtxt.Emplace(*contextAccessory);
@@ -422,8 +422,8 @@ void TestPASESession::FuzzHandlePBKDFParamRequest(vector<uint8_t> fuzzPBKDFLocal
     payloadHeaderAccessory.SetMessageType(Protocols::SecureChannel::MsgType::PBKDFParamRequest);
     pairingAccessory.mNextExpectedMsg.SetValue(Protocols::SecureChannel::MsgType::PBKDFParamRequest);
 
-    (void) pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory,
-                                              std::move(req));
+    RETURN_SAFELY_IGNORED pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory,
+                                                             std::move(req));
 
     DrainAndServiceIO();
 }
@@ -462,7 +462,7 @@ void TestPASESession::FuzzHandlePBKDFParamResponse(vector<uint8_t> fuzzPBKDFLoca
 
     /*************************** Preparing Commissioner ***************************/
 
-    (void) CallAllocateSecureSession(sessionManager, pairingCommissioner);
+    RETURN_SAFELY_IGNORED CallAllocateSecureSession(sessionManager, pairingCommissioner);
 
     ExchangeContext * contextCommissioner = NewUnauthenticatedExchangeToBob(&pairingCommissioner);
 
@@ -475,8 +475,8 @@ void TestPASESession::FuzzHandlePBKDFParamResponse(vector<uint8_t> fuzzPBKDFLoca
     pairingCommissioner.mLocalMRPConfig = MakeOptional(LocalMRPConfig);
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    (void) pairingCommissioner.mCommissioningHash.Begin();
-    (void) pairingCommissioner.mCommissioningHash.AddData(ByteSpan(fuzzedSalt.data(), fuzzedSalt.size()));
+    RETURN_SAFELY_IGNORED pairingCommissioner.mCommissioningHash.Begin();
+    RETURN_SAFELY_IGNORED pairingCommissioner.mCommissioningHash.AddData(ByteSpan(fuzzedSalt.data(), fuzzedSalt.size()));
 
     // The Commissioner will check if the PBKDFLocalRandomData it received in TLV is same as the stored mPBKDFLocalRandomData. So we
     // inject it here to be able to pass that check
@@ -535,8 +535,8 @@ void TestPASESession::FuzzHandlePBKDFParamResponse(vector<uint8_t> fuzzPBKDFLoca
     payloadHeaderCommissioner.SetMessageType(Protocols::SecureChannel::MsgType::PBKDFParamResponse);
     pairingCommissioner.mNextExpectedMsg.SetValue(Protocols::SecureChannel::MsgType::PBKDFParamResponse);
 
-    (void) pairingCommissioner.OnMessageReceived(&pairingCommissioner.mExchangeCtxt.Value().Get(), payloadHeaderCommissioner,
-                                                 std::move(resp));
+    RETURN_SAFELY_IGNORED pairingCommissioner.OnMessageReceived(&pairingCommissioner.mExchangeCtxt.Value().Get(),
+                                                                payloadHeaderCommissioner, std::move(resp));
 
     DrainAndServiceIO();
 }
@@ -586,15 +586,16 @@ void TestPASESession::FuzzHandlePake1(const uint32_t fuzzedSetupPasscode, const 
     /*************************** Preparing Commissioner ***************************/
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    (void) pairingCommissioner.mCommissioningHash.Begin();
-    (void) pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
+    RETURN_SAFELY_IGNORED pairingCommissioner.mCommissioningHash.Begin();
+    RETURN_SAFELY_IGNORED pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingCommissioner.SetupSpake2p());
 
     uint8_t serializedWS[kSpake2p_WS_Length * 2] = { 0 };
 
     // Compute serializedWS, to be used in BeginProver()
 
-    (void) Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS, sizeof(serializedWS));
+    RETURN_SAFELY_IGNORED Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS,
+                                                     sizeof(serializedWS));
 
     EXPECT_EQ(CHIP_NO_ERROR,
               pairingCommissioner.mSpake2p.BeginProver(nullptr, 0, nullptr, 0, &serializedWS[0], kSpake2p_WS_Length,
@@ -629,13 +630,13 @@ void TestPASESession::FuzzHandlePake1(const uint32_t fuzzedSetupPasscode, const 
         System::Clock::Milliseconds32(100), System::Clock::Milliseconds32(200), System::Clock::Milliseconds16(4000)));
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    (void) pairingAccessory.mCommissioningHash.Begin();
-    (void) pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
+    RETURN_SAFELY_IGNORED pairingAccessory.mCommissioningHash.Begin();
+    RETURN_SAFELY_IGNORED pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingAccessory.SetupSpake2p());
 
     //  Compute mPASEVerifier (in order for mSpake2p.BeginVerifier() to use it, once it is called by the pairingAccessory through
     //  HandleMsg1_and_SendMsg2)
-    (void) pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
+    RETURN_SAFELY_IGNORED pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
 
     /************************Injecting Fuzzed Pake1 Message into PaseSession::OnMessageReceived*************************/
 
@@ -645,8 +646,8 @@ void TestPASESession::FuzzHandlePake1(const uint32_t fuzzedSetupPasscode, const 
     payloadHeaderAccessory.SetMessageType(Protocols::SecureChannel::MsgType::PASE_Pake1);
     pairingAccessory.mNextExpectedMsg.SetValue(Protocols::SecureChannel::MsgType::PASE_Pake1);
 
-    (void) pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory,
-                                              std::move(msg));
+    RETURN_SAFELY_IGNORED pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory,
+                                                             std::move(msg));
 
     DrainAndServiceIO();
 }
@@ -697,7 +698,7 @@ void TestPASESession::FuzzHandlePake2(const uint32_t fuzzedSetupPasscode, const 
 
     /*************************** Preparing Commissioner ***************************/
 
-    (void) CallAllocateSecureSession(sessionManager, pairingCommissioner);
+    RETURN_SAFELY_IGNORED CallAllocateSecureSession(sessionManager, pairingCommissioner);
 
     ExchangeContext * contextCommissioner = NewUnauthenticatedExchangeToBob(&pairingCommissioner);
 
@@ -708,14 +709,15 @@ void TestPASESession::FuzzHandlePake2(const uint32_t fuzzedSetupPasscode, const 
         System::Clock::Milliseconds32(100), System::Clock::Milliseconds32(200), System::Clock::Milliseconds16(4000)));
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    (void) pairingCommissioner.mCommissioningHash.Begin();
-    (void) pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
+    RETURN_SAFELY_IGNORED pairingCommissioner.mCommissioningHash.Begin();
+    RETURN_SAFELY_IGNORED pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingCommissioner.SetupSpake2p());
 
     uint8_t serializedWS[kSpake2p_WS_Length * 2] = { 0 };
 
     // Compute serializedWS, to be used in BeginProver()
-    (void) Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS, sizeof(serializedWS));
+    RETURN_SAFELY_IGNORED Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS,
+                                                     sizeof(serializedWS));
 
     EXPECT_EQ(CHIP_NO_ERROR,
               pairingCommissioner.mSpake2p.BeginProver(nullptr, 0, nullptr, 0, &serializedWS[0], kSpake2p_WS_Length,
@@ -725,21 +727,22 @@ void TestPASESession::FuzzHandlePake2(const uint32_t fuzzedSetupPasscode, const 
     // mSpake2p.state = CHIP_SPAKE2P_STATE::R1), the computed values are not used in the test.
     uint8_t X[kMAX_Point_Length];
     size_t X_len = sizeof(X);
-    (void) pairingCommissioner.mSpake2p.ComputeRoundOne(nullptr, 0, X, &X_len);
+    RETURN_SAFELY_IGNORED pairingCommissioner.mSpake2p.ComputeRoundOne(nullptr, 0, X, &X_len);
 
     /*************************** Preparing Accessory  ***************************/
 
     // Init mCommissioningHash; needed for SetupSpake2p()
-    (void) pairingAccessory.mCommissioningHash.Begin();
-    (void) pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
+    RETURN_SAFELY_IGNORED pairingAccessory.mCommissioningHash.Begin();
+    RETURN_SAFELY_IGNORED pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingAccessory.SetupSpake2p());
 
     // Below Steps take place in HandleMsg1
     // Compute mPASEVerifier to be able to pass it to BeginVerifier()
-    (void) pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
+    RETURN_SAFELY_IGNORED pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
 
-    (void) pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0, kP256_FE_Length,
-                                                   pairingAccessory.mPASEVerifier.mL, kP256_Point_Length);
+    RETURN_SAFELY_IGNORED pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0,
+                                                                  kP256_FE_Length, pairingAccessory.mPASEVerifier.mL,
+                                                                  kP256_Point_Length);
 
     /*********************** Constructing Fuzzed PAKE2 Message, to later inject it into PASE Session *********************/
 
@@ -771,8 +774,8 @@ void TestPASESession::FuzzHandlePake2(const uint32_t fuzzedSetupPasscode, const 
     payloadHeaderCommissioner.SetMessageType(Protocols::SecureChannel::MsgType::PASE_Pake2);
     pairingCommissioner.mNextExpectedMsg.SetValue(Protocols::SecureChannel::MsgType::PASE_Pake2);
 
-    (void) pairingCommissioner.OnMessageReceived(&pairingCommissioner.mExchangeCtxt.Value().Get(), payloadHeaderCommissioner,
-                                                 std::move(msg2));
+    RETURN_SAFELY_IGNORED pairingCommissioner.OnMessageReceived(&pairingCommissioner.mExchangeCtxt.Value().Get(),
+                                                                payloadHeaderCommissioner, std::move(msg2));
 
     DrainAndServiceIO();
 }
@@ -823,15 +826,16 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
     /*************************** Preparing Commissioner  ***************************/
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    (void) pairingCommissioner.mCommissioningHash.Begin();
-    (void) pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
+    RETURN_SAFELY_IGNORED pairingCommissioner.mCommissioningHash.Begin();
+    RETURN_SAFELY_IGNORED pairingCommissioner.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingCommissioner.SetupSpake2p());
 
     uint8_t serializedWS[kSpake2p_WS_Length * 2] = { 0 };
 
     // Compute serializedWS, to be used in BeginProver()
 
-    (void) Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS, sizeof(serializedWS));
+    RETURN_SAFELY_IGNORED Spake2pVerifier::ComputeWS(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode, serializedWS,
+                                                     sizeof(serializedWS));
 
     EXPECT_EQ(CHIP_NO_ERROR,
               pairingCommissioner.mSpake2p.BeginProver(nullptr, 0, nullptr, 0, &serializedWS[0], kSpake2p_WS_Length,
@@ -841,11 +845,11 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
     // CHIP_SPAKE2P_STATE::R1), the computed values are not used.
     uint8_t X[kMAX_Point_Length];
     size_t X_len = sizeof(X);
-    (void) pairingCommissioner.mSpake2p.ComputeRoundOne(nullptr, 0, X, &X_len);
+    RETURN_SAFELY_IGNORED pairingCommissioner.mSpake2p.ComputeRoundOne(nullptr, 0, X, &X_len);
 
     /*************************** Preparing Accessory ***************************/
 
-    (void) CallAllocateSecureSession(sessionManager, pairingAccessory);
+    RETURN_SAFELY_IGNORED CallAllocateSecureSession(sessionManager, pairingAccessory);
 
     // One Limitation of using this is that contextAccessory will automatically be an Initiator, while in real-life it should be a
     // responder.
@@ -858,16 +862,17 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
         System::Clock::Milliseconds32(100), System::Clock::Milliseconds32(200), System::Clock::Milliseconds16(4000)));
 
     // preparing CommissioningHash needed for SetupSpake2p()
-    (void) pairingAccessory.mCommissioningHash.Begin();
-    (void) pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
+    RETURN_SAFELY_IGNORED pairingAccessory.mCommissioningHash.Begin();
+    RETURN_SAFELY_IGNORED pairingAccessory.mCommissioningHash.AddData(fuzzedSaltSpan);
     EXPECT_EQ(CHIP_NO_ERROR, pairingAccessory.SetupSpake2p());
 
     // Below Steps take place in HandleMsg1
     //  compute mPASEVerifier to be able to pass it to BeginVerifier()
-    (void) pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
+    RETURN_SAFELY_IGNORED pairingAccessory.mPASEVerifier.Generate(fuzzedPBKDF2Iter, fuzzedSaltSpan, fuzzedSetupPasscode);
 
-    (void) pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0, kP256_FE_Length,
-                                                   pairingAccessory.mPASEVerifier.mL, kP256_Point_Length);
+    RETURN_SAFELY_IGNORED pairingAccessory.mSpake2p.BeginVerifier(nullptr, 0, nullptr, 0, pairingAccessory.mPASEVerifier.mW0,
+                                                                  kP256_FE_Length, pairingAccessory.mPASEVerifier.mL,
+                                                                  kP256_Point_Length);
 
     /*************************** Preparing Accessory for Receiving PAKE3 Message ***************************/
 
@@ -879,8 +884,8 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
 
     // These calls are usually done on the Accessory before sending Pake2. They are needed to make sure that the Accessory is at the
     // correct Spake2p state (CHIP_SPAKE2P_STATE::R2) to handle Pake3 Messages.
-    (void) pairingAccessory.mSpake2p.ComputeRoundOne(X, X_len, Y, &Y_len);
-    (void) pairingAccessory.mSpake2p.ComputeRoundTwo(X, X_len, verifier, &verifier_len);
+    RETURN_SAFELY_IGNORED pairingAccessory.mSpake2p.ComputeRoundOne(X, X_len, Y, &Y_len);
+    RETURN_SAFELY_IGNORED pairingAccessory.mSpake2p.ComputeRoundTwo(X, X_len, verifier, &verifier_len);
 
     /*********************** Constructing Fuzzed PAKE3 Message, to later inject it into PASE Session *********************/
 
@@ -910,8 +915,8 @@ void TestPASESession::FuzzHandlePake3(const uint32_t fuzzedSetupPasscode, const 
     payloadHeaderAccessory.SetMessageType(Protocols::SecureChannel::MsgType::PASE_Pake3);
     pairingAccessory.mNextExpectedMsg.SetValue(Protocols::SecureChannel::MsgType::PASE_Pake3);
 
-    (void) pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory,
-                                              std::move(msg3));
+    RETURN_SAFELY_IGNORED pairingAccessory.OnMessageReceived(&pairingAccessory.mExchangeCtxt.Value().Get(), payloadHeaderAccessory,
+                                                             std::move(msg3));
 
     DrainAndServiceIO();
 }

--- a/src/setup_payload/tests/FuzzBase38Decode.cpp
+++ b/src/setup_payload/tests/FuzzBase38Decode.cpp
@@ -18,7 +18,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t len)
 
     // Ignoring return value, because in general the data is garbage and won't decode properly.
     // We're just testing that the decoder does not crash on the fuzzer-generated inputs.
-    TEMPORARY_RETURN_IGNORED chip::base38Decode(base38EncodedString, decodedData);
+    RETURN_SAFELY_IGNORED chip::base38Decode(base38EncodedString, decodedData);
 
     return 0;
 }

--- a/src/setup_payload/tests/FuzzBase38Decode.cpp
+++ b/src/setup_payload/tests/FuzzBase38Decode.cpp
@@ -18,7 +18,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t len)
 
     // Ignoring return value, because in general the data is garbage and won't decode properly.
     // We're just testing that the decoder does not crash on the fuzzer-generated inputs.
-    chip::base38Decode(base38EncodedString, decodedData);
+    TEMPORARY_RETURN_IGNORED chip::base38Decode(base38EncodedString, decodedData);
 
     return 0;
 }

--- a/src/setup_payload/tests/FuzzBase38PW.cpp
+++ b/src/setup_payload/tests/FuzzBase38PW.cpp
@@ -22,7 +22,7 @@ void Base38DecodeFuzz(const std::vector<uint8_t> & bytes)
 
     // Ignoring return value, because in general the data is garbage and won't decode properly.
     // We're just testing that the decoder does not crash on the fuzzer-generated inputs.
-    chip::base38Decode(base38EncodedString, decodedData);
+    (void) chip::base38Decode(base38EncodedString, decodedData);
 }
 
 // The invocation of the FuzzTest
@@ -66,10 +66,10 @@ FUZZ_TEST(Base38Decoder, Base38RoundTripFuzz).WithDomains(Arbitrary<std::vector<
 
 void FuzzQRCodeSetupPayloadParser(const std::string & s)
 {
-    chip::Platform::MemoryInit();
+    (void) chip::Platform::MemoryInit();
 
     SetupPayload payload;
-    QRCodeSetupPayloadParser(s).populatePayload(payload);
+    (void) QRCodeSetupPayloadParser(s).populatePayload(payload);
 }
 
 FUZZ_TEST(Base38Decoder, FuzzQRCodeSetupPayloadParser).WithDomains(Arbitrary<std::string>());

--- a/src/setup_payload/tests/FuzzBase38PW.cpp
+++ b/src/setup_payload/tests/FuzzBase38PW.cpp
@@ -22,7 +22,7 @@ void Base38DecodeFuzz(const std::vector<uint8_t> & bytes)
 
     // Ignoring return value, because in general the data is garbage and won't decode properly.
     // We're just testing that the decoder does not crash on the fuzzer-generated inputs.
-    (void) chip::base38Decode(base38EncodedString, decodedData);
+    RETURN_SAFELY_IGNORED chip::base38Decode(base38EncodedString, decodedData);
 }
 
 // The invocation of the FuzzTest
@@ -66,10 +66,10 @@ FUZZ_TEST(Base38Decoder, Base38RoundTripFuzz).WithDomains(Arbitrary<std::vector<
 
 void FuzzQRCodeSetupPayloadParser(const std::string & s)
 {
-    (void) chip::Platform::MemoryInit();
+    RETURN_SAFELY_IGNORED chip::Platform::MemoryInit();
 
     SetupPayload payload;
-    (void) QRCodeSetupPayloadParser(s).populatePayload(payload);
+    RETURN_SAFELY_IGNORED QRCodeSetupPayloadParser(s).populatePayload(payload);
 }
 
 FUZZ_TEST(Base38Decoder, FuzzQRCodeSetupPayloadParser).WithDomains(Arbitrary<std::string>());


### PR DESCRIPTION
#### Summary

- making libfuzzer and pw_fuzztests both ignore the return value of function calls that have CHIP_ERROR 

#### Testing

- Tested locally using:
```bash
./scripts/build/build_examples.py --target linux-x64-tests-clang-asan-libfuzzer build
./scripts/build/build_examples.py --target linux-x64-tests-clang-pw-fuzztest build

```
