### PR TITLE
[Push AV] Refactor clip recorder with status enums and error handling

### DIFF
--- a/examples/camera-app/linux/include/pushav-clip-recorder.h
+++ b/examples/camera-app/linux/include/pushav-clip-recorder.h
@@ -52,6 +52,30 @@ class PushAvStreamTransportManager; // Forward declaration
 } // namespace chip
 
 /**
+ * @enum ClipFinalizationReason
+ *
+ * Enumerates the reasons why a clip recording is finalized.
+ */
+enum class ClipFinalizationReason : uint8_t
+{
+    kErrorOccurred      = 0, ///< Clip finalized due to an error
+    kSegmentUploadCheck = 1, ///< Normal packet processing - check for segment upload
+    kCleanupUpload      = 2, ///< Cleanup time - skip finalization logic, just upload segments
+};
+
+/**
+ * @enum RecorderStatus
+ *
+ * Status codes for recorder operations.
+ */
+enum class RecorderStatus : uint8_t
+{
+    kSuccess = 0, ///< Operation completed successfully
+    kWarning = 1, ///< Operation completed with warnings
+    kFail    = 2, ///< Operation failed
+};
+
+/**
  * @struct BufferData
  * @brief Contains buffer information for custom IO operations
  */
@@ -133,33 +157,74 @@ public:
 
     /// @name Construction/Destruction
     /// @{
+    /**
+     * @brief Constructs a PushAVClipRecorder instance
+     * @param aClipInfo Reference to clip configuration structure
+     * @param aAudioInfo Reference to audio stream configuration structure
+     * @param aVideoInfo Reference to video stream configuration structure
+     * @param aUploader Pointer to the uploader instance for file uploads
+     */
     PushAVClipRecorder(ClipInfoStruct & aClipInfo, AudioInfoStruct & aAudioInfo, VideoInfoStruct & aVideoInfo,
                        PushAVUploader * aUploader);
+
+    /**
+     * @brief Destroys the PushAVClipRecorder instance
+     *
+     * Ensures proper cleanup of all resources including stopping the recording thread,
+     * cleaning up FFmpeg contexts, and releasing memory allocations.
+     */
     ~PushAVClipRecorder();
     /// @}
 
     /// @name Recording Control
     /// @{
+    /**
+     * @brief Starts the clip recording process
+     *
+     * Initializes the recording worker thread and begins processing media packets.
+     * Sets up the output format context and starts the DASH/CMAF segmentation.
+     */
     void Start();
+
+    /**
+     * @brief Stops the clip recording process
+     *
+     * Signals the worker thread to stop, finalizes the current clip,
+     * and cleans up all recording resources. Waits for the worker thread
+     * to complete before returning.
+     */
     void Stop();
     /// @}
 
     /**
      * @brief Enqueues media data for processing
-     * @param data Raw media data pointer
+     * @param data Raw media data pointer containing encoded audio/video data
      * @param size Data size in bytes
-     * @param isVideo True for video data, false for audio
+     * @param isVideo True for video data, false for audio data
      */
     void PushPacket(const uint8_t * data, size_t size, bool isVideo);
 
+    /**
+     * @brief Sets the callback function to be called when recording stops
+     * @param cb The callback function to execute on recording stop
+     */
     void SetOnStopCallback(std::function<void()> cb) { mOnStopCallback = std::move(cb); }
 
-    // Set the cluster server reference for direct API calls
+    /**
+     * @brief Sets the PushAV stream transport server reference for direct API calls
+     * @param server Pointer to the PushAV stream transport server instance
+     */
     void SetPushAvStreamTransportServer(chip::app::Clusters::PushAvStreamTransportServer * server)
     {
         mPushAvStreamTransportServer = server;
     }
 
