### PR TITLE
Add port retry

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -870,6 +870,9 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
     initParams.userDirectedCommissioningPort = LinuxDeviceOptions::GetInstance().unsecuredCommissionerPort;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
+    // Enable automatic port retry to handle port conflicts
+    initParams.portRetryCount = 9;
+
 #if ENABLE_TRACING
     chip::CommandLineApp::TracingSetup tracing_setup;
 

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -870,8 +870,10 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
     initParams.userDirectedCommissioningPort = LinuxDeviceOptions::GetInstance().unsecuredCommissionerPort;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
+#if CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     // Enable automatic port retry to handle port conflicts
-    initParams.portRetryCount = 9;
+    initParams.portRetryCount = CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT;
+#endif
 
 #if ENABLE_TRACING
     chip::CommandLineApp::TracingSetup tracing_setup;
@@ -1073,9 +1075,9 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
     // NOLINTEND(bugprone-signal-handler)
 #endif
 #else
-    struct sigaction sa                        = {};
-    sa.sa_handler                              = StopSignalHandler;
-    sa.sa_flags                                = SA_RESETHAND;
+    struct sigaction sa = {};
+    sa.sa_handler       = StopSignalHandler;
+    sa.sa_flags         = SA_RESETHAND;
     sigaction(SIGINT, &sa, nullptr);
     sigaction(SIGTERM, &sa, nullptr);
 #endif

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -1075,9 +1075,9 @@ void ChipLinuxAppMainLoop(chip::ServerInitParams & initParams, AppMainLoopImplem
     // NOLINTEND(bugprone-signal-handler)
 #endif
 #else
-    struct sigaction sa = {};
-    sa.sa_handler       = StopSignalHandler;
-    sa.sa_flags         = SA_RESETHAND;
+    struct sigaction sa                        = {};
+    sa.sa_handler                              = StopSignalHandler;
+    sa.sa_flags                                = SA_RESETHAND;
     sigaction(SIGINT, &sa, nullptr);
     sigaction(SIGTERM, &sa, nullptr);
 #endif

--- a/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
@@ -74,7 +74,7 @@
 #define CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_ENTRIES_PER_FABRIC 20
 
 // Change port to make it easy to run against tv-casting-app
-#define CHIP_PORT 5640
+// #define CHIP_PORT 5640
 
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 

--- a/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
@@ -74,7 +74,11 @@
 #define CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_ENTRIES_PER_FABRIC 20
 
 // Change port to make it easy to run against tv-casting-app
-// #define CHIP_PORT 5640
+// #define CHIP_PORT 5640 - not needed due to CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
+
+// Enable automatic port retry to handle port conflicts
+#define CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY 1
+#define CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT 9
 
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCommonCaseDeviceServerInitParamsProvider.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCommonCaseDeviceServerInitParamsProvider.h
@@ -39,6 +39,8 @@ public:
                             ChipLogError(AppServer, "Initialization of ServerInitParams failed %" CHIP_ERROR_FORMAT, err.Format()));
         serverInitParams.dataModelProvider =
             chip::app::CodegenDataModelProviderInstance(serverInitParams.persistentStorageDelegate);
+        // Enable automatic port retry for casting apps to handle port conflicts
+        serverInitParams.portRetryCount = 9;
         return &serverInitParams;
     }
 };

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCommonCaseDeviceServerInitParamsProvider.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCommonCaseDeviceServerInitParamsProvider.h
@@ -39,8 +39,10 @@ public:
                             ChipLogError(AppServer, "Initialization of ServerInitParams failed %" CHIP_ERROR_FORMAT, err.Format()));
         serverInitParams.dataModelProvider =
             chip::app::CodegenDataModelProviderInstance(serverInitParams.persistentStorageDelegate);
+#if CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
         // Enable automatic port retry for casting apps to handle port conflicts
-        serverInitParams.portRetryCount = 9;
+        serverInitParams.portRetryCount = CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT;
+#endif
         return &serverInitParams;
     }
 };

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -192,6 +192,8 @@ int main(int argc, char * argv[])
     static chip::CommonCaseDeviceServerInitParams initParams;
     VerifyOrDie(CHIP_NO_ERROR == initParams.InitializeStaticResourcesBeforeServerInit());
     initParams.dataModelProvider = app::CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
+    // Enable automatic port retry for casting apps to handle port conflicts
+    initParams.portRetryCount = 9;
     VerifyOrDie(CHIP_NO_ERROR == chip::Server::GetInstance().Init(initParams));
 
     if (argc > 1)

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -192,8 +192,10 @@ int main(int argc, char * argv[])
     static chip::CommonCaseDeviceServerInitParams initParams;
     VerifyOrDie(CHIP_NO_ERROR == initParams.InitializeStaticResourcesBeforeServerInit());
     initParams.dataModelProvider = app::CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
+#if CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     // Enable automatic port retry for casting apps to handle port conflicts
-    initParams.portRetryCount = 9;
+    initParams.portRetryCount = CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT;
+#endif
     VerifyOrDie(CHIP_NO_ERROR == chip::Server::GetInstance().Init(initParams));
 
     if (argc > 1)

--- a/examples/tv-casting-app/linux/simple-app.cpp
+++ b/examples/tv-casting-app/linux/simple-app.cpp
@@ -88,6 +88,8 @@ public:
                             ChipLogError(AppServer, "Initialization of ServerInitParams failed %" CHIP_ERROR_FORMAT, err.Format()));
         serverInitParams.dataModelProvider =
             chip::app::CodegenDataModelProviderInstance(serverInitParams.persistentStorageDelegate);
+        // Enable automatic port retry for casting apps to handle port conflicts
+        serverInitParams.portRetryCount = 9;
         return &serverInitParams;
     }
 };

--- a/examples/tv-casting-app/linux/simple-app.cpp
+++ b/examples/tv-casting-app/linux/simple-app.cpp
@@ -88,8 +88,10 @@ public:
                             ChipLogError(AppServer, "Initialization of ServerInitParams failed %" CHIP_ERROR_FORMAT, err.Format()));
         serverInitParams.dataModelProvider =
             chip::app::CodegenDataModelProviderInstance(serverInitParams.persistentStorageDelegate);
+#if CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
         // Enable automatic port retry for casting apps to handle port conflicts
-        serverInitParams.portRetryCount = 9;
+        serverInitParams.portRetryCount = CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT;
+#endif
         return &serverInitParams;
     }
 };

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -108,6 +108,10 @@
 // delay (in sec) before which we assume undiscovered cached players may be in STR mode
 #define CHIP_DEVICE_CONFIG_STR_DISCOVERY_DELAY_SEC 5
 
