### PR TITLE
[YAML CI] Move all app-specific CI to the CI section of the YAML files

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -24,7 +24,7 @@ from typing import Iterator, Set
 import yaml
 
 from . import runner
-from .test_definition import StandardTargets, TestDefinition, TestTag, TestTarget
+from .test_definition import TestDefinition, TestTag, TestTarget
 
 log = logging.getLogger(__name__)
 
@@ -293,7 +293,7 @@ def _TargetsForYaml(yaml_path: Path) -> list[TestTarget]:
 
     # default to a 'standard app name' if nothing set in the yaml file
     if not targets:
-        targets.append(StandardTargets.for_test_name(yaml_path.name))
+        targets.append(TestTarget(name='all-clusters', command='all-clusters'))
 
     return targets
 

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -232,66 +232,6 @@ class TestTarget:
     arguments: list[str] = field(default_factory=list)
 
 
-def _standard_ci_target(app_placeholder: str):
-    """Returns a command tailored for a standard CI execution.
-
-    Generally this is just the given command without any arguments.
-    """
-    return TestTarget(name=app_placeholder, command=app_placeholder, arguments=[])
-
-
-class StandardTargets:
-    """Defines some commonly used run targets (app placeholders)"""
-    ALL_CLUSTERS = _standard_ci_target('all-clusters')
-    TV = _standard_ci_target('tv')
-    LOCK = _standard_ci_target('lock')
-    OTA = _standard_ci_target('ota-requestor')
-    BRIDGE = _standard_ci_target('bridge')
-    LIT_ICD = _standard_ci_target('lit-icd')
-    FABRIC_SYNC = _standard_ci_target('fabric-sync')
-    MWO = _standard_ci_target('microwave-oven')
-    RVC = _standard_ci_target('rvc')
-    NETWORK_MANAGER = _standard_ci_target('network-manager')
-    ENERGY_GATEWAY = _standard_ci_target('energy-gateway')
-    ENERGY_MANAGEMENT = _standard_ci_target('energy-management')
-    CLOSURE = _standard_ci_target('closure')
-
-    @classmethod
-    def for_test_name(cls, name) -> TestTarget:
-        if (name.startswith("TV_") or name.startswith("Test_TC_MC_") or
-            name.startswith("Test_TC_LOWPOWER_") or name.startswith("Test_TC_KEYPADINPUT_") or
-            name.startswith("Test_TC_APPLAUNCHER_") or name.startswith("Test_TC_MEDIAINPUT_") or
-            name.startswith("Test_TC_WAKEONLAN_") or name.startswith("Test_TC_CHANNEL_") or
-            name.startswith("Test_TC_MEDIAPLAYBACK_") or name.startswith("Test_TC_AUDIOOUTPUT_") or
-            name.startswith("Test_TC_TGTNAV_") or name.startswith("Test_TC_APBSC_") or
-                name.startswith("Test_TC_CONTENTLAUNCHER_") or name.startswith("Test_TC_ALOGIN_")):
-            return StandardTargets.TV
-        if name.startswith("DL_") or name.startswith("Test_TC_DRLK_"):
-            return StandardTargets.LOCK
-        if name.startswith("TestFabricSync"):
-            return StandardTargets.FABRIC_SYNC
-        if name.startswith("OTA_"):
-            return StandardTargets.OTA
-        if name.startswith("Test_TC_BRBINFO_") or name.startswith("Test_TC_ACT_"):
-            return StandardTargets.BRIDGE
-        if name.startswith("TestIcd") or name.startswith("Test_TC_ICDM_"):
-            return StandardTargets.LIT_ICD
-        if name.startswith("Test_TC_MWOCTRL_") or name.startswith("Test_TC_MWOM_"):
-            return StandardTargets.MWO
-        if name.startswith("Test_TC_RVCRUNM_") or name.startswith("Test_TC_RVCCLEANM_") or name.startswith("Test_TC_RVCOPSTATE_"):
-            return StandardTargets.RVC
-        if name.startswith("Test_TC_TBRM_") or name.startswith("Test_TC_THNETDIR_") or name.startswith("Test_TC_WIFINM_"):
-            return StandardTargets.NETWORK_MANAGER
-        if name.startswith("Test_TC_MTRID_"):
-            return StandardTargets.ENERGY_GATEWAY
-        if (name.startswith("Test_TC_DEM_") or name.startswith("Test_TC_DEMM_") or
-                name.startswith("Test_TC_EEVSE_") or name.startswith("Test_TC_EEVSEM_")):
-            return StandardTargets.ENERGY_MANAGEMENT
-        if name.startswith("Test_TC_CLCTRL_") or name.startswith("Test_TC_CLDIM_"):
-            return StandardTargets.CLOSURE
-        return StandardTargets.ALL_CLUSTERS
-
-
 @dataclass
 class KnownSubprocessEntry:
     kind: SubprocessKind

