### PR TITLE
[ESP32] Add support for optional Vendor Info retrieval

### DIFF
--- a/src/platform/ESP32/ESP32FactoryDataProvider.cpp
+++ b/src/platform/ESP32/ESP32FactoryDataProvider.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <algorithm>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/support/Base64.h>
 #include <platform/ESP32/ESP32Config.h>
@@ -30,6 +29,55 @@ using namespace chip::DeviceLayer::Internal;
 namespace {
 static constexpr uint32_t kDACPrivateKeySize = 32;
 static constexpr uint32_t kDACPublicKeySize  = 65;
+
+inline CHIP_ERROR GetManufacturingDateOrSuffix(uint16_t * year, uint8_t * month, uint8_t * day, MutableCharSpan * vendorSuffixSpan)
+{
+    VerifyOrReturnError((year != nullptr && month != nullptr && day != nullptr) || vendorSuffixSpan != nullptr,
+                        CHIP_ERROR_INVALID_ARGUMENT);
+    CHIP_ERROR err                               = CHIP_NO_ERROR;
+    constexpr size_t kMaxManufacturingDateLength = 16; // YYYY-MM-DD<vendor info> or YYYYMMDD<vendor info>
+    constexpr size_t kMaxDateLength              = 8;  // YYYYMMDD
+    char dateStr[kMaxManufacturingDateLength + 1];
+    size_t dateLen;
+    err = ESP32Config::ReadConfigValueStr(ESP32Config::kConfigKey_ManufacturingDate, dateStr, sizeof(dateStr), dateLen);
+    if (err != CHIP_NO_ERROR && err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        ChipLogError(DeviceLayer, "Invalid manufacturing date: %s", dateStr);
+        return err;
+    }
+    VerifyOrReturnError(dateLen >= kMaxDateLength && dateLen <= kMaxManufacturingDateLength, CHIP_ERROR_INVALID_ARGUMENT);
+    size_t index = 4;
+    if (dateStr[index] == '-')
+        index++;
+    size_t monthIdx = index;
+    index += 2;
+    if (dateStr[index] == '-')
+        index++;
+    size_t dayIdx = index;
+    index += 2;
+
+    if (year && month && day)
+    {
+        char buf[5];
+        memcpy(buf, dateStr, 4);
+        buf[4] = '\0';
+        *year  = static_cast<uint16_t>(strtol(buf, nullptr, 10));
+        memcpy(buf, dateStr + monthIdx, 2);
+        buf[2] = '\0';
+        *month = static_cast<uint8_t>(strtol(buf, nullptr, 10));
+        memcpy(buf, dateStr + dayIdx, 2);
+        buf[2] = '\0';
+        *day   = static_cast<uint8_t>(strtol(buf, nullptr, 10));
+    }
+
+    if (index < dateLen && vendorSuffixSpan && vendorSuffixSpan->size() > 0)
+    {
+        vendorSuffixSpan->reduce_size(dateLen - index);
+        memcpy(vendorSuffixSpan->data(), dateStr + index, dateLen - index);
+    }
+    return CHIP_NO_ERROR;
+}
+
 } // namespace
 
 CHIP_ERROR ESP32FactoryDataProvider::GetSetupDiscriminator(uint16_t & setupDiscriminator)
