### PR TITLE
Add support for revision conformances in spec

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
@@ -455,7 +455,9 @@ class ArithmeticConformance(Conformance):
     ''' Base class for arithmetic operations - do not use directly.'''
 
     def _type_ok(self, op1: Conformance, op2: Conformance):
-        return ((issubclass(type(op1), ValueConformance) or (type(op1) == attribute)) and issubclass(type(op2), ValueConformance))
+        def _is_valid_operand(op: Conformance) -> bool:
+            return issubclass(type(op), ValueConformance) or type(op) == attribute
+        return _is_valid_operand(op1) and _is_valid_operand(op2)
 
     def __init__(self, op1: Conformance, op2: Conformance):
         if not self._type_ok(op1, op2):

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
@@ -464,7 +464,7 @@ class ArithmeticConformance(Conformance):
             raise ConformanceException('Arithmetic operations can only have attribute + literal or revision children')
         self.op1 = op1
         self.op2 = op2
-        self.operator = operator.eq
+        self.operator = operator.gt
         self.opstr = "???"
 
     def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
@@ -473,7 +473,7 @@ class ArithmeticConformance(Conformance):
         # For now, this is fully optional, need to implement this properly later, but it requires access to the actual attribute values
         # We need to reach into the attribute, but can't use it directly because the attribute callable is an EXISTENCE check and
         # the arithmetic functions require a value.
-        if issubclass(type(self.op1), ValueConformance) and issubclass(type(self.op2), ValueConformance):
+        if hasattr(self.op1, 'get_value') and hasattr(self.op2, 'get_value'):
             if self.operator(self.op1.get_value(conformance_assessment_data), self.op2.get_value(conformance_assessment_data)):
                 return ConformanceDecisionWithChoice(ConformanceDecision.MANDATORY)
             return ConformanceDecisionWithChoice(ConformanceDecision.NOT_APPLICABLE)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
@@ -254,7 +254,7 @@ class literal(ValueConformance):
 class revision(ValueConformance):
     def __init__(self, value: str):
         self.value: Optional[int]
-        if value.lower == 'current':
+        if value.lower() == 'current':
             self.value = None
         else:
             self.value = int(value, 0)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
