### PR TITLE
Add Additional glib 'GAutoPtr' Template Specializations

### DIFF
--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -91,6 +91,11 @@ struct GBytesDeleter
     void operator()(GBytes * object) { g_bytes_unref(object); }
 };
 
+struct GStrvDeleter
+{
+    void operator()(gchar ** object) { g_strfreev(object); }
+};
+
 template <typename T>
 struct GAutoPtrDeleter
 {
@@ -142,6 +147,12 @@ template <>
 struct GAutoPtrDeleter<GError>
 {
     using deleter = GErrorDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<gchar *>
+{
+    using deleter = GStrvDeleter;
 };
 
 template <>

--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -61,6 +61,11 @@ struct GErrorDeleter
     void operator()(GError * object) { g_error_free(object); }
 };
 
+struct GHashTableDeleter
+{
+    void operator()(GHashTable * hash) { g_hash_table_destroy(hash); }
+};
+
 struct GIOChannelDeleter
 {
     void operator()(GIOChannel * object) { g_io_channel_unref(object); }
@@ -137,6 +142,12 @@ template <>
 struct GAutoPtrDeleter<GError>
 {
     using deleter = GErrorDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<GHashTable>
+{
+    using deleter = GHashTableDeleter;
 };
 
 template <>

--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -157,6 +157,12 @@ struct GAutoPtrDeleter<GIOChannel>
 };
 
 template <>
+struct GAutoPtrDeleter<GObject>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
 struct GAutoPtrDeleter<GSource>
 {
     using deleter = GSourceDeleter;


### PR DESCRIPTION
#### Summary

This partially addresses #42516 by adding three `GAutoPtr` template specialization for the following types:

* `GHashTable`
    * This will be leveraged by the third-party, open source _Connection Manager_ (also known as _connman_) Linux platform `ConnectivtyManager_Impl` implementation for mapping GLib D-Bus object paths to client proxies and properties.
 * `GObject`
    * This will be leveraged by the third-party, open source _Connection Manager_ (also known as _connman_) Linux platform `ConnectivtyManager_Impl` implementation for neutrally retaining GLib D-Bus network service and network technology client proxies across asynchronous GLib D-Bus calls.
* `gchar **` / `g_strv`
    * This will be leveraged by the third-party, open source _Connection Manager_ (also known as _connman_) Linux platform `ConnectivtyManager_Impl` implementation for making a `g_strdupv` deep copy of removed GLib D-Bus network service across a GLib-to-Matter thread lambda trampoline.

#### Related issues

#42516

#### Testing

Successfully paired / commissioned an armvl-unknown-linux-gnu device using the iOS 26.2 Apple "Home" app.