+// Enable automatic port retry to handle port conflicts
+#define CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY 1
+#define CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT 9
+
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 
 #ifndef CHIP_DEVICE_LAYER_TARGET_DARWIN

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -109,6 +109,8 @@ if (chip_build_tests) {
       "${chip_root}/src/data-model-providers/codedriven/endpoint/tests",
       "${chip_root}/src/inet/tests",
       "${chip_root}/src/lib/address_resolve/tests",
+      "${chip_root}/src/app/server-cluster/tests",
+      "${chip_root}/src/app/server/tests",
       "${chip_root}/src/lib/asn1/tests",
       "${chip_root}/src/lib/core/tests",
       "${chip_root}/src/lib/dnssd/minimal_mdns/core/tests",

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -98,6 +98,23 @@ chip::Access::DynamicProviderDeviceTypeResolver sDeviceTypeResolver([] {
 
 namespace chip {
 
+namespace {
+
+/**
+ * Helper function to check if an error is an "address already in use" error
+ * 
+ * @param err The error to check
+ * @return true if the error indicates the address/port is already in use
+ */
+bool IsAddressInUseError(CHIP_ERROR err)
+{
+    // CHIP_ERROR_POSIX(EADDRINUSE) - Address already in use
+    // The error code 0x02000062 mentioned in the task corresponds to this
+    return (err == CHIP_ERROR_POSIX(EADDRINUSE));
+}
+
+} // anonymous namespace
+
 Server Server::sServer;
 
 #if CHIP_CONFIG_ENABLE_SERVER_IM_EVENT
@@ -226,42 +243,99 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     //
     // The logic below expects that the IPv6 transport is at index 0. Keep that logic in sync with
     // this code.
-    err = mTransports.Init(UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                               .SetAddressType(IPAddressType::kIPv6)
-                               .SetListenPort(mOperationalServicePort)
-                               .SetNativeParams(initParams.endpointNativeParams)
+    //
+    // Implement automatic port selection with retry logic if enabled
+    {
+        uint16_t portToTry = mOperationalServicePort;
+        uint16_t attemptNumber = 0;
+        
+        for (;;)
+        {
+            // Try next sequential port if retrying
+            if (attemptNumber > 0)
+            {
+                portToTry = static_cast<uint16_t>(mOperationalServicePort + attemptNumber);
+                ChipLogProgress(AppServer, "Retrying transport initialization with port %u (attempt %u/%u)", 
+                               portToTry, attemptNumber + 1, initParams.portRetryCount + 1);
+            }
+            
+            // Update TCP listen params if enabled
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+            tcpListenParams.SetListenPort(portToTry);
+#endif
+            
+            // Attempt to initialize transports with the selected port
+            err = mTransports.Init(UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                                       .SetAddressType(IPAddressType::kIPv6)
+                                       .SetListenPort(portToTry)
+                                       .SetNativeParams(initParams.endpointNativeParams)
 #if INET_CONFIG_ENABLE_IPV4
-                               ,
-                           // The logic below expects that the IPv4 transport, if enabled, is at
-                           // index 1. Keep that logic in sync with this code.
-                           UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                               .SetAddressType(IPAddressType::kIPv4)
-                               .SetListenPort(mOperationalServicePort)
+                                       ,
+                                   // The logic below expects that the IPv4 transport, if enabled, is at
+                                   // index 1. Keep that logic in sync with this code.
+                                   UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                                       .SetAddressType(IPAddressType::kIPv4)
+                                       .SetListenPort(portToTry)
 #endif
 #if CONFIG_NETWORK_LAYER_BLE
-                               ,
-                           BleListenParameters(DeviceLayer::ConnectivityMgr().GetBleLayer())
+                                       ,
+                                   BleListenParameters(DeviceLayer::ConnectivityMgr().GetBleLayer())
 #endif
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-                               ,
-                           tcpListenParams
+                                       ,
+                                   tcpListenParams
 #if INET_CONFIG_ENABLE_IPV4
-                           ,
-                           TcpListenParameters(DeviceLayer::TCPEndPointManager())
-                               .SetAddressType(IPAddressType::kIPv4)
-                               .SetListenPort(mOperationalServicePort)
+                                   ,
+                                   TcpListenParameters(DeviceLayer::TCPEndPointManager())
+                                       .SetAddressType(IPAddressType::kIPv4)
+                                       .SetListenPort(portToTry)
 #endif
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-                               ,
-                           Transport::WiFiPAFListenParameters(static_cast<Transport::WiFiPAFBase *>(
-                               DeviceLayer::ConnectivityMgr().GetWiFiPAF()->mWiFiPAFTransport))
+                                       ,
+                                   Transport::WiFiPAFListenParameters(static_cast<Transport::WiFiPAFBase *>(
+                                       DeviceLayer::ConnectivityMgr().GetWiFiPAF()->mWiFiPAFTransport))
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
-                               ,
-                           NfcListenParameters(nullptr)
+                                       ,
+                                   NfcListenParameters(nullptr)
 #endif
-    );
+            );
+            
+            // Check if initialization succeeded
+            if (err == CHIP_NO_ERROR)
+            {
+                // Success! Update the operational service port to the actually bound port
+                mOperationalServicePort = portToTry;
+                if (attemptNumber > 0)
+                {
+                    ChipLogProgress(AppServer, "Successfully bound to port %u after %u attempt(s)", 
+                                   mOperationalServicePort, attemptNumber + 1);
+                }
+                break;
+            }
+            
+            // Check if we should retry
+            if (IsAddressInUseError(err) && attemptNumber < initParams.portRetryCount)
+            {
+                ChipLogProgress(AppServer, "Port %u already in use (error: %" CHIP_ERROR_FORMAT "), will retry with different port", 
+                               portToTry, err.Format());
+                // Close transports from the failed attempt before retrying
+                // BLE transport now handles re-initialization gracefully as a no-op
+                mTransports.Close();
+                attemptNumber++;
+                continue;
+            }
+            
+            // No retry possible or different error - break out
+            if (IsAddressInUseError(err))
+            {
+                ChipLogError(AppServer, "Failed to bind to port %u: Address already in use. "
+                            "Consider setting portRetryCount > 0 to enable automatic port selection.", portToTry);
+            }
+            break;
+        }
+    }
 
     SuccessOrExit(err);
     err = mListener.Init(this);
@@ -485,17 +559,69 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT // support UDC port for commissioner declaration msgs
-    mUdcTransportMgr = Platform::New<UdcTransportMgr>();
-    ReturnErrorOnFailure(mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                                    .SetAddressType(Inet::IPAddressType::kIPv6)
-                                                    .SetListenPort(static_cast<uint16_t>(mCdcListenPort))
+    // Initialize UDC transport with automatic port selection retry logic if enabled
+    {
+        mUdcTransportMgr = Platform::New<UdcTransportMgr>();
+        uint16_t udcPortToTry = mCdcListenPort;
+        uint16_t udcAttemptNumber = 0;
+        CHIP_ERROR udcErr = CHIP_NO_ERROR;
+        
+        for (;;)
+        {
+            // Try next sequential port if retrying
+            if (udcAttemptNumber > 0)
+            {
+                udcPortToTry = static_cast<uint16_t>(mCdcListenPort + udcAttemptNumber);
+                ChipLogProgress(AppServer, "Retrying UDC transport initialization with port %u (attempt %u/%u)", 
+                               udcPortToTry, udcAttemptNumber + 1, initParams.portRetryCount + 1);
+            }
+            
+            // Attempt to initialize UDC transport with the selected port
+            udcErr = mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                                                .SetAddressType(Inet::IPAddressType::kIPv6)
+                                                .SetListenPort(static_cast<uint16_t>(udcPortToTry))
 #if INET_CONFIG_ENABLE_IPV4
-                                                    ,
-                                                Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                                    .SetAddressType(Inet::IPAddressType::kIPv4)
-                                                    .SetListenPort(static_cast<uint16_t>(mCdcListenPort))
+                                                ,
+                                            Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                                                .SetAddressType(Inet::IPAddressType::kIPv4)
+                                                .SetListenPort(static_cast<uint16_t>(udcPortToTry))
 #endif // INET_CONFIG_ENABLE_IPV4
-                                                    ));
+                                                );
+            
+            // Check if initialization succeeded
+            if (udcErr == CHIP_NO_ERROR)
+            {
+                // Success! Update mCdcListenPort to the actually bound port
+                mCdcListenPort = udcPortToTry;
+                if (udcAttemptNumber > 0)
+                {
+                    ChipLogProgress(AppServer, "Successfully bound UDC transport to port %u after %u attempt(s)", 
+                                   mCdcListenPort, udcAttemptNumber + 1);
+                }
+                break;
+            }
+            
+            // Check if we should retry
+            if (IsAddressInUseError(udcErr) && udcAttemptNumber < initParams.portRetryCount)
+            {
+                mUdcTransportMgr->Close();
+                ChipLogProgress(AppServer, "UDC port %u already in use (error: %" CHIP_ERROR_FORMAT "), will retry with different port", 
+                               udcPortToTry, udcErr.Format());
+                udcAttemptNumber++;
+                continue;
+            }
+            
+            // No retry possible or different error - break out
+            if (IsAddressInUseError(udcErr))
+            {
+                ChipLogError(AppServer, "Failed to bind UDC transport to port %u: Address already in use. "
+                            "Consider setting portRetryCount > 0 to enable automatic port selection.", udcPortToTry);
+            }
+            break;
+        }
+        
+        ReturnErrorOnFailure(udcErr);
+    }
 
     gUDCClient = Platform::New<Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient>();
     mUdcTransportMgr->SetSessionManager(gUDCClient);

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -148,8 +148,8 @@ bool SafePortIncrement(uint16_t basePort, uint16_t increment, uint16_t & outPort
  * @return CHIP_ERROR indicating success or failure of the initialization
  */
 CHIP_ERROR InitTransportWithPortRetry(uint16_t basePort, uint16_t maxRetries, const char * componentName,
-                                      std::function<CHIP_ERROR(uint16_t)> initFunction,
-                                      std::function<void()> closeFunction, uint16_t & outBoundPort)
+                                      std::function<CHIP_ERROR(uint16_t)> initFunction, std::function<void()> closeFunction,
+                                      uint16_t & outBoundPort)
 {
     uint16_t portToTry     = basePort;
     uint16_t attemptNumber = 0;
@@ -346,7 +346,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     err = InitTransportWithPortRetry(
         mOperationalServicePort, initParams.portRetryCount, "transport",
         [&](uint16_t port) -> CHIP_ERROR {
-            // Update TCP listen params if enabled
+    // Update TCP listen params if enabled
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
             tcpListenParams.SetListenPort(port);
 #endif
@@ -622,8 +622,8 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         [&](uint16_t port) -> CHIP_ERROR {
             // Attempt to initialize UDC transport with the selected port
             return mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                              .SetAddressType(Inet::IPAddressType::kIPv6)
-                                              .SetListenPort(port)
+                                                           .SetAddressType(Inet::IPAddressType::kIPv6)
+                                                           .SetListenPort(port)
 #if INET_CONFIG_ENABLE_IPV4
                                               ,
                                           Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -397,12 +397,13 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         },
         mOperationalServicePort);
 #else // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
+    // Initialize transports without port retry
+
     // Update TCP listen params if enabled
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     tcpListenParams.SetListenPort(mOperationalServicePort);
 #endif
 
-    // Initialize transports without port retry
     err = mTransports.Init(UdpListenParameters(DeviceLayer::UDPEndPointManager())
                                .SetAddressType(IPAddressType::kIPv6)
                                .SetListenPort(mOperationalServicePort)
@@ -682,19 +683,19 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
             );
         },
         [&]() { mUdcTransportMgr->Close(); }, mCdcListenPort);
-#else // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
+#else  // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     // Initialize UDC transport without port retry
     mUdcTransportMgr = Platform::New<UdcTransportMgr>();
     err              = mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                                  .SetAddressType(Inet::IPAddressType::kIPv6)
-                                                  .SetListenPort(mCdcListenPort)
+                                                           .SetAddressType(Inet::IPAddressType::kIPv6)
+                                                           .SetListenPort(mCdcListenPort)
 #if INET_CONFIG_ENABLE_IPV4
-                                     ,
-                                 Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                     .SetAddressType(Inet::IPAddressType::kIPv4)
-                                     .SetListenPort(mCdcListenPort)
+                                                  ,
+                                              Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                                                  .SetAddressType(Inet::IPAddressType::kIPv4)
+                                                  .SetListenPort(mCdcListenPort)
 #endif // INET_CONFIG_ENABLE_IPV4
-    );
+                 );
 #endif // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     SuccessOrExit(err);
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -683,19 +683,19 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
             );
         },
         [&]() { mUdcTransportMgr->Close(); }, mCdcListenPort);
