### PR TITLE
Add ambient context sensor device type

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1234,6 +1234,23 @@ limitations under the License.
         </clusters>
     </deviceType>
     <deviceType>
+        <name>MA-ambient-context-sensor</name>
+        <domain>CHIP</domain>
+        <typeName>Ambient Context Sensor</typeName>
+        <profileId editable="false">0x0103</profileId>
+        <deviceId editable="false">0x0150</deviceId>
+        <revision editable="false">1</revision>
+        <class>Simple</class>
+        <scope>Endpoint</scope>
+        <clusters>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Service Area" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Ambient Context Sensing" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Boolean State Configuration" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+        </clusters>
+    </deviceType>
+    <deviceType>
         <name>MA-closure</name>
         <domain>CHIP</domain>
         <typeName>Closure</typeName>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1245,9 +1245,9 @@ limitations under the License.
         <clusters>
             <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Service Area" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Ambient Context Sensing" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Boolean State Configuration" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Ambient Context Sensing" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Boolean State Configuration" client="false" server="true" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
     <deviceType>

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -7069,6 +7069,7 @@ typedef NS_ENUM(uint32_t, MTRDeviceTypeIDType) {
     MTRDeviceTypeIDTypeChimeID MTR_PROVISIONALLY_AVAILABLE = 0x00000146,
     MTRDeviceTypeIDTypeCameraControllerID MTR_PROVISIONALLY_AVAILABLE = 0x00000147,
     MTRDeviceTypeIDTypeDoorbellID MTR_PROVISIONALLY_AVAILABLE = 0x00000148,
+    MTRDeviceTypeIDTypeAmbientContextSensorID MTR_PROVISIONALLY_AVAILABLE = 0x00000150,
     MTRDeviceTypeIDTypeWindowCoveringID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x00000202,
     MTRDeviceTypeIDTypeWindowCoveringControllerID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x00000203,
     MTRDeviceTypeIDTypeClosureID MTR_PROVISIONALLY_AVAILABLE = 0x00000230,

--- a/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
@@ -90,6 +90,7 @@ static /* constexpr */ const MTRDeviceTypeData knownDeviceTypes[] = {
     { 0x00000146, MTRDeviceTypeClass::Simple, @"Chime" },
     { 0x00000147, MTRDeviceTypeClass::Simple, @"Camera Controller" },
     { 0x00000148, MTRDeviceTypeClass::Simple, @"Doorbell" },
+    { 0x00000150, MTRDeviceTypeClass::Simple, @"Ambient Context Sensor" },
     { 0x00000202, MTRDeviceTypeClass::Simple, @"Window Covering" },
     { 0x00000203, MTRDeviceTypeClass::Simple, @"Window Covering Controller" },
     { 0x00000230, MTRDeviceTypeClass::Simple, @"Closure" },

--- a/zzz_generated/app-common/devices/Ids.h
+++ b/zzz_generated/app-common/devices/Ids.h
@@ -224,6 +224,9 @@ constexpr uint8_t kCameraControllerDeviceTypeRevision = 1;
 constexpr DeviceTypeId kDoorbellDeviceTypeId  = 0x00000148;
 constexpr uint8_t kDoorbellDeviceTypeRevision = 1;
 
+constexpr DeviceTypeId kAmbientContextSensorDeviceTypeId  = 0x00000150;
+constexpr uint8_t kAmbientContextSensorDeviceTypeRevision = 1;
+
 constexpr DeviceTypeId kWindowCoveringDeviceTypeId  = 0x00000202;
 constexpr uint8_t kWindowCoveringDeviceTypeRevision = 4;
 

--- a/zzz_generated/app-common/devices/Types.h
+++ b/zzz_generated/app-common/devices/Types.h
@@ -359,6 +359,11 @@ constexpr DataModel::DeviceTypeEntry kDoorbell = {
     .deviceTypeRevision = kDoorbellDeviceTypeRevision,
 };
 
+constexpr DataModel::DeviceTypeEntry kAmbientContextSensor = {
+    .deviceTypeId       = kAmbientContextSensorDeviceTypeId,
+    .deviceTypeRevision = kAmbientContextSensorDeviceTypeRevision,
+};
+
 constexpr DataModel::DeviceTypeEntry kWindowCovering = {
     .deviceTypeId       = kWindowCoveringDeviceTypeId,
     .deviceTypeRevision = kWindowCoveringDeviceTypeRevision,

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
@@ -7323,6 +7323,8 @@ char const * DeviceTypeIdToText(chip::DeviceTypeId id)
         return "Camera Controller";
     case 0x00000148:
         return "Doorbell";
+    case 0x00000150:
+        return "Ambient Context Sensor";
     case 0x00000202:
         return "Window Covering";
     case 0x00000203:


### PR DESCRIPTION
#### Summary

[Ambient Context Sensor] Add ambient context sensor device type

This is done by adding the definition of spec to matter-devices.xml and generated by zap_regen_all.py

#### Related issues

N/A

#### Testing

No error in console messages



