### PR TITLE
fix the else if statement that never executs in LogEventPrivate

### DIFF
--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -470,13 +470,7 @@ CHIP_ERROR EventManagement::LogEventPrivate(EventLoggingDelegate * apDelegate, c
 
     mBytesWritten += writer.GetLengthWritten();
 
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(EventLogging, "Log event with error %" CHIP_ERROR_FORMAT, err.Format());
-        writer = checkpoint;
-    }
-    else if (opts.mPriority >= CHIP_CONFIG_EVENT_GLOBAL_PRIORITY)
+    if (opts.mPriority >= CHIP_CONFIG_EVENT_GLOBAL_PRIORITY)
     {
         aEventNumber = mLastEventNumber;
         VendEventNumber();
@@ -491,6 +485,13 @@ exit:
 #endif // CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
 
         err = mpEventReporter->NewEventGenerated(opts.mPath, mBytesWritten);
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(EventLogging, "Log event with error %" CHIP_ERROR_FORMAT, err.Format());
+        writer = checkpoint;
     }
 
     return err;


### PR DESCRIPTION
When jump to `exit`, the `err` always not equal to `CHIP_NO_ERROR`, so the ` else if (opts.mPriority >= CHIP_CONFIG_EVENT_GLOBAL_PRIORITY)` will never be trigger. Which lead to the `VendEventNumber` never be executed, and `mpEventNumberCounter` will never increase. 