-#else  // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
+#else // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     // Initialize UDC transport without port retry
     mUdcTransportMgr = Platform::New<UdcTransportMgr>();
     err              = mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                                           .SetAddressType(Inet::IPAddressType::kIPv6)
-                                                           .SetListenPort(mCdcListenPort)
-#if INET_CONFIG_ENABLE_IPV4
-                                                  ,
-                                              Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                                  .SetAddressType(Inet::IPAddressType::kIPv4)
+                                                  .SetAddressType(Inet::IPAddressType::kIPv6)
                                                   .SetListenPort(mCdcListenPort)
+#if INET_CONFIG_ENABLE_IPV4
+                                     ,
+                                 Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                                     .SetAddressType(Inet::IPAddressType::kIPv4)
+                                     .SetListenPort(mCdcListenPort)
 #endif // INET_CONFIG_ENABLE_IPV4
-                 );
+    );
 #endif // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     SuccessOrExit(err);
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -690,12 +690,12 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
                                                   .SetAddressType(Inet::IPAddressType::kIPv6)
                                                   .SetListenPort(mCdcListenPort)
 #if INET_CONFIG_ENABLE_IPV4
-                                     ,
-                                 Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
-                                     .SetAddressType(Inet::IPAddressType::kIPv4)
-                                     .SetListenPort(mCdcListenPort)
+                                                  ,
+                                              Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                                                  .SetAddressType(Inet::IPAddressType::kIPv4)
+                                                  .SetListenPort(mCdcListenPort)
 #endif // INET_CONFIG_ENABLE_IPV4
