### PR TITLE
[Zephyr][config][common] Moving CHIP_CRYPTO Kconfig to common file and convert to choice

### DIFF
--- a/config/common/cmake/Kconfig
+++ b/config/common/cmake/Kconfig
@@ -350,12 +350,28 @@ config CHIP_OPERATIONAL_TIME_SAVE_INTERVAL
 	  performing frequent saves to know the precise operational time (in case of
 	  device reboot) and maximizing the flash memory lifetime.
 
-config CHIP_CRYPTO_PSA
-	bool "Use PSA crypto API for cryptographic operations"
-	help
-	  Enables the implementation of the Matter cryptographic operations that is
-	  based on the PSA crypto API (instead of the default implementation, which
-	  is based on the legacy mbedTLS APIs).
+choice CHIP_CRYPTO
+	prompt "CHIP Crypto selection"
+	default CHIP_CRYPTO_MBEDTLS
+
+	config CHIP_CRYPTO_MBEDTLS
+		bool "CHIP MbedTLS crypto"
+		help
+			Enables the implementation of the Matter cryptographic operations that is
+			based on the mbedTLS crypto API.
+
+	config CHIP_CRYPTO_PLATFORM
+		bool "CHIP platform crypto"
+		help
+			Enables the implementation of the Matter cryptographic operations that is
+			based on the platform crypto API.
+
+	config CHIP_CRYPTO_PSA
+		bool "CHIP PSA crypto"
+		help
+			Enables the implementation of the Matter cryptographic operations that is
+			based on the PSA crypto API.
+endchoice
 
 config CHIP_CRYPTO_PSA_AEAD_SINGLE_PART
     bool "Use PSA AEAD single-part API"

--- a/config/common/cmake/Kconfig
+++ b/config/common/cmake/Kconfig
@@ -371,6 +371,7 @@ choice CHIP_CRYPTO
 		help
 			Enables the implementation of the Matter cryptographic operations that is
 			based on the PSA crypto API.
+
 endchoice
 
 config CHIP_CRYPTO_PSA_AEAD_SINGLE_PART

--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -358,6 +358,7 @@ config MBEDTLS_HEAP_SIZE
 
 choice CHIP_CRYPTO
     default CHIP_CRYPTO_PSA if !CHIP_WIFI
+
 endchoice
 
 config CHIP_CRYPTO_PSA

--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -356,8 +356,11 @@ config MBEDTLS_HEAP_SIZE
 
 # Enable PSA Crypto dependencies for Matter
 
+choice CHIP_CRYPTO
+    default CHIP_CRYPTO_PSA if !CHIP_WIFI
+endchoice
+
 config CHIP_CRYPTO_PSA
-    default y if !CHIP_WIFI
     imply PSA_WANT_ALG_SPAKE2P_MATTER
     imply PSA_WANT_KEY_TYPE_SPAKE2P_KEY_PAIR_IMPORT if PSA_CRYPTO_DRIVER_OBERON
 

--- a/config/nxp/chip-cmake-freertos/Kconfig
+++ b/config/nxp/chip-cmake-freertos/Kconfig
@@ -113,30 +113,6 @@ choice CHIP_NVM_COMPONENT
 			Use the NVM Framework component to store CHIP data.
 endchoice
 
-choice CHIP_CRYPTO
-	prompt "CHIP Crypto selection"
-	default CHIP_CRYPTO_PLATFORM if CHIP_NXP_PLATFORM_MCXW71 || CHIP_NXP_PLATFORM_MCXW72 || CHIP_SE05X
-	default CHIP_CRYPTO_MBEDTLS if CHIP_NXP_PLATFORM_RW61X || CHIP_NXP_PLATFORM_RT1170 || CHIP_NXP_PLATFORM_RT1060
-
-	config CHIP_CRYPTO_MBEDTLS
-		bool "CHIP MbedTLS crypto"
-		help
-			Enables the implementation of the Matter cryptographic operations that is
-			based on the mbedTLS crypto API.
-
-	config CHIP_CRYPTO_PLATFORM
-		bool "CHIP platform crypto"
-		help
-			Enables the implementation of the Matter cryptographic operations that is
-			based on the platform crypto API.
-
-	config CHIP_CRYPTO_PSA
-		bool "CHIP PSA crypto"
-		help
-			Enables the implementation of the Matter cryptographic operations that is
-			based on the PSA crypto API.
-endchoice
-
 config CHIP_USE_GENERATED_CONFIG
 	bool "Use generated config"
 	default y

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -456,6 +456,7 @@ config MBEDTLS_ECP_DP_SECP256R1_ENABLED
 
 choice CHIP_CRYPTO
     default CHIP_CRYPTO_PSA
+
 endchoice
 
 if CHIP_CRYPTO_PSA

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -454,8 +454,9 @@ config MBEDTLS_ECP_C
 config MBEDTLS_ECP_DP_SECP256R1_ENABLED
 	default y
 
-config CHIP_CRYPTO_PSA
-	default y
+choice CHIP_CRYPTO
+    default CHIP_CRYPTO_PSA
+endchoice
 
 if CHIP_CRYPTO_PSA
 

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -524,10 +524,6 @@ config MBEDTLS_PSA_CRYPTO_C
     bool "MBEDTLS_PSA_CRYPTO_C"
     default n
 
-config CHIP_CRYPTO_PSA
-    bool "CHIP_CRYPTO_PSA"
-    default n
-
 endif # !ZEPHYR_VERSION_3_3
 
 config GETOPT_LONG


### PR DESCRIPTION
#### Summary

This PR is part of Issue #42453 and focuses on centralizing the **CHIP_CRYPTO** Kconfig option into the shared file **config/common/cmake/Kconfig**.
Additionally, CHIP_CRYPTO has been refactored into a **choice** to allow selecting between **mbedtls**, **platform**, and **psa** implementations.
Platform-specific Kconfig files were updated accordingly to align with this new structure.

This change improves modularity, ensures consistent crypto configuration across platforms, and simplifies maintenance by centralizing the crypto selection logic.

#### Related issues

This PR is part of #42453

#### Testing

Testing done by building NXP Zephyr and NXP FreeRTOS applications:
- zephyr: "west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr/"
- freertos: "west build -d build_nxp_freertos -b frdmrw612 examples/nxp/thermostat"