--- a/src/app/tests/suites/DL_LockUnlock.yaml
+++ b/src/app/tests/suites/DL_LockUnlock.yaml
@@ -582,3 +582,9 @@ tests:
           values:
               - name: "UserIndex"
                 value: 0xFFFE
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lock
+      app: lock

--- a/src/app/tests/suites/DL_Schedules.yaml
+++ b/src/app/tests/suites/DL_Schedules.yaml
@@ -2173,3 +2173,9 @@ tests:
           values:
               - name: "UserIndex"
                 value: 0xFFFE
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lock
+      app: lock

--- a/src/app/tests/suites/DL_UsersAndCredentials.yaml
+++ b/src/app/tests/suites/DL_UsersAndCredentials.yaml
@@ -3312,3 +3312,9 @@ tests:
           values:
               - name: "UserIndex"
                 value: 1
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lock
+      app: lock

--- a/src/app/tests/suites/OTA_SuccessfulTransfer.yaml
+++ b/src/app/tests/suites/OTA_SuccessfulTransfer.yaml
@@ -175,3 +175,9 @@ tests:
                 value: rawImageFilePath
               - name: "file2"
                 value: downloadImageFilePath
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: ota-requestor
+      app: ota-requestor

--- a/src/app/tests/suites/TV_AccountLoginCluster.yaml
+++ b/src/app/tests/suites/TV_AccountLoginCluster.yaml
@@ -58,3 +58,9 @@ tests:
           values:
               - name: "Node"
                 value: nodeId
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TV_ApplicationBasicCluster.yaml
+++ b/src/app/tests/suites/TV_ApplicationBasicCluster.yaml
@@ -78,3 +78,9 @@ tests:
       attribute: "AllowedVendorList"
       response:
           value: [1, 456]
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TV_ApplicationLauncherCluster.yaml
+++ b/src/app/tests/suites/TV_ApplicationLauncherCluster.yaml
@@ -80,3 +80,9 @@ tests:
                 value: "data"
               - name: "Status"
                 value: 0
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TV_AudioOutputCluster.yaml
+++ b/src/app/tests/suites/TV_AudioOutputCluster.yaml
@@ -71,3 +71,9 @@ tests:
                   { Index: 2, OutputType: 0, Name: "HDMI" },
                   { Index: 3, OutputType: 0, Name: "HDMI" },
               ]
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TV_ChannelCluster.yaml
+++ b/src/app/tests/suites/TV_ChannelCluster.yaml
@@ -716,3 +716,9 @@ tests:
                   CallSign: "KCTS-TV",
                   AffiliateCallSign: "KCTS",
               }
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TV_ContentLauncherCluster.yaml
+++ b/src/app/tests/suites/TV_ContentLauncherCluster.yaml
@@ -138,3 +138,9 @@ tests:
                 value: "exampleData"
               - name: "Status"
                 value: 0
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TV_KeypadInputCluster.yaml
+++ b/src/app/tests/suites/TV_KeypadInputCluster.yaml
@@ -38,3 +38,9 @@ tests:
           values:
               - name: "Status"
                 value: 0
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TV_LowPowerCluster.yaml
+++ b/src/app/tests/suites/TV_LowPowerCluster.yaml
@@ -30,3 +30,9 @@ tests:
 
     - label: "Sleep Input Status Command"
       command: "Sleep"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TV_MediaInputCluster.yaml
