### PR TITLE
[NXP] Fix NXP zephyr docker image size issue

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-179 : [NXP] Update VSCode Docker image (Zephyr update)
+180 : [NXP] Update VSCode Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /opt/nxp-zephyr
 RUN set -x \
     && ZEPHYR_SDK_VERSION=0.17.4 \
     && NXP_ZSDK_VERSION=nxp-v4.3.0 \
-    && wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION}/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64.tar.xz | tar -xJ \
+    && wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION}/zephyr-sdk-${ZEPHYR_SDK_VERSION}_linux-x86_64_minimal.tar.xz | tar -xJ \
     && zephyr-sdk-${ZEPHYR_SDK_VERSION}/setup.sh -t arm-zephyr-eabi \
     && pip3 install --break-system-packages -U --no-cache-dir west \
     && west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr ${NXP_ZSDK_VERSION} \


### PR DESCRIPTION
#### Summary

The latest NXP Zephyr Docker image update introduced an issue where the final image size exceeds 10 GB.
This PR reduces the footprint by ensuring that only the ARM toolchain is retained.

#### Testing

Built the image locally and verified that the ARM toolchain is the only toolchain included.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
