### PR TITLE
[Java] UDC passcode length: replace NewStringUTF with CharToStringUTF (to handle invalid UTF8 sequences without a crash) + more fixes

### DIFF
--- a/examples/tv-app/android/java/AppPlatformShellCommands-JNI.cpp
+++ b/examples/tv-app/android/java/AppPlatformShellCommands-JNI.cpp
@@ -395,5 +395,11 @@ JNI_METHOD(jstring, OnExecuteCommand)(JNIEnv * env, jobject, jobjectArray string
         env->ReleaseStringUTFChars(string, argv[i]);
     }
 
-    return env->NewStringUTF(buf);
+    jstring result = nullptr;
+    CHIP_ERROR err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(buf, strlen(buf)), reinterpret_cast<jobject&>(result));
+    if (err != CHIP_NO_ERROR)
+    {
+        return nullptr;
+    }
+    return result;
 }

--- a/examples/tv-app/android/java/AppPlatformShellCommands-JNI.cpp
+++ b/examples/tv-app/android/java/AppPlatformShellCommands-JNI.cpp
@@ -396,7 +396,8 @@ JNI_METHOD(jstring, OnExecuteCommand)(JNIEnv * env, jobject, jobjectArray string
     }
 
     jstring result = nullptr;
-    CHIP_ERROR err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(buf, strlen(buf)), reinterpret_cast<jobject&>(result));
+    CHIP_ERROR err =
+        JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(buf, strlen(buf)), reinterpret_cast<jobject &>(result));
     if (err != CHIP_NO_ERROR)
     {
         return nullptr;

--- a/examples/tv-app/android/java/MessagesManager.cpp
+++ b/examples/tv-app/android/java/MessagesManager.cpp
@@ -325,8 +325,9 @@ CHIP_ERROR MessagesManager::HandlePresentMessagesRequest(
                 chip::Encoding::BytesToUppercaseHexString(messageId.data(), messageId.size(), hex_buf, sizeof(hex_buf)),
             CHIP_ERROR_INCORRECT_STATE, ChipLogError(Zcl, "BytesToUppercaseHexString failed"));
 
-        jstring jid = nullptr;
-        CHIP_ERROR err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(hex_buf, strlen(hex_buf)), reinterpret_cast<jobject&>(jid));
+        jstring jid    = nullptr;
+        CHIP_ERROR err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(hex_buf, strlen(hex_buf)),
+                                                                      reinterpret_cast<jobject &>(jid));
         if (err != CHIP_NO_ERROR)
         {
             return CHIP_ERROR_INTERNAL;
@@ -334,7 +335,8 @@ CHIP_ERROR MessagesManager::HandlePresentMessagesRequest(
 
         std::string smessageText(messageText.data(), messageText.size());
         jstring jmessageText = nullptr;
-        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(smessageText.c_str(), smessageText.length()), reinterpret_cast<jobject&>(jmessageText));
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(smessageText.c_str(), smessageText.length()),
+                                                           reinterpret_cast<jobject &>(jmessageText));
         if (err != CHIP_NO_ERROR)
         {
             return CHIP_ERROR_INTERNAL;
@@ -380,8 +382,9 @@ CHIP_ERROR MessagesManager::HandlePresentMessagesRequest(
                 auto & response = iter.GetValue();
 
                 std::string label(response.label.Value().data(), response.label.Value().size());
-                jstring jlabel = nullptr;
-                CHIP_ERROR labelErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(label.c_str(), label.length()), reinterpret_cast<jobject&>(jlabel));
+                jstring jlabel      = nullptr;
+                CHIP_ERROR labelErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(label.c_str(), label.length()),
+                                                                                   reinterpret_cast<jobject &>(jlabel));
                 if (labelErr != CHIP_NO_ERROR)
                 {
                     return CHIP_ERROR_INTERNAL;
@@ -440,8 +443,9 @@ CHIP_ERROR MessagesManager::HandleCancelMessagesRequest(const DataModel::Decodab
                                 chip::Encoding::BytesToUppercaseHexString(id.data(), id.size(), hex_buf, sizeof(hex_buf)),
                             CHIP_ERROR_INCORRECT_STATE, ChipLogError(Zcl, "BytesToUppercaseHexString failed"));
 
-        jstring jid = nullptr;
-        CHIP_ERROR idErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(hex_buf, strlen(hex_buf)), reinterpret_cast<jobject&>(jid));
+        jstring jid      = nullptr;
+        CHIP_ERROR idErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(hex_buf, strlen(hex_buf)),
+                                                                        reinterpret_cast<jobject &>(jid));
         if (idErr != CHIP_NO_ERROR)
         {
             return CHIP_ERROR_INTERNAL;

--- a/examples/tv-app/android/java/MessagesManager.cpp
+++ b/examples/tv-app/android/java/MessagesManager.cpp
@@ -325,15 +325,17 @@ CHIP_ERROR MessagesManager::HandlePresentMessagesRequest(
                 chip::Encoding::BytesToUppercaseHexString(messageId.data(), messageId.size(), hex_buf, sizeof(hex_buf)),
             CHIP_ERROR_INCORRECT_STATE, ChipLogError(Zcl, "BytesToUppercaseHexString failed"));
 
-        jstring jid = env->NewStringUTF(hex_buf);
-        if (jid == nullptr)
+        jstring jid = nullptr;
+        CHIP_ERROR err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(hex_buf, strlen(hex_buf)), reinterpret_cast<jobject&>(jid));
+        if (err != CHIP_NO_ERROR)
         {
             return CHIP_ERROR_INTERNAL;
         }
 
         std::string smessageText(messageText.data(), messageText.size());
