### PR TITLE
Decouple `FixedLabel` Cluster

### DIFF
--- a/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
+++ b/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
@@ -41,7 +41,7 @@ public:
     ServerClusterRegistration & CreateRegistration(EndpointId endpointId, unsigned clusterInstanceIndex,
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
-        gServers[clusterInstanceIndex].Create(endpointId, &DeviceLayer::GetDeviceInfoProvider());
+        gServers[clusterInstanceIndex].Create(endpointId, *DeviceLayer::GetDeviceInfoProvider());
         return gServers[clusterInstanceIndex].Registration();
     }
 

--- a/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
+++ b/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
@@ -41,7 +41,7 @@ public:
     ServerClusterRegistration & CreateRegistration(EndpointId endpointId, unsigned clusterInstanceIndex,
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
-        gServers[clusterInstanceIndex].Create(endpointId);
+        gServers[clusterInstanceIndex].Create(endpointId, DeviceLayer::GetDeviceInfoProvider());
         return gServers[clusterInstanceIndex].Registration();
     }
 

--- a/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
+++ b/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
@@ -41,7 +41,7 @@ public:
     ServerClusterRegistration & CreateRegistration(EndpointId endpointId, unsigned clusterInstanceIndex,
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
-        gServers[clusterInstanceIndex].Create(endpointId);
+        gServers[clusterInstanceIndex].Create(endpointId, mDeviceInfoProvider);
         return gServers[clusterInstanceIndex].Registration();
     }
 

--- a/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
+++ b/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
@@ -21,7 +21,6 @@
 #include <app/util/attribute-storage.h>
 #include <data-model-providers/codegen/ClusterIntegration.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
-#include <platform/DeviceInfoProvider.h>
 
 using namespace chip;
 using namespace chip::app;
@@ -42,7 +41,7 @@ public:
     ServerClusterRegistration & CreateRegistration(EndpointId endpointId, unsigned clusterInstanceIndex,
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
-        gServers[clusterInstanceIndex].Create(endpointId, DeviceLayer::GetDeviceInfoProvider());
+        gServers[clusterInstanceIndex].Create(endpointId, &DeviceLayer::GetDeviceInfoProvider());
         return gServers[clusterInstanceIndex].Registration();
     }
 

--- a/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
+++ b/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
@@ -41,6 +41,9 @@ public:
     ServerClusterRegistration & CreateRegistration(EndpointId endpointId, unsigned clusterInstanceIndex,
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
+        DeviceLayer::DeviceInfoProvider * deviceInfoProvider = DeviceLayer::GetDeviceInfoProvider();
+        VerifyOrDie(deviceInfoProvider != nullptr);
+
         gServers[clusterInstanceIndex].Create(endpointId, *DeviceLayer::GetDeviceInfoProvider());
         return gServers[clusterInstanceIndex].Registration();
     }

--- a/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
+++ b/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
@@ -41,7 +41,7 @@ public:
     ServerClusterRegistration & CreateRegistration(EndpointId endpointId, unsigned clusterInstanceIndex,
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
-        gServers[clusterInstanceIndex].Create(endpointId, DeviceLayer::GetDeviceInfoProvider());
+        gServers[clusterInstanceIndex].Create(endpointId);
         return gServers[clusterInstanceIndex].Registration();
     }
 

--- a/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
+++ b/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
@@ -41,7 +41,7 @@ public:
     ServerClusterRegistration & CreateRegistration(EndpointId endpointId, unsigned clusterInstanceIndex,
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
-        gServers[clusterInstanceIndex].Create(endpointId, mDeviceInfoProvider);
+        gServers[clusterInstanceIndex].Create(endpointId);
         return gServers[clusterInstanceIndex].Registration();
     }
 

--- a/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
+++ b/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
@@ -21,6 +21,7 @@
 #include <app/util/attribute-storage.h>
 #include <data-model-providers/codegen/ClusterIntegration.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
+#include <platform/DeviceInfoProvider.h>
 
 using namespace chip;
 using namespace chip::app;

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
@@ -67,6 +67,8 @@ FixedLabelCluster::FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInf
     DefaultServerCluster({ endpoint, FixedLabel::Id }), mDeviceInfoProvider(deviceInfoProvider)
 {}
 
