### PR TITLE
Matter Casting: fix init and memory issues

### DIFF
--- a/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
@@ -78,5 +78,9 @@
 
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 
+#ifndef CHIP_DEVICE_LAYER_TARGET_DARWIN
+// Increase memory pools for better attribute reading performance
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 500 // Default is 15
 // Include the CHIPProjectConfig from platform implementation config
 #include <CHIPProjectConfig.h>
+#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
@@ -107,7 +107,7 @@ public class DACProviderStub implements DACProvider {
       return signature.sign();
 
     } catch (Exception e) {
-      Log.i(TAG, "SignWithDeviceAttestationKey failed", e);
+      Log.e(TAG, "SignWithDeviceAttestationKey failed", e);
       return null;
     }
   }

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
@@ -80,7 +80,6 @@ public class DACProviderStub implements DACProvider {
     try {
       byte[] privateKeyBytes = Base64.decode(kDevelopmentDAC_PrivateKey_FFF1_8001, Base64.DEFAULT);
 
-      boolean isPKCS8 = false;
       PrivateKey privateKey = null;
       KeyFactory keyFactory = KeyFactory.getInstance("EC");
       // the format can be determined by the header in the private key file:
@@ -108,7 +107,7 @@ public class DACProviderStub implements DACProvider {
       return signature.sign();
 
     } catch (Exception e) {
-      Log.i(TAG, "SignWithDeviceAttestationKey e:" + e, e);
+      Log.i(TAG, "SignWithDeviceAttestationKey failed", e);
       return null;
     }
   }

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
@@ -17,6 +17,7 @@
 package com.matter.casting;
 
 import android.util.Base64;
+import android.util.Log;
 import com.matter.casting.support.DACProvider;
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
@@ -26,8 +27,11 @@ import java.security.Signature;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPrivateKeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
 
 public class DACProviderStub implements DACProvider {
+
+  private static final String TAG = DACProviderStub.class.getSimpleName();
 
   private String kDevelopmentDAC_Cert_FFF1_8001 =
       "MIIB5zCCAY6gAwIBAgIIac3xDenlTtEwCgYIKoZIzj0EAwIwPTElMCMGA1UEAwwcTWF0dGVyIERldiBQQUkgMHhGRkYxIG5vIFBJRDEUMBIGCisGAQQBgqJ8AgEMBEZGRjEwIBcNMjIwMjA1MDAwMDAwWhgPOTk5OTEyMzEyMzU5NTlaMFMxJTAjBgNVBAMMHE1hdHRlciBEZXYgREFDIDB4RkZGMS8weDgwMDExFDASBgorBgEEAYKifAIBDARGRkYxMRQwEgYKKwYBBAGConwCAgwEODAwMTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEY6xpNCkQoOVYj8b/Vrtj5i7M7LFI99TrA+5VJgFBV2fRalxmP3k+SRIyYLgpenzX58/HsxaznZjpDSk3dzjoKjYDBeMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMB0GA1UdDgQWBBSI3eezADgpMs/3NMBGJIEPRBaKbzAfBgNVHSMEGDAWgBRjVA5H9kscONE4hKRi0WwZXY/7PDAKBggqhkjOPQQDAgNHADBEAiABJ6J7S0RhDuL83E0reIVWNmC8D3bxchntagjfsrPBzQIga1ngr0Xz6yqFuRnTVzFSjGAoxBUjlUXhCOTlTnCXE1M=";
@@ -76,14 +80,25 @@ public class DACProviderStub implements DACProvider {
     try {
       byte[] privateKeyBytes = Base64.decode(kDevelopmentDAC_PrivateKey_FFF1_8001, Base64.DEFAULT);
 
-      AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance("EC");
-      algorithmParameters.init(new ECGenParameterSpec("secp256r1"));
-      ECParameterSpec parameterSpec = algorithmParameters.getParameterSpec(ECParameterSpec.class);
-      ECPrivateKeySpec ecPrivateKeySpec =
-          new ECPrivateKeySpec(new BigInteger(1, privateKeyBytes), parameterSpec);
-
+      boolean isPKCS8 = false;
+      PrivateKey privateKey = null;
       KeyFactory keyFactory = KeyFactory.getInstance("EC");
-      PrivateKey privateKey = keyFactory.generatePrivate(ecPrivateKeySpec);
+      // the format can be determined by the header in the private key file:
+      // -----BEGIN PRIVATE KEY----- - PKCS#8 format
+      // -----BEGIN EC PRIVATE KEY----- - SEC1/traditional EC format
+      try {
+        // Try PKCS#8 format first.
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKeyBytes);
+        privateKey = keyFactory.generatePrivate(keySpec);
+      } catch (java.security.spec.InvalidKeySpecException e) {
+        // Fallback to SEC1 format.
+        AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance("EC");
+        algorithmParameters.init(new ECGenParameterSpec("secp256r1"));
+        ECParameterSpec parameterSpec = algorithmParameters.getParameterSpec(ECParameterSpec.class);
+        ECPrivateKeySpec ecPrivateKeySpec =
+            new ECPrivateKeySpec(new BigInteger(1, privateKeyBytes), parameterSpec);
+        privateKey = keyFactory.generatePrivate(ecPrivateKeySpec);
+      }
 
       Signature signature = Signature.getInstance("SHA256withECDSA");
       signature.initSign(privateKey);
@@ -93,6 +108,7 @@ public class DACProviderStub implements DACProvider {
       return signature.sign();
 
     } catch (Exception e) {
+      Log.i(TAG, "SignWithDeviceAttestationKey e:" + e, e);
       return null;
     }
   }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -35,8 +35,8 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
     ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() called");
 
     CastingPlayerDiscovery * castingPlayerDiscovery = CastingPlayerDiscovery::GetInstance();
-    std::vector<core::CastingPlayer>::iterator it;
-    std::vector<core::CastingPlayer> cachedCastingPlayers = support::CastingStore::GetInstance()->ReadAll();
+    std::list<core::CastingPlayer>::iterator it;
+    std::list<core::CastingPlayer> cachedCastingPlayers = support::CastingStore::GetInstance()->ReadAll();
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -116,12 +116,18 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
             ChipLogProgress(
                 AppServer,
                 "CastingPlayer::VerifyOrEstablishConnection() *this* CastingPlayer found in cache; checking for TargetApp(s)");
-            unsigned index = (unsigned int) std::distance(cachedCastingPlayers.begin(), it);
-            if (ContainsDesiredTargetApp(&cachedCastingPlayers[index], idOptions.getTargetAppInfoList()))
+            auto it_index = it;
+            if (ContainsDesiredTargetApp(&(*it_index), idOptions.getTargetAppInfoList()))
             {
                 ChipLogProgress(
                     AppServer,
                     "CastingPlayer::VerifyOrEstablishConnection() Attempting to Re-establish CASE with cached CastingPlayer");
+
+                ChipLogProgress(AppServer,
+                                "Assigning from cache. Current: nodeId=0x" ChipLogFormatX64
+                                " fabricIndex=%d, Cached: nodeId=0x" ChipLogFormatX64 " fabricIndex=%d",
+                                ChipLogValueX64(mAttributes.nodeId), mAttributes.fabricIndex,
+                                ChipLogValueX64(it_index->GetNodeId()), it_index->GetFabricIndex());
 
                 // Preserve the IP addresses from the discovered CastingPlayer before overwriting with cached data
                 unsigned int discoveredNumIPs = mAttributes.numIPs;
@@ -131,11 +137,10 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                     discoveredIpAddresses[i] = mAttributes.ipAddresses[i];
                 }
                 chip::Inet::InterfaceId discoveredInterfaceId = mAttributes.interfaceId;
-
-                *this                          = cachedCastingPlayers[index];
-                mConnectionState               = CASTING_PLAYER_CONNECTING;
-                mOnCompleted                   = connectionCallbacks.mOnConnectionComplete;
-                mCommissioningWindowTimeoutSec = commissioningWindowTimeoutSec;
+                *this                                         = *it_index;
+                mConnectionState                              = CASTING_PLAYER_CONNECTING;
+                mOnCompleted                                  = connectionCallbacks.mOnConnectionComplete;
+                mCommissioningWindowTimeoutSec                = commissioningWindowTimeoutSec;
 
                 // Restore the IP addresses from the discovered CastingPlayer
                 mAttributes.numIPs = discoveredNumIPs;
@@ -545,11 +550,28 @@ CastingPlayer & CastingPlayer::operator=(const CastingPlayer & other)
     if (this != &other)
     {
         mAttributes                    = other.mAttributes;
-        mEndpoints                     = other.mEndpoints;
         mConnectionState               = other.mConnectionState;
         mIdOptions                     = other.mIdOptions;
         mCommissioningWindowTimeoutSec = other.mCommissioningWindowTimeoutSec;
         mOnCompleted                   = other.mOnCompleted;
+
+        // Create new Endpoint objects instead of sharing them
+        mEndpoints.clear();
+        for (const auto & endpoint : other.mEndpoints)
+        {
+            // Create EndpointAttributes from the existing endpoint
+            EndpointAttributes attrs;
+            attrs.mId             = endpoint->GetId();
+            attrs.mVendorId       = endpoint->GetVendorId();
+            attrs.mProductId      = endpoint->GetProductId();
+            attrs.mDeviceTypeList = endpoint->GetDeviceTypeList();
+
+            // Create a new Endpoint with the same attributes but pointing to this CastingPlayer
+            auto newEndpoint = std::make_shared<Endpoint>(this, attrs);
+            // Register the same clusters
+            newEndpoint->RegisterClusters(endpoint->GetServerList());
+            mEndpoints.push_back(newEndpoint);
+        }
     }
     return *this;
 }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -125,8 +125,8 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                 ChipLogProgress(AppServer,
                                 "Assigning from cache. Current: nodeId=0x" ChipLogFormatX64
                                 " fabricIndex=%d, Cached: nodeId=0x" ChipLogFormatX64 " fabricIndex=%d",
-                                ChipLogValueX64(mAttributes.nodeId), mAttributes.fabricIndex,
-                                ChipLogValueX64(it->GetNodeId()), it->GetFabricIndex());
+                                ChipLogValueX64(mAttributes.nodeId), mAttributes.fabricIndex, ChipLogValueX64(it->GetNodeId()),
+                                it->GetFabricIndex());
 
                 // Preserve the IP addresses from the discovered CastingPlayer before overwriting with cached data
                 unsigned int discoveredNumIPs = mAttributes.numIPs;

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -116,7 +116,12 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
             ChipLogProgress(
                 AppServer,
                 "CastingPlayer::VerifyOrEstablishConnection() *this* CastingPlayer found in cache; checking for TargetApp(s)");
