### PR TITLE
[Bugfix] VerifyOrDie if DeviceInfoProvider is not set + SetDeviceInfoProvider in TV-Casting Sample and in Fuzzed All Clusters

### DIFF
--- a/examples/all-clusters-app/linux/BUILD.gn
+++ b/examples/all-clusters-app/linux/BUILD.gn
@@ -197,6 +197,7 @@ if (enable_fuzz_test_targets) {
     public_deps = [
       ":chip-all-clusters-common",
       "${chip_root}/examples/platform/linux:app-main",
+      "${chip_root}/examples/providers:all_clusters_device_info_provider",
     ]
   }
 }

--- a/examples/all-clusters-app/linux/BUILD.gn
+++ b/examples/all-clusters-app/linux/BUILD.gn
@@ -136,6 +136,7 @@ if (is_libfuzzer) {
     deps = [
       ":chip-all-clusters-common",
       "${chip_root}/examples/platform/linux:app-main",
+      "${chip_root}/examples/providers:all_clusters_device_info_provider",
     ]
 
     cflags = [ "-Wconversion" ]

--- a/examples/all-clusters-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-app/linux/fuzzing-main.cpp
@@ -21,14 +21,17 @@
 
 #include <CommissionableInit.h>
 
+#include "../../providers/AllClustersExampleDeviceInfoProviderImpl.h" // nogncheck
+
 using namespace chip;
 using namespace chip::DeviceLayer;
 
 namespace {
 
 LinuxCommissionableDataProvider gCommissionableDataProvider;
+chip::DeviceLayer::AllClustersExampleDeviceInfoProviderImpl gAllClustersExampleDeviceInfoProvider;
 
-}
+} // namespace
 
 void CleanShutdown()
 {
@@ -53,6 +56,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
         VerifyOrDie(chip::examples::InitCommissionableDataProvider(gCommissionableDataProvider,
                                                                    LinuxDeviceOptions::GetInstance()) == CHIP_NO_ERROR);
         SetCommissionableDataProvider(&gCommissionableDataProvider);
+
+        DeviceLayer::SetDeviceInfoProvider(&gAllClustersExampleDeviceInfoProvider);
 
         // ChipLinuxAppMainLoop blocks, and we don't want that here.
         static chip::CommonCaseDeviceServerInitParams initParams;

--- a/examples/all-clusters-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-app/linux/fuzzing-main.cpp
@@ -21,7 +21,7 @@
 
 #include <CommissionableInit.h>
 
-#include "../../providers/AllClustersExampleDeviceInfoProviderImpl.h" // nogncheck
+#include "../../providers/AllClustersExampleDeviceInfoProviderImpl.h"
 
 using namespace chip;
 using namespace chip::DeviceLayer;

--- a/examples/all-clusters-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-app/linux/fuzzing-main.cpp
@@ -21,7 +21,7 @@
 
 #include <CommissionableInit.h>
 
-#include "../../providers/AllClustersExampleDeviceInfoProviderImpl.h"
+#include <providers/AllClustersExampleDeviceInfoProviderImpl.h>
 
 using namespace chip;
 using namespace chip::DeviceLayer;

--- a/examples/providers/BUILD.gn
+++ b/examples/providers/BUILD.gn
@@ -16,7 +16,10 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 config("include_providers_dir") {
-  include_dirs = [ "." ]
+  include_dirs = [
+    ".",
+    "${chip_root}/examples",
+  ]
 }
 
 static_library("device_info_provider_please_do_not_reuse_as_is") {

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -33,6 +33,7 @@
 
 #include "LinuxCommissionableDataProvider.h"
 #include "Options.h"
+#include <DeviceInfoProviderImpl.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
@@ -96,6 +97,8 @@ LinuxCommissionableDataProvider gCommissionableDataProvider;
 // For shell and command line processing of commands
 ExampleCredentialIssuerCommands gCredIssuerCommands;
 Commands gCommands;
+
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 CHIP_ERROR ProcessClusterCommand(int argc, char ** argv)
 {
@@ -180,6 +183,10 @@ int main(int argc, char * argv[])
     }
 
     SuccessOrExit(err = CastingServer::GetInstance()->PreInit());
+
+    // DeviceInfoProvider is needed by localization configuration cluster, so we set it before Server::Init to set up the storage of
+    // DeviceInfoProvider properly.
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Enter commissioning mode, open commissioning window
     static chip::CommonCaseDeviceServerInitParams initParams;

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -135,7 +135,10 @@ chip_data_model("tv-casting-common") {
     "${chip_root}/third_party/jsoncpp",
   ]
 
-  public_deps = [ "${chip_root}/src/app/clusters/bindings:binding-manager" ]
+  public_deps = [
+    "${chip_root}/examples/providers:device_info_provider_please_do_not_reuse_as_is",
+    "${chip_root}/src/app/clusters/bindings:binding-manager",
+  ]
 
   if (chip_enable_transport_trace) {
     public_deps +=

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -23,12 +23,17 @@
 #include "support/CastingStore.h"
 #include "support/ChipDeviceEventHandler.h"
 
+#include <DeviceInfoProviderImpl.h>
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/bindings/BindingManager.h>
 #include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
 
+namespace {
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
+
+}
 namespace matter {
 namespace casting {
 namespace core {
@@ -110,6 +115,10 @@ CHIP_ERROR CastingApp::Start()
 {
     ChipLogProgress(Discovery, "CastingApp::Start()");
     VerifyOrReturnError(mState == CASTING_APP_NOT_RUNNING, CHIP_ERROR_INCORRECT_STATE);
+
+    // DeviceInfoProvider is needed by localization configuration cluster, so we set it before Server::Init to set up the storage of
+    // DeviceInfoProvider properly.
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Start Matter server
     chip::ServerInitParams * serverInitParams = mAppParameters->GetServerInitParamsProvider()->Get();

--- a/src/app/clusters/localization-configuration-server/CodegenIntegration.cpp
+++ b/src/app/clusters/localization-configuration-server/CodegenIntegration.cpp
@@ -54,6 +54,7 @@ public:
             ChipLogError(AppServer, "Failed to get active locale on endpoint %u: 0x%02x", endpointId, to_underlying(status));
         }
 
+        VerifyOrDie(DeviceLayer::GetDeviceInfoProvider() != nullptr);
         gServer.Create(*DeviceLayer::GetDeviceInfoProvider(), activeLocale);
         return gServer.Registration();
     }

--- a/src/app/clusters/localization-configuration-server/CodegenIntegration.cpp
+++ b/src/app/clusters/localization-configuration-server/CodegenIntegration.cpp
@@ -54,8 +54,9 @@ public:
             ChipLogError(AppServer, "Failed to get active locale on endpoint %u: 0x%02x", endpointId, to_underlying(status));
         }
 
-        VerifyOrDie(DeviceLayer::GetDeviceInfoProvider() != nullptr);
-        gServer.Create(*DeviceLayer::GetDeviceInfoProvider(), activeLocale);
+        DeviceLayer::DeviceInfoProvider * provider = DeviceLayer::GetDeviceInfoProvider();
+        VerifyOrDie(provider != nullptr);
+        gServer.Create(*provider, activeLocale);
         return gServer.Registration();
     }
 


### PR DESCRIPTION
#### Summary

- during `LocalizationConfigurationCluster` Registration: Ensure DeviceInfoProvider by Adding `VerifyOrDie`  if DeviceInfoProvider is not set. 
- TV Casting App was not setting DeviceInfoProvider; Fix for that
- Setting DeviceInfoProvider in Fuzzed All Clusters App.


#### Testing
- Build and Run TV Casting App (both simplified and non simplified version)
  - `scripts/build/build_examples.py --target linux-x64-tv-casting-app-clang-asan build`
  - `"scripts/examples/gn_build_example.sh examples/tv-casting-app/linux/ out/tv-casting-app chip_casting_simplified=true"`
- Running libfuzzer Fuzzed all clusters after compiling using `scripts/build/build_examples.py --target linux-x64-tests-clang-asan-libfuzzer  build`
- Running Dockerized OSS Fuzz 