+FixedLabelCluster::FixedLabelCluster(EndpointId endpoint) : FixedLabelCluster(endpoint, DeviceLayer::GetDeviceInfoProvider()) {}
+
 DataModel::ActionReturnStatus FixedLabelCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                                AttributeValueEncoder & encoder)
 {

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
@@ -27,8 +27,8 @@ namespace {
 class AutoReleaseIterator
 {
 public:
-    AutoReleaseIterator(DeviceLayer::DeviceInfoProvider & provider, EndpointId endpointId) :
-        mIterator(provider.IterateFixedLabel(endpointId))
+    AutoReleaseIterator(DeviceLayer::DeviceInfoProvider * provider, EndpointId endpointId) :
+        mIterator(provider != nullptr ? provider->IterateFixedLabel(endpointId) : nullptr)
     {}
     ~AutoReleaseIterator()
     {
@@ -66,8 +66,6 @@ CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, D
 FixedLabelCluster::FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider & deviceInfoProvider) :
     DefaultServerCluster({ endpoint, FixedLabel::Id }), mDeviceInfoProvider(deviceInfoProvider)
 {}
-
-FixedLabelCluster::FixedLabelCluster(EndpointId endpoint) : FixedLabelCluster(endpoint, DeviceLayer::GetDeviceInfoProvider()) {}
 
 DataModel::ActionReturnStatus FixedLabelCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                                AttributeValueEncoder & encoder)

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
@@ -46,9 +46,9 @@ private:
     DeviceLayer::DeviceInfoProvider::FixedLabelIterator * mIterator;
 };
 
-CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder)
+CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, DeviceLayer::DeviceInfoProvider * provider)
 {
-    AutoReleaseIterator it(DeviceLayer::GetDeviceInfoProvider(), endpoint);
+    AutoReleaseIterator it(provider, endpoint);
     VerifyOrReturnValue(it.IsValid(), encoder.EncodeEmptyList());
 
     return encoder.EncodeList([&it](const auto & encod) -> CHIP_ERROR {
@@ -63,7 +63,11 @@ CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder)
 
 } // namespace
 
-FixedLabelCluster::FixedLabelCluster(EndpointId endpoint) : DefaultServerCluster({ endpoint, FixedLabel::Id }) {}
+FixedLabelCluster::FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider * deviceInfoProvider) :
+    DefaultServerCluster({ endpoint, FixedLabel::Id }), mDeviceInfoProvider(deviceInfoProvider)
+{}
+
+FixedLabelCluster::FixedLabelCluster(EndpointId endpoint) : FixedLabelCluster(endpoint, DeviceLayer::GetDeviceInfoProvider()) {}
 
 DataModel::ActionReturnStatus FixedLabelCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                                AttributeValueEncoder & encoder)
@@ -71,7 +75,7 @@ DataModel::ActionReturnStatus FixedLabelCluster::ReadAttribute(const DataModel::
     switch (request.path.mAttributeId)
     {
     case LabelList::Id:
-        return ReadLabelList(mPath.mEndpointId, encoder);
+        return ReadLabelList(mPath.mEndpointId, encoder, mDeviceInfoProvider);
     case ClusterRevision::Id:
         return encoder.Encode(FixedLabel::kRevision);
     case FeatureMap::Id:

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
@@ -17,6 +17,7 @@
 #include <app/clusters/fixed-label-server/FixedLabelCluster.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <clusters/FixedLabel/Metadata.h>
+#include <platform/DeviceInfoProvider.h>
 
 namespace chip::app::Clusters {
 
@@ -46,7 +47,7 @@ private:
     DeviceLayer::DeviceInfoProvider::FixedLabelIterator * mIterator;
 };
 
-CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, DeviceLayer::DeviceInfoProvider & provider)
+CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, DeviceLayer::DeviceInfoProvider * provider)
 {
     AutoReleaseIterator it(provider, endpoint);
     VerifyOrReturnValue(it.IsValid(), encoder.EncodeEmptyList());
@@ -63,7 +64,7 @@ CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, D
 
 } // namespace
 
