### PR TITLE
IDM conformance: use dataclass

### DIFF
--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -29,7 +29,7 @@ import click
 import paths
 from lxml import etree
 
-from matter.testing.conformance import ConformanceDecision
+from matter.testing.conformance import ConformanceDecision, MinimalConformance
 from matter.testing.spec_parsing import build_xml_clusters, build_xml_device_types
 
 log = logging.getLogger(__name__)
@@ -431,10 +431,10 @@ def dump_ids_from_data_model_dirs():
         def device_type_support_str(d):
             log.info("checking device type for '%s' for '%s'", d.name, dir)
             dt_server_mandatory = [id for id, requirement in d.server_clusters.items() if requirement.conformance(
-                [], 0, 0).decision == ConformanceDecision.MANDATORY]
+                MinimalConformance()).decision == ConformanceDecision.MANDATORY]
             server_provisional = [clusters[c].name for c in dt_server_mandatory if clusters[c].is_provisional]
             dt_client_mandatory = [id for id, requirement in d.client_clusters.items(
-            ) if requirement.conformance([], 0, 0).decision == ConformanceDecision.MANDATORY]
+            ) if requirement.conformance(MinimalConformance()).decision == ConformanceDecision.MANDATORY]
             client_provisional = [clusters[c].name for c in dt_client_mandatory if clusters[c].is_provisional]
             if server_provisional or client_provisional:
                 log.info("Found provisional mandatory clusters server:'%s' "

--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -29,7 +29,7 @@ import click
 import paths
 from lxml import etree
 
-from matter.testing.conformance import ConformanceDecision
+from matter.testing.conformance import ConformanceDecision, MinimalConformance
 from matter.testing.spec_parsing import build_xml_clusters, build_xml_device_types
 
 log = logging.getLogger(__name__)
@@ -45,23 +45,9 @@ except ModuleNotFoundError:
     import generate_data_model_xmls_gni
 
 
+# 1.5.1 current per the 0.9 ballot email
 CURRENT_IN_PROGRESS_DEFINES = [
-    "access-closure",
     "cameras",
-    "closures",
-    "electrical-grid-conditions",
-    "energy-mtrid",
-    "energy-price",
-    "energy-tariff",
-    "irrigation-system",
-    "metering",
-    "nfcCommissioning",
-    "q-phase-2",
-    "rvc-direct-mode",
-    "rvc-go-home",
-    "soil-sensor",
-    "temperature-sensor-with-screen",
-    "tls"
 ]
 
 
@@ -431,10 +417,10 @@ def dump_ids_from_data_model_dirs():
         def device_type_support_str(d):
             log.info("checking device type for '%s' for '%s'", d.name, dir)
             dt_server_mandatory = [id for id, requirement in d.server_clusters.items() if requirement.conformance(
-                [], 0, 0).decision == ConformanceDecision.MANDATORY]
+                MinimalConformance()).decision == ConformanceDecision.MANDATORY]
             server_provisional = [clusters[c].name for c in dt_server_mandatory if clusters[c].is_provisional]
             dt_client_mandatory = [id for id, requirement in d.client_clusters.items(
-            ) if requirement.conformance([], 0, 0).decision == ConformanceDecision.MANDATORY]
+            ) if requirement.conformance(MinimalConformance()).decision == ConformanceDecision.MANDATORY]
             client_provisional = [clusters[c].name for c in dt_client_mandatory if clusters[c].is_provisional]
             if server_provisional or client_provisional:
                 log.info("Found provisional mandatory clusters server:'%s' "

--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -29,7 +29,7 @@ import click
 import paths
 from lxml import etree
 
-from matter.testing.conformance import ConformanceDecision, MinimalConformance
+from matter.testing.conformance import ConformanceDecision
 from matter.testing.spec_parsing import build_xml_clusters, build_xml_device_types
 
 log = logging.getLogger(__name__)
@@ -45,9 +45,23 @@ except ModuleNotFoundError:
     import generate_data_model_xmls_gni
 
 
-# 1.5.1 current per the 0.9 ballot email
 CURRENT_IN_PROGRESS_DEFINES = [
+    "access-closure",
     "cameras",
+    "closures",
+    "electrical-grid-conditions",
+    "energy-mtrid",
+    "energy-price",
+    "energy-tariff",
+    "irrigation-system",
+    "metering",
+    "nfcCommissioning",
+    "q-phase-2",
+    "rvc-direct-mode",
+    "rvc-go-home",
+    "soil-sensor",
+    "temperature-sensor-with-screen",
+    "tls"
 ]
 
 
@@ -417,10 +431,10 @@ def dump_ids_from_data_model_dirs():
         def device_type_support_str(d):
             log.info("checking device type for '%s' for '%s'", d.name, dir)
             dt_server_mandatory = [id for id, requirement in d.server_clusters.items() if requirement.conformance(
-                MinimalConformance()).decision == ConformanceDecision.MANDATORY]
+                [], 0, 0).decision == ConformanceDecision.MANDATORY]
             server_provisional = [clusters[c].name for c in dt_server_mandatory if clusters[c].is_provisional]
             dt_client_mandatory = [id for id, requirement in d.client_clusters.items(
-            ) if requirement.conformance(MinimalConformance()).decision == ConformanceDecision.MANDATORY]
+            ) if requirement.conformance([], 0, 0).decision == ConformanceDecision.MANDATORY]
             client_provisional = [clusters[c].name for c in dt_client_mandatory if clusters[c].is_provisional]
             if server_provisional or client_provisional:
                 log.info("Found provisional mandatory clusters server:'%s' "

--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -29,7 +29,7 @@ import click
 import paths
 from lxml import etree
 
-from matter.testing.conformance import ConformanceDecision, MinimalConformance
+from matter.testing.conformance import ConformanceDecision, EMPTY_CLUSTER_GLOBAL_ATTRIBUTES
 from matter.testing.spec_parsing import build_xml_clusters, build_xml_device_types
 
 log = logging.getLogger(__name__)
@@ -431,10 +431,10 @@ def dump_ids_from_data_model_dirs():
         def device_type_support_str(d):
             log.info("checking device type for '%s' for '%s'", d.name, dir)
             dt_server_mandatory = [id for id, requirement in d.server_clusters.items() if requirement.conformance(
-                MinimalConformance()).decision == ConformanceDecision.MANDATORY]
+                EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision == ConformanceDecision.MANDATORY]
             server_provisional = [clusters[c].name for c in dt_server_mandatory if clusters[c].is_provisional]
             dt_client_mandatory = [id for id, requirement in d.client_clusters.items(
-            ) if requirement.conformance(MinimalConformance()).decision == ConformanceDecision.MANDATORY]
+            ) if requirement.conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision == ConformanceDecision.MANDATORY]
             client_provisional = [clusters[c].name for c in dt_client_mandatory if clusters[c].is_provisional]
             if server_provisional or client_provisional:
                 log.info("Found provisional mandatory clusters server:'%s' "

--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -29,7 +29,7 @@ import click
 import paths
 from lxml import etree
 
-from matter.testing.conformance import ConformanceDecision, EMPTY_CLUSTER_GLOBAL_ATTRIBUTES
+from matter.testing.conformance import EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, ConformanceDecision
 from matter.testing.spec_parsing import build_xml_clusters, build_xml_device_types
 
 log = logging.getLogger(__name__)

--- a/scripts/spec_xml/spec_revision_diff_summary.py
+++ b/scripts/spec_xml/spec_revision_diff_summary.py
@@ -22,7 +22,7 @@
 
 import click
 
-from matter.testing.conformance import ConformanceDecision
+from matter.testing.conformance import ConformanceDecision, MinimalConformance
 from matter.testing.spec_parsing import PrebuiltDataModelDirectory, build_xml_clusters, build_xml_device_types
 
 
@@ -119,7 +119,7 @@ def diff_device_types(prior_revision: PrebuiltDataModelDirectory, new_revision: 
 
 
 def _get_provisional(items):
-    return [e.name for e in items if e.conformance(0, [], []).decision == ConformanceDecision.PROVISIONAL]
+    return [e.name for e in items if e.conformance(MinimalConformance()).decision == ConformanceDecision.PROVISIONAL]
 
 
 def get_all_provisional_clusters(new_revision: PrebuiltDataModelDirectory):

--- a/scripts/spec_xml/spec_revision_diff_summary.py
+++ b/scripts/spec_xml/spec_revision_diff_summary.py
@@ -22,7 +22,7 @@
 
 import click
 
-from matter.testing.conformance import ConformanceDecision, EMPTY_CLUSTER_GLOBAL_ATTRIBUTES
+from matter.testing.conformance import EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, ConformanceDecision
 from matter.testing.spec_parsing import PrebuiltDataModelDirectory, build_xml_clusters, build_xml_device_types
 
 

--- a/scripts/spec_xml/spec_revision_diff_summary.py
+++ b/scripts/spec_xml/spec_revision_diff_summary.py
@@ -22,7 +22,7 @@
 
 import click
 
-from matter.testing.conformance import ConformanceDecision, MinimalConformance
+from matter.testing.conformance import ConformanceDecision, EMPTY_CLUSTER_GLOBAL_ATTRIBUTES
 from matter.testing.spec_parsing import PrebuiltDataModelDirectory, build_xml_clusters, build_xml_device_types
 
 
@@ -119,7 +119,7 @@ def diff_device_types(prior_revision: PrebuiltDataModelDirectory, new_revision: 
 
 
 def _get_provisional(items):
-    return [e.name for e in items if e.conformance(MinimalConformance()).decision == ConformanceDecision.PROVISIONAL]
+    return [e.name for e in items if e.conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision == ConformanceDecision.PROVISIONAL]
 
 
 def get_all_provisional_clusters(new_revision: PrebuiltDataModelDirectory):

--- a/src/python_testing/MinimalRepresentation.py
+++ b/src/python_testing/MinimalRepresentation.py
@@ -64,7 +64,8 @@ class MinimalRepresentationChecker(DeviceConformanceTests):
                 all_command_list = cluster[GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID] + \
                     cluster[GlobalAttributeIds.GENERATED_COMMAND_LIST_ID]
                 accepted_command_list = cluster[GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID]
-                cluster_info = ConformanceAssessmentData(feature_map, attribute_list, all_command_list)
+                revision = cluster[GlobalAttributeIds.CLUSTER_REVISION_ID]
+                cluster_info = ConformanceAssessmentData(feature_map, attribute_list, all_command_list, revision)
 
                 # All optional features
                 feature_masks = [1 << i for i in range(32) if feature_map & (1 << i)]

--- a/src/python_testing/MinimalRepresentation.py
+++ b/src/python_testing/MinimalRepresentation.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 
 from TC_DeviceConformance import DeviceConformanceTests
 
-from matter.testing.conformance import ConformanceDecision
+from matter.testing.conformance import ConformanceAssessmentData, ConformanceDecision
 from matter.testing.decorators import async_test_body
 from matter.testing.global_attribute_ids import GlobalAttributeIds
 from matter.testing.matter_testing import MatterBaseTest
@@ -64,12 +64,13 @@ class MinimalRepresentationChecker(DeviceConformanceTests):
                 all_command_list = cluster[GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID] + \
                     cluster[GlobalAttributeIds.GENERATED_COMMAND_LIST_ID]
                 accepted_command_list = cluster[GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID]
+                cluster_info = ConformanceAssessmentData(feature_map, attribute_list, all_command_list)
 
                 # All optional features
                 feature_masks = [1 << i for i in range(32) if feature_map & (1 << i)]
                 for f in feature_masks:
                     xml_feature = self.xml_clusters[cluster_id].features[f]
-                    conformance_decision = xml_feature.conformance(feature_map, attribute_list, all_command_list)
+                    conformance_decision = xml_feature.conformance(cluster_info)
                     if conformance_decision == ConformanceDecision.OPTIONAL:
                         minimal.feature_masks.append(f)
 
@@ -81,7 +82,7 @@ class MinimalRepresentationChecker(DeviceConformanceTests):
                             minimal.attribute_ids.append(attribute_id)
                         continue
                     xml_attribute = self.xml_clusters[cluster_id].attributes[attribute_id]
-                    conformance_decision = xml_attribute.conformance(feature_map, attribute_list, all_command_list)
+                    conformance_decision = xml_attribute.conformance(cluster_info)
                     if conformance_decision == ConformanceDecision.OPTIONAL:
                         minimal.attribute_ids.append(attribute_id)
 
@@ -93,7 +94,7 @@ class MinimalRepresentationChecker(DeviceConformanceTests):
                             minimal.attribute_ids.append(command_id)
                         continue
                     xml_command = self.xml_clusters[cluster_id].accepted_commands[command_id]
-                    conformance_decision = xml_command.conformance(feature_map, attribute_list, all_command_list)
+                    conformance_decision = xml_command.conformance(cluster_info)
                     if conformance_decision == ConformanceDecision.OPTIONAL:
                         minimal.command_ids.append(command_id)
 

--- a/src/python_testing/MinimalRepresentation.py
+++ b/src/python_testing/MinimalRepresentation.py
@@ -65,13 +65,13 @@ class MinimalRepresentationChecker(DeviceConformanceTests):
                     cluster[GlobalAttributeIds.GENERATED_COMMAND_LIST_ID]
                 accepted_command_list = cluster[GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID]
                 revision = cluster[GlobalAttributeIds.CLUSTER_REVISION_ID]
-                cluster_info = ConformanceAssessmentData(feature_map, attribute_list, all_command_list, revision)
+                conformance_assessment_data = ConformanceAssessmentData(feature_map, attribute_list, all_command_list, revision)
 
                 # All optional features
                 feature_masks = [1 << i for i in range(32) if feature_map & (1 << i)]
                 for f in feature_masks:
                     xml_feature = self.xml_clusters[cluster_id].features[f]
-                    conformance_decision = xml_feature.conformance(cluster_info)
+                    conformance_decision = xml_feature.conformance(conformance_assessment_data)
                     if conformance_decision == ConformanceDecision.OPTIONAL:
                         minimal.feature_masks.append(f)
 
@@ -83,7 +83,7 @@ class MinimalRepresentationChecker(DeviceConformanceTests):
                             minimal.attribute_ids.append(attribute_id)
                         continue
                     xml_attribute = self.xml_clusters[cluster_id].attributes[attribute_id]
-                    conformance_decision = xml_attribute.conformance(cluster_info)
+                    conformance_decision = xml_attribute.conformance(conformance_assessment_data)
                     if conformance_decision == ConformanceDecision.OPTIONAL:
                         minimal.attribute_ids.append(attribute_id)
 
@@ -95,7 +95,7 @@ class MinimalRepresentationChecker(DeviceConformanceTests):
                             minimal.attribute_ids.append(command_id)
                         continue
                     xml_command = self.xml_clusters[cluster_id].accepted_commands[command_id]
-                    conformance_decision = xml_command.conformance(cluster_info)
+                    conformance_decision = xml_command.conformance(conformance_assessment_data)
                     if conformance_decision == ConformanceDecision.OPTIONAL:
                         minimal.command_ids.append(command_id)
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/choice_conformance.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/choice_conformance.py
@@ -15,7 +15,7 @@
 #    limitations under the License.
 #
 
-from matter.testing.conformance import Choice, ConformanceDecisionWithChoice
+from matter.testing.conformance import Choice, ConformanceAssessmentData, ConformanceDecisionWithChoice
 from matter.testing.global_attribute_ids import GlobalAttributeIds
 from matter.testing.problem_notices import AttributePathLocation, ProblemNotice, ProblemSeverity
 from matter.testing.spec_parsing import XmlCluster
@@ -47,7 +47,7 @@ def _evaluate_choices(location: AttributePathLocation, counts: dict[Choice, int]
     return problems
 
 
-def evaluate_feature_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], feature_map: uint, attribute_list: list[uint], all_command_list: list[uint]) -> list[ChoiceConformanceProblemNotice]:
+def evaluate_feature_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], info: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
     all_features = [uint(1 << i) for i in range(32)]
     all_features = [f for f in all_features if f in xml_clusters[cluster_id].features]
 
@@ -55,36 +55,34 @@ def evaluate_feature_choice_conformance(endpoint_id: int, cluster_id: int, xml_c
     counts: dict[Choice, int] = {}
     for f in all_features:
         xml_feature = xml_clusters[cluster_id].features[f]
-        conformance_decision_with_choice = xml_feature.conformance(feature_map, attribute_list, all_command_list)
-        _add_to_counts_if_required(conformance_decision_with_choice, (feature_map & f) != 0, counts)
+        conformance_decision_with_choice = xml_feature.conformance(info)
+        _add_to_counts_if_required(conformance_decision_with_choice, (info.feature_map & f) != 0, counts)
 
     location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
                                      attribute_id=GlobalAttributeIds.FEATURE_MAP_ID)
     return _evaluate_choices(location, counts)
 
 
-def evaluate_attribute_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], feature_map: uint, attribute_list: list[uint], all_command_list: list[uint]) -> list[ChoiceConformanceProblemNotice]:
+def evaluate_attribute_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], info: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
     all_attributes = xml_clusters[cluster_id].attributes.keys()
 
     counts: dict[Choice, int] = {}
     for attribute_id in all_attributes:
-        conformance_decision_with_choice = xml_clusters[cluster_id].attributes[attribute_id].conformance(
-            feature_map, attribute_list, all_command_list)
-        _add_to_counts_if_required(conformance_decision_with_choice, attribute_id in attribute_list, counts)
+        conformance_decision_with_choice = xml_clusters[cluster_id].attributes[attribute_id].conformance(info)
+        _add_to_counts_if_required(conformance_decision_with_choice, attribute_id in info.attribute_list, counts)
 
     location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
                                      attribute_id=GlobalAttributeIds.ATTRIBUTE_LIST_ID)
     return _evaluate_choices(location, counts)
 
 
-def evaluate_command_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], feature_map: uint, attribute_list: list[uint], all_command_list: list[uint]) -> list[ChoiceConformanceProblemNotice]:
+def evaluate_command_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], info: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
     all_commands = xml_clusters[cluster_id].accepted_commands.keys()
 
     counts: dict[Choice, int] = {}
     for command_id in all_commands:
-        conformance_decision_with_choice = xml_clusters[cluster_id].accepted_commands[command_id].conformance(
-            feature_map, attribute_list, all_command_list)
-        _add_to_counts_if_required(conformance_decision_with_choice, command_id in all_command_list, counts)
+        conformance_decision_with_choice = xml_clusters[cluster_id].accepted_commands[command_id].conformance(info)
+        _add_to_counts_if_required(conformance_decision_with_choice, command_id in info.all_command_list, counts)
 
     location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
                                      attribute_id=GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/choice_conformance.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/choice_conformance.py
