### PR TITLE
Ensure storage is initialized for all-devices on linux.

### DIFF
--- a/examples/all-devices-app/linux/main.cpp
+++ b/examples/all-devices-app/linux/main.cpp
@@ -67,6 +67,8 @@ void StopSignalHandler(int /* signal */)
 chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentStorageDelegate * delegate)
 {
     static chip::app::DefaultAttributePersistenceProvider attributePersistenceProvider;
+    SuccessOrDie(attributePersistenceProvider.Init(delegate));
+
     static chip::app::CodeDrivenDataModelProvider dataModelProvider =
         chip::app::CodeDrivenDataModelProvider(*delegate, attributePersistenceProvider);
 


### PR DESCRIPTION
#### Summary

Without this, attribute storage does not work at all for all-devices (because the underlying attribute storage is not initialized).

#### Testing

I found this when enabling tests for the OnOff light in all devices. Without this, OO_2_4 was failing. After this, all works.