### PR TITLE
[YAML tests] - allow yaml file to contain a `CI` section to define what to run in CI (and allow multi-execution)

### DIFF
--- a/docs/testing/yaml.md
+++ b/docs/testing/yaml.md
@@ -423,8 +423,8 @@ up examples apps, PICS and PIXIT values for use in the CI.
 Generally YAML auto-selects an application to run the test against based on the
 YAML name. You may need more control in cases when you want the same test to
 apply to multiple applications or provide custom arguments. In that case, the
-YAML file supports a `CI` entry that contains a list of `name`, `app` and
-`args` (optional) to execute.
+YAML file supports a `CI` entry that contains a list of `name`, `app` and `args`
+(optional) to execute.
 
 ```yaml
 CI:

--- a/docs/testing/yaml.md
+++ b/docs/testing/yaml.md
@@ -444,10 +444,22 @@ CI:
 ```
 
 Application names are supported placeholders that will be replaced with the full
-application path. Example supported applications (see `test_definition.py` for
-a full list): - `all-clusters` - `bridge` - `closure` - `energy-gateway` -
-`energy-management` - `fabric-sync` - `lit-icd` - `lock` - `microwave-oven` -
-`network-manager` - `ota-requestor` - `rvc` - `tv`
+application path. Example supported applications (see `test_definition.py` for a
+full list):
+
+-   `all-clusters`
+-   `bridge`
+-   `closure`
+-   `energy-gateway`
+-   `energy-management`
+-   `fabric-sync`
+-   `lit-icd`
+-   `lock`
+-   `microwave-oven`
+-   `network-manager`
+-   `ota-requestor`
+-   `rvc`
+-   `tv`
 
 ### Running in the TH
 

--- a/docs/testing/yaml.md
+++ b/docs/testing/yaml.md
@@ -418,6 +418,37 @@ application, the KVS file will be in /tmp as chip_kvs
 Please see [CI testing](./ci_testing.md) for more information about how to set
 up examples apps, PICS and PIXIT values for use in the CI.
 
+### Defining the CI test arguments
+
+Generally YAML auto-selects an application to run the test against based on the
+YAML name. You may need more control in cases when you want the same test to
+apply to multiple applications or provide custom arguments. In that case, the
+YAML file supports a `CI` entry that contains a list of `name`, `command` and
+`args` (optional) to execute.
+
+```yaml
+CI:
+    - name: "This is displayed in logs"
+      # application name MUST be a supported placeholder
+      app: all-clusters
+    - name: "Some other names"
+      app: rvc
+      # Optional arguments, a list
+      args: ["--vendor-name", "Testing"]
+    - name: "Test against lit-icd app"
+      app: lit-icd
+      # List can be split in separate lines
+      args:
+          - --vendor-name
+          - test123
+```
+
+Application names are supported placeholders that will be replaced with the full
+application path. Example supported applications (see `test_definition.py` for
+a full list): - `all-clusters` - `bridge` - `closure` - `energy-gateway` -
+`energy-management` - `fabric-sync` - `lit-icd` - `lock` - `microwave-oven` -
+`network-manager` - `ota-requestor` - `rvc` - `tv`
+
 ### Running in the TH
 
 TODO: Do we have a permanent link to the most up to date TH documentation? If

--- a/docs/testing/yaml.md
+++ b/docs/testing/yaml.md
@@ -423,7 +423,7 @@ up examples apps, PICS and PIXIT values for use in the CI.
 Generally YAML auto-selects an application to run the test against based on the
 YAML name. You may need more control in cases when you want the same test to
 apply to multiple applications or provide custom arguments. In that case, the
