### PR TITLE
Remove reference to CHI list from CodeDrivenClusters implementation guide

### DIFF
--- a/docs/cluster_and_device_type_dev/how_to_add_new_dts_and_clusters.md
+++ b/docs/cluster_and_device_type_dev/how_to_add_new_dts_and_clusters.md
@@ -151,7 +151,7 @@ related SDK tests.
                section.
             2. Add an `XYZ Mode` entry to the
                `CommandHandlerInterfaceOnlyClusters` or, if a "code-driven"
-               approach is used,`CodeDrivenClusters` section.
+               approach is used, `CodeDrivenClusters` section.
         8. In
            [src/app/util/util.cpp](https://github.com/project-chip/connectedhomeip/blob/master/src/app/util/util.cpp),
            in the `// Cluster Init Functions...` section, add a void

--- a/docs/cluster_and_device_type_dev/how_to_add_new_dts_and_clusters.md
+++ b/docs/cluster_and_device_type_dev/how_to_add_new_dts_and_clusters.md
@@ -150,8 +150,8 @@ related SDK tests.
             1. Add a `<XYZMode>::ModeTag` to the `EnumsNotUsedAsTypeInXML`
                section.
             2. Add an `XYZ Mode` entry to the
-               `CommandHandlerInterfaceOnlyClusters` or, if a "code-driven" approach
-               is used,`CodeDrivenClusters` section.
+               `CommandHandlerInterfaceOnlyClusters` or, if a "code-driven"
+               approach is used,`CodeDrivenClusters` section.
         8. In
            [src/app/util/util.cpp](https://github.com/project-chip/connectedhomeip/blob/master/src/app/util/util.cpp),
            in the `// Cluster Init Functions...` section, add a void

--- a/docs/cluster_and_device_type_dev/how_to_add_new_dts_and_clusters.md
+++ b/docs/cluster_and_device_type_dev/how_to_add_new_dts_and_clusters.md
@@ -150,7 +150,8 @@ related SDK tests.
             1. Add a `<XYZMode>::ModeTag` to the `EnumsNotUsedAsTypeInXML`
                section.
             2. Add an `XYZ Mode` entry to the
-               `CommandHandlerInterfaceOnlyClusters` section.
+               `CommandHandlerInterfaceOnlyClusters` or, if a "code-driven" approach
+               is used,`CodeDrivenClusters` section.
         8. In
            [src/app/util/util.cpp](https://github.com/project-chip/connectedhomeip/blob/master/src/app/util/util.cpp),
            in the `// Cluster Init Functions...` section, add a void

--- a/docs/cluster_and_device_type_dev/how_to_add_new_dts_and_clusters.md
+++ b/docs/cluster_and_device_type_dev/how_to_add_new_dts_and_clusters.md
@@ -150,8 +150,7 @@ related SDK tests.
             1. Add a `<XYZMode>::ModeTag` to the `EnumsNotUsedAsTypeInXML`
                section.
             2. Add an `XYZ Mode` entry to the
-               `CommandHandlerInterfaceOnlyClusters` or, if a "code-driven"
-               approach is used, `CodeDrivenClusters` section.
+               `CommandHandlerInterfaceOnlyClusters` section.
         8. In
            [src/app/util/util.cpp](https://github.com/project-chip/connectedhomeip/blob/master/src/app/util/util.cpp),
            in the `// Cluster Init Functions...` section, add a void

--- a/docs/guides/migrating_ember_cluster_to_code_driven.md
+++ b/docs/guides/migrating_ember_cluster_to_code_driven.md
@@ -175,7 +175,7 @@ project's Slack channel.
 
 -   [ ] **3.3: Update ZAP Configuration:**
     -   [ ] In `src/app/common/templates/config-data.yaml`, add the cluster to
-            the `CodeDrivenClusters` array.
+            the `CodeDrivenClusters` array and remove it from `CommandHandlerInterfaceOnlyClusters` if it exists there.
     -   [ ] In `src/app/zap-templates/zcl/zcl.json` and
             `zcl-with-test-extensions.json`, add all non-list attributes to the
             `attributeAccessInterfaceAttributes` list.

--- a/docs/guides/migrating_ember_cluster_to_code_driven.md
+++ b/docs/guides/migrating_ember_cluster_to_code_driven.md
@@ -175,7 +175,8 @@ project's Slack channel.
 
 -   [ ] **3.3: Update ZAP Configuration:**
     -   [ ] In `src/app/common/templates/config-data.yaml`, add the cluster to
-            the `CodeDrivenClusters` array and remove it from `CommandHandlerInterfaceOnlyClusters` if it exists there.
+            the `CodeDrivenClusters` array and remove it from
+            `CommandHandlerInterfaceOnlyClusters` if it exists there.
     -   [ ] In `src/app/zap-templates/zcl/zcl.json` and
             `zcl-with-test-extensions.json`, add all non-list attributes to the
             `attributeAccessInterfaceAttributes` list.

--- a/docs/guides/migrating_ember_cluster_to_code_driven.md
+++ b/docs/guides/migrating_ember_cluster_to_code_driven.md
@@ -175,8 +175,7 @@ project's Slack channel.
 
 -   [ ] **3.3: Update ZAP Configuration:**
     -   [ ] In `src/app/common/templates/config-data.yaml`, add the cluster to
-            the `CommandHandlerInterfaceOnlyClusters` and `CodeDrivenClusters`
-            arrays.
+            the `CodeDrivenClusters` array.
     -   [ ] In `src/app/zap-templates/zcl/zcl.json` and
             `zcl-with-test-extensions.json`, add all non-list attributes to the
             `attributeAccessInterfaceAttributes` list.

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -364,7 +364,7 @@ implementation.
    memory for your cluster's attributes (which are now managed by your
    `ClusterLogic`), you must:
     - In `src/app/common/templates/config-data.yaml`, consider adding your
-      cluster to `CommandHandlerInterfaceOnlyClusters` if it does not need Ember
+      cluster to `CodeDrivenClusters` if it does not need Ember
       command dispatch.
     - In `src/app/zap-templates/zcl/zcl.json` and
       `zcl-with-test-extensions.json`, add all non-list attributes of your

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -364,8 +364,8 @@ implementation.
    memory for your cluster's attributes (which are now managed by your
    `ClusterLogic`), you must:
     - In `src/app/common/templates/config-data.yaml`, consider adding your
-      cluster to `CodeDrivenClusters` if it does not need Ember
-      command dispatch.
+      cluster to `CodeDrivenClusters` if it does not need Ember command
+      dispatch.
     - In `src/app/zap-templates/zcl/zcl.json` and
       `zcl-with-test-extensions.json`, add all non-list attributes of your
       cluster to `attributeAccessInterfaceAttributes`. This marks them as

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -363,9 +363,6 @@ implementation.
 6. **Update ZAP Configuration:** To prevent the Ember framework from allocating
    memory for your cluster's attributes (which are now managed by your
    `ClusterLogic`), you must:
-    - In `src/app/common/templates/config-data.yaml`, consider adding your
-      cluster to `CodeDrivenClusters` if it does not need Ember command
-      dispatch.
     - In `src/app/zap-templates/zcl/zcl.json` and
       `zcl-with-test-extensions.json`, add all non-list attributes of your
       cluster to `attributeAccessInterfaceAttributes`. This marks them as


### PR DESCRIPTION
#### Summary

The change from #42557 removed the need to add clusters to the `CommandHandlerInterface` list in the `config-data.yaml` file.

The documentation still references this list in the implementation guide, however this is not needed anymore.

#### Testing

Just a documentation change, no code or implementation was affected.