-        jstring jmessageText = env->NewStringUTF(smessageText.c_str());
-        if (jmessageText == nullptr)
+        jstring jmessageText = nullptr;
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(smessageText.c_str(), smessageText.length()), reinterpret_cast<jobject&>(jmessageText));
+        if (err != CHIP_NO_ERROR)
         {
             return CHIP_ERROR_INTERNAL;
         }
@@ -378,8 +380,9 @@ CHIP_ERROR MessagesManager::HandlePresentMessagesRequest(
                 auto & response = iter.GetValue();
 
                 std::string label(response.label.Value().data(), response.label.Value().size());
-                jstring jlabel = env->NewStringUTF(label.c_str());
-                if (jlabel == nullptr)
+                jstring jlabel = nullptr;
+                CHIP_ERROR labelErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(label.c_str(), label.length()), reinterpret_cast<jobject&>(jlabel));
+                if (labelErr != CHIP_NO_ERROR)
                 {
                     return CHIP_ERROR_INTERNAL;
                 }
@@ -437,8 +440,9 @@ CHIP_ERROR MessagesManager::HandleCancelMessagesRequest(const DataModel::Decodab
                                 chip::Encoding::BytesToUppercaseHexString(id.data(), id.size(), hex_buf, sizeof(hex_buf)),
                             CHIP_ERROR_INCORRECT_STATE, ChipLogError(Zcl, "BytesToUppercaseHexString failed"));
 
-        jstring jid = env->NewStringUTF(hex_buf);
-        if (jid == nullptr)
+        jstring jid = nullptr;
+        CHIP_ERROR idErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(hex_buf, strlen(hex_buf)), reinterpret_cast<jobject&>(jid));
+        if (idErr != CHIP_NO_ERROR)
         {
             return CHIP_ERROR_INTERNAL;
         }

--- a/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
+++ b/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
@@ -156,12 +156,16 @@ void JNIMyUserPrompter::PromptForCommissionPasscode(uint16_t vendorId, uint16_t 
         jstring jcommissioneeName = env->NewStringUTF(commissioneeName);
         VerifyOrExit(jcommissioneeName != nullptr, ChipLogError(Zcl, "Could not create jstring"); err = CHIP_ERROR_INTERNAL);
 
+        jstring jpairingInstruction = env->NewStringUTF(pairingInstruction);
+        VerifyOrExit(jpairingInstruction != nullptr, ChipLogError(Zcl, "Could not create pairingInstruction jstring");
+                     err = CHIP_ERROR_INTERNAL);
+
         ChipLogError(Zcl, "JNIMyUserPrompter::PromptForCommissionPasscode length=%d", static_cast<uint16_t>(passcodeLength));
 
         env->ExceptionClear();
         env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptForCommissionPincodeMethod, static_cast<jint>(vendorId),
                             static_cast<jint>(productId), static_cast<jint>(passcodeLength), jcommissioneeName,
-                            static_cast<jint>(pairingHint), pairingInstruction);
+                            static_cast<jint>(pairingHint), jpairingInstruction);
         if (env->ExceptionCheck())
         {
             ChipLogError(Zcl, "Java exception in PromptForCommissionPincode");

--- a/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
+++ b/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
@@ -111,7 +111,8 @@ void JNIMyUserPrompter::PromptForCommissionOKPermission(uint16_t vendorId, uint1
 
     {
         jstring jcommissioneeName = nullptr;
-        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)),
+                                                           reinterpret_cast<jobject &>(jcommissioneeName));
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();
@@ -155,11 +156,13 @@ void JNIMyUserPrompter::PromptForCommissionPasscode(uint16_t vendorId, uint16_t 
 
     {
         jstring jcommissioneeName = nullptr;
-        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)),
+                                                           reinterpret_cast<jobject &>(jcommissioneeName));
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         jstring jpairingInstruction = nullptr;
-        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(pairingInstruction, strlen(pairingInstruction)), reinterpret_cast<jobject&>(jpairingInstruction));
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(pairingInstruction, strlen(pairingInstruction)),
+                                                           reinterpret_cast<jobject &>(jpairingInstruction));
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create pairingInstruction jstring"));
 
         ChipLogError(Zcl, "JNIMyUserPrompter::PromptForCommissionPasscode length=%d", static_cast<uint16_t>(passcodeLength));
