### PR TITLE
clang-format: disable `AlignTrailingComments.OverEmptyLines`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,9 @@ AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Right
 AlignOperands:   false
-AlignTrailingComments: true
+AlignTrailingComments:
+  Kind: Always      # Equivalent to true
+  OverEmptyLines: 0 # Align even if there are 2 blank lines between code
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false


### PR DESCRIPTION
#### Summary

This commit disables `AlignTrailingComments.OverEmptyLines` to align with the restyled check.

#### Related issues

I often end up with additional spaces with local format, which fails the restyled check in the CI.

#### Testing

This is checked by the restyled.