### PR TITLE
[TLS] Cleanup the fabric table in TearDown phase of TLS test to avoid affecting subsequent tests.

### DIFF
--- a/src/app/clusters/tls-certificate-management-server/TlsCertificateManagementCluster.cpp
+++ b/src/app/clusters/tls-certificate-management-server/TlsCertificateManagementCluster.cpp
@@ -77,9 +77,6 @@ TlsCertificateManagementCluster::~TlsCertificateManagementCluster()
 {
     // null out the ref to us on the delegate
     mDelegate.SetTlsCertificateManagementCluster(nullptr);
-
-    mCertificateTable.Finish();
-    TEMPORARY_RETURN_IGNORED Server::GetInstance().GetFabricTable().RemoveFabricDelegate(this);
 }
 
 CHIP_ERROR TlsCertificateManagementCluster::Startup(ServerClusterContext & context)
@@ -95,6 +92,9 @@ CHIP_ERROR TlsCertificateManagementCluster::Startup(ServerClusterContext & conte
 void TlsCertificateManagementCluster::Shutdown(ClusterShutdownType shutdownType)
 {
     ChipLogProgress(DataManagement, "TlsCertificateManagementCluster: shutdown");
+
+    mCertificateTable.Finish();
+    Server::GetInstance().GetFabricTable().RemoveFabricDelegate(this);
 
     DefaultServerCluster::Shutdown(shutdownType);
 }

--- a/src/app/clusters/tls-certificate-management-server/tests/TestTlsCertificateManagementCluster.cpp
+++ b/src/app/clusters/tls-certificate-management-server/tests/TestTlsCertificateManagementCluster.cpp
@@ -470,7 +470,11 @@ struct TestTlsCertificateManagementCluster : public ::testing::Test
         EXPECT_EQ(mCluster.Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
     }
 
-    void TearDown() override { app::SetSafeAttributePersistenceProvider(nullptr); }
+    void TearDown() override
+    {
+        mCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+        app::SetSafeAttributePersistenceProvider(nullptr);
+    }
 
     MockTlsCertificateManagementDelegate mMockDelegate;
     MockCertificateTable mMockCertTable;

--- a/src/app/clusters/tls-client-management-server/tests/TestTlsClientManagementCluster.cpp
+++ b/src/app/clusters/tls-client-management-server/tests/TestTlsClientManagementCluster.cpp
@@ -295,7 +295,11 @@ struct TestTlsClientManagementCluster : public ::testing::Test
         EXPECT_EQ(mCluster.Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
     }
 
-    void TearDown() override { app::SetSafeAttributePersistenceProvider(nullptr); }
+    void TearDown() override
+    {
+        mCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+        app::SetSafeAttributePersistenceProvider(nullptr);
+    }
 
     MockTlsClientManagementDelegate mMockDelegate;
     MockCertificateTable mMockCertTable;


### PR DESCRIPTION
#### Summary

The CI job “Run unit tests for the Zephyr native_posix_64 platform” compiles all unit tests into a single binary and executes them sequentially. Therefore, each test must properly clean up in its TearDown phase to avoid affecting subsequent tests.

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