-    );
+                 );
 #endif // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     SuccessOrExit(err);
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -98,6 +98,8 @@ chip::Access::DynamicProviderDeviceTypeResolver sDeviceTypeResolver([] {
 
 namespace chip {
 
+#if CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
+
 namespace {
 
 /**
@@ -212,6 +214,7 @@ CHIP_ERROR InitTransportWithPortRetry(uint16_t basePort, uint16_t maxRetries, co
 }
 
 } // anonymous namespace
+#endif // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
 
 Server Server::sServer;
 
@@ -342,6 +345,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     // The logic below expects that the IPv6 transport is at index 0. Keep that logic in sync with
     // this code.
     //
+#if CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     // Use helper function for automatic port selection with retry logic and overflow protection
     err = InitTransportWithPortRetry(
         mOperationalServicePort, initParams.portRetryCount, "transport",
@@ -392,6 +396,50 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
             mTransports.Close();
         },
         mOperationalServicePort);
+#else // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
+    // Update TCP listen params if enabled
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    tcpListenParams.SetListenPort(mOperationalServicePort);
+#endif
+
+    // Initialize transports without port retry
+    err = mTransports.Init(UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                               .SetAddressType(IPAddressType::kIPv6)
+                               .SetListenPort(mOperationalServicePort)
+                               .SetNativeParams(initParams.endpointNativeParams)
+#if INET_CONFIG_ENABLE_IPV4
+                               ,
+                           // The logic below expects that the IPv4 transport, if enabled, is at
+                           // index 1. Keep that logic in sync with this code.
+                           UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                               .SetAddressType(IPAddressType::kIPv4)
+                               .SetListenPort(mOperationalServicePort)
+#endif
+#if CONFIG_NETWORK_LAYER_BLE
+                               ,
+                           BleListenParameters(DeviceLayer::ConnectivityMgr().GetBleLayer())
+#endif
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+                               ,
+                           tcpListenParams
+#if INET_CONFIG_ENABLE_IPV4
+                           ,
+                           TcpListenParameters(DeviceLayer::TCPEndPointManager())
+                               .SetAddressType(IPAddressType::kIPv4)
+                               .SetListenPort(mOperationalServicePort)
+#endif
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+                               ,
+                           Transport::WiFiPAFListenParameters(static_cast<Transport::WiFiPAFBase *>(
+                               DeviceLayer::ConnectivityMgr().GetWiFiPAF()->mWiFiPAFTransport))
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
+                               ,
+                           NfcListenParameters(nullptr)
+#endif
+    );
+#endif // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
 
     SuccessOrExit(err);
     err = mListener.Init(this);
@@ -615,6 +663,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT // support UDC port for commissioner declaration msgs
+#if CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     // Use helper function for UDC transport initialization with automatic port selection and overflow protection
     mUdcTransportMgr = Platform::New<UdcTransportMgr>();
     err              = InitTransportWithPortRetry(
@@ -633,6 +682,20 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
             );
         },
         [&]() { mUdcTransportMgr->Close(); }, mCdcListenPort);
+#else // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
+    // Initialize UDC transport without port retry
+    mUdcTransportMgr = Platform::New<UdcTransportMgr>();
+    err              = mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                                                  .SetAddressType(Inet::IPAddressType::kIPv6)
+                                                  .SetListenPort(mCdcListenPort)
+#if INET_CONFIG_ENABLE_IPV4
+                                     ,
+                                 Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
+                                     .SetAddressType(Inet::IPAddressType::kIPv4)
+                                     .SetListenPort(mCdcListenPort)
+#endif // INET_CONFIG_ENABLE_IPV4
+    );
+#endif // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     SuccessOrExit(err);
 
     gUDCClient = Platform::New<Protocols::UserDirectedCommissioning::UserDirectedCommissioningClient>();

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -157,7 +157,7 @@ struct ServerInitParams
     uint16_t userDirectedCommissioningPort = CHIP_UDC_PORT;
     // Interface on which to run daemon
     Inet::InterfaceId interfaceId = Inet::InterfaceId::Null();
-    
+
     // Number of sequential port retries if binding fails with "address in use"
     // When > 0, if binding to operationalServicePort (or userDirectedCommissioningPort) fails,
     // the system will automatically try portRetryCount additional sequential ports.

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -157,6 +157,14 @@ struct ServerInitParams
     uint16_t userDirectedCommissioningPort = CHIP_UDC_PORT;
     // Interface on which to run daemon
     Inet::InterfaceId interfaceId = Inet::InterfaceId::Null();
+    
+    // Number of sequential port retries if binding fails with "address in use"
+    // When > 0, if binding to operationalServicePort (or userDirectedCommissioningPort) fails,
+    // the system will automatically try portRetryCount additional sequential ports.
+    // For example: if operationalServicePort=5540 and portRetryCount=10, it will try
+    // ports 5540, 5541, 5542, ... up to 5550 until one succeeds.
+    // When set to 0 (default), no retry is attempted - implements single port behavior.
+    uint16_t portRetryCount = 0;
 
     // Persistent storage delegate: MUST be injected. Used to maintain storage by much common code.
     // Must be initialized before being provided.

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -158,13 +158,15 @@ struct ServerInitParams
     // Interface on which to run daemon
     Inet::InterfaceId interfaceId = Inet::InterfaceId::Null();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     // Number of sequential port retries if binding fails with "address in use"
     // When > 0, if binding to operationalServicePort (or userDirectedCommissioningPort) fails,
     // the system will automatically try portRetryCount additional sequential ports.
     // For example: if operationalServicePort=5540 and portRetryCount=10, it will try
     // ports 5540, 5541, 5542, ... up to 5550 until one succeeds.
     // When set to 0 (default), no retry is attempted - implements single port behavior.
-    uint16_t portRetryCount = 0;
+    uint16_t portRetryCount = CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
 
     // Persistent storage delegate: MUST be injected. Used to maintain storage by much common code.
     // Must be initialized before being provided.

--- a/src/app/server/java/AndroidAppServerWrapper.cpp
+++ b/src/app/server/java/AndroidAppServerWrapper.cpp
@@ -61,6 +61,9 @@ CHIP_ERROR ChipAndroidAppInit(AppDelegate * appDelegate)
     initParams.operationalServicePort        = CHIP_PORT;
     initParams.userDirectedCommissioningPort = CHIP_UDC_PORT;
 
+    // Enable automatic port retry to handle port conflicts
+    initParams.portRetryCount = 9;
+
     err = chip::Server::GetInstance().Init(initParams);
     SuccessOrExit(err);
 

--- a/src/app/server/java/AndroidAppServerWrapper.cpp
+++ b/src/app/server/java/AndroidAppServerWrapper.cpp
@@ -61,8 +61,10 @@ CHIP_ERROR ChipAndroidAppInit(AppDelegate * appDelegate)
     initParams.operationalServicePort        = CHIP_PORT;
     initParams.userDirectedCommissioningPort = CHIP_UDC_PORT;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
     // Enable automatic port retry to handle port conflicts
     initParams.portRetryCount = 9;
+#endif
 
     err = chip::Server::GetInstance().Init(initParams);
     SuccessOrExit(err);

--- a/src/app/server/tests/BUILD.gn
+++ b/src/app/server/tests/BUILD.gn
@@ -19,9 +19,12 @@ import("//build_overrides/pigweed.gni")
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
 chip_test_suite("tests") {
-  output_name = "jointFabricDatastoreTests"
+  output_name = "libAppServerTests"
 
-  test_sources = [ "TestJointFabricDatastore.cpp" ]
+  test_sources = [
+    "TestJointFabricDatastore.cpp",
+    "TestServerPortRetry.cpp",
+  ]
 
   public_deps = [
     "${chip_root}/src/app/server",

--- a/src/app/server/tests/TestServerPortRetry.cpp
+++ b/src/app/server/tests/TestServerPortRetry.cpp
@@ -1,0 +1,378 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for the Server port retry functionality.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/CHIPCore.h>
+#include <lib/support/CodeUtils.h>
+
+#include <functional>
+#include <limits>
+
+namespace chip {
+namespace app {
+namespace {
+
+/**
+ * Helper function to check if an error is an "address already in use" error
+ * (Copied from Server.cpp for testing)
+ */
+bool IsAddressInUseError(CHIP_ERROR err)
+{
+    return (err == CHIP_ERROR_POSIX(EADDRINUSE));
+}
+
+/**
+ * Helper function to safely increment a port number with overflow protection
+ * (Copied from Server.cpp for testing)
+ */
+bool SafePortIncrement(uint16_t basePort, uint16_t increment, uint16_t & outPort)
+{
+    if (increment > (UINT16_MAX - basePort))
+    {
+        return false;
+    }
+    outPort = static_cast<uint16_t>(basePort + increment);
+    return true;
+}
+
+/**
+ * Helper function to initialize a transport with automatic port selection and retry logic
+ * (Copied from Server.cpp for testing)
+ */
+CHIP_ERROR InitTransportWithPortRetry(uint16_t basePort, uint16_t maxRetries, const char * componentName,
+                                      std::function<CHIP_ERROR(uint16_t)> initFunction, std::function<void()> closeFunction,
+                                      uint16_t & outBoundPort)
+{
+    uint16_t portToTry     = basePort;
+    uint16_t attemptNumber = 0;
+    CHIP_ERROR err         = CHIP_NO_ERROR;
+
+    for (;;)
+    {
+        if (attemptNumber > 0)
+        {
+            if (!SafePortIncrement(basePort, attemptNumber, portToTry))
+            {
+                return CHIP_ERROR_INVALID_ARGUMENT;
+            }
+        }
+
+        err = initFunction(portToTry);
+
+        if (err == CHIP_NO_ERROR)
+        {
+            outBoundPort = portToTry;
+            break;
+        }
+
+        if (IsAddressInUseError(err) && attemptNumber < maxRetries)
+        {
+            closeFunction();
+            attemptNumber++;
+            continue;
+        }
+
+        break;
+    }
+
+    return err;
+}
+
+// Test fixture for Server port retry tests
+class TestServerPortRetry : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+};
+
+// Test IsAddressInUseError function
+TEST_F(TestServerPortRetry, TestIsAddressInUseError)
+{
+    // Test that EADDRINUSE is correctly identified
+    EXPECT_TRUE(IsAddressInUseError(CHIP_ERROR_POSIX(EADDRINUSE)));
+
+    // Test that other errors are not identified as address in use
+    EXPECT_FALSE(IsAddressInUseError(CHIP_NO_ERROR));
+    EXPECT_FALSE(IsAddressInUseError(CHIP_ERROR_INVALID_ARGUMENT));
+    EXPECT_FALSE(IsAddressInUseError(CHIP_ERROR_POSIX(ECONNREFUSED)));
+    EXPECT_FALSE(IsAddressInUseError(CHIP_ERROR_POSIX(ETIMEDOUT)));
+}
+
+// Test SafePortIncrement with normal values
+TEST_F(TestServerPortRetry, TestSafePortIncrementNormal)
+{
+    uint16_t outPort = 0;
+
+    // Test normal increment
+    EXPECT_TRUE(SafePortIncrement(5000, 1, outPort));
+    EXPECT_EQ(outPort, 5001);
+
+    // Test larger increment
+    EXPECT_TRUE(SafePortIncrement(5000, 100, outPort));
+    EXPECT_EQ(outPort, 5100);
+
+    // Test zero increment
+    EXPECT_TRUE(SafePortIncrement(5000, 0, outPort));
+    EXPECT_EQ(outPort, 5000);
+}
+
+// Test SafePortIncrement with overflow conditions
+TEST_F(TestServerPortRetry, TestSafePortIncrementOverflow)
+{
+    uint16_t outPort = 0;
+
+    // Test overflow at max value
+    EXPECT_FALSE(SafePortIncrement(UINT16_MAX, 1, outPort));
+
+    // Test overflow near max value
+    EXPECT_FALSE(SafePortIncrement(UINT16_MAX - 5, 10, outPort));
+
+    // Test exact boundary (should succeed)
+    EXPECT_TRUE(SafePortIncrement(UINT16_MAX - 10, 10, outPort));
+    EXPECT_EQ(outPort, UINT16_MAX);
+
+    // Test one past boundary (should fail)
+    EXPECT_FALSE(SafePortIncrement(UINT16_MAX - 10, 11, outPort));
+}
+
+// Test SafePortIncrement with edge cases
+TEST_F(TestServerPortRetry, TestSafePortIncrementEdgeCases)
+{
+    uint16_t outPort = 0;
+
+    // Test from port 0
+    EXPECT_TRUE(SafePortIncrement(0, 1, outPort));
+    EXPECT_EQ(outPort, 1);
+
+    // Test maximum safe increment from 0
+    EXPECT_TRUE(SafePortIncrement(0, UINT16_MAX, outPort));
+    EXPECT_EQ(outPort, UINT16_MAX);
+
+    // Test increment that would overflow from 0
+    EXPECT_FALSE(SafePortIncrement(1, UINT16_MAX, outPort));
+}
+
+// Test InitTransportWithPortRetry with successful first attempt
+TEST_F(TestServerPortRetry, TestInitTransportSuccessFirstAttempt)
+{
+    uint16_t boundPort    = 0;
+    int initCallCount     = 0;
+    int closeCallCount    = 0;
+    uint16_t expectedPort = 5000;
+
+    auto initFunc = [&](uint16_t port) -> CHIP_ERROR {
+        initCallCount++;
+        EXPECT_EQ(port, expectedPort);
+        return CHIP_NO_ERROR;
+    };
+
+    auto closeFunc = [&]() { closeCallCount++; };
+
+    CHIP_ERROR err = InitTransportWithPortRetry(5000, 3, "test", initFunc, closeFunc, boundPort);
+
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(boundPort, 5000);
+    EXPECT_EQ(initCallCount, 1);
+    EXPECT_EQ(closeCallCount, 0); // Should not call close on success
+}
+
+// Test InitTransportWithPortRetry with retry on address in use
+TEST_F(TestServerPortRetry, TestInitTransportRetryOnAddressInUse)
+{
+    uint16_t boundPort = 0;
+    int initCallCount  = 0;
+    int closeCallCount = 0;
+    int successAttempt = 2; // Succeed on third attempt (0-indexed)
+
+    auto initFunc = [&](uint16_t port) -> CHIP_ERROR {
+        int currentAttempt = initCallCount++;
+        if (currentAttempt < successAttempt)
+        {
+            return CHIP_ERROR_POSIX(EADDRINUSE);
+        }
+        return CHIP_NO_ERROR;
+    };
+
+    auto closeFunc = [&]() { closeCallCount++; };
+
+    CHIP_ERROR err = InitTransportWithPortRetry(5000, 5, "test", initFunc, closeFunc, boundPort);
+
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(boundPort, 5002);   // Should bind to port 5002 (base + 2)
+    EXPECT_EQ(initCallCount, 3);  // Should have tried 3 times
+    EXPECT_EQ(closeCallCount, 2); // Should have closed 2 times (after first two failures)
+}
+
+// Test InitTransportWithPortRetry with max retries exceeded
+TEST_F(TestServerPortRetry, TestInitTransportMaxRetriesExceeded)
+{
+    uint16_t boundPort  = 0;
+    int initCallCount   = 0;
+    int closeCallCount  = 0;
+    uint16_t maxRetries = 3;
+
+    auto initFunc = [&](uint16_t port) -> CHIP_ERROR {
+        initCallCount++;
+        return CHIP_ERROR_POSIX(EADDRINUSE); // Always fail
+    };
+
+    auto closeFunc = [&]() { closeCallCount++; };
+
+    CHIP_ERROR err = InitTransportWithPortRetry(5000, maxRetries, "test", initFunc, closeFunc, boundPort);
+
+    EXPECT_EQ(err, CHIP_ERROR_POSIX(EADDRINUSE));
+    EXPECT_EQ(initCallCount, maxRetries + 1); // Should try maxRetries + 1 times (initial + retries)
+    EXPECT_EQ(closeCallCount, maxRetries);    // Should close maxRetries times
+}
+
+// Test InitTransportWithPortRetry with non-retryable error
+TEST_F(TestServerPortRetry, TestInitTransportNonRetryableError)
+{
+    uint16_t boundPort = 0;
+    int initCallCount  = 0;
+    int closeCallCount = 0;
+
+    auto initFunc = [&](uint16_t port) -> CHIP_ERROR {
+        initCallCount++;
+        return CHIP_ERROR_INVALID_ARGUMENT; // Non-retryable error
+    };
+
+    auto closeFunc = [&]() { closeCallCount++; };
+
+    CHIP_ERROR err = InitTransportWithPortRetry(5000, 5, "test", initFunc, closeFunc, boundPort);
+
+    EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(initCallCount, 1);  // Should only try once
+    EXPECT_EQ(closeCallCount, 0); // Should not close on non-retryable error
+}
+
+// Test InitTransportWithPortRetry with port overflow
+TEST_F(TestServerPortRetry, TestInitTransportPortOverflow)
+{
+    uint16_t boundPort = 0;
+    int initCallCount  = 0;
+    int closeCallCount = 0;
+
+    auto initFunc = [&](uint16_t port) -> CHIP_ERROR {
+        initCallCount++;
+        return CHIP_ERROR_POSIX(EADDRINUSE);
+    };
+
+    auto closeFunc = [&]() { closeCallCount++; };
+
+    // Start near max port value
+    CHIP_ERROR err = InitTransportWithPortRetry(UINT16_MAX - 1, 5, "test", initFunc, closeFunc, boundPort);
+
+    // Should fail with INVALID_ARGUMENT when port increment would overflow
+    EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(initCallCount, 2);  // Should try twice before overflow
+    EXPECT_EQ(closeCallCount, 2); // Should close twice (after each failure before overflow)
+}
+
+// Test InitTransportWithPortRetry with zero retries
+TEST_F(TestServerPortRetry, TestInitTransportZeroRetries)
+{
+    uint16_t boundPort = 0;
+    int initCallCount  = 0;
+    int closeCallCount = 0;
+
+    auto initFunc = [&](uint16_t port) -> CHIP_ERROR {
+        initCallCount++;
+        return CHIP_ERROR_POSIX(EADDRINUSE);
+    };
+
+    auto closeFunc = [&]() { closeCallCount++; };
+
+    CHIP_ERROR err = InitTransportWithPortRetry(5000, 0, "test", initFunc, closeFunc, boundPort);
+
+    EXPECT_EQ(err, CHIP_ERROR_POSIX(EADDRINUSE));
+    EXPECT_EQ(initCallCount, 1);  // Should only try once
+    EXPECT_EQ(closeCallCount, 0); // Should not close when no retries allowed
+}
+
+// Test InitTransportWithPortRetry with alternating errors
+TEST_F(TestServerPortRetry, TestInitTransportAlternatingErrors)
+{
+    uint16_t boundPort = 0;
+    int initCallCount  = 0;
+    int closeCallCount = 0;
+
+    auto initFunc = [&](uint16_t port) -> CHIP_ERROR {
+        int attempt = initCallCount++;
+        if (attempt == 0)
+        {
+            return CHIP_ERROR_POSIX(EADDRINUSE); // Retryable
+        }
+        else if (attempt == 1)
+        {
+            return CHIP_ERROR_INVALID_ARGUMENT; // Non-retryable
+        }
+        return CHIP_NO_ERROR;
+    };
+
+    auto closeFunc = [&]() { closeCallCount++; };
+
+    CHIP_ERROR err = InitTransportWithPortRetry(5000, 5, "test", initFunc, closeFunc, boundPort);
+
+    // Should stop on non-retryable error
+    EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(initCallCount, 2);  // Should try twice
+    EXPECT_EQ(closeCallCount, 1); // Should close once after first failure
+}
+
+// Test InitTransportWithPortRetry verifies correct port increments
+TEST_F(TestServerPortRetry, TestInitTransportPortIncrements)
+{
+    uint16_t boundPort = 0;
+    int initCallCount  = 0;
+    uint16_t basePort  = 5000;
+    std::vector<uint16_t> attemptedPorts;
+
+    auto initFunc = [&](uint16_t port) -> CHIP_ERROR {
+        attemptedPorts.push_back(port);
+        int attempt = initCallCount++;
+        if (attempt < 3)
+        {
+            return CHIP_ERROR_POSIX(EADDRINUSE);
+        }
+        return CHIP_NO_ERROR;
+    };
+
+    auto closeFunc = [&]() {};
+
+    CHIP_ERROR err = InitTransportWithPortRetry(basePort, 5, "test", initFunc, closeFunc, boundPort);
+
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(boundPort, 5003);
+    EXPECT_EQ(attemptedPorts.size(), 4u);
+    EXPECT_EQ(attemptedPorts[0], 5000);
+    EXPECT_EQ(attemptedPorts[1], 5001);
+    EXPECT_EQ(attemptedPorts[2], 5002);
+    EXPECT_EQ(attemptedPorts[3], 5003);
+}
+
+} // namespace
+} // namespace app
+} // namespace chip

