### PR TITLE
[CI] Run linux asan unit tests in pull requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -197,7 +197,11 @@ jobs:
                   CHIP_ROOT_PATH=examples/placeholder/linux
                   CHIP_ROOT_PATH="$CHIP_ROOT_PATH" BUILD_TYPE="$BUILD_TYPE" scripts/build/gn_gen.sh --args="$GN_ARGS"
                   scripts/run_in_build_env.sh "ninja -C ./out/$BUILD_TYPE"
-            - name: Setup Build, Run Build and Run Tests
+            - name: Setup Build, Run Build and Run Tests (gcc_release)
+              # Running gcc_release tests on pull requests is redundant
+              # it is unlikely to find extra issues beyond the other unit tests already run on PRs.
+              # Instead keep this run for master only
+              if: github.event.pull_request.number == null
               run: |
                   BUILD_TYPE=gcc_release scripts/build/gn_gen.sh --args="is_debug=false"
                   scripts/run_in_build_env.sh "ninja -C ./out/gcc_release"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -204,6 +204,12 @@ jobs:
                   BUILD_TYPE=gcc_release scripts/tests/gn_tests.sh
             - name: Clean output
               run: rm -rf ./out
+            - name: Build and run AddressSanitizer (ASAN) unit tests (Pull Requests only)
+              if: github.event_name == 'pull_request'
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --target linux-x64-tests-asan-clang build \
+                    && rm -rf out/linux-x64-tests-asan-clang"
             - name: Run Tests with sanitizers
               # Sanitizer tests are not likely to find extra issues so running the same tests
               # as above repeatedly on every pull request seems extra time. Instead keep this run


### PR DESCRIPTION
#### Summary

- Previously, we only run asan unit tests after the PR is merged, this could let asan errors sneak in. 
- Its better to run this in the PRs themselves to save time and uncover errors beforehand.

#### Testing

-  Will check in CI that the Step I added was actually run, by looking at the logs