### PR TITLE
Add Fixed Buffer Templates to Address Common Fixed-size Backing Array + Length / Size Pattern

### DIFF
--- a/src/include/platform/internal/DeviceNetworkInfo.h
+++ b/src/include/platform/internal/DeviceNetworkInfo.h
@@ -22,6 +22,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <lib/support/FixedBuffer.h>
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -33,6 +35,9 @@ namespace Internal {
 inline constexpr size_t kMaxWiFiSSIDLength = 32;
 inline constexpr size_t kMaxWiFiKeyLength  = 64;
 inline constexpr size_t kWiFiBSSIDLength   = 6;
+
+using WiFiKeyFixedBuffer  = FixedByteBuffer<kMaxWiFiKeyLength, uint8_t>;
+using WiFiSSIDFixedBuffer = FixedByteBuffer<kMaxWiFiSSIDLength, uint8_t>;
 
 /**
  * Ids for well-known network provision types.

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -198,6 +198,10 @@ source_set("span") {
   ]
 }
 
+source_set("fixedbuffer") {
+  sources = [ "FixedBuffer.h" ]
+}
+
 source_set("chip_version_header") {
   sources = get_target_outputs(":gen_chip_version")
 

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -347,6 +347,7 @@ static_library("support") {
   public_deps = [
     ":attributes",
     ":chip_version_header",
+    ":fixedbuffer",
     ":logging_constants",
     ":memory",
     ":safeint",

--- a/src/lib/support/FixedBuffer.h
+++ b/src/lib/support/FixedBuffer.h
@@ -1,0 +1,659 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iterator>
+#include <limits>
+#include <type_traits>
+
+#include <lib/support/Span.h>
+
+namespace chip {
+
+/**
+ *  @brief
+ *    A fixed-capacity, size-tracked buffer container.
+ *
+ *  This provides a lightweight container abstraction for the common
+ *  pattern of a fixed-size backing array paired with a logical length
+ *  (that is, count or size). The container never allocates, never
+ *  grows beyond its compile-time capacity, and supports efficient
+ *  assignment/appending from raw memory.
+ *
+ *  The container models a "logical (used) prefix" of the backing
+ *  storage:
+ *
+ *    * The backing store is always @p N elements.
+ *    * The logical size is tracked in @p mSize and is always in the
+ *      range [0, N].
+ *    * Iteration and comparisons operate on the logical (used)
+ *      portion.
+ *
+ *  Operations that may fail (e.g. assign/append/resize) return @c
+ *  bool and do not modify the logical size on failure.
+ *
+ *  @tparam T
+ *    The element type stored in the backing array.
+ *
+ *  @tparam N
+ *    The fixed element capacity of the buffer.
+ *
+ *  @tparam SizeT
+ *    An integral type used to represent the logical size. This may be
+ *    selected smaller than @c std::size_t (e.g. @c uint8_t) to reduce
+ *    object footprint.
+ *
+ */
+template <typename T, std::size_t N, typename SizeT = std::size_t>
+class FixedBuffer
+{
+    static_assert(N > 0, "FixedBuffer capacity must be > 0");
+    static_assert(std::is_unsigned<SizeT>::value, "FixedBuffer size type must be an unsigned type");
+
+public:
+    using value_type             = T;
+    using size_type              = SizeT;
+    using difference_type        = std::ptrdiff_t;
+    using reference              = value_type &;
+    using const_reference        = const value_type &;
+    using pointer                = value_type *;
+    using const_pointer          = const value_type *;
+    using iterator               = pointer;
+    using const_iterator         = const_pointer;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    /**
+     *  Mutable and immutable views over the fixed buffer logical
+     *  (used) prefix size.
+     */
+    using span_type       = Span<value_type>;
+    using const_span_type = Span<const value_type>;
+
+    /**
+     *  Mutable and immutable views over the fixed buffer capacity
+     *  size.
+     */
+    using fixed_span_type       = FixedSpan<value_type, N>;
+    using const_fixed_span_type = FixedSpan<const value_type, N>;
+
+public:
+    // Construction
+
+    FixedBuffer(void) noexcept : mData{}, mSize(0) {}
+    FixedBuffer(const std::initializer_list<value_type> & inData) noexcept : mData{}, mSize(0)
+    {
+        // assign will return false if @a inData.begin() is null, @a
+        // inData.size() is zero (0) or greater than the number of
+        // allowed elements, or if @a inData.size() exceeds the
+        // maximum representable size for this buffer's @c size_type.
+        //
+        // Since this is a constructor and is marked 'noexcept', there
+        // is no error status that can be returned or thrown;
+        // likewise, to avoid propagating project-internal assertion
+        // macros into integrating projects or products, we elide the
+        // return status.
+
+        (void) assign(inData.begin(), inData.size());
+    }
+
+    FixedBuffer(const value_type * inData, const std::size_t & inSize) noexcept : mData{}, mSize(0)
+    {
+        // assign will return false if @a inData is null, @a inSzie is
+        // zero (0) or greater than the number of allowed elements, or
+        // if @a inSize exceeds the maximum representable size for
+        // this buffer's @c size_type.
+        //
+        // Since this is a constructor and is marked 'noexcept', there
+        // is no error status that can be returned or thrown;
+        // likewise, to avoid propagating project-internal assertion
+        // macros into integrating projects or products, we elide the
+        // return status.
+
+        (void) assign(inData, inSize);
+    }
+
+    FixedBuffer(const FixedBuffer & inFixedBuffer) noexcept : mData{}, mSize(0)
+    {
+        // assign will return false if @a inFixedBuffer.begin() is null, @a
+        // inFixedBuffer.size() is zero (0) or greater than the number of
+        // allowed elements, or if @a inFixedBuffer.size() exceeds the
+        // maximum representable size for this buffer's @c size_type.
+        //
+        // Since this is a constructor and is marked 'noexcept', there
+        // is no error status that can be returned or thrown;
+        // likewise, to avoid propagating project-internal assertion
+        // macros into integrating projects or products, we elide the
+        // return status.
+
+        (void) assign(inFixedBuffer.data(), static_cast<std::size_t>(inFixedBuffer.size()));
+    }
+
+    FixedBuffer(const const_span_type & inSpan) noexcept : mData{}, mSize(0)
+    {
+        // assign will return false if @a inSpan.data() is null and @a
+        // inSpan.size() != 0, if @a inSpan.size() > capacity(), or if
+        // @a inSpan.size() exceeds the maximum representable size for
+        // this buffer's @c size_type.
+        //
+        // Since this is a constructor and is marked 'noexcept', there
+        // is no error status that can be returned or thrown;
+        // likewise, to avoid propagating project-internal assertion
+        // macros into integrating projects or products, we elide the
+        // return status.
+
+        (void) assign(inSpan);
+    }
+
+    // Destruction
+
+    ~FixedBuffer(void) noexcept = default;
+
+    // Assignment
+
+    FixedBuffer & operator=(const std::initializer_list<value_type> & inData) noexcept
+    {
+        // assign will return false if @a inData.begin() is null, @a
+        // inData.size() is zero (0) or greater than the number of
+        // allowed elements, or if @a inData.size() exceeds the
+        // maximum representable size for this buffer's @c size_type.
+        //
+        // Since this is an assignment operator and is marked
+        // 'noexcept', there is no error status that can be returned
+        // or thrown; likewise, to avoid propagating project-internal
+        // assertion macros into integrating projects or products, we
+        // elide the return status.
+
+        (void) assign(inData.begin(), inData.size());
+
+        return *this;
+    }
+
+    FixedBuffer & operator=(const FixedBuffer & inFixedBuffer) noexcept
+    {
+        if (this != &inFixedBuffer)
+        {
+            // assign will return false if @a inFixedBuffer.begin() is
+            // null, @a inFixedBuffer.size() is zero (0) or greater
+            // than the number of allowed elements, or if @a
+            // inFixedBuffer.size() exceeds the maximum representable
+            // size for this buffer's @c size_type.
+            //
+            // Since this is an assignment operator and is marked
+            // 'noexcept', there is no error status that can be
+            // returned or thrown; likewise, to avoid propagating
+            // project-internal assertion macros into integrating
+            // projects or products, we elide the return status.
+
+            (void) assign(inFixedBuffer.data(), static_cast<std::size_t>(inFixedBuffer.size()));
+        }
+
+        return *this;
+    }
+
+    FixedBuffer & operator=(const const_span_type & inSpan) noexcept
+    {
+        // assign will return false if @a inSpan.data() is null and @a
+        // inSpan.size() != 0, if @a inSpan.size() > capacity(), or if
+        // @a inSpan.size() exceeds the maximum representable size for
+        // this buffer's @c size_type.
+        //
+        // Since this is an assignment operator and is marked
+        // 'noexcept', there is no error status that can be returned
+        // or thrown; likewise, to avoid propagating project-internal
+        // assertion macros into integrating projects or products, we
+        // elide the return status.
+
+        (void) assign(inSpan);
+
+        return *this;
+    }
+
+    // Introspection
+
+    bool empty(void) const noexcept { return (mSize == 0); }
+
+    bool full(void) const noexcept { return (mSize == capacity()); }
+
+    // Equality
+
+    bool operator==(const FixedBuffer & inFixedBuffer) const noexcept
+    {
+        if (mSize != inFixedBuffer.mSize)
+        {
+            return false;
+        }
+        else
+        {
+            const std::size_t lSize = static_cast<std::size_t>(mSize);
+
+            if (lSize == 0)
+            {
+                return true;
+            }
+            else if constexpr (std::is_trivially_copyable<value_type>::value)
+            {
+                return memcmp(mData.data(), inFixedBuffer.mData.data(), lSize * sizeof(value_type)) == 0;
+            }
+            else
+            {
+                return std::equal(begin(), end(), inFixedBuffer.begin());
+            }
+        }
+    }
+
+    bool operator==(const const_span_type & inSpan) const noexcept
+    {
+        if (static_cast<std::size_t>(mSize) != inSpan.size())
+        {
+            return false;
+        }
+        else
+        {
+            const std::size_t lSize = inSpan.size();
+
+            if (lSize == 0)
+            {
+                return true;
+            }
+            else if constexpr (std::is_trivially_copyable<value_type>::value)
+            {
+                return memcmp(mData.data(), inSpan.data(), lSize * sizeof(value_type)) == 0;
+            }
+            else
+            {
+                return std::equal(begin(), end(), inSpan.begin());
+            }
+        }
+    }
+
+    bool operator!=(const FixedBuffer & inFixedBuffer) const noexcept { return !(*this == inFixedBuffer); }
+    bool operator!=(const const_span_type & inSpan) const noexcept { return !(*this == inSpan); }
+
+    // Observation
+
+    pointer at_ptr(const std::size_t & inPosition) noexcept
+    {
+        return (inPosition < static_cast<std::size_t>(mSize)) ? (mData.data() + inPosition) : nullptr;
+    }
+
+    const_pointer at_ptr(const std::size_t & inPosition) const noexcept
+    {
+        return (inPosition < static_cast<std::size_t>(mSize)) ? (mData.data() + inPosition) : nullptr;
+    }
+
+    size_type available(void) const noexcept { return capacity() - mSize; }
+
+    static constexpr size_type capacity(void) noexcept { return static_cast<size_type>(N); }
+
+    pointer data(void) noexcept { return mData.data(); }
+
+    const_pointer data(void) const noexcept { return mData.data(); }
+
+    reference operator[](const std::size_t & inPosition) noexcept { return mData[inPosition]; }
+
+    const_reference operator[](const std::size_t & inPosition) const noexcept { return mData[inPosition]; }
+
+    size_type size(void) const noexcept { return mSize; }
+
+    span_type span(void) noexcept { return span_type(data(), static_cast<std::size_t>(size())); }
+    const_span_type span(void) const noexcept { return const_span_type(data(), static_cast<std::size_t>(size())); }
+    fixed_span_type fixed_span(void) noexcept { return fixed_span_type(mData); }
+    const_fixed_span_type fixed_span(void) const noexcept { return const_fixed_span_type(mData); }
+
+    // Mutation
+
+    /**
+     *  @brief
+     *    Append span to the fixed buffer.
+     *
+     *  This attempts to append @a inSpan to the fixed buffer,
+     *  starting at the tail.
+     *
+     *  @param[in]  inSpan
+     *    A reference to the immutable span to append to the fixed
+     *    buffer.
+     *
+     *  @returns
+     *    True if the @a inSpan was successfully appended to this
+     *    fixed buffer; otherwise, false if @a inSpan.data() was null,
+     *    @a inSpan.size() was zero (0) or greater than the number of
+     *    available elements, or if the current size plus @a
+     *    inSpan.size() would exceed the maximum representable size
+     *    for this buffer's @c size_type.
+     *
+     */
+    bool append(const const_span_type & inSpan) noexcept { return append(inSpan.data(), inSpan.size()); }
+
+    /**
+     *  @brief
+     *    Append elements to the fixed buffer.
+     *
+     *  This attempts to append @a inSize elements at @a inData to the
+     *  fixed buffer, starting at the tail.
+     *
+     *  @param[in]  inData
+     *    A pointer to the immutable elements to append to the fixed
+     *    buffer.
+     *
+     *  @param[in]  inSize
+     *    A reference to the immutable number of elements in @a inData
+     *    to append to the fixed buffer.
+     *
+     *  @returns
+     *    True if the @a inSize elements at @a inData were
+     *    successfully appended to this fixed buffer; otherwise, false
+     *    if @a inData was null, @a inSize was zero (0) or greater
+     *    than the number of available elements, or if the current
+     *    size plus @a inSize would exceed the maximum representable
+     *    size for this buffer's @c size_type.
+     *
+     */
+    bool append(const value_type * inData, const std::size_t & inSize) noexcept
+    {
+        const std::size_t lCurSize = static_cast<std::size_t>(mSize);
+        const std::size_t lNewSize = lCurSize + inSize;
+
+        if (inData == nullptr && inSize != 0)
+        {
+            return false;
+        }
+
+        if (inSize > (N - lCurSize))
+        {
+            return false;
+        }
+
+        if (lNewSize > static_cast<std::size_t>(std::numeric_limits<size_type>::max()))
+        {
+            return false;
+        }
+
+        if (inSize > 0)
+        {
+            memmove(mData.data() + lCurSize, inData, inSize * sizeof(value_type));
+        }
+
+        mSize = static_cast<size_type>(lNewSize);
+
+        return true;
+    }
+
+    /**
+     *  @brief
+     *    Assign span to the fixed buffer.
+     *
+     *  This attempts to assign @a inSpan to the fixed buffer,
+     *  starting at the head.
+     *
+     *  @param[in]  inSpan
+     *    A reference to the immutable span to assign to the fixed
+     *    buffer.
+     *
+     *  @returns
+     *    True if the @a inSpan was successfully assigned to this
+     *    fixed buffer; otherwise, false if @a inSpan.data() was null,
+     *    @a inSpan.size() was zero (0) or greater than the number of
+     *    allowed elements, or if @a inSpan.size() exceeds the maximum
+     *    representable size for this buffer's @c size_type.
+     *
+     */
+    bool assign(const const_span_type & inSpan) noexcept { return assign(inSpan.data(), inSpan.size()); }
+
+    /**
+     *  @brief
+     *    Assign elements to the fixed buffer.
+     *
+     *  This attempts to assign @a inSize elements at @a inData to the
+     *  fixed buffer, starting at the head.
+     *
+     *  @param[in]  inData
+     *    A pointer to the immutable elements to assign to the fixed
+     *    buffer.
+     *
+     *  @param[in]  inSize
+     *    A reference to the immutable number of elements in @a inData
+     *    to assign to the fixed buffer.
+     *
+     *  @returns
+     *    True if the @a inSize elements at @a inData were
+     *    successfully assigned to this fixed buffer; otherwise, false
+     *    if @a inData was null, @a inSize was zero (0) or greater
+     *    than the number of allowed elements, or if @a inSize exceeds
+     *    the maximum representable size for this buffer's @c
+     *    size_type.
+     *
+     */
+    bool assign(const value_type * inData, const std::size_t & inSize) noexcept
+    {
+        if (inData == nullptr && inSize != 0)
+        {
+            return false;
+        }
+
+        if (inSize > N)
+        {
+            return false;
+        }
+
+        if (inSize > static_cast<std::size_t>(std::numeric_limits<size_type>::max()))
+        {
+            return false;
+        }
+
+        if (inSize > 0)
+        {
+            memmove(mData.data(), inData, inSize * sizeof(value_type));
+        }
+
+        mSize = static_cast<size_type>(inSize);
+
+        return true;
+    }
+
+    /**
+     *  @brief
+     *    Remove all elements from the fixed buffer.
+     *
+     *  This removes all elements from the fixed buffer, resetting the
+     *  size to zero (0) and invalidating all pointers, references,
+     *  and iterators to the fixed buffer contents.
+     *
+     *  @sa fill
+     *  @sa reset
+     *
+     */
+    void clear(void) noexcept { mSize = 0; }
+
+    /**
+     *  @brief
+     *    Assigns the specified value to all elements in the fixed
+     *    buffer.
+     *
+     *  This assigns the specified value to all elements in the fixed
+     *  buffer and sets the size to the fixed buffer capacity. Callers
+     *  looking to do the same but @b without setting the size to
+     *  capacity and instead setting the size to zero (0) should use
+     *  #reset.
+     *
+     *  @param[in]  inValue
+     *    A reference to the immutable value to assign to the elements
+     *    of the fixed buffer.
+     *
+     *  @sa clear
+     *  @sa reset
+     *
+     */
+    void fill(const_reference inValue) noexcept
+    {
+        mData.fill(inValue);
+
+        mSize = capacity();
+    }
+
+    /**
+     *  @brief
+     *    Assigns the default value to all elements in the fixed
+     *    buffer.
+     *
+     *  This assigns the default value for @c value_type to all
+     *  elements in the fixed buffer and sets the size to zero
+     *  (0). Callers looking to do the same but @b without setting the
+     *  size to zero (0) and instead setting the size to capacity
+     *  should use #fill.
+     *
+     *  @sa clear
+     *  @sa fill
+     *
+     */
+    void reset(void) noexcept { reset(value_type{}); }
+
+    /**
+     *  @brief
+     *    Assigns the specified value to all elements in the fixed
+     *    buffer.
+     *
+     *  This assigns the specified value to all elements in the fixed
+     *  buffer and sets the size to zero (0). Callers
+     *  looking to do the same but @b without setting the size to
+     *  zero (0) and instead setting the size to capacity should use
+     *  #fill.
+     *
+     *  @param[in]  inValue
+     *    A reference to the immutable value to assign to the elements
+     *    of the fixed buffer.
+     *
+     *  @sa clear
+     *  @sa fill
+     *
+     */
+    void reset(const_reference inValue) noexcept
+    {
+        mData.fill(inValue);
+        mSize = 0;
+    }
+
+    /**
+     *  @brief
+     *    Resize the fixed buffer.
+     *
+     *  This attempts to resize the fixed buffer to @a inSize.
+     *
+     *  @note
+     *    No attempt is made to fill or otherwise invalidate elements
+     *    between the tail of the former size and that of @a inSize.
+     *
+     *  @param[in]  inSize
+     *    A reference to the immutable size, in number of elements, to
+     *    set the fixed buffer to.
+     *
+     *  @returns
+     *    True if the fixed buffer was resized to @a inSize elements;
+     *    otherwise, false if @a inSize was greater than the number of
+     *    allowed elements or if @a inSize exceeds the maximum
+     *    representable size for this buffer's @c size_type.
+     *
+     *  @sa append
+     *  @sa assign
+     *  @sa available
+     *  @sa capacity
+     *  @sa clear
+     *  @sa fill
+     *  @sa reset
+     *  @sa size
+     *
+     */
+    bool resize(const std::size_t & inSize) noexcept
+    {
+        if (inSize > N)
+        {
+            return false;
+        }
+
+        if (inSize > static_cast<std::size_t>(std::numeric_limits<size_type>::max()))
+        {
+            return false;
+        }
+
+        mSize = static_cast<size_type>(inSize);
+
+        return true;
+    }
+
+    // Iteration
+
+    iterator begin(void) noexcept { return data(); }
+    const_iterator begin(void) const noexcept { return data(); }
+    const_iterator cbegin(void) const noexcept { return data(); }
+    iterator end(void) noexcept { return data() + static_cast<std::size_t>(mSize); }
+    const_iterator end(void) const noexcept { return data() + static_cast<std::size_t>(mSize); }
+    const_iterator cend(void) const noexcept { return data() + static_cast<std::size_t>(mSize); }
+
+    reverse_iterator rbegin(void) noexcept { return reverse_iterator(end()); }
+    const_reverse_iterator rbegin(void) const noexcept { return const_reverse_iterator(end()); }
+    const_reverse_iterator crbegin(void) const noexcept { return const_reverse_iterator(end()); }
+    reverse_iterator rend(void) noexcept { return reverse_iterator(begin()); }
+    const_reverse_iterator rend(void) const noexcept { return const_reverse_iterator(begin()); }
+    const_reverse_iterator crend(void) const noexcept { return const_reverse_iterator(begin()); }
+
+private:
+    std::array<value_type, N> mData;
+    size_type mSize;
+};
+
+/**
+ *  @brief
+ *    A fixed-capacity, size-tracked buffer of bytes.
+ *
+ *  This specializes and extends @c FixedBuffer as a fixed-capacity,
+ *  size-tracked buffer of bytes.
+ *
+ *  @tparam N
+ *    The fixed byte capacity of the buffer.
+ *
+ *  @tparam SizeT
+ *    An integral type used to represent the logical size.
+ *
+ */
+template <std::size_t N, typename SizeT = std::size_t>
+using FixedByteBuffer = FixedBuffer<std::uint8_t, N, SizeT>;
+
+/**
+ *  @brief
+ *    A fixed-capacity, size-tracked buffer of characters.
+ *
+ *  This specializes and extends @c FixedBuffer as a fixed-capacity,
+ *  size-tracked buffer of characters.
+ *
+ *  @tparam N
+ *    The fixed character capacity of the buffer.
+ *
+ *  @tparam SizeT
+ *    An integral type used to represent the logical size.
+ *
+ */
+template <std::size_t N, typename SizeT = std::size_t>
+using FixedCharBuffer = FixedBuffer<char, N, SizeT>;
+
+} // namespace chip

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -43,6 +43,7 @@ chip_test_suite("tests") {
     "TestCHIPMemString.cpp",
     "TestDefer.cpp",
     "TestErrorStr.cpp",
+    "TestFixedBuffer.cpp",
     "TestFixedBufferAllocator.cpp",
     "TestFold.cpp",
     "TestIniEscaping.cpp",

--- a/src/lib/support/tests/TestFixedBuffer.cpp
+++ b/src/lib/support/tests/TestFixedBuffer.cpp
@@ -1,0 +1,728 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <array>
+#include <type_traits>
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/support/FixedBuffer.h>
+#include <lib/support/Span.h>
+
+using namespace chip;
+
+namespace {
+
+template <typename FixedBufferType>
+static void ExpectEqBytes(const FixedBufferType & inFixedBufferType,
+                          const std::initializer_list<typename FixedBufferType::value_type> & inExpected)
+{
+    ASSERT_EQ(static_cast<std::size_t>(inFixedBufferType.size()), inExpected.size());
+    std::size_t i = 0;
+    for (auto v : inExpected)
+    {
+        EXPECT_EQ(inFixedBufferType[i], v);
+        i++;
+    }
+}
+
+} // namespace
+
+TEST(TestFixedBuffer, TestFixedBufferConstruction)
+{
+    using FixedBufferType = FixedBuffer<uint8_t, 8, uint8_t>;
+
+    // Default construction
+    {
+        FixedBufferType b;
+        EXPECT_EQ(b.size(), 0u);
+        EXPECT_TRUE(b.empty());
+        EXPECT_FALSE(b.full());
+        EXPECT_EQ(FixedBufferType::capacity(), 8u);
+        EXPECT_NE(b.data(), nullptr);
+        EXPECT_EQ(b.begin(), b.end());
+    }
+
+    // initializer_list construction (within capacity)
+    {
+        FixedBufferType b{ 1, 2, 3 };
+        EXPECT_EQ(b.size(), 3u);
+        EXPECT_FALSE(b.empty());
+        EXPECT_FALSE(b.full());
+        ExpectEqBytes(b, { 1, 2, 3 });
+    }
+
+    // pointer+size construction
+    {
+        const uint8_t src[] = { 9, 8, 7, 6 };
+        FixedBufferType b(src, sizeof(src));
+        EXPECT_EQ(b.size(), 4u);
+        ExpectEqBytes(b, { 9, 8, 7, 6 });
+    }
+
+    // pointer+size with nullptr + 0 is OK
+    {
+        FixedBufferType b(nullptr, 0);
+        EXPECT_EQ(b.size(), 0u);
+        EXPECT_TRUE(b.empty());
+    }
+
+    // Copy construction
+    {
+        FixedBufferType a{ 4, 5 };
+        FixedBufferType b(a);
+        EXPECT_EQ(b.size(), 2u);
+        ExpectEqBytes(b, { 4, 5 });
+
+        // Ensure deep copy (mutating b does not change a)
+        b[0] = 99;
+        EXPECT_EQ(a[0], 4u);
+        EXPECT_EQ(b[0], 99u);
+    }
+}
+
+TEST(TestFixedBuffer, TestFixedByteBufferEqualityAgainstByteSpan)
+{
+    using FixedByteBufferType = FixedByteBuffer<8, uint8_t>;
+
+    // Empty buffer equals empty span
+    {
+        FixedByteBufferType b;
+        ByteSpan s;
+        EXPECT_TRUE(b == s);
+        EXPECT_FALSE(b != s);
+    }
+
+    // Equal content
+    {
+        const uint8_t src[] = { 1, 2, 3 };
+        FixedByteBufferType b(ByteSpan(src, sizeof(src)));
+        EXPECT_TRUE(b == ByteSpan(src, sizeof(src)));
+        EXPECT_FALSE(b != ByteSpan(src, sizeof(src)));
+    }
+
+    // Size mismatch
+    {
+        const uint8_t a[] = { 1, 2, 3 };
+        const uint8_t c[] = { 1, 2, 3, 4 };
+        FixedByteBufferType b(ByteSpan(a, sizeof(a)));
+        EXPECT_FALSE(b == ByteSpan(c, sizeof(c)));
+        EXPECT_TRUE(b != ByteSpan(c, sizeof(c)));
+    }
+
+    // Content mismatch same size
+    {
+        const uint8_t a[] = { 1, 2, 3 };
+        const uint8_t d[] = { 1, 2, 9 };
+        FixedByteBufferType b(ByteSpan(a, sizeof(a)));
+        EXPECT_FALSE(b == ByteSpan(d, sizeof(d)));
+        EXPECT_TRUE(b != ByteSpan(d, sizeof(d)));
+    }
+
+    // Capacity bytes beyond size do not affect equality
+    {
+        const uint8_t used[] = { 9, 8, 7 };
+        FixedByteBufferType b;
+        ASSERT_TRUE(b.assign(ByteSpan(used, sizeof(used))));
+
+        b.fill(0xAA);
+        ASSERT_TRUE(b.assign(ByteSpan(used, sizeof(used))));
+
+        EXPECT_TRUE(b == ByteSpan(used, sizeof(used)));
+        EXPECT_FALSE(b != ByteSpan(used, sizeof(used)));
+    }
+}
+
+TEST(TestFixedBuffer, TestFixedCharBufferEqualityAgainstCharSpanAndSpanViews)
+{
+    using FixedCharBufferType = FixedCharBuffer<8, uint8_t>;
+
+    FixedCharBufferType b;
+    const char src[] = { 'a', 'b', 'c' };
+    ASSERT_TRUE(b.assign(src, sizeof(src)));
+
+    // span type behavior falls out naturally
+    static_assert(std::is_same<decltype(b.span()), MutableCharSpan>::value, "non-const span() should be MutableCharSpan");
+    const FixedCharBufferType & cb = b;
+    static_assert(std::is_same<decltype(cb.span()), CharSpan>::value, "const span() should be CharSpan");
+
+    // Equality against CharSpan via FixedBuffer::operator==(Span<const T>)
+    const CharSpan cs = cb.span();
+    EXPECT_TRUE(cb == cs);
+    EXPECT_FALSE(cb != cs);
+
+    // Mismatch
+    const char other[] = { 'a', 'b', 'x' };
+    EXPECT_FALSE(cb == CharSpan(other, sizeof(other)));
+    EXPECT_TRUE(cb != CharSpan(other, sizeof(other)));
+}
+
+TEST(TestFixedBuffer, TestFixedBufferAssignment)
+{
+    using FixedBufferType = FixedBuffer<uint8_t, 8, uint8_t>;
+
+    // initializer_list assignment
+    {
+        FixedBufferType b;
+        b = { 10, 11, 12 };
+        EXPECT_EQ(b.size(), 3u);
+        ExpectEqBytes(b, { 10, 11, 12 });
+    }
+
+    // copy assignment
+    {
+        FixedBufferType a{ 1, 2, 3, 4 };
+        FixedBufferType b{ 9 };
+        b = a;
+        EXPECT_EQ(b.size(), 4u);
+        ExpectEqBytes(b, { 1, 2, 3, 4 });
+    }
+
+    // Assignment from a subrange of itself should be overlap-safe (memmove hardening)
+    {
+        FixedBufferType b{ 0, 1, 2, 3, 4, 5 };
+        // assign first 4 bytes from offset 2 -> {2,3,4,5}
+        ASSERT_TRUE(b.assign(b.data() + 2, 4));
+        EXPECT_EQ(b.size(), 4u);
+        ExpectEqBytes(b, { 2, 3, 4, 5 });
+    }
+}
+
+TEST(TestFixedBuffer, TestFixedByteBufferSpanTypesAndConstruction)
+{
+    using FixedByteBufferType = FixedByteBuffer<8, uint8_t>;
+
+    const uint8_t src[] = { 9, 8, 7 };
+    const ByteSpan in(src, sizeof(src));
+
+    // Construct from ByteSpan (falls out of FixedBuffer<const_span_type> constructor)
+    FixedByteBufferType b(in);
+    EXPECT_EQ(b.size(), 3u);
+    ExpectEqBytes(b, { 9, 8, 7 });
+
+    // Non-const span() is MutableByteSpan, const span() is ByteSpan.
+    static_assert(std::is_same<decltype(b.span()), MutableByteSpan>::value, "non-const span() should be MutableByteSpan");
+    const FixedByteBufferType & cb = b;
+    static_assert(std::is_same<decltype(cb.span()), ByteSpan>::value, "const span() should be ByteSpan");
+
+    // Verify span views reflect logical size and alias the same backing storage.
+    {
+        ByteSpan s = cb.span();
+        EXPECT_EQ(s.size(), 3u);
+        EXPECT_EQ(s.data(), b.data());
+        EXPECT_EQ(s.data()[0], 9u);
+        EXPECT_EQ(s.data()[1], 8u);
+        EXPECT_EQ(s.data()[2], 7u);
+    }
+    {
+        MutableByteSpan ms = b.span();
+        EXPECT_EQ(ms.size(), 3u);
+        ms.data()[1] = 99;
+        EXPECT_EQ(b[1], 99u);
+    }
+}
+
+TEST(TestFixedBuffer, TestFixedBufferEquality)
+{
+    using FixedBufferType = FixedBuffer<uint8_t, 8, uint8_t>;
+
+    // Empty buffers compare equal
+    {
+        FixedBufferType a;
+        FixedBufferType b;
+        EXPECT_TRUE(a == b);
+        EXPECT_FALSE(a != b);
+    }
+
+    // Same content and size => equal
+    {
+        FixedBufferType a{ 1, 2, 3 };
+        FixedBufferType b{ 1, 2, 3 };
+        EXPECT_TRUE(a == b);
+        EXPECT_FALSE(a != b);
+    }
+
+    // Different size (even if prefix matches) => not equal
+    {
+        FixedBufferType a{ 1, 2, 3 };
+        FixedBufferType b{ 1, 2, 3, 4 };
+        EXPECT_FALSE(a == b);
+        EXPECT_TRUE(a != b);
+    }
+
+    // Same size, different content => not equal
+    {
+        FixedBufferType a{ 1, 2, 3 };
+        FixedBufferType b{ 1, 2, 9 };
+        EXPECT_FALSE(a == b);
+        EXPECT_TRUE(a != b);
+    }
+
+    // Self equality
+    {
+        FixedBufferType a{ 7, 8 };
+        EXPECT_TRUE(a == a);
+        EXPECT_FALSE(a != a);
+    }
+
+    // Bytes beyond size must not affect equality:
+    // Make two buffers with same used bytes, then perturb capacity bytes via fill().
+    {
+        const uint8_t src[] = { 9, 9, 9 };
+        FixedBufferType a;
+        FixedBufferType b;
+        ASSERT_TRUE(a.assign(src, sizeof(src)));
+        ASSERT_TRUE(b.assign(src, sizeof(src)));
+
+        // Change entire capacity backing store in 'a' but keep logical used bytes same by re-assign.
+        a.fill(0xAA);
+        ASSERT_TRUE(a.assign(src, sizeof(src))); // restores used portion to match
+
+        // Change entire capacity backing store in 'b' differently but keep used bytes same.
+        b.fill(0x55);
+        ASSERT_TRUE(b.assign(src, sizeof(src))); // restores used portion to match
+
+        EXPECT_TRUE(a == b);
+        EXPECT_FALSE(a != b);
+    }
+}
+
+TEST(TestFixedBuffer, TestFixedBufferIntrospection)
+{
+    using FixedBufferType = FixedBuffer<uint8_t, 4, uint8_t>;
+
+    FixedBufferType b;
+    EXPECT_TRUE(b.empty());
+    EXPECT_FALSE(b.full());
+
+    // Default constructed: all capacity available.
+
+    FixedBufferType c;
+    EXPECT_EQ(c.size(), 0u);
+    EXPECT_EQ(c.available(), FixedBufferType::capacity());
+    EXPECT_EQ(c.available(), 4u);
+
+    // After assign: available decreases; at full, available is 0.
+
+    FixedBufferType d{ 1, 2, 3 };
+    EXPECT_EQ(d.size(), 3u);
+    EXPECT_EQ(d.available(), 1u);
+
+    const uint8_t one[] = { 9 };
+    ASSERT_TRUE(d.append(one, sizeof(one)));
+    EXPECT_TRUE(d.full());
+    EXPECT_EQ(d.available(), 0u);
+
+    // Fill to capacity
+    const uint8_t src[] = { 1, 2, 3, 4 };
+    ASSERT_TRUE(b.assign(src, sizeof(src)));
+    EXPECT_FALSE(b.empty());
+    EXPECT_TRUE(b.full());
+    EXPECT_EQ(b.size(), 4u);
+    EXPECT_EQ(FixedBufferType::capacity(), 4u);
+
+    // clear drops size only
+    b.clear();
+    EXPECT_TRUE(b.empty());
+    EXPECT_FALSE(b.full());
+    EXPECT_EQ(b.size(), 0u);
+}
+
+TEST(TestFixedBuffer, TestFixedBufferObservation)
+{
+    using FixedBufferType = FixedBuffer<uint8_t, 8, uint8_t>;
+
+    FixedBufferType b{ 7, 8, 9 };
+
+    // operator[] and data() consistency
+    EXPECT_EQ(b[0], 7u);
+    EXPECT_EQ(b[1], 8u);
+    EXPECT_EQ(b[2], 9u);
+    EXPECT_EQ(b.data()[0], 7u);
+    EXPECT_EQ(b.data()[1], 8u);
+    EXPECT_EQ(b.data()[2], 9u);
+
+    // const view
+    const FixedBufferType & cb = b;
+    EXPECT_EQ(cb[0], 7u);
+    EXPECT_NE(cb.data(), nullptr);
+
+    // at_ptr checks against used size
+    EXPECT_NE(b.at_ptr(0), nullptr);
+    EXPECT_NE(b.at_ptr(2), nullptr);
+    EXPECT_EQ(b.at_ptr(3), nullptr);
+    EXPECT_EQ(cb.at_ptr(3), nullptr);
+}
+
+TEST(TestFixedBuffer, TestFixedBufferMutation)
+{
+    using FixedBufferType = FixedBuffer<uint8_t, 6, uint8_t>;
+
+    FixedBufferType b;
+
+    // assign negative: nullptr + nonzero
+    {
+        EXPECT_FALSE(b.assign(nullptr, 1));
+        EXPECT_EQ(b.size(), 0u);
+    }
+
+    // assign negative: too large
+    {
+        const uint8_t big[] = { 1, 2, 3, 4, 5, 6, 7 };
+        EXPECT_FALSE(b.assign(big, sizeof(big)));
+        EXPECT_EQ(b.size(), 0u);
+    }
+
+    // assign positive
+    {
+        const uint8_t src[] = { 1, 2, 3 };
+        EXPECT_TRUE(b.assign(src, sizeof(src)));
+        EXPECT_EQ(b.size(), 3u);
+        ExpectEqBytes(b, { 1, 2, 3 });
+    }
+
+    // append negative: nullptr + nonzero
+    {
+        EXPECT_FALSE(b.append(nullptr, 1));
+        EXPECT_EQ(b.size(), 3u);
+    }
+
+    // append negative: overflow capacity
+    {
+        const uint8_t src[] = { 4, 5, 6, 7 };
+        // current size=3, capacity=6, appending 4 would overflow
+        EXPECT_FALSE(b.append(src, sizeof(src)));
+        EXPECT_EQ(b.size(), 3u);
+        ExpectEqBytes(b, { 1, 2, 3 });
+    }
+
+    // append positive: fits exactly
+    {
+        const uint8_t src[] = { 4, 5, 6 };
+        EXPECT_TRUE(b.append(src, sizeof(src)));
+        EXPECT_EQ(b.size(), 6u);
+        ExpectEqBytes(b, { 1, 2, 3, 4, 5, 6 });
+        EXPECT_TRUE(b.full());
+    }
+
+    // Overlap-safe append (self-append from within used range)
+    {
+        // Start fresh with {10,11,12,13}
+        FixedBufferType c;
+        const uint8_t src[] = { 10, 11, 12, 13 };
+        ASSERT_TRUE(c.assign(src, sizeof(src)));
+        // Append last 2 bytes (12,13) -> {10,11,12,13,12,13}
+        ASSERT_TRUE(c.append(c.data() + 2, 2));
+        EXPECT_EQ(c.size(), 6u);
+        ExpectEqBytes(c, { 10, 11, 12, 13, 12, 13 });
+    }
+
+    // fill fills capacity and does change size
+    {
+        FixedBufferType d;
+        const uint8_t src[] = { 1, 2 };
+        ASSERT_TRUE(d.assign(src, sizeof(src)));
+        EXPECT_EQ(d.size(), 2u);
+
+        d.fill(0xAA);
+        EXPECT_EQ(d.size(), d.capacity());
+
+        // Used portion now also 0xAA (since capacity fill overwrote all)
+        EXPECT_EQ(d[0], 0xAA);
+        EXPECT_EQ(d[1], 0xAA);
+    }
+
+    // reset scrubs capacity and clears size
+    {
+        FixedBufferType e{ 1, 2, 3 };
+        e.reset(0x00);
+        EXPECT_TRUE(e.empty());
+        EXPECT_EQ(e.size(), 0u);
+        // Can't directly observe scrubbed bytes via public API without peeking at data(),
+        // but data() is public; at least check the first few bytes.
+        EXPECT_EQ(e.data()[0], 0x00);
+        EXPECT_EQ(e.data()[1], 0x00);
+        EXPECT_EQ(e.data()[2], 0x00);
+    }
+
+    // resize negative/positive
+    {
+        FixedBufferType f{ 1, 2, 3 };
+        EXPECT_FALSE(f.resize(7)); // > capacity
+        EXPECT_EQ(f.size(), 3u);
+
+        EXPECT_TRUE(f.resize(6)); // == capacity ok
+        EXPECT_EQ(f.size(), 6u);
+        EXPECT_TRUE(f.full());
+
+        EXPECT_TRUE(f.resize(0));
+        EXPECT_TRUE(f.empty());
+    }
+}
+
+TEST(TestFixedBuffer, TestFixedBufferIteration)
+{
+    using FixedBufferType = FixedBuffer<uint8_t, 8, uint8_t>;
+    FixedBufferType b{ 1, 2, 3, 4 };
+
+    // forward iteration
+    {
+        uint8_t sum = 0;
+        for (auto it = b.begin(); it != b.end(); ++it)
+        {
+            sum = static_cast<uint8_t>(sum + *it);
+        }
+        EXPECT_EQ(sum, static_cast<uint8_t>(1 + 2 + 3 + 4));
+    }
+
+    // range-for works due to begin/end
+    {
+        uint8_t x = 0;
+        for (auto v : b)
+        {
+            x ^= v;
+        }
+        EXPECT_EQ(x, static_cast<uint8_t>(1 ^ 2 ^ 3 ^ 4));
+    }
+
+    // const iteration
+    {
+        const FixedBufferType & cb = b;
+        std::size_t count          = 0;
+        for (auto it = cb.cbegin(); it != cb.cend(); ++it)
+        {
+            count++;
+        }
+        EXPECT_EQ(count, 4u);
+    }
+
+    // reverse iteration
+    {
+        std::array<uint8_t, 4> got{};
+        std::size_t i = 0;
+        for (auto it = b.rbegin(); it != b.rend(); ++it)
+        {
+            got[i++] = *it;
+        }
+        EXPECT_EQ(i, 4u);
+        EXPECT_EQ(got[0], 4u);
+        EXPECT_EQ(got[1], 3u);
+        EXPECT_EQ(got[2], 2u);
+        EXPECT_EQ(got[3], 1u);
+    }
+
+    // const reverse iteration
+    {
+        const FixedBufferType & cb = b;
+        std::array<uint8_t, 4> got{};
+        std::size_t i = 0;
+        for (auto it = cb.rbegin(); it != cb.rend(); ++it)
+        {
+            got[i++] = *it;
+        }
+        EXPECT_EQ(i, 4u);
+        EXPECT_EQ(got[0], 4u);
+        EXPECT_EQ(got[1], 3u);
+        EXPECT_EQ(got[2], 2u);
+        EXPECT_EQ(got[3], 1u);
+    }
+
+    // empty iteration: begin == end
+    {
+        FixedBufferType e;
+        EXPECT_EQ(e.begin(), e.end());
+        EXPECT_EQ(e.rbegin(), e.rend());
+    }
+}
+
+TEST(FixedByteBuffer, FixedByteBufferConstruction)
+{
+    using FixedBufferType = FixedByteBuffer<8, uint8_t>;
+
+    // Construct from ByteSpan
+    {
+        const uint8_t src[] = { 9, 8, 7 };
+        ByteSpan s(src, sizeof(src));
+        FixedBufferType e(s);
+        EXPECT_EQ(e.size(), 3u);
+        ExpectEqBytes(e, { 9, 8, 7 });
+    }
+}
+
+TEST(FixedByteBuffer, FixedByteBufferEquality)
+{
+    using FixedBufferType = FixedByteBuffer<8, uint8_t>;
+
+    // Empty vs empty span
+    {
+        FixedBufferType e;
+        ByteSpan s;
+        EXPECT_TRUE(e == s);
+        EXPECT_FALSE(e != s);
+    }
+
+    // Equal content
+    {
+        const uint8_t src[] = { 1, 2, 3 };
+        FixedBufferType e(ByteSpan(src, sizeof(src)));
+        EXPECT_TRUE(e == ByteSpan(src, sizeof(src)));
+        EXPECT_FALSE(e != ByteSpan(src, sizeof(src)));
+    }
+
+    // Size mismatch => not equal
+    {
+        const uint8_t a[] = { 1, 2, 3 };
+        const uint8_t b[] = { 1, 2, 3, 4 };
+        FixedBufferType e(ByteSpan(a, sizeof(a)));
+        EXPECT_FALSE(e == ByteSpan(b, sizeof(b)));
+        EXPECT_TRUE(e != ByteSpan(b, sizeof(b)));
+    }
+
+    // Content mismatch same size => not equal
+    {
+        const uint8_t a[] = { 1, 2, 3 };
+        const uint8_t b[] = { 1, 2, 9 };
+        FixedBufferType e(ByteSpan(a, sizeof(a)));
+        EXPECT_FALSE(e == ByteSpan(b, sizeof(b)));
+        EXPECT_TRUE(e != ByteSpan(b, sizeof(b)));
+    }
+
+    // Equality should ignore capacity bytes beyond size.
+    {
+        const uint8_t used[] = { 9, 8, 7 };
+        FixedBufferType e;
+        ASSERT_TRUE(e.assign(ByteSpan(used, sizeof(used))));
+
+        // Smash capacity bytes; then restore used bytes.
+        e.fill(0xAA);
+        ASSERT_TRUE(e.assign(ByteSpan(used, sizeof(used))));
+
+        EXPECT_TRUE(e == ByteSpan(used, sizeof(used)));
+        EXPECT_FALSE(e != ByteSpan(used, sizeof(used)));
+    }
+}
+
+TEST(FixedByteBuffer, FixedByteBufferAssignment)
+{
+    using FixedBufferType = FixedByteBuffer<8, uint8_t>;
+
+    FixedBufferType e;
+    const uint8_t src[] = { 1, 2, 3, 4 };
+    ByteSpan s(src, sizeof(src));
+
+    e = s;
+    EXPECT_EQ(e.size(), 4u);
+    ExpectEqBytes(e, { 1, 2, 3, 4 });
+
+    // Overlap-safe assign via span into same backing buffer
+    {
+        // e currently has {1,2,3,4}; assign from subrange {3,4}
+        ByteSpan sub(e.data() + 2, 2);
+        ASSERT_TRUE(e.assign(sub));
+        EXPECT_EQ(e.size(), 2u);
+        ExpectEqBytes(e, { 3, 4 });
+    }
+}
+
+TEST(FixedByteBuffer, TestFixedBufferExtensionObservation)
+{
+    using FixedBufferType = FixedByteBuffer<8, uint8_t>;
+
+    const uint8_t src[] = { 5, 6, 7 };
+    FixedBufferType e(ByteSpan(src, sizeof(src)));
+
+    // const span view
+    {
+        ByteSpan s = e.span();
+        EXPECT_EQ(s.size(), 3u);
+        EXPECT_EQ(s.data()[0], 5u);
+        EXPECT_EQ(s.data()[1], 6u);
+        EXPECT_EQ(s.data()[2], 7u);
+    }
+
+    // mutable span view
+    {
+        MutableByteSpan ms = e.span();
+        EXPECT_EQ(ms.size(), 3u);
+        ms.data()[1] = 99;
+        EXPECT_EQ(e[1], 99u);
+    }
+}
+
+TEST(TestFixedBufferExtension, TestFixedBufferExtensionMutation)
+{
+    using FixedBufferType = FixedByteBuffer<6, uint8_t>;
+
+    FixedBufferType e;
+
+    // assign negative: too large
+    {
+        const uint8_t big[] = { 1, 2, 3, 4, 5, 6, 7 };
+        EXPECT_FALSE(e.assign(ByteSpan(big, sizeof(big))));
+        EXPECT_EQ(e.size(), 0u);
+    }
+
+    // assign positive then append positive
+    {
+        const uint8_t a[] = { 1, 2, 3 };
+        ASSERT_TRUE(e.assign(ByteSpan(a, sizeof(a))));
+        EXPECT_EQ(e.size(), 3u);
+        ExpectEqBytes(e, { 1, 2, 3 });
+
+        const uint8_t b[] = { 4, 5, 6 };
+        ASSERT_TRUE(e.append(ByteSpan(b, sizeof(b))));
+        EXPECT_EQ(e.size(), 6u);
+        ExpectEqBytes(e, { 1, 2, 3, 4, 5, 6 });
+    }
+
+    // append negative: overflow
+    {
+        const uint8_t c[] = { 7 };
+        EXPECT_FALSE(e.append(ByteSpan(c, sizeof(c))));
+        EXPECT_EQ(e.size(), 6u);
+    }
+
+    // overlap-safe append from self via span
+    {
+        FixedBufferType x;
+        const uint8_t d[] = { 10, 11, 12, 13 };
+        ASSERT_TRUE(x.assign(ByteSpan(d, sizeof(d))));
+        // Append last 2 bytes: {12,13} -> {10,11,12,13,12,13}
+        ByteSpan tail(x.data() + 2, 2);
+        ASSERT_TRUE(x.append(tail));
+        EXPECT_EQ(x.size(), 6u);
+        ExpectEqBytes(x, { 10, 11, 12, 13, 12, 13 });
+    }
+}
+
+TEST(TestFixedBuffer, TestFixedBufferSpanAssignAndAppend)
+{
+    using FixedBufferType = FixedBuffer<uint8_t, 8, uint8_t>;
+
+    FixedBufferType b;
+    const uint8_t a[] = { 1, 2, 3 };
+    const uint8_t c[] = { 4, 5 };
+
+    ASSERT_TRUE(b.assign(ByteSpan(a, sizeof(a))));
+    EXPECT_EQ(b.size(), 3u);
+    ExpectEqBytes(b, { 1, 2, 3 });
+
+    ASSERT_TRUE(b.append(ByteSpan(c, sizeof(c))));
+    EXPECT_EQ(b.size(), 5u);
+    ExpectEqBytes(b, { 1, 2, 3, 4, 5 });
+}

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -584,6 +584,7 @@ if (chip_device_platform != "none") {
       "${chip_root}/src/app/util:types",
       "${chip_root}/src/crypto",
       "${chip_root}/src/lib/support",
+      "${chip_root}/src/lib/support:fixedbuffer",
       "${chip_root}/src/lib/support:timer-delegate",
     ]
 


### PR DESCRIPTION
#### Summary

This partially addresses #42516 by adding a lightweight template container abstraction.
    
This adds a lightweight template container abstraction.
    
It provides a lightweight container abstraction for the common pattern of a fixed-size backing array paired with a logical length (that is, count or size). The container never allocates, never grows beyond its compile-time capacity, and supports efficient assignment/appending from raw memory.
    
The container models a "logical (used) prefix" of the backing storage:

* The backing store is always `N` elements.
* The logical size is tracked in  `mSize` and is always in the range [0, N].
* Iteration and comparisons operate on the logical (used) portion.
    
The container naturally interfaces with the Matter immutable and mutable span templates, taking construction or assignment from them or equality with them.
    
In addition, there are view accessors that return immutable or mutable span views of the logical (used) portion of the container or that return immutable or mutable fixed span views of the container capacity.
    
Finally, specializations are provided for `char` and `uint8_t`, mirroring the immutable and mutable char and byte span specializations.

This type is intended to reduce boilerplate at call sites that frequently translate between fixed-capacity storage (for example, Wi-Fi credentials or SSIDs) and span types.

With that use case in mind, two instantiated types are added to _src/include/platform/internal/DeviceNetworkInfo.h_:

* `WiFiKeyFixedBuffer`
* `WiFiSSIDFixedBuffer`

Both of which serve to make common or eliminate the _fiddly_ handling of Wi-Fi credentials and SSIDs in _Connectivity Manager_ implementations.

#### Related issues

#42516

#### Testing

This pull request includes the addition of new unit tests for these template classes which pass.

In addition, an armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.2 Apple "Home" app with a _Connectivity Manager_ implementation using this infrastructure.