@@ -204,7 +207,8 @@ void JNIMyUserPrompter::HidePromptsOnCancel(uint16_t vendorId, uint16_t productI
 
     {
         jstring jcommissioneeName = nullptr;
-        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)),
+                                                           reinterpret_cast<jobject &>(jcommissioneeName));
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();
@@ -259,11 +263,13 @@ void JNIMyUserPrompter::PromptWithCommissionerPasscode(uint16_t vendorId, uint16
 
     {
         jstring jcommissioneeName = nullptr;
-        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)),
+                                                           reinterpret_cast<jobject &>(jcommissioneeName));
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         jstring jpairingInstruction = nullptr;
-        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(pairingInstruction, strlen(pairingInstruction)), reinterpret_cast<jobject&>(jpairingInstruction));
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(pairingInstruction, strlen(pairingInstruction)),
+                                                           reinterpret_cast<jobject &>(jpairingInstruction));
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();
@@ -305,7 +311,8 @@ void JNIMyUserPrompter::PromptCommissioningStarted(uint16_t vendorId, uint16_t p
 
     {
         jstring jcommissioneeName = nullptr;
-        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)),
+                                                           reinterpret_cast<jobject &>(jcommissioneeName));
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();
@@ -343,7 +350,8 @@ void JNIMyUserPrompter::PromptCommissioningSucceeded(uint16_t vendorId, uint16_t
 
     {
         jstring jcommissioneeName = nullptr;
-        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)),
+                                                           reinterpret_cast<jobject &>(jcommissioneeName));
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();
@@ -382,11 +390,13 @@ void JNIMyUserPrompter::PromptCommissioningFailed(const char * commissioneeName,
 
     {
         jstring jcommissioneeError = nullptr;
-        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(error.AsString(), strlen(error.AsString())), reinterpret_cast<jobject&>(jcommissioneeError));
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(error.AsString(), strlen(error.AsString())),
+                                                           reinterpret_cast<jobject &>(jcommissioneeError));
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         jstring jcommissioneeName = nullptr;
-        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)),
+                                                           reinterpret_cast<jobject &>(jcommissioneeName));
         VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();