-            if (ContainsDesiredTargetApp(&*it, idOptions.getTargetAppInfoList()))
+            if (!ContainsDesiredTargetApp(&*it, idOptions.getTargetAppInfoList()))
+            {
+                ChipLogProgress(
+                    AppServer,
+                    "CastingPlayer::VerifyOrEstablishConnection() *this* CastingPlayer not found in cache; TargetApp(s) not found");
+            }
             {
                 ChipLogProgress(
                     AppServer,
@@ -172,7 +177,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                             //
                             // persist the TargetCastingPlayer information into the CastingStore and call mOnCompleted()
                             support::EndpointListLoader::GetInstance()->Initialize(&exchangeMgr, &sessionHandle);
-                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance()->Load();
+                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance() -> Load();
                         },
                         [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
                             ChipLogError(AppServer,

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -116,8 +116,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
             ChipLogProgress(
                 AppServer,
                 "CastingPlayer::VerifyOrEstablishConnection() *this* CastingPlayer found in cache; checking for TargetApp(s)");
-            auto it_index = it;
-            if (ContainsDesiredTargetApp(&(*it_index), idOptions.getTargetAppInfoList()))
+            if (ContainsDesiredTargetApp(&*it, idOptions.getTargetAppInfoList()))
             {
                 ChipLogProgress(
                     AppServer,
@@ -127,7 +126,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                                 "Assigning from cache. Current: nodeId=0x" ChipLogFormatX64
                                 " fabricIndex=%d, Cached: nodeId=0x" ChipLogFormatX64 " fabricIndex=%d",
                                 ChipLogValueX64(mAttributes.nodeId), mAttributes.fabricIndex,
-                                ChipLogValueX64(it_index->GetNodeId()), it_index->GetFabricIndex());
+                                ChipLogValueX64(it->GetNodeId()), it->GetFabricIndex());
 
                 // Preserve the IP addresses from the discovered CastingPlayer before overwriting with cached data
                 unsigned int discoveredNumIPs = mAttributes.numIPs;
@@ -137,7 +136,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                     discoveredIpAddresses[i] = mAttributes.ipAddresses[i];
                 }
                 chip::Inet::InterfaceId discoveredInterfaceId = mAttributes.interfaceId;
-                *this                                         = *it_index;
+                *this                                         = *it;
                 mConnectionState                              = CASTING_PLAYER_CONNECTING;
                 mOnCompleted                                  = connectionCallbacks.mOnConnectionComplete;
                 mCommissioningWindowTimeoutSec                = commissioningWindowTimeoutSec;

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -177,7 +177,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                             //
                             // persist the TargetCastingPlayer information into the CastingStore and call mOnCompleted()
                             support::EndpointListLoader::GetInstance()->Initialize(&exchangeMgr, &sessionHandle);
-                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance() -> Load();
+                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance()->Load();
                         },
                         [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
                             ChipLogError(AppServer,

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -110,8 +110,11 @@
 
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 
+#ifndef CHIP_DEVICE_LAYER_TARGET_DARWIN
+// Increase memory pools for better attribute reading performance
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 500 // Default is 15
+
 // Include the CHIPProjectConfig from config/standalone
 // Add this at the end so that we can hit our #defines first
-#ifndef CHIP_DEVICE_LAYER_TARGET_DARWIN
 #include <CHIPProjectConfig.h>
 #endif // CHIP_DEVICE_LAYER_TARGET_DARWIN

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "core/CastingPlayer.h"
+#include <list>
 
 namespace matter {
 namespace casting {
@@ -40,9 +41,9 @@ public:
     CHIP_ERROR AddOrUpdate(core::CastingPlayer castingPlayer);
 
     /**
-     * @brief Reads and returns a vector of all CastingPlayers found in the cache
+     * @brief Reads and returns a list of all CastingPlayers found in the cache
      */
-    std::vector<core::CastingPlayer> ReadAll();
+    std::list<core::CastingPlayer> ReadAll();
 
     /**
      * @brief If castingPlayer is found in the cache, this will delete it. If it is not found, this method is a no-op
@@ -65,9 +66,9 @@ private:
     static CastingStore * _CastingStore;
 
     /**
-     * @brief Writes the vector of CastingPlayers to the cache. This method will overwrite any pre-existing cached data.
+     * @brief Writes the list of CastingPlayers to the cache. This method will overwrite any pre-existing cached data.
      */
-    CHIP_ERROR WriteAll(std::vector<core::CastingPlayer> castingPlayers);
+    CHIP_ERROR WriteAll(std::list<core::CastingPlayer> castingPlayers);
 
     enum CastingStoreTLVTag
     {

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -70,12 +70,20 @@ void ConfigurationManagerImpl::InitiateFactoryReset() {}
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    AndroidConfig::Key configKey{ AndroidConfig::kConfigNamespace_ChipCounters, key };
+
+    CHIP_ERROR err = ReadConfigValue(configKey, value);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+    return err;
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    AndroidConfig::Key configKey{ AndroidConfig::kConfigNamespace_ChipCounters, key };
+    return WriteConfigValue(configKey, value);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)

--- a/src/platform/android/java/chip/platform/NsdManagerServiceBrowser.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceBrowser.java
@@ -127,7 +127,11 @@ public class NsdManagerServiceBrowser implements ServiceBrowser {
       mainThreadHandler.removeCallbacksAndMessages(null);
     }
 
-    this.nsdManager.stopServiceDiscovery(discovery);
+    try {
+      this.nsdManager.stopServiceDiscovery(discovery);
+    } catch (Exception e) {
+      Log.d(TAG, "Exception in stopDiscover " + e, e);
+    }
   }
 
   public class NsdManagerDiscovery implements NsdManager.DiscoveryListener {

--- a/src/platform/android/java/chip/platform/NsdManagerServiceBrowser.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceBrowser.java
@@ -130,7 +130,7 @@ public class NsdManagerServiceBrowser implements ServiceBrowser {
     try {
       this.nsdManager.stopServiceDiscovery(discovery);
     } catch (Exception e) {
-      Log.d(TAG, "Exception in stopDiscover " + e, e);
+      Log.e(TAG, "Exception in stopDiscover " + e, e);
     }
   }
 


### PR DESCRIPTION
#### Summary

Fixes a number of issues relating to memory and recent changes in master:
- corrupt nodeId/fabric index in Endpoints of CastingPlayer
- "PacketBuffer: pool EMPTY." error when reading cluster list
- android init error in PersistentLifetimeCounter
- helper method for DACProvider when using PKCS8 key format

#### Testing

Tested using linux and android casting video app. 
1. The corrupt nodeId/fabric was reproducible via repeated commissioning followed by a check of cached endpoint ids on android (to see bogus values).
2. The PacketBuffer: pool EMPTY regression occurred when reading the ServerCluster list on endpoint 0 of a casting video player which contained a large number of clusters. This test was performed using a production Matter casting android app by an unnamed partner.
3. The android init regression was caused by recent changes to make errors during CHIP::init fatal. This can only be tested by running an android app.
4. The DAC Provider code was tested using a production DAC encoded using PKCS8 format.