+++ b/src/app/tests/suites/TV_MediaInputCluster.yaml
@@ -95,3 +95,9 @@ tests:
                       Description: "High-Definition Multimedia Interface",
                   },
               ]
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
+++ b/src/app/tests/suites/TV_MediaPlaybackCluster.yaml
@@ -198,3 +198,9 @@ tests:
       attribute: "SampledPosition"
       response:
           value: { UpdatedAt: 0, Position: 1000 }
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TV_TargetNavigatorCluster.yaml
+++ b/src/app/tests/suites/TV_TargetNavigatorCluster.yaml
@@ -58,3 +58,9 @@ tests:
                 value: "data response"
               - name: "Status"
                 value: 0
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TV_WakeOnLanCluster.yaml
+++ b/src/app/tests/suites/TV_WakeOnLanCluster.yaml
@@ -34,3 +34,9 @@ tests:
       response:
           constraints:
               minLength: 3
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/TestIcdManagementCluster.yaml
+++ b/src/app/tests/suites/TestIcdManagementCluster.yaml
@@ -507,3 +507,9 @@ tests:
                     type: int32u
                     minValue: 19500
                     maxValue: 20500
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lit-icd
+      app: lit-icd

--- a/src/app/tests/suites/certification/Test_TC_ACT_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACT_2_1.yaml
@@ -458,3 +458,9 @@ tests:
       verification: |
           Compare 5a and 6a, Verify SetupURL appended by "?/a=" and the decimal numeric value of one of the exposed ActionIDs
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: bridge
+      app: bridge

--- a/src/app/tests/suites/certification/Test_TC_ACT_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACT_2_2.yaml
@@ -589,3 +589,9 @@ tests:
       verification: |
           Only InstantAction command is supported in bridge-app. When testing with a real DUT, test for all the actions supported by the DUT (list from step 4b)
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: bridge
+      app: bridge

--- a/src/app/tests/suites/certification/Test_TC_ACT_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACT_3_2.yaml
@@ -194,3 +194,9 @@ tests:
       verification: |
           The reference app doesn't have implementation for this command
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: bridge
+      app: bridge

--- a/src/app/tests/suites/certification/Test_TC_ALOGIN_12_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ALOGIN_12_1.yaml
@@ -104,3 +104,9 @@ tests:
           values:
               - name: "Node"
                 value: nodeId
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_ALOGIN_12_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ALOGIN_12_2.yaml
@@ -187,3 +187,9 @@ tests:
           [1658531872518] [21924:331051] CHIP: [DMG]         InteractionModelRevision = 1
           [1658531872518] [21924:331051] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_APBSC_9_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APBSC_9_1.yaml
@@ -100,3 +100,9 @@ tests:
       response:
           constraints:
               type: list
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_5.yaml
@@ -41,3 +41,9 @@ tests:
       PICS: APPLAUNCHER.S.A0000
       command: "readAttribute"
       attribute: "CatalogList"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_6.yaml
@@ -41,3 +41,9 @@ tests:
       PICS: APPLAUNCHER.S.A0001
       command: "readAttribute"
       attribute: "CurrentApp"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_7.yaml
@@ -77,3 +77,9 @@ tests:
           values:
               - name: "Status"
                 value: 1
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_7_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_7_1.yaml
@@ -76,3 +76,9 @@ tests:
 
           Refer to device or application documentation for special argument values to each command, and/or additional steps required to put device into in correct state to exhibit test behavior.
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_8.yaml
@@ -64,3 +64,9 @@ tests:
       attribute: "Status"
       response:
           value: 0
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_8_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_8_1.yaml
@@ -72,3 +72,9 @@ tests:
           [1674562683.652177][12550:12550] CHIP:DMG: },
           [1674562683.652193][12550:12550] CHIP:DMG: AccessControl: checking f=2 a=c s=0x000000000001B669 t= c=0x0000_050C e=1 p=o
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_9.yaml
@@ -61,3 +61,9 @@ tests:
       response:
           constraints:
               anyOf: [0, 2]
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_9_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_APPLAUNCHER_3_9_1.yaml
@@ -72,3 +72,9 @@ tests:
           [1674562762.319104][12550:12550] CHIP:DMG: AccessControl: checking f=2 a=c s=0x000000000001B669 t= c=0x0000_050C e=1 p=o
           [1674562762.319118][12550:12550] CHIP:DMG: AccessControl: allowed
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_1.yaml
@@ -61,3 +61,9 @@ tests:
       attribute: "CurrentOutput"
       response:
           value: Index
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_2.yaml
@@ -90,3 +90,9 @@ tests:
                 value: "Please enter 'y' for success"
               - name: "expectedValue"
                 value: "y"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_3.yaml