-FixedLabelCluster::FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider & deviceInfoProvider) :
+FixedLabelCluster::FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider * deviceInfoProvider) :
     DefaultServerCluster({ endpoint, FixedLabel::Id }), mDeviceInfoProvider(deviceInfoProvider)
 {}
 

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
@@ -67,8 +67,6 @@ FixedLabelCluster::FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInf
     DefaultServerCluster({ endpoint, FixedLabel::Id }), mDeviceInfoProvider(deviceInfoProvider)
 {}
 
-FixedLabelCluster::FixedLabelCluster(EndpointId endpoint) : FixedLabelCluster(endpoint, DeviceLayer::GetDeviceInfoProvider()) {}
-
 DataModel::ActionReturnStatus FixedLabelCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                                AttributeValueEncoder & encoder)
 {

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
@@ -46,7 +46,7 @@ private:
     DeviceLayer::DeviceInfoProvider::FixedLabelIterator * mIterator;
 };
 
-CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, DeviceLayer::DeviceInfoProvider * provider)
+CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, DeviceLayer::DeviceInfoProvider & provider)
 {
     AutoReleaseIterator it(provider, endpoint);
     VerifyOrReturnValue(it.IsValid(), encoder.EncodeEmptyList());

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
@@ -17,7 +17,6 @@
 #include <app/clusters/fixed-label-server/FixedLabelCluster.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <clusters/FixedLabel/Metadata.h>
-#include <platform/DeviceInfoProvider.h>
 
 namespace chip::app::Clusters {
 
@@ -28,8 +27,8 @@ namespace {
 class AutoReleaseIterator
 {
 public:
-    AutoReleaseIterator(DeviceLayer::DeviceInfoProvider * provider, EndpointId endpointId) :
-        mIterator(provider != nullptr ? provider->IterateFixedLabel(endpointId) : nullptr)
+    AutoReleaseIterator(DeviceLayer::DeviceInfoProvider & provider, EndpointId endpointId) :
+        mIterator(provider.IterateFixedLabel(endpointId))
     {}
     ~AutoReleaseIterator()
     {
@@ -64,7 +63,7 @@ CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, D
 
 } // namespace
 
-FixedLabelCluster::FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider * deviceInfoProvider) :
+FixedLabelCluster::FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider & deviceInfoProvider) :
     DefaultServerCluster({ endpoint, FixedLabel::Id }), mDeviceInfoProvider(deviceInfoProvider)
 {}
 

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
@@ -27,8 +27,8 @@ namespace {
 class AutoReleaseIterator
 {
 public:
-    AutoReleaseIterator(DeviceLayer::DeviceInfoProvider * provider, EndpointId endpointId) :
-        mIterator(provider != nullptr ? provider->IterateFixedLabel(endpointId) : nullptr)
+    AutoReleaseIterator(DeviceLayer::DeviceInfoProvider & provider, EndpointId endpointId) :
+        mIterator(provider.IterateFixedLabel(endpointId))
     {}
     ~AutoReleaseIterator()
     {
@@ -46,7 +46,7 @@ private:
     DeviceLayer::DeviceInfoProvider::FixedLabelIterator * mIterator;
 };
 
-CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, DeviceLayer::DeviceInfoProvider * provider)
+CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, DeviceLayer::DeviceInfoProvider & provider)
 {
     AutoReleaseIterator it(provider, endpoint);
     VerifyOrReturnValue(it.IsValid(), encoder.EncodeEmptyList());
@@ -63,7 +63,7 @@ CHIP_ERROR ReadLabelList(EndpointId endpoint, AttributeValueEncoder & encoder, D
 
 } // namespace
 
-FixedLabelCluster::FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider * deviceInfoProvider) :
+FixedLabelCluster::FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider & deviceInfoProvider) :
     DefaultServerCluster({ endpoint, FixedLabel::Id }), mDeviceInfoProvider(deviceInfoProvider)
 {}
 

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.h
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.h
@@ -29,7 +29,6 @@ namespace chip::app::Clusters {
 class FixedLabelCluster : public DefaultServerCluster
 {
 public:
-    FixedLabelCluster(EndpointId endpoint);
     FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider * deviceInfoProvider);
 
     // Server cluster implementation

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.h
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.h
@@ -17,19 +17,14 @@
 #pragma once
 
 #include <app/server-cluster/DefaultServerCluster.h>
-
-namespace chip {
-namespace DeviceLayer {
-class DeviceInfoProvider;
-} // namespace DeviceLayer
-} // namespace chip
+#include <platform/DeviceInfoProvider.h>
 
 namespace chip::app::Clusters {
 
 class FixedLabelCluster : public DefaultServerCluster
 {
 public:
-    FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider * deviceInfoProvider);
+    FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider & deviceInfoProvider);
 
     // Server cluster implementation
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
@@ -37,7 +32,7 @@ public:
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
 private:
-    DeviceLayer::DeviceInfoProvider * mDeviceInfoProvider;
+    DeviceLayer::DeviceInfoProvider & mDeviceInfoProvider;
 };
 
 } // namespace chip::app::Clusters

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.h
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.h
@@ -34,7 +34,6 @@ public:
 
 private:
     DeviceLayer::DeviceInfoProvider * mDeviceInfoProvider;