--- a/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
+++ b/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
@@ -110,8 +110,9 @@ void JNIMyUserPrompter::PromptForCommissionOKPermission(uint16_t vendorId, uint1
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
     {
-        jstring jcommissioneeName = env->NewStringUTF(commissioneeName);
-        VerifyOrExit(jcommissioneeName != nullptr, ChipLogError(Zcl, "Could not create jstring"); err = CHIP_ERROR_INTERNAL);
+        jstring jcommissioneeName = nullptr;
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();
         env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptForCommissionOKPermissionMethod,
@@ -153,12 +154,13 @@ void JNIMyUserPrompter::PromptForCommissionPasscode(uint16_t vendorId, uint16_t 
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
     {
-        jstring jcommissioneeName = env->NewStringUTF(commissioneeName);
-        VerifyOrExit(jcommissioneeName != nullptr, ChipLogError(Zcl, "Could not create jstring"); err = CHIP_ERROR_INTERNAL);
+        jstring jcommissioneeName = nullptr;
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
-        jstring jpairingInstruction = env->NewStringUTF(pairingInstruction);
-        VerifyOrExit(jpairingInstruction != nullptr, ChipLogError(Zcl, "Could not create pairingInstruction jstring");
-                     err = CHIP_ERROR_INTERNAL);
+        jstring jpairingInstruction = nullptr;
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(pairingInstruction, strlen(pairingInstruction)), reinterpret_cast<jobject&>(jpairingInstruction));
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create pairingInstruction jstring"));
 
         ChipLogError(Zcl, "JNIMyUserPrompter::PromptForCommissionPasscode length=%d", static_cast<uint16_t>(passcodeLength));
 
@@ -201,8 +203,9 @@ void JNIMyUserPrompter::HidePromptsOnCancel(uint16_t vendorId, uint16_t productI
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
     {
-        jstring jcommissioneeName = env->NewStringUTF(commissioneeName);
-        VerifyOrExit(jcommissioneeName != nullptr, ChipLogError(Zcl, "Could not create jstring"); err = CHIP_ERROR_INTERNAL);
+        jstring jcommissioneeName = nullptr;
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();
         env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mHidePromptsOnCancelMethod, static_cast<jint>(vendorId),
@@ -255,11 +258,13 @@ void JNIMyUserPrompter::PromptWithCommissionerPasscode(uint16_t vendorId, uint16
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
     {
-        jstring jcommissioneeName = env->NewStringUTF(commissioneeName);
-        VerifyOrExit(jcommissioneeName != nullptr, ChipLogError(Zcl, "Could not create jstring"); err = CHIP_ERROR_INTERNAL);
+        jstring jcommissioneeName = nullptr;
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
-        jstring jpairingInstruction = env->NewStringUTF(pairingInstruction);
-        VerifyOrExit(jpairingInstruction != nullptr, ChipLogError(Zcl, "Could not create jstring"); err = CHIP_ERROR_INTERNAL);
+        jstring jpairingInstruction = nullptr;
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(pairingInstruction, strlen(pairingInstruction)), reinterpret_cast<jobject&>(jpairingInstruction));
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();
         env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptWithCommissionerPasscodeMethod,
@@ -299,8 +304,9 @@ void JNIMyUserPrompter::PromptCommissioningStarted(uint16_t vendorId, uint16_t p
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
     {
-        jstring jcommissioneeName = env->NewStringUTF(commissioneeName);
-        VerifyOrExit(jcommissioneeName != nullptr, ChipLogError(Zcl, "Could not create jstring"); err = CHIP_ERROR_INTERNAL);
+        jstring jcommissioneeName = nullptr;
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();
         env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptCommissioningStartedMethod, static_cast<jint>(vendorId),
@@ -336,8 +342,9 @@ void JNIMyUserPrompter::PromptCommissioningSucceeded(uint16_t vendorId, uint16_t
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
     {
-        jstring jcommissioneeName = env->NewStringUTF(commissioneeName);
-        VerifyOrExit(jcommissioneeName != nullptr, ChipLogError(Zcl, "Could not create jstring"); err = CHIP_ERROR_INTERNAL);
+        jstring jcommissioneeName = nullptr;
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();
         env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptCommissioningSucceededMethod, static_cast<jint>(vendorId),
@@ -374,11 +381,13 @@ void JNIMyUserPrompter::PromptCommissioningFailed(const char * commissioneeName,
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
     {
-        jstring jcommissioneeError = env->NewStringUTF(error.AsString());
-        VerifyOrExit(jcommissioneeError != nullptr, ChipLogError(Zcl, "Could not create jstring"); err = CHIP_ERROR_INTERNAL);
+        jstring jcommissioneeError = nullptr;
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(error.AsString(), strlen(error.AsString())), reinterpret_cast<jobject&>(jcommissioneeError));
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
-        jstring jcommissioneeName = env->NewStringUTF(commissioneeName);
-        VerifyOrExit(jcommissioneeName != nullptr, ChipLogError(Zcl, "Could not create jstring"); err = CHIP_ERROR_INTERNAL);
+        jstring jcommissioneeName = nullptr;
+        err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(commissioneeName, strlen(commissioneeName)), reinterpret_cast<jobject&>(jcommissioneeName));
+        VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not create jstring"));
 
         env->ExceptionClear();
         env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptCommissioningFailedMethod, jcommissioneeName,

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -196,7 +196,10 @@ JNI_METHOD(jstring, getConnectionStateNative)
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::getConnectionState()");
 
     CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
-    VerifyOrReturnValue(castingPlayer != nullptr, env->NewStringUTF("Cast Player is nullptr"));
+    jstring result                = nullptr;
+    LogErrorOnFailure(JniReferences::GetInstance().CharToStringUTF(
+        chip::CharSpan("Cast Player is nullptr", strlen("Cast Player is nullptr")), reinterpret_cast<jobject &>(result)));
+    VerifyOrReturnValue(castingPlayer != nullptr, result);
 
     matter::casting::core::ConnectionState state = castingPlayer->GetConnectionState();
     switch (state)

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -181,7 +181,13 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
         {
             char addrCString[chip::Inet::IPAddress::kMaxStringLength];
             ipAddresses[i].ToString(addrCString, chip::Inet::IPAddress::kMaxStringLength);
-            jstring jIPAddressStr = env->NewStringUTF(addrCString);
+            jstring jIPAddressStr = nullptr;
+            CHIP_ERROR err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(addrCString, strlen(addrCString)), reinterpret_cast<jobject&>(jIPAddressStr));
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(AppServer, "convertCastingPlayerFromCppToJava() failed to create jIPAddressStr");
+                continue;
+            }
 
             jclass jIPAddressClass = env->FindClass("java/net/InetAddress");
             jmethodID jGetByNameMid =
@@ -194,9 +200,24 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
 
     // Create a new instance of the MatterCastingPlayer Java class
     jobject jMatterCastingPlayer = nullptr;
+    jstring jId = nullptr;
+    jstring jHostName = nullptr;
+    jstring jDeviceName = nullptr;
+    jstring jInstanceName = nullptr;
+    
+    CHIP_ERROR idErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(player->GetId(), strlen(player->GetId())), reinterpret_cast<jobject&>(jId));
+    CHIP_ERROR hostErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(player->GetHostName(), strlen(player->GetHostName())), reinterpret_cast<jobject&>(jHostName));
+    CHIP_ERROR deviceErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(player->GetDeviceName(), strlen(player->GetDeviceName())), reinterpret_cast<jobject&>(jDeviceName));
+    CHIP_ERROR instanceErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(player->GetInstanceName(), strlen(player->GetInstanceName())), reinterpret_cast<jobject&>(jInstanceName));
+    
+    if (idErr != CHIP_NO_ERROR || hostErr != CHIP_NO_ERROR || deviceErr != CHIP_NO_ERROR || instanceErr != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "convertCastingPlayerFromCppToJava() failed to create string fields");
+        return nullptr;
+    }
+    
     jMatterCastingPlayer = env->NewObject(matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(player->IsConnected()),
-                                          env->NewStringUTF(player->GetId()), env->NewStringUTF(player->GetHostName()),
-                                          env->NewStringUTF(player->GetDeviceName()), env->NewStringUTF(player->GetInstanceName()),
+                                          jId, jHostName, jDeviceName, jInstanceName,
                                           jIpAddressList, (jint) (player->GetPort()), (jint) (player->GetProductId()),
                                           (jint) (player->GetVendorId()), (jlong) (player->GetDeviceType()),
                                           static_cast<jboolean>(player->GetSupportsCommissionerGeneratedPasscode()));

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -182,7 +182,8 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
             char addrCString[chip::Inet::IPAddress::kMaxStringLength];
             ipAddresses[i].ToString(addrCString, chip::Inet::IPAddress::kMaxStringLength);
             jstring jIPAddressStr = nullptr;
-            CHIP_ERROR err = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(addrCString, strlen(addrCString)), reinterpret_cast<jobject&>(jIPAddressStr));
+            CHIP_ERROR err        = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(addrCString, strlen(addrCString)),
+                                                                                 reinterpret_cast<jobject &>(jIPAddressStr));
             if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(AppServer, "convertCastingPlayerFromCppToJava() failed to create jIPAddressStr");
@@ -200,27 +201,30 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
 
     // Create a new instance of the MatterCastingPlayer Java class
     jobject jMatterCastingPlayer = nullptr;
-    jstring jId = nullptr;
-    jstring jHostName = nullptr;
-    jstring jDeviceName = nullptr;
-    jstring jInstanceName = nullptr;
-    
-    CHIP_ERROR idErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(player->GetId(), strlen(player->GetId())), reinterpret_cast<jobject&>(jId));
-    CHIP_ERROR hostErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(player->GetHostName(), strlen(player->GetHostName())), reinterpret_cast<jobject&>(jHostName));
-    CHIP_ERROR deviceErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(player->GetDeviceName(), strlen(player->GetDeviceName())), reinterpret_cast<jobject&>(jDeviceName));
-    CHIP_ERROR instanceErr = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(player->GetInstanceName(), strlen(player->GetInstanceName())), reinterpret_cast<jobject&>(jInstanceName));
-    
+    jstring jId                  = nullptr;
+    jstring jHostName            = nullptr;
+    jstring jDeviceName          = nullptr;
+    jstring jInstanceName        = nullptr;
+
+    CHIP_ERROR idErr   = JniReferences::GetInstance().CharToStringUTF(chip::CharSpan(player->GetId(), strlen(player->GetId())),
+                                                                      reinterpret_cast<jobject &>(jId));
+    CHIP_ERROR hostErr = JniReferences::GetInstance().CharToStringUTF(
+        chip::CharSpan(player->GetHostName(), strlen(player->GetHostName())), reinterpret_cast<jobject &>(jHostName));
+    CHIP_ERROR deviceErr = JniReferences::GetInstance().CharToStringUTF(
+        chip::CharSpan(player->GetDeviceName(), strlen(player->GetDeviceName())), reinterpret_cast<jobject &>(jDeviceName));
+    CHIP_ERROR instanceErr = JniReferences::GetInstance().CharToStringUTF(
+        chip::CharSpan(player->GetInstanceName(), strlen(player->GetInstanceName())), reinterpret_cast<jobject &>(jInstanceName));
+
     if (idErr != CHIP_NO_ERROR || hostErr != CHIP_NO_ERROR || deviceErr != CHIP_NO_ERROR || instanceErr != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "convertCastingPlayerFromCppToJava() failed to create string fields");
         return nullptr;
     }