@@ -47,7 +47,7 @@ def _evaluate_choices(location: AttributePathLocation, counts: dict[Choice, int]
     return problems
 
 
-def evaluate_feature_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], info: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
+def evaluate_feature_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], conformance_assessment_data: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
     all_features = [uint(1 << i) for i in range(32)]
     all_features = [f for f in all_features if f in xml_clusters[cluster_id].features]
 
@@ -55,34 +55,38 @@ def evaluate_feature_choice_conformance(endpoint_id: int, cluster_id: int, xml_c
     counts: dict[Choice, int] = {}
     for f in all_features:
         xml_feature = xml_clusters[cluster_id].features[f]
-        conformance_decision_with_choice = xml_feature.conformance(info)
-        _add_to_counts_if_required(conformance_decision_with_choice, (info.feature_map & f) != 0, counts)
+        conformance_decision_with_choice = xml_feature.conformance(conformance_assessment_data)
+        _add_to_counts_if_required(conformance_decision_with_choice, (conformance_assessment_data.feature_map & f) != 0, counts)
 
     location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
                                      attribute_id=GlobalAttributeIds.FEATURE_MAP_ID)
     return _evaluate_choices(location, counts)
 
 
-def evaluate_attribute_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], info: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
+def evaluate_attribute_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], conformance_assessment_data: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
     all_attributes = xml_clusters[cluster_id].attributes.keys()
 
     counts: dict[Choice, int] = {}
     for attribute_id in all_attributes:
-        conformance_decision_with_choice = xml_clusters[cluster_id].attributes[attribute_id].conformance(info)
-        _add_to_counts_if_required(conformance_decision_with_choice, attribute_id in info.attribute_list, counts)
+        conformance_decision_with_choice = xml_clusters[cluster_id].attributes[attribute_id].conformance(
+            conformance_assessment_data)
+        _add_to_counts_if_required(conformance_decision_with_choice,
+                                   attribute_id in conformance_assessment_data.attribute_list, counts)
 
     location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
                                      attribute_id=GlobalAttributeIds.ATTRIBUTE_LIST_ID)
     return _evaluate_choices(location, counts)
 
 
-def evaluate_command_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], info: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
+def evaluate_command_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], conformance_assessment_data: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
     all_commands = xml_clusters[cluster_id].accepted_commands.keys()
 
     counts: dict[Choice, int] = {}
     for command_id in all_commands:
-        conformance_decision_with_choice = xml_clusters[cluster_id].accepted_commands[command_id].conformance(info)
-        _add_to_counts_if_required(conformance_decision_with_choice, command_id in info.all_command_list, counts)
+        conformance_decision_with_choice = xml_clusters[cluster_id].accepted_commands[command_id].conformance(
+            conformance_assessment_data)
+        _add_to_counts_if_required(conformance_decision_with_choice,
+                                   command_id in conformance_assessment_data.all_command_list, counts)
 
     location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
                                      attribute_id=GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
@@ -126,6 +126,7 @@ class ConformanceAssessmentData:
     feature_map: uint
     attribute_list: list[uint]
     all_command_list: list[uint]
+    cluster_revision: uint
 
 
 @dataclass
@@ -134,6 +135,7 @@ class MinimalConformance(ConformanceAssessmentData):
         self.feature_map = uint(0)
         self.attribute_list = []
         self.all_command_list = []
+        self.cluster_revision = uint(1)
 
 
 def conformance_allowed(conformance_decision: ConformanceDecisionWithChoice, allow_provisional: bool):

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
@@ -130,12 +130,15 @@ class ConformanceAssessmentData:
 
 
 @dataclass
-class MinimalConformance(ConformanceAssessmentData):
+class EmptyClusterGlobalAttributes(ConformanceAssessmentData):
     def __init__(self):
         self.feature_map = uint(0)
         self.attribute_list = []
         self.all_command_list = []
         self.cluster_revision = uint(1)
+
+
+EMPTY_CLUSTER_GLOBAL_ATTRIBUTES = EmptyClusterGlobalAttributes()
 
 
 def conformance_allowed(conformance_decision: ConformanceDecisionWithChoice, allow_provisional: bool):