@@ -66,3 +66,9 @@ tests:
           [1658531323969] [21924:323905] CHIP: [DMG]         InteractionModelRevision = 1
           [1658531323969] [21924:323905] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_4.yaml
@@ -67,3 +67,9 @@ tests:
           [1658531363038] [21924:323905] CHIP: [DMG]         InteractionModelRevision = 1
           [1658531363038] [21924:323905] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_BRBINFO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BRBINFO_2_1.yaml
@@ -638,3 +638,9 @@ tests:
       attribute: "ConfigurationVersion"
       response:
           value: ConfigurationVersionValue
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: bridge
+      app: bridge

--- a/src/app/tests/suites/certification/Test_TC_BRBINFO_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BRBINFO_2_2.yaml
@@ -82,3 +82,9 @@ tests:
 
           ./chip-tool bridgeddevicebasicinformation read-event shut-down  1 3
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: bridge
+      app: bridge

--- a/src/app/tests/suites/certification/Test_TC_CHANNEL_5_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CHANNEL_5_1.yaml
@@ -44,3 +44,9 @@ tests:
       PICS: CHANNEL.S.A0000
       command: "readAttribute"
       attribute: "ChannelList"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_CHANNEL_5_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CHANNEL_5_2.yaml
@@ -74,3 +74,9 @@ tests:
       attribute: "CurrentChannel"
       response:
           value: { MajorNumber: majornumber, MinorNumber: minornumber }
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_CHANNEL_5_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CHANNEL_5_3.yaml
@@ -96,3 +96,9 @@ tests:
           value: { MajorNumber: majornumber2, MinorNumber: minornumber2 }
           constraints:
               type: ChannelInfoStruct
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_CHANNEL_5_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CHANNEL_5_4.yaml
@@ -73,3 +73,9 @@ tests:
           Enter the below command to read the current input.
            ./chip-tool channel read current-channel 1 1
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_CHANNEL_5_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CHANNEL_5_5.yaml
@@ -80,3 +80,9 @@ tests:
 
           Enter the below command to read the current input. ./chip-tool channel read current-channel 1 1
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_CHANNEL_5_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CHANNEL_5_6.yaml
@@ -65,3 +65,9 @@ tests:
           [1658530897782] [21924:317544] CHIP: [DMG]         InteractionModelRevision = 1
           [1658530897782] [21924:317544] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_1.yaml
@@ -48,3 +48,9 @@ tests:
       response:
           constraints:
               type: bitmap32
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_3.yaml
@@ -186,3 +186,9 @@ tests:
                     matched the given search criteria"
               - name: "expectedValue"
                 value: "y"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_4.yaml
@@ -99,3 +99,9 @@ tests:
           [1706167504.649703][12245:12245] CHIP:DMG: AccessControl: checking f=2 a=c s=0x000000000001B669 t= c=0x0000_050A e=1 p=o
           [1706167504.649746][12245:12245] CHIP:DMG: AccessControl: allowed
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_5.yaml
@@ -174,3 +174,9 @@ tests:
           values:
               - name: "Status"
                 value: 2 #AUTH_FAILED
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_6.yaml
@@ -68,3 +68,9 @@ tests:
           [1658531502040] [21924:325733] CHIP: [DMG]         InteractionModelRevision = 1
           [1658531502040] [21924:325733] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CONTENTLAUNCHER_10_7.yaml
@@ -657,3 +657,9 @@ tests:
                     "Please enter 'y' if DUT play or display the search result."
               - name: "expectedValue"
                 value: "y"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_DEMM_1_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DEMM_1_2.yaml