-YAML file supports a `CI` entry that contains a list of `name`, `command` and
+YAML file supports a `CI` entry that contains a list of `name`, `app` and
 `args` (optional) to execute.
 
 ```yaml

--- a/scripts/py_matter_yamltests/matter/yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/yaml_loader.py
@@ -160,8 +160,8 @@ _ci_tree = SchemaTree(schema=_CI_SCHEMA)
 yaml_tree = SchemaTree(schema=_TOP_LEVEL_SCHEMA, children={
     'tests': _test_step_tree, 'config': _config_tree, 'CI': _ci_tree})
 
- class YamlLoader:
-     """This class loads a file from the disk and validates that the content is a well formed yaml test."""
+class YamlLoader:
+    """This class loads a file from the disk and validates that the content is a well formed yaml test."""
 
     def load(self, yaml_file: str) -> Tuple[str, Union[list, str], dict, list]:
         filename = ''

--- a/scripts/py_matter_yamltests/matter/yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/yaml_loader.py
@@ -37,6 +37,13 @@ _TOP_LEVEL_SCHEMA = {
     'PICS': (str, list),
     'config': dict,
     'tests': list,
+    'CI': list,
+}
+
+_CI_SCHEMA = {
+    'name': str,
+    'app': str,
+    'args': (type(None), list),
 }
 
 _TEST_STEP_SCHEMA = {
@@ -145,15 +152,16 @@ _test_step_tree = SchemaTree(schema=_TEST_STEP_SCHEMA, children={
                              'arguments': _arguments_tree, 'response': _response_tree})
 
 _config_variable_tree = SchemaTree(schema=_CONFIG_VARIABLE_SCHEMA)
+
 _config_tree = SchemaTree(schema=_CONFIG_SCHEMA, children={
-                          '_variableName_': _config_variable_tree})
+                           '_variableName_': _config_variable_tree})
+_ci_tree = SchemaTree(schema=_CI_SCHEMA)
 
 yaml_tree = SchemaTree(schema=_TOP_LEVEL_SCHEMA, children={
-                       'tests': _test_step_tree, 'config': _config_tree})
+    'tests': _test_step_tree, 'config': _config_tree, 'CI': _ci_tree})
 
-
-class YamlLoader:
-    """This class loads a file from the disk and validates that the content is a well formed yaml test."""
+ class YamlLoader:
+     """This class loads a file from the disk and validates that the content is a well formed yaml test."""
 
     def load(self, yaml_file: str) -> Tuple[str, Union[list, str], dict, list]:
         filename = ''

--- a/scripts/py_matter_yamltests/matter/yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter/yamltests/yaml_loader.py
@@ -154,11 +154,12 @@ _test_step_tree = SchemaTree(schema=_TEST_STEP_SCHEMA, children={
 _config_variable_tree = SchemaTree(schema=_CONFIG_VARIABLE_SCHEMA)
 
 _config_tree = SchemaTree(schema=_CONFIG_SCHEMA, children={
-                           '_variableName_': _config_variable_tree})
+    '_variableName_': _config_variable_tree})
 _ci_tree = SchemaTree(schema=_CI_SCHEMA)
 
 yaml_tree = SchemaTree(schema=_TOP_LEVEL_SCHEMA, children={
     'tests': _test_step_tree, 'config': _config_tree, 'CI': _ci_tree})
+
 
 class YamlLoader:
     """This class loads a file from the disk and validates that the content is a well formed yaml test."""

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -17,8 +17,6 @@
 import json
 import logging
 import os
-import shlex
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Set

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Iterator, Set
 
 from . import runner
-from .test_definition import TestDefinition, TestTag, TestTarget
+from .test_definition import TestDefinition, TestTag, TestTarget, StandardTargets
 
 log = logging.getLogger(__name__)
 
@@ -278,77 +278,6 @@ def _AllYamlTests():
         yield path
 
 
-def target_for_name(name: str):
-    if (name.startswith("TV_") or name.startswith("Test_TC_MC_") or
-            name.startswith("Test_TC_LOWPOWER_") or name.startswith("Test_TC_KEYPADINPUT_") or
-            name.startswith("Test_TC_APPLAUNCHER_") or name.startswith("Test_TC_MEDIAINPUT_") or
-            name.startswith("Test_TC_WAKEONLAN_") or name.startswith("Test_TC_CHANNEL_") or
-            name.startswith("Test_TC_MEDIAPLAYBACK_") or name.startswith("Test_TC_AUDIOOUTPUT_") or
-            name.startswith("Test_TC_TGTNAV_") or name.startswith("Test_TC_APBSC_") or
-            name.startswith("Test_TC_CONTENTLAUNCHER_") or name.startswith("Test_TC_ALOGIN_")):
-        return TestTarget.TV
-    if name.startswith("DL_") or name.startswith("Test_TC_DRLK_"):
-        return TestTarget.LOCK
-    if name.startswith("TestFabricSync"):
-        return TestTarget.FABRIC_SYNC
-    if name.startswith("OTA_"):
-        return TestTarget.OTA
-    if name.startswith("Test_TC_BRBINFO_") or name.startswith("Test_TC_ACT_"):
-        return TestTarget.BRIDGE
-    if name.startswith("TestIcd") or name.startswith("Test_TC_ICDM_"):
-        return TestTarget.LIT_ICD
-    if name.startswith("Test_TC_MWOCTRL_") or name.startswith("Test_TC_MWOM_"):
-        return TestTarget.MWO
-    if name.startswith("Test_TC_RVCRUNM_") or name.startswith("Test_TC_RVCCLEANM_") or name.startswith("Test_TC_RVCOPSTATE_"):
-        return TestTarget.RVC
-    if name.startswith("Test_TC_TBRM_") or name.startswith("Test_TC_THNETDIR_") or name.startswith("Test_TC_WIFINM_"):
-        return TestTarget.NETWORK_MANAGER
-    if name.startswith("Test_TC_MTRID_"):
-        return TestTarget.ENERGY_GATEWAY
-    if (name.startswith("Test_TC_DEM_") or name.startswith("Test_TC_DEMM_") or
-            name.startswith("Test_TC_EEVSE_") or name.startswith("Test_TC_EEVSEM_")):
-        return TestTarget.ENERGY_MANAGEMENT
-    if name.startswith("Test_TC_CLCTRL_") or name.startswith("Test_TC_CLDIM_"):
-        return TestTarget.CLOSURE
-    return TestTarget.ALL_CLUSTERS
-
-
-def tests_with_command(chip_tool: str, is_manual: bool):
-    """Executes `chip_tool` binary to see what tests are available, using cmd
-    to get the list.
-    """
-    cmd_list = "list"
-    if is_manual:
-        cmd_list += "-manual"
-
-    cmd = [chip_tool, "tests", cmd_list]
-    result = subprocess.run(cmd, capture_output=True, encoding="utf-8")
-    if result.returncode != 0:
-        log.error("Failed to run %s:", shlex.join(cmd))
-        log.error("STDOUT: %s", result.stdout)
-        log.error("STDERR: %s", result.stderr)
-        result.check_returncode()
-
-    test_tags: set[TestTag] = set()
-    if is_manual:
-        test_tags.add(TestTag.MANUAL)
-
-    in_development_tests = [s.replace(".yaml", "") for s in _GetInDevelopmentTests()]
-
-    for name in result.stdout.split("\n"):
-        if not name:
-            continue
-
-        target = target_for_name(name)
-        tags = test_tags.copy()
-        if name in in_development_tests:
-            tags.add(TestTag.IN_DEVELOPMENT)
-
-        yield TestDefinition(
-            run_name=name, name=name, target=target, tags=tags
-        )
-
-
 def _AllFoundYamlTests(treat_repl_unsupported_as_in_development: bool, treat_dft_unsupported_as_in_development: bool, treat_chip_tool_unsupported_as_in_development: bool, use_short_run_name: bool):
     """
     use_short_run_name should be true if we want the run_name to be "Test_ABC" instead of "some/path/Test_ABC.yaml"
@@ -400,10 +329,13 @@ def _AllFoundYamlTests(treat_repl_unsupported_as_in_development: bool, treat_dft
         if treat_chip_tool_unsupported_as_in_development and run_name in chip_tool_unsupported_as_in_development_tests:
             tags.add(TestTag.IN_DEVELOPMENT)
 
+        # TODO: figure out the targets
+        targets = [StandardTargets.for_test_name(path.name)]
+
         yield TestDefinition(
             run_name=run_name,
             name=path.stem,  # `path.stem` converts "some/path/Test_ABC_1.2.yaml" to "Test_ABC.1.2"
-            target=target_for_name(path.name),
+            targets=targets,
             tags=tags,
         )
 
@@ -422,10 +354,3 @@ def AllDarwinFrameworkToolYamlTests():
     for test in _AllFoundYamlTests(treat_repl_unsupported_as_in_development=False, treat_dft_unsupported_as_in_development=True, treat_chip_tool_unsupported_as_in_development=False, use_short_run_name=True):
         yield test
 
-
-def AllChipToolTests(chip_tool: str):
-    for test in tests_with_command(chip_tool, is_manual=False):
-        yield test
-
-    for test in tests_with_command(chip_tool, is_manual=True):
-        yield test

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -233,7 +233,7 @@ class TestTarget:
 
 
 def _standard_ci_target(app_placeholder: str):
-    """Returns a command taylored for a standard CI execution.
+    """Returns a command tailored for a standard CI execution.
 
     Generally this is just the given command without any arguments.
     """

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -14,7 +14,9 @@
 #    limitations under the License.
 
 import logging
+import itertools
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -221,20 +223,74 @@ class App:
         return True
 
 
-class TestTarget(StrEnum):
-    ALL_CLUSTERS = 'all-clusters'
-    TV = 'tv'
-    LOCK = 'lock'
-    OTA = 'ota-requestor'
-    BRIDGE = 'bridge'
-    LIT_ICD = 'lit-icd'
-    FABRIC_SYNC = 'fabric-sync'
-    MWO = 'microwave-oven'
-    RVC = 'rvc'
-    NETWORK_MANAGER = 'network-manager'
-    ENERGY_GATEWAY = 'energy-gateway'
-    ENERGY_MANAGEMENT = 'energy-management'
-    CLOSURE = 'closure'
+@dataclass
+class TestTarget:
+    # command to execute. MUST be a placeholder like tv or lock
+    command: str
+
+    # arguments to pass in to the command to execute
+    arguments: list[str] = field(default_factory=list)
+
+
+def _standard_ci_target(app_placeholder: str):
+    """Returns a command taylored for a standard CI execution.
+
+    Generaly this is just the given command without any arguments.
+    """
+    return TestTarget(command=app_placeholder, arguments=[])
+
+
+class StandardTargets:
+    """Defines some commonly used run targets (app placeholders)"""
+    ALL_CLUSTERS = _standard_ci_target('all-clusters')
+    TV = _standard_ci_target('tv')
+    LOCK = _standard_ci_target('lock')
+    OTA = _standard_ci_target('ota-requestor')
+    BRIDGE = _standard_ci_target('bridge')
+    LIT_ICD = _standard_ci_target('lit-icd')
+    FABRIC_SYNC = _standard_ci_target('fabric-sync')
+    MWO = _standard_ci_target('microwave-oven')
+    RVC = _standard_ci_target('rvc')
+    NETWORK_MANAGER = _standard_ci_target('network-manager')
+    ENERGY_GATEWAY = _standard_ci_target('energy-gateway')
+    ENERGY_MANAGEMENT = _standard_ci_target('energy-management')
+    CLOSURE = _standard_ci_target('closure')
+
+    @classmethod
+    def for_test_name(cls, name) -> TestTarget:
+        if (name.startswith("TV_") or name.startswith("Test_TC_MC_") or
+            name.startswith("Test_TC_LOWPOWER_") or name.startswith("Test_TC_KEYPADINPUT_") or
+            name.startswith("Test_TC_APPLAUNCHER_") or name.startswith("Test_TC_MEDIAINPUT_") or
+            name.startswith("Test_TC_WAKEONLAN_") or name.startswith("Test_TC_CHANNEL_") or
+            name.startswith("Test_TC_MEDIAPLAYBACK_") or name.startswith("Test_TC_AUDIOOUTPUT_") or
+            name.startswith("Test_TC_TGTNAV_") or name.startswith("Test_TC_APBSC_") or
+            name.startswith("Test_TC_CONTENTLAUNCHER_") or name.startswith("Test_TC_ALOGIN_")):
+            return StandardTargets.TV
+        if name.startswith("DL_") or name.startswith("Test_TC_DRLK_"):
+            return StandardTargets.LOCK
+        if name.startswith("TestFabricSync"):
+            return StandardTargets.FABRIC_SYNC
+        if name.startswith("OTA_"):
+            return StandardTargets.OTA
+        if name.startswith("Test_TC_BRBINFO_") or name.startswith("Test_TC_ACT_"):
+            return StandardTargets.BRIDGE
+        if name.startswith("TestIcd") or name.startswith("Test_TC_ICDM_"):
+            return StandardTargets.LIT_ICD
+        if name.startswith("Test_TC_MWOCTRL_") or name.startswith("Test_TC_MWOM_"):
+            return StandardTargets.MWO
+        if name.startswith("Test_TC_RVCRUNM_") or name.startswith("Test_TC_RVCCLEANM_") or name.startswith("Test_TC_RVCOPSTATE_"):
+            return StandardTargets.RVC
+        if name.startswith("Test_TC_TBRM_") or name.startswith("Test_TC_THNETDIR_") or name.startswith("Test_TC_WIFINM_"):
+            return StandardTargets.NETWORK_MANAGER
+        if name.startswith("Test_TC_MTRID_"):
+            return StandardTargets.ENERGY_GATEWAY
+        if (name.startswith("Test_TC_DEM_") or name.startswith("Test_TC_DEMM_") or
+                name.startswith("Test_TC_EEVSE_") or name.startswith("Test_TC_EEVSEM_")):
+            return StandardTargets.ENERGY_MANAGEMENT
+        if name.startswith("Test_TC_CLCTRL_") or name.startswith("Test_TC_CLDIM_"):
+            return StandardTargets.CLOSURE
+        return StandardTargets.ALL_CLUSTERS
+
 
 
 @dataclass
@@ -436,7 +492,7 @@ class TestRunTime(Enum):
 class TestDefinition:
     name: str
     run_name: str
-    target: TestTarget
+    targets: list[TestTarget]
     tags: set[TestTag] = field(default_factory=set)
 
     @property
@@ -462,25 +518,39 @@ class TestDefinition:
             ble_controller_tool: int | None = None):
         """
         Executes the given test case using the provided runner for execution.
+        Will iterate and execute every target.
         """
+        for target in self.targets:
+            self._RunImpl(target, runner, apps_register, subproc_info_repo, pics_file, timeout_seconds, dry_run,
+                     test_runtime, ble_controller_app, ble_controller_tool)
+
+    def _RunImpl(self, target: TestTarget, runner: Runner, apps_register: AppsRegister, subproc_info_repo: SubprocessInfoRepo,
+            pics_file: Path, timeout_seconds: int | None, dry_run: bool = False,
+            test_runtime: TestRunTime = TestRunTime.CHIP_TOOL_PYTHON,
+            ble_controller_app: int | None = None,
+            ble_controller_tool: int | None = None):
         runner.capture_delegate = ExecutionCapture()
 
         tool_storage_dir = None
 
         loggedCapturedLogs = False
         try:
-            if self.target.value not in subproc_info_repo:
+            if target.command not in subproc_info_repo:
                 log.warning("Path to default target '%s' for test '%s' is not known, test will likely fail",
-                            self.target.value, self.name)
+                            target.command, self.name)
             if not dry_run:
                 for key, subproc in subproc_info_repo.items():
                     # Do not add tools to the register
                     if subproc.kind == SubprocessKind.TOOL:
                         continue
 
-                    # For the app indicated by self.target, give it the 'default' key to add to the register
-                    if key == self.target.value:
+                    # For the app indicated by target, give it the 'default' key to add to the register
+                    if key == target.command:
                         key = 'default'
+
+                    for arg in target.arguments:
+                        subproc = subproc.with_args(arg)
+
                     if ble_controller_app is not None:
                         subproc = subproc.with_args("--ble-controller", str(ble_controller_app), "--wifi")
                     app = App(runner, subproc)
@@ -540,7 +610,7 @@ class TestDefinition:
                 else:
                     pairing_cmd = pairing_cmd.with_args('pairing', 'code', TEST_NODE_ID, setupCode)
 
-                if self.target == TestTarget.LIT_ICD and test_runtime == TestRunTime.CHIP_TOOL_PYTHON:
+                if target.command == 'lit-icd' and test_runtime == TestRunTime.CHIP_TOOL_PYTHON:
                     pairing_cmd = pairing_cmd.with_args('--icd-registration', 'true')
 
                 test_cmd = subproc_info_repo['chip-tool-with-python'].with_args('tests', self.run_name, '--PICS', str(pics_file))

--- a/src/app/tests/suites/certification/Test_TC_BINFO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BINFO_2_2.yaml
@@ -12,6 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: "Test against all clusters app"
+      app: all-clusters
+    - name: "Test against rvc app"
+      app: rvc
+      # These arguments are not needed, just testing that arguments work
+      args: ["--vendor-name", "Testing"]
+    - name: "Test against lit-icd app"
+      app: lit-icd
+      # These arguments are not needed, just testing that arguments work
+      args:
+          - --vendor-name
+          - test123
+
 name: 12.2.2. [TC-BINFO-2.2] Events [DUT-Server]
 
 PICS:


### PR DESCRIPTION
#### Summary

This is intended to allow existing YAML files to test both existing apps AND new apps like all-devices.

Also deleted some unused methods (e.g. `tests_with_command`) because we do not use chip_tool to execute tests directly (no more codegen there).

#### Testing

I added this option to a BINFO test and test against multiple applications. It passed locally and expect CI to also validate it.