### PR TITLE
Scenes cluster: define a integration delegate and move constants around.

### DIFF
--- a/src/app/clusters/scenes-server/BUILD.gn
+++ b/src/app/clusters/scenes-server/BUILD.gn
@@ -19,6 +19,7 @@ import("//build_overrides/chip.gni")
 source_set("scenes") {
   sources = [
     "AttributeValuePairValidator.h",
+    "Constants.h",
     "ExtensionFieldSets.h",
     "ExtensionFieldSetsImpl.cpp",
     "ExtensionFieldSetsImpl.h",
@@ -27,6 +28,7 @@ source_set("scenes") {
     "SceneTable.h",
     "SceneTableImpl.cpp",
     "SceneTableImpl.h",
+    "ScenesIntegrationDelegate.h",
   ]
 
   deps = [ "${chip_root}/src/app" ]

--- a/src/app/clusters/scenes-server/CodegenIntegration.h
+++ b/src/app/clusters/scenes-server/CodegenIntegration.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <app/clusters/scenes-server/Constants.h>
 #include <app/clusters/scenes-server/ScenesManagementCluster.h>
 
 // most ember implementations will want access to these
@@ -25,8 +26,8 @@ namespace chip::app::Clusters::ScenesManagement {
 class ScenesServer
 {
 public:
-    static constexpr SceneId kGlobalSceneId      = 0x00;
-    static constexpr GroupId kGlobalSceneGroupId = 0x0000;
+    static constexpr SceneId kGlobalSceneId      = chip::scenes::kGlobalSceneId;
+    static constexpr GroupId kGlobalSceneGroupId = chip::scenes::kGlobalSceneGroupId;
 
     ScenesServer()  = default;
     ~ScenesServer() = default;

--- a/src/app/clusters/scenes-server/Constants.h
+++ b/src/app/clusters/scenes-server/Constants.h
@@ -1,0 +1,26 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/DataModelTypes.h>
+
+namespace chip::scenes {
+
+static constexpr SceneId kGlobalSceneId      = 0;
+static constexpr GroupId kGlobalSceneGroupId = 0;
+
+} // namespace chip::scenes

--- a/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
+++ b/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
@@ -34,7 +34,7 @@ public:
     // == Global Scene Methods ==
     // These methods interact with the Global Scene (Group ID 0, Scene ID 0).
 
-    /// Stores the current state of into the Global Scene for the fabric.
+    /// Stores the current state into the Global Scene for the fabric.
     virtual CHIP_ERROR StoreCurrentGlobalScene(FabricIndex fabricIndex) = 0;
 
     /// Recalls the Global Scene for the given fabric.

--- a/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
+++ b/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
@@ -1,0 +1,58 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/core/DataModelTypes.h>
+
+namespace chip::scenes {
+
+/// Delegate interface for clusters to integrate with the Scenes cluster functionality.
+///
+/// This allows other clusters (e.g., OnOff, LevelControl, ColorControl) to be notified of
+/// scene-related events or to trigger scene operations like storing/recalling the global scene.
+/// An instance of this delegate is expected to be endpoint-specific.
+class ScenesIntegrationDelegate
+{
+public:
+    virtual ~ScenesIntegrationDelegate() = default;
+
+    // == Global Scene Methods ==
+    // These methods interact with the Global Scene (Group ID 0, Scene ID 0).
+
+    // Stores the current state of the calling cluster into the Global Scene for the fabric.
+    // This operation is scoped to the endpoint associated with this delegate instance.
+    virtual CHIP_ERROR StoreCurrentGlobalScene(FabricIndex fabricIndex) = 0;
+
+    // Recalls the Global Scene for the fabric, expecting the Scene Table to update the calling cluster.
+    // This operation is scoped to the endpoint associated with this delegate instance.
+    virtual CHIP_ERROR RecallGlobalScene(FabricIndex fabricIndex) = 0;
+
+    // == General Scene Management Notifications ==
+
+    // Notifies that a group is about to be removed from the given fabric.
+    // Clusters using this delegate should remove any scene entries associated with this group and fabric on the endpoint
+    // associated with this delegate instance.
+    virtual CHIP_ERROR GroupWillBeRemoved(FabricIndex fabricIndex, GroupId groupId) = 0;
+
+    // Marks all scenes on the associated endpoint as invalid for all fabrics.
+    // This is typically called when the cluster's state changes outside of a scene recall.
+    virtual CHIP_ERROR MakeSceneInvalidForAllFabrics() = 0;
+};
+
+} // namespace chip::scenes

--- a/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
+++ b/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
@@ -47,7 +47,7 @@ public:
     /// This can be used to invalidate scenes that reference the given group.
     virtual CHIP_ERROR GroupWillBeRemoved(FabricIndex fabricIndex, GroupId groupId) = 0;
 
-    // Marks all scenes on the associated endpoint as invalid for all fabrics.
+    /// Marks all scenes on the associated endpoint as invalid for all fabrics.
     virtual CHIP_ERROR MakeSceneInvalidForAllFabrics() = 0;
 };
 

--- a/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
+++ b/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
@@ -35,23 +35,20 @@ public:
     // == Global Scene Methods ==
     // These methods interact with the Global Scene (Group ID 0, Scene ID 0).
 
-    // Stores the current state of the calling cluster into the Global Scene for the fabric.
-    // This operation is scoped to the endpoint associated with this delegate instance.
+    /// Stores the current state of into the Global Scene for the fabric.
     virtual CHIP_ERROR StoreCurrentGlobalScene(FabricIndex fabricIndex) = 0;
 
-    // Recalls the Global Scene for the fabric, expecting the Scene Table to update the calling cluster.
-    // This operation is scoped to the endpoint associated with this delegate instance.
+    /// Recalls the Global Scene for the given fabric.
     virtual CHIP_ERROR RecallGlobalScene(FabricIndex fabricIndex) = 0;
 
     // == General Scene Management Notifications ==
 
-    // Notifies that a group is about to be removed from the given fabric.
-    // Clusters using this delegate should remove any scene entries associated with this group and fabric on the endpoint
-    // associated with this delegate instance.
+    /// Notifies that a group is about to be removed from the given fabric.
+    ///
+    /// This can be used to invalidate scenes that reference the given group.
     virtual CHIP_ERROR GroupWillBeRemoved(FabricIndex fabricIndex, GroupId groupId) = 0;
 
     // Marks all scenes on the associated endpoint as invalid for all fabrics.
-    // This is typically called when the cluster's state changes outside of a scene recall.
     virtual CHIP_ERROR MakeSceneInvalidForAllFabrics() = 0;
 };
 

--- a/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
+++ b/src/app/clusters/scenes-server/ScenesIntegrationDelegate.h
@@ -24,9 +24,8 @@ namespace chip::scenes {
 
 /// Delegate interface for clusters to integrate with the Scenes cluster functionality.
 ///
-/// This allows other clusters (e.g., OnOff, LevelControl, ColorControl) to be notified of
-/// scene-related events or to trigger scene operations like storing/recalling the global scene.
-/// An instance of this delegate is expected to be endpoint-specific.
+/// This allows other clusters (e.g., OnOff, LevelControl, ColorControl) to interact with
+/// scenes: store/recall global scenes or invalidate scenes based on various conditions.
 class ScenesIntegrationDelegate
 {
 public:

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.cpp
@@ -18,6 +18,7 @@
 
 #include "ScenesManagementCluster.h"
 
+#include <app/clusters/scenes-server/Constants.h>
 #include <app/clusters/scenes-server/SceneTable.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <app/server-cluster/DefaultServerCluster.h>
@@ -40,6 +41,7 @@ using chip::Protocols::InteractionModel::Status;
 using namespace chip::app::Clusters::ScenesManagement::Attributes;
 using namespace chip::app::Clusters::ScenesManagement::Commands;
 using namespace chip::app::Clusters::ScenesManagement::Structs;
+using namespace chip::app::Clusters::ScenesManagement;
 
 namespace chip::app::Clusters {
 
@@ -99,6 +101,16 @@ private:
     } while (0)
 
 } // namespace
+
+CHIP_ERROR ScenesManagementCluster::StoreCurrentGlobalScene(FabricIndex fabricIndex)
+{
+    return StoreCurrentScene(fabricIndex, scenes::kGlobalSceneGroupId, scenes::kGlobalSceneId);
+}
+
+CHIP_ERROR ScenesManagementCluster::RecallGlobalScene(FabricIndex fabricIndex)
+{
+    return RecallScene(fabricIndex, scenes::kGlobalSceneGroupId, scenes::kGlobalSceneId);
+}
 
 CHIP_ERROR ScenesManagementCluster::UpdateFabricSceneInfo(FabricIndex fabric, Optional<GroupId> group, Optional<SceneId> scene,
                                                           Optional<bool> sceneValid)
@@ -531,6 +543,7 @@ CHIP_ERROR ScenesManagementCluster::GroupWillBeRemoved(FabricIndex aFabricIdx, G
     }
 
     VerifyOrReturnError(nullptr != mGroupProvider, CHIP_ERROR_INCORRECT_STATE);
+
     if (0 != aGroupId && !mGroupProvider->HasEndpoint(aFabricIdx, aGroupId, mPath.mEndpointId))
     {
         return CHIP_NO_ERROR;

--- a/src/app/clusters/scenes-server/ScenesManagementCluster.h
+++ b/src/app/clusters/scenes-server/ScenesManagementCluster.h
@@ -20,6 +20,7 @@
 #include <app/clusters/scenes-server/ExtensionFieldSets.h>
 #include <app/clusters/scenes-server/ExtensionFieldSetsImpl.h>
 #include <app/clusters/scenes-server/SceneTable.h>
+#include <app/clusters/scenes-server/ScenesIntegrationDelegate.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/ScenesManagement/AttributeIds.h>
 #include <clusters/ScenesManagement/ClusterId.h>
@@ -44,7 +45,7 @@ public:
     virtual void Release(ScenesManagementSceneTable *) = 0;
 };
 
-class ScenesManagementCluster : public DefaultServerCluster, public FabricTable::Delegate
+class ScenesManagementCluster : public DefaultServerCluster, public FabricTable::Delegate, public scenes::ScenesIntegrationDelegate
 {
 public:
     // NOTE: this is not great as this means the cluster itself uses fixed storage/sizes
@@ -124,13 +125,17 @@ public:
     /// Can only be called while started up (i.e. after Startup() and before Shutdown()).
     CHIP_ERROR ClearPersistentData();
 
+    // ScenesIntegrationDelegate implementation
+    CHIP_ERROR StoreCurrentGlobalScene(FabricIndex fabricIndex) override;
+    CHIP_ERROR RecallGlobalScene(FabricIndex fabricIndex) override;
+    CHIP_ERROR GroupWillBeRemoved(FabricIndex fabricIndex, GroupId groupId) override;
+    CHIP_ERROR MakeSceneInvalidForAllFabrics() override;
+
     // Integration methods for other cluster integrations
-    CHIP_ERROR GroupWillBeRemoved(FabricIndex aFabricIdx, GroupId aGroupId);
     CHIP_ERROR MakeSceneInvalid(FabricIndex aFabricIdx);
     CHIP_ERROR StoreCurrentScene(FabricIndex aFabricIx, GroupId aGroupId, SceneId aSceneId);
     CHIP_ERROR RecallScene(FabricIndex aFabricIx, GroupId aGroupId, SceneId aSceneId);
     CHIP_ERROR RemoveFabric(FabricIndex aFabricIndex);
-    CHIP_ERROR MakeSceneInvalidForAllFabrics();
 
 private:
     const BitMask<ScenesManagement::Feature> mFeatures;


### PR DESCRIPTION
#### Summary

Changes to scenes to allow for better code driven integration.

Changes are split out as a separate reviewable code from #42634

#### Testing

Existing unit tests still apply. The OnOff cluster PR uses these integration points