@@ -109,3 +109,9 @@ tests:
           [1705923927.418327][23602:23604] CHIP:TOO: Endpoint: 1 Cluster: 0x0000_009F Attribute 0x0000_0001 DataVersion: 2217281174
           [1705923927.418389][23602:23604] CHIP:TOO:   CurrentMode: 0
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: energy-management
+      app: energy-management

--- a/src/app/tests/suites/certification/Test_TC_DEMM_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DEMM_2_1.yaml
@@ -217,3 +217,9 @@ tests:
       attribute: "CurrentMode"
       response:
           value: PIXIT.DEMM.MODE_CHANGE_OK
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: energy-management
+      app: energy-management

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_1.yaml
@@ -1830,3 +1830,9 @@ tests:
       attribute: "NumberOfAliroEndpointKeysSupported"
       response:
           value: aliroepkeysupported
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lock
+      app: lock

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_10.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_10.yaml
@@ -705,3 +705,9 @@ tests:
 
           [1657631472.017012][2661:2666] CHIP:DMG:                                        status = 0x00 (SUCCESS),
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lock
+      app: lock

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_11.yaml
@@ -422,3 +422,9 @@ tests:
                 value: null
               - name: "NextCredentialIndex"
                 value: null
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lock
+      app: lock

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_4.yaml
@@ -232,3 +232,9 @@ tests:
           values:
               - name: "UserIndex"
                 value: 1
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lock
+      app: lock

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_6.yaml
@@ -182,3 +182,9 @@ tests:
           values:
               - name: "UserIndex"
                 value: 1
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lock
+      app: lock

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_7.yaml
@@ -351,3 +351,9 @@ tests:
           values:
               - name: "UserIndex"
                 value: 0xFFFE
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lock
+      app: lock

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_8.yaml
@@ -352,3 +352,9 @@ tests:
                 value: null
               - name: "NextUserIndex"
                 value: null
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lock
+      app: lock

--- a/src/app/tests/suites/certification/Test_TC_DRLK_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_3_2.yaml
@@ -757,3 +757,9 @@ tests:
           [1698647393.728794][11905:11905] CHIP:DMG:         InteractionModelRevision = 11
           [1698647393.728829][11905:11905] CHIP:DMG: },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lock
+      app: lock

--- a/src/app/tests/suites/certification/Test_TC_EEVSEM_1_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_EEVSEM_1_2.yaml
@@ -99,3 +99,9 @@ tests:
           [1705995474.391347][7551:7553] CHIP:TOO: Endpoint: 1 Cluster: 0x0000_009D Attribute 0x0000_0001 DataVersion: 1324786556
           [1705995474.391367][7551:7553] CHIP:TOO:   CurrentMode: 0
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: energy-management
+      app: energy-management

--- a/src/app/tests/suites/certification/Test_TC_EEVSEM_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_EEVSEM_2_1.yaml
@@ -217,3 +217,9 @@ tests:
       attribute: "CurrentMode"
       response:
           value: PIXIT.EEVSEM.MODE_CHANGE_OK
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: energy-management
+      app: energy-management

--- a/src/app/tests/suites/certification/Test_TC_EEVSE_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_EEVSE_2_1.yaml
@@ -282,3 +282,9 @@ tests:
           constraints:
               type: energy-mWh
               minValue: 0
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: energy-management
+      app: energy-management

--- a/src/app/tests/suites/certification/Test_TC_ICDM_4_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ICDM_4_1.yaml
@@ -71,3 +71,9 @@ tests:
                 constraints:
                     type: int32u
                     minValue: 19995
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: lit-icd
+      app: lit-icd

--- a/src/app/tests/suites/certification/Test_TC_KEYPADINPUT_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_KEYPADINPUT_3_1.yaml
@@ -66,3 +66,9 @@ tests:
           [1658530264507] [21469:308294] CHIP: [DMG]         InteractionModelRevision = 1
           [1658530264507] [21469:308294] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_KEYPADINPUT_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_KEYPADINPUT_3_2.yaml
@@ -54,3 +54,9 @@ tests:
           values:
               - name: "Status"
                 value: 0
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_KEYPADINPUT_3_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_KEYPADINPUT_3_3.yaml
@@ -138,3 +138,9 @@ tests:
           values:
               - name: "Status"
                 value: 0
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_LOWPOWER_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LOWPOWER_2_1.yaml
@@ -35,3 +35,9 @@ tests:
     - label: "Step 1: TH sends Sleep command to DUT"
       PICS: LOWPOWER.S.C00.Rsp
       command: "Sleep"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_LOWPOWER_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LOWPOWER_2_2.yaml
