### PR TITLE
TC-SC-4.1: Allow expanded table for pairing hint and add checks for PI

### DIFF
--- a/src/python_testing/TC_SC_4_1.py
+++ b/src/python_testing/TC_SC_4_1.py
@@ -618,6 +618,12 @@ class TC_SC_4_1(MatterBaseTest):
             # text, omitting any leading zeros, and value different than '0'
             assert_valid_ph_key(ph_key)
 
+            # Verify that if any of bits 4, 8, 10, 12, 15, 17, 19, 20, 21, or 22 are set, then the PI key is present
+            ph_val = int(ph_key)
+            mandatory_pi_bits = [4, 8, 10, 12, 15, 17, 19, 20, 21, 22]
+            if any((ph_val & (1 << bit)) for bit in mandatory_pi_bits):
+                asserts.assert_in('PI', txt_record.txt, "'PI' key must be present if any of bits 4, 8, 10, 12, 15, 17, 19, 20, 21, or 22 are set in 'PH' key.")
+
         # *** PI KEY ***
         # If the PI key is present
         if 'PI' in txt_record.txt:
@@ -628,6 +634,14 @@ class TC_SC_4_1(MatterBaseTest):
             # Verify it is encoded as a valid UTF-8 string
             # with a maximum length of 128 bytes
             assert_valid_pi_key(pi_key)
+
+            # Verify that the PH key is present and has at least one of the bits 4, 8, 9, 10, 11, 12, 15, 16, 17, 18, 19, 20, 21, or 22 set
+            asserts.assert_in('PH', txt_record.txt, "'PH' key must be present if 'PI' key is present.")
+            ph_key = txt_record.txt['PH']
+            ph_val = int(ph_key)
+            pi_related_bits = [4, 8, 9, 10, 11, 12, 15, 16, 17, 18, 19, 20, 21, 22]
+            asserts.assert_true(any((ph_val & (1 << bit)) for bit in pi_related_bits),
+                                "'PH' key must have at least one of bits 4, 8, 9, 10, 11, 12, 15, 16, 17, 18, 19, 20, 21, or 22 set if 'PI' key is present.")
 
     def verify_t_key(self, txt_record) -> None:
         # If 'supports_tcp' is False and T key is not present, nothing to check

--- a/src/python_testing/TC_SC_4_1.py
+++ b/src/python_testing/TC_SC_4_1.py
@@ -65,7 +65,8 @@ from mdns_discovery.utils.asserts import (assert_is_commissionable_type, assert_
                                           assert_valid_commissionable_instance_name, assert_valid_d_key,
                                           assert_valid_devtype_subtype, assert_valid_dn_key, assert_valid_dt_key,
                                           assert_valid_hostname, assert_valid_icd_key, assert_valid_ipv6_addresses,
-                                          assert_valid_long_discriminator_subtype, assert_valid_ph_key, assert_valid_pi_key,
+                                          assert_valid_long_discriminator_subtype, assert_valid_ph_key,
+                                          assert_valid_ph_pi_relationship, assert_valid_pi_key,
                                           assert_valid_ri_key, assert_valid_sai_key, assert_valid_sat_key,
                                           assert_valid_short_discriminator_subtype, assert_valid_sii_key, assert_valid_t_key,
                                           assert_valid_vendor_subtype, assert_valid_vp_key)
@@ -618,13 +619,6 @@ class TC_SC_4_1(MatterBaseTest):
             # text, omitting any leading zeros, and value different than '0'
             assert_valid_ph_key(ph_key)
 
-            # Verify that if any of bits 4, 8, 10, 12, 15, 17, 19, 20, 21, or 22 are set, then the PI key is present
-            ph_val = int(ph_key)
-            mandatory_pi_bits = [4, 8, 10, 12, 15, 17, 19, 20, 21, 22]
-            if any((ph_val & (1 << bit)) for bit in mandatory_pi_bits):
-                asserts.assert_in(
-                    'PI', txt_record.txt, "'PI' key must be present if any of bits 4, 8, 10, 12, 15, 17, 19, 20, 21, or 22 are set in 'PH' key.")
-
         # *** PI KEY ***
         # If the PI key is present
         if 'PI' in txt_record.txt:
@@ -636,13 +630,8 @@ class TC_SC_4_1(MatterBaseTest):
             # with a maximum length of 128 bytes
             assert_valid_pi_key(pi_key)
 
-            # Verify that the PH key is present and has at least one of the bits 4, 8, 9, 10, 11, 12, 15, 16, 17, 18, 19, 20, 21, or 22 set
-            asserts.assert_in('PH', txt_record.txt, "'PH' key must be present if 'PI' key is present.")
-            ph_key = txt_record.txt['PH']
-            ph_val = int(ph_key)
-            pi_related_bits = [4, 8, 9, 10, 11, 12, 15, 16, 17, 18, 19, 20, 21, 22]
-            asserts.assert_true(any((ph_val & (1 << bit)) for bit in pi_related_bits),
-                                "'PH' key must have at least one of bits 4, 8, 9, 10, 11, 12, 15, 16, 17, 18, 19, 20, 21, or 22 set if 'PI' key is present.")
+        # Verify the relationship between PH and PI keys
+        assert_valid_ph_pi_relationship(txt_record.txt)
 
     def verify_t_key(self, txt_record) -> None:
         # If 'supports_tcp' is False and T key is not present, nothing to check

--- a/src/python_testing/TC_SC_4_1.py
+++ b/src/python_testing/TC_SC_4_1.py
@@ -66,10 +66,10 @@ from mdns_discovery.utils.asserts import (assert_is_commissionable_type, assert_
                                           assert_valid_devtype_subtype, assert_valid_dn_key, assert_valid_dt_key,
                                           assert_valid_hostname, assert_valid_icd_key, assert_valid_ipv6_addresses,
                                           assert_valid_long_discriminator_subtype, assert_valid_ph_key,
-                                          assert_valid_ph_pi_relationship, assert_valid_pi_key,
-                                          assert_valid_ri_key, assert_valid_sai_key, assert_valid_sat_key,
-                                          assert_valid_short_discriminator_subtype, assert_valid_sii_key, assert_valid_t_key,
-                                          assert_valid_vendor_subtype, assert_valid_vp_key)
+                                          assert_valid_ph_pi_relationship, assert_valid_pi_key, assert_valid_ri_key,
+                                          assert_valid_sai_key, assert_valid_sat_key, assert_valid_short_discriminator_subtype,
+                                          assert_valid_sii_key, assert_valid_t_key, assert_valid_vendor_subtype,
+                                          assert_valid_vp_key)
 from mobly import asserts
 
 import matter.clusters as Clusters

--- a/src/python_testing/TC_SC_4_1.py
+++ b/src/python_testing/TC_SC_4_1.py
@@ -622,7 +622,8 @@ class TC_SC_4_1(MatterBaseTest):
             ph_val = int(ph_key)
             mandatory_pi_bits = [4, 8, 10, 12, 15, 17, 19, 20, 21, 22]
             if any((ph_val & (1 << bit)) for bit in mandatory_pi_bits):
-                asserts.assert_in('PI', txt_record.txt, "'PI' key must be present if any of bits 4, 8, 10, 12, 15, 17, 19, 20, 21, or 22 are set in 'PH' key.")
+                asserts.assert_in(
+                    'PI', txt_record.txt, "'PI' key must be present if any of bits 4, 8, 10, 12, 15, 17, 19, 20, 21, or 22 are set in 'PH' key.")
 
         # *** PI KEY ***
         # If the PI key is present

--- a/src/python_testing/mdns_discovery/tests/test_asserts.py
+++ b/src/python_testing/mdns_discovery/tests/test_asserts.py
@@ -1187,10 +1187,6 @@ class TestAssertValidPhPiRelationship(unittest.TestCase):
         # 16 = 0b10000
         assert_valid_ph_pi_relationship({'PH': '16', 'PI': 'some instruction'})
 
-    def test_valid_pi_with_correct_ph(self):
-        # PI is present, PH has bit 4 set
-        assert_valid_ph_pi_relationship({'PH': '16', 'PI': 'some instruction'})
-
     def test_invalid_ph_mandatory_pi_bit_set_no_pi(self):
         # PH bit 4 is set, but PI is missing
         msg = fail_msg(assert_valid_ph_pi_relationship, {'PH': '16'})

