### PR TITLE
[NXP] Fix possible double free of the resolve context

### DIFF
--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -996,7 +996,7 @@ static void DispatchResolve(intptr_t context)
 
     if (IsResolveElementValid(pResolveContext))
     {
-        Dnssd::DnssdService & service  = pResolveContext->mMdnsService;
+        Dnssd::DnssdService & service = pResolveContext->mMdnsService;
         Span<Inet::IPAddress> ipAddrs;
 
         // Stop Address resolver, we have finished resolving the service
@@ -1120,7 +1120,7 @@ static mDnsQueryCtx * GetResolveElement(const char * aName, NameType aType)
     return pResolveContext;
 }
 
-static bool IsResolveElementValid(const mDnsQueryCtx *pResolveContext)
+static bool IsResolveElementValid(const mDnsQueryCtx * pResolveContext)
 {
     mDnsQueryCtx * pContextIterator = reinterpret_cast<mDnsQueryCtx *>(LIST_GetHead(&mResolveList));
     while (pContextIterator)

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -137,7 +137,7 @@ static void DispatchResolveError(intptr_t context);
 static void HandleResolveCleanup(mDnsQueryCtx & resolveContext, ResolveStep stepType);
 
 static mDnsQueryCtx * GetResolveElement(const char * instanceName, NameType aType);
-static bool IsResolveElementValid(const mDnsQueryCtx * pResolveContext);
+static bool IsInResolveList(const mDnsQueryCtx * pResolveContext);
 
 static CHIP_ERROR ResolveBySrp(otInstance * thrInstancePtr, char * serviceName, mDnsQueryCtx * context, DnssdService * mdnsReq);
 static CHIP_ERROR BrowseBySrp(otInstance * thrInstancePtr, char * serviceName, mDnsQueryCtx * context);
@@ -943,50 +943,49 @@ static void DispatchBrowse(intptr_t context)
 
 static void DispatchTxtResolve(intptr_t context)
 {
-    mDnsQueryCtx * resolveContext = reinterpret_cast<mDnsQueryCtx *>(context);
+    mDnsQueryCtx * pResolveContext = reinterpret_cast<mDnsQueryCtx *>(context);
     otError error;
 
-    if (IsResolveElementValid(resolveContext))
+    VerifyOrReturn(IsInResolveList(pResolveContext));
+
+    // Stop SRV resolver before starting TXT one, ignore error as it will only happen if mMDS module is not initialized
+    (void)otMdnsStopSrvResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mSrvInfo);
+
+    pResolveContext->mTxtInfo.mServiceInstance = pResolveContext->mMdnsService.mName;
+    pResolveContext->mTxtInfo.mServiceType     = pResolveContext->mServiceType;
+    pResolveContext->mTxtInfo.mCallback        = OtTxtCallback;
+    pResolveContext->mTxtInfo.mInfraIfIndex    = mNetifIndex;
+
+    error = otMdnsStartTxtResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mTxtInfo);
+    if (error != OT_ERROR_NONE)
     {
-        // Stop SRV resolver before starting TXT one, ignore error as it will only happen if mMDS module is not initialized
-        otMdnsStopSrvResolver(ThreadStackMgrImpl().OTInstance(), &resolveContext->mSrvInfo);
-
-        resolveContext->mTxtInfo.mServiceInstance = resolveContext->mMdnsService.mName;
-        resolveContext->mTxtInfo.mServiceType     = resolveContext->mServiceType;
-        resolveContext->mTxtInfo.mCallback        = OtTxtCallback;
-        resolveContext->mTxtInfo.mInfraIfIndex    = mNetifIndex;
-
-        error = otMdnsStartTxtResolver(ThreadStackMgrImpl().OTInstance(), &resolveContext->mTxtInfo);
-        if (error != OT_ERROR_NONE)
-        {
-            resolveContext->error = MapOpenThreadError(error);
-            TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError,
-                                                                             reinterpret_cast<intptr_t>(resolveContext));
-        }
+        pResolveContext->error = MapOpenThreadError(error);
+        TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError,
+                                                                        reinterpret_cast<intptr_t>(pResolveContext));
     }
