### PR TITLE
Add the ability for clustertester to have a subject descriptor on invoke

### DIFF
--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -33,7 +33,6 @@
 #include <app/server-cluster/testing/FabricTestFixture.h>
 #include <app/server-cluster/testing/MockCommandHandler.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
-#include <app/server-cluster/testing/ValidateGlobalAttributes.h>
 #include <clusters/shared/Attributes.h>
 #include <credentials/FabricTable.h>
 #include <credentials/PersistentStorageOpCertStore.h>

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -232,10 +232,10 @@ public:
 
         const Access::SubjectDescriptor subjectDescriptor{ .fabricIndex = mHandler.GetAccessingFabricIndex() };
         const app::DataModel::InvokeRequest invokeRequest = [&]() {
-            app::DataModel::InvokeRequest request;
-            request.path              = { paths[0].mEndpointId, paths[0].mClusterId, commandId };
-            request.subjectDescriptor = &subjectDescriptor;
-            return request;
+            app::DataModel::InvokeRequest req;
+            req.path              = { paths[0].mEndpointId, paths[0].mClusterId, commandId };
+            req.subjectDescriptor = &subjectDescriptor;
+            return req;
         }();
 
         TLV::TLVWriter writer;

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -333,12 +333,9 @@ private:
         // These methods work IF AND ONLY IF cluster path contains exactly one path since
         // we get attributes by path.
         VerifyOrDie(mCluster.GetPaths().size() == 1);
-        auto path = mCluster.GetPaths()[0];
 
-        // Get the list of attributes from the cluster's metadata
         ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> builder;