@@ -63,3 +63,9 @@ tests:
           [1658530100234] [21469:308294] CHIP: [DMG]         InteractionModelRevision = 1
           [1658530100234] [21469:308294] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MC_11_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_11_1.yaml
@@ -144,3 +144,9 @@ tests:
           [1653180214397] [48426:1919098] CHIP: [TOO]       Revision: 1
           [1653180214397] [48426:1919098] CHIP: [TOO]      }
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MC_11_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_11_2.yaml
@@ -137,3 +137,9 @@ tests:
           [1653180214397] [48426:1919098] CHIP: [TOO]       Revision: 1
           [1653180214397] [48426:1919098] CHIP: [TOO]      }
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_10.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_10.yaml
@@ -44,3 +44,9 @@ tests:
       PICS: MEDIAINPUT.S.A0000
       command: "readAttribute"
       attribute: "InputList"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_11.yaml
@@ -66,3 +66,9 @@ tests:
       attribute: "CurrentInput"
       response:
           value: Index
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_12.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_12.yaml
@@ -57,3 +57,9 @@ tests:
           of the input list"
       PICS: MEDIAINPUT.S.C02.Rsp
       command: "HideInputStatus"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_13.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_13.yaml
@@ -90,3 +90,9 @@ tests:
                 value: "Please enter 'y' for success"
               - name: "expectedValue"
                 value: "y"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_14.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_14.yaml
@@ -66,3 +66,9 @@ tests:
             [1658530529710] [21870:315334] CHIP: [DMG]         InteractionModelRevision = 1
             [1658530529710] [21870:315334] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_15.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_15.yaml
@@ -65,3 +65,9 @@ tests:
           [1658530640755] [21882:316283] CHIP: [DMG]         InteractionModelRevision = 1
           [1658530640755] [21882:316283] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_16.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_16.yaml
@@ -65,3 +65,9 @@ tests:
           [1658530684044] [21892:316791] CHIP: [DMG]         InteractionModelRevision = 1
           [1658530684044] [21892:316791] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_17.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_3_17.yaml
@@ -67,3 +67,9 @@ tests:
           [1658530748548] [21924:317544] CHIP: [DMG]         InteractionModelRevision = 1
           [1658530748548] [21924:317544] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_1.yaml
@@ -126,3 +126,9 @@ tests:
       attribute: "CurrentState"
       response:
           value: 2
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_10.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_10.yaml
@@ -145,3 +145,9 @@ tests:
           [1706092292.772814][4555:4555] CHIP:DMG: AccessControl: allowed
           [1706092292.772837][4555:4555] CHIP:DMG: Received command for Endpoint=3 Cluster=0x0000_0506 Command=0x0000_000E
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_2.yaml
@@ -200,3 +200,9 @@ tests:
       attribute: "SampledPosition"
       response:
           value: { "Position": 0 }
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_3.yaml
@@ -144,3 +144,9 @@ tests:
                 value: "Please enter 'y' if media has not moved"
               - name: "expectedValue"
                 value: "y"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_4.yaml
@@ -265,3 +265,9 @@ tests:
                 value: "Please enter 'y' for success"
               - name: "expectedValue"
                 value: "y"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_5.yaml
@@ -138,3 +138,9 @@ tests:
           [1658531007495] [21924:317544] CHIP: [DMG]         InteractionModelRevision = 1
           [1658531007495] [21924:317544] CHIP: [DMG]
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_7.yaml
@@ -251,3 +251,9 @@ tests:
           [1658531281369] [21924:323905] CHIP: [DMG]         InteractionModelRevision = 1
           [1658531281369] [21924:323905] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_8.yaml