+
 }
 
 static void DispatchAddressResolve(intptr_t context)
 {
     otError error;
-    mDnsQueryCtx * resolveContext = reinterpret_cast<mDnsQueryCtx *>(context);
+    mDnsQueryCtx * pResolveContext = reinterpret_cast<mDnsQueryCtx *>(context);
 
-    if (IsResolveElementValid(resolveContext))
+    VerifyOrReturn(IsInResolveList(pResolveContext));
+
+    // Stop TXT resolver before starting address one, ignore error as it will only happen if mMDS module is not initialized
+    (void)otMdnsStopTxtResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mTxtInfo);
+
+    pResolveContext->mAddrInfo.mCallback     = OtAddressCallback;
+    pResolveContext->mAddrInfo.mHostName     = pResolveContext->mMdnsService.mHostName;
+    pResolveContext->mAddrInfo.mInfraIfIndex = mNetifIndex;
+
+    error = otMdnsStartIp6AddressResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mAddrInfo);
+    if (error != OT_ERROR_NONE)
     {
-        // Stop TXT resolver before starting address one, ignore error as it will only happen if mMDS module is not initialized
-        otMdnsStopTxtResolver(ThreadStackMgrImpl().OTInstance(), &resolveContext->mTxtInfo);
-
-        resolveContext->mAddrInfo.mCallback     = OtAddressCallback;
-        resolveContext->mAddrInfo.mHostName     = resolveContext->mMdnsService.mHostName;
-        resolveContext->mAddrInfo.mInfraIfIndex = mNetifIndex;
-
-        error = otMdnsStartIp6AddressResolver(ThreadStackMgrImpl().OTInstance(), &resolveContext->mAddrInfo);
-        if (error != OT_ERROR_NONE)
-        {
-            resolveContext->error = MapOpenThreadError(error);
-            TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError,
-                                                                             reinterpret_cast<intptr_t>(resolveContext));
-        }
+        pResolveContext->error = MapOpenThreadError(error);
+        TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError,
+                                                                        reinterpret_cast<intptr_t>(pResolveContext));
     }
 }
 
@@ -994,27 +993,27 @@ static void DispatchResolve(intptr_t context)
 {
     mDnsQueryCtx * pResolveContext = reinterpret_cast<mDnsQueryCtx *>(context);
 
-    if (IsResolveElementValid(pResolveContext))
+    VerifyOrReturn(IsInResolveList(pResolveContext));
+
+    Dnssd::DnssdService & service = pResolveContext->mMdnsService;
+    Span<Inet::IPAddress> ipAddrs;
+
+    // Stop Address resolver, we have finished resolving the service. Ignore error as it will only happen if
+    // mMDS module is not initialized
+    (void)otMdnsStopIp6AddressResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mAddrInfo);
+
+    if (service.mAddress.has_value())
     {
-        Dnssd::DnssdService & service = pResolveContext->mMdnsService;
-        Span<Inet::IPAddress> ipAddrs;
-
-        // Stop Address resolver, we have finished resolving the service
-        otMdnsStopIp6AddressResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mAddrInfo);
-
-        if (service.mAddress.has_value())
-        {
-            ipAddrs = Span<Inet::IPAddress>(&*service.mAddress, 1);
-        }
-
-        // The context will be freed and the resolve operation is stopped. Matter will
-        // try to stop it again on the mDnsResolveCallback but nothing will happen because the
-        // element is no longer present in the list.
-        LIST_RemoveElement(&pResolveContext->link);
-
-        pResolveContext->mDnsResolveCallback(pResolveContext->matterCtx, &service, ipAddrs, pResolveContext->error);
-        Platform::Delete<mDnsQueryCtx>(pResolveContext);
+        ipAddrs = Span<Inet::IPAddress>(&*service.mAddress, 1);
     }
+
+    // The context will be freed and the resolve operation is stopped. Matter will
+    // try to stop it again on the mDnsResolveCallback but nothing will happen because the
+    // element is no longer present in the list.
+    LIST_RemoveElement(&pResolveContext->link);
+
+    pResolveContext->mDnsResolveCallback(pResolveContext->matterCtx, &service, ipAddrs, pResolveContext->error);
+    Platform::Delete<mDnsQueryCtx>(pResolveContext);
 }
 
 static void DispatchResolveSrp(intptr_t context)