+    /**
+     * @brief Sets connection information for the recording session
+     * @param connectionID The unique connection identifier
+     * @param triggerType The type of transport trigger that initiated the recording
+     * @param reasonType The optional reason for trigger activation
+     */
     void SetConnectionInfo(uint16_t connectionID, chip::app::Clusters::PushAvStreamTransport::TransportTriggerTypeEnum triggerType,
                            chip::Optional<chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum> reasonType)
     {
@@ -170,9 +235,29 @@ public:
 
     std::atomic<bool> mDeinitializeRecorder{ false }; ///< Deinitialization flag
     ClipInfoStruct mClipInfo;                         ///< Clip configuration parameters
-    void SetRecorderStatus(bool status);              ///< Sets the recorder status
-    bool GetRecorderStatus();                         ///< Gets the recorder status
+
+    /**
+     * @brief Sets the recorder status
+     * @param status The recorder status to set (true for active, false for inactive)
+     */
+    void SetRecorderStatus(bool status);
+
+    /**
+     * @brief Gets the current recorder status
+     * @return true if recorder is active, false otherwise
+     */
+    bool GetRecorderStatus();
+
+    /**
+     * @brief Sets the fabric index for the recording session
+     * @param fabricIndex The fabric index to associate with this recorder
+     */
     void SetFabricIndex(chip::FabricIndex fabricIndex) { mFabricIndex = fabricIndex; }
+
+    /**
+     * @brief Sets the PushAV stream transport manager reference
+     * @param manager Pointer to the PushAV stream transport manager instance
+     */
     void SetPushAvStreamTransportManager(chip::app::Clusters::PushAvStreamTransport::PushAvStreamTransportManager * manager)
     {
         mPushAvStreamTransportManager = manager;
@@ -230,17 +315,35 @@ private:
      */
     bool EnsureDirectoryExists(const std::string & path);
 
+    /**
+     * @brief Checks if a file exists and adds it to the upload queue.
+     * @param path The file path to check and upload
+     * @return true if the file was successfully added to the upload queue, false otherwise
+     */
     bool CheckAndUploadFile(std::string path);
 
+    /**
+     * @brief Determines if H.264 data contains an I-frame (IDR frame).
+     * @param data Pointer to the H.264 NALU data.
+     * @param length Length of the data in bytes.
+     * @return true if the data contains an I-frame, false otherwise.
+     */
     bool IsH264IFrame(const uint8_t * data, unsigned int length);
 
+    /**
+     * @brief Creates an AVPacket from raw media data
+     * @param data Pointer to the raw media data
+     * @param size Size of the data in bytes
+     * @param isVideo True for video data, false for audio data
+     * @return Pointer to the created AVPacket, or nullptr on failure
+     */
     AVPacket * CreatePacket(const uint8_t * data, int size, bool isVideo);
 
     /**
      * @brief Processes queued packets and writes them to the output file.
-     * @return Zero if processing was successful, negative otherwise, positive for warnings.
+     * @return RecorderStatus::kSuccess if processing was successful, RecorderStatus::kFail otherwise.
      */
-    int ProcessBuffersAndWrite();
+    RecorderStatus ProcessBuffersAndWrite();
 
     /**
      * @brief Configures the output format context for DASH/CMAF VoD.
@@ -248,21 +351,24 @@ private:
      * @param output_prefix Base path for output files.
      * @param init_seg_pattern Pattern for initialization segments.
      * @param media_seg_pattern Pattern for media segments.
+     * @return RecorderStatus::kSuccess on success, RecorderStatus::kFail otherwise.
      */
-    int SetupOutput(const std::string & outputPrefix, const std::string & initSegPattern, const std::string & mediaSegPattern);
+    RecorderStatus SetupOutput(const std::string & outputPrefix, const std::string & initSegPattern,
+                               const std::string & mediaSegPattern);
 
     /**
      * @brief Starts the clip recording process.
-     * @return 0 on success, error code otherwise.
+     * @return RecorderStatus::kSuccess on success, RecorderStatus::kFail otherwise.
      */
-    int StartClipRecording();
+    RecorderStatus StartClipRecording();
 
     /**
      * @brief Adds a video or audio stream to the output context.
      *
      * @param type The type of stream to add (AVMEDIA_TYPE_VIDEO or AVMEDIA_TYPE_AUDIO).
+     * @return RecorderStatus::kSuccess on success, RecorderStatus::kFail otherwise.
      */
-    int AddStreamToOutput(AVMediaType type);
+    RecorderStatus AddStreamToOutput(AVMediaType type);
 
     /**
      * @brief Cleans up the output context and associated resources.
@@ -272,8 +378,11 @@ private:
     /**
      * @brief Finalizes the current clip and prepares for a new one.
      *
-     * @param reason Zero for normal clip finalization or Positive number for abrupt finalization
+     * Handles the clip finalization process based on the provided reason, including
+     * uploading segments, updating metadata, and preparing for the next recording session.
+     *
+     * @param reason The reason for clip finalization (error, segment upload check, or cleanup)
      */
-    void FinalizeCurrentClip(int reason);
+    void FinalizeCurrentClip(ClipFinalizationReason reason);
     /// @}
 };

--- a/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
+++ b/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
@@ -55,6 +55,7 @@ class PushAVTransport : public Transport
 public:
     PushAVTransport(const chip::app::Clusters::PushAvStreamTransport::TransportOptionsStruct & transportOptions,
                     const uint16_t connectionID, AudioStreamStruct & audioStreamParams, VideoStreamStruct & videoStreamParams);
+
     ~PushAVTransport() override;
 
     // Send video data for a given stream ID
@@ -90,10 +91,11 @@ public:
         return (mTransportStatus == chip::app::Clusters::PushAvStreamTransport::TransportStatusEnum::kInactive);
     } // 0:Active 1:Inactive
 
