### PR TITLE
[CMSIS-OS] Stack Lock fix

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_CMSISOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_CMSISOS.ipp
@@ -188,17 +188,18 @@ void GenericPlatformManagerImpl_CMSISOS<ImplClass>::_RunEventLoop(void)
 
         // Unlock the CHIP stack, allowing other threads to enter CHIP while
         // the event loop thread is sleeping.
-        StackUnlock unlock;
         ChipDeviceEvent event;
+        _UnlockChipStack();
         osStatus_t eventReceived = osMessageQueueGet(mChipEventQueue, &event, nullptr, waitTimeInTicks);
+        _LockChipStack();
 
         // If an event was received, dispatch it and continue until the queue is empty.
         while (eventReceived == osOK)
         {
-            StackLock lock;
             Impl()->DispatchEvent(&event);
-            StackUnlock unlock;
+            _UnlockChipStack();
             eventReceived = osMessageQueueGet(mChipEventQueue, &event, nullptr, 0);
+            _LockChipStack();
         }
     }
 }


### PR DESCRIPTION


#### Summary

Removed StackLock declaration to ensure coherently handling lock-unlock in the event loop

#### Related issues

Timer handling in CMSIS Platform Manager Impl resulted in an unlock state on timer callbacks.

#### Testing

Build->Flash->Commission and verify timers are in locked state.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