@@ -1041,18 +1040,18 @@ static void DispatchResolveSrp(intptr_t context)
 static void DispatchResolveError(intptr_t context)
 {
     mDnsQueryCtx * pResolveContext = reinterpret_cast<mDnsQueryCtx *>(context);
-    if (IsResolveElementValid(pResolveContext))
-    {
-        Span<Inet::IPAddress> ipAddrs;
 
-        // The context will be freed and the resolve operation is stopped. Matter will
-        // try to stop it again on the mDnsResolveCallback but nothing will happen because the
-        // element is no longer present in the list.
-        LIST_RemoveElement(&pResolveContext->link);
+    VerifyOrReturn(IsInResolveList(pResolveContext));
 
-        pResolveContext->mDnsResolveCallback(pResolveContext->matterCtx, nullptr, ipAddrs, pResolveContext->error);
-        Platform::Delete<mDnsQueryCtx>(pResolveContext);
-    }
+    Span<Inet::IPAddress> ipAddrs;
+
+    // The context will be freed and the resolve operation is stopped. Matter will
+    // try to stop it again on the mDnsResolveCallback but nothing will happen because the
+    // element is no longer present in the list.
+    LIST_RemoveElement(&pResolveContext->link);
+
+    pResolveContext->mDnsResolveCallback(pResolveContext->matterCtx, nullptr, ipAddrs, pResolveContext->error);
+    Platform::Delete<mDnsQueryCtx>(pResolveContext);
 }
 
 static void HandleResolveCleanup(mDnsQueryCtx & resolveContext, ResolveStep stepType)
@@ -1120,7 +1119,7 @@ static mDnsQueryCtx * GetResolveElement(const char * aName, NameType aType)
     return pResolveContext;
 }
 
-static bool IsResolveElementValid(const mDnsQueryCtx * pResolveContext)
+static bool IsInResolveList(const mDnsQueryCtx * pResolveContext)
 {
     mDnsQueryCtx * pContextIterator = reinterpret_cast<mDnsQueryCtx *>(LIST_GetHead(&mResolveList));
     while (pContextIterator)

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -949,7 +949,7 @@ static void DispatchTxtResolve(intptr_t context)
     VerifyOrReturn(IsInResolveList(pResolveContext));
 
     // Stop SRV resolver before starting TXT one, ignore error as it will only happen if mMDS module is not initialized
-    (void)otMdnsStopSrvResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mSrvInfo);
+    (void) otMdnsStopSrvResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mSrvInfo);
 
     pResolveContext->mTxtInfo.mServiceInstance = pResolveContext->mMdnsService.mName;
     pResolveContext->mTxtInfo.mServiceType     = pResolveContext->mServiceType;
@@ -961,9 +961,8 @@ static void DispatchTxtResolve(intptr_t context)
     {
         pResolveContext->error = MapOpenThreadError(error);
         TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError,
-                                                                        reinterpret_cast<intptr_t>(pResolveContext));
+                                                                         reinterpret_cast<intptr_t>(pResolveContext));
     }
-
 }
 
 static void DispatchAddressResolve(intptr_t context)
@@ -974,7 +973,7 @@ static void DispatchAddressResolve(intptr_t context)
     VerifyOrReturn(IsInResolveList(pResolveContext));
 
     // Stop TXT resolver before starting address one, ignore error as it will only happen if mMDS module is not initialized
-    (void)otMdnsStopTxtResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mTxtInfo);
+    (void) otMdnsStopTxtResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mTxtInfo);
 
     pResolveContext->mAddrInfo.mCallback     = OtAddressCallback;
     pResolveContext->mAddrInfo.mHostName     = pResolveContext->mMdnsService.mHostName;
@@ -985,7 +984,7 @@ static void DispatchAddressResolve(intptr_t context)
     {
         pResolveContext->error = MapOpenThreadError(error);
         TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(DispatchResolveError,
-                                                                        reinterpret_cast<intptr_t>(pResolveContext));
+                                                                         reinterpret_cast<intptr_t>(pResolveContext));
     }
 }
 
@@ -1000,7 +999,7 @@ static void DispatchResolve(intptr_t context)
 
     // Stop Address resolver, we have finished resolving the service. Ignore error as it will only happen if
     // mMDS module is not initialized
-    (void)otMdnsStopIp6AddressResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mAddrInfo);
+    (void) otMdnsStopIp6AddressResolver(ThreadStackMgrImpl().OTInstance(), &pResolveContext->mAddrInfo);
 
     if (service.mAddress.has_value())
     {


### PR DESCRIPTION
This commit fixes a rare case where the resolve context is being freed a second time in a Dispatch function. To prevent this scenario a new function was added, IsResolveElementValid() to check if the current resolve context is present in the resolve list. If that is false, it means the context was freed by NxpChipDnssdShutdown or NxpChipDnssdResolveNoLongerNeeded.

#### Testing
Tested in a large network setup with multiple Matter over Thread devices. The border router was performing multiple mDNS queries and was rebooted once every 30 seconds. Without the fix issue would happen after around 24 hours.