### PR TITLE
[Camera SDK 1.5.1] Push AV Max Pre Roll Length Validation

### DIFF
--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -100,7 +100,8 @@ public:
 
     bool ValidateSegmentDuration(uint16_t segmentDuration, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override;
 
-    bool ValidateMaxPreRollLength(uint16_t maxPreRollLength, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override;
+    bool ValidateMaxPreRollLength(uint16_t maxPreRollLength,
+                                  const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override;
 
     Protocols::InteractionModel::Status
     ValidateBandwidthLimit(StreamUsageEnum streamUsage, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,

--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -100,6 +100,8 @@ public:
 
     bool ValidateSegmentDuration(uint16_t segmentDuration, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override;
 
+    bool ValidateMaxPreRollLength(uint16_t maxPreRollLength, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override;
+
     Protocols::InteractionModel::Status
     ValidateBandwidthLimit(StreamUsageEnum streamUsage, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
                            const Optional<DataModel::Nullable<uint16_t>> & audioStreamId) override;

--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -100,8 +100,7 @@ public:
 
     bool ValidateSegmentDuration(uint16_t segmentDuration, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override;
 
-    bool ValidateMaxPreRollLength(uint16_t maxPreRollLength,
-                                  const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override;
+    bool ValidateMaxPreRollLength(uint16_t maxPreRollLength, const DataModel::Nullable<uint16_t> & videoStreamId) override;
 
     Protocols::InteractionModel::Status
     ValidateBandwidthLimit(StreamUsageEnum streamUsage, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -465,8 +465,8 @@ bool PushAvStreamTransportManager::ValidateMaxPreRollLength(uint16_t maxPreRollL
     {
         if (stream.videoStreamID == videoStreamId.Value().Value())
         {
-            // Max pre roll length must be less than key frame interval
-            if (maxPreRollLength < stream.keyFrameInterval)
+            // Max pre-roll length must be greater than or equal to key frame interval of the stream. Otherwise, it's invalid.
+            if (maxPreRollLength >= stream.keyFrameInterval)
             {
                 return true;
             }

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -439,12 +439,12 @@ bool PushAvStreamTransportManager::ValidateSegmentDuration(uint16_t segmentDurat
 }
 
 bool PushAvStreamTransportManager::ValidateMaxPreRollLength(uint16_t maxPreRollLength,
-                                                            const Optional<DataModel::Nullable<uint16_t>> & videoStreamId)
+                                                            const DataModel::Nullable<uint16_t> & videoStreamId)
 {
-    // If the video stream ID is missing or null, log error and return false
-    if (!videoStreamId.HasValue() || videoStreamId.Value().IsNull())
+    // If the video stream ID is null, log error and return false
+    if (videoStreamId.IsNull())
     {
-        ChipLogError(Camera, "MaxPreRollLength validation requested with no or null video stream ID");
+        ChipLogError(Camera, "MaxPreRollLength validation requested with null video stream ID");
         return false;
     }
 
@@ -457,13 +457,17 @@ bool PushAvStreamTransportManager::ValidateMaxPreRollLength(uint16_t maxPreRollL
 
     for (const VideoStreamStruct & stream : videoStreams)
     {
-        if (stream.videoStreamID == videoStreamId.Value().Value())
+        if (stream.videoStreamID == videoStreamId.Value())
         {
             // If non-zero, Max pre roll length must be greater than or equal to key frame interval
             if (maxPreRollLength >= stream.keyFrameInterval)
             {
                 return true;
             }
+            ChipLogError(Camera,
+                         "Max pre-roll length validation falied for video stream id [%u], max pre-roll length [%u], key frame "
+                         "interval [%u] ",
+                         stream.videoStreamID, maxPreRollLength, stream.keyFrameInterval);
             break;
         }
     }

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -441,17 +441,11 @@ bool PushAvStreamTransportManager::ValidateSegmentDuration(uint16_t segmentDurat
 bool PushAvStreamTransportManager::ValidateMaxPreRollLength(uint16_t maxPreRollLength,
                                                             const Optional<DataModel::Nullable<uint16_t>> & videoStreamId)
 {
-    // If the video stream ID is missing or null, error log and return false
-    if (!videoStreamId.HasValue())
+    // If the video stream ID is missing or null, log error and return false
+    if (!videoStreamId.HasValue() || videoStreamId.Value().IsNull())
     {
-        ChipLogError(Camera, "MaxPreRollLength validation requested with no provided stream") return false;
-    }
-    else
-    {
-        if (videoStreamId.Value().IsNull())
-        {
-            ChipLogError(Camera, "MaxPreRollLength validation requested against a Null stream") return false;
-        }
+        ChipLogError(Camera, "MaxPreRollLength validation requested with no or null video stream ID");
+        return false;
     }
 
     auto & videoStreams = mCameraDevice->GetCameraAVStreamMgmtDelegate().GetAllocatedVideoStreams();
@@ -465,7 +459,7 @@ bool PushAvStreamTransportManager::ValidateMaxPreRollLength(uint16_t maxPreRollL
     {
         if (stream.videoStreamID == videoStreamId.Value().Value())
         {
-            // Max pre-roll length must be greater than or equal to key frame interval of the stream. Otherwise, it's invalid.
+            // If non-zero, Max pre roll length must be greater than or equal to key frame interval
             if (maxPreRollLength >= stream.keyFrameInterval)
             {
                 return true;

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -439,7 +439,7 @@ bool PushAvStreamTransportManager::ValidateSegmentDuration(uint16_t segmentDurat
 }
 
 bool PushAvStreamTransportManager::ValidateMaxPreRollLength(uint16_t maxPreRollLength,
-                                                           const Optional<DataModel::Nullable<uint16_t>> & videoStreamId)
+                                                            const Optional<DataModel::Nullable<uint16_t>> & videoStreamId)
 {
     // If the video stream ID is missing or null, error log and return false
     if (!videoStreamId.HasValue())

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -452,6 +452,7 @@ bool PushAvStreamTransportManager::ValidateMaxPreRollLength(uint16_t maxPreRollL
 
     if (videoStreams.empty())
     {
+        ChipLogError(Camera, "Attempt to validate max pre-roll length when no video streams are allocated.");
         return false;
     }
 
@@ -465,7 +466,7 @@ bool PushAvStreamTransportManager::ValidateMaxPreRollLength(uint16_t maxPreRollL
                 return true;
             }
             ChipLogError(Camera,
-                         "Max pre-roll length validation falied for video stream id [%u], max pre-roll length [%u], key frame "
+                         "Max pre-roll length validation failed for video stream id [%u], max pre-roll length [%u], key frame "
                          "interval [%u] ",
                          stream.videoStreamID, maxPreRollLength, stream.keyFrameInterval);
             break;

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -867,6 +867,20 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
         }
     }
 
+    // Validate MaxPreRollLength constraint
+    if (transportOptionsPtr->videoStreamID.HasValue())
+    {
+        uint16_t maxPreRollLength = transportOptions.triggerOptions.maxPreRollLen.Value();
+        if (maxPreRollLength == 0 || !mDelegate->ValidateSegmentDuration(maxPreRollLength, transportOptionsPtr->videoStreamID))
+        {
+            auto maxPreRolllLengthStatus = to_underlying(StatusCodeEnum::kInvalidPreRollLength);
+            ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: MaxPreRollLength (%u) validation failed", 
+                            mEndpointId, maxPreRollLength);
+            TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, maxPreRolllLengthStatus);
+            return std::nullopt;
+        }
+    }
+
     uint16_t connectionID = GenerateConnectionID();
 
     if (connectionID == kMaxConnectionId)

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -874,8 +874,8 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
         if (maxPreRollLength == 0 || !mDelegate->ValidateSegmentDuration(maxPreRollLength, transportOptionsPtr->videoStreamID))
         {
             auto maxPreRolllLengthStatus = to_underlying(StatusCodeEnum::kInvalidPreRollLength);
-            ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: MaxPreRollLength (%u) validation failed",
-                            mEndpointId, maxPreRollLength);
+            ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: MaxPreRollLength (%u) validation failed", mEndpointId,
+                         maxPreRollLength);
             TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, maxPreRolllLengthStatus);
             return std::nullopt;
         }

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -868,10 +868,10 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
     }
 
     // Validate MaxPreRollLength constraint
-    if (transportOptionsPtr->videoStreamID.HasValue())
+    if (transportOptions.triggerOptions.maxPreRollLen.HasValue())
     {
         uint16_t maxPreRollLength = transportOptions.triggerOptions.maxPreRollLen.Value();
-        if (maxPreRollLength == 0 || !mDelegate->ValidateSegmentDuration(maxPreRollLength, transportOptionsPtr->videoStreamID))
+        if (maxPreRollLength != 0 && !mDelegate->ValidateMaxPreRollLength(maxPreRollLength, transportOptionsPtr->videoStreamID))
         {
             auto maxPreRolllLengthStatus = to_underlying(StatusCodeEnum::kInvalidPreRollLength);
             ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: MaxPreRollLength (%u) validation failed", mEndpointId,

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -871,7 +871,8 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
     if (transportOptionsPtr->videoStreamID.HasValue() && transportOptions.triggerOptions.maxPreRollLen.HasValue())
     {
         uint16_t maxPreRollLength = transportOptions.triggerOptions.maxPreRollLen.Value();
-        if (maxPreRollLength != 0 && !mDelegate->ValidateMaxPreRollLength(maxPreRollLength, transportOptionsPtr->videoStreamID))
+        if (maxPreRollLength != 0 &&
+            !mDelegate->ValidateMaxPreRollLength(maxPreRollLength, transportOptionsPtr->videoStreamID.Value()))
         {
             auto maxPreRollLengthStatus = to_underlying(StatusCodeEnum::kInvalidPreRollLength);
             ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: MaxPreRollLength (%u) validation failed", mEndpointId,

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -874,7 +874,7 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
         if (maxPreRollLength == 0 || !mDelegate->ValidateSegmentDuration(maxPreRollLength, transportOptionsPtr->videoStreamID))
         {
             auto maxPreRolllLengthStatus = to_underlying(StatusCodeEnum::kInvalidPreRollLength);
-            ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: MaxPreRollLength (%u) validation failed", 
+            ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: MaxPreRollLength (%u) validation failed",
                             mEndpointId, maxPreRollLength);
             TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, maxPreRolllLengthStatus);
             return std::nullopt;

--- a/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
@@ -868,15 +868,15 @@ PushAvStreamTransportServerLogic::HandleAllocatePushTransport(CommandHandler & h
     }
 
     // Validate MaxPreRollLength constraint
-    if (transportOptions.triggerOptions.maxPreRollLen.HasValue())
+    if (transportOptionsPtr->videoStreamID.HasValue() && transportOptions.triggerOptions.maxPreRollLen.HasValue())
     {
         uint16_t maxPreRollLength = transportOptions.triggerOptions.maxPreRollLen.Value();
         if (maxPreRollLength != 0 && !mDelegate->ValidateMaxPreRollLength(maxPreRollLength, transportOptionsPtr->videoStreamID))
         {
-            auto maxPreRolllLengthStatus = to_underlying(StatusCodeEnum::kInvalidPreRollLength);
+            auto maxPreRollLengthStatus = to_underlying(StatusCodeEnum::kInvalidPreRollLength);
             ChipLogError(Zcl, "HandleAllocatePushTransport[ep=%d]: MaxPreRollLength (%u) validation failed", mEndpointId,
                          maxPreRollLength);
-            TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, maxPreRolllLengthStatus);
+            TEMPORARY_RETURN_IGNORED handler.AddClusterSpecificFailure(commandPath, maxPreRollLengthStatus);
             return std::nullopt;
         }
     }

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -156,8 +156,7 @@ public:
      * @return true if the Max pre-roll length is greater than or equal to KeyFrameInterval for the provided videoStreamId, false
        otherwise
      */
-    virtual bool ValidateMaxPreRollLength(uint16_t maxPreRollLength,
-                                          const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) = 0;
+    virtual bool ValidateMaxPreRollLength(uint16_t maxPreRollLength, const DataModel::Nullable<uint16_t> & videoStreamId) = 0;
 
     /**
      * @brief Validates bandwidth requirements against camera's resource management.

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -153,8 +153,8 @@ public:
      *
      * @param maxPreRollLength Max Pre Roll length to validate
      * @param videoStreamId The video stream ID to be validated against
-     * @return true if the Max pre-roll length must be greater than or equal to key frame interval for the provided videoStreamId,
-     * false otherwise
+     * @return true if the Max pre-roll length is greater than or equal to KeyFrameInterval for the provided videoStreamId, false
+       otherwise
      */
     virtual bool ValidateMaxPreRollLength(uint16_t maxPreRollLength,
                                           const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) = 0;

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -153,7 +153,7 @@ public:
      *
      * @param maxPreRollLength Max Pre Roll length to validate
      * @param videoStreamId The video stream ID to be validated against
-     * @return true if the Max Pre Roll length is less than KeyFrameInterval for the provided videoStreamId, false otherwise
+     * @return true if the Max pre-roll length must be greater than or equal to key frame interval for the provided videoStreamId, false otherwise
      */
     virtual bool ValidateMaxPreRollLength(uint16_t maxPreRollLength,
                                           const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) = 0;

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -156,7 +156,7 @@ public:
      * @return true if the Max Pre Roll length is less than KeyFrameInterval for the provided videoStreamId, false otherwise
      */
     virtual bool ValidateMaxPreRollLength(uint16_t maxPreRollLength,
-                                         const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) = 0;
+                                          const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) = 0;
 
     /**
      * @brief Validates bandwidth requirements against camera's resource management.

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -149,6 +149,16 @@ public:
                                          const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) = 0;
 
     /**
+     * @brief Validates the provided Max Pre Roll Length.
+     *
+     * @param maxPreRollLength Max Pre Roll length to validate
+     * @param videoStreamId The video stream ID to be validated against
+     * @return true if the Max Pre Roll length is less than KeyFrameInterval for the provided videoStreamId, false otherwise
+     */
+    virtual bool ValidateMaxPreRollLength(uint16_t maxPreRollLength,
+                                         const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) = 0;
+
+    /**
      * @brief Validates bandwidth requirements against camera's resource management.
      *
      * @param streamUsage The desired usage type for the stream (e.g. live view, recording)
@@ -307,6 +317,7 @@ public:
      */
     virtual void SetPushAvStreamTransportServer(PushAvStreamTransportServer * server) = 0;
 };
+
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -153,7 +153,8 @@ public:
      *
      * @param maxPreRollLength Max Pre Roll length to validate
      * @param videoStreamId The video stream ID to be validated against
-     * @return true if the Max pre-roll length must be greater than or equal to key frame interval for the provided videoStreamId, false otherwise
+     * @return true if the Max pre-roll length must be greater than or equal to key frame interval for the provided videoStreamId,
+     * false otherwise
      */
     virtual bool ValidateMaxPreRollLength(uint16_t maxPreRollLength,
                                           const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) = 0;

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -188,6 +188,11 @@ public:
         return true;
     }
 
+    bool ValidateMaxPreRollLength(uint16_t maxPreRollLength,  const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override
+    {
+        return true;
+    }
+
     Protocols::InteractionModel::Status
     ValidateBandwidthLimit(StreamUsageEnum streamUsage, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
                            const Optional<DataModel::Nullable<uint16_t>> & audioStreamId) override

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -188,7 +188,7 @@ public:
         return true;
     }
 
-    bool ValidateMaxPreRollLength(uint16_t maxPreRollLength, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override
+    bool ValidateMaxPreRollLength(uint16_t maxPreRollLength, const DataModel::Nullable<uint16_t> & videoStreamId) override
     {
         return true;
     }

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -188,7 +188,7 @@ public:
         return true;
     }
 
-    bool ValidateMaxPreRollLength(uint16_t maxPreRollLength,  const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override
+    bool ValidateMaxPreRollLength(uint16_t maxPreRollLength, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId) override
     {
         return true;
     }

--- a/src/python_testing/TC_PAVSTI_1_1.py
+++ b/src/python_testing/TC_PAVSTI_1_1.py
@@ -293,7 +293,7 @@ class TC_PAVSTI_1_1(MatterBaseTest, AVSMTestBase, PAVSTIUtils):
             "audioStreamID": audioStreamId,
             "TLSEndpointID": tlsEndpointId,
             "url": f"https://{self.host_ip}:1234/streams/{uploadStreamId}/",
-            "triggerOptions": {"triggerType": pushavCluster.Enums.TransportTriggerTypeEnum.kCommand, "maxPreRollLen": 10},
+            "triggerOptions": {"triggerType": pushavCluster.Enums.TransportTriggerTypeEnum.kCommand, "maxPreRollLen": 10000},
             "ingestMethod": pushavCluster.Enums.IngestMethodsEnum.kCMAFIngest,
             "containerFormat": pushavCluster.Enums.ContainerFormatEnum.kCmaf,
             "containerOptions": {


### PR DESCRIPTION
#### Summary

Implement the following constraint:

If the [MaxPreRollLen](https://vscode-remote+ssh-002dremote-002b107-002e99-002e235-002e233.vscode-resource.vscode-cdn.net/home/raveendra/source-code/connectedhomeip-spec/src/app_clusters/PushAVStreamTransport.adoc#ref_PushTransportTriggerOptionsMaxPreRollLen) field of the passed in TransportOptions is non-zero and is less than the [KeyFrameInterval](https://vscode-remote+ssh-002dremote-002b107-002e99-002e235-002e233.vscode-resource.vscode-cdn.net/home/raveendra/source-code/connectedhomeip-spec/src/app_clusters/PushAVStreamTransport.adoc#ref_VideoStreamKeyFrameInterval) value of that entry:
-- Fail the command with the cluster-specific status code of InvalidPreRollLength, and end processing with no other side effects.


#### Testing
```
# Build and run camera application
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debug/chip-camera-app

# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run Push AV TC
Example:
python3 src/python_testing/TC_PAVST_2_11.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1
