### PR TITLE
[OccupancySensingCluster] Cancel Hold Timer on Shutdown

### DIFF
--- a/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp
+++ b/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp
@@ -120,6 +120,15 @@ CHIP_ERROR OccupancySensingCluster::Startup(ServerClusterContext & context)
     return CHIP_NO_ERROR;
 }
 
+void OccupancySensingCluster::Shutdown(ClusterShutdownType shutdownType)
+{
+    if (mHoldTimeDelegate)
+    {
+        mHoldTimeDelegate->CancelTimer(this);
+    }
+    DefaultServerCluster::Shutdown(shutdownType);
+}
+
 DataModel::ActionReturnStatus OccupancySensingCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                                      AttributeValueEncoder & encoder)
 {

--- a/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.h
+++ b/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.h
@@ -89,6 +89,7 @@ public:
     ~OccupancySensingCluster() = default;
 
     CHIP_ERROR Startup(ServerClusterContext & context) override;
+    void Shutdown(ClusterShutdownType shutdownType) override;
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                 AttributeValueEncoder & encoder) override;
     DataModel::ActionReturnStatus WriteAttribute(const DataModel::WriteAttributeRequest & request,

--- a/src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp
+++ b/src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp
@@ -1001,8 +1001,8 @@ TEST_F(TestOccupancySensingCluster, TestShutdownCancelsTimer)
     OccupancySensing::Structs::HoldTimeLimitsStruct::Type holdTimeLimitsConfig = { .holdTimeMin     = 10,
                                                                                    .holdTimeMax     = 200,
                                                                                    .holdTimeDefault = kHoldTime };
-    OccupancySensingCluster cluster{ OccupancySensingCluster::Config{ kTestEndpointId }
-                                         .WithHoldTime(kHoldTime, holdTimeLimitsConfig, mMockTimerDelegate) };
+    OccupancySensingCluster cluster{ OccupancySensingCluster::Config{ kTestEndpointId }.WithHoldTime(
+        kHoldTime, holdTimeLimitsConfig, mMockTimerDelegate) };
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
     // 1. Set occupancy to true, then false to start the timer.

--- a/src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp
+++ b/src/app/clusters/occupancy-sensor-server/tests/TestOccupancySensingCluster.cpp
@@ -994,4 +994,28 @@ TEST_F(TestOccupancySensingCluster, TestDeprecatedAttributesVisibility)
     }
 }
 
+TEST_F(TestOccupancySensingCluster, TestShutdownCancelsTimer)
+{
+    chip::Testing::TestServerClusterContext context;
+    constexpr uint16_t kHoldTime                                               = 100;
+    OccupancySensing::Structs::HoldTimeLimitsStruct::Type holdTimeLimitsConfig = { .holdTimeMin     = 10,
+                                                                                   .holdTimeMax     = 200,
+                                                                                   .holdTimeDefault = kHoldTime };
+    OccupancySensingCluster cluster{ OccupancySensingCluster::Config{ kTestEndpointId }
+                                         .WithHoldTime(kHoldTime, holdTimeLimitsConfig, mMockTimerDelegate) };
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    // 1. Set occupancy to true, then false to start the timer.
+    cluster.SetOccupancy(true);
+    cluster.SetOccupancy(false);
+    EXPECT_TRUE(cluster.IsOccupied());
+    EXPECT_TRUE(mMockTimerDelegate.IsTimerActive(&cluster));
+
+    // 2. Shutdown the cluster.
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+
+    // 3. Verify that the timer is cancelled.
+    EXPECT_FALSE(mMockTimerDelegate.IsTimerActive(&cluster));
+}
+
 } // namespace


### PR DESCRIPTION
#### Summary

This PR addresses a potential use-after-free issue in the `OccupancySensingCluster`. Previously, the cluster did not cancel its hold time timer upon shutdown. If the cluster object was destroyed while the timer was still active, the timer firing later could lead to accessing freed memory.

Changes included:
*   **Added `Shutdown` Override:** Implemented the `Shutdown` method in `OccupancySensingCluster` to explicitly cancel the hold time timer if it is active.
*   **Regression Test:** Added `TestShutdownCancelsTimer` to `TestOccupancySensingCluster.cpp` to verify that the timer is indeed cancelled when the cluster is shut down.

#### Testing

*   **Unit Tests:** Added a new unit test case `TestShutdownCancelsTimer` which confirmed the bug (failure) before the fix and passed after the fix.
*   **Regression:** Ran all tests in `TestOccupancySensingCluster` to ensure no regressions were introduced.
    *   Command: `ninja -C out src/app/clusters/occupancy-sensor-server/tests:TestOccupancySensingCluster && ./out/tests/TestOccupancySensingCluster`