-    void ConfigureRecorderSettings(const chip::app::Clusters::PushAvStreamTransport::TransportOptionsStruct & transportOptions,
-                                   AudioStreamStruct & audioStreamParams, VideoStreamStruct & videoStreamParams);
+    CHIP_ERROR
+    ConfigureRecorderSettings(const chip::app::Clusters::PushAvStreamTransport::TransportOptionsStruct & transportOptions,
+                              AudioStreamStruct & audioStreamParams, VideoStreamStruct & videoStreamParams);
 
-    void ModifyPushTransport(const chip::app::Clusters::PushAvStreamTransport::TransportOptionsStorage & transportOptions);
+    CHIP_ERROR ModifyPushTransport(const chip::app::Clusters::PushAvStreamTransport::TransportOptionsStorage & transportOptions);
 
     bool HandleTriggerDetected();
 

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -105,7 +105,7 @@ PushAvStreamTransportManager::AllocatePushTransport(const TransportOptionsStruct
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Camera, "PushAvStreamTransportManager, failed to configure recorder settings for Connection: [%u], error: %s",
-                     connectionID, chip::ErrorStr(err));
+                     connectionID, ErrorStr(err));
         return Status::Failure;
     }
     mTransportMap[connectionID] = std::move(transport);
@@ -218,7 +218,7 @@ PushAvStreamTransportManager::ModifyPushTransport(const uint16_t connectionID, c
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Camera, "PushAvStreamTransportManager, failed to modify Connection :[%u], error: %s", connectionID,
-                     chip::ErrorStr(err));
+                     ErrorStr(err));
         return Status::Failure;
     }
 

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -329,7 +329,7 @@ void PushAVClipRecorder::Start()
     if (!EnsureDirectoryExists(mClipInfo.mOutputPath))
     {
         ChipLogError(Camera, "ERROR: Invalid output directory");
-        Stop();
+        mDeinitializeRecorder = true;
     }
 
     SetRecorderStatus(true);
@@ -417,19 +417,19 @@ void PushAVClipRecorder::PushPacket(const uint8_t * data, size_t size, bool isVi
     mCondition.notify_one();
 }
 