-    
-    jMatterCastingPlayer = env->NewObject(matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(player->IsConnected()),
-                                          jId, jHostName, jDeviceName, jInstanceName,
-                                          jIpAddressList, (jint) (player->GetPort()), (jint) (player->GetProductId()),
-                                          (jint) (player->GetVendorId()), (jlong) (player->GetDeviceType()),
-                                          static_cast<jboolean>(player->GetSupportsCommissionerGeneratedPasscode()));
+
+    jMatterCastingPlayer = env->NewObject(
+        matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(player->IsConnected()), jId, jHostName, jDeviceName,
+        jInstanceName, jIpAddressList, (jint) (player->GetPort()), (jint) (player->GetProductId()), (jint) (player->GetVendorId()),
+        (jlong) (player->GetDeviceType()), static_cast<jboolean>(player->GetSupportsCommissionerGeneratedPasscode()));
     if (jMatterCastingPlayer == nullptr)
     {
         ChipLogError(AppServer, "convertCastingPlayerFromCppToJava(): Could not create MatterCastingPlayer Java object");

--- a/src/controller/CommissionerDiscoveryController.cpp
+++ b/src/controller/CommissionerDiscoveryController.cpp
@@ -495,7 +495,7 @@ void CommissionerDiscoveryController::InternalHandleContentAppPasscodeResponse()
                           client->GetPairingInst(), ChipLogValueMEI(client->GetVendorId()), ChipLogValueMEI(client->GetProductId()),
                           client->GetInstanceName());
             mUserPrompter->PromptWithCommissionerPasscode(client->GetVendorId(), client->GetProductId(), client->GetDeviceName(),
-                                                          passcode, client->GetPasscodeLength(), client->GetPairingHint(),
+                                                          passcode, passcodeInfo.displayLength, client->GetPairingHint(),
                                                           client->GetPairingInst());
             return;
         }


### PR DESCRIPTION
#### Summary

- Fix 2 bugs found in example tv-app during UDC passcode length field testing:
- 1. [CommissionerDiscoveryController.cpp](https://github.com/project-chip/connectedhomeip/pull/42692#diff-828770158d3226d53556b9b513b02d618a1a493bedca2c8301a4a3ae3f90764c)
- 2. [PromptForCommissionPasscode](https://github.com/project-chip/connectedhomeip/pull/42692/files#r2705703491).
- Migrate char* -> jstring conversion from use of env->NewStringUTF to JniReferences::GetInstance().CharToStringUTF while we are fixing item 2


#### Testing

Tested using android tv-app
