### PR TITLE
Add Issue Number Comment to Disabled EFR32 Test

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -31,8 +31,8 @@ env:
 
 jobs:
   efr32:
-    #TODO: Re-enable these tests once the Silabs version of the DeviceInstanceInfoProvider is updated
-    # to support the latest changes with reporting device capability minima. 
+    # TODO: Re-enable these tests once the Silabs version of the DeviceInstanceInfoProvider is updated
+    # to support the latest changes with reporting device capability minima. Issue #42709
     name: EFR32
     if: false
 

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -32,7 +32,8 @@ env:
 jobs:
   efr32:
     # TODO: Re-enable these tests once the Silabs version of the DeviceInstanceInfoProvider is updated
-    # to support the latest changes with reporting device capability minima. Issue #42709
+    # to support the latest changes with reporting device capability minima. 
+    # See [Issue #42709](https://github.com/project-chip/connectedhomeip/issues/42709)
     name: EFR32
     if: false
 


### PR DESCRIPTION
#### Summary

This PR adds an issue number to a comment that outlines why some EFR32 tests are being temporarily disabled. This is purely a comment change, test was already disabled previously as part of [this PR](https://github.com/project-chip/connectedhomeip/pull/42355)

#### Related issues

#42709 

#### Testing

- Just a change in comments. All tests should still pass