-        CHIP_ERROR err = mCluster.Attributes(path, builder);
-        if (err != CHIP_NO_ERROR)
+        if (CHIP_ERROR err = mCluster.Attributes(mCluster.GetPaths()[0], builder); err != CHIP_NO_ERROR)
         {
             ChipLogError(Test, "Failed to get attribute list: %" CHIP_ERROR_FORMAT, err.Format());
             return false;
@@ -354,12 +351,9 @@ private:
         // These methods work IF AND ONLY IF cluster path contains exactly one path since
         // we get accepted commands by path.
         VerifyOrDie(mCluster.GetPaths().size() == 1);
-        auto path = mCluster.GetPaths()[0];
 
-        // Get the list of accepted commands from the cluster
         ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> builder;
-        CHIP_ERROR err = mCluster.AcceptedCommands(path, builder);
-        if (err != CHIP_NO_ERROR)
+        if (CHIP_ERROR err = mCluster.AcceptedCommands(mCluster.GetPaths()[0], builder); err != CHIP_NO_ERROR)
         {
             ChipLogError(Test, "Failed to get accepted commands: %" CHIP_ERROR_FORMAT, err.Format());
             return false;

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -333,8 +333,7 @@ private:
 
     bool IsAttributeInAttributeList(AttributeId attr_id)
     {
-        // These methods work IF AND ONLY IF cluster path contains exactly one path since
-        // we get attributes by path.
+        // Attributes are listed by path, so this is only correct for single-path clusters.
         VerifyOrDie(mCluster.GetPaths().size() == 1);
 
         ReadOnlyBufferBuilder<app::DataModel::AttributeEntry> builder;
@@ -351,8 +350,7 @@ private:
 
     bool IsCommandAnAcceptedCommand(CommandId commandId)
     {
-        // These methods work IF AND ONLY IF cluster path contains exactly one path since
-        // we get accepted commands by path.
+        // Commands are listed by path, so this is only correct for single-path clusters.
         VerifyOrDie(mCluster.GetPaths().size() == 1);
 
         ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> builder;

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -15,8 +15,7 @@
  */
 
 #pragma once
-#include "FabricTestFixture.h"
-#include "app/server-cluster/testing/ValidateGlobalAttributes.h"
+
 #include <app/AttributeValueDecoder.h>
 #include <app/AttributeValueEncoder.h>
 #include <app/CommandHandler.h>
@@ -31,8 +30,10 @@
 #include <app/data-model/List.h>
 #include <app/data-model/NullObject.h>
 #include <app/server-cluster/ServerClusterInterface.h>
+#include <app/server-cluster/testing/FabricTestFixture.h>
 #include <app/server-cluster/testing/MockCommandHandler.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
+#include <app/server-cluster/testing/ValidateGlobalAttributes.h>
 #include <clusters/shared/Attributes.h>
 #include <credentials/FabricTable.h>
 #include <credentials/PersistentStorageOpCertStore.h>
@@ -220,10 +221,9 @@ public:
 
         // Verify that the command is present in AcceptedCommands before attempting to invoke it.
         // This ensures tests match real-world behavior where the Interaction Model checks AcceptedCommands first.
-        auto checkStatus = IsCommandAnAcceptedCommand(commandId);
-        if (!checkStatus.IsSuccess())
+        if (!IsCommandAnAcceptedCommand(commandId))
         {
-            result.status = checkStatus;
+            result.status = CHIP_ERROR_INVALID_ARGUMENT;
             return result;
         }
 

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "protocols/interaction_model/StatusCode.h"
 #include <app/AttributeValueDecoder.h>
 #include <app/AttributeValueEncoder.h>
 #include <app/CommandHandler.h>
@@ -104,7 +105,7 @@ public:
 
         // Verify that the attribute is present in AttributeList before attempting to read it.
         // This ensures tests match real-world behavior where the Interaction Model checks AttributeList first.
-        VerifyOrReturnError(IsAttributeInAttributeList(attr_id), CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(IsAttributeInAttributeList(attr_id), Protocols::InteractionModel::Status::UnsupportedAttribute);
 
         auto path = mCluster.GetPaths()[0];
 
@@ -148,7 +149,7 @@ public:
 
         // Verify that the attribute is present in AttributeList before attempting to write it.
         // This ensures tests match real-world behavior where the Interaction Model checks AttributeList first.
-        VerifyOrReturnError(IsAttributeInAttributeList(attr), CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(IsAttributeInAttributeList(attr), Protocols::InteractionModel::Status::UnsupportedAttribute);
 
         app::ConcreteAttributePath path(paths[0].mEndpointId, paths[0].mClusterId, attr);
         chip::Testing::WriteOperation writeOp(path);
@@ -223,7 +224,7 @@ public:
         // This ensures tests match real-world behavior where the Interaction Model checks AcceptedCommands first.
         if (!IsCommandAnAcceptedCommand(commandId))
         {
-            result.status = CHIP_ERROR_INVALID_ARGUMENT;
+            result.status = Protocols::InteractionModel::Status::InvalidCommand;
             return result;
         }
 

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -46,6 +46,7 @@
 #include <lib/support/Span.h>
 #include <protocols/interaction_model/StatusCode.h>
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <type_traits>
@@ -53,6 +54,7 @@
 
 namespace chip {
 namespace Testing {
+
 // Helper class for testing clusters.
 //
 // This class ensures that data read by attribute is referencing valid memory for all
@@ -343,17 +345,8 @@ private:
         }
 
         ReadOnlyBuffer<app::DataModel::AttributeEntry> attributeEntries = builder.TakeBuffer();
-
-        // Check if the requested attribute ID is present in the attribute list
-        for (const auto & entry : attributeEntries)
-        {
-            if (entry.attributeId == attr_id)
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return std::any_of(attributeEntries.begin(), attributeEntries.end(),
+                           [&](const app::DataModel::AttributeEntry & entry) { return entry.attributeId == attr_id; });
     }
 
     bool IsCommandAnAcceptedCommand(CommandId commandId)
@@ -373,18 +366,8 @@ private:
         }
 
         ReadOnlyBuffer<app::DataModel::AcceptedCommandEntry> commandEntries = builder.TakeBuffer();
-
-        // Check if the requested command ID is present in the accepted commands list
-        for (const auto & entry : commandEntries)
-        {
-            if (entry.commandId == commandId)
-            {
-                return true;
-            }
-        }
-
-        // Command not found in AcceptedCommands
-        return false;
+        return std::any_of(commandEntries.begin(), commandEntries.end(),
+                           [&](const app::DataModel::AcceptedCommandEntry & entry) { return entry.commandId == commandId; });
     }
 
     TestServerClusterContext mTestServerClusterContext{};

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -23,12 +23,12 @@
 #include <app/ConcreteClusterPath.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/ConcreteEventPath.h>
-#include <app/data-model/List.h>
-#include <app/data-model/NullObject.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/data-model-provider/tests/ReadTesting.h>
 #include <app/data-model-provider/tests/WriteTesting.h>
+#include <app/data-model/List.h>
+#include <app/data-model/NullObject.h>
 #include <app/server-cluster/ServerClusterInterface.h>
 #include <app/server-cluster/testing/FabricTestFixture.h>
 #include <app/server-cluster/testing/MockCommandHandler.h>

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -219,7 +219,19 @@ public:
         mHandler.ClearResponses();
         mHandler.ClearStatuses();
 
-        const app::DataModel::InvokeRequest invokeRequest = { .path = { paths[0].mEndpointId, paths[0].mClusterId, commandId } };
+        // Verify that the command is present in AcceptedCommands before attempting to invoke it.
+        // This ensures tests match real-world behavior where the Interaction Model checks AcceptedCommands first.
+        auto checkStatus = VerifyCommandInAcceptedCommandsList(commandId);
+        if (!checkStatus.IsSuccess())
+        {
+            result.status = checkStatus;
+            return result;
+        }
+
+        Access::SubjectDescriptor subjectDescriptor{ .fabricIndex = mHandler.GetAccessingFabricIndex() };
+        app::DataModel::InvokeRequest invokeRequest;
+        invokeRequest.path              = { paths[0].mEndpointId, paths[0].mClusterId, commandId };
+        invokeRequest.subjectDescriptor = &subjectDescriptor;
 
         TLV::TLVWriter writer;
         writer.Init(mTlvBuffer);
@@ -339,6 +351,34 @@ private:
 
         // Attribute not found in AttributeList
         return CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute);
+    }
+
+    // Verifies that a command is present in the cluster's AcceptedCommands list.
+    // @returns CHIP_NO_ERROR if the command is found in AcceptedCommands.
+    // @returns CHIP_IM_GLOBAL_STATUS(UnsupportedCommand) if the command is not found in AcceptedCommands.
+    // @returns error status if AcceptedCommands cannot be retrieved.
+    app::DataModel::ActionReturnStatus VerifyCommandInAcceptedCommandsList(CommandId command_id)
+    {
+        auto path = mCluster.GetPaths()[0];
+
+        // Get the list of accepted commands from the cluster
+        ReadOnlyBufferBuilder<app::DataModel::AcceptedCommandEntry> builder;
+        CHIP_ERROR err = mCluster.AcceptedCommands(path, builder);
+        ReturnErrorOnFailure(err);
+
+        ReadOnlyBuffer<app::DataModel::AcceptedCommandEntry> commandEntries = builder.TakeBuffer();
+
+        // Check if the requested command ID is present in the accepted commands list
+        for (const auto & entry : commandEntries)
+        {
+            if (entry.commandId == command_id)
+            {
+                return CHIP_NO_ERROR;
+            }
+        }
+
+        // Command not found in AcceptedCommands
+        return CHIP_IM_GLOBAL_STATUS(UnsupportedCommand);
     }
 
     TestServerClusterContext mTestServerClusterContext{};

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -232,9 +232,12 @@ public:
         }
 
         const Access::SubjectDescriptor subjectDescriptor{ .fabricIndex = mHandler.GetAccessingFabricIndex() };
-        app::DataModel::InvokeRequest invokeRequest;
-        invokeRequest.path              = { paths[0].mEndpointId, paths[0].mClusterId, commandId };
-        invokeRequest.subjectDescriptor = &subjectDescriptor;
+        const app::DataModel::InvokeRequest invokeRequest = [&]() {
+            app::DataModel::InvokeRequest request;
+            request.path              = { paths[0].mEndpointId, paths[0].mClusterId, commandId };
+            request.subjectDescriptor = &subjectDescriptor;
+            return request;
+        }();
 
         TLV::TLVWriter writer;
         writer.Init(mTlvBuffer);

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -228,7 +228,7 @@ public:
             return result;
         }
 
-        Access::SubjectDescriptor subjectDescriptor{ .fabricIndex = mHandler.GetAccessingFabricIndex() };
+        const Access::SubjectDescriptor subjectDescriptor{ .fabricIndex = mHandler.GetAccessingFabricIndex() };
         app::DataModel::InvokeRequest invokeRequest;
         invokeRequest.path              = { paths[0].mEndpointId, paths[0].mClusterId, commandId };
         invokeRequest.subjectDescriptor = &subjectDescriptor;

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -357,7 +357,7 @@ private:
     // @returns CHIP_NO_ERROR if the command is found in AcceptedCommands.
     // @returns CHIP_IM_GLOBAL_STATUS(UnsupportedCommand) if the command is not found in AcceptedCommands.
     // @returns error status if AcceptedCommands cannot be retrieved.
-    app::DataModel::ActionReturnStatus VerifyCommandInAcceptedCommandsList(CommandId command_id)
+    app::DataModel::ActionReturnStatus VerifyCommandInAcceptedCommandsList(CommandId commandId)
     {
         auto path = mCluster.GetPaths()[0];
 
@@ -371,7 +371,7 @@ private:
         // Check if the requested command ID is present in the accepted commands list
         for (const auto & entry : commandEntries)
         {
-            if (entry.commandId == command_id)
+            if (entry.commandId == commandId)
             {
                 return CHIP_NO_ERROR;
             }

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "protocols/interaction_model/StatusCode.h"
 #include <app/AttributeValueDecoder.h>
 #include <app/AttributeValueEncoder.h>
 #include <app/CommandHandler.h>
@@ -24,12 +23,12 @@
 #include <app/ConcreteClusterPath.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/ConcreteEventPath.h>
+#include <app/data-model/List.h>
+#include <app/data-model/NullObject.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/data-model-provider/tests/ReadTesting.h>
 #include <app/data-model-provider/tests/WriteTesting.h>
-#include <app/data-model/List.h>
-#include <app/data-model/NullObject.h>
 #include <app/server-cluster/ServerClusterInterface.h>
 #include <app/server-cluster/testing/FabricTestFixture.h>
 #include <app/server-cluster/testing/MockCommandHandler.h>
@@ -45,6 +44,8 @@
 #include <lib/core/TLVReader.h>
 #include <lib/support/ReadOnlyBuffer.h>
 #include <lib/support/Span.h>
+#include <protocols/interaction_model/StatusCode.h>
+
 #include <memory>
 #include <optional>
 #include <type_traits>

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -331,6 +331,9 @@ private:
     // @returns error status if Attributes cannot be retrieved.
     app::DataModel::ActionReturnStatus VerifyAttributeInAttributeList(AttributeId attr_id)
     {
+        // These methods work IF AND ONLY IF cluster path contains exactly one path since
+        // we get accepted commands by path.
+        VerifyOrReturnError(mCluster.GetPaths().size() == 1, CHIP_ERROR_INVALID_ARGUMENT);
         auto path = mCluster.GetPaths()[0];
 
         // Get the list of attributes from the cluster's metadata
@@ -359,6 +362,9 @@ private:
     // @returns error status if AcceptedCommands cannot be retrieved.
     app::DataModel::ActionReturnStatus VerifyCommandInAcceptedCommandsList(CommandId commandId)
     {
+        // These methods work IF AND ONLY IF cluster path contains exactly one path since
+        // we get accepted commands by path.
+        VerifyOrReturnError(mCluster.GetPaths().size() == 1, CHIP_ERROR_INCORRECT_STATE);
         auto path = mCluster.GetPaths()[0];
 
         // Get the list of accepted commands from the cluster

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -329,7 +329,7 @@ private:
     bool IsAttributeInAttributeList(AttributeId attr_id)
     {
         // These methods work IF AND ONLY IF cluster path contains exactly one path since
-        // we get accepted commands by path.
+        // we get attributes by path.
         VerifyOrDie(mCluster.GetPaths().size() == 1);
         auto path = mCluster.GetPaths()[0];
 

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -226,7 +226,7 @@ public:
         // This ensures tests match real-world behavior where the Interaction Model checks AcceptedCommands first.
         if (!IsCommandAnAcceptedCommand(commandId))
         {
-            result.status = Protocols::InteractionModel::Status::InvalidCommand;
+            result.status = Protocols::InteractionModel::Status::UnsupportedCommand;
             return result;
         }
 


### PR DESCRIPTION
#### Summary

Update clustertester:
- have invoke provide a subject descriptor
- add a `IsCommandAnAcceptedCommand` method and use it to validate invoke requests
- update the methods to validate commands are in a list to be `bool` instead of an actionreturnstatus.

Changes are split out as a separate reviewable code from #42634

#### Testing

Existing CI tests heavily exercise this code already (so no breakages).
Changes in #62634 will make use of fabric scoped commands (tested it there)