@@ -235,64 +283,19 @@ CHIP_ERROR ESP32FactoryDataProvider::GetSerialNumber(char * buf, size_t bufSize)
 
 CHIP_ERROR ESP32FactoryDataProvider::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)
 {
-    CHIP_ERROR err                               = CHIP_NO_ERROR;
-    constexpr size_t kMaxManufacturingDateLength = 16; // YYYY-MM-DD<vendor info> or YYYYMMDD<vendor info>
-    constexpr size_t kMaxDateLength              = 8;  // YYYYMMDD
-    char dateStr[kMaxManufacturingDateLength + 1];
-    size_t dateLen;
-    err = ESP32Config::ReadConfigValueStr(ESP32Config::kConfigKey_ManufacturingDate, dateStr, sizeof(dateStr), dateLen);
-    std::string mfgDateStr(dateStr);
-    SuccessOrExit(err);
-    VerifyOrExit(dateLen <= kMaxManufacturingDateLength, err = CHIP_ERROR_INVALID_ARGUMENT);
-    mfgDateStr.erase(std::remove(mfgDateStr.begin(), mfgDateStr.end(), '-'), mfgDateStr.end());
-    VerifyOrExit(mfgDateStr.size() >= kMaxDateLength && mfgDateStr.size() <= kMaxManufacturingDateLength,
-                 err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    year  = static_cast<uint16_t>(std::stoi(mfgDateStr.substr(0, 4)));
-    month = static_cast<uint8_t>(std::stoi(mfgDateStr.substr(4, 2)));
-    day   = static_cast<uint8_t>(std::stoi(mfgDateStr.substr(6, 2)));
-
-    VerifyOrExit(year >= 1000 && year <= 9999, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(month >= 1 && month <= 12, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(day >= 1 && day <= 31, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-exit:
-    if (err != CHIP_NO_ERROR && err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
-    {
-        ChipLogError(DeviceLayer, "Invalid manufacturing date: %s", dateStr);
-    }
-    return err;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    err            = GetManufacturingDateOrSuffix(&year, &month, &day, nullptr);
+    ReturnErrorOnFailure(err);
+    VerifyOrReturnError(year >= 1000 && year <= 9999, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(month >= 1 && month <= 12, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(day >= 1 && day <= 31, CHIP_ERROR_INVALID_ARGUMENT);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ESP32FactoryDataProvider::GetManufacturingDateSuffix(MutableCharSpan & vendorInfoSpan)
 {
     VerifyOrReturnError(!vendorInfoSpan.empty(), CHIP_ERROR_BUFFER_TOO_SMALL);
-    CHIP_ERROR err                               = CHIP_NO_ERROR;
-    constexpr size_t kMaxManufacturingDateLength = 16; // YYYY-MM-DD<vendor info> or YYYYMMDD<vendor info>
-    constexpr size_t kMaxDateLength              = 8;  // YYYYMMDD
-    constexpr size_t kMaxVendorInfoLength        = kMaxManufacturingDateLength - kMaxDateLength;
-    char dateStr[kMaxManufacturingDateLength + 1];
-    size_t dateLen;
-    size_t vendorInfoLen;
-    err = ESP32Config::ReadConfigValueStr(ESP32Config::kConfigKey_ManufacturingDate, dateStr, sizeof(dateStr), dateLen);
-    std::string mfgDateStr(dateStr);
-    SuccessOrExit(err);
-    VerifyOrExit(dateLen <= kMaxManufacturingDateLength, err = CHIP_ERROR_INVALID_ARGUMENT);
-    mfgDateStr.erase(std::remove(mfgDateStr.begin(), mfgDateStr.end(), '-'), mfgDateStr.end());
-    VerifyOrExit(mfgDateStr.size() >= kMaxDateLength && mfgDateStr.size() <= kMaxManufacturingDateLength,
-                 err = CHIP_ERROR_INVALID_ARGUMENT);
-    vendorInfoLen = mfgDateStr.size() - kMaxDateLength;
-    VerifyOrExit(vendorInfoLen <= kMaxVendorInfoLength, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(vendorInfoSpan.size() >= vendorInfoLen, err = CHIP_ERROR_BUFFER_TOO_SMALL);
-    memcpy(vendorInfoSpan.data(), mfgDateStr.substr(kMaxDateLength).c_str(), vendorInfoLen);
-    vendorInfoSpan.reduce_size(vendorInfoLen);
-
-exit:
-    if (err != CHIP_NO_ERROR && err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
-    {
-        ChipLogError(DeviceLayer, "Invalid manufacturing date: %s", dateStr);
-    }
-    return err;
+    return GetManufacturingDateOrSuffix(nullptr, nullptr, nullptr, &vendorInfoSpan);
 }
 
 CHIP_ERROR ESP32FactoryDataProvider::GetProductFinish(app::Clusters::BasicInformation::ProductFinishEnum * finish)

--- a/src/platform/ESP32/ESP32FactoryDataProvider.cpp
+++ b/src/platform/ESP32/ESP32FactoryDataProvider.cpp
@@ -45,7 +45,7 @@ static constexpr uint32_t kDACPublicKeySize  = 65;
  */
 inline CHIP_ERROR GetManufacturingDateOrSuffix(uint16_t * year, uint8_t * month, uint8_t * day, MutableCharSpan * vendorSuffixSpan)
 {
-    constexpr size_t kMaxManufacturingDateLength  = 18; // (10 + 8) for YYYY-MM-DD<vendor info> or (8 + 8) forYYYYMMDD<vendor info>
+    constexpr size_t kMaxManufacturingDateLength  = 18; // (10 + 8) for YYYY-MM-DD<vendor info> or (8 + 8) for YYYYMMDD<vendor info>
     constexpr size_t kMaxDateLength               = 8;  // YYYYMMDD
     char dateStr[kMaxManufacturingDateLength + 1] = {};
     size_t readDateLen                            = kMaxManufacturingDateLength;
@@ -298,19 +298,11 @@ CHIP_ERROR ESP32FactoryDataProvider::GetSerialNumber(char * buf, size_t bufSize)
 
 CHIP_ERROR ESP32FactoryDataProvider::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)
 {
-    ReturnErrorOnFailure(GetManufacturingDateOrSuffix(&year, &month, &day, nullptr));
-    VerifyOrReturnError(year >= 1000 && year <= 9999, CHIP_ERROR_INTERNAL,
-                        ChipLogError(AppServer, "Year %d is not in the range of 1000-9999", year));
-    VerifyOrReturnError(month >= 1 && month <= 12, CHIP_ERROR_INTERNAL,
-                        ChipLogError(AppServer, "Month %d is not in the range of 1-12", month));
-    VerifyOrReturnError(day >= 1 && day <= 31, CHIP_ERROR_INTERNAL,
-                        ChipLogError(AppServer, "Day %d is not in the range of 1-31", day));
-    return CHIP_NO_ERROR;
+    return GetManufacturingDateOrSuffix(&year, &month, &day, nullptr);
 }
 
 CHIP_ERROR ESP32FactoryDataProvider::GetManufacturingDateSuffix(MutableCharSpan & vendorInfoSpan)
 {
-    VerifyOrReturnError(!vendorInfoSpan.empty(), CHIP_ERROR_BUFFER_TOO_SMALL);
     return GetManufacturingDateOrSuffix(nullptr, nullptr, nullptr, &vendorInfoSpan);
 }
 

--- a/src/platform/ESP32/ESP32FactoryDataProvider.cpp
+++ b/src/platform/ESP32/ESP32FactoryDataProvider.cpp
@@ -34,12 +34,12 @@ static constexpr uint32_t kDACPublicKeySize  = 65;
  * @brief Get the manufacturing date or suffix from the ESP32 config.
  *
  * @Note: The manufacturing date is stored in the format YYYY-MM-DD<vendor info> or YYYYMMDD<vendor info>.
- * To retrive only the manufacturing date, pass nullptr for vendorSuffixSpan.
- * To retrive only the vendor suffix, pass a non-empty MutableCharSpan for vendorSuffixSpan and nullptr for year, month, and day.
+ * To retrieve only the manufacturing date, pass nullptr for vendorSuffixSpan.
+ * To retrieve only the vendor suffix, pass a non-empty MutableCharSpan for vendorSuffixSpan and nullptr for year, month, and day.
  * @param year The year to store the manufacturing date.
  * @param month The month to store the manufacturing date.
  * @param day The day to store the manufacturing date.
- * @param vendorSuffixSpan The vendor suffix to store the manufacturing date. @Note: It not gaurenteed to be null terminated and
+ * @param vendorSuffixSpan The vendor suffix to store the manufacturing date. @Note: It not guaranteed to be null terminated and
  * should be treated as a raw string.
  * @return CHIP_ERROR indicating the success or failure of the operation.
  */
@@ -67,22 +67,28 @@ inline CHIP_ERROR GetManufacturingDateOrSuffix(uint16_t * year, uint8_t * month,
         char buf[5];
         memcpy(buf, dateStr, 4);
         buf[4] = '\0';
-        *year  = static_cast<uint16_t>(strtol(buf, nullptr, 10));
+        *year  = static_cast<uint16_t>(strtoul(buf, nullptr, 10));
         memcpy(buf, dateStr + monthIdx, 2);
         buf[2] = '\0';
-        *month = static_cast<uint8_t>(strtol(buf, nullptr, 10));
+        *month = static_cast<uint8_t>(strtoul(buf, nullptr, 10));
         memcpy(buf, dateStr + dayIdx, 2);
         buf[2] = '\0';
-        *day   = static_cast<uint8_t>(strtol(buf, nullptr, 10));
+        *day   = static_cast<uint8_t>(strtoul(buf, nullptr, 10));
     }
 
     if (vendorSuffixSpan)
     {
-        VerifyOrReturnError(index < readDateLen, CHIP_ERROR_INTERNAL);
         size_t suffixLen = readDateLen - index;
-        VerifyOrReturnError(suffixLen <= vendorSuffixSpan->size(), CHIP_ERROR_BUFFER_TOO_SMALL);
-        vendorSuffixSpan->reduce_size(suffixLen);
-        memcpy(vendorSuffixSpan->data(), dateStr + index, suffixLen);
+        if (suffixLen > 0)
+        {
+            VerifyOrReturnError(suffixLen <= vendorSuffixSpan->size(), CHIP_ERROR_BUFFER_TOO_SMALL);
+            vendorSuffixSpan->reduce_size(suffixLen);
+            memcpy(vendorSuffixSpan->data(), dateStr + index, suffixLen);
+        }
+        else
+        {
+            vendorSuffixSpan->reduce_size(0);
+        }
     }
     return CHIP_NO_ERROR;
 }
@@ -293,9 +299,12 @@ CHIP_ERROR ESP32FactoryDataProvider::GetSerialNumber(char * buf, size_t bufSize)
 CHIP_ERROR ESP32FactoryDataProvider::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)
 {
     ReturnErrorOnFailure(GetManufacturingDateOrSuffix(&year, &month, &day, nullptr));
-    VerifyOrReturnError(year >= 1000 && year <= 9999, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(month >= 1 && month <= 12, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(day >= 1 && day <= 31, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(year >= 1000 && year <= 9999, CHIP_ERROR_INTERNAL,
+                        ChipLogError(AppServer, "Year %d is not in the range of 1000-9999", year));
+    VerifyOrReturnError(month >= 1 && month <= 12, CHIP_ERROR_INTERNAL,
+                        ChipLogError(AppServer, "Month %d is not in the range of 1-12", month));
+    VerifyOrReturnError(day >= 1 && day <= 31, CHIP_ERROR_INTERNAL,
+                        ChipLogError(AppServer, "Day %d is not in the range of 1-31", day));
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/ESP32/ESP32FactoryDataProvider.cpp
+++ b/src/platform/ESP32/ESP32FactoryDataProvider.cpp
@@ -30,22 +30,28 @@ namespace {
 static constexpr uint32_t kDACPrivateKeySize = 32;
 static constexpr uint32_t kDACPublicKeySize  = 65;
 
+/**
+ * @brief Get the manufacturing date or suffix from the ESP32 config.
+ *
+ * @Note: The manufacturing date is stored in the format YYYY-MM-DD<vendor info> or YYYYMMDD<vendor info>.
+ * To retrive only the manufacturing date, pass nullptr for vendorSuffixSpan.
+ * To retrive only the vendor suffix, pass a non-empty MutableCharSpan for vendorSuffixSpan and nullptr for year, month, and day.
+ * @param year The year to store the manufacturing date.
+ * @param month The month to store the manufacturing date.
+ * @param day The day to store the manufacturing date.
+ * @param vendorSuffixSpan The vendor suffix to store the manufacturing date. @Note: It not gaurenteed to be null terminated and
+ * should be treated as a raw string.
+ * @return CHIP_ERROR indicating the success or failure of the operation.
+ */
 inline CHIP_ERROR GetManufacturingDateOrSuffix(uint16_t * year, uint8_t * month, uint8_t * day, MutableCharSpan * vendorSuffixSpan)
 {
-    VerifyOrReturnError((year != nullptr && month != nullptr && day != nullptr) || vendorSuffixSpan != nullptr,
-                        CHIP_ERROR_INVALID_ARGUMENT);
-    CHIP_ERROR err                               = CHIP_NO_ERROR;
-    constexpr size_t kMaxManufacturingDateLength = 16; // YYYY-MM-DD<vendor info> or YYYYMMDD<vendor info>
-    constexpr size_t kMaxDateLength              = 8;  // YYYYMMDD
-    char dateStr[kMaxManufacturingDateLength + 1];
-    size_t dateLen;
-    err = ESP32Config::ReadConfigValueStr(ESP32Config::kConfigKey_ManufacturingDate, dateStr, sizeof(dateStr), dateLen);
-    if (err != CHIP_NO_ERROR && err != CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
-    {
-        ChipLogError(DeviceLayer, "Invalid manufacturing date: %s", dateStr);
-        return err;
-    }
-    VerifyOrReturnError(dateLen >= kMaxDateLength && dateLen <= kMaxManufacturingDateLength, CHIP_ERROR_INVALID_ARGUMENT);
+    constexpr size_t kMaxManufacturingDateLength  = 18; // (10 + 8) for YYYY-MM-DD<vendor info> or (8 + 8) forYYYYMMDD<vendor info>
+    constexpr size_t kMaxDateLength               = 8;  // YYYYMMDD
+    char dateStr[kMaxManufacturingDateLength + 1] = {};
+    size_t readDateLen                            = kMaxManufacturingDateLength;
+    ReturnErrorOnFailure(
+        ESP32Config::ReadConfigValueStr(ESP32Config::kConfigKey_ManufacturingDate, dateStr, sizeof(dateStr), readDateLen));
+    VerifyOrReturnError(readDateLen >= kMaxDateLength && readDateLen <= kMaxManufacturingDateLength, CHIP_ERROR_INTERNAL);
     size_t index = 4;
     if (dateStr[index] == '-')
         index++;
@@ -70,10 +76,13 @@ inline CHIP_ERROR GetManufacturingDateOrSuffix(uint16_t * year, uint8_t * month,
         *day   = static_cast<uint8_t>(strtol(buf, nullptr, 10));
     }
 
-    if (index < dateLen && vendorSuffixSpan && vendorSuffixSpan->size() > 0)
+    if (vendorSuffixSpan)
     {
-        vendorSuffixSpan->reduce_size(dateLen - index);
-        memcpy(vendorSuffixSpan->data(), dateStr + index, dateLen - index);
+        VerifyOrReturnError(index < readDateLen, CHIP_ERROR_INTERNAL);
+        size_t suffixLen = readDateLen - index;
+        VerifyOrReturnError(suffixLen <= vendorSuffixSpan->size(), CHIP_ERROR_BUFFER_TOO_SMALL);
+        vendorSuffixSpan->reduce_size(suffixLen);
+        memcpy(vendorSuffixSpan->data(), dateStr + index, suffixLen);
     }
     return CHIP_NO_ERROR;
 }
@@ -283,12 +292,10 @@ CHIP_ERROR ESP32FactoryDataProvider::GetSerialNumber(char * buf, size_t bufSize)
 
 CHIP_ERROR ESP32FactoryDataProvider::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    err            = GetManufacturingDateOrSuffix(&year, &month, &day, nullptr);
-    ReturnErrorOnFailure(err);
-    VerifyOrReturnError(year >= 1000 && year <= 9999, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(month >= 1 && month <= 12, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(day >= 1 && day <= 31, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorOnFailure(GetManufacturingDateOrSuffix(&year, &month, &day, nullptr));
+    VerifyOrReturnError(year >= 1000 && year <= 9999, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(month >= 1 && month <= 12, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(day >= 1 && day <= 31, CHIP_ERROR_INTERNAL);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/ESP32/ESP32FactoryDataProvider.h
+++ b/src/platform/ESP32/ESP32FactoryDataProvider.h
@@ -94,6 +94,7 @@ public:
     CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override;
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;
+    CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & vendorInfoSpan) override;
     CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
     CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override;
     CHIP_ERROR GetProductFinish(app::Clusters::BasicInformation::ProductFinishEnum * finish) override;


### PR DESCRIPTION
#### Summary
Added support for retrieving optional Vendor Info on the ESP32 platform.

#### Related issues
https://github.com/espressif/esp-matter/issues/1622

#### Testing
Verified successful retrieval of Vendor Info on the ESP32 platform.


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