-    ;
 };
 
 } // namespace chip::app::Clusters

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.h
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.h
@@ -18,13 +18,19 @@
 
 #include <app/server-cluster/DefaultServerCluster.h>
 
+namespace chip {
+namespace DeviceLayer {
+class DeviceInfoProvider;
+} // namespace DeviceLayer
+} // namespace chip
+
 namespace chip::app::Clusters {
 
 class FixedLabelCluster : public DefaultServerCluster
 {
 public:
     FixedLabelCluster(EndpointId endpoint);
-    FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider & deviceInfoProvider);
+    FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider * deviceInfoProvider);
 
     // Server cluster implementation
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
@@ -32,7 +38,7 @@ public:
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
 private:
-    DeviceLayer::DeviceInfoProvider & mDeviceInfoProvider;
+    DeviceLayer::DeviceInfoProvider * mDeviceInfoProvider;
 };
 
 } // namespace chip::app::Clusters

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.h
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.h
@@ -25,7 +25,7 @@ class FixedLabelCluster : public DefaultServerCluster
 {
 public:
     FixedLabelCluster(EndpointId endpoint);
-    FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider * deviceInfoProvider);
+    FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider & deviceInfoProvider);
 
     // Server cluster implementation
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
@@ -33,7 +33,7 @@ public:
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
 private:
-    DeviceLayer::DeviceInfoProvider * mDeviceInfoProvider;
+    DeviceLayer::DeviceInfoProvider & mDeviceInfoProvider;
 };
 
 } // namespace chip::app::Clusters

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.h
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.h
@@ -25,11 +25,16 @@ class FixedLabelCluster : public DefaultServerCluster
 {
 public:
     FixedLabelCluster(EndpointId endpoint);
+    FixedLabelCluster(EndpointId endpoint, DeviceLayer::DeviceInfoProvider * deviceInfoProvider);
 
     // Server cluster implementation
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                 AttributeValueEncoder & encoder) override;
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
+
+private:
+    DeviceLayer::DeviceInfoProvider * mDeviceInfoProvider;
+    ;
 };
 
 } // namespace chip::app::Clusters

