### PR TITLE
[Silabs] Optimize logging

### DIFF
--- a/examples/air-quality-sensor-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/air-quality-sensor-app/silabs/src/DataModelCallbacks.cpp
@@ -40,7 +40,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     ClusterId clusterId                      = attributePath.mClusterId;
     [[maybe_unused]] AttributeId attributeId = attributePath.mAttributeId;
-    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     if (clusterId == Identify::Id)
     {

--- a/examples/chef/silabs/src/DataModelCallbacks.cpp
+++ b/examples/chef/silabs/src/DataModelCallbacks.cpp
@@ -36,7 +36,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     ClusterId clusterId     = attributePath.mClusterId;
     AttributeId attributeId = attributePath.mAttributeId;
-    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     if (clusterId == Identify::Id)
     {

--- a/examples/dishwasher-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/dishwasher-app/silabs/src/DataModelCallbacks.cpp
@@ -41,7 +41,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     ClusterId clusterId     = attributePath.mClusterId;
     AttributeId attributeId = attributePath.mAttributeId;
-    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     if ((clusterId == OperationalState::Id) && (attributeId == OperationalState::Attributes::OperationalState::Id))
     {

--- a/examples/light-switch-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/light-switch-app/silabs/src/DataModelCallbacks.cpp
@@ -35,7 +35,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     ClusterId clusterId                      = attributePath.mClusterId;
     [[maybe_unused]] AttributeId attributeId = attributePath.mAttributeId;
-    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     if (clusterId == Identify::Id)
     {

--- a/examples/lighting-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/lighting-app/silabs/src/DataModelCallbacks.cpp
@@ -44,7 +44,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     ClusterId clusterId     = attributePath.mClusterId;
     AttributeId attributeId = attributePath.mAttributeId;
-    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     if (clusterId == OnOff::Id && attributeId == OnOff::Attributes::OnOff::Id)
     {

--- a/examples/lit-icd-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/lit-icd-app/silabs/src/DataModelCallbacks.cpp
@@ -36,7 +36,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     ClusterId clusterId     = attributePath.mClusterId;
     AttributeId attributeId = attributePath.mAttributeId;
-    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     if (clusterId == Identify::Id)
     {

--- a/examples/lock-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/lock-app/silabs/src/DataModelCallbacks.cpp
@@ -44,7 +44,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     ClusterId clusterId     = attributePath.mClusterId;
     AttributeId attributeId = attributePath.mAttributeId;
-    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     if (clusterId == DoorLock::Id && attributeId == DoorLock::Attributes::LockState::Id)
     {

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -692,7 +692,7 @@ void BaseApplication::StopStatusLEDTimer()
 #ifdef MATTER_DM_PLUGIN_IDENTIFY_SERVER
 void BaseApplication::OnIdentifyStart(Identify * identify)
 {
-    ChipLogProgress(Zcl, "onIdentifyStart");
+    ChipLogDetail(Zcl, "onIdentifyStart");
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     StartStatusLEDTimer();
@@ -701,7 +701,7 @@ void BaseApplication::OnIdentifyStart(Identify * identify)
 
 void BaseApplication::OnIdentifyStop(Identify * identify)
 {
-    ChipLogProgress(Zcl, "onIdentifyStop");
+    ChipLogDetail(Zcl, "onIdentifyStop");
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     StopStatusLEDTimer();
@@ -710,7 +710,7 @@ void BaseApplication::OnIdentifyStop(Identify * identify)
 
 void BaseApplication::OnTriggerIdentifyEffectCompleted(chip::System::Layer * systemLayer, void * appState)
 {
-    ChipLogProgress(Zcl, "Trigger Identify Complete");
+    ChipLogDetail(Zcl, "Trigger Identify Complete");
     sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -753,7 +753,7 @@ void BaseApplication::OnTriggerIdentifyEffect(Identify * identify)
         break;
     default:
         sIdentifyEffect = Clusters::Identify::EffectIdentifierEnum::kStopEffect;
-        ChipLogProgress(Zcl, "No identifier effect");
+        ChipLogDetail(Zcl, "No identifier effect");
     }
 }
 

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -218,7 +218,6 @@ void SilabsMatterConfig::AppInit()
 
     TEMPORARY_RETURN_IGNORED GetPlatform().Init();
     sMainTaskHandle = osThreadNew(ApplicationStart, nullptr, &kMainTaskAttr);
-    ChipLogProgress(DeviceLayer, "Starting scheduler");
     VerifyOrDie(sMainTaskHandle); // We can't proceed if the Main Task creation failed.
 
 // Use sl_system for projects upgraded to 2025.6, identified by the presence of SL_CATALOG_CUSTOM_MAIN_PRESENT
@@ -236,9 +235,7 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 {
     using namespace chip::DeviceLayer::Silabs;
 
-    ChipLogProgress(DeviceLayer, "==================================================");
-    ChipLogProgress(DeviceLayer, "%s starting", appName);
-    ChipLogProgress(DeviceLayer, "==================================================");
+    SILABS_LOG("=====%s starting=====", appName);
 
 #if PW_RPC_ENABLED
     chip::rpc::Init();
@@ -251,7 +248,6 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     //==============================================
     // Init Matter Stack
     //==============================================
-    ChipLogProgress(DeviceLayer, "Init CHIP Stack");
 
 #ifdef SL_WIFI
     ReturnErrorOnFailure(WifiInterface::GetInstance().InitWiFiStack());

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -32,8 +32,6 @@ declare_args() {
   ota_periodic_query_timeout_sec = 86400
 }
 
-chip_detail_logging = sl_verbose_mode
-
 import("${silabs_common_plat_dir}/args.gni")
 
 # Sanity check

--- a/examples/platform/silabs/rgb_led/RGBLEDWidget.cpp
+++ b/examples/platform/silabs/rgb_led/RGBLEDWidget.cpp
@@ -36,7 +36,7 @@ void RGBLEDWidget::SetColor(uint8_t red, uint8_t green, uint8_t blue)
 {
     if (GetPlatform().GetRGBLedState(GetLED()))
     {
-        ChipLogProgress(Zcl, "SetColor : R:%u|G:%u|B:%u", red, green, blue);
+        ChipLogDetail(Zcl, "SetColor : R:%u|G:%u|B:%u", red, green, blue);
         TEMPORARY_RETURN_IGNORED GetPlatform().SetLedColor(GetLED(), red, green, blue);
     }
 }
@@ -52,7 +52,7 @@ void RGBLEDWidget::GetColor(uint16_t & r, uint16_t & g, uint16_t & b)
     g = static_cast<uint16_t>((rawG / TICK_DELAY) & 0xFF);
     b = static_cast<uint16_t>((rawB / TICK_DELAY) & 0xFF);
 
-    ChipLogProgress(Zcl, "RGB Values: R=%u G=%u B=%u", r, g, b);
+    ChipLogDetail(Zcl, "RGB Values: R=%u G=%u B=%u", r, g, b);
 }
 /**
  * @brief Convert Data model hue and saturation to RGB and set the color
@@ -129,7 +129,7 @@ void RGBLEDWidget::SetColorFromHSV(uint8_t hue, uint8_t saturation)
 
 void RGBLEDWidget::SetColorFromXY(uint16_t currentX, uint16_t currentY)
 {
-    ChipLogProgress(Zcl, "SetColorFromXY: %u|%u", currentX, currentY);
+    ChipLogDetail(Zcl, "SetColorFromXY: %u|%u", currentX, currentY);
     RGBLEDWidget::RgbColor_t rgb = RGBLEDWidget::XYToRgb(GetLevel(), currentX, currentY);
     SetColor(rgb.r, rgb.g, rgb.b);
 }
@@ -137,7 +137,7 @@ void RGBLEDWidget::SetColorFromXY(uint16_t currentX, uint16_t currentY)
 void RGBLEDWidget::SetColorFromCT(uint16_t ctMireds)
 {
     RGBLEDWidget::RgbColor_t rgb = RGBLEDWidget::CTToRgb(ctMireds);
-    ChipLogProgress(Zcl, "SetColorFromCT: %u", ctMireds);
+    ChipLogDetail(Zcl, "SetColorFromCT: %u", ctMireds);
     SetColor(rgb.r, rgb.g, rgb.b);
 }
 

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -23,6 +23,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <sl_cmsis_os2_common.h>
 
+#include <platform/silabs/Logging.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -147,14 +149,16 @@ typedef struct
 #if SLI_SI91X_MCU_INTERFACE
 #define UART_MAX_QUEUE_SIZE 125
 #else
-#define UART_MAX_QUEUE_SIZE 10
+#if CHIP_DETAIL_LOGGING
+#define UART_MAX_QUEUE_SIZE 60
+#else
+#define UART_MAX_QUEUE_SIZE 20
+#endif
 #endif
 
-#ifdef CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE
-#define UART_TX_MAX_BUF_LEN (CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE)
-#else
-#error "CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE is not defined. Please define it in your project configuration."
-#endif
+#define UART_TX_MAX_BUF_LEN 100 // Just enough for the QR code
+
+#define SILABS_TRUNCATED_TERMINATOR "....."
 
 static constexpr uint32_t kUartTxCompleteFlag = 1;
 static osThreadId_t sUartTaskHandle;
@@ -169,13 +173,17 @@ constexpr osThreadAttr_t kUartTaskAttr = { .name       = "UART",
                                            .stack_size = kUartTaskSize,
                                            .priority   = osPriorityRealtime6 }; // Must be above Matter Task priority
 
-uint32_t sMissedLogCount = 0; // Count of logs that were not sent to the UART due to queue full
+static uint32_t sMissedLogCount = 0; // Count of logs that were not sent to the UART due to queue full
 
+namespace SilabsCoreLogs = chip::Logging::Platform;
+// sizeof struct on arm is 4+8 +sizeof(data) so 12 + number of character in the string
 typedef struct
 {
     uint8_t data[UART_TX_MAX_BUF_LEN];
-    uint16_t length = 0;
-    bool isLog      = false; // True if this is a log message, false if it is a command line message
+    uint64_t timestamp                   = 0;
+    uint8_t length                       = 0;
+    SilabsCoreLogs::LogCategory category = SilabsCoreLogs::kLog_None;
+    bool isLog                           = false; // True if this is a log message, false if it is a command line message
 
 } UartTxStruct_t;
 
@@ -194,7 +202,7 @@ static Fifo_t sReceiveFifo;
 #if SLI_SI91X_MCU_INTERFACE == 0
 static void UART_rx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, uint8_t * data, UARTDRV_Count_t transferCount);
 #endif // SLI_SI91X_MCU_INTERFACE == 0
-static void uartSendBytes(UartTxStruct_t & bufferStruct);
+static void uartSendBytes(uint8_t * data, uint16_t length);
 
 #if SLI_SI91X_MCU_INTERFACE
 static void ensureNullTermination(UartTxStruct_t & bufferStruct)
@@ -484,18 +492,30 @@ int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength)
  * @param length number of bytes to write
  * @return int16_t Amount of bytes written or ERROR (-1)
  */
-int16_t uartLogWrite(const char * log, uint16_t length)
+int16_t uartLogWrite(const char * log, uint8_t length, uint8_t category, uint64_t timestamp)
 {
-    if (log == NULL || length < 1 || length > UART_TX_MAX_BUF_LEN)
+    if (log == NULL || length < 2)
     {
         return UART_CONSOLE_ERR;
     }
+    bool truncated = false;
+    if (length > UART_TX_MAX_BUF_LEN)
+    {
+        length    = UART_TX_MAX_BUF_LEN - sizeof(SILABS_TRUNCATED_TERMINATOR); // Reserve space for headers and ...
+        truncated = true;
+    }
 
     UartTxStruct_t workBuffer;
-
     memcpy(workBuffer.data, log, length);
-    workBuffer.length = length;
-    workBuffer.isLog  = true; // This is a log message
+    if (truncated)
+    {
+        memcpy(workBuffer.data + length, SILABS_TRUNCATED_TERMINATOR, sizeof(SILABS_TRUNCATED_TERMINATOR));
+        length += sizeof(SILABS_TRUNCATED_TERMINATOR);
+    }
+    workBuffer.length    = length;
+    workBuffer.isLog     = true; // This is a log message
+    workBuffer.category  = SilabsCoreLogs::LogCategory(category);
+    workBuffer.timestamp = timestamp;
 
     // Don't wait when queue is full. Drop the log and return UART_CONSOLE_ERR
     if (osMessageQueuePut(sUartTxQueue, &workBuffer, osPriorityNormal, 0) == osOK)
@@ -545,20 +565,31 @@ int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead)
 void uartMainLoop(void * args)
 {
     UartTxStruct_t workBuffer;
-    bool isLog = false;
+    uint8_t timeStampString[SilabsCoreLogs::kTimeStampStringSize];
+    uint8_t logWorkBuffer[1 + SilabsCoreLogs::kTimeStampStringSize + SilabsCoreLogs::kMaxCategoryStrLen + UART_TX_MAX_BUF_LEN +
+                          3]; // Header + Timestamp + Category + Data + \r\n + Footer
 
     while (1)
     {
         osStatus_t eventReceived = osMessageQueueGet(sUartTxQueue, &workBuffer, nullptr, osWaitForever);
         while (eventReceived == osOK)
         {
-            isLog = workBuffer.isLog; // Check if this is a log message
-            uartSendBytes(workBuffer);
-            if (isLog)
+            if (workBuffer.isLog)
             {
-                memcpy(workBuffer.data, "\r\n", 2);
-                workBuffer.length = 2; // Reset length to 2 for the log end
-                uartSendBytes(workBuffer);
+                SilabsCoreLogs::FormatTimestamp(reinterpret_cast<char *>(timeStampString), sizeof(timeStampString),
+                                                workBuffer.timestamp);
+                int32_t len = snprintf(
+                    reinterpret_cast<char *>(logWorkBuffer), sizeof(logWorkBuffer), "%c%s%s%.*s\r\n%c", kLogHeader,
+                    timeStampString, // Timestamp will be filled later
+                    SilabsCoreLogs::GetCategoryString(workBuffer.category), workBuffer.length, workBuffer.data, kLogFooter);
+                if (len > 0)
+                {
+                    uartSendBytes(logWorkBuffer, static_cast<uint16_t>(len));
+                }
+            }
+            else
+            {
+                uartSendBytes(workBuffer.data, workBuffer.length);
             }
             if (sMissedLogCount)
             {
@@ -566,7 +597,7 @@ void uartMainLoop(void * args)
 
                 workBuffer.length = sprintf(reinterpret_cast<char *>(workBuffer.data), "\r\nMissed Logs: %lu\r\n", sMissedLogCount);
                 sMissedLogCount   = 0; // Reset the count after logging
-                uartSendBytes(workBuffer);
+                uartSendBytes(workBuffer.data, workBuffer.length);
             }
             eventReceived = osMessageQueueGet(sUartTxQueue, &workBuffer, nullptr, 0);
         }
@@ -578,11 +609,21 @@ void uartMainLoop(void * args)
  *
  * @param bufferStruct reference to the UartTxStruct_t containing the data
  */
-void uartSendBytes(UartTxStruct_t & bufferStruct)
+void uartSendBytes(uint8_t * data, uint16_t length)
 {
+    if (data == nullptr || length == 0)
+    {
+        return;
+    }
 #if SLI_SI91X_MCU_INTERFACE
-    ensureNullTermination(bufferStruct);
-    Board_UARTPutSTR(bufferStruct.data);
+    // Not optimal, waiting for a more efficient way to send logs over UART on SI91x
+    //
+    // Board_UARTPutSTR(data) does the exact same thing and is not compatible with
+    // the Silabs Matter console.
+    for (uint8_t i = 0; i < length; i++)
+    {
+        Board_UARTPutChar(data[i]);
+    }
 #else
 #if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
     sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM1);
@@ -595,10 +636,10 @@ void uartSendBytes(UartTxStruct_t & bufferStruct)
 #if (defined(EFR32MG24) && defined(WF200_WIFI))
     // Blocking transmit for the MG24 + WF200 since UART TX is multiplexed with
     // WF200 SPI IRQ
-    UARTDRV_ForceTransmit(vcom_handle, bufferStruct.data, bufferStruct.length);
+    UARTDRV_ForceTransmit(vcom_handle, data, length);
 #else
     // Non Blocking Transmit
-    UARTDRV_Transmit(vcom_handle, bufferStruct.data, bufferStruct.length, UART_tx_callback);
+    UARTDRV_Transmit(vcom_handle, data, length, UART_tx_callback);
     osThreadFlagsWait(kUartTxCompleteFlag, osFlagsWaitAny, osWaitForever);
 #endif /* EFR32MG24 && WF200_WIFI */
 

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -566,8 +566,9 @@ void uartMainLoop(void * args)
 {
     UartTxStruct_t workBuffer;
     uint8_t timeStampString[SilabsCoreLogs::kTimeStampStringSize];
-    uint8_t logWorkBuffer[kHeaderSize + SilabsCoreLogs::kTimeStampStringSize + SilabsCoreLogs::kMaxCategoryStrLen + UART_TX_MAX_BUF_LEN +
-                          kEndOfLineSize + kFooterSize]; // Header + Timestamp + Category + Data + \r\n + Footer
+    uint8_t logWorkBuffer[kHeaderSize + SilabsCoreLogs::kTimeStampStringSize + SilabsCoreLogs::kMaxCategoryStrLen +
+                          UART_TX_MAX_BUF_LEN + kEndOfLineSize +
+                          kFooterSize]; // Header + Timestamp + Category + Data + \r\n + Footer
 
     while (1)
     {

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -566,8 +566,8 @@ void uartMainLoop(void * args)
 {
     UartTxStruct_t workBuffer;
     uint8_t timeStampString[SilabsCoreLogs::kTimeStampStringSize];
-    uint8_t logWorkBuffer[1 + SilabsCoreLogs::kTimeStampStringSize + SilabsCoreLogs::kMaxCategoryStrLen + UART_TX_MAX_BUF_LEN +
-                          3]; // Header + Timestamp + Category + Data + \r\n + Footer
+    uint8_t logWorkBuffer[kHeaderSize + SilabsCoreLogs::kTimeStampStringSize + SilabsCoreLogs::kMaxCategoryStrLen + UART_TX_MAX_BUF_LEN +
+                          kEndOfLineSize + kFooterSize]; // Header + Timestamp + Category + Data + \r\n + Footer
 
     while (1)
     {

--- a/examples/platform/silabs/uart.h
+++ b/examples/platform/silabs/uart.h
@@ -22,6 +22,9 @@
 
 constexpr uint8_t kLogHeader = 0x01; // ASCII Start of Heading
 constexpr uint8_t kLogFooter = 0x04; // ASCII End of Transmission
+constexpr uint8_t kHeaderSize = 1;
+constexpr uint8_t kFooterSize = 1;
+constexpr uint8_t kEndOfLineSize = 2; // \r\n
 
 #ifdef __cplusplus
 extern "C" {

--- a/examples/platform/silabs/uart.h
+++ b/examples/platform/silabs/uart.h
@@ -20,13 +20,16 @@
 
 #include <stdint.h>
 
+constexpr uint8_t kLogHeader = 0x01; // ASCII Start of Heading
+constexpr uint8_t kLogFooter = 0x04; // ASCII End of Transmission
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void uartConsoleInit(void);
 int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength);
-int16_t uartLogWrite(const char * log, uint16_t length);
+int16_t uartLogWrite(const char * log, uint8_t length, uint8_t category, uint64_t timestamp);
 int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead);
 void uartFlushTxQueue(void);
 void uartForceTransmit(const uint8_t * data, uint16_t length);

--- a/examples/platform/silabs/uart.h
+++ b/examples/platform/silabs/uart.h
@@ -20,10 +20,10 @@
 
 #include <stdint.h>
 
-constexpr uint8_t kLogHeader = 0x01; // ASCII Start of Heading
-constexpr uint8_t kLogFooter = 0x04; // ASCII End of Transmission
-constexpr uint8_t kHeaderSize = 1;
-constexpr uint8_t kFooterSize = 1;
+constexpr uint8_t kLogHeader     = 0x01; // ASCII Start of Heading
+constexpr uint8_t kLogFooter     = 0x04; // ASCII End of Transmission
+constexpr uint8_t kHeaderSize    = 1;
+constexpr uint8_t kFooterSize    = 1;
 constexpr uint8_t kEndOfLineSize = 2; // \r\n
 
 #ifdef __cplusplus

--- a/examples/refrigerator-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/refrigerator-app/silabs/src/DataModelCallbacks.cpp
@@ -39,7 +39,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     ClusterId clusterId     = attributePath.mClusterId;
     AttributeId attributeId = attributePath.mAttributeId;
-    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     switch (clusterId)
     {

--- a/examples/smoke-co-alarm-app/silabs/src/DataModelCallbacks.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/DataModelCallbacks.cpp
@@ -36,7 +36,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     ClusterId clusterId     = attributePath.mClusterId;
     AttributeId attributeId = attributePath.mAttributeId;
-    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     if (clusterId == SmokeCoAlarm::Id && attributeId == SmokeCoAlarm::Attributes::ExpressedState::Id)
     {

--- a/examples/thermostat/silabs/src/DataModelCallbacks.cpp
+++ b/examples/thermostat/silabs/src/DataModelCallbacks.cpp
@@ -40,7 +40,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     ClusterId clusterId     = attributePath.mClusterId;
     AttributeId attributeId = attributePath.mAttributeId;
-    ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
+    ChipLogDetail(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     if (clusterId == Identify::Id)
     {

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -273,7 +273,7 @@ else
                 shift
                 ;;
             --verbose)
-                optArgs+="sl_verbose_mode=true "
+                optArgs+="sl_verbose_mode=true chip_detail_logging=true "
                 VERBOSE_MODE=true
                 shift
                 ;;
@@ -345,6 +345,10 @@ else
     if [ "$USE_DOCKER" == true ] && [ "$USE_WIFI" == false ]; then
         echo "Switching OpenThread ROOT"
         optArgs+="openthread_root=\"$GSDK_ROOT/util/third_party/openthread\" "
+    fi
+
+    if [ "$VERBOSE_MODE" == false ]; then
+        optArgs+="chip_detail_logging=false "
     fi
 
     "$GN_PATH" gen --check --script-executable="$PYTHON_PATH" --fail-on-unused-args --add-export-compile-commands=* --root="$ROOT" --dotfile="$DOTFILE" --args="silabs_board=\"$SILABS_BOARD\" $optArgs" "$BUILD_DIR"

--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -124,7 +124,7 @@ size_t FormatTimestamp(char * buffer, size_t maxSize, uint64_t timestampMillis)
     uint8_t minutes = totalSeconds % 60;
     uint32_t hours  = totalSeconds / 60;
 
-    return snprintf(buffer, maxSize, "[%02lu:%02u:%02u.%03u]", hours, minutes, seconds, milliseconds);
+    return snprintf(buffer, maxSize, "[%04lu:%02u:%02u.%03u]", hours, minutes, seconds, milliseconds);
 }
 
 void HandleLog(const char * module, LogCategory category, const char * aFormat, va_list v)

--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -1,4 +1,6 @@
 /* See Project CHIP LICENSE file for licensing information. */
+#include <platform/silabs/Logging.h>
+
 #include <platform/logging/LogV.h>
 
 #include <lib/core/CHIPConfig.h>
@@ -57,22 +59,7 @@
 #include "SEGGER_RTT_Conf.h"
 #endif
 
-#define LOG_ERROR "[error ]"
-#define LOG_WARN "[warn  ]"
-#define LOG_INFO "[info  ]"
-#define LOG_DETAIL "[detail]"
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-#define LOG_LWIP "[lwip  ]"
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-#define LOG_SILABS "[silabs ]"
-// If a new category string LOG_* is created, add it in the MaxStringLength arguments below
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-static constexpr size_t kMaxCategoryStrLen = chip::MaxStringLength(LOG_ERROR, LOG_WARN, LOG_INFO, LOG_DETAIL, LOG_LWIP, LOG_SILABS);
-#else
-static constexpr size_t kMaxCategoryStrLen = chip::MaxStringLength(LOG_ERROR, LOG_WARN, LOG_INFO, LOG_DETAIL, LOG_SILABS);
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-static constexpr size_t kMaxTimestampStrLen = 16; // "[" (HH)HH:MM:SS + "." + miliseconds(3digits) + "]"
+using namespace chip::Logging::Platform;
 
 #if SILABS_LOG_ENABLED
 static bool sLogInitialized = false;
@@ -86,32 +73,108 @@ static uint8_t sCmdLineBuffer[LOG_RTT_BUFFER_SIZE];
 
 using namespace chip;
 
+// Forward declaration
+#if !SILABS_LOG_OUT_UART
+static void PrintLog(const char * msg);
+#endif // !SILABS_LOG_OUT_UART
+
+namespace chip {
+namespace DeviceLayer {
+
 /**
- * @brief Add a timestamp in hh:mm:ss.ms format and the given prefix string to the given char buffer
- * The time stamp is derived from the boot time
+ * Called whenever a log message is emitted by Chip or LwIP.
  *
- * @param logBuffer: pointer to the buffer where to add the information
- *        prefix: A prefix to add to the trace e.g. The category
- *        maxSize: Space availaible in the given buffer.
+ * This function is intended be overridden by the application to, e.g.,
+ * schedule output of queued log entries.
  */
-static size_t AddTimeStampAndPrefixStr(char * logBuffer, const char * prefix, size_t maxSize)
+void __attribute__((weak)) OnLogOutput(void) {}
+
+} // namespace DeviceLayer
+} // namespace chip
+
+namespace chip {
+namespace Logging {
+namespace Platform {
+
+size_t AddTimeStampAndPrefixStr(char * logBuffer, const char * prefix, size_t maxSize)
 {
     VerifyOrDie(logBuffer != nullptr);
     VerifyOrDie(prefix != nullptr);
-    VerifyOrDie(maxSize > kMaxTimestampStrLen + strlen(prefix)); // Greater than to at least accommodate a ending Null Character
+    VerifyOrDie(maxSize > kTimeStampStringSize + strlen(prefix)); // Greater than to at least accommodate a ending Null Character
 
     // Derive the hours, minutes, seconds and milliseconds since boot time millisecond counter
-    uint64_t bootTime     = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
-    uint16_t milliseconds = bootTime % 1000;
-    uint32_t totalSeconds = bootTime / 1000;
+    uint64_t bootTime   = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
+    size_t timestampLen = FormatTimestamp(logBuffer, maxSize, bootTime);
+    if (timestampLen >= maxSize)
+    {
+        return 0; // Likely a snprintf error
+    }
+    return snprintf(logBuffer + timestampLen, maxSize - timestampLen, "%s", prefix);
+}
+size_t FormatTimestamp(char * buffer, size_t maxSize, uint64_t timestampMillis)
+{
+    VerifyOrDie(buffer != nullptr);
+    VerifyOrDie(maxSize >= kTimeStampStringSize); // Greater than to at least accommodate a ending Null Character
+
+    // Derive the hours, minutes, seconds and milliseconds since boot time millisecond counter
+    uint16_t milliseconds = timestampMillis % 1000;
+    uint32_t totalSeconds = timestampMillis / 1000;
     uint8_t seconds       = totalSeconds % 60;
     totalSeconds /= 60;
     uint8_t minutes = totalSeconds % 60;
     uint32_t hours  = totalSeconds / 60;
 
-    return snprintf(logBuffer, maxSize, "[%02lu:%02u:%02u.%03u]%s", hours, minutes, seconds, milliseconds, prefix);
+    return snprintf(buffer, maxSize, "[%02lu:%02u:%02u.%03u]", hours, minutes, seconds, milliseconds);
 }
 
+void HandleLog(const char * module, LogCategory category, const char * aFormat, va_list v)
+{
+    char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+
+    static_assert(sizeof(formattedMsg) >
+                  kTimeStampStringSize + kMaxCategoryStrLen); // Greater than to at least accommodate a ending Null Character
+
+    size_t prefixLen = 0;
+    size_t moduleLen = strlen(module);
+    if ((moduleLen > 0) && (moduleLen < CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE))
+    {
+        // Prepend module name if available
+        prefixLen = snprintf(formattedMsg, sizeof(formattedMsg), "[%s] ", module);
+    }
+
+#if !SILABS_LOG_OUT_UART
+    prefixLen += chip::Logging::Platform::AddTimeStampAndPrefixStr(
+        formattedMsg, reinterpret_cast<const char *>(GetCategoryString(category)), CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
+#endif // SILABS_LOG_OUT_UART
+    if (prefixLen >= sizeof formattedMsg)
+    {
+        prefixLen = sizeof formattedMsg - 1; // prevent overflow
+    }
+
+    size_t len = vsnprintf(formattedMsg + prefixLen, sizeof formattedMsg - prefixLen, aFormat, v);
+
+    if (len >= sizeof formattedMsg - prefixLen)
+    {
+        formattedMsg[sizeof formattedMsg - 1] = '\0';
+    }
+
+#if SILABS_LOG_OUT_UART
+    // Silabs UART Log trunc
+    uint8_t messageLen = len + prefixLen > 255 ? 255 : static_cast<uint8_t>(len + prefixLen);
+    uartLogWrite(formattedMsg, messageLen, category, chip::System::SystemClock().GetMonotonicMilliseconds64().count());
+#else
+    PrintLog(formattedMsg);
+#endif // SILABS_LOG_OUT_UART
+
+    // Let the application know that a log message has been emitted.
+    chip::DeviceLayer::OnLogOutput();
+}
+
+} // namespace Platform
+} // namespace Logging
+} // namespace chip
+
+#if !SILABS_LOG_OUT_UART
 /**
  * Print a log message
  */
@@ -122,16 +185,12 @@ static void PrintLog(const char * msg)
         size_t sz;
         sz = strlen(msg);
 
-#if SILABS_LOG_OUT_UART
-        uartLogWrite(msg, sz);
-#else
 #if PW_RPC_ENABLED
         PigweedLogger::putString(msg, sz);
 #endif // PW_RPC_ENABLED
         SEGGER_RTT_WriteNoLock(LOG_RTT_BUFFER_INDEX, msg, sz);
-#endif // SILABS_LOG_OUT_UART
 
-#if !SILABS_LOG_OUT_UART || PW_RPC_ENABLED
+#if PW_RPC_ENABLED
         const char * newline = "\r\n";
         sz                   = strlen(newline);
 #if PW_RPC_ENABLED
@@ -141,6 +200,7 @@ static void PrintLog(const char * msg)
 #endif
     }
 }
+#endif // !SILABS_LOG_OUT_UART
 #endif // SILABS_LOG_ENABLED
 
 /**
@@ -177,37 +237,11 @@ extern "C" void silabsLog(const char * aFormat, ...)
 
     va_start(v, aFormat);
 #if SILABS_LOG_ENABLED
-    char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
-    static_assert(sizeof(formattedMsg) >
-                  kMaxTimestampStrLen + kMaxCategoryStrLen); // Greater than to at least accommodate a ending Null Character
-
-    size_t prefixLen = AddTimeStampAndPrefixStr(formattedMsg, LOG_SILABS, CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
-    size_t len       = vsnprintf(formattedMsg + prefixLen, sizeof formattedMsg - prefixLen, aFormat, v);
-
-    if (len >= sizeof formattedMsg - prefixLen)
-    {
-        formattedMsg[sizeof formattedMsg - 1] = '\0';
-    }
-
-    PrintLog(formattedMsg);
+    chip::Logging::Platform::HandleLog(reinterpret_cast<const char *>(kLogNone), kLog_Silabs, aFormat, v);
 #endif // SILABS_LOG_ENABLED
 
     va_end(v);
 }
-
-namespace chip {
-namespace DeviceLayer {
-
-/**
- * Called whenever a log message is emitted by Chip or LwIP.
- *
- * This function is intended be overridden by the application to, e.g.,
- * schedule output of queued log entries.
- */
-void __attribute__((weak)) OnLogOutput(void) {}
-
-} // namespace DeviceLayer
-} // namespace chip
 
 namespace chip {
 namespace Logging {
@@ -221,40 +255,22 @@ void LogV(const char * module, uint8_t category, const char * aFormat, va_list v
 #if SILABS_LOG_ENABLED && _CHIP_USE_LOGGING
     if (IsCategoryEnabled(category))
     {
-        char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
-        size_t formattedMsgLen;
-
-        // len for Category string + "[" + Module name + "] " (Brackets and space =3)
-        constexpr size_t maxPrefixLen = kMaxTimestampStrLen + kMaxCategoryStrLen + chip::Logging::kMaxModuleNameLen + 3;
-        static_assert(sizeof(formattedMsg) > maxPrefixLen); // Greater than to at least accommodate a ending Null Character
+        LogCategory categoryEnum = kLog_None;
 
         switch (category)
         {
         case kLogCategory_Error:
-            formattedMsgLen = AddTimeStampAndPrefixStr(formattedMsg, LOG_ERROR, CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
+            categoryEnum = kLog_Error;
+            break;
+        case kLogCategory_Detail:
+            categoryEnum = kLog_Detail;
             break;
         case kLogCategory_Progress:
         default:
-            formattedMsgLen = AddTimeStampAndPrefixStr(formattedMsg, LOG_INFO, CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
-            break;
-        case kLogCategory_Detail:
-            formattedMsgLen = AddTimeStampAndPrefixStr(formattedMsg, LOG_DETAIL, CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
+            categoryEnum = kLog_Progress;
             break;
         }
-
-        // Add the module name to the log prefix , e.g. "[DL] "
-        snprintf(formattedMsg + formattedMsgLen, sizeof(formattedMsg) - formattedMsgLen, "[%s] ", module);
-        formattedMsg[sizeof(formattedMsg) - 1] = 0;
-        formattedMsgLen                        = strlen(formattedMsg);
-
-        size_t len = vsnprintf(formattedMsg + formattedMsgLen, sizeof formattedMsg - formattedMsgLen, aFormat, v);
-
-        if (len >= sizeof formattedMsg - formattedMsgLen)
-        {
-            formattedMsg[sizeof formattedMsg - 1] = '\0';
-        }
-
-        PrintLog(formattedMsg);
+        chip::Logging::Platform::HandleLog(module, categoryEnum, aFormat, v);
     }
 
     // Let the application know that a log message has been emitted.
@@ -274,21 +290,9 @@ void LogV(const char * module, uint8_t category, const char * aFormat, va_list v
 extern "C" void LwIPLog(const char * aFormat, ...)
 {
     va_list v;
-
     va_start(v, aFormat);
 #if SILABS_LOG_ENABLED
-    char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
-
-    size_t prefixLen = AddTimeStampAndPrefixStr(formattedMsg, LOG_LWIP, CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
-    size_t len       = vsnprintf(formattedMsg + prefixLen, sizeof formattedMsg - prefixLen, aFormat, v);
-
-    if (len >= sizeof formattedMsg - prefixLen)
-    {
-        formattedMsg[sizeof formattedMsg - 1] = '\0';
-    }
-
-    PrintLog(formattedMsg);
-    // Let the application know that a log message has been emitted.
+    chip::Logging::Platform::HandleLog(reinterpret_cast<const char *>(kLogLwip), kLog_Lwip, aFormat, v);
     chip::DeviceLayer::OnLogOutput();
 #endif // SILABS_LOG_ENABLED
     va_end(v);
@@ -305,37 +309,27 @@ extern "C" void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const ch
 
     va_start(v, aFormat);
 #if SILABS_LOG_ENABLED
-    size_t prefixLen;
-    char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
-
+    LogCategory category = kLog_Silabs;
     if (sLogInitialized)
     {
         switch (aLogLevel)
         {
         case OT_LOG_LEVEL_CRIT:
-            prefixLen = AddTimeStampAndPrefixStr(formattedMsg, LOG_ERROR "[ot] ", CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
+            category = kLog_Error;
             break;
         case OT_LOG_LEVEL_WARN:
-            prefixLen = AddTimeStampAndPrefixStr(formattedMsg, LOG_WARN "[ot] ", CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
+            category = kLog_Warning;
             break;
         case OT_LOG_LEVEL_NOTE:
         case OT_LOG_LEVEL_INFO:
-            prefixLen = AddTimeStampAndPrefixStr(formattedMsg, LOG_INFO "[ot] ", CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
+            category = kLog_Progress;
             break;
         case OT_LOG_LEVEL_DEBG:
         default:
-            prefixLen = AddTimeStampAndPrefixStr(formattedMsg, LOG_DETAIL "[ot] ", CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE);
+            category = kLog_Detail;
             break;
         }
-
-        size_t len = vsnprintf(formattedMsg + prefixLen, sizeof(formattedMsg) - prefixLen, aFormat, v);
-
-        if (len >= sizeof formattedMsg - prefixLen)
-        {
-            formattedMsg[sizeof formattedMsg - 1] = '\0';
-        }
-
-        PrintLog(formattedMsg);
+        chip::Logging::Platform::HandleLog(reinterpret_cast<const char *>(kOTModule), category, aFormat, v);
     }
 
     // Let the application know that a log message has been emitted.

--- a/src/platform/silabs/Logging.h
+++ b/src/platform/silabs/Logging.h
@@ -36,9 +36,9 @@ constexpr const uint8_t kLogSilabs[] = "[silabs]";
 constexpr const uint8_t kLogNone[]   = "-";
 constexpr const uint8_t kOTModule[]  = "[ot]";
 
-static constexpr size_t kTimeStampStringSize = sizeof("[00:00:00.000]"); // includes null terminator
+static constexpr size_t kTimeStampStringSize = sizeof("[0000:00:00.000]"); // includes null terminator
 static constexpr size_t kMaxCategoryStrLen =
-    std::max({ sizeof(kLogError), sizeof(kLogWarn), sizeof(kLogInfo), sizeof(kLogDetail), sizeof(kLogLwip), sizeof(kLogSilabs) });
+    std::max({ sizeof(kLogError), sizeof(kLogWarn), sizeof(kLogInfo), sizeof(kLogDetail), sizeof(kLogLwip), sizeof(kLogSilabs), sizeof(kLogNone), sizeof(kOTModule) });
 
 enum LogCategory : uint8_t
 {
@@ -49,26 +49,29 @@ enum LogCategory : uint8_t
     kLog_Lwip     = 4,
     kLog_Silabs   = 5,
     kLog_None     = 6,
+    kLog_OT       = 7,
 };
 
-inline uint8_t * GetCategoryString(LogCategory category)
+inline const uint8_t * GetCategoryString(LogCategory category)
 {
     switch (category)
     {
     case kLog_Error:
-        return const_cast<uint8_t *>(kLogError);
+        return (kLogError);
     case kLog_Progress:
-        return const_cast<uint8_t *>(kLogInfo);
+        return (kLogInfo);
     case kLog_Detail:
-        return const_cast<uint8_t *>(kLogDetail);
+        return (kLogDetail);
     case kLog_Warning:
-        return const_cast<uint8_t *>(kLogWarn);
+        return (kLogWarn);
     case kLog_Lwip:
-        return const_cast<uint8_t *>(kLogLwip);
+        return (kLogLwip);
     case kLog_Silabs:
-        return const_cast<uint8_t *>(kLogSilabs);
+        return (kLogSilabs);
+    case kLog_OT:
+        return (kOTModule);
     default:
-        return const_cast<uint8_t *>(kLogNone);
+        return (kLogNone);
     }
 }
 
@@ -86,6 +89,8 @@ inline uint8_t GetCategoryStringSize(LogCategory category)
         return sizeof(kLogLwip) - 1;
     case kLog_Silabs:
         return sizeof(kLogSilabs) - 1;
+    case kLog_OT:
+        return sizeof(kOTModule) - 1;    
     default:
         return sizeof(kLogNone) - 1;
     }

--- a/src/platform/silabs/Logging.h
+++ b/src/platform/silabs/Logging.h
@@ -90,7 +90,7 @@ inline uint8_t GetCategoryStringSize(LogCategory category)
     case kLog_Silabs:
         return sizeof(kLogSilabs) - 1;
     case kLog_OT:
-        return sizeof(kOTModule) - 1;    
+        return sizeof(kOTModule) - 1;
     default:
         return sizeof(kLogNone) - 1;
     }

--- a/src/platform/silabs/Logging.h
+++ b/src/platform/silabs/Logging.h
@@ -1,0 +1,108 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <algorithm>
+
+namespace chip {
+namespace Logging {
+namespace Platform {
+
+// Log category string constants
+constexpr const uint8_t kLogError[]  = "[error]";
+constexpr const uint8_t kLogWarn[]   = "[warn]";
+constexpr const uint8_t kLogInfo[]   = "[info]";
+constexpr const uint8_t kLogDetail[] = "[detail]";
+constexpr const uint8_t kLogLwip[]   = "[lwip]";
+constexpr const uint8_t kLogSilabs[] = "[silabs]";
+constexpr const uint8_t kLogNone[]   = "-";
+constexpr const uint8_t kOTModule[]  = "[ot]";
+
+static constexpr size_t kTimeStampStringSize = sizeof("[00:00:00.000]"); // includes null terminator
+static constexpr size_t kMaxCategoryStrLen =
+    std::max({ sizeof(kLogError), sizeof(kLogWarn), sizeof(kLogInfo), sizeof(kLogDetail), sizeof(kLogLwip), sizeof(kLogSilabs) });
+
+enum LogCategory : uint8_t
+{
+    kLog_Error    = 0,
+    kLog_Progress = 1,
+    kLog_Detail   = 2,
+    kLog_Warning  = 3,
+    kLog_Lwip     = 4,
+    kLog_Silabs   = 5,
+    kLog_None     = 6,
+};
+
+inline uint8_t * GetCategoryString(LogCategory category)
+{
+    switch (category)
+    {
+    case kLog_Error:
+        return const_cast<uint8_t *>(kLogError);
+    case kLog_Progress:
+        return const_cast<uint8_t *>(kLogInfo);
+    case kLog_Detail:
+        return const_cast<uint8_t *>(kLogDetail);
+    case kLog_Warning:
+        return const_cast<uint8_t *>(kLogWarn);
+    case kLog_Lwip:
+        return const_cast<uint8_t *>(kLogLwip);
+    case kLog_Silabs:
+        return const_cast<uint8_t *>(kLogSilabs);
+    default:
+        return const_cast<uint8_t *>(kLogNone);
+    }
+}
+
+inline uint8_t GetCategoryStringSize(LogCategory category)
+{
+    switch (category)
+    {
+    case kLog_Error:
+        return sizeof(kLogError) - 1;
+    case kLog_Progress:
+        return sizeof(kLogInfo) - 1;
+    case kLog_Detail:
+        return sizeof(kLogDetail) - 1;
+    case kLog_Lwip:
+        return sizeof(kLogLwip) - 1;
+    case kLog_Silabs:
+        return sizeof(kLogSilabs) - 1;
+    default:
+        return sizeof(kLogNone) - 1;
+    }
+}
+
+/**
+ * @brief Add a timestamp in hh:mm:ss.ms format and the given prefix string to the given char buffer
+ * The time stamp is derived from the boot time
+ *
+ * @param logBuffer: pointer to the buffer where to add the information
+ * @param prefix: A prefix to add to the trace e.g. The category
+ * @param maxSize: Space available in the given buffer.
+ * @return size_t: Number of characters written to the buffer
+ */
+size_t AddTimeStampAndPrefixStr(char * logBuffer, const char * prefix, size_t maxSize);
+size_t FormatTimestamp(char * buffer, size_t maxSize, uint64_t timestampMillis);
+
+} // namespace Platform
+} // namespace Logging
+} // namespace chip

--- a/src/platform/silabs/Logging.h
+++ b/src/platform/silabs/Logging.h
@@ -38,7 +38,8 @@ constexpr const uint8_t kOTModule[]  = "[ot]";
 
 static constexpr size_t kTimeStampStringSize = sizeof("[0000:00:00.000]"); // includes null terminator
 static constexpr size_t kMaxCategoryStrLen =
-    std::max({ sizeof(kLogError), sizeof(kLogWarn), sizeof(kLogInfo), sizeof(kLogDetail), sizeof(kLogLwip), sizeof(kLogSilabs), sizeof(kLogNone), sizeof(kOTModule) });
+    std::max({ sizeof(kLogError), sizeof(kLogWarn), sizeof(kLogInfo), sizeof(kLogDetail), sizeof(kLogLwip), sizeof(kLogSilabs),
+               sizeof(kLogNone), sizeof(kOTModule) });
 
 enum LogCategory : uint8_t
 {


### PR DESCRIPTION
#### Summary

When using UART, logs are mingled with CLI, with this rework we add framing to the logs as to differentiate them in our user interface..

Also optimize log propagation as to save some ram, current build should allows us to buffer twice as many logs while reducing RAM usage by 1.6KB. 
#### Related issues

none

#### Testing
Tested with MG24