--- a/src/python_testing/mdns_discovery/tests/test_asserts.py
+++ b/src/python_testing/mdns_discovery/tests/test_asserts.py
@@ -1019,14 +1019,14 @@ class TestAssertValidOperationalInstanceName(unittest.TestCase):
 class TestAssertValidPhKey(unittest.TestCase):
     INT_MSG = "Must be a decimal integer without leading zeroes"
     GT0_MSG = "Value must be greater than 0"
-    BIT_MSG = "Only bits 0-19 may be set (value must fit in 20 bits)"
+    BIT_MSG = "Only bits 0-22 may be set"
 
     # Valid values
     VALID_VALUES = [
         "1",          # minimum allowed
         "33",         # typical example
-        "1048575",    # max 20-bit value (2^20 - 1)
-        "524288",     # power of two within 20 bits
+        "8388607",    # all 22-bits enabled (1<<23 - 1)
+        "524288",     # power of two within 23 bits
         "999999",     # large but still valid under mask
     ]
 
@@ -1052,8 +1052,8 @@ class TestAssertValidPhKey(unittest.TestCase):
         self.assertIn(self.GT0_MSG, msg)
 
     def test_invalid_due_to_out_of_range(self):
-        # Exceeds 20-bit mask
-        msg = fail_msg(assert_valid_ph_key, str((1 << 20)))
+        # Only bits 1 through 22 are defined.
+        msg = fail_msg(assert_valid_ph_key, str((1 << 23)))
         self.assertIn(self.BIT_MSG, msg)
 
     def test_invalid_due_to_empty_string(self):
@@ -1069,8 +1069,8 @@ class TestAssertValidPhKey(unittest.TestCase):
         self.assertNotIn(self.BIT_MSG, msg)
 
     def test_invalid_due_to_leading_zero_and_out_of_range(self):
-        # Leading zero present and numeric value beyond 20-bit mask → INT + BIT
-        msg = fail_msg(assert_valid_ph_key, "01048576")  # 1_048_576 == 1 << 20
+        # Leading zero present and numeric value beyond range
+        msg = fail_msg(assert_valid_ph_key, "08388608")  # 8,388,608 == 1 << 23
         self.assertIn(self.INT_MSG, msg)
         self.assertIn(self.BIT_MSG, msg)
         self.assertNotIn(self.GT0_MSG, msg)
@@ -1091,8 +1091,8 @@ class TestAssertValidPhKey(unittest.TestCase):
         self.assertNotIn(self.BIT_MSG, msg)
 
     def test_invalid_due_to_leading_zero_and_out_of_range_variant(self):
-        # Leading zero plus value beyond 20-bit mask -> INT + BIT, no GT0
-        msg = fail_msg(assert_valid_ph_key, "0001048577")  # 1_048_577 > (1<<20) - 1
+        # Leading zero plus value beyond 22-bit mask -> INT + BIT, no GT0
+        msg = fail_msg(assert_valid_ph_key, "0008388608")  # 1_048_577 > (1<<20) - 1
         self.assertIn(self.INT_MSG, msg)
         self.assertIn(self.BIT_MSG, msg)
         self.assertNotIn(self.GT0_MSG, msg)

--- a/src/python_testing/mdns_discovery/tests/test_asserts.py
+++ b/src/python_testing/mdns_discovery/tests/test_asserts.py
@@ -24,8 +24,8 @@ from mdns_discovery.utils.asserts import (assert_is_border_router_type, assert_i
                                           assert_valid_hostname, assert_valid_icd_key, assert_valid_ipv6_addresses,
                                           assert_valid_jf_key, assert_valid_long_discriminator_subtype,
                                           assert_valid_operational_instance_name, assert_valid_ph_key,
-                                          assert_valid_ph_pi_relationship, assert_valid_pi_key,
-                                          assert_valid_product_id, assert_valid_ri_key, assert_valid_sai_key, assert_valid_sat_key,
+                                          assert_valid_ph_pi_relationship, assert_valid_pi_key, assert_valid_product_id,
+                                          assert_valid_ri_key, assert_valid_sai_key, assert_valid_sat_key,
                                           assert_valid_short_discriminator_subtype, assert_valid_sii_key, assert_valid_t_key,
                                           assert_valid_vendor_id, assert_valid_vendor_subtype, assert_valid_vp_key)
 from mobly import signals

