### PR TITLE
[Realtek] Add watchdog support for thread task

### DIFF
--- a/src/platform/realtek/freertos/ThreadStackManagerImpl.cpp
+++ b/src/platform/realtek/freertos/ThreadStackManagerImpl.cpp
@@ -112,7 +112,12 @@ CHIP_ERROR ThreadStackManagerImpl::InitThreadStack(otInstance * otInst)
     mThreadTask = NULL;
 
 #if WATCH_DOG_ENABLE
-    os_msg_queue_create(&matter_wdt_io_queue_handle, "wdtQ", WATCH_DOG_MSG_MAX_NUM, sizeof(T_IO_MSG));
+    if (os_msg_queue_create(&matter_wdt_io_queue_handle, "wdtQ", WATCH_DOG_MSG_MAX_NUM, sizeof(T_IO_MSG)) == false)
+    {
+        ChipLogError(DeviceLayer, "Failed to create watchdog message queue");
+        err = CHIP_ERROR_INTERNAL;
+        goto exit;
+    }
     matter_wdt_init(matter_wdt_io_queue_handle);
 #endif
 

--- a/src/platform/realtek/freertos/ThreadStackManagerImpl.cpp
+++ b/src/platform/realtek/freertos/ThreadStackManagerImpl.cpp
@@ -31,6 +31,8 @@
 #else
 #include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp>
 #endif
+#include "board.h"
+#include "os_msg.h"
 #include "os_task.h"
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPPlatformMemory.h>
@@ -39,6 +41,13 @@
 #include <platform/OpenThread/OpenThreadUtils.h>
 #include <platform/ThreadStackManager.h>
 #include <platforms/openthread-system.h>
+
+#if WATCH_DOG_ENABLE
+#include "matter_wdt.h"
+
+#define WATCH_DOG_MSG_MAX_NUM 5
+static void * matter_wdt_io_queue_handle;
+#endif
 
 namespace {
 #if defined(FEATURE_TRUSTZONE_ENABLE) && (FEATURE_TRUSTZONE_ENABLE == 1)
@@ -101,6 +110,11 @@ CHIP_ERROR ThreadStackManagerImpl::InitThreadStack(otInstance * otInst)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     mThreadTask = NULL;
+
+#if WATCH_DOG_ENABLE
+    os_msg_queue_create(&matter_wdt_io_queue_handle, "wdtQ", WATCH_DOG_MSG_MAX_NUM, sizeof(T_IO_MSG));
+    matter_wdt_init(matter_wdt_io_queue_handle);
+#endif
 
     ChipLogProgress(DeviceLayer, "ThreadStackManagerImpl::InitThreadStack");
     // Initialize the OpenThread platform layer
@@ -197,6 +211,10 @@ void ThreadStackManagerImpl::SignalThreadActivityPendingFromISR()
 
 CHIP_ERROR ThreadStackManagerImpl::_StartThreadTask()
 {
+#if WATCH_DOG_ENABLE
+    matter_wdt_watchdog_open();
+#endif
+
     if (os_task_create(&mThreadTask, CHIP_DEVICE_CONFIG_THREAD_TASK_NAME, ThreadTaskMain, this,
                        CHIP_DEVICE_CONFIG_THREAD_TASK_STACK_SIZE, CHIP_DEVICE_CONFIG_THREAD_TASK_PRIORITY))
     {
@@ -211,8 +229,20 @@ void ThreadStackManagerImpl::ExecuteThreadTask(void)
     AllocateThreadTaskSecureContext();
 #endif
     uint32_t notify;
+    T_IO_MSG io_msg;
+
     while (true)
     {
+#if WATCH_DOG_ENABLE
+        while (os_msg_recv(matter_wdt_io_queue_handle, &io_msg, 0) == true)
+        {
+            if (io_msg.type == IO_MSG_TYPE_RESET_WDG_TIMER)
+            {
+                matter_wdt_watchdog_feed();
+            }
+        }
+#endif
+
         LockThreadStack();
         ProcessThreadActivity();
         UnlockThreadStack();


### PR DESCRIPTION
#### Summary

Add watchdog mechanism  to detect and recover from abnormal system hangs. If the Thread task fails to run normally for an extended period, the watchdog detects this and initiates a system reset, thus maintaining system stability and reliability.

#### Related issues

NA

#### Testing

Tested manually by building these apps with latest docker container.
