### PR TITLE
[Coverage/Conformance report] - Upgrade appengine to python312

### DIFF
--- a/integrations/appengine/webapp_config.yaml
+++ b/integrations/appengine/webapp_config.yaml
@@ -1,4 +1,4 @@
-runtime: python39
+runtime: python312
 handlers:
     - url: /
       static_files: html/index.html


### PR DESCRIPTION
#### Summary

Coverage and conformance reports are broken since October: https://matter-build-automation.ue.r.appspot.com/

The error message says python 39 is EOL.
```
startup-script: ERROR: (gcloud.app.deploy) INVALID_ARGUMENT: Error(s) encountered validating runtime. Runtime python39 is end of support and no longer allowed. Please use the latest Python runtime for App Engine Standard. For internal google applications, please see go/gae-end-of-support.
```

This attempts to fix the issue by upgrading it to python 3.12.

#### Testing

Untested. We'll test once it lands, it's already broken, so not worse.