--- a/src/python_testing/mdns_discovery/utils/asserts.py
+++ b/src/python_testing/mdns_discovery/utils/asserts.py
@@ -746,7 +746,7 @@ def assert_valid_ph_key(ph_key: str) -> None:
     - Encoded as a variable-length decimal number in ASCII text
     - Omitting any leading zeroes
     - Must be greater than 0
-    - Only bits 0-19 are valid
+    - Only bits 0-22 are valid
 
     Example:
         "33"
@@ -760,7 +760,7 @@ def assert_valid_ph_key(ph_key: str) -> None:
     constraints = [
         "Must be a decimal integer without leading zeroes",
         "Value must be greater than 0",
-        "Only bits 0-19 may be set (value must fit in 20 bits)",
+        "Only bits 0-22 may be set (value must fit in 23 bits)",
     ]
 
     failed: list[str] = []
@@ -777,7 +777,7 @@ def assert_valid_ph_key(ph_key: str) -> None:
             if v <= 0:
                 failed.append(constraints[1])
             # Bit-mask validity only meaningful for positive integers
-            allowed_mask = (1 << 20) - 1
+            allowed_mask = (1 << 23) - 1
             if v > 0 and (v & ~allowed_mask):
                 failed.append(constraints[2])
         except ValueError:

--- a/src/python_testing/mdns_discovery/utils/asserts.py
+++ b/src/python_testing/mdns_discovery/utils/asserts.py
@@ -830,6 +830,41 @@ def assert_valid_pi_key(pi_key: str) -> None:
 
 
 @not_none_args
+def assert_valid_ph_pi_relationship(txt: dict[str, str]) -> None:
+    """
+    Verify the relationship between Pairing Hint (PH) and Pairing Instruction (PI) keys.
+
+    Constraints:
+    - If any of bits 4, 8, 10, 12, 15, 17, 19, 20, 21, or 22 are set in PH, then PI MUST be present.
+    - If PI is present, PH MUST be present and have at least one of the bits 4, 8, 9, 10, 11, 12, 15, 16, 17, 18, 19, 20, 21, or 22 set.
+
+    Raises:
+        TestFailure: If the relationship constraints are violated.
+    """
+    ph_key = txt.get('PH')
+    pi_key = txt.get('PI')
+
+    if ph_key:
+        try:
+            ph_val = int(ph_key)
+            mandatory_pi_bits = [4, 8, 10, 12, 15, 17, 19, 20, 21, 22]
+            if any((ph_val & (1 << bit)) for bit in mandatory_pi_bits):
+                asserts.assert_in('PI', txt, f"'PI' key must be present if any of bits {mandatory_pi_bits} are set in 'PH' key.")
+        except (ValueError, TypeError):
+            pass
+
+    if pi_key is not None:
+        asserts.assert_in('PH', txt, "'PH' key must be present if 'PI' key is present.")
+        try:
+            ph_val = int(ph_key)
+            pi_related_bits = [4, 8, 9, 10, 11, 12, 15, 16, 17, 18, 19, 20, 21, 22]
+            asserts.assert_true(any((ph_val & (1 << bit)) for bit in pi_related_bits),
+                                f"'PH' key must have at least one of bits {pi_related_bits} set if 'PI' key is present.")
+        except (ValueError, TypeError):
+            pass
+
+
+@not_none_args
 def assert_valid_jf_key(jf_key: str) -> None:
     """
     **Joint Fabric**


### PR DESCRIPTION
#### Summary
Pairing hint table was expanded, tests need to be expanded to accommodate. Also adding checks for the pairing hint table.

#### Related issues
test plan - https://github.com/CHIP-Specifications/chip-test-plans/pull/5820

#### Testing

Runs in CI
#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
