### PR TITLE
Use dependency injection in `AccessControl` cluster for global values

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -88,7 +88,13 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
     mSoftwareDiagnosticsServerCluster.Create(SoftwareDiagnosticsLogic::OptionalAttributeSet{});
     ReturnErrorOnFailure(provider.AddCluster(mSoftwareDiagnosticsServerCluster.Registration()));
 
-    mAccessControlCluster.Create();
+    mAccessControlCluster.Create(
+        AccessControlCluster::Context{
+            .persistentStorage = Server::GetInstance().GetPersistentStorage(),
+            .fabricTable      = Server::GetInstance().GetFabricTable(),
+            .accessControl    = Access::GetAccessControl(),
+        }
+    );
     ReturnErrorOnFailure(provider.AddCluster(mAccessControlCluster.Registration()));
 
     mOperationalCredentialsCluster.Create(endpointId,

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -89,9 +89,9 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
     ReturnErrorOnFailure(provider.AddCluster(mSoftwareDiagnosticsServerCluster.Registration()));
 
     mAccessControlCluster.Create(AccessControlCluster::Context{
-        .persistentStorage = Server::GetInstance().GetPersistentStorage(),
-        .fabricTable       = Server::GetInstance().GetFabricTable(),
-        .accessControl     = Access::GetAccessControl(),
+        .persistentStorage = mContext.persistentStorage,
+        .fabricTable       = mContext.fabricTable,
+        .accessControl     = mContext.accessControl,
     });
     ReturnErrorOnFailure(provider.AddCluster(mAccessControlCluster.Registration()));
 

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -88,13 +88,11 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
     mSoftwareDiagnosticsServerCluster.Create(SoftwareDiagnosticsLogic::OptionalAttributeSet{});
     ReturnErrorOnFailure(provider.AddCluster(mSoftwareDiagnosticsServerCluster.Registration()));
 
-    mAccessControlCluster.Create(
-        AccessControlCluster::Context{
-            .persistentStorage = Server::GetInstance().GetPersistentStorage(),
-            .fabricTable      = Server::GetInstance().GetFabricTable(),
-            .accessControl    = Access::GetAccessControl(),
-        }
-    );
+    mAccessControlCluster.Create(AccessControlCluster::Context{
+        .persistentStorage = Server::GetInstance().GetPersistentStorage(),
+        .fabricTable       = Server::GetInstance().GetFabricTable(),
+        .accessControl     = Access::GetAccessControl(),
+    });
     ReturnErrorOnFailure(provider.AddCluster(mAccessControlCluster.Registration()));
 
     mOperationalCredentialsCluster.Create(endpointId,

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
@@ -42,7 +42,9 @@ public:
         DeviceLayer::ConfigurationManager & configurationManager;
         DeviceLayer::DeviceControlServer & deviceControlServer;
         FabricTable & fabricTable;
-        FailSafeContext & failSafeContext;
+        Access::AccessControl & accessControl;
+        PersistentStorageDelegate & persistentStorage;
+        FailSafeContext & failsafeContext;
         DeviceLayer::PlatformManager & platformManager;
         Credentials::GroupDataProvider & groupDataProvider;
         SessionManager & sessionManager;

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
@@ -44,7 +44,7 @@ public:
         FabricTable & fabricTable;
         Access::AccessControl & accessControl;
         PersistentStorageDelegate & persistentStorage;
-        FailSafeContext & failsafeContext;
+        FailSafeContext & failSafeContext;
         DeviceLayer::PlatformManager & platformManager;
         Credentials::GroupDataProvider & groupDataProvider;
         SessionManager & sessionManager;

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -202,7 +202,8 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
                 .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
                 .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
                 .fabricTable            = Server::GetInstance().GetFabricTable(),                //
-                .failSafeContext        = Server::GetInstance().GetFailSafeContext(),            //
+                .accessControl          = Server::GetInstance().GetAccessControl(),              //
+                .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
                 .platformManager        = DeviceLayer::PlatformMgr(),                            //
                 .groupDataProvider      = gGropupDataProvider,                                   //
                 .sessionManager         = Server::GetInstance().GetSecureSessionManager(),       //

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -203,6 +203,7 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
                 .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
                 .fabricTable            = Server::GetInstance().GetFabricTable(),                //
                 .accessControl          = Server::GetInstance().GetAccessControl(),              //
+                .persistentStorage      = Server::GetInstance().GetPersistentStorage(),          //
                 .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
                 .platformManager        = DeviceLayer::PlatformMgr(),                            //
                 .groupDataProvider      = gGropupDataProvider,                                   //

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -204,7 +204,7 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
                 .fabricTable            = Server::GetInstance().GetFabricTable(),                //
                 .accessControl          = Server::GetInstance().GetAccessControl(),              //
                 .persistentStorage      = Server::GetInstance().GetPersistentStorage(),          //
-                .failsafeContext        = Server::GetInstance().GetFailSafeContext(),            //
+                .failSafeContext        = Server::GetInstance().GetFailSafeContext(),            //
                 .platformManager        = DeviceLayer::PlatformMgr(),                            //
                 .groupDataProvider      = gGropupDataProvider,                                   //
                 .sessionManager         = Server::GetInstance().GetSecureSessionManager(),       //

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -79,7 +79,7 @@ public:
         FabricTable & fabricTable;
         Access::AccessControl & accessControl;
         PersistentStorageDelegate & persistentStorage;
-        FailSafeContext & failsafeContext;
+        FailSafeContext & failSafeContext;
         DeviceLayer::PlatformManager & platformManager;
         Credentials::GroupDataProvider & groupDataProvider;
         SessionManager & sessionManager;
@@ -100,7 +100,7 @@ public:
                     .fabricTable            = mContext.fabricTable,                //
                     .accessControl          = mContext.accessControl,              //
                     .persistentStorage      = mContext.persistentStorage,          //
-                    .failsafeContext        = mContext.failsafeContext,            //
+                    .failSafeContext        = mContext.failSafeContext,            //
                     .platformManager        = mContext.platformManager,            //
                     .groupDataProvider      = mContext.groupDataProvider,          //
                     .sessionManager         = mContext.sessionManager,             //
@@ -180,7 +180,7 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
             .fabricTable                = Server::GetInstance().GetFabricTable(),                //
             .accessControl              = Server::GetInstance().GetAccessControl(),              //
             .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
-            .failsafeContext            = Server::GetInstance().GetFailSafeContext(),            //
+            .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
             .platformManager            = DeviceLayer::PlatformMgr(),                            //
             .groupDataProvider          = gGroupDataProvider,                                    //
             .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -77,7 +77,9 @@ public:
         DeviceLayer::ConfigurationManager & configurationManager;
         DeviceLayer::DeviceControlServer & deviceControlServer;
         FabricTable & fabricTable;
-        FailSafeContext & failSafeContext;
+        Access::AccessControl & accessControl;
+        PersistentStorageDelegate & persistentStorage;
+        FailSafeContext & failsafeContext;
         DeviceLayer::PlatformManager & platformManager;
         Credentials::GroupDataProvider & groupDataProvider;
         SessionManager & sessionManager;
@@ -96,7 +98,9 @@ public:
                     .configurationManager   = mContext.configurationManager,       //
                     .deviceControlServer    = mContext.deviceControlServer,        //
                     .fabricTable            = mContext.fabricTable,                //
-                    .failSafeContext        = mContext.failSafeContext,            //
+                    .accessControl          = mContext.accessControl,              //
+                    .persistentStorage      = mContext.persistentStorage,          //
+                    .failsafeContext        = mContext.failsafeContext,            //
                     .platformManager        = mContext.platformManager,            //
                     .groupDataProvider      = mContext.groupDataProvider,          //
                     .sessionManager         = mContext.sessionManager,             //
@@ -174,7 +178,9 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
             .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
             .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
             .fabricTable                = Server::GetInstance().GetFabricTable(),                //
-            .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
+            .accessControl              = Server::GetInstance().GetAccessControl(),              //
+            .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
+            .failsafeContext            = Server::GetInstance().GetFailSafeContext(),            //
             .platformManager            = DeviceLayer::PlatformMgr(),                            //
             .groupDataProvider          = gGroupDataProvider,                                    //
             .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //

--- a/src/app/clusters/access-control-server/CodegenIntegration.cpp
+++ b/src/app/clusters/access-control-server/CodegenIntegration.cpp
@@ -42,7 +42,7 @@ public:
         gServer.Create(AccessControlCluster::Context{
             .persistentStorage = Server::GetInstance().GetPersistentStorage(),
             .fabricTable       = Server::GetInstance().GetFabricTable(),
-            .accessControl     = Access::GetAccessControl(),
+            .accessControl     = Server::GetInstance().GetAccessControl(),
         });
         return gServer.Registration();
     }

--- a/src/app/clusters/access-control-server/CodegenIntegration.cpp
+++ b/src/app/clusters/access-control-server/CodegenIntegration.cpp
@@ -39,7 +39,13 @@ public:
     ServerClusterRegistration & CreateRegistration(EndpointId endpointId, unsigned clusterInstanceIndex,
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
-        gServer.Create();
+        gServer.Create(
+            AccessControlCluster::Context{
+                .persistentStorage = Server::GetInstance().GetPersistentStorage(),
+                .fabricTable      = Server::GetInstance().GetFabricTable(),
+                .accessControl    = Access::GetAccessControl(),
+            }
+        );
         return gServer.Registration();
     }
 

--- a/src/app/clusters/access-control-server/CodegenIntegration.cpp
+++ b/src/app/clusters/access-control-server/CodegenIntegration.cpp
@@ -39,13 +39,11 @@ public:
     ServerClusterRegistration & CreateRegistration(EndpointId endpointId, unsigned clusterInstanceIndex,
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
-        gServer.Create(
-            AccessControlCluster::Context{
-                .persistentStorage = Server::GetInstance().GetPersistentStorage(),
-                .fabricTable      = Server::GetInstance().GetFabricTable(),
-                .accessControl    = Access::GetAccessControl(),
-            }
-        );
+        gServer.Create(AccessControlCluster::Context{
+            .persistentStorage = Server::GetInstance().GetPersistentStorage(),
+            .fabricTable       = Server::GetInstance().GetFabricTable(),
+            .accessControl     = Access::GetAccessControl(),
+        });
         return gServer.Registration();
     }
 

--- a/src/app/clusters/access-control-server/access-control-cluster.cpp
+++ b/src/app/clusters/access-control-server/access-control-cluster.cpp
@@ -95,7 +95,8 @@ CHIP_ERROR IsValidAclEntryList(const DataModel::DecodableList<AclStorage::Decoda
     return validationIterator.GetStatus();
 }
 
-CHIP_ERROR WriteAcl(Access::AccessControl & accessControl, const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder)
+CHIP_ERROR WriteAcl(Access::AccessControl & accessControl, const ConcreteDataAttributePath & aPath,
+                    AttributeValueDecoder & aDecoder)
 {
     FabricIndex accessingFabricIndex = aDecoder.AccessingFabricIndex();
 
@@ -125,12 +126,12 @@ CHIP_ERROR WriteAcl(Access::AccessControl & accessControl, const ConcreteDataAtt
             if (i < oldCount)
             {
                 ReturnErrorOnFailure(accessControl.UpdateEntry(&aDecoder.GetSubjectDescriptor(), accessingFabricIndex, i,
-                                                                    iterator.GetValue().GetEntry()));
+                                                               iterator.GetValue().GetEntry()));
             }
             else
             {
                 ReturnErrorOnFailure(accessControl.CreateEntry(&aDecoder.GetSubjectDescriptor(), accessingFabricIndex, nullptr,
-                                                                    iterator.GetValue().GetEntry()));
+                                                               iterator.GetValue().GetEntry()));
             }
             ++i;
         }
