### PR TITLE
[all-devices]: fix "--help" to not crash and dynamically update device list

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/device-factory/DeviceFactory.h
+++ b/examples/all-devices-app/all-devices-common/devices/device-factory/DeviceFactory.h
@@ -65,6 +65,16 @@ public:
         return nullptr;
     }
 
+    std::vector<std::string> SupportedDeviceTypes() const
+    {
+        std::vector<std::string> result;
+        for (auto & item : mRegistry)
+        {
+            result.push_back(item.first);
+        }
+        return result;
+    }
+
 private:
     std::map<std::string, DeviceCreator> mRegistry;
     DefaultTimerDelegate timer;

--- a/examples/all-devices-app/linux/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/linux/app_options/AppOptions.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app_options/AppOptions.h>
+#include <devices/device-factory/DeviceFactory.h>
 
 using namespace chip;
 using namespace chip::ArgParser;
@@ -64,15 +65,29 @@ OptionSet * AppOptions::GetOptions()
     static OptionDef sAllDevicesAppOptionDefs[] = {
         { "device", kArgumentRequired, kOptionDeviceType },
         { "endpoint", kArgumentRequired, kOptionEndpoint },
+        {}, // need empty terminator
     };
 
-    // TODO: This message on supported device types needs to be updated to scale
-    //  better once new devices are added.
+    static const std::string gHelpText = []() {
+        // Device option - this is dynamic
+        std::string result = "-d, --device<";
+        for (auto & name : app::DeviceFactory::GetInstance().SupportedDeviceTypes())
+        {
+            result.append(name);
+            result.append("|");
+        }
+        result.replace(result.length() - 1, 1, ">");
+        result += "\n";
+
+        // rest of the help
+        result += "-e, --endpoint <endpoint-number>\n";
+        return result;
+    }();
+
     static OptionSet sCmdLineOptions = { AllDevicesAppOptionHandler, // handler function
                                          sAllDevicesAppOptionDefs,   // array of option definitions
                                          "PROGRAM OPTIONS",          // help group
-                                         "-d, --device <contact-sensor|water-leak-detector|occupancy-sensor|chime>\n"
-                                         "-e, --endpoint <endpoint-number>\n" };
+                                         gHelpText.c_str() };
 
     return &sCmdLineOptions;
 }

--- a/examples/all-devices-app/linux/app_options/AppOptions.cpp
+++ b/examples/all-devices-app/linux/app_options/AppOptions.cpp
@@ -70,7 +70,7 @@ OptionSet * AppOptions::GetOptions()
 
     static const std::string gHelpText = []() {
         // Device option - this is dynamic
-        std::string result = "-d, --device<";
+        std::string result = "--device <";
         for (auto & name : app::DeviceFactory::GetInstance().SupportedDeviceTypes())
         {
             result.append(name);
@@ -80,7 +80,7 @@ OptionSet * AppOptions::GetOptions()
         result += "\n";
 
         // rest of the help
-        result += "-e, --endpoint <endpoint-number>\n";
+        result += "--endpoint <endpoint-number>\n";
         return result;
     }();
 

--- a/examples/all-devices-app/linux/app_options/BUILD.gn
+++ b/examples/all-devices-app/linux/app_options/BUILD.gn
@@ -26,6 +26,7 @@ source_set("app-options") {
   ]
 
   public_deps = [
+    "${chip_root}/examples/all-devices-app/all-devices-common/devices/device-factory",
     "${chip_root}/examples/common/tracing:commandline",
     "${chip_root}/examples/platform/linux:app-options",
     "${chip_root}/src/lib",


### PR DESCRIPTION
#### Summary

- Option set was not terminated, which led to a crash in "--help"
- Device list was not dynamically updated. Fixed that.
- Short options were documented but were not enabled. Fixed the documentation.

#### Testing

This is an example app. I just ran `--help`.