### PR TITLE
[1.4.2][Cherrypick] Recovery for bad cached video players (#41693)

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -177,4 +177,10 @@ public interface CastingPlayer {
    * @returns A String representation of the CastingPlayer's current connectation.
    */
   String getConnectionStateNative();
+
+  /**
+   * @brief Removes any fabric associated with this player in order to cause the UDC flow when
+   *     verifyOrEstablishConnection is called
+   */
+  void removeFabric();
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -269,6 +269,9 @@ public class MatterCastingPlayer implements CastingPlayer {
   @Override
   public native void disconnect();
 
+  @Override
+  public native void removeFabric();
+
   /**
    * @brief Get CastingPlayer's current ConnectionState.
    * @throws IllegalArgumentException or NullPointerException when native layer returns invalid

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -165,6 +165,19 @@ JNI_METHOD(void, disconnect)
     castingPlayer->Disconnect();
 }
 
+JNI_METHOD(void, removeFabric)
+(JNIEnv * env, jobject thiz)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::removeFabric()");
+
+    core::CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
+    VerifyOrReturn(castingPlayer != nullptr,
+                   ChipLogError(AppServer, "MatterCastingPlayer-JNI::removeFabric() castingPlayer == nullptr"));
+
+    castingPlayer->RemoveFabric();
+}
+
 JNI_METHOD(jstring, getConnectionStateNative)
 (JNIEnv * env, jobject thiz)
 {

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
@@ -159,6 +159,12 @@ typedef enum {
 - (void)disconnect;
 
 /**
+ * @brief Removes any fabric associated with this player in order to cause the UDC flow when
+ *     verifyOrEstablishConnection is called
+ */
+- (void)removeFabric;
+
+/**
  * @brief Get the CastingPlayer's connection state
  * @param state The current connection state that will be return.
  * @return nil if request submitted successfully, otherwise a NSError object corresponding to the error.

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
@@ -190,6 +190,17 @@ static const NSInteger kMinCommissioningWindowTimeoutSec = matter::casting::core
     });
 }
 
+- (void)removeFabric
+{
+    ChipLogProgress(AppServer, "MCCastingPlayer.removeFabric() called");
+    VerifyOrReturn([[MCCastingApp getSharedInstance] isRunning], ChipLogError(AppServer, "MCCastingPlayer.removeFabric() MCCastingApp NOT running"));
+
+    dispatch_queue_t workQueue = [[MCCastingApp getSharedInstance] getWorkQueue];
+    dispatch_sync(workQueue, ^{
+        _cppCastingPlayer->RemoveFabric();
+    });
+}
+
 - (NSError * _Nullable)getConnectionState:(MCCastingPlayerConnectionState * _Nonnull)state;
 {
     ChipLogProgress(AppServer, "MCCastingPlayer.getConnectionState() called");

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/compat-shim/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/compat-shim/CastingServerBridge.h
@@ -169,6 +169,15 @@ __attribute__((deprecated("Use the APIs described in /examples/tv-casting-app/AP
 - (void)disconnect:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler;
 
 /*!
+ @brief  Removes any fabric associated with this player in order to cause the UDC flow when verifyOrEstablishConnection is called.
+
+ @param clientQueue Queue to invoke callbacks on
+
+ @param requestSentHandler Called after the request has been sent
+ */
+- (void)removeFabric:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler;
+
+/*!
  @brief Purge data cached by the Matter casting library
 
  @param clientQueue Queue to invoke callbacks on

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/compat-shim/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/compat-shim/CastingServerBridge.mm
@@ -339,6 +339,18 @@ static const uint32_t kTargetPlayerDeviceType = 0x23;
     });
 }
 
+- (void)removeFabric:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler
+{
+    ChipLogProgress(AppServer, "CastingServerBridge().removeFabric() called");
+    MCCastingPlayer * castingPlayer = [MCCastingPlayer getTargetCastingPlayer];
+    if (castingPlayer != nil) {
+        [castingPlayer removeFabric];
+    }
+    dispatch_async(clientQueue, ^{
+        requestSentHandler();
+    });
+}
+
 - (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(void (^)(MatterError * _Nonnull))responseHandler
 {
     ChipLogProgress(AppServer, "CastingServerBridge().purgeCache() called");

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -223,6 +223,14 @@ public:
     void Disconnect();
 
     /**
+     * @brief Removes any fabric associated with this player in order to cause the UDC flow when
+     * verifyOrEstablishConnection is called
+     *
+     * @note This method will set nodeId and fabricIndex to 0.
+     */
+    void RemoveFabric();
+
+    /**
      * @brief Find an existing session for this CastingPlayer, or trigger a new session
      * request.
      *

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -511,7 +511,7 @@ CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayer
         chip::TLV::TLVType endpointsContainerType;
         ReturnErrorOnFailure(tlvWriter.StartContainer(chip::TLV::ContextTag(kCastingPlayerEndpointsContainerTag),
                                                       chip::TLV::kTLVType_Array, endpointsContainerType));
-        std::vector<memory::Strong<core::Endpoint>> endpoints = core::CastingPlayer::GetTargetCastingPlayer()->GetEndpoints();
+        std::vector<memory::Strong<core::Endpoint>> endpoints = castingPlayer.GetEndpoints();
         for (auto & endpoint : endpoints)
         {
             ChipLogProgress(

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -114,11 +114,6 @@ void ChipDeviceEventHandler::HandleFailSafeTimerExpired()
     {
         ChipLogProgress(AppServer, "ChipDeviceEventHandler::HandleFailSafeTimerExpired() when sUdcInProgress: %d, returning early",
                         sUdcInProgress);
-        sUdcInProgress                                            = false;
-        CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
-        CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(CHIP_ERROR_TIMEOUT, nullptr);
-        CastingPlayer::GetTargetCastingPlayer()->mOnCompleted = nullptr;
-        CastingPlayer::GetTargetCastingPlayer()->mTargetCastingPlayer.reset();
         return;
     }
 


### PR DESCRIPTION
* Casting Client Fixes

* revert dns copy

* don't connect is nodeId is 0

* save castingPlayer after clearing fabric

* add back address copy

* copy fields needed for UDC

* fix crash

* restyled

* restyled

* add darwin version of removeFabric

(cherry picked from commit bd6781302b9cb689f853633eda20931730bc31c8)

#### Testing

android tv-casting-app