@@ -33,6 +33,7 @@ should be present on a device based on the device's implemented features, attrib
 commands.
 """
 
+import operator
 import xml.etree.ElementTree as ElementTree
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -52,11 +53,13 @@ AND_TERM = 'andTerm'
 OR_TERM = 'orTerm'
 NOT_TERM = 'notTerm'
 GREATER_TERM = 'greaterTerm'
+GREATER_EQUAL_TERM = 'greaterOrEqualTerm'
 FEATURE_TAG = 'feature'
 ATTRIBUTE_TAG = 'attribute'
 COMMAND_TAG = 'command'
 CONDITION_TAG = 'condition'
 LITERAL_TAG = 'literal'
+REVISION_TAG = 'revision'
 ZIGBEE_CONDITION = 'zigbee'
 
 
@@ -225,19 +228,46 @@ class provisional(Conformance):
         return 'P'
 
 
-class literal(Conformance):
+class ValueConformance(Conformance):
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData):
+        # This should never be called
+        raise ConformanceException('Value conformance function should not be called - this is simply a value holder')
+
+    def get_value(self, conformance_assessment_data: ConformanceAssessmentData) -> int:
+        raise ConformanceException('Base get_value function should not be called directly')
+
+
+class literal(ValueConformance):
     def __init__(self, value: str):
         # base=0 allows automatic detection of number format from string prefix:
         # "10" -> 10 (decimal), "0x10" -> 16 (hex), "0o10" -> 8 (octal), "0b10" -> 2 (binary)
         # This is needed because XML literal values can be in different formats
         self.value = int(value, 0)
 
-    def __call__(self, conformance_assessment_data: ConformanceAssessmentData):
-        # This should never be called
-        raise ConformanceException('Literal conformance function should not be called - this is simply a value holder')
-
     def __str__(self):
         return str(self.value)
+
+    def get_value(self, conformance_assessment_data: ConformanceAssessmentData) -> int:
+        return self.value
+
+
+class revision(ValueConformance):
+    def __init__(self, value: str):
+        self.value: Optional[int]
+        if value.lower == 'current':
+            self.value = None
+        else:
+            self.value = int(value, 0)
+
+    def __str__(self):
+        if self.value is None:
+            return "Rev"
+        return f'v{str(self.value)}'
+
+    def get_value(self, conformance_assessment_data: ConformanceAssessmentData) -> int:
+        if self.value is None:
+            return conformance_assessment_data.cluster_revision
+        return self.value
 
 
 # Conformance options that apply regardless of the element set of the cluster or device
@@ -421,24 +451,48 @@ class or_operation(Conformance):
         return f'({" | ".join(op_strs)})'
 
 
-class greater_operation(Conformance):
-    def _type_ok(self, op: Conformance):
-        return type(op) == attribute or type(op) == literal
+class ArithmeticConformance(Conformance):
+    ''' Base class for arithmetic operations - do not use directly.'''
+
+    def _type_ok(self, op1: Conformance, op2: Conformance):
+        return ((issubclass(type(op1), ValueConformance) or (type(op1) == attribute)) and issubclass(type(op2), ValueConformance))
 
     def __init__(self, op1: Conformance, op2: Conformance):
-        if not self._type_ok(op1) or not self._type_ok(op2):
-            raise ConformanceException('Arithmetic operations can only have attribute or literal value children')
+        if not self._type_ok(op1, op2):
+            raise ConformanceException('Arithmetic operations can only have attribute + literal or revision children')
         self.op1 = op1
         self.op2 = op2
+        self.operator = operator.eq
+        self.opstr = "???"
 
     def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+        # If there are any non-value ops, return optional, as it represents an attribute comparison and we don't have the data
+        # for that currently.
         # For now, this is fully optional, need to implement this properly later, but it requires access to the actual attribute values
         # We need to reach into the attribute, but can't use it directly because the attribute callable is an EXISTENCE check and
         # the arithmetic functions require a value.
+        if issubclass(type(self.op1), ValueConformance) and issubclass(type(self.op2), ValueConformance):
+            if self.operator(self.op1.get_value(conformance_assessment_data), self.op2.get_value(conformance_assessment_data)):
+                return ConformanceDecisionWithChoice(ConformanceDecision.MANDATORY)
+            return ConformanceDecisionWithChoice(ConformanceDecision.NOT_APPLICABLE)
         return ConformanceDecisionWithChoice(ConformanceDecision.OPTIONAL)
 
     def __str__(self):
-        return f'{str(self.op1)} > {str(self.op2)}'
+        return f'{str(self.op1)} {self.opstr} {str(self.op2)}'
+
+
+class greater_operation(ArithmeticConformance):
+    def __init__(self, op1: Conformance, op2: Conformance):
+        super().__init__(op1, op2)
+        self.operator = operator.gt
+        self.opstr = '>'
+
+
+class greater_equal_operation(ArithmeticConformance):
+    def __init__(self, op1: Conformance, op2: Conformance):
+        super().__init__(op1, op2)
+        self.operator = operator.ge
+        self.opstr = '>='
 
 
 class otherwise(Conformance):
@@ -509,6 +563,12 @@ def parse_basic_callable_from_xml(element: ElementTree.Element) -> Conformance:
                 raise ConformanceException(
                     f"Literal tag missing 'value' attribute: {ElementTree.tostring(element, encoding='unicode').strip()}")
             return literal(literal_value)
+        if element.tag == REVISION_TAG:
+            value = element.get('value')
+            if value is None:
+                raise ConformanceException(
+                    f"Revision tag missing 'value' attribute: {ElementTree.tostring(element, encoding='unicode').strip()}")
+            return revision(value)
         raise BasicConformanceException(
             f'parse_basic_callable_from_xml called for unknown element {str(element.tag)} {str(element.attrib)}')
 
@@ -563,6 +623,10 @@ def parse_wrapper_callable_from_xml(element: ElementTree.Element, ops: list[Conf
         if len(ops) != 2:
             raise ConformanceException(f'Greater than term found with more than two subelements {list(element)}')
         return greater_operation(ops[0], ops[1])
+    if element.tag == GREATER_EQUAL_TERM:
+        if len(ops) != 2:
+            raise ConformanceException(f'Greater than term found with more than two subelements {list(element)}')
+        return greater_equal_operation(ops[0], ops[1])
     raise ConformanceException(f'Unexpected conformance tag with children {element}')
 
 

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -719,7 +719,7 @@ class TestConformanceSupport(MatterBaseTest):
         xml = create_xml(1)
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
-        asserts.assert_equal(str(xml_callable), f'Rev >= v1')
+        asserts.assert_equal(str(xml_callable), 'Rev >= v1')
 
         conformance_assessment_data.cluster_revision = 1
         asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.MANDATORY)
@@ -729,7 +729,7 @@ class TestConformanceSupport(MatterBaseTest):
         xml = create_xml(5)
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
-        asserts.assert_equal(str(xml_callable), f'Rev >= v5')
+        asserts.assert_equal(str(xml_callable), 'Rev >= v5')
 
         conformance_assessment_data.cluster_revision = 1
         asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.NOT_APPLICABLE)

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -695,7 +695,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         try:
             xml_callable = parse_callable_from_xml(et, self.params)
-            asserts.fail("Incorrectly parsed greater term with feature value")
+            asserts.fail(f"Incorrectly parsed {term} with feature value")
         except ConformanceException:
             pass
 

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -655,10 +655,10 @@ class TestConformanceSupport(MatterBaseTest):
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.PROVISIONAL)
         asserts.assert_equal(str(xml_callable), 'AB & !CD, P')
 
-    def test_conformance_greater(self):
+    def _test_conformance_arithmetic(self, term: str):
         # AB, [CD]
         xml = ('<mandatoryConform>'
-               '<greaterTerm>'
+               f'{term}'
                '<attribute name="attr1" />'
                '<literal value="1" />'
                '</greaterTerm>'
@@ -709,6 +709,9 @@ class TestConformanceSupport(MatterBaseTest):
             asserts.fail("Incorrectly parsed greater term with feature value")
         except ConformanceException:
             pass
+
+    def test_conformance_greater(self):
+        self._test_conformance_arithmetic('<greaterTerm>')
 
     def test_basic_conformance(self):
         basic_test('<mandatoryConform />', mandatory)

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -716,14 +716,16 @@ class TestConformanceSupport(MatterBaseTest):
 
         conformance_assessment_data = EMPTY_CLUSTER_GLOBAL_ATTRIBUTES
 
-        xml = create_xml(1)
+        xml = create_xml(2)
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
-        asserts.assert_equal(str(xml_callable), 'Rev >= v1')
+        asserts.assert_equal(str(xml_callable), 'Rev >= v2')
 
         conformance_assessment_data.cluster_revision = 1
-        asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.MANDATORY)
+        asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.NOT_APPLICABLE)
         conformance_assessment_data.cluster_revision = 2
+        asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.MANDATORY)
+        conformance_assessment_data.cluster_revision = 3
         asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.MANDATORY)
 
         xml = create_xml(5)
@@ -745,8 +747,8 @@ class TestConformanceSupport(MatterBaseTest):
         too_many_terms = ('<mandatoryConform>'
                           '<greaterOrEqualTerm>'
                           '<revision value="current"/>'
-                          '<revision value="1"/>'
-                          '<revision value="1"/>'
+                          '<revision value="2"/>'
+                          '<revision value="2"/>'
                           '</greaterOrEqualTerm>'
                           '</mandatoryConform>')
         et = ElementTree.fromstring(too_many_terms)
@@ -764,7 +766,7 @@ class TestConformanceSupport(MatterBaseTest):
 
         too_few_terms_value = ('<mandatoryConform>'
                                '<greaterOrEqualTerm>'
-                               '<revision value="1"/>'
+                               '<revision value="2"/>'
                                '</greaterOrEqualTerm>'
                                '</mandatoryConform>')
         et = ElementTree.fromstring(too_few_terms_value)

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -677,7 +677,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         try:
             xml_callable = parse_callable_from_xml(et, self.params)
-            asserts.fail("Incorrectly parsed bad greaterTerm XML with > 2 values")
+            asserts.fail(f"Incorrectly parsed bad {term} XML with > 2 values")
         except ConformanceException:
             pass
 


### PR DESCRIPTION
#### Summary
1.5.1 is introducing a new type of conformance - revision. This is supported in alchmy, but needs support on the testing framework to properly assess these conformances. This PR introduces the processing functions for revision conformance, along with unit tests. The DM files are not yet pulled into the SDK (and cannot land until this PR lands), so these functions are not yet used in processing. However, 1.5.1 DM files were tested locally with this change.

#### Related issues

spec PR adding revision conformance - https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/12218
initial SDK PR adding revision to the conformance call sites - https://github.com/project-chip/connectedhomeip/pull/42553

#### Testing
Added unit tests. I opted to split this implementation from the addition of the 1.5.1 data model files, but I put up a demo PR to show the new conformance parsing working with the 1.5.1 DM files that contain these structures (includes additions to the spec parsing tests to show them being parsed and used) - https://github.com/project-chip/connectedhomeip/pull/42660

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