-int PushAVClipRecorder::SetupOutput(const std::string & outputPrefix, const std::string & initSegPattern,
-                                    const std::string & mediaSegPattern)
+RecorderStatus PushAVClipRecorder::SetupOutput(const std::string & outputPrefix, const std::string & initSegPattern,
+                                               const std::string & mediaSegPattern)
 {
     const std::string mpdFilename = outputPrefix + ".mpd";
     if (avformat_alloc_output_context2(&mFormatContext, nullptr, nullptr, mpdFilename.c_str()) < 0)
     {
         ChipLogError(Camera, "ERROR: Failed to allocate output context");
-        Stop();
-        return -1;
+        return RecorderStatus::kFail;
     }
     if (!mFormatContext)
     {
         ChipLogError(Camera, "ERROR: Output context is null");
+        return RecorderStatus::kFail;
     }
     double segSeconds = static_cast<double>(mClipInfo.mSegmentDurationMs) / 1000.0;
     // Set DASH/CMAF options
@@ -454,15 +454,15 @@ int PushAVClipRecorder::SetupOutput(const std::string & outputPrefix, const std:
     av_dict_set_int(&options, "use_timeline", 1, 0);
     av_dict_set(&options, "strict", "experimental", 0);
     av_dict_set(&options, "start_number", std::to_string(kSegmentIdOffset).c_str(), 0);
-    if (mClipInfo.mHasVideo && (AddStreamToOutput(AVMEDIA_TYPE_VIDEO) < 0))
+    if (mClipInfo.mHasVideo && (AddStreamToOutput(AVMEDIA_TYPE_VIDEO) == RecorderStatus::kFail))
     {
         ChipLogError(Camera, "ERROR: adding video stream to output");
-        return -1;
+        return RecorderStatus::kFail;
     }
-    if (mClipInfo.mHasAudio && (AddStreamToOutput(AVMEDIA_TYPE_AUDIO) < 0))
+    if (mClipInfo.mHasAudio && (AddStreamToOutput(AVMEDIA_TYPE_AUDIO) == RecorderStatus::kFail))
     {
         ChipLogError(Camera, "ERROR: adding video stream to output");
-        return -1;
+        return RecorderStatus::kFail;
     }
 
     if (!(mFormatContext->oformat->flags & AVFMT_NOFILE))
@@ -470,27 +470,27 @@ int PushAVClipRecorder::SetupOutput(const std::string & outputPrefix, const std:
         if (avio_open(&mFormatContext->pb, mpdFilename.c_str(), AVIO_FLAG_WRITE) < 0)
         {
             ChipLogError(Camera, "ERROR: Failed to open output file: %s", mpdFilename.c_str());
-            Stop();
-            return -1;
+            return RecorderStatus::kFail;
         }
     }
 
     if (avformat_write_header(mFormatContext, &options) < 0)
     {
         ChipLogError(Camera, "Error: writing output header");
-        Stop();
-        return -1;
+        return RecorderStatus::kFail;
     }
-    return 0;
+    return RecorderStatus::kSuccess;
 }
 
-int PushAVClipRecorder::StartClipRecording()
+RecorderStatus PushAVClipRecorder::StartClipRecording()
 {
     if (!mClipInfo.mHasVideo && !mClipInfo.mHasAudio)
     {
         ChipLogError(Camera, "ERROR: No video or audio stream available. Not starting recording");
-        return -1;
+        return RecorderStatus::kFail;
     }
+
+    RecorderStatus result = RecorderStatus::kSuccess;
 
     while (GetRecorderStatus())
     {
@@ -503,14 +503,19 @@ int PushAVClipRecorder::StartClipRecording()
                             mClipInfo.mSessionNumber, mClipInfo.mTrackName.c_str());
             break; // Exit loop
         }
-        ProcessBuffersAndWrite();
+        if (ProcessBuffersAndWrite() == RecorderStatus::kFail)
+        {
+            ChipLogError(Camera, "Error processing buffers and writing");
+            result = RecorderStatus::kFail;
+            Stop();
+        }
     }
     CleanupOutput();
     ChipLogProgress(Camera, "Recorder thread closing");
-    return 0;
+    return result;
 }
 
