### PR TITLE
[NXP][zephyr] Move NXP Post‑Build Processes From CHIP Module to Application Level

### DIFF
--- a/config/nxp/app/zephyr-post-build.cmake
+++ b/config/nxp/app/zephyr-post-build.cmake
@@ -1,0 +1,75 @@
+#
+#   Copyright (c) 2025 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+include(${CHIP_ROOT}/config/zephyr/ota-image.cmake)
+include(${CHIP_ROOT}/config/nxp/chip-module/generate_factory_data.cmake)
+
+# ==============================================================================
+# Define 'chip-ota-image' target for building CHIP OTA image
+# ==============================================================================
+if(CONFIG_CHIP_OTA_REQUESTOR)
+    if(CONFIG_MCUBOOT_SIGNATURE_KEY_FILE STREQUAL "")
+        set(ZEPHYR_OUTPUT_NAME "zephyr")
+    else()
+        set(ZEPHYR_OUTPUT_NAME "zephyr.signed")
+    endif()
+
+    set(GLOBAL_BOOTLOADER_CONF_OVERLAY_FILE "${CHIP_ROOT}/config/nxp/app/bootloader.conf")
+
+    set(ZEPHYR_OUTPUT_DIR ${PROJECT_BINARY_DIR}/zephyr)
+
+    add_custom_target(build_mcuboot ALL
+        COMMAND
+        west build -b ${BOARD} -d build_mcuboot ${ZEPHYR_BASE}/../bootloader/mcuboot/boot/zephyr
+            -- -DOVERLAY_CONFIG=${GLOBAL_BOOTLOADER_CONF_OVERLAY_FILE}
+            -DEXTRA_DTC_OVERLAY_FILE="${DTC_OVERLAY_FILE};${EXTRA_DTC_OVERLAY_FILE}"
+        COMMAND
+        cp ${ZEPHYR_OUTPUT_DIR}/../build_mcuboot/zephyr/zephyr.bin ${ZEPHYR_OUTPUT_DIR}/zephyr.mcuboot.bin
+    )
+    add_dependencies(build_mcuboot app)
+    set(BLOCK_SIZE "1024")
+    dt_nodelabel(dts_partition_path NODELABEL "boot_partition")
+    dt_reg_size(mcuboot_size PATH ${dts_partition_path})
+    math(EXPR boot_blocks "${mcuboot_size} / ${BLOCK_SIZE}" OUTPUT_FORMAT DECIMAL)
+
+    add_custom_command( 
+        OUTPUT ${ZEPHYR_OUTPUT_DIR}/zephyr_full.bin
+        DEPENDS build_mcuboot ${ZEPHYR_OUTPUT_DIR}/${ZEPHYR_OUTPUT_NAME}.bin
+        COMMAND dd if=${ZEPHYR_OUTPUT_DIR}/zephyr.mcuboot.bin of=${ZEPHYR_OUTPUT_DIR}/zephyr_full.bin
+        COMMAND dd if=${ZEPHYR_OUTPUT_DIR}/${ZEPHYR_OUTPUT_NAME}.bin of=${ZEPHYR_OUTPUT_DIR}/zephyr_full.bin bs=${BLOCK_SIZE} seek=${boot_blocks}
+    )
+
+    add_custom_target(merge_mcuboot ALL
+        DEPENDS ${ZEPHYR_OUTPUT_DIR}/zephyr_full.bin
+    )
+
+    add_dependencies(merge_mcuboot build_mcuboot)
+
+    if (CONFIG_CHIP_OTA_IMAGE_BUILD)
+        chip_ota_image(chip-ota-image
+            INPUT_FILES ${ZEPHYR_OUTPUT_DIR}/${ZEPHYR_OUTPUT_NAME}.bin
+            OUTPUT_FILE ${ZEPHYR_OUTPUT_DIR}/${CONFIG_CHIP_OTA_IMAGE_FILE_NAME}
+        )
+    endif()
+endif()
+
+# ==============================================================================
+# Define 'factory_data' target for generating a factory data partition
+# ==============================================================================
+
+if (CONFIG_CHIP_FACTORY_DATA_BUILD)
+    nxp_generate_factory_data()
+endif()

--- a/config/nxp/app/zephyr-post-build.cmake
+++ b/config/nxp/app/zephyr-post-build.cmake
@@ -56,8 +56,6 @@ if(CONFIG_CHIP_OTA_REQUESTOR)
         DEPENDS ${ZEPHYR_OUTPUT_DIR}/zephyr_full.bin
     )
 
-    add_dependencies(merge_mcuboot build_mcuboot)
-
     if (CONFIG_CHIP_OTA_IMAGE_BUILD)
         chip_ota_image(chip-ota-image
             INPUT_FILES ${ZEPHYR_OUTPUT_DIR}/${ZEPHYR_OUTPUT_NAME}.bin

--- a/config/nxp/chip-module/CMakeLists.txt
+++ b/config/nxp/chip-module/CMakeLists.txt
@@ -28,9 +28,7 @@
 if (CONFIG_CHIP)
 
 include(ExternalProject)
-include(../../zephyr/ota-image.cmake)
 include(../../zephyr/zephyr-util.cmake)
-include(generate_factory_data.cmake)
 
 # ==============================================================================
 # Prepare CHIP configuration based on the project Kconfig configuration
@@ -167,56 +165,6 @@ if (CONFIG_CHIP_MALLOC_SYS_HEAP_OVERRIDE)
         -Wl,--wrap=_realloc_r
         -Wl,--wrap=_free_r
     )
