### PR TITLE
Update minmdns buildconfig.

### DIFF
--- a/src/lib/dnssd/ActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/ActiveResolveAttempts.cpp
@@ -17,8 +17,8 @@
 
 #include "ActiveResolveAttempts.h"
 
+#include <lib/dnssd/minimal_mdns/MinMdnsConfig.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <minmdns/MinMdnsConfig.h>
 
 using namespace chip;
 

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -27,6 +27,7 @@
 #include <crypto/RandUtils.h>
 #include <lib/dnssd/Advertiser_ImplMinimalMdnsAllocator.h>
 #include <lib/dnssd/minimal_mdns/AddressPolicy.h>
+#include <lib/dnssd/minimal_mdns/MinMdnsConfig.h>
 #include <lib/dnssd/minimal_mdns/ResponseSender.h>
 #include <lib/dnssd/minimal_mdns/Server.h>
 #include <lib/dnssd/minimal_mdns/core/FlatAllocatedQName.h>
@@ -39,7 +40,6 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/IntrusiveList.h>
 #include <lib/support/StringBuilder.h>
-#include <minmdns/MinMdnsConfig.h>
 
 namespace chip {
 namespace Dnssd {

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -20,9 +20,9 @@
 #include <lib/dnssd/ServiceNaming.h>
 #include <lib/dnssd/TxtFields.h>
 #include <lib/dnssd/minimal_mdns/Logging.h>
+#include <lib/dnssd/minimal_mdns/MinMdnsConfig.h>
 #include <lib/dnssd/minimal_mdns/core/RecordWriter.h>
 #include <lib/support/CHIPMemString.h>
-#include <minmdns/MinMdnsConfig.h>
 #include <tracing/macros.h>
 
 namespace chip {

--- a/src/lib/dnssd/MinimalMdnsServer.cpp
+++ b/src/lib/dnssd/MinimalMdnsServer.cpp
@@ -17,7 +17,7 @@
 #include "MinimalMdnsServer.h"
 
 #include <lib/dnssd/minimal_mdns/AddressPolicy.h>
-#include <minmdns/MinMdnsConfig.h>
+#include <lib/dnssd/minimal_mdns/MinMdnsConfig.h>
 
 #ifndef CHIP_MINMDNS_DEFAULT_POLICY
 #define CHIP_MINMDNS_DEFAULT_POLICY 0

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -23,13 +23,13 @@
 #include <lib/dnssd/MinimalMdnsServer.h>
 #include <lib/dnssd/ServiceNaming.h>
 #include <lib/dnssd/minimal_mdns/Logging.h>
+#include <lib/dnssd/minimal_mdns/MinMdnsConfig.h>
 #include <lib/dnssd/minimal_mdns/Parser.h>
 #include <lib/dnssd/minimal_mdns/QueryBuilder.h>
 #include <lib/dnssd/minimal_mdns/RecordData.h>
 #include <lib/dnssd/minimal_mdns/core/FlatAllocatedQName.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <minmdns/MinMdnsConfig.h>
 #include <tracing/macros.h>
 
 namespace chip {

--- a/src/lib/dnssd/minimal_mdns/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/BUILD.gn
@@ -45,8 +45,8 @@ declare_args() {
   chip_minmdns_default_policy = "default"
 }
 
-buildconfig_header("buildconfig") {
-  header = "MinMdnsConfig.h"
+buildconfig_header("minmdns_buildconfig") {
+  header = "MinMdnsBuildConfig.h"
   header_dir = "minmdns"
 
   defines = []
@@ -72,6 +72,13 @@ buildconfig_header("buildconfig") {
     assert(chip_minmdns_default_policy == "none",
            "minmdns default policy should be a supported value")
   }
+
+  visibility = [ ":config" ]
+}
+
+source_set("config") {
+  sources = [ "MinMdnsConfig.h" ]
+  deps = [ ":minmdns_buildconfig" ]
 }
 
 source_set("address_policy") {
@@ -150,7 +157,7 @@ static_library("minimal_mdns") {
 
   public_deps = [
     ":address_policy",
-    ":buildconfig",
+    ":config",
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/dnssd/minimal_mdns/core",

--- a/src/lib/dnssd/minimal_mdns/Logging.h
+++ b/src/lib/dnssd/minimal_mdns/Logging.h
@@ -18,9 +18,9 @@
 
 #include <inet/IPAddress.h>
 #include <lib/core/PeerId.h>
+#include <lib/dnssd/minimal_mdns/MinMdnsConfig.h>
 #include <lib/dnssd/minimal_mdns/Parser.h>
 #include <lib/dnssd/minimal_mdns/Query.h>
-#include <minmdns/MinMdnsConfig.h>
 
 namespace mdns {
 namespace Minimal {

--- a/src/lib/dnssd/minimal_mdns/MinMdnsConfig.h
+++ b/src/lib/dnssd/minimal_mdns/MinMdnsConfig.h
@@ -1,0 +1,20 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#if CHIP_HAVE_CONFIG_H
+#include <minmdns/MinMdnsBuildConfig.h>
+#endif

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
@@ -19,7 +19,7 @@
 
 #include "QueryReplyFilter.h"
 
-#include <minmdns/MinMdnsConfig.h>
+#include <lib/dnssd/minimal_mdns/MinMdnsConfig.h>
 #include <system/SystemClock.h>
 
 namespace mdns {

--- a/src/lib/dnssd/minimal_mdns/Server.h
+++ b/src/lib/dnssd/minimal_mdns/Server.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <minmdns/MinMdnsConfig.h>
+#include <lib/dnssd/minimal_mdns/MinMdnsConfig.h>
 
 #include <inet/IPAddress.h>
 #include <inet/InetInterface.h>


### PR DESCRIPTION
#### Summary

All existing buildconfig headers in matter are guarded by a CHIP_HAVE_CONFIG_H guard. Use the same pattern in minmdns.

#### Testing

There are no functional changes here: compile testing should be sufficient. This just allows for better integration in 3rd party when no config_h files are used.