### PR TITLE
Use `reset` not `release` to be explicit about smart pointer cleanup.

### DIFF
--- a/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
@@ -365,7 +365,7 @@ struct TestScenesManagementCluster : public ::testing::Test
     {
         sceneTableProvider.mSceneTable->UnregisterHandler(&mMockSceneHandler);
         cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
-        clusterContext.release();
+        clusterContext.reset();
         fabricTable.Shutdown();
     }
 


### PR DESCRIPTION
Without this the test leaks and asan fails.

#### Testing

Locally tested with ASAN.