-int PushAVClipRecorder::AddStreamToOutput(AVMediaType type)
+RecorderStatus PushAVClipRecorder::AddStreamToOutput(AVMediaType type)
 {
     if (type == AVMEDIA_TYPE_VIDEO)
     {
@@ -518,13 +523,12 @@ int PushAVClipRecorder::AddStreamToOutput(AVMediaType type)
         if (avcodec_parameters_copy(mVideoStream->codecpar, mInputFormatContext->streams[0]->codecpar) < 0)
         {
             ChipLogError(Camera, "ERROR: Failed to copy codec parameters for media type: %d", type);
-            Stop();
-            return -1;
+            return RecorderStatus::kFail;
         }
         mVideoStream->codecpar->codec_tag = 0;
         mVideoStream->codecpar->width     = mVideoInfo.mWidth;
         mVideoStream->codecpar->height    = mVideoInfo.mHeight;
-        mVideoStream->avg_frame_rate      = (AVRational){ mVideoInfo.mFrameRate, 1 };
+        mVideoStream->avg_frame_rate      = (AVRational) { mVideoInfo.mFrameRate, 1 };
     }
     else if (type == AVMEDIA_TYPE_AUDIO)
     {
@@ -532,22 +536,19 @@ int PushAVClipRecorder::AddStreamToOutput(AVMediaType type)
         if (!mAudioStream)
         {
             ChipLogError(Camera, "ERROR: Failed to add audio stream");
-            Stop();
-            return -1;
+            return RecorderStatus::kFail;
         }
         const AVCodec * audioCodec = avcodec_find_encoder(mAudioInfo.mAudioCodecId);
         if (!audioCodec)
         {
             ChipLogError(Camera, "ERROR: Audio encoder not found");
-            Stop();
-            return -1;
+            return RecorderStatus::kFail;
         }
         mAudioEncoderContext = avcodec_alloc_context3(audioCodec);
         if (!mAudioEncoderContext)
         {
             ChipLogError(Camera, "Error: failed to allocate the encoder context");
-            Stop();
-            return -1;
+            return RecorderStatus::kFail;
         }
 
         mAudioEncoderContext->sample_rate = mAudioInfo.mSampleRate;
@@ -563,35 +564,33 @@ int PushAVClipRecorder::AddStreamToOutput(AVMediaType type)
 
         mAudioEncoderContext->bit_rate              = mAudioInfo.mBitRate;
         mAudioEncoderContext->sample_fmt            = audioCodec->sample_fmts[0];
-        mAudioEncoderContext->time_base             = (AVRational){ 1, mAudioInfo.mSampleRate };
+        mAudioEncoderContext->time_base             = (AVRational) { 1, mAudioInfo.mSampleRate };
         mAudioEncoderContext->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;
         AVDictionary * opts                         = NULL;
         av_dict_set(&opts, "strict", "experimental", 0);
         if (avcodec_open2(mAudioEncoderContext, audioCodec, &opts) < 0)
         {
             ChipLogError(Camera, "Error: Cannot open audio encoder for audio stream");
-            Stop();
-            return -1;
+            return RecorderStatus::kFail;
         }
         if (avcodec_parameters_from_context(mAudioStream->codecpar, mAudioEncoderContext) < 0)
         {
             ChipLogError(Camera, "Error: Failed to copy encoder parameters to audio output stream");
-            Stop();
-            return -1;
+            return RecorderStatus::kFail;
         }
         if (mFormatContext->oformat->flags & AVFMT_GLOBALHEADER)
         {
             mAudioEncoderContext->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
         }
     }
-    return 0;
+    return RecorderStatus::kSuccess;
 }
 
-int PushAVClipRecorder::ProcessBuffersAndWrite()
+RecorderStatus PushAVClipRecorder::ProcessBuffersAndWrite()
 {
     if (mVideoQueue.empty() && mAudioQueue.empty())
     {
-        return -1;
+        return RecorderStatus::kWarning;
     }
 
     bool useVideo  = false;
@@ -602,17 +601,16 @@ int PushAVClipRecorder::ProcessBuffersAndWrite()
         AVPacket * videoPkt = mVideoQueue.front();
         AVPacket * audioPkt = mAudioQueue.front();
 
-        if (videoPkt->pts != AV_NOPTS_VALUE && audioPkt->pts != AV_NOPTS_VALUE)
+        const bool videoHasValidPts = (videoPkt->pts != AV_NOPTS_VALUE);
+        const bool audioHasValidPts = (audioPkt->pts != AV_NOPTS_VALUE);
+
+        if (videoHasValidPts && audioHasValidPts)
         {
             useVideo = (videoPkt->pts <= audioPkt->pts);
         }
-        else if (videoPkt->pts != AV_NOPTS_VALUE)
+        else
         {
-            useVideo = true;
-        }
-        else if (audioPkt->pts != AV_NOPTS_VALUE)
-        {
-            useVideo = false;
+            useVideo = videoHasValidPts;
         }
         pkt = useVideo ? videoPkt : audioPkt;
     }
@@ -621,28 +619,14 @@ int PushAVClipRecorder::ProcessBuffersAndWrite()
         pkt      = mVideoQueue.front();
         useVideo = true;
     }
-    else if (!mAudioQueue.empty())
+    else
     {
         pkt      = mAudioQueue.front();
         useVideo = false;
     }
