### PR TITLE
[1.4.2][Cherrypick][Android]upgrade android with ndk 28c and 16kb page size (#40455)

### DIFF
--- a/build/chip/java/BUILD.gn
+++ b/build/chip/java/BUILD.gn
@@ -17,6 +17,28 @@ import("//build_overrides/build.gni")
 import("${build_root}/config/android/config.gni")
 import("${build_root}/config/android_abi.gni")
 
+if (current_os == "linux" || current_os == "android") {
+  android_ndk_host_platform = "linux-x86_64"
+} else if (current_os == "mac") {
+  android_ndk_host_platform = "darwin-x86_64"
+} else {
+  assert(false, "Unsupported host OS for Android NDK prebuilts")
+}
+
+if (current_cpu == "arm") {
+  android_toolchain_dir = "arm-linux-androideabi"
+} else if (current_cpu == "arm64") {
+  android_toolchain_dir = "aarch64-linux-android"
+} else if (current_cpu == "x64") {
+  android_toolchain_dir = "x86_64-linux-android"
+} else if (current_cpu == "x86") {
+  android_toolchain_dir = "i686-linux-android"
+} else if (current_cpu == "riscv64") {
+  android_toolchain_dir = "riscv64-linux-android"
+} else {
+  assert(false, "Unsupported target_cpu for Android: ${current_cpu}")
+}
+
 # Place a copy of the shared c++ support library in the jni output directory
 # See:
 #   https://developer.android.com/ndk/guides/cpp-support
@@ -24,6 +46,6 @@ import("${build_root}/config/android_abi.gni")
 # Generally CHIP cannot ensure a single shared library per java application, so a shared
 # CPP support library is used
 copy("shared_cpplib") {
-  sources = [ "${android_ndk_root}/sources/cxx-stl/llvm-libc++/libs/${android_abi}/libc++_shared.so" ]
+  sources = [ "${android_ndk_root}/toolchains/llvm/prebuilt/${android_ndk_host_platform}/sysroot/usr/lib/${android_toolchain_dir}/libc++_shared.so" ]
   outputs = [ "${root_out_dir}/lib/jni/${android_abi}/libc++_shared.so" ]
 }

--- a/build/config/android_abi.gni
+++ b/build/config/android_abi.gni
@@ -7,6 +7,8 @@ if (current_os == "android") {
     android_abi = "x86_64"
   } else if (current_cpu == "x86") {
     android_abi = "x86"
+  } else if (current_cpu == "riscv64") {
+    android_abi = "riscv64"
   } else {
     assert(false, "Unsupported target_cpu: ${current_cpu}")
   }

--- a/docs/platforms/android/android_building.md
+++ b/docs/platforms/android/android_building.md
@@ -43,7 +43,7 @@ directory.
 
 ## Requirements for building
 
-You need Android SDK 26 & NDK 23.2.8568313 downloaded to your machine. Set the
+You need Android SDK 30 & NDK 28.2.13676358 downloaded to your machine. Set the
 `$ANDROID_HOME` environment variable to where the SDK is downloaded and the
 `$ANDROID_NDK_HOME` environment variable to point to where the NDK package is
 downloaded.
@@ -52,7 +52,7 @@ downloaded.
 2. Install NDK:
     1. Tools -> SDK Manager -> SDK Tools Tab
     2. Click [x] Show Package Details
-    3. Select NDK (Side by Side) -> 23.2.8568313
+    3. Select NDK (Side by Side) -> 28.2.13676358
     4. Apply
 3. Install Command Line Tools:
     1. Tools -> SDK Manager -> SDK Tools Tab -> Android SDK Command Line Tools
@@ -70,14 +70,14 @@ downloaded.
 
 ```
 export ANDROID_HOME=~/Android/Sdk
-export ANDROID_NDK_HOME=~/Android/Sdk/ndk/23.2.8568313
+export ANDROID_NDK_HOME=~/Android/Sdk/ndk/28.2.13676358
 ```
 
 ### MacOS
 
 ```
 export ANDROID_HOME=~/Library/Android/sdk
-export ANDROID_NDK_HOME=~/Library/Android/sdk/ndk/23.2.8568313
+export ANDROID_NDK_HOME=~/Library/Android/sdk/ndk/28.2.13676358
 ```
 
 <a name="abi"></a>

--- a/examples/android/CHIPTool/app/build.gradle
+++ b/examples/android/CHIPTool/app/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion 31
     ndkPath System.getenv("ANDROID_NDK_HOME")
 
-    ndkVersion "23.2.8568313"
+    ndkVersion "28.2.13676358"
 
     defaultConfig {
         applicationId "com.google.chip.chiptool"

--- a/examples/android/CHIPTool/chip-library/build.gradle
+++ b/examples/android/CHIPTool/chip-library/build.gradle
@@ -38,6 +38,9 @@ android {
             ]
         }
     }
+    packagingOptions {
+        jniLibs.useLegacyPackaging = true
+    }
 }
 
 dependencies {

--- a/gn_build.sh
+++ b/gn_build.sh
@@ -125,8 +125,8 @@ if [[ -d "${ANDROID_NDK_HOME}/toolchains" && -d "${ANDROID_HOME}/platforms" ]]; 
 else
     echo
     echo "Hint: Set \$ANDROID_HOME and \$ANDROID_NDK_HOME to enable building for Android"
-    echo "      The required android sdk platform version is 21. It can be obtained from"
-    echo "      https://dl.google.com/android/repository/platform-26_r02.zip"
+    echo "      The required android sdk platform version is 30. It can be obtained from"
+    echo "      https://dl.google.com/android/repository/platform-30_r03.zip"
 fi
 
 echo

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -229,6 +229,10 @@ shared_library("jni") {
     ldflags = [ "-Wl,--gc-sections" ]
   }
 
+  # Compatibility with 16K pages for Andropid 15+ support on 64-bit devices.
+  # See https://developer.android.com/guide/practices/page-sizes
+  ldflags += [ "-Wl,-z,max-page-size=16384" ]
+
   public_configs = [ "${chip_root}/src:includes" ]
 }
 

--- a/src/platform/android/InetInterfaceImpl.cpp
+++ b/src/platform/android/InetInterfaceImpl.cpp
@@ -51,7 +51,6 @@ struct if_nameindex * if_nameindexImpl()
     size_t intfIter              = 0;
     size_t maxIntfNum            = 0;
     size_t numIntf               = 0;
-    size_t numAddrs              = 0;
     struct if_nameindex * retval = nullptr;
     struct if_nameindex * tmpval = nullptr;
     struct ifaddrs * addrList    = nullptr;
@@ -64,7 +63,6 @@ struct if_nameindex * if_nameindexImpl()
     // coalesce on consecutive interface names
     for (addrIter = addrList; addrIter != nullptr; addrIter = addrIter->ifa_next)
     {
-        numAddrs++;
         if (strcmp(addrIter->ifa_name, lastIntfName) != 0)
         {
             numIntf++;


### PR DESCRIPTION
* upgrade android with 16kb page size

* Update src/controller/java/BUILD.gn



* Update src/controller/java/BUILD.gn

* fix unused variabled error

* add support for ndk 28+ where libc++_shared location has been changed

* update gradle for android chiptool with ndk 28c

* update docker and doc for new ndk

* Restyled by prettier-markdown

* generalize the location for libc++_shared.so

* remove docker change

---------



(cherry picked from commit cbc3feed2e6fcb104808682eedd551ce670c67b2)

#### Testing

build Android tv-casting-app