@@ -148,11 +151,11 @@ def conformance_allowed(conformance_decision: ConformanceDecisionWithChoice, all
 
 def is_disallowed(conformance: Callable):
     # Deprecated and disallowed conformances will come back as disallowed regardless of the implemented features / attributes / etc.
-    return conformance(MinimalConformance()).decision == ConformanceDecision.DISALLOWED
+    return conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision == ConformanceDecision.DISALLOWED
 
 
 def is_provisional(conformance: Callable):
-    return conformance(MinimalConformance()).decision == ConformanceDecision.PROVISIONAL
+    return conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision == ConformanceDecision.PROVISIONAL
 
 
 @dataclass

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
@@ -160,7 +160,7 @@ def is_provisional(conformance: Callable):
 
 @dataclass
 class Conformance:
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         ''' Evaluates the conformance of a specific cluster or device type element.
 
             feature_map: The feature_map for the given cluster for which this conformance applies. Used to evaluate feature conformances
@@ -175,7 +175,7 @@ class Conformance:
 
 
 class zigbee(Conformance):
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         return ConformanceDecisionWithChoice(ConformanceDecision.NOT_APPLICABLE)
 
     def __str__(self):
@@ -183,7 +183,7 @@ class zigbee(Conformance):
 
 
 class mandatory(Conformance):
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         return ConformanceDecisionWithChoice(ConformanceDecision.MANDATORY)
 
     def __str__(self):
@@ -194,7 +194,7 @@ class optional(Conformance):
     def __init__(self, choice: Optional[Choice] = None):
         self.choice = choice
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         return ConformanceDecisionWithChoice(ConformanceDecision.OPTIONAL, self.choice)
 
     def __str__(self):
@@ -202,7 +202,7 @@ class optional(Conformance):
 
 
 class deprecated(Conformance):
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         return ConformanceDecisionWithChoice(ConformanceDecision.DISALLOWED)
 
     def __str__(self):
@@ -210,7 +210,7 @@ class deprecated(Conformance):
 
 
 class disallowed(Conformance):
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         return ConformanceDecisionWithChoice(ConformanceDecision.DISALLOWED)
 
     def __str__(self):
@@ -218,7 +218,7 @@ class disallowed(Conformance):
 
 
 class provisional(Conformance):
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         return ConformanceDecisionWithChoice(ConformanceDecision.PROVISIONAL)
 
     def __str__(self):
@@ -232,7 +232,7 @@ class literal(Conformance):
         # This is needed because XML literal values can be in different formats
         self.value = int(value, 0)
 
-    def __call__(self, info: ConformanceAssessmentData):
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData):
         # This should never be called
         raise ConformanceException('Literal conformance function should not be called - this is simply a value holder')
 
@@ -255,8 +255,8 @@ class feature(Conformance):
         self.requiredFeature = requiredFeature
         self.code = code
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
-        if self.requiredFeature & info.feature_map != 0:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+        if self.requiredFeature & conformance_assessment_data.feature_map != 0:
             return ConformanceDecisionWithChoice(ConformanceDecision.MANDATORY)
         return ConformanceDecisionWithChoice(ConformanceDecision.NOT_APPLICABLE)
 
@@ -270,7 +270,7 @@ class device_feature(Conformance):
     def __init__(self, feature: str):
         self.feature = feature
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         if (self.feature.lower() == "matter"):
             return ConformanceDecisionWithChoice(ConformanceDecision.MANDATORY)
         if (self.feature.lower() == 'zigbee'):
@@ -286,8 +286,8 @@ class attribute(Conformance):
         self.requiredAttribute = requiredAttribute
         self.name = name
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
-        if self.requiredAttribute in info.attribute_list:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+        if self.requiredAttribute in conformance_assessment_data.attribute_list:
             return ConformanceDecisionWithChoice(ConformanceDecision.MANDATORY)
         return ConformanceDecisionWithChoice(ConformanceDecision.NOT_APPLICABLE)
 
@@ -300,8 +300,8 @@ class command(Conformance):
         self.requiredCommand = requiredCommand
         self.name = name
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
-        if self.requiredCommand in info.all_command_list:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+        if self.requiredCommand in conformance_assessment_data.all_command_list:
             return ConformanceDecisionWithChoice(ConformanceDecision.MANDATORY)
         return ConformanceDecisionWithChoice(ConformanceDecision.NOT_APPLICABLE)
 
@@ -320,8 +320,8 @@ class optional_wrapper(Conformance):
         self.op = op
         self.choice = choice
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
-        decision_with_choice = self.op(info)
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+        decision_with_choice = self.op(conformance_assessment_data)
 
         if decision_with_choice.decision in [ConformanceDecision.MANDATORY, ConformanceDecision.OPTIONAL]:
             return ConformanceDecisionWithChoice(ConformanceDecision.OPTIONAL, self.choice)
@@ -337,8 +337,8 @@ class mandatory_wrapper(Conformance):
     def __init__(self, op: Conformance):
         self.op = op
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
-        return self.op(info)
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+        return self.op(conformance_assessment_data)
 
     def __str__(self):
         return strip_outer_parentheses(str(self.op))
@@ -350,11 +350,11 @@ class not_operation(Conformance):
             raise ChoiceConformanceException('NOT operation called on choice conformance')
         self.op = op
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         # not operations can't be used with anything that returns DISALLOWED
         # not operations also can't be used with things that are optional
         # ie, ![AB] doesn't make sense, nor does !O
-        decision_with_choice = self.op(info)
+        decision_with_choice = self.op(conformance_assessment_data)
         if decision_with_choice.decision in [ConformanceDecision.DISALLOWED, ConformanceDecision.PROVISIONAL]:
             raise ConformanceException('NOT operation on optional or disallowed item')
         # Features in device types degrade to optional so a not operation here is still optional because we don't have any way to verify the features since they're not exposed anywhere
@@ -377,9 +377,9 @@ class and_operation(Conformance):
                 raise ChoiceConformanceException('AND operation with internal choice conformance')
         self.op_list = op_list
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         for op in self.op_list:
-            decision_with_choice = op(info)
+            decision_with_choice = op(conformance_assessment_data)
             # and operations can't happen on optional or disallowed
             if decision_with_choice.decision == ConformanceDecision.OPTIONAL and all(type(op) == device_feature for op in self.op_list):
                 return decision_with_choice
@@ -404,9 +404,9 @@ class or_operation(Conformance):
                 raise ChoiceConformanceException('OR operation with internal choice conformance')
         self.op_list = op_list
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         for op in self.op_list:
-            decision_with_choice = op(info)
+            decision_with_choice = op(conformance_assessment_data)
             if decision_with_choice.decision in [ConformanceDecision.DISALLOWED, ConformanceDecision.PROVISIONAL]:
                 raise ConformanceException('OR operation on optional or disallowed item')
             if decision_with_choice.decision == ConformanceDecision.NOT_APPLICABLE:
@@ -431,7 +431,7 @@ class greater_operation(Conformance):
         self.op1 = op1
         self.op2 = op2
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         # For now, this is fully optional, need to implement this properly later, but it requires access to the actual attribute values
         # We need to reach into the attribute, but can't use it directly because the attribute callable is an EXISTENCE check and
         # the arithmetic functions require a value.
@@ -445,7 +445,7 @@ class otherwise(Conformance):
     def __init__(self, op_list: list[Conformance]):
         self.op_list = op_list
 
-    def __call__(self, info: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
         # Otherwise operations apply from left to right. If any of them
         # has a definite decision (optional, mandatory or disallowed), that is the one that applies
         # Provisional items are meant to be marked as the first item in the list
@@ -453,7 +453,7 @@ class otherwise(Conformance):
         # For O,D, optional applies (leftmost), but we should consider some way to warn here as well,
         # possibly in another function
         for op in self.op_list:
-            decision_with_choice = op(info)
+            decision_with_choice = op(conformance_assessment_data)
             if decision_with_choice.decision == ConformanceDecision.NOT_APPLICABLE:
                 continue
             return decision_with_choice

--- a/src/python_testing/test_testing/DeviceConformanceTests.py
+++ b/src/python_testing/test_testing/DeviceConformanceTests.py
@@ -161,7 +161,8 @@ class DeviceConformanceTests(BasicCompositionTests):
                 attribute_list = cluster[GlobalAttributeIds.ATTRIBUTE_LIST_ID]
                 all_command_list = cluster[GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID] + \
                     cluster[GlobalAttributeIds.GENERATED_COMMAND_LIST_ID]
-                cluster_info = ConformanceAssessmentData(feature_map, attribute_list, all_command_list)
+                revision = cluster[GlobalAttributeIds.CLUSTER_REVISION_ID]
+                cluster_info = ConformanceAssessmentData(feature_map, attribute_list, all_command_list, revision)
 
                 # Feature conformance checking
                 location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
@@ -435,7 +436,8 @@ class DeviceConformanceTests(BasicCompositionTests):
                     feature_map = endpoint[cluster][cluster.Attributes.FeatureMap]
                     attribute_list = endpoint[cluster][cluster.Attributes.AttributeList]
                     cmd_list = endpoint[cluster][cluster.Attributes.AcceptedCommandList]
-                    cluster_info = ConformanceAssessmentData(feature_map, attribute_list, cmd_list)
+                    revision = endpoint[cluster][cluster.Attributes.ClusterRevision]
+                    cluster_info = ConformanceAssessmentData(feature_map, attribute_list, cmd_list, revision)
 
                     check_feature_overrides(cluster_requirement, cluster_info)
                     check_attribute_overrides(cluster_requirement, cluster_info)

--- a/src/python_testing/test_testing/DeviceConformanceTests.py
+++ b/src/python_testing/test_testing/DeviceConformanceTests.py
@@ -22,7 +22,7 @@ import matter.clusters as Clusters
 from matter.testing.basic_composition import BasicCompositionTests
 from matter.testing.choice_conformance import (evaluate_attribute_choice_conformance, evaluate_command_choice_conformance,
                                                evaluate_feature_choice_conformance)
-from matter.testing.conformance import ConformanceAssessmentData, EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, conformance_allowed
+from matter.testing.conformance import EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, ConformanceAssessmentData, conformance_allowed
 from matter.testing.global_attribute_ids import (ClusterIdType, DeviceTypeIdType, GlobalAttributeIds, cluster_id_type,
                                                  device_type_id_type, is_valid_device_type_id)
 from matter.testing.problem_notices import (AttributePathLocation, ClusterPathLocation, CommandPathLocation, DeviceTypePathLocation,

--- a/src/python_testing/test_testing/DeviceConformanceTests.py
+++ b/src/python_testing/test_testing/DeviceConformanceTests.py
@@ -22,7 +22,7 @@ import matter.clusters as Clusters
 from matter.testing.basic_composition import BasicCompositionTests
 from matter.testing.choice_conformance import (evaluate_attribute_choice_conformance, evaluate_command_choice_conformance,
                                                evaluate_feature_choice_conformance)
-from matter.testing.conformance import ConformanceAssessmentData, MinimalConformance, conformance_allowed
+from matter.testing.conformance import ConformanceAssessmentData, EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, conformance_allowed
 from matter.testing.global_attribute_ids import (ClusterIdType, DeviceTypeIdType, GlobalAttributeIds, cluster_id_type,
                                                  device_type_id_type, is_valid_device_type_id)
 from matter.testing.problem_notices import (AttributePathLocation, ClusterPathLocation, CommandPathLocation, DeviceTypePathLocation,
@@ -382,7 +382,7 @@ class DeviceConformanceTests(BasicCompositionTests):
                 # TODO: check client clusters too?
                 for cluster_id, cluster_requirement in xml_device.server_clusters.items():
                     # Device type cluster conformances do not include any conformances based on cluster elements
-                    conformance_decision_with_choice = cluster_requirement.conformance(MinimalConformance())
+                    conformance_decision_with_choice = cluster_requirement.conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES)
                     location = DeviceTypePathLocation(device_type_id=device_type_id, cluster_id=cluster_id)
                     if conformance_decision_with_choice.is_mandatory() and cluster_id not in server_clusters:
                         record_error(location=location,

--- a/src/python_testing/test_testing/TestChoiceConformanceSupport.py
+++ b/src/python_testing/test_testing/TestChoiceConformanceSupport.py
@@ -197,19 +197,19 @@ class TestConformanceSupport(MatterBaseTest):
             return feature_map
 
         for combo, expected_failures in self.all_id_combos:
-            info = ConformanceAssessmentData(make_feature_map(combo), [], [])
+            info = ConformanceAssessmentData(make_feature_map(combo), [], [], 1)
             problems = evaluate_feature_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 
     def test_attributes(self):
         for combo, expected_failures in self.all_id_combos:
-            info = ConformanceAssessmentData(0, list(combo), [])
+            info = ConformanceAssessmentData(0, list(combo), [], 1)
             problems = evaluate_attribute_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 
     def test_commands(self):
         for combo, expected_failures in self.all_id_combos:
-            info = ConformanceAssessmentData(0, [], list(combo))
+            info = ConformanceAssessmentData(0, [], list(combo), 1)
             problems = evaluate_command_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 

--- a/src/python_testing/test_testing/TestChoiceConformanceSupport.py
+++ b/src/python_testing/test_testing/TestChoiceConformanceSupport.py
@@ -23,6 +23,7 @@ from mobly import asserts
 
 from matter.testing.choice_conformance import (evaluate_attribute_choice_conformance, evaluate_command_choice_conformance,
                                                evaluate_feature_choice_conformance)
+from matter.testing.conformance import ConformanceAssessmentData
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.problem_notices import ProblemNotice
 from matter.testing.runner import default_matter_test_main
@@ -196,17 +197,20 @@ class TestConformanceSupport(MatterBaseTest):
             return feature_map
 
         for combo, expected_failures in self.all_id_combos:
-            problems = evaluate_feature_choice_conformance(0, 1, self.clusters, make_feature_map(combo), [], [])
+            info = ConformanceAssessmentData(make_feature_map(combo), [], [])
+            problems = evaluate_feature_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 
     def test_attributes(self):
         for combo, expected_failures in self.all_id_combos:
-            problems = evaluate_attribute_choice_conformance(0, 1, self.clusters, 0, list(combo), [])
+            info = ConformanceAssessmentData(0, list(combo), [])
+            problems = evaluate_attribute_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 
     def test_commands(self):
         for combo, expected_failures in self.all_id_combos:
-            problems = evaluate_command_choice_conformance(0, 1, self.clusters, 0, [], list(combo))
+            info = ConformanceAssessmentData(0, [], list(combo))
+            problems = evaluate_command_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 
 

--- a/src/python_testing/test_testing/TestChoiceConformanceSupport.py
+++ b/src/python_testing/test_testing/TestChoiceConformanceSupport.py
@@ -197,19 +197,20 @@ class TestConformanceSupport(MatterBaseTest):
             return feature_map
 
         for combo, expected_failures in self.all_id_combos:
-            info = ConformanceAssessmentData(make_feature_map(combo), [], [], 1)
+            info = ConformanceAssessmentData(feature_map=make_feature_map(
+                combo), attribute_list=[], all_command_list=[], cluster_revision=1)
             problems = evaluate_feature_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 
     def test_attributes(self):
         for combo, expected_failures in self.all_id_combos:
-            info = ConformanceAssessmentData(0, list(combo), [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=list(combo), all_command_list=[], cluster_revision=1)
             problems = evaluate_attribute_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 
     def test_commands(self):
         for combo, expected_failures in self.all_id_combos:
-            info = ConformanceAssessmentData(0, [], list(combo), 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=[], all_command_list=list(combo), cluster_revision=1)
             problems = evaluate_command_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -62,7 +62,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
         asserts.assert_equal(str(xml_callable), 'M')
 
@@ -71,7 +71,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         asserts.assert_equal(str(xml_callable), 'O')
 
@@ -80,7 +80,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.DISALLOWED)
         asserts.assert_equal(str(xml_callable), 'X')
 
@@ -88,7 +88,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.DISALLOWED)
         asserts.assert_equal(str(xml_callable), 'D')
 
@@ -97,7 +97,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.PROVISIONAL)
         asserts.assert_equal(str(xml_callable), 'P')
 
@@ -106,7 +106,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'Zigbee')
 
@@ -117,7 +117,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -130,7 +130,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -144,7 +144,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [])
+            info = ConformanceAssessmentData(0, a, [], 1)
             if self.has_attr1[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -157,7 +157,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [])
+            info = ConformanceAssessmentData(0, a, [], 1)
             if self.has_attr2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -174,7 +174,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -187,7 +187,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -201,7 +201,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [])
+            info = ConformanceAssessmentData(0, a, [], 1)
             if self.has_attr1[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -214,7 +214,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [])
+            info = ConformanceAssessmentData(0, a, [], 1)
             if self.has_attr2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -228,7 +228,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, c in enumerate(self.cmd_lists):
-            info = ConformanceAssessmentData(0, [], c)
+            info = ConformanceAssessmentData(0, [], c, 1)
             if self.has_cmd1[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -241,7 +241,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, c in enumerate(self.cmd_lists):
-            info = ConformanceAssessmentData(0, [], c)
+            info = ConformanceAssessmentData(0, [], c, 1)
             if self.has_cmd2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -258,7 +258,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if not self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -273,7 +273,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if not self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -289,7 +289,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [])
+            info = ConformanceAssessmentData(0, a, [], 1)
             if not self.has_attr1[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -304,7 +304,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [])
+            info = ConformanceAssessmentData(0, a, [], 1)
             if not self.has_attr2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -321,7 +321,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if not self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -336,7 +336,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if not self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -354,7 +354,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if self.has_ab[i] and self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -371,7 +371,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [])
+            info = ConformanceAssessmentData(0, a, [], 1)
             if self.has_attr1[i] and self.has_attr2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -389,7 +389,7 @@ class TestConformanceSupport(MatterBaseTest):
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
-                info = ConformanceAssessmentData(f, a, [])
+                info = ConformanceAssessmentData(f, a, [], 1)
                 if self.has_ab[i] and self.has_attr2[j]:
                     asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
                 else:
@@ -407,7 +407,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if self.has_ab[i] or self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -424,7 +424,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [])
+            info = ConformanceAssessmentData(0, a, [], 1)
             if self.has_attr1[i] or self.has_attr2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -442,7 +442,7 @@ class TestConformanceSupport(MatterBaseTest):
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
-                info = ConformanceAssessmentData(f, a, [])
+                info = ConformanceAssessmentData(f, a, [], 1)
                 if self.has_ab[i] or self.has_attr2[j]:
                     asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
                 else:
@@ -462,7 +462,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if not self.has_ab[i] and self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -482,7 +482,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if self.has_ab[i] or not self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -501,7 +501,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if not (self.has_ab[i] or self.has_cd[i]):
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -521,13 +521,13 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         # no features
-        info = ConformanceAssessmentData(0, [], [])
+        info = ConformanceAssessmentData(0, [], [], 1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         # one feature
-        info = ConformanceAssessmentData(0x01, [], [])
+        info = ConformanceAssessmentData(0x01, [], [], 1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         # all features
-        info = ConformanceAssessmentData(0x07, [], [])
+        info = ConformanceAssessmentData(0x07, [], [], 1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         asserts.assert_equal(str(xml_callable), '[AB & CD & EF]')
 
@@ -544,7 +544,7 @@ class TestConformanceSupport(MatterBaseTest):
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
                 for k, c in enumerate(self.cmd_lists):
-                    info = ConformanceAssessmentData(f, a, c)
+                    info = ConformanceAssessmentData(f, a, c, 1)
                     if self.has_ab[i] and self.has_attr1[j] and self.has_cmd1[k]:
                         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
                     else:
@@ -563,13 +563,13 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         # no features
-        info = ConformanceAssessmentData(0x00, [], [])
+        info = ConformanceAssessmentData(0x00, [], [], 1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         # one feature
-        info = ConformanceAssessmentData(0x01, [], [])
+        info = ConformanceAssessmentData(0x01, [], [], 1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         # all features
-        info = ConformanceAssessmentData(0x07, [], [])
+        info = ConformanceAssessmentData(0x07, [], [], 1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         asserts.assert_equal(str(xml_callable), '[AB | CD | EF]')
 
@@ -586,7 +586,7 @@ class TestConformanceSupport(MatterBaseTest):
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
                 for k, c in enumerate(self.cmd_lists):
-                    info = ConformanceAssessmentData(f, a, c)
+                    info = ConformanceAssessmentData(f, a, c, 1)
                     if self.has_ab[i] or self.has_attr1[j] or self.has_cmd1[k]:
                         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
                     else:
@@ -604,7 +604,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -623,7 +623,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             elif self.has_cd[i]:
@@ -647,7 +647,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [])
+            info = ConformanceAssessmentData(f, [], [], 1)
             if self.has_ab[i] and not self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -799,7 +799,7 @@ class TestConformanceSupport(MatterBaseTest):
         return xml_callable
 
     def check_decision(self, more_expected: bool, conformance: Conformance, feature_map: uint, attr_list: list[uint], cmd_list: list[uint]):
-        info = ConformanceAssessmentData(feature_map, attr_list, cmd_list)
+        info = ConformanceAssessmentData(feature_map, attr_list, cmd_list, 1)
         decision = conformance(info)
         asserts.assert_true(decision.choice, 'Expected choice conformance on decision, but did not get one')
         asserts.assert_equal(decision.choice.marker, 'a', 'Unexpected conformance string returned')
@@ -868,7 +868,7 @@ class TestConformanceSupport(MatterBaseTest):
                    '</orTerm>'
                    '</optionalConform>')
             conformance = self.check_good_choice(xml, f'[AB | CD].{suffix}')
-            asserts.assert_equal(conformance(ConformanceAssessmentData(0, [], [])).decision,
+            asserts.assert_equal(conformance(ConformanceAssessmentData(0, [], [], 1)).decision,
                                  ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             self.check_decision(more, conformance, AB, [], [])
 
@@ -878,7 +878,7 @@ class TestConformanceSupport(MatterBaseTest):
                    '</notTerm>'
                    '</optionalConform>')
             conformance = self.check_good_choice(xml, f'[!attr1].{suffix}')
-            asserts.assert_equal(conformance(ConformanceAssessmentData(0, attr1, [])).decision,
+            asserts.assert_equal(conformance(ConformanceAssessmentData(0, attr1, [], 1)).decision,
                                  ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             self.check_decision(more, conformance, 0, [], [])
 
@@ -893,11 +893,11 @@ class TestConformanceSupport(MatterBaseTest):
             # with no features or attributes, this should end up as O.a, so there should be a choice
             self.check_decision(more, conformance, 0, [], [])
             # when we have this attribute, we should not have a choice
-            info = ConformanceAssessmentData(0, attr1, [])
+            info = ConformanceAssessmentData(0, attr1, [], 1)
             asserts.assert_equal(conformance(info).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
             asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
             # when we have only this feature, we should not have a choice
-            info = ConformanceAssessmentData(AB, [], [])
+            info = ConformanceAssessmentData(AB, [], [], 1)
             asserts.assert_equal(conformance(info).decision, ConformanceDecision.OPTIONAL, 'Unexpected conformance')
             asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
 
@@ -914,13 +914,13 @@ class TestConformanceSupport(MatterBaseTest):
             conformance = self.check_good_choice(xml, f'attr1, [AB].{suffix}, [CD].b')
             asserts.assert_equal(conformance(MinimalConformance()).decision, ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             # when we have this attribute, we should not have a choice
-            info = ConformanceAssessmentData(0, attr1, [])
+            info = ConformanceAssessmentData(0, attr1, [], 1)
             asserts.assert_equal(conformance(info).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
             asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
             # When it's just AB, we should have a choice
             self.check_decision(more, conformance, AB, [], [])
             # When we have both the attribute and AB, we should not have a choice
-            info = ConformanceAssessmentData(0, attr1, [])
+            info = ConformanceAssessmentData(0, attr1, [], 1)
             asserts.assert_equal(conformance(info).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
             asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
             # When we have AB and CD, we should be using the AB choice
@@ -928,7 +928,7 @@ class TestConformanceSupport(MatterBaseTest):
             ABCD = AB | CD
             self.check_decision(more, conformance, ABCD, [], [])
             # When we just have CD, we still have a choice, but the string should be b
-            info = ConformanceAssessmentData(CD, [], [])
+            info = ConformanceAssessmentData(CD, [], [], 1)
             asserts.assert_equal(conformance(info).decision, ConformanceDecision.OPTIONAL, 'Unexpected conformance')
             asserts.assert_equal(conformance(info).choice, Choice('b', False), 'Unexpected choice in conformance')
 

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -21,7 +21,7 @@ from typing import Callable
 from mobly import asserts
 
 from matter.testing.conformance import (Choice, Conformance, ConformanceAssessmentData, ConformanceDecision, ConformanceException,
-                                        ConformanceParseParameters, deprecated, disallowed, mandatory, optional,
+                                        ConformanceParseParameters, MinimalConformance, deprecated, disallowed, mandatory, optional,
                                         parse_basic_callable_from_xml, parse_callable_from_xml, provisional, zigbee)
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import default_matter_test_main

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -62,7 +62,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
         asserts.assert_equal(str(xml_callable), 'M')
 
@@ -71,7 +71,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         asserts.assert_equal(str(xml_callable), 'O')
 
@@ -80,7 +80,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.DISALLOWED)
         asserts.assert_equal(str(xml_callable), 'X')
 
@@ -88,7 +88,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.DISALLOWED)
         asserts.assert_equal(str(xml_callable), 'D')
 
@@ -97,7 +97,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.PROVISIONAL)
         asserts.assert_equal(str(xml_callable), 'P')
 
@@ -106,7 +106,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'Zigbee')
 
@@ -117,7 +117,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -130,7 +130,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -144,7 +144,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr1[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -157,7 +157,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -174,7 +174,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -187,7 +187,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -201,7 +201,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr1[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -214,7 +214,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -228,7 +228,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, c in enumerate(self.cmd_lists):
-            info = ConformanceAssessmentData(0, [], c, 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=[], all_command_list=c, cluster_revision=1)
             if self.has_cmd1[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -241,7 +241,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, c in enumerate(self.cmd_lists):
-            info = ConformanceAssessmentData(0, [], c, 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=[], all_command_list=c, cluster_revision=1)
             if self.has_cmd2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -258,7 +258,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -273,7 +273,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -289,7 +289,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if not self.has_attr1[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -304,7 +304,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if not self.has_attr2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -321,7 +321,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -336,7 +336,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -354,7 +354,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i] and self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -371,7 +371,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr1[i] and self.has_attr2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -389,7 +389,7 @@ class TestConformanceSupport(MatterBaseTest):
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
-                info = ConformanceAssessmentData(f, a, [], 1)
+                info = ConformanceAssessmentData(feature_map=f, attribute_list=a, all_command_list=[], cluster_revision=1)
                 if self.has_ab[i] and self.has_attr2[j]:
                     asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
                 else:
@@ -407,7 +407,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i] or self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -424,7 +424,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
-            info = ConformanceAssessmentData(0, a, [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr1[i] or self.has_attr2[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -442,7 +442,7 @@ class TestConformanceSupport(MatterBaseTest):
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
-                info = ConformanceAssessmentData(f, a, [], 1)
+                info = ConformanceAssessmentData(feature_map=f, attribute_list=a, all_command_list=[], cluster_revision=1)
                 if self.has_ab[i] or self.has_attr2[j]:
                     asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
                 else:
@@ -462,7 +462,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not self.has_ab[i] and self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -482,7 +482,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i] or not self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -501,7 +501,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not (self.has_ab[i] or self.has_cd[i]):
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
@@ -521,13 +521,13 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         # no features
-        info = ConformanceAssessmentData(0, [], [], 1)
+        info = ConformanceAssessmentData(feature_map=0, attribute_list=[], all_command_list=[], cluster_revision=1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         # one feature
-        info = ConformanceAssessmentData(0x01, [], [], 1)
+        info = ConformanceAssessmentData(feature_map=0x01, attribute_list=[], all_command_list=[], cluster_revision=1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         # all features
-        info = ConformanceAssessmentData(0x07, [], [], 1)
+        info = ConformanceAssessmentData(feature_map=0x07, attribute_list=[], all_command_list=[], cluster_revision=1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         asserts.assert_equal(str(xml_callable), '[AB & CD & EF]')
 
@@ -544,7 +544,7 @@ class TestConformanceSupport(MatterBaseTest):
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
                 for k, c in enumerate(self.cmd_lists):
-                    info = ConformanceAssessmentData(f, a, c, 1)
+                    info = ConformanceAssessmentData(feature_map=f, attribute_list=a, all_command_list=c, cluster_revision=1)
                     if self.has_ab[i] and self.has_attr1[j] and self.has_cmd1[k]:
                         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
                     else:
@@ -563,13 +563,13 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         # no features
-        info = ConformanceAssessmentData(0x00, [], [], 1)
+        info = ConformanceAssessmentData(feature_map=0x00, attribute_list=[], all_command_list=[], cluster_revision=1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         # one feature
-        info = ConformanceAssessmentData(0x01, [], [], 1)
+        info = ConformanceAssessmentData(feature_map=0x01, attribute_list=[], all_command_list=[], cluster_revision=1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         # all features
-        info = ConformanceAssessmentData(0x07, [], [], 1)
+        info = ConformanceAssessmentData(feature_map=0x07, attribute_list=[], all_command_list=[], cluster_revision=1)
         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         asserts.assert_equal(str(xml_callable), '[AB | CD | EF]')
 
@@ -586,7 +586,7 @@ class TestConformanceSupport(MatterBaseTest):
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
                 for k, c in enumerate(self.cmd_lists):
-                    info = ConformanceAssessmentData(f, a, c, 1)
+                    info = ConformanceAssessmentData(feature_map=f, attribute_list=a, all_command_list=c, cluster_revision=1)
                     if self.has_ab[i] or self.has_attr1[j] or self.has_cmd1[k]:
                         asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
                     else:
@@ -604,7 +604,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -623,7 +623,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             elif self.has_cd[i]:
@@ -647,7 +647,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
-            info = ConformanceAssessmentData(f, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i] and not self.has_cd[i]:
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
@@ -799,7 +799,8 @@ class TestConformanceSupport(MatterBaseTest):
         return xml_callable
 
     def check_decision(self, more_expected: bool, conformance: Conformance, feature_map: uint, attr_list: list[uint], cmd_list: list[uint]):
-        info = ConformanceAssessmentData(feature_map, attr_list, cmd_list, 1)
+        info = ConformanceAssessmentData(feature_map=feature_map, attribute_list=attr_list,
+                                         all_command_list=cmd_list, cluster_revision=1)
         decision = conformance(info)
         asserts.assert_true(decision.choice, 'Expected choice conformance on decision, but did not get one')
         asserts.assert_equal(decision.choice.marker, 'a', 'Unexpected conformance string returned')
@@ -871,7 +872,7 @@ class TestConformanceSupport(MatterBaseTest):
                    '</orTerm>'
                    '</optionalConform>')
             conformance = self.check_good_choice(xml, f'[AB | CD].{suffix}')
-            asserts.assert_equal(conformance(ConformanceAssessmentData(0, [], [], 1)).decision,
+            asserts.assert_equal(conformance(ConformanceAssessmentData(feature_map=0, attribute_list=[], all_command_list=[], cluster_revision=1)).decision,
                                  ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             self.check_decision(more, conformance, AB, [], [])
 
@@ -881,7 +882,7 @@ class TestConformanceSupport(MatterBaseTest):
                    '</notTerm>'
                    '</optionalConform>')
             conformance = self.check_good_choice(xml, f'[!attr1].{suffix}')
-            asserts.assert_equal(conformance(ConformanceAssessmentData(0, attr1, [], 1)).decision,
+            asserts.assert_equal(conformance(ConformanceAssessmentData(feature_map=0, attribute_list=attr1, all_command_list=[], cluster_revision=1)).decision,
                                  ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             self.check_decision(more, conformance, 0, [], [])
 
@@ -896,11 +897,11 @@ class TestConformanceSupport(MatterBaseTest):
             # with no features or attributes, this should end up as O.a, so there should be a choice
             self.check_decision(more, conformance, 0, [], [])
             # when we have this attribute, we should not have a choice
-            info = ConformanceAssessmentData(0, attr1, [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=attr1, all_command_list=[], cluster_revision=1)
             asserts.assert_equal(conformance(info).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
             asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
             # when we have only this feature, we should not have a choice
-            info = ConformanceAssessmentData(AB, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=AB, attribute_list=[], all_command_list=[], cluster_revision=1)
             asserts.assert_equal(conformance(info).decision, ConformanceDecision.OPTIONAL, 'Unexpected conformance')
             asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
 
@@ -918,13 +919,13 @@ class TestConformanceSupport(MatterBaseTest):
             asserts.assert_equal(conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision,
                                  ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             # when we have this attribute, we should not have a choice
-            info = ConformanceAssessmentData(0, attr1, [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=attr1, all_command_list=[], cluster_revision=1)
             asserts.assert_equal(conformance(info).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
             asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
             # When it's just AB, we should have a choice
             self.check_decision(more, conformance, AB, [], [])
             # When we have both the attribute and AB, we should not have a choice
-            info = ConformanceAssessmentData(0, attr1, [], 1)
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=attr1, all_command_list=[], cluster_revision=1)
             asserts.assert_equal(conformance(info).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
             asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
             # When we have AB and CD, we should be using the AB choice
@@ -932,7 +933,7 @@ class TestConformanceSupport(MatterBaseTest):
             ABCD = AB | CD
             self.check_decision(more, conformance, ABCD, [], [])
             # When we just have CD, we still have a choice, but the string should be b
-            info = ConformanceAssessmentData(CD, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=CD, attribute_list=[], all_command_list=[], cluster_revision=1)
             asserts.assert_equal(conformance(info).decision, ConformanceDecision.OPTIONAL, 'Unexpected conformance')
             asserts.assert_equal(conformance(info).choice, Choice('b', False), 'Unexpected choice in conformance')
 

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -20,9 +20,10 @@ from typing import Callable
 
 from mobly import asserts
 
-from matter.testing.conformance import (Choice, Conformance, ConformanceAssessmentData, ConformanceDecision, ConformanceException,
-                                        ConformanceParseParameters, EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, deprecated, disallowed, mandatory, optional,
-                                        parse_basic_callable_from_xml, parse_callable_from_xml, provisional, zigbee)
+from matter.testing.conformance import (EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, Choice, Conformance, ConformanceAssessmentData,
+                                        ConformanceDecision, ConformanceException, ConformanceParseParameters, deprecated,
+                                        disallowed, mandatory, optional, parse_basic_callable_from_xml, parse_callable_from_xml,
+                                        provisional, zigbee)
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import default_matter_test_main
 from matter.tlv import uint

--- a/src/python_testing/test_testing/TestSpecParsingDeviceType.py
+++ b/src/python_testing/test_testing/TestSpecParsingDeviceType.py
@@ -23,7 +23,7 @@ from jinja2 import Template
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.testing.conformance import conformance_allowed
+from matter.testing.conformance import MinimalConformance, conformance_allowed
 from matter.testing.runner import default_matter_test_main
 from matter.testing.spec_parsing import (PrebuiltDataModelDirectory, XmlDeviceType, build_xml_clusters, build_xml_device_types,
                                          parse_single_device_type)
@@ -444,7 +444,7 @@ class TestSpecParsingDeviceType(DeviceConformanceTests):
             expected_problems = 0
             self.create_good_device(id)
             for cluster_id, cluster in dt.server_clusters.items():
-                if not conformance_allowed(cluster.conformance(0, [], []), False):
+                if not conformance_allowed(cluster.conformance(MinimalConformance()), False):
                     self.endpoints[1][Clusters.Descriptor][Clusters.Descriptor.Attributes.ServerList].append(cluster_id)
                     expected_problems += 1
             if expected_problems == 0:

--- a/src/python_testing/test_testing/TestSpecParsingDeviceType.py
+++ b/src/python_testing/test_testing/TestSpecParsingDeviceType.py
@@ -23,7 +23,7 @@ from jinja2 import Template
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.testing.conformance import MinimalConformance, conformance_allowed
+from matter.testing.conformance import EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, conformance_allowed
 from matter.testing.runner import default_matter_test_main
 from matter.testing.spec_parsing import (PrebuiltDataModelDirectory, XmlDeviceType, build_xml_clusters, build_xml_device_types,
                                          parse_single_device_type)
@@ -444,7 +444,7 @@ class TestSpecParsingDeviceType(DeviceConformanceTests):
             expected_problems = 0
             self.create_good_device(id)
             for cluster_id, cluster in dt.server_clusters.items():
-                if not conformance_allowed(cluster.conformance(MinimalConformance()), False):
+                if not conformance_allowed(cluster.conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES), False):
                     self.endpoints[1][Clusters.Descriptor][Clusters.Descriptor.Attributes.ServerList].append(cluster_id)
                     expected_problems += 1
             if expected_problems == 0:

--- a/src/python_testing/test_testing/TestSpecParsingSelection.py
+++ b/src/python_testing/test_testing/TestSpecParsingSelection.py
@@ -20,7 +20,7 @@ from DeviceConformanceTests import DeviceConformanceTests
 from mobly import asserts, signals
 
 import matter.clusters as Clusters
-from matter.testing.conformance import ConformanceDecision, ConformanceException
+from matter.testing.conformance import ConformanceAssessmentData, ConformanceDecision, ConformanceException
 from matter.testing.global_attribute_ids import is_standard_attribute_id
 from matter.testing.runner import default_matter_test_main
 from matter.testing.spec_parsing import PrebuiltDataModelDirectory, build_xml_clusters, dm_from_spec_version
@@ -94,13 +94,14 @@ class TestSpecParsingSelection(DeviceConformanceTests):
             spec_attributes = xml_clusters[cluster.id].attributes
             spec_accepted_commands = xml_clusters[cluster.id].accepted_commands
             spec_generated_commands = xml_clusters[cluster.id].generated_commands
+            info = ConformanceAssessmentData(feature_map, [], [])
             # Build just the lists - basic composition checks the wildcard against the lists, conformance just uses lists
             attributes = [id for id, a in spec_attributes.items() if a.conformance(
-                feature_map, [], []).decision == ConformanceDecision.MANDATORY]
+                info).decision == ConformanceDecision.MANDATORY]
             accepted_commands = [id for id, c in spec_accepted_commands.items() if c.conformance(
-                feature_map, [], []).decision == ConformanceDecision.MANDATORY]
+                info).decision == ConformanceDecision.MANDATORY]
             generated_commands = [id for id, c in spec_generated_commands.items() if c.conformance(
-                feature_map, [], []).decision == ConformanceDecision.MANDATORY]
+                info).decision == ConformanceDecision.MANDATORY]
             attr = cluster.Attributes
 
             resp = {}

--- a/src/python_testing/test_testing/TestSpecParsingSelection.py
+++ b/src/python_testing/test_testing/TestSpecParsingSelection.py
@@ -94,7 +94,7 @@ class TestSpecParsingSelection(DeviceConformanceTests):
             spec_attributes = xml_clusters[cluster.id].attributes
             spec_accepted_commands = xml_clusters[cluster.id].accepted_commands
             spec_generated_commands = xml_clusters[cluster.id].generated_commands
-            info = ConformanceAssessmentData(feature_map, [], [])
+            info = ConformanceAssessmentData(feature_map, [], [], 1)
             # Build just the lists - basic composition checks the wildcard against the lists, conformance just uses lists
             attributes = [id for id, a in spec_attributes.items() if a.conformance(
                 info).decision == ConformanceDecision.MANDATORY]

--- a/src/python_testing/test_testing/TestSpecParsingSelection.py
+++ b/src/python_testing/test_testing/TestSpecParsingSelection.py
@@ -94,7 +94,7 @@ class TestSpecParsingSelection(DeviceConformanceTests):
             spec_attributes = xml_clusters[cluster.id].attributes
             spec_accepted_commands = xml_clusters[cluster.id].accepted_commands
             spec_generated_commands = xml_clusters[cluster.id].generated_commands
-            info = ConformanceAssessmentData(feature_map, [], [], 1)
+            info = ConformanceAssessmentData(feature_map=feature_map, attribute_list=[], all_command_list=[], cluster_revision=1)
             # Build just the lists - basic composition checks the wildcard against the lists, conformance just uses lists
             attributes = [id for id, a in spec_attributes.items() if a.conformance(
                 info).decision == ConformanceDecision.MANDATORY]

--- a/src/python_testing/test_testing/fake_device_builder.py
+++ b/src/python_testing/test_testing/fake_device_builder.py
@@ -17,14 +17,15 @@
 from typing import Any, Optional
 
 import matter.clusters as Clusters
-from matter.testing.conformance import ConformanceDecision
+from matter.testing.conformance import ConformanceAssessmentData, ConformanceDecision
 from matter.testing.global_attribute_ids import GlobalAttributeIds
 from matter.testing.spec_parsing import XmlCluster, XmlDeviceType
 from matter.tlv import uint
 
 
 def _is_mandatory(conformance, feature_map=0):
-    return conformance(feature_map, [], []).decision == ConformanceDecision.MANDATORY
+    info = ConformanceAssessmentData(feature_map, [], [])
+    return conformance(info).decision == ConformanceDecision.MANDATORY
 
 
 def _get_field_by_label(cl_object: Clusters.ClusterObjects.ClusterObject, label: str) -> Optional[Clusters.ClusterObjects.ClusterObjectFieldDescriptor]:
@@ -42,16 +43,17 @@ def create_minimal_cluster(xml_clusters: dict[uint, XmlCluster], cluster_id: int
     for mask in mandatory_features:
         feature_map |= mask
 
+    info = ConformanceAssessmentData(feature_map, [], [])
     mandatory_attributes = [id for id, a in xml_clusters[cluster_id].attributes.items(
-    ) if a.conformance(feature_map, [], []).decision == ConformanceDecision.MANDATORY]
+    ) if a.conformance(info).decision == ConformanceDecision.MANDATORY]
     mandatory_attributes.extend(additional_attributes)
 
     mandatory_accepted_commands = [id for id, c in xml_clusters[cluster_id].accepted_commands.items(
-    ) if c.conformance(feature_map, [], []).decision == ConformanceDecision.MANDATORY]
+    ) if c.conformance(info).decision == ConformanceDecision.MANDATORY]
     mandatory_accepted_commands.extend(additional_commands)
 
     mandatory_generated_commands = [id for id, c in xml_clusters[cluster_id].generated_commands.items(
-    ) if c.conformance(feature_map, [], []).decision == ConformanceDecision.MANDATORY]
+    ) if c.conformance(info).decision == ConformanceDecision.MANDATORY]
 
     revision = xml_clusters[cluster_id].revision
     if is_tlv_endpoint:

--- a/src/python_testing/test_testing/fake_device_builder.py
+++ b/src/python_testing/test_testing/fake_device_builder.py
@@ -23,8 +23,8 @@ from matter.testing.spec_parsing import XmlCluster, XmlDeviceType
 from matter.tlv import uint
 
 
-def _is_mandatory(conformance, feature_map=0):
-    info = ConformanceAssessmentData(feature_map, [], [])
+def _is_mandatory(conformance, feature_map=0, revision=1):
+    info = ConformanceAssessmentData(feature_map, [], [], revision)
     return conformance(info).decision == ConformanceDecision.MANDATORY
 
 
@@ -37,13 +37,15 @@ def _get_field_by_label(cl_object: Clusters.ClusterObjects.ClusterObject, label:
 
 def create_minimal_cluster(xml_clusters: dict[uint, XmlCluster], cluster_id: int, is_tlv_endpoint: bool = True, additional_features: list[uint] = [], additional_attributes: list[uint] = [], additional_commands: list[uint] = []) -> dict[int, Any]:
     attrs = {}
-    mandatory_features = [mask for mask, f in xml_clusters[cluster_id].features.items() if _is_mandatory(f.conformance)]
+    mandatory_features = [mask for mask, f in xml_clusters[cluster_id].features.items(
+    ) if _is_mandatory(f.conformance, revision=xml_clusters[cluster_id].revision)]
     mandatory_features.extend(additional_features)
     feature_map = 0
     for mask in mandatory_features:
         feature_map |= mask
 
-    info = ConformanceAssessmentData(feature_map, [], [])
+    revision = xml_clusters[cluster_id].revision
+    info = ConformanceAssessmentData(feature_map, [], [], revision)
     mandatory_attributes = [id for id, a in xml_clusters[cluster_id].attributes.items(
     ) if a.conformance(info).decision == ConformanceDecision.MANDATORY]
     mandatory_attributes.extend(additional_attributes)
@@ -55,7 +57,6 @@ def create_minimal_cluster(xml_clusters: dict[uint, XmlCluster], cluster_id: int
     mandatory_generated_commands = [id for id, c in xml_clusters[cluster_id].generated_commands.items(
     ) if c.conformance(info).decision == ConformanceDecision.MANDATORY]
 
-    revision = xml_clusters[cluster_id].revision
     if is_tlv_endpoint:
         for m in mandatory_attributes:
             # dummy versions - we're not using the values in this test


### PR DESCRIPTION
#### Summary

This is a setup PR for supporting cluster revision conformance. Right now, the conformance functions are based on the feature map, the attributes and the commands. We now also need to add the cluster revision. Instead of just endlessly extending the function signature, let's pack these into a dataclass like sensible people who plan at least somewhat for the future. Unlike past me.

This PR adds no additional functionality, this is a function signature change, albeit a large one.

#### Related issues

#### Testing

The conformance sections are covered by the TestSpecParsing* and TestConformance* tests, and are used by the TestDeviceBasicComposition and TestDeviceConformance scripts, all run in the CI.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