--- a/src/app/clusters/fixed-label-server/FixedLabelCluster.h
+++ b/src/app/clusters/fixed-label-server/FixedLabelCluster.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <app/server-cluster/DefaultServerCluster.h>
-#include <platform/DeviceInfoProvider.h>
 
 namespace chip::app::Clusters {
 

--- a/src/app/clusters/fixed-label-server/tests/TestFixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/tests/TestFixedLabelCluster.cpp
@@ -72,7 +72,7 @@ struct TestFixedLabelCluster : public ::testing::Test
 
     void TearDown() override { fixedLabel.Shutdown(ClusterShutdownType::kClusterShutdown); }
 
-    TestFixedLabelCluster() : fixedLabel(kRootEndpointId, &mDeviceInfoProvider) {}
+    TestFixedLabelCluster() : fixedLabel(kRootEndpointId, mDeviceInfoProvider) {}
 
     TestServerClusterContext testContext;
     MockDeviceInfoProvider mDeviceInfoProvider;

--- a/src/app/clusters/fixed-label-server/tests/TestFixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/tests/TestFixedLabelCluster.cpp
@@ -26,6 +26,9 @@
 #include <clusters/FixedLabel/Attributes.h>
 #include <clusters/FixedLabel/Metadata.h>
 
+#include <clusters/FixedLabel/Structs.h>
+#include <platform/DeviceInfoProvider.h>
+
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
@@ -35,6 +38,29 @@ using namespace chip::Testing;
 using chip::Testing::IsAttributesListEqualTo;
 
 namespace {
+
+// Mock DeviceInfoProvider for testing
+class MockDeviceInfoProvider : public DeviceLayer::DeviceInfoProvider
+{
+public:
+    MockDeviceInfoProvider()           = default;
+    ~MockDeviceInfoProvider() override = default;
+
+    FixedLabelIterator * IterateFixedLabel(EndpointId endpoint) override { return nullptr; }
+    UserLabelIterator * IterateUserLabel(EndpointId endpoint) override { return nullptr; }
+    SupportedCalendarTypesIterator * IterateSupportedCalendarTypes() override { return nullptr; }
+    SupportedLocalesIterator * IterateSupportedLocales() override { return nullptr; }
+
+protected:
+    CHIP_ERROR SetUserLabelLength(EndpointId endpoint, size_t val) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR GetUserLabelLength(EndpointId endpoint, size_t & val) override
+    {
+        val = 0;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR DeleteUserLabelAt(EndpointId endpoint, size_t index) override { return CHIP_NO_ERROR; }
+};
 
 struct TestFixedLabelCluster : public ::testing::Test
 {
@@ -46,9 +72,10 @@ struct TestFixedLabelCluster : public ::testing::Test
 
     void TearDown() override { fixedLabel.Shutdown(ClusterShutdownType::kClusterShutdown); }
 
-    TestFixedLabelCluster() : fixedLabel(kRootEndpointId) {}
+    TestFixedLabelCluster() : fixedLabel(kRootEndpointId, &mDeviceInfoProvider) {}
 
     TestServerClusterContext testContext;
+    MockDeviceInfoProvider mDeviceInfoProvider;
     FixedLabelCluster fixedLabel;
 };
 

--- a/src/app/clusters/fixed-label-server/tests/TestFixedLabelCluster.cpp
+++ b/src/app/clusters/fixed-label-server/tests/TestFixedLabelCluster.cpp
@@ -72,7 +72,7 @@ struct TestFixedLabelCluster : public ::testing::Test
 
     void TearDown() override { fixedLabel.Shutdown(ClusterShutdownType::kClusterShutdown); }
 
-    TestFixedLabelCluster() : fixedLabel(kRootEndpointId, mDeviceInfoProvider) {}
+    TestFixedLabelCluster() : fixedLabel(kRootEndpointId, &mDeviceInfoProvider) {}
 
     TestServerClusterContext testContext;
     MockDeviceInfoProvider mDeviceInfoProvider;


### PR DESCRIPTION
#### Summary

Refactored `FixedLabelCluster` to decouple it from the global `DeviceLayer::GetDeviceInfoProvider()` singleton. This change introduces a new constructor that accepts a `DeviceInfoProvider*`, allowing for dependency injection. This improves testability by enabling the use of mock providers and aligns the cluster with the dependency injection pattern used in other server clusters (e.g., `UserLabel`, `WiFiNetworkDiagnostics`).
Key changes:
* Added FixedLabelCluster(EndpointId, DeviceInfoProvider*) constructor.
* Moved constructor implementations from .h to .cpp to ensure correct base class initialization.
* Updated `TestFixedLabelCluster` to use a `MockDeviceInfoProvider` injected via the new constructor, validating that the cluster correctly uses the provided dependency.

#### Related issues

#### Testing
All existing tests pass with the new dependency injection approach.