-    else
-    {
-        return false;
-    }
-    if (!pkt)
-    {
-        ChipLogError(Camera, "Error: No valid packet to process");
-        return -1;
-    }
 
     if (mMetadataSet == false)
     {
-        if (mClipInfo.mHasVideo && !useVideo)
-        {
-            return false;
-        }
-
         std::string initSegName =
             mClipInfo.mTrackName + std::filesystem::path::preferred_separator + mClipInfo.mTrackName + ".init";
         std::string mediaSegName = mClipInfo.mTrackName + std::filesystem::path::preferred_separator + "segment_$Number%04d$.m4s";
@@ -664,15 +648,13 @@ int PushAVClipRecorder::ProcessBuffersAndWrite()
             if (avformat_open_input(&mInputFormatContext, "", nullptr, nullptr) < 0)
             {
                 ChipLogError(Camera, "Error: Failed to open input format for video");
-                Stop();
-                return -1;
+                return RecorderStatus::kFail;
             }
 
             if (avformat_find_stream_info(mInputFormatContext, nullptr) < 0)
             {
                 ChipLogError(Camera, "Error: Failed to find stream info for video");
-                Stop();
-                return -1;
+                return RecorderStatus::kFail;
             }
         }
         else if (mClipInfo.mHasAudio)
@@ -682,25 +664,24 @@ int PushAVClipRecorder::ProcessBuffersAndWrite()
             ChipLogProgress(Camera, "Setting up audio-only stream, skipping input format initialization");
         }
 
-        if (SetupOutput(mClipInfo.mOutputPath + mpdPrefix, initSegName, mediaSegName) < 0)
+        if (SetupOutput(mClipInfo.mOutputPath + mpdPrefix, initSegName, mediaSegName) == RecorderStatus::kFail)
         {
             ChipLogError(Camera, "Error: setting up output");
-            return -1;
+            return RecorderStatus::kFail;
         }
         if (!mFormatContext)
         {
             ChipLogError(Camera, "Error: Output context not initialized. Skipping packet");
-            Stop();
-            return -1;
+            return RecorderStatus::kFail;
         }
         mMetadataSet = true;
     }
 
     if (pkt->pts == AV_NOPTS_VALUE && pkt->dts == AV_NOPTS_VALUE)
     {
-        ChipLogError(Camera, "Warning packet has no valid timestamps\n");
+        ChipLogError(Camera, "Warning packet has no valid timestamps");
         av_packet_unref(pkt);
-        return 0;
+        return RecorderStatus::kSuccess;
     }
 
     currentPts = (pkt->pts != AV_NOPTS_VALUE) ? pkt->pts : pkt->dts;
@@ -719,8 +700,8 @@ int PushAVClipRecorder::ProcessBuffersAndWrite()
     if (av_interleaved_write_frame(mFormatContext, pkt) < 0)
     {
         ChipLogError(Camera, "Error writing frame to output file");
-        FinalizeCurrentClip(1);
-        return -1;
+        FinalizeCurrentClip(ClipFinalizationReason::kErrorOccurred);
+        return RecorderStatus::kWarning;
     }
 
     av_packet_free(&pkt);
@@ -732,9 +713,9 @@ int PushAVClipRecorder::ProcessBuffersAndWrite()
     {
         mAudioQueue.pop();
     }
-    FinalizeCurrentClip(0);
+    FinalizeCurrentClip(ClipFinalizationReason::kSegmentUploadCheck);
 
-    return 0;
+    return RecorderStatus::kSuccess;
 }
 
 void PushAVClipRecorder::CleanupOutput()
@@ -762,7 +743,7 @@ void PushAVClipRecorder::CleanupOutput()
     {
         avcodec_free_context(&mAudioEncoderContext);
     }
-    FinalizeCurrentClip(0);
+    FinalizeCurrentClip(ClipFinalizationReason::kCleanupUpload);
     mVideoStream = nullptr;
     mAudioStream = nullptr;
     mMetadataSet = false;
@@ -858,7 +839,7 @@ void UpdateMPDStartNumber(const std::string & mpdPath)
  * Writes the trailer of the current clip and initializes a new output file.
  */
 
-void PushAVClipRecorder::FinalizeCurrentClip(int reason)
+void PushAVClipRecorder::FinalizeCurrentClip(ClipFinalizationReason reason)
 {
     int64_t clipLengthInPTS = currentPts - mCurrentClipStartPts;
     // Final duration has to be (clipDuration + preRollLen) seconds
@@ -870,7 +851,7 @@ void PushAVClipRecorder::FinalizeCurrentClip(int reason)
         ChipLogError(Camera,
                      "Invalid remaining duration: %" PRId64 " for sessionID: %" PRIu64 " Track name: %s - stopping recording",
                      remainingDuration, mClipInfo.mSessionNumber, mClipInfo.mTrackName.c_str());
-        reason = 1; // Set reason to trigger existing stop logic
+        reason = ClipFinalizationReason::kErrorOccurred;
     }
     else
     {
@@ -890,11 +871,27 @@ void PushAVClipRecorder::FinalizeCurrentClip(int reason)
     std::filesystem::path basePath = std::filesystem::path(mClipInfo.mOutputPath) /
         ("session_" + std::to_string(mClipInfo.mSessionNumber)) / mClipInfo.mTrackName;
 
-    if (reason || ((clipLengthInPTS >= clipDuration) && (mClipInfo.mTriggerType != 2)))
+    const char * reasonStr = "Unknown";
+    switch (reason)
+    {
+    case ClipFinalizationReason::kErrorOccurred:
+        reasonStr = "Error occurred";
+        break;
+    case ClipFinalizationReason::kSegmentUploadCheck:
+        reasonStr = "Segment upload check";
+        break;
+    case ClipFinalizationReason::kCleanupUpload:
+        reasonStr = "Cleanup upload";
+        break;
+    }
+
+    bool shouldFinalize =
+        (reason == ClipFinalizationReason::kErrorOccurred) || ((clipLengthInPTS >= clipDuration) && (mClipInfo.mTriggerType != 2));
+
+    if (shouldFinalize)
     {
         ChipLogDetail(Camera, "Clip record completed, finalizing clip for sessionID: %" PRIu64 " Track name: %s, Reason: %s",
-                      mClipInfo.mSessionNumber, mClipInfo.mTrackName.c_str(),
-                      (reason == 0) ? "End of clip reached" : "Error occurred");
+                      mClipInfo.mSessionNumber, mClipInfo.mTrackName.c_str(), reasonStr);
         Stop();
         mCurrentClipStartPts = AV_NOPTS_VALUE;
     }

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -528,7 +528,7 @@ RecorderStatus PushAVClipRecorder::AddStreamToOutput(AVMediaType type)
         mVideoStream->codecpar->codec_tag = 0;
         mVideoStream->codecpar->width     = mVideoInfo.mWidth;
         mVideoStream->codecpar->height    = mVideoInfo.mHeight;