@@ -152,7 +153,7 @@ CHIP_ERROR WriteAcl(Access::AccessControl & accessControl, const ConcreteDataAtt
         ReturnErrorOnFailure(aDecoder.Decode(decodableEntry));
 
         return accessControl.CreateEntry(&aDecoder.GetSubjectDescriptor(), accessingFabricIndex, nullptr,
-                                              decodableEntry.GetEntry());
+                                         decodableEntry.GetEntry());
     }
 
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
@@ -235,7 +236,8 @@ CHIP_ERROR CheckExtensionEntryDataFormat(const ByteSpan & data)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WriteExtension(PersistentStorageDelegate & storage, const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder, ServerClusterContext * context)
+CHIP_ERROR WriteExtension(PersistentStorageDelegate & storage, const ConcreteDataAttributePath & aPath,
+                          AttributeValueDecoder & aDecoder, ServerClusterContext * context)
 {
     FabricIndex accessingFabricIndex = aDecoder.AccessingFabricIndex();
 
@@ -396,7 +398,8 @@ CHIP_ERROR ChipErrorToImErrorMap(CHIP_ERROR err)
     return CHIP_ERROR_IM_GLOBAL_STATUS_VALUE(statusOfErr);
 }
 
-CHIP_ERROR WriteImpl(Access::AccessControl & accessControl, PersistentStorageDelegate & storage, const DataModel::WriteAttributeRequest & request, AttributeValueDecoder & decoder,
+CHIP_ERROR WriteImpl(Access::AccessControl & accessControl, PersistentStorageDelegate & storage,
+                     const DataModel::WriteAttributeRequest & request, AttributeValueDecoder & decoder,
                      ServerClusterContext * context)
 {
     switch (request.path.mAttributeId)
@@ -513,7 +516,10 @@ DataModel::ActionReturnStatus AccessControlCluster::ReadAttribute(const DataMode
 DataModel::ActionReturnStatus AccessControlCluster::WriteAttribute(const DataModel::WriteAttributeRequest & request,
                                                                    AttributeValueDecoder & decoder)
 {
-    return NotifyAttributeChangedIfSuccess(request.path.mAttributeId, ChipErrorToImErrorMap(WriteImpl(mClusterContext.accessControl, mClusterContext.persistentStorage, request, decoder, mContext)));
+    return NotifyAttributeChangedIfSuccess(
+        request.path.mAttributeId,
+        ChipErrorToImErrorMap(
+            WriteImpl(mClusterContext.accessControl, mClusterContext.persistentStorage, request, decoder, mContext)));
 }
 
 CHIP_ERROR AccessControlCluster::Attributes(const ConcreteClusterPath & path,

--- a/src/app/clusters/access-control-server/access-control-cluster.cpp
+++ b/src/app/clusters/access-control-server/access-control-cluster.cpp
@@ -63,16 +63,16 @@ using ArlReviewEvent = Events::FabricRestrictionReviewUpdate::Type;
 #endif // CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
 
 namespace {
-CHIP_ERROR ReadAcl(AttributeValueEncoder & aEncoder)
+CHIP_ERROR ReadAcl(FabricTable & fabricTable, Access::AccessControl & accessControl, AttributeValueEncoder & aEncoder)
 {
     AccessControl::EntryIterator iterator;
     AccessControl::Entry entry;
     AclStorage::EncodableEntry encodableEntry(entry);
     return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
-        for (auto & info : Server::GetInstance().GetFabricTable())
+        for (auto & info : fabricTable)
         {
             auto fabric = info.GetFabricIndex();
-            ReturnErrorOnFailure(GetAccessControl().Entries(fabric, iterator));
+            ReturnErrorOnFailure(accessControl.Entries(fabric, iterator));
             CHIP_ERROR err = CHIP_NO_ERROR;
             while ((err = iterator.Next(entry)) == CHIP_NO_ERROR)
             {
@@ -95,14 +95,14 @@ CHIP_ERROR IsValidAclEntryList(const DataModel::DecodableList<AclStorage::Decoda
     return validationIterator.GetStatus();
 }
 
-CHIP_ERROR WriteAcl(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder)
+CHIP_ERROR WriteAcl(Access::AccessControl & accessControl, const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder)
 {
     FabricIndex accessingFabricIndex = aDecoder.AccessingFabricIndex();
 
     size_t oldCount;
-    ReturnErrorOnFailure(GetAccessControl().GetEntryCount(accessingFabricIndex, oldCount));
+    ReturnErrorOnFailure(accessControl.GetEntryCount(accessingFabricIndex, oldCount));
     size_t maxCount;
-    ReturnErrorOnFailure(GetAccessControl().GetMaxEntriesPerFabric(maxCount));
+    ReturnErrorOnFailure(accessControl.GetMaxEntriesPerFabric(maxCount));
 
     if (!aPath.IsListItemOperation())
     {
@@ -124,12 +124,12 @@ CHIP_ERROR WriteAcl(const ConcreteDataAttributePath & aPath, AttributeValueDecod
         {
             if (i < oldCount)
             {
-                ReturnErrorOnFailure(GetAccessControl().UpdateEntry(&aDecoder.GetSubjectDescriptor(), accessingFabricIndex, i,
+                ReturnErrorOnFailure(accessControl.UpdateEntry(&aDecoder.GetSubjectDescriptor(), accessingFabricIndex, i,
                                                                     iterator.GetValue().GetEntry()));
             }
             else
             {
-                ReturnErrorOnFailure(GetAccessControl().CreateEntry(&aDecoder.GetSubjectDescriptor(), accessingFabricIndex, nullptr,
+                ReturnErrorOnFailure(accessControl.CreateEntry(&aDecoder.GetSubjectDescriptor(), accessingFabricIndex, nullptr,
                                                                     iterator.GetValue().GetEntry()));
             }
             ++i;
@@ -139,7 +139,7 @@ CHIP_ERROR WriteAcl(const ConcreteDataAttributePath & aPath, AttributeValueDecod
         while (i < oldCount)
         {
             --oldCount;
-            ReturnErrorOnFailure(GetAccessControl().DeleteEntry(&aDecoder.GetSubjectDescriptor(), accessingFabricIndex, oldCount));
+            ReturnErrorOnFailure(accessControl.DeleteEntry(&aDecoder.GetSubjectDescriptor(), accessingFabricIndex, oldCount));
         }
         return CHIP_NO_ERROR;
     }
@@ -151,7 +151,7 @@ CHIP_ERROR WriteAcl(const ConcreteDataAttributePath & aPath, AttributeValueDecod
         AclStorage::DecodableEntry decodableEntry;
         ReturnErrorOnFailure(aDecoder.Decode(decodableEntry));
 
-        return GetAccessControl().CreateEntry(&aDecoder.GetSubjectDescriptor(), accessingFabricIndex, nullptr,
+        return accessControl.CreateEntry(&aDecoder.GetSubjectDescriptor(), accessingFabricIndex, nullptr,
                                               decodableEntry.GetEntry());
     }
 
@@ -159,11 +159,8 @@ CHIP_ERROR WriteAcl(const ConcreteDataAttributePath & aPath, AttributeValueDecod
 }
 
 #if CHIP_CONFIG_ENABLE_ACL_EXTENSIONS
-CHIP_ERROR ReadExtension(AttributeValueEncoder & aEncoder)
+CHIP_ERROR ReadExtension(PersistentStorageDelegate & storage, FabricTable & fabrics, AttributeValueEncoder & aEncoder)
 {
-    auto & storage = Server::GetInstance().GetPersistentStorage();
-    auto & fabrics = Server::GetInstance().GetFabricTable();
-
     return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
         for (auto & fabric : fabrics)
         {
@@ -238,10 +235,8 @@ CHIP_ERROR CheckExtensionEntryDataFormat(const ByteSpan & data)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WriteExtension(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder, ServerClusterContext * context)
+CHIP_ERROR WriteExtension(PersistentStorageDelegate & storage, const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder, ServerClusterContext * context)
 {
-    auto & storage = Server::GetInstance().GetPersistentStorage();
-
     FabricIndex accessingFabricIndex = aDecoder.AccessingFabricIndex();
 
     uint8_t buffer[kExtensionDataMaxLength] = { 0 };
@@ -329,9 +324,9 @@ CHIP_ERROR WriteExtension(const ConcreteDataAttributePath & aPath, AttributeValu
 #endif
 
 #if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
-CHIP_ERROR ReadCommissioningArl(AttributeValueEncoder & aEncoder)
+CHIP_ERROR ReadCommissioningArl(Access::AccessControl & accessControl, AttributeValueEncoder & aEncoder)
 {
-    auto accessRestrictionProvider = GetAccessControl().GetAccessRestrictionProvider();
+    auto accessRestrictionProvider = accessControl.GetAccessRestrictionProvider();
 
     return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
         if (accessRestrictionProvider != nullptr)
@@ -348,14 +343,14 @@ CHIP_ERROR ReadCommissioningArl(AttributeValueEncoder & aEncoder)
     });
 }
 
-CHIP_ERROR ReadArl(AttributeValueEncoder & aEncoder)
+CHIP_ERROR ReadArl(Access::AccessControl & accessControl, FabricTable & fabricTable, AttributeValueEncoder & aEncoder)
 {
-    auto accessRestrictionProvider = GetAccessControl().GetAccessRestrictionProvider();
+    auto accessRestrictionProvider = accessControl.GetAccessRestrictionProvider();
 
     return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
         if (accessRestrictionProvider != nullptr)
         {
-            for (const auto & info : Server::GetInstance().GetFabricTable())
+            for (const auto & info : fabricTable)
             {
                 auto fabric = info.GetFabricIndex();
                 // get entries for fabric
@@ -401,16 +396,16 @@ CHIP_ERROR ChipErrorToImErrorMap(CHIP_ERROR err)
     return CHIP_ERROR_IM_GLOBAL_STATUS_VALUE(statusOfErr);
 }
 
-CHIP_ERROR WriteImpl(const DataModel::WriteAttributeRequest & request, AttributeValueDecoder & decoder,
+CHIP_ERROR WriteImpl(Access::AccessControl & accessControl, PersistentStorageDelegate & storage, const DataModel::WriteAttributeRequest & request, AttributeValueDecoder & decoder,
                      ServerClusterContext * context)
 {
     switch (request.path.mAttributeId)
     {
     case Acl::Id:
-        return WriteAcl(request.path, decoder);
+        return WriteAcl(accessControl, request.path, decoder);
 #if CHIP_CONFIG_ENABLE_ACL_EXTENSIONS
     case Extension::Id:
-        return WriteExtension(request.path, decoder, context);
+        return WriteExtension(storage, request.path, decoder, context);
 #endif
     default:
         return CHIP_IM_GLOBAL_STATUS(UnsupportedWrite);
@@ -427,10 +422,10 @@ CHIP_ERROR AccessControlCluster::Startup(ServerClusterContext & context)
     ChipLogProgress(DataManagement, "AccessControlCluster: initializing");
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
 
-    GetAccessControl().AddEntryListener(*this);
+    mClusterContext.accessControl.AddEntryListener(*this);
 
 #if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
-    auto accessRestrictionProvider = GetAccessControl().GetAccessRestrictionProvider();
+    auto accessRestrictionProvider = mClusterContext.accessControl.GetAccessRestrictionProvider();
     if (accessRestrictionProvider != nullptr)
     {
         accessRestrictionProvider->AddListener(*this);
@@ -445,14 +440,14 @@ void AccessControlCluster::Shutdown(ClusterShutdownType shutdownType)
     ChipLogProgress(DataManagement, "AccessControlCluster: shutdown");
 
 #if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
-    auto accessRestrictionProvider = GetAccessControl().GetAccessRestrictionProvider();
+    auto accessRestrictionProvider = mClusterContext.accessControl.GetAccessRestrictionProvider();
     if (accessRestrictionProvider != nullptr)
     {
         accessRestrictionProvider->RemoveListener(*this);
     }
 #endif
 
-    GetAccessControl().RemoveEntryListener(*this);
+    mClusterContext.accessControl.RemoveEntryListener(*this);
     DefaultServerCluster::Shutdown(shutdownType);
 }
 
@@ -465,21 +460,21 @@ DataModel::ActionReturnStatus AccessControlCluster::ReadAttribute(const DataMode
     //   - valueFetchError is the underlying CHIP_ERROR that we get when fetching `value`
     size_t value                       = 0;
     CHIP_ERROR valueFetchError         = CHIP_NO_ERROR;
-    const Access::AccessControl & ctrl = GetAccessControl();
+    const Access::AccessControl & ctrl = mClusterContext.accessControl;
 
     switch (request.path.mAttributeId)
     {
     case AccessControl::Attributes::Acl::Id:
-        return ReadAcl(encoder);
+        return ReadAcl(mClusterContext.fabricTable, mClusterContext.accessControl, encoder);
 #if CHIP_CONFIG_ENABLE_ACL_EXTENSIONS
     case AccessControl::Attributes::Extension::Id:
-        return ReadExtension(encoder);
+        return ReadExtension(mClusterContext.persistentStorage, mClusterContext.fabricTable, encoder);
 #endif // CHIP_CONFIG_ENABLE_ACL_EXTENSIONS
 #if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
     case AccessControl::Attributes::CommissioningARL::Id:
-        return ReadCommissioningArl(encoder);
+        return ReadCommissioningArl(mClusterContext.accessControl, encoder);
     case AccessControl::Attributes::Arl::Id:
-        return ReadArl(encoder);
+        return ReadArl(mClusterContext.accessControl, mClusterContext.fabricTable, encoder);
 #endif
     case AccessControl::Attributes::SubjectsPerAccessControlEntry::Id:
         valueFetchError = ctrl.GetMaxSubjectsPerEntry(value);
@@ -518,7 +513,7 @@ DataModel::ActionReturnStatus AccessControlCluster::ReadAttribute(const DataMode
 DataModel::ActionReturnStatus AccessControlCluster::WriteAttribute(const DataModel::WriteAttributeRequest & request,
                                                                    AttributeValueDecoder & decoder)
 {
-    return NotifyAttributeChangedIfSuccess(request.path.mAttributeId, ChipErrorToImErrorMap(WriteImpl(request, decoder, mContext)));
+    return NotifyAttributeChangedIfSuccess(request.path.mAttributeId, ChipErrorToImErrorMap(WriteImpl(mClusterContext.accessControl, mClusterContext.persistentStorage, request, decoder, mContext)));
 }
 
 CHIP_ERROR AccessControlCluster::Attributes(const ConcreteClusterPath & path,
@@ -636,7 +631,7 @@ std::optional<DataModel::ActionReturnStatus> AccessControlCluster::HandleReviewF
         return Protocols::InteractionModel::Status::InvalidCommand;
     }
 
-    CHIP_ERROR err = GetAccessControl().GetAccessRestrictionProvider()->RequestFabricRestrictionReview(
+    CHIP_ERROR err = mClusterContext.accessControl.GetAccessRestrictionProvider()->RequestFabricRestrictionReview(
         commandObj->GetAccessingFabricIndex(), entries, token);
 
     if (err != CHIP_NO_ERROR)

--- a/src/app/clusters/access-control-server/access-control-cluster.h
+++ b/src/app/clusters/access-control-server/access-control-cluster.h
@@ -47,8 +47,7 @@ public:
     };
 
     constexpr AccessControlCluster(const Context & context) :
-        DefaultServerCluster(ConcreteClusterPath::ConstExpr(kRootEndpointId, AccessControl::Id)),
-        mClusterContext(context)
+        DefaultServerCluster(ConcreteClusterPath::ConstExpr(kRootEndpointId, AccessControl::Id)), mClusterContext(context)
     {}
 
     CHIP_ERROR Startup(ServerClusterContext & context) override;

--- a/src/app/clusters/access-control-server/access-control-cluster.h
+++ b/src/app/clusters/access-control-server/access-control-cluster.h
@@ -46,9 +46,9 @@ public:
         Access::AccessControl & accessControl;
     };
 
-    constexpr AccessControlCluster(Context && context) :
+    constexpr AccessControlCluster(const Context & context) :
         DefaultServerCluster(ConcreteClusterPath::ConstExpr(kRootEndpointId, AccessControl::Id)),
-        mClusterContext(std::move(context))
+        mClusterContext(context)
     {}
 
     CHIP_ERROR Startup(ServerClusterContext & context) override;

--- a/src/app/clusters/access-control-server/access-control-cluster.h
+++ b/src/app/clusters/access-control-server/access-control-cluster.h
@@ -21,9 +21,9 @@
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/OptionalAttributeSet.h>
 #include <app/server/Server.h>
-#include <credentials/FabricTable.h>
 #include <clusters/AccessControl/ClusterId.h>
 #include <clusters/AccessControl/Metadata.h>
+#include <credentials/FabricTable.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <platform/DiagnosticDataProvider.h>
 

--- a/src/app/clusters/access-control-server/access-control-cluster.h
+++ b/src/app/clusters/access-control-server/access-control-cluster.h
@@ -21,8 +21,10 @@
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/OptionalAttributeSet.h>
 #include <app/server/Server.h>
+#include <credentials/FabricTable.h>
 #include <clusters/AccessControl/ClusterId.h>
 #include <clusters/AccessControl/Metadata.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <platform/DiagnosticDataProvider.h>
 
 namespace chip {
@@ -37,7 +39,17 @@ class AccessControlCluster : public DefaultServerCluster,
 #endif
 {
 public:
-    constexpr AccessControlCluster() : DefaultServerCluster(ConcreteClusterPath::ConstExpr(kRootEndpointId, AccessControl::Id)) {}
+    struct Context
+    {
+        PersistentStorageDelegate & persistentStorage;
+        FabricTable & fabricTable;
+        Access::AccessControl & accessControl;
+    };
+
+    constexpr AccessControlCluster(Context && context) :
+        DefaultServerCluster(ConcreteClusterPath::ConstExpr(kRootEndpointId, AccessControl::Id)),
+        mClusterContext(std::move(context))
+    {}
 
     CHIP_ERROR Startup(ServerClusterContext & context) override;
 
@@ -81,6 +93,8 @@ private:
     void OnFabricRestrictionReviewUpdate(FabricIndex fabricIndex, uint64_t token, Optional<CharSpan> instruction,
                                          Optional<CharSpan> arlRequestFlowUrl) override;
 #endif
+
+    Context mClusterContext;
 };
 
 } // namespace Clusters

--- a/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
+++ b/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
@@ -119,10 +119,7 @@ struct TestAccessControlCluster : public ::testing::Test
 // and restores the previous provider in TearDown().
 struct TestAccessControlClusterWithMockProvider : public TestAccessControlCluster
 {
-    TestAccessControlClusterWithMockProvider() :
-        mCluster(defaultContext),
-        mTester(mCluster)
-    {}
+    TestAccessControlClusterWithMockProvider() : mCluster(defaultContext), mTester(mCluster) {}
 
     void SetUp() override
     {

--- a/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
+++ b/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
@@ -109,7 +109,7 @@ struct TestAccessControlCluster : public ::testing::Test
     inline static AccessControlCluster::Context defaultContext{
         .persistentStorage = Server::GetInstance().GetPersistentStorage(),
         .fabricTable       = Server::GetInstance().GetFabricTable(),
-        .accessControl     = Server::GetInstance().GetAccessControl(),
+        .accessControl     = Access::GetAccessControl(),
     };
 };
 

--- a/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
+++ b/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
@@ -156,13 +156,13 @@ private:
 
 TEST_F(TestAccessControlCluster, CompileTest)
 {
-    AccessControlCluster cluster(std::move(defaultContext));
+    AccessControlCluster cluster(defaultContext);
     ASSERT_EQ(cluster.GetClusterFlags({ kRootEndpointId, AccessControl::Id }), BitFlags<ClusterQualityFlags>());
 }
 
 TEST_F(TestAccessControlCluster, CommandsTest)
 {
-    AccessControlCluster cluster(std::move(defaultContext));
+    AccessControlCluster cluster(defaultContext);
     ConcreteClusterPath accessControlPath = ConcreteClusterPath(kRootEndpointId, AccessControl::Id);
 
     ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> acceptedCommandsBuilder;
@@ -193,7 +193,7 @@ TEST_F(TestAccessControlCluster, CommandsTest)
 
 TEST_F(TestAccessControlCluster, AttributesTest)
 {
-    AccessControlCluster cluster(std::move(defaultContext));
+    AccessControlCluster cluster(defaultContext);
 
     std::vector<DataModel::AttributeEntry> expectedAttributes(AccessControl::Attributes::kMandatoryMetadata.begin(),
                                                               AccessControl::Attributes::kMandatoryMetadata.end());
@@ -228,7 +228,7 @@ CHIP_ERROR CountListElements(DecodableListType & list, size_t & count)
 // Test that all available attributes (mandatory and optional) can be read
 TEST_F(TestAccessControlCluster, ReadAttributesTest)
 {
-    AccessControlCluster cluster(std::move(defaultContext));
+    AccessControlCluster cluster(defaultContext);
     Testing::ClusterTester tester(cluster);
 
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);

--- a/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
+++ b/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
@@ -108,8 +108,8 @@ struct TestAccessControlCluster : public ::testing::Test
     }
     inline static AccessControlCluster::Context defaultContext{
         .persistentStorage = Server::GetInstance().GetPersistentStorage(),
-        .fabricTable      = Server::GetInstance().GetFabricTable(),
-        .accessControl    = Access::GetAccessControl(),
+        .fabricTable       = Server::GetInstance().GetFabricTable(),
+        .accessControl     = Access::GetAccessControl(),
     };
 };
 
@@ -120,12 +120,11 @@ struct TestAccessControlCluster : public ::testing::Test
 struct TestAccessControlClusterWithMockProvider : public TestAccessControlCluster
 {
     TestAccessControlClusterWithMockProvider() :
-        mCluster(
-            AccessControlCluster::Context{
-                .persistentStorage = Server::GetInstance().GetPersistentStorage(),
-                .fabricTable      = Server::GetInstance().GetFabricTable(),
-                .accessControl    = Access::GetAccessControl(),
-            }),
+        mCluster(AccessControlCluster::Context{
+            .persistentStorage = Server::GetInstance().GetPersistentStorage(),
+            .fabricTable       = Server::GetInstance().GetFabricTable(),
+            .accessControl     = Access::GetAccessControl(),
+        }),
         mTester(mCluster)
     {}
 

--- a/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
+++ b/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
@@ -106,6 +106,11 @@ struct TestAccessControlCluster : public ::testing::Test
         Access::GetAccessControl().Finish();
         Platform::MemoryShutdown();
     }
+    inline static AccessControlCluster::Context defaultContext{
+        .persistentStorage = Server::GetInstance().GetPersistentStorage(),
+        .fabricTable      = Server::GetInstance().GetFabricTable(),
+        .accessControl    = Access::GetAccessControl(),
+    };
 };
 
 #if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
@@ -114,7 +119,15 @@ struct TestAccessControlCluster : public ::testing::Test
 // and restores the previous provider in TearDown().
 struct TestAccessControlClusterWithMockProvider : public TestAccessControlCluster
 {
-    TestAccessControlClusterWithMockProvider() : mTester(mCluster) {}
+    TestAccessControlClusterWithMockProvider() :
+        mCluster(
+            AccessControlCluster::Context{
+                .persistentStorage = Server::GetInstance().GetPersistentStorage(),
+                .fabricTable      = Server::GetInstance().GetFabricTable(),
+                .accessControl    = Access::GetAccessControl(),
+            }),
+        mTester(mCluster)
+    {}
 
     void SetUp() override
     {
@@ -134,6 +147,7 @@ struct TestAccessControlClusterWithMockProvider : public TestAccessControlCluste
 
     TestAccessRestrictionProvider mMockProvider;
     AccessControlCluster mCluster;
+    // mTester must be declared after mCluster to ensure proper construction order
     Testing::ClusterTester mTester;
 
 private:
@@ -143,13 +157,13 @@ private:
 
 TEST_F(TestAccessControlCluster, CompileTest)
 {
-    AccessControlCluster cluster;
+    AccessControlCluster cluster(std::move(defaultContext));
     ASSERT_EQ(cluster.GetClusterFlags({ kRootEndpointId, AccessControl::Id }), BitFlags<ClusterQualityFlags>());
 }
 
 TEST_F(TestAccessControlCluster, CommandsTest)
 {
-    AccessControlCluster cluster;
+    AccessControlCluster cluster(std::move(defaultContext));
     ConcreteClusterPath accessControlPath = ConcreteClusterPath(kRootEndpointId, AccessControl::Id);
 
     ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> acceptedCommandsBuilder;
@@ -180,7 +194,7 @@ TEST_F(TestAccessControlCluster, CommandsTest)
 
 TEST_F(TestAccessControlCluster, AttributesTest)
 {
-    AccessControlCluster cluster;
+    AccessControlCluster cluster(std::move(defaultContext));
 
     std::vector<DataModel::AttributeEntry> expectedAttributes(AccessControl::Attributes::kMandatoryMetadata.begin(),
                                                               AccessControl::Attributes::kMandatoryMetadata.end());
@@ -215,7 +229,7 @@ CHIP_ERROR CountListElements(DecodableListType & list, size_t & count)
 // Test that all available attributes (mandatory and optional) can be read
 TEST_F(TestAccessControlCluster, ReadAttributesTest)
 {
-    AccessControlCluster cluster;
+    AccessControlCluster cluster(std::move(defaultContext));
     Testing::ClusterTester tester(cluster);
 
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);

--- a/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
+++ b/src/app/clusters/access-control-server/tests/TestAccessControlCluster.cpp
@@ -109,7 +109,7 @@ struct TestAccessControlCluster : public ::testing::Test
     inline static AccessControlCluster::Context defaultContext{
         .persistentStorage = Server::GetInstance().GetPersistentStorage(),
         .fabricTable       = Server::GetInstance().GetFabricTable(),
-        .accessControl     = Access::GetAccessControl(),
+        .accessControl     = Server::GetInstance().GetAccessControl(),
     };
 };
 
@@ -120,11 +120,7 @@ struct TestAccessControlCluster : public ::testing::Test
 struct TestAccessControlClusterWithMockProvider : public TestAccessControlCluster
 {
     TestAccessControlClusterWithMockProvider() :
-        mCluster(AccessControlCluster::Context{
-            .persistentStorage = Server::GetInstance().GetPersistentStorage(),
-            .fabricTable       = Server::GetInstance().GetFabricTable(),
-            .accessControl     = Access::GetAccessControl(),
-        }),
+        mCluster(defaultContext),
         mTester(mCluster)
     {}
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -423,6 +423,8 @@ public:
 
     FabricTable & GetFabricTable() { return mFabrics; }
 
+    Access::AccessControl & GetAccessControl() { return mAccessControl; }
+
     CASESessionManager * GetCASESessionManager() { return &mCASESessionManager; }
 
     Messaging::ExchangeManager & GetExchangeManager() { return mExchangeMgr; }


### PR DESCRIPTION
#### Summary

This PR removes all direct uses of these global values in the `AccessContrtol` cluster
- `Server::GetInstance().GetFabricTable()`
- `Server::GetInstance().GetPersistentStorage()`
- `Server::GetInstance().GetAccessControl` (**NOTE**: new function to replace usage in Access::GetAccessControl()` 

Note the new usage/reference to server instead of GetAccessControl global getter. This seems ok here as we already assume `Server::GetInstance`. This results in slightly smaller code than `GetAccessControl` and non-null assertion.

#### Related issues

Fixes: #42593

#### Testing

Green CI

