### PR TITLE
Add validation for UnitLocalization endpoint.

### DIFF
--- a/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
+++ b/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
@@ -27,6 +27,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::UnitLocalization;
 
+// UnitLocalization may be present in the root endpoint and shall not be present in any other endpoint.
 static_assert((UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 1 &&
                UnitLocalization::StaticApplicationConfig::kFixedClusterConfig[0].endpointNumber == kRootEndpointId) ||
               (UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 0));

--- a/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
+++ b/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
@@ -30,7 +30,8 @@ using namespace chip::app::Clusters::UnitLocalization;
 // UnitLocalization may be present in the root endpoint and shall not be present in any other endpoint.
 static_assert((UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 1 &&
                UnitLocalization::StaticApplicationConfig::kFixedClusterConfig[0].endpointNumber == kRootEndpointId) ||
-              (UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 0));
+              (UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 0),
+              "UnitLocalization MAY be present only in root endpoint");
 
 namespace {
 

--- a/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
+++ b/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
@@ -27,13 +27,13 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::UnitLocalization;
 
-LazyRegisteredServerCluster<UnitLocalizationServer> gServer;
+static_assert((UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 1 &&
+               UnitLocalization::StaticApplicationConfig::kFixedClusterConfig[0].endpointNumber == kRootEndpointId) ||
+              (UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 0));
 
-UnitLocalizationServer & UnitLocalizationServer::Instance()
-{
-    VerifyOrDie(gServer.IsConstructed());
-    return gServer.Cluster();
-}
+namespace {
+
+LazyRegisteredServerCluster<UnitLocalizationServer> gServer;
 
 class IntegrationDelegate : public CodegenClusterIntegration::Delegate
 {
@@ -55,6 +55,14 @@ public:
     // Nothing to destroy: separate singleton class without constructor/destructor is used
     void ReleaseRegistration(unsigned clusterInstanceIndex) override { gServer.Destroy(); }
 };
+
+}
+
+UnitLocalizationServer & UnitLocalizationServer::Instance()
+{
+    VerifyOrDie(gServer.IsConstructed());
+    return gServer.Cluster();
+}
 
 void MatterUnitLocalizationClusterInitCallback(chip::EndpointId endpointId)
 {

--- a/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
+++ b/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
@@ -30,7 +30,7 @@ using namespace chip::app::Clusters::UnitLocalization;
 // UnitLocalization may be present in the root endpoint and shall not be present in any other endpoint.
 static_assert((UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 1 &&
                UnitLocalization::StaticApplicationConfig::kFixedClusterConfig[0].endpointNumber == kRootEndpointId) ||
-              (UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 0),
+                  (UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 0),
               "UnitLocalization MAY be present only in root endpoint");
 
 namespace {

--- a/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
+++ b/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
@@ -31,7 +31,7 @@ using namespace chip::app::Clusters::UnitLocalization;
 static_assert((UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 1 &&
                UnitLocalization::StaticApplicationConfig::kFixedClusterConfig[0].endpointNumber == kRootEndpointId) ||
                   (UnitLocalization::StaticApplicationConfig::kFixedClusterConfig.size() == 0),
-              "UnitLocalization MAY be present only in root endpoint");
+              "UnitLocalization MAY be present only in the root endpoint");
 
 namespace {
 

--- a/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
+++ b/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
@@ -57,7 +57,7 @@ public:
     void ReleaseRegistration(unsigned clusterInstanceIndex) override { gServer.Destroy(); }
 };
 
-}
+} // namespace
 
 UnitLocalizationServer & UnitLocalizationServer::Instance()
 {


### PR DESCRIPTION
#### Summary

The UnitLocalization cluster can only be present in the root endpoint (or not present), this validation checks for this at compile time.

#### Testing

No change in logic, compiled example app and unit tests. The CI will validate with integration tests.