--- a/src/app/server/tests/TestServerPortRetry.cpp
+++ b/src/app/server/tests/TestServerPortRetry.cpp
@@ -325,7 +325,7 @@ TEST_F(TestServerPortRetry, TestInitTransportAlternatingErrors)
         {
             return CHIP_ERROR_POSIX(EADDRINUSE); // Retryable
         }
-        else if (attempt == 1)
+        if (attempt == 1)
         {
             return CHIP_ERROR_INVALID_ARGUMENT; // Non-retryable
         }

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -1688,3 +1688,33 @@ static_assert(CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MIN <= CHIP_DEVICE
 #ifndef CHIP_DEVICE_ENABLE_PORT_PARAMS
 #define CHIP_DEVICE_ENABLE_PORT_PARAMS 0
 #endif // CHIP_DEVICE_ENABLE_PORT_PARAMS
+
+/**
+ * CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
+ *
+ * Enable automatic port retry to handle port conflicts.
+ * When enabled, if binding to the operational service port (or user directed commissioning port)
+ * fails with "address in use", the system will automatically try additional sequential ports
+ * up to CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT.
+ *
+ * For example: if operationalServicePort=5540 and CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT=9,
+ * it will try ports 5540, 5541, 5542, ... up to 5549 until one succeeds.
+ *
+ * When set to 0 (default), no retry is attempted - implements single port behavior.
+ */
+#ifndef CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
+#define CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY 0
+#endif // CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY
+
+/**
+ * CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT
+ *
+ * Number of sequential port retries if binding fails with "address in use".
+ * Only used when CHIP_DEVICE_CONFIG_ENABLE_PORT_RETRY is enabled.
+ *
+ * Default value is 9, which means up to 10 ports will be tried (original + 9 retries).
+ * 9 was chosen since CHIP_UDC_PORT defaults to CHIP_PORT + 10 so trying to avoid UDC port.
+ */
+#ifndef CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT
+#define CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT 9
+#endif // CHIP_DEVICE_CONFIG_PORT_RETRY_COUNT

--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -63,7 +63,15 @@ CHIP_ERROR BLEBase::Init(const BleListenParameters & param)
 {
     BleLayer * bleLayer = param.GetBleLayer();
 
-    VerifyOrReturnError(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
+    // Allow re-initialization (no-op) if already initialized.
+    // This supports port retry scenarios where other transports need to reinitialize
+    // but BLE doesn't use ports and doesn't need re-initialization.
+    if (mState != State::kNotReady)
+    {
+        ChipLogDetail(Inet, "BLEBase::Init - already initialized, skipping re-init");
+        return CHIP_NO_ERROR;
+    }
+
     VerifyOrReturnError(bleLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     mBleLayer = bleLayer;

--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -59,19 +59,16 @@ void BLEBase::ClearState()
     mState = State::kNotReady;
 }
 
+void BLEBase::Close()
+{
+    ClearState();
+}
+
 CHIP_ERROR BLEBase::Init(const BleListenParameters & param)
 {
     BleLayer * bleLayer = param.GetBleLayer();
 
-    // Allow re-initialization (no-op) if already initialized.
-    // This supports port retry scenarios where other transports need to reinitialize
-    // but BLE doesn't use ports and doesn't need re-initialization.
-    if (mState != State::kNotReady)
-    {
-        ChipLogDetail(Inet, "BLEBase::Init - already initialized, skipping re-init");
-        return CHIP_NO_ERROR;
-    }
-
+    VerifyOrReturnError(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(bleLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     mBleLayer = bleLayer;

--- a/src/transport/raw/BLE.h
+++ b/src/transport/raw/BLE.h
@@ -120,6 +120,12 @@ public:
     CHIP_ERROR SetEndPoint(Ble::BLEEndPoint * endPoint) override;
 
     /**
+     * Close the BLE transport and reset its state.
+     * This ensures proper cleanup during transport reinitialization scenarios.
+     */
+    void Close() override;
+
+    /**
      * Change BLE transport to this
      *
      * This is relevant when there is more than one TransportMgr,

--- a/src/transport/raw/tests/BUILD.gn
+++ b/src/transport/raw/tests/BUILD.gn
@@ -48,6 +48,10 @@ chip_test_suite("tests") {
     test_sources += [ "TestTCP.cpp" ]
   }
 
+  if (chip_config_network_layer_ble) {
+    test_sources += [ "TestBLEReinitialization.cpp" ]
+  }
+
   sources = [ "TCPBaseTestAccess.h" ]
 
   public_deps = [

--- a/src/transport/raw/tests/TestBLEReinitialization.cpp
+++ b/src/transport/raw/tests/TestBLEReinitialization.cpp
@@ -1,0 +1,279 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for the BLE transport re-initialization functionality.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/CHIPCore.h>
+#include <lib/support/CodeUtils.h>
+#include <transport/raw/BLE.h>
+
+#if CONFIG_NETWORK_LAYER_BLE
+
+namespace chip {
+namespace Transport {
+namespace {
+
+// Mock BLE layer for testing
+class MockBleLayer : public Ble::BleLayer
+{
+public:
+    MockBleLayer() {}
+};
+
+// Test fixture for BLE re-initialization tests
+class TestBLEReinitialization : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
+protected:
+    void SetUp() override
+    {
+        mBleLayer = new MockBleLayer();
+        ASSERT_NE(mBleLayer, nullptr);
+    }
+
+    void TearDown() override
+    {
+        if (mBleLayer != nullptr)
+        {
+            delete mBleLayer;
+            mBleLayer = nullptr;
+        }
+    }
+
+    MockBleLayer * mBleLayer = nullptr;
+};
+
+// Test basic BLE initialization
+TEST_F(TestBLEReinitialization, TestBasicInitialization)
+{
+    BLE<1> bleTransport;
+    BleListenParameters params(mBleLayer);
+
+    CHIP_ERROR err = bleTransport.Init(params);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    // Verify transport was set on the BLE layer
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport);
+}
+
+// Test re-initialization with PreserveExistingBleLayerTransport = false (default)
+TEST_F(TestBLEReinitialization, TestReinitializationOverridesTransport)
+{
+    BLE<1> bleTransport1;
+    BLE<1> bleTransport2;
+
+    // First initialization
+    BleListenParameters params1(mBleLayer);
+    CHIP_ERROR err = bleTransport1.Init(params1);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport1);
+
+    // Second initialization should override the transport
+    BleListenParameters params2(mBleLayer);
+    params2.SetPreserveExistingBleLayerTransport(false);
+    err = bleTransport2.Init(params2);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport2);
+}
+
+// Test re-initialization with PreserveExistingBleLayerTransport = true
+TEST_F(TestBLEReinitialization, TestReinitializationPreservesTransport)
+{
+    BLE<1> bleTransport1;
+    BLE<1> bleTransport2;
+
+    // First initialization
+    BleListenParameters params1(mBleLayer);
+    CHIP_ERROR err = bleTransport1.Init(params1);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport1);
+
+    // Second initialization with preserve flag should NOT override
+    BleListenParameters params2(mBleLayer);
+    params2.SetPreserveExistingBleLayerTransport(true);
+    err = bleTransport2.Init(params2);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport1); // Should still be first transport
+}
+
+// Test re-initialization when no existing transport
+TEST_F(TestBLEReinitialization, TestReinitializationNoExistingTransport)
+{
+    BLE<1> bleTransport;
+
+    // Initialize with preserve flag when no existing transport
+    BleListenParameters params(mBleLayer);
+    params.SetPreserveExistingBleLayerTransport(true);
+
+    CHIP_ERROR err = bleTransport.Init(params);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    // Should set the transport even with preserve flag since there was none
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport);
+}
+
+// Test multiple re-initializations
+TEST_F(TestBLEReinitialization, TestMultipleReinitializations)
+{
+    BLE<1> bleTransport1;
+    BLE<1> bleTransport2;
+    BLE<1> bleTransport3;
+
+    // First initialization
+    BleListenParameters params1(mBleLayer);
+    EXPECT_EQ(bleTransport1.Init(params1), CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport1);
+
+    // Second initialization (override)
+    BleListenParameters params2(mBleLayer);
+    params2.SetPreserveExistingBleLayerTransport(false);
+    EXPECT_EQ(bleTransport2.Init(params2), CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport2);
+
+    // Third initialization (preserve)
+    BleListenParameters params3(mBleLayer);
+    params3.SetPreserveExistingBleLayerTransport(true);
+    EXPECT_EQ(bleTransport3.Init(params3), CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport2); // Should still be second
+}
+
+// Test initialization with null BLE layer
+TEST_F(TestBLEReinitialization, TestInitializationWithNullBleLayer)
+{
+    BLE<1> bleTransport;
+    BleListenParameters params(nullptr);
+
+    CHIP_ERROR err = bleTransport.Init(params);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+}
+
+// Test re-initialization after close
+TEST_F(TestBLEReinitialization, TestReinitializationAfterClose)
+{
+    BLE<1> bleTransport;
+
+    // First initialization
+    BleListenParameters params1(mBleLayer);
+    EXPECT_EQ(bleTransport.Init(params1), CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport);
+
+    // Close the transport
+    bleTransport.Close();
+    EXPECT_EQ(mBleLayer->mBleTransport, nullptr);
+
+    // Re-initialize should work
+    BleListenParameters params2(mBleLayer);
+    EXPECT_EQ(bleTransport.Init(params2), CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport);
+}
+
+// Test double initialization without close (error case)
+TEST_F(TestBLEReinitialization, TestDoubleInitializationSameTransport)
+{
+    BLE<1> bleTransport;
+
+    // First initialization
+    BleListenParameters params1(mBleLayer);
+    EXPECT_EQ(bleTransport.Init(params1), CHIP_NO_ERROR);
+
+    // Second initialization of same transport should fail
+    BleListenParameters params2(mBleLayer);
+    CHIP_ERROR err = bleTransport.Init(params2);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+}
+
+// Test that ClearState is called on close
+TEST_F(TestBLEReinitialization, TestClearStateOnClose)
+{
+    BLE<1> bleTransport;
+
+    BleListenParameters params(mBleLayer);
+    EXPECT_EQ(bleTransport.Init(params), CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport);
+
+    bleTransport.Close();
+
+    // Verify transport was cleared
+    EXPECT_EQ(mBleLayer->mBleTransport, nullptr);
+
+    // Note: CancelBleIncompleteConnection is called internally but we can't easily
+    // track it without modifying the BleLayer implementation. The important thing
+    // is that the transport reference is cleared, which we verify above.
+}
+
+// Test preserve flag behavior with sequential initializations
+TEST_F(TestBLEReinitialization, TestPreserveFlagSequence)
+{
+    BLE<1> bleTransport1;
+    BLE<1> bleTransport2;
+    BLE<1> bleTransport3;
+
+    // Init 1: Set transport
+    BleListenParameters params1(mBleLayer);
+    EXPECT_EQ(bleTransport1.Init(params1), CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport1);
+
+    // Init 2: Preserve (should keep transport1)
+    BleListenParameters params2(mBleLayer);
+    params2.SetPreserveExistingBleLayerTransport(true);
+    EXPECT_EQ(bleTransport2.Init(params2), CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport1);
+
+    // Init 3: Override (should set transport3)
+    BleListenParameters params3(mBleLayer);
+    params3.SetPreserveExistingBleLayerTransport(false);
+    EXPECT_EQ(bleTransport3.Init(params3), CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport3);
+}
+
+// Test that state is properly managed across re-initializations
+TEST_F(TestBLEReinitialization, TestStateManagement)
+{
+    BLE<1> bleTransport1;
+    BLE<1> bleTransport2;
+
+    // First initialization
+    BleListenParameters params1(mBleLayer);
+    EXPECT_EQ(bleTransport1.Init(params1), CHIP_NO_ERROR);
+
+    // Close first transport
+    bleTransport1.Close();
+
+    // Second initialization should work independently
+    BleListenParameters params2(mBleLayer);
+    EXPECT_EQ(bleTransport2.Init(params2), CHIP_NO_ERROR);
+    EXPECT_EQ(mBleLayer->mBleTransport, &bleTransport2);
+
+    // Close second transport
+    bleTransport2.Close();
+    EXPECT_EQ(mBleLayer->mBleTransport, nullptr);
+}
+
+} // namespace
+} // namespace Transport
+} // namespace chip
+
+#endif // CONFIG_NETWORK_LAYER_BLE


### PR DESCRIPTION
#### Summary

We are seeing mobile apps fail chip init with the following error:

Failed to initialize TCP transport: src/inet/TCPEndPointImplSockets.cpp:133: OS Error 0x02000062: Address already in use

This fix adds the option to specify a ServerInitParams.portRetryCount which will cause the Server to detect the already in use scenario and try the next incremental port.

#### Testing

tv-app and tv-casting-app can now run at the same time with no manual port configuration
added unit tests for new functionality