### PR TITLE
[OSS-Fuzz] Stop Static Linking after migrating to ubuntu 24.04 runner

### DIFF
--- a/build/config/linux/pkg_config.gni
+++ b/build/config/linux/pkg_config.gni
@@ -139,26 +139,6 @@ template("pkg_config") {
         lib_dirs = pkgresult[4]
       }
 
-      # Link libraries statically for OSS-Fuzz fuzzer build
-      if (oss_fuzz) {
-        # Output libs needed for static linking (direct + transitive/non-direct libs), we will re-execute the script to get those libs
-        args += [ "--static" ]
-        pkgresult_static = exec_script(pkg_config_script, args, "value")
-        libs = []
-        ldflags = [ "-Wl,-Bstatic" ]
-        foreach(lib, pkgresult_static[3]) {
-          # dl(dynamic loading) lib is not needed for linking statically and its presence triggers errors.
-          # example of errors:
-          #   ld.lld: error: undefined symbol: __dlsym
-          #   >>> referenced by dlsym.o:(dlsym) in archive /lib/x86_64-linux-gnu/libdl.a
-          if (lib != "dl") {
-            ldflags += [ "-l$lib" ]
-          }
-        }
-        ldflags += [ "-Wl,-Bdynamic" ]
-        lib_dirs = pkgresult[4]
-      }
-
       forward_variables_from(invoker, [ "defines" ])
     }
   }


### PR DESCRIPTION

#### Summary

- Stop static linking of libraries after migrating to Ubuntu 24.04 runners, as static versions of many system libraries are no longer provided by the distribution, increasing maintenance cost and build complexity.

 - For example, the libmount-dev package no longer includes a static `.a` library.
 

#### Testing

- Tested in dockerised OSS Fuzz
- and in https://github.com/google/oss-fuzz/pull/14104
