### PR TITLE
[1.4.2][Cherrypick] Fix Matter Cast tv-casting-app crash on Android x86 platform (#39424)

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -79,7 +79,8 @@ jobject convertMatterErrorFromCppToJava(CHIP_ERROR inErr)
         return nullptr;
     }
 
-    return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, inErr.AsInteger(), nullptr);
+    // Explicitly cast to jlong for JNI: Java ctor expects long (64-bit), ensures correct arg size on 32-bit platforms
+    return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, static_cast<jlong>(inErr.AsInteger()), nullptr);
 }
 
 jobject convertEndpointFromCppToJava(matter::casting::memory::Strong<core::Endpoint> endpoint)


### PR DESCRIPTION
* Explicit cast uint32_t to jlong to prevent JNI crash on Android x86

* Add suggested JNI crash explanation

* Update comment

* Use static_cast

(cherry picked from commit 220e981537fbcd8edfc6a9656fe204d4caecb98a)

### Testing

Build the sample app for Android x86 and run it on 32-bit x86 Android emulator image.
`./scripts/build/build_examples.py --clean --target android-x86-tv-casting-app build`



