### PR TITLE
[CI speedup] Better filtering of codegen targets.

### DIFF
--- a/scripts/run_codegen_targets.sh
+++ b/scripts/run_codegen_targets.sh
@@ -56,7 +56,8 @@ for name in $(ninja -C "$OUT_DIR" -t targets | grep -E 'dbus.*codegen:' | sed 's
 done
 
 # TLV decoding metadata
-for name in $(ninja -C "$OUT_DIR" -t targets | grep -E '_generate' | sed 's/: .*//'); do
+for name in $(ninja -C "$OUT_DIR" -t targets | grep -E 'lib/format.*_generate' | sed 's/: .*//'); do
     echo "Generating $name ..."
     ninja -C "$OUT_DIR" "$name"
 done
+

--- a/scripts/run_codegen_targets.sh
+++ b/scripts/run_codegen_targets.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# This script runs all targets taht are generating code
+# This script runs all targets that are generating code
 # in the given output directory
 # CHIP_ROOT with a build environment activated.
 
@@ -49,7 +49,7 @@ for name in $(ninja -C "$OUT_DIR" -t targets | grep -E -v '_no_codegen:' | grep 
     ninja -C "$OUT_DIR" "$name"
 done
 
-# Linus targets: dbus generate hdeaders
+# Linux targets: dbus generate headers
 for name in $(ninja -C "$OUT_DIR" -t targets | grep -E 'dbus.*codegen:' | sed 's/: .*//'); do
     echo "Generating $name ..."
     ninja -C "$OUT_DIR" "$name"


### PR DESCRIPTION
#### Summary

ensuring codegen is done for tidy is taking an unreasonable amount of time (https://github.com/project-chip/connectedhomeip/actions/runs/21076111082/job/60618290291?pr=42683 says almost 15 minutes).

This seems to be because we are trying to generate all zzz_generate data again (which is already done) and we only need tlv metadata. Added more filtering.

#### Testing

```
> ninja -C out/linux-x64-all-clusters-clang/ -t targets | grep '_generate' | wc -l
1755
> ninja -C out/linux-x64-all-clusters-clang/ -t targets | grep -E 'lib/format.*_generate' | wc -l 
2
```