@@ -139,3 +139,9 @@ tests:
       attribute: "ActiveTextTrack"
       response:
           value: { ID: "", TrackAttributes: null }
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_9.yaml
@@ -74,3 +74,9 @@ tests:
       attribute: "ActiveAudioTrack"
       response:
           value: { ID: AudioTrack_ID_Value }
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_MWOCTRL_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MWOCTRL_2_5.yaml
@@ -53,3 +53,9 @@ tests:
           value: 90
           constraints:
               type: elapsed_s
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: microwave-oven
+      app: microwave-oven

--- a/src/app/tests/suites/certification/Test_TC_TBRM_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TBRM_2_1.yaml
@@ -81,3 +81,9 @@ tests:
       response:
           constraints:
               type: int64u
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: network-manager
+      app: network-manager

--- a/src/app/tests/suites/certification/Test_TC_TBRM_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TBRM_2_2.yaml
@@ -165,3 +165,9 @@ tests:
                 value: PIXIT.TBRM.THREAD_ACTIVE_DATASET
                 constraints:
                     type: octet_string
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: network-manager
+      app: network-manager

--- a/src/app/tests/suites/certification/Test_TC_TBRM_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TBRM_2_3.yaml
@@ -191,3 +191,9 @@ tests:
       attribute: InterfaceEnabled
       response:
           value: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: network-manager
+      app: network-manager

--- a/src/app/tests/suites/certification/Test_TC_TBRM_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TBRM_2_4.yaml
@@ -122,3 +122,9 @@ tests:
       cluster: Administrator Commissioning
       command: RevokeCommissioning
       timedInteractionTimeoutMs: 2000
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: network-manager
+      app: network-manager

--- a/src/app/tests/suites/certification/Test_TC_TBRM_3_1_Simulated.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TBRM_3_1_Simulated.yaml
@@ -42,3 +42,9 @@ tests:
     - label: "DUT send GetPendingDatasetRequest to TH"
       PICS: TBRM.C.C01.Tx
       wait: "GetPendingDatasetRequest"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: network-manager
+      app: network-manager

--- a/src/app/tests/suites/certification/Test_TC_TGTNAV_8_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TGTNAV_8_1.yaml
@@ -67,3 +67,9 @@ tests:
       attribute: "CurrentTarget"
       response:
           value: targetvalue
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_TGTNAV_8_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TGTNAV_8_2.yaml
@@ -65,3 +65,9 @@ tests:
           [1658531406475] [21924:325733] CHIP: [DMG]         InteractionModelRevision = 1
           [1658531406475] [21924:325733] CHIP: [DMG] },
       disabled: true
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_1.yaml
@@ -48,3 +48,9 @@ tests:
           constraints:
               type: int8u
               python: value >= 2 * supportedFabrics
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: network-manager
+      app: network-manager

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
@@ -298,3 +298,9 @@ tests:
       attribute: PreferredExtendedPanID
       arguments:
           value: initialPreferredExtendedPanID
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: network-manager
+      app: network-manager

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_3.yaml
@@ -89,3 +89,9 @@ tests:
       cluster: Administrator Commissioning
       command: RevokeCommissioning
       timedInteractionTimeoutMs: 2000
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: network-manager
+      app: network-manager

--- a/src/app/tests/suites/certification/Test_TC_WAKEONLAN_4_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WAKEONLAN_4_1.yaml
@@ -68,3 +68,9 @@ tests:
                 value: "Please enter 'y' after success"
               - name: "expectedValue"
                 value: "y"
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: tv
+      app: tv

--- a/src/app/tests/suites/certification/Test_TC_WIFINM_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WIFINM_2_1.yaml
@@ -61,3 +61,9 @@ tests:
                     hasValue: true
                     minLength: 8
                     maxLength: 64
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: network-manager
+      app: network-manager

--- a/src/app/tests/suites/certification/Test_TC_WIFINM_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WIFINM_2_2.yaml
@@ -86,3 +86,9 @@ tests:
       cluster: Administrator Commissioning
       command: RevokeCommissioning
       timedInteractionTimeoutMs: 2000
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/yaml.md#defining-the-ci-test-arguments
+# for details about the block below.
+CI:
+    - name: network-manager
+      app: network-manager


### PR DESCRIPTION
#### Summary

Previously we had logic of guessing based on test case name what test app to use.

This change uses "all-clusters" by default and everything else is sent to the CI section of the YAML file.

#### Testing

CI will validate