-endif()
-
-# ==============================================================================
-# Define 'chip-ota-image' target for building CHIP OTA image
-# ==============================================================================
-if(CONFIG_CHIP_OTA_REQUESTOR)
-    if(CONFIG_MCUBOOT_SIGNATURE_KEY_FILE STREQUAL "")
-        set(ZEPHYR_OUTPUT_NAME "zephyr")
-    else()
-        set(ZEPHYR_OUTPUT_NAME "zephyr.signed")
-    endif()
-
-    set(GLOBAL_BOOTLOADER_CONF_OVERLAY_FILE "${CHIP_ROOT}/config/nxp/app/bootloader.conf")
-
-    add_custom_target(build_mcuboot ALL
-        COMMAND
-        west build -b ${BOARD} -d build_mcuboot ${ZEPHYR_BASE}/../bootloader/mcuboot/boot/zephyr
-            -- -DOVERLAY_CONFIG=${GLOBAL_BOOTLOADER_CONF_OVERLAY_FILE}
-            -DEXTRA_DTC_OVERLAY_FILE="${DTC_OVERLAY_FILE};${EXTRA_DTC_OVERLAY_FILE}"
-        COMMAND
-        cp ${PROJECT_BINARY_DIR}/../modules/connectedhomeip/build_mcuboot/zephyr/zephyr.bin ${PROJECT_BINARY_DIR}/zephyr.mcuboot.bin
-    )
-    add_dependencies(build_mcuboot ${ZEPHYR_FINAL_EXECUTABLE})
-    set(BLOCK_SIZE "1024")
-    dt_nodelabel(dts_partition_path NODELABEL "boot_partition")
-    dt_reg_size(mcuboot_size PATH ${dts_partition_path})
-    math(EXPR boot_blocks "${mcuboot_size} / ${BLOCK_SIZE}" OUTPUT_FORMAT DECIMAL)
-
-    add_custom_target(merge_mcuboot ALL
-        COMMAND
-        dd if=${PROJECT_BINARY_DIR}/zephyr.mcuboot.bin of=${PROJECT_BINARY_DIR}/zephyr_full.bin
-        COMMAND
-        dd if=${PROJECT_BINARY_DIR}/${ZEPHYR_OUTPUT_NAME}.bin of=${PROJECT_BINARY_DIR}/zephyr_full.bin bs=${BLOCK_SIZE} seek=${boot_blocks}
-    )
-    add_dependencies(merge_mcuboot build_mcuboot)
-
-    if (CONFIG_CHIP_OTA_IMAGE_BUILD)
-        chip_ota_image(chip-ota-image
-            INPUT_FILES ${PROJECT_BINARY_DIR}/${ZEPHYR_OUTPUT_NAME}.bin
-            OUTPUT_FILE ${PROJECT_BINARY_DIR}/${CONFIG_CHIP_OTA_IMAGE_FILE_NAME}
-        )
-    endif()
-endif()
-
-# ==============================================================================
-# Define 'factory_data' target for generating a factory data partition
-# ==============================================================================
-
-if (CONFIG_CHIP_FACTORY_DATA_BUILD)
-    nxp_generate_factory_data()
 endif()
 
 endif() # CONFIG_CHIP

--- a/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
@@ -127,3 +127,6 @@ target_sources(app
     ${ALL_CLUSTERS_COMMON_DIR}/src/resource-monitoring-delegates.cpp
     ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/icd/source/ICDUtil.cpp
 )
+
+# Post-build steps
+include(${CHIP_ROOT}/config/nxp/app/zephyr-post-build.cmake)

--- a/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
@@ -126,3 +126,6 @@ target_sources(app
     ${ALL_CLUSTERS_COMMON_DIR}/src/operational-state-delegate-impl.cpp
     ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/icd/source/ICDUtil.cpp
 )
+
+# Post-build steps
+include(${CHIP_ROOT}/config/nxp/app/zephyr-post-build.cmake)

--- a/examples/thermostat/nxp/zephyr/CMakeLists.txt
+++ b/examples/thermostat/nxp/zephyr/CMakeLists.txt
@@ -115,3 +115,6 @@ if(CONFIG_CHIP_LIB_SHELL)
                    ${CHIP_ROOT}/examples/shell/shell_common/cmd_server.cpp
     )
 endif()
+
+# Post-build steps
+include(${CHIP_ROOT}/config/nxp/app/zephyr-post-build.cmake)


### PR DESCRIPTION

#### Summary

This PR begins the migration required for Issue #42716, which aims to switch NXP Zephyr applications from the NXP‑specific CHIP module to the generic Zephyr CHIP module.
To enable that transition, all NXP‑specific post‑build logic must be removed from the NXP CHIP module and relocated to the application layer.
This PR focuses exclusively on extracting and relocating those post‑build steps while preserving full functionality for existing NXP applications.

#### Related issues

Part of issue #42716 

#### Testing

Tested by building NXP Zephyr application with OTA and factory data enabled, then verified the post-build generation of the MCUBoot image, the `.ota` image and the factory data binary. 
Command used:

- "west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr -DEXTRA_CONF_FILE=prj_ota.conf -DFILE_SUFFIX=fdata -DCONFIG_CHIP_FACTORY_DATA_BUILD=y -DCONFIG_CHIP_FACTORY_DATA_CERT_SOURCE_GENERATED=y -DCONFIG_CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER=y"