-        mVideoStream->avg_frame_rate      = (AVRational) { mVideoInfo.mFrameRate, 1 };
+        mVideoStream->avg_frame_rate      = (AVRational){ mVideoInfo.mFrameRate, 1 };
     }
     else if (type == AVMEDIA_TYPE_AUDIO)
     {
@@ -564,7 +564,7 @@ RecorderStatus PushAVClipRecorder::AddStreamToOutput(AVMediaType type)
 
         mAudioEncoderContext->bit_rate              = mAudioInfo.mBitRate;
         mAudioEncoderContext->sample_fmt            = audioCodec->sample_fmts[0];
-        mAudioEncoderContext->time_base             = (AVRational) { 1, mAudioInfo.mSampleRate };
+        mAudioEncoderContext->time_base             = (AVRational){ 1, mAudioInfo.mSampleRate };
         mAudioEncoderContext->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;
         AVDictionary * opts                         = NULL;
         av_dict_set(&opts, "strict", "experimental", 0);

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -29,7 +29,6 @@ PushAVTransport::PushAVTransport(const TransportOptionsStruct & transportOptions
     mAudioStreamParams(audioStreamParams),
     mVideoStreamParams(videoStreamParams)
 {
-    ConfigureRecorderSettings(transportOptions, audioStreamParams, videoStreamParams);
     mConnectionID                     = connectionID;
     mTransportStatus                  = TransportStatusEnum::kInactive;
     mActivationTimeSetByManualTrigger = false;
@@ -132,9 +131,34 @@ void PushAVTransport::ConfigureRecorderTimeSetting(
     }
 }
 
-void PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStruct & transportOptions,
-                                                AudioStreamStruct & audioStreamParams, VideoStreamStruct & videoStreamParams)
+CHIP_ERROR PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStruct & transportOptions,
+                                                      AudioStreamStruct & audioStreamParams, VideoStreamStruct & videoStreamParams)
 {
+    uint8_t audioCodec = static_cast<uint8_t>(audioStreamParams.audioCodec);
+    if (audioCodec == 2)
+    {
+        ChipLogError(Camera, "Unknown Audio codec");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    else if (audioCodec != 0)
+    {
+        ChipLogError(Camera, "Unsupported Audio codec");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    int8_t videoCodec = static_cast<uint8_t>(videoStreamParams.videoCodec);
+    if (videoCodec == 4)
+    {
+        ChipLogError(Camera, "Unknown Video codec");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    else if (videoCodec != 0)
+    {
+        ChipLogError(Camera, "Unsupported Video codec");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    // Codecs are valid, proceed with configuration
     mClipInfo.mHasAudio = transportOptions.audioStreamID.HasValue();
     mClipInfo.mHasVideo = transportOptions.videoStreamID.HasValue();
     if (mClipInfo.mHasAudio && mClipInfo.mHasVideo)
@@ -166,7 +190,7 @@ void PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStruct & t
 
     mTransportTriggerType = transportOptions.triggerOptions.triggerType;
 
-    uint8_t audioCodec = static_cast<uint8_t>(audioStreamParams.audioCodec);
+    // Configure audio settings
     if (audioStreamParams.channelCount == 0)
     {
         ChipLogError(Camera, "Invalid channel count: 0. Using fallback 1 channel.");
@@ -185,14 +209,6 @@ void PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStruct & t
         mAudioInfo.mAudioTimeBase      = { 1, static_cast<int>(audioStreamParams.sampleRate) };
         mAudioInfo.mAudioFrameDuration = 20000; // Default OPUS frame duration
     }
-    else if (audioCodec == 2)
-    {
-        ChipLogError(Camera, "Unknown Audio codec")
-    }
-    else
-    {
-        ChipLogError(Camera, "Unsupported Audio codec");
-    }
 
     mAudioInfo.mSampleRate = audioStreamParams.sampleRate;
     if (audioStreamParams.bitRate == 0)
@@ -205,19 +221,11 @@ void PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStruct & t
     mAudioInfo.mAudioDts         = 0;
     mAudioInfo.mAudioStreamIndex = -1;
 
-    int8_t VideoCodec = static_cast<uint8_t>(videoStreamParams.videoCodec);
-    if (VideoCodec == 0)
+    // Configure video settings
+    if (videoCodec == 0)
     {
         mVideoInfo.mVideoCodecId  = AV_CODEC_ID_H264;
         mVideoInfo.mVideoTimeBase = { 1, 90000 };
-    }
-    else if (VideoCodec == 4)
-    {
-        ChipLogError(Camera, "Unknown Video codec")
-    }
-    else
-    {
-        ChipLogError(Camera, "Unsupported Video codec");
     }
     mVideoInfo.mVideoPts = 0;
     mVideoInfo.mVideoDts = 0;
@@ -241,6 +249,8 @@ void PushAVTransport::ConfigureRecorderSettings(const TransportOptionsStruct & t
 
     PrintTransportSettings(mClipInfo, mAudioInfo, mVideoInfo);
     ChipLogProgress(Camera, "PushAvStreamTransportManager, Configure Recorder Settings done !!!");
+
+    return CHIP_NO_ERROR;
 }
 
 void PushAVTransport::InitializeRecorder()
@@ -687,9 +697,15 @@ bool PushAVTransport::CanSendAudio()
     return IsStreaming() && mClipInfo.mHasAudio;
 }
 
-void PushAVTransport::ModifyPushTransport(const TransportOptionsStorage & transportOptions)
+CHIP_ERROR PushAVTransport::ModifyPushTransport(const TransportOptionsStorage & transportOptions)
 {
-    ConfigureRecorderSettings(transportOptions, mAudioStreamParams, mVideoStreamParams);
+    CHIP_ERROR err = ConfigureRecorderSettings(transportOptions, mAudioStreamParams, mVideoStreamParams);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Camera, "Failed to modify push transport settings for connection %u: %s", mConnectionID, chip::ErrorStr(err));
+        return err;
+    }
+    return CHIP_NO_ERROR;
 }
 
 bool PushAVTransport::GetBusyStatus()


### PR DESCRIPTION
#### Summary
Refactors PushAV transport system to improve error handling, type safety, and robustness.

Changes

- Added ClipFinalizationReason and RecorderStatus enums to replace magic integers
- Changed method return types from int to proper enum types for type safety
- Added error propagation and rollback mechanisms in transport allocation and modification

#### Related issues

#### Testing
Manual Testing

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

