### PR TITLE
Basic information dependency injection

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -69,15 +69,15 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
 
     ReturnErrorOnFailure(provider.AddCluster(mBasicInformationCluster.Registration()));
     mGeneralCommissioningCluster.Create(
-        GeneralCommissioningCluster::Context{
+        GeneralCommissioningCluster::Context {
             .commissioningWindowManager = mContext.commissioningWindowManager, //
-            .configurationManager       = mContext.configurationManager,       //
-            .deviceControlServer        = mContext.deviceControlServer,        //
-            .fabricTable                = mContext.fabricTable,                //
-            .failSafeContext            = mContext.failSafeContext,            //
-            .platformManager            = mContext.platformManager,            //
+                .configurationManager   = mContext.configurationManager,       //
+                .deviceControlServer    = mContext.deviceControlServer,        //
+                .fabricTable            = mContext.fabricTable,                //
+                .failSafeContext        = mContext.failSafeContext,            //
+                .platformManager        = mContext.platformManager,            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-            .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         GeneralCommissioningCluster::OptionalAttributes());

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -46,25 +46,23 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
             .Set<BasicInformation::Attributes::LocalConfigDisabled::Id>()
             .Set<BasicInformation::Attributes::Reachable::Id>();
 
-    DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();
-    VerifyOrDie(provider != nullptr);
-
-    mBasicInformationCluster.Create(optionalAttributeSet,
-                                    BasicInformationCluster::Context{ .deviceInstanceInfoProvider = provider,
-                                                                      .configurationManager       = DeviceLayer::ConfigurationMgr(),
-                                                                      .platformManager            = DeviceLayer::PlatformMgr() });
+    mBasicInformationCluster.Create(
+        optionalAttributeSet,
+        BasicInformationCluster::Context{ .deviceInstanceInfoProvider = mContext.deviceInstanceInfoProvider,
+                                          .configurationManager       = mContext.configurationManager,
+                                          .platformManager            = mContext.platformManager });
 
     ReturnErrorOnFailure(provider.AddCluster(mBasicInformationCluster.Registration()));
     mGeneralCommissioningCluster.Create(
-        GeneralCommissioningCluster::Context{
+        GeneralCommissioningCluster::Context {
             .commissioningWindowManager = mContext.commissioningWindowManager, //
-            .configurationManager       = mContext.configurationManager,       //
-            .deviceControlServer        = mContext.deviceControlServer,        //
-            .fabricTable                = mContext.fabricTable,                //
-            .failSafeContext            = mContext.failSafeContext,            //
-            .platformManager            = mContext.platformManager,            //
+                .configurationManager   = mContext.configurationManager,       //
+                .deviceControlServer    = mContext.deviceControlServer,        //
+                .fabricTable            = mContext.fabricTable,                //
+                .failSafeContext        = mContext.failSafeContext,            //
+                .platformManager        = mContext.platformManager,            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-            .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         GeneralCommissioningCluster::OptionalAttributes());

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -28,6 +28,24 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::DeviceLayer;
 
+namespace {
+
+class RootNodeBasicInfoDelegate : public BasicInformationCluster::Delegate
+{
+public:
+    DeviceLayer::DeviceInstanceInfoProvider * GetDeviceInstanceInfoProvider() override
+    {
+        return DeviceLayer::GetDeviceInstanceInfoProvider();
+    }
+
+    DeviceLayer::ConfigurationManager & GetConfigurationManager() override { return DeviceLayer::ConfigurationMgr(); }
+
+    DeviceLayer::PlatformManager & GetPlatformManager() override { return DeviceLayer::PlatformMgr(); }
+};
+
+static RootNodeBasicInfoDelegate gBasicInfoDelegate;
+
+} // namespace
 namespace chip {
 namespace app {
 
@@ -47,19 +65,19 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
             .Set<BasicInformation::Attributes::LocalConfigDisabled::Id>()
             .Set<BasicInformation::Attributes::Reachable::Id>();
 
-    mBasicInformationCluster.Create(optionalAttributeSet);
+    mBasicInformationCluster.Create(optionalAttributeSet, &gBasicInfoDelegate);
 
     ReturnErrorOnFailure(provider.AddCluster(mBasicInformationCluster.Registration()));
     mGeneralCommissioningCluster.Create(
-        GeneralCommissioningCluster::Context {
+        GeneralCommissioningCluster::Context{
             .commissioningWindowManager = mContext.commissioningWindowManager, //
-                .configurationManager   = mContext.configurationManager,       //
-                .deviceControlServer    = mContext.deviceControlServer,        //
-                .fabricTable            = mContext.fabricTable,                //
-                .failSafeContext        = mContext.failSafeContext,            //
-                .platformManager        = mContext.platformManager,            //
+            .configurationManager       = mContext.configurationManager,       //
+            .deviceControlServer        = mContext.deviceControlServer,        //
+            .fabricTable                = mContext.fabricTable,                //
+            .failSafeContext            = mContext.failSafeContext,            //
+            .platformManager            = mContext.platformManager,            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+            .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         GeneralCommissioningCluster::OptionalAttributes());

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -50,7 +50,7 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
     VerifyOrDie(provider != nullptr);
 
     mBasicInformationCluster.Create(optionalAttributeSet,
-                                    BasicInformationCluster::Context{ .deviceInstanceInfoProvider = *provider,
+                                    BasicInformationCluster::Context{ .deviceInstanceInfoProvider = provider,
                                                                       .configurationManager       = DeviceLayer::ConfigurationMgr(),
                                                                       .platformManager            = DeviceLayer::PlatformMgr() });
 

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -27,25 +27,6 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::DeviceLayer;
-
-namespace {
-
-class RootNodeBasicInfoDelegate : public BasicInformationCluster::Delegate
-{
-public:
-    DeviceLayer::DeviceInstanceInfoProvider * GetDeviceInstanceInfoProvider() override
-    {
-        return DeviceLayer::GetDeviceInstanceInfoProvider();
-    }
-
-    DeviceLayer::ConfigurationManager & GetConfigurationManager() override { return DeviceLayer::ConfigurationMgr(); }
-
-    DeviceLayer::PlatformManager & GetPlatformManager() override { return DeviceLayer::PlatformMgr(); }
-};
-
-static RootNodeBasicInfoDelegate gBasicInfoDelegate;
-
-} // namespace
 namespace chip {
 namespace app {
 
@@ -65,19 +46,25 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
             .Set<BasicInformation::Attributes::LocalConfigDisabled::Id>()
             .Set<BasicInformation::Attributes::Reachable::Id>();
 
-    mBasicInformationCluster.Create(optionalAttributeSet, &gBasicInfoDelegate);
+    DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();
+    VerifyOrDie(provider != nullptr);
+
+    mBasicInformationCluster.Create(optionalAttributeSet,
+                                    BasicInformationCluster::Context{ .deviceInstanceInfoProvider = *provider,
+                                                                      .configurationManager       = DeviceLayer::ConfigurationMgr(),
+                                                                      .platformManager            = DeviceLayer::PlatformMgr() });
 
     ReturnErrorOnFailure(provider.AddCluster(mBasicInformationCluster.Registration()));
     mGeneralCommissioningCluster.Create(
-        GeneralCommissioningCluster::Context {
+        GeneralCommissioningCluster::Context{
             .commissioningWindowManager = mContext.commissioningWindowManager, //
-                .configurationManager   = mContext.configurationManager,       //
-                .deviceControlServer    = mContext.deviceControlServer,        //
-                .fabricTable            = mContext.fabricTable,                //
-                .failSafeContext        = mContext.failSafeContext,            //
-                .platformManager        = mContext.platformManager,            //
+            .configurationManager       = mContext.configurationManager,       //
+            .deviceControlServer        = mContext.deviceControlServer,        //
+            .fabricTable                = mContext.fabricTable,                //
+            .failSafeContext            = mContext.failSafeContext,            //
+            .platformManager            = mContext.platformManager,            //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+            .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         GeneralCommissioningCluster::OptionalAttributes());

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
@@ -45,6 +45,7 @@ public:
         Access::AccessControl & accessControl;
         PersistentStorageDelegate & persistentStorage;
         FailSafeContext & failSafeContext;
+        DeviceLayer::DeviceInstanceInfoProvider & deviceInstanceInfoProvider;
         DeviceLayer::PlatformManager & platformManager;
         Credentials::GroupDataProvider & groupDataProvider;
         SessionManager & sessionManager;

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -196,19 +196,27 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
 
     gDataModelProvider = &dataModelProvider;
 
+    DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();
+    if (provider == nullptr)
+    {
+        ESP_LOGE(TAG, "Failed to get DeviceInstanceInfoProvider.");
+        return nullptr;
+    }
+
     gRootNodeDevice = std::make_unique<WifiRootNodeDevice>(
         RootNodeDevice::Context {
-            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
-                .configurationManager   = DeviceLayer::ConfigurationMgr(),                       //
-                .deviceControlServer    = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-                .fabricTable            = Server::GetInstance().GetFabricTable(),                //
-                .accessControl          = Server::GetInstance().GetAccessControl(),              //
-                .persistentStorage      = Server::GetInstance().GetPersistentStorage(),          //
-                .failSafeContext        = Server::GetInstance().GetFailSafeContext(),            //
-                .platformManager        = DeviceLayer::PlatformMgr(),                            //
-                .groupDataProvider      = gGropupDataProvider,                                   //
-                .sessionManager         = Server::GetInstance().GetSecureSessionManager(),       //
-                .dnssdServer            = DnssdServer::Instance(),                               //
+            .commissioningWindowManager     = Server::GetInstance().GetCommissioningWindowManager(), //
+                .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
+                .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                .fabricTable                = Server::GetInstance().GetFabricTable(),                //
+                .accessControl              = Server::GetInstance().GetAccessControl(),              //
+                .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
+                .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
+                .deviceInstanceInfoProvider = *provider,                                             //
+                .platformManager            = DeviceLayer::PlatformMgr(),                            //
+                .groupDataProvider          = gGropupDataProvider,                                   //
+                .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //
+                .dnssdServer                = DnssdServer::Instance(),                               //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
                 .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -95,21 +95,21 @@ public:
         mContext(context), mDataModelProvider(mContext.storageDelegate, mAttributePersistence),
         mRootNode(
             {
-                .commissioningWindowManager = mContext.commissioningWindowManager, //
-                .configurationManager       = mContext.configurationManager,       //
-                .deviceControlServer        = mContext.deviceControlServer,        //
-                .fabricTable                = mContext.fabricTable,                //
-                .accessControl              = mContext.accessControl,              //
-                .persistentStorage          = mContext.persistentStorage,          //
-                .failSafeContext            = mContext.failSafeContext,            //
-                .deviceInstanceInfoProvider = mContext.deviceInstanceInfoProvider, //
-                .platformManager            = mContext.platformManager,            //
-                .groupDataProvider          = mContext.groupDataProvider,          //
-                .sessionManager             = mContext.sessionManager,             //
-                .dnssdServer                = mContext.dnssdServer,                //
+                .commissioningWindowManager     = mContext.commissioningWindowManager, //
+                    .configurationManager       = mContext.configurationManager,       //
+                    .deviceControlServer        = mContext.deviceControlServer,        //
+                    .fabricTable                = mContext.fabricTable,                //
+                    .accessControl              = mContext.accessControl,              //
+                    .persistentStorage          = mContext.persistentStorage,          //
+                    .failSafeContext            = mContext.failSafeContext,            //
+                    .deviceInstanceInfoProvider = mContext.deviceInstanceInfoProvider, //
+                    .platformManager            = mContext.platformManager,            //
+                    .groupDataProvider          = mContext.groupDataProvider,          //
+                    .sessionManager             = mContext.sessionManager,             //
+                    .dnssdServer                = mContext.dnssdServer,                //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+                    .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
             },
             []() {
@@ -182,22 +182,22 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
     }
 
     static CodeDrivenDataModelDevices devices({
-        .storageDelegate            = *initParams.persistentStorageDelegate,                 //
-        .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
-        .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
-        .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-        .fabricTable                = Server::GetInstance().GetFabricTable(),                //
-        .accessControl              = Server::GetInstance().GetAccessControl(),              //
-        .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
-        .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
-        .deviceInstanceInfoProvider = *provider,                                             //
-        .platformManager            = DeviceLayer::PlatformMgr(),                            //
-        .groupDataProvider          = gGroupDataProvider,                                    //
-        .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //
-        .dnssdServer                = DnssdServer::Instance(),                               //
+        .storageDelegate                = *initParams.persistentStorageDelegate,                 //
+            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
+            .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
+            .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+            .fabricTable                = Server::GetInstance().GetFabricTable(),                //
+            .accessControl              = Server::GetInstance().GetAccessControl(),              //
+            .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
+            .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
+            .deviceInstanceInfoProvider = *provider,                                             //
+            .platformManager            = DeviceLayer::PlatformMgr(),                            //
+            .groupDataProvider          = gGroupDataProvider,                                    //
+            .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //
+            .dnssdServer                = DnssdServer::Instance(),                               //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-        .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
     });
 

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -80,6 +80,7 @@ public:
         Access::AccessControl & accessControl;
         PersistentStorageDelegate & persistentStorage;
         FailSafeContext & failSafeContext;
+        DeviceLayer::DeviceInstanceInfoProvider & deviceInstanceInfoProvider;
         DeviceLayer::PlatformManager & platformManager;
         Credentials::GroupDataProvider & groupDataProvider;
         SessionManager & sessionManager;
@@ -95,19 +96,20 @@ public:
         mRootNode(
             {
                 .commissioningWindowManager = mContext.commissioningWindowManager, //
-                    .configurationManager   = mContext.configurationManager,       //
-                    .deviceControlServer    = mContext.deviceControlServer,        //
-                    .fabricTable            = mContext.fabricTable,                //
-                    .accessControl          = mContext.accessControl,              //
-                    .persistentStorage      = mContext.persistentStorage,          //
-                    .failSafeContext        = mContext.failSafeContext,            //
-                    .platformManager        = mContext.platformManager,            //
-                    .groupDataProvider      = mContext.groupDataProvider,          //
-                    .sessionManager         = mContext.sessionManager,             //
-                    .dnssdServer            = mContext.dnssdServer,                //
+                .configurationManager       = mContext.configurationManager,       //
+                .deviceControlServer        = mContext.deviceControlServer,        //
+                .fabricTable                = mContext.fabricTable,                //
+                .accessControl              = mContext.accessControl,              //
+                .persistentStorage          = mContext.persistentStorage,          //
+                .failSafeContext            = mContext.failSafeContext,            //
+                .deviceInstanceInfoProvider = mContext.deviceInstanceInfoProvider, //
+                .platformManager            = mContext.platformManager,            //
+                .groupDataProvider          = mContext.groupDataProvider,          //
+                .sessionManager             = mContext.sessionManager,             //
+                .dnssdServer                = mContext.dnssdServer,                //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                    .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
             },
             []() {
@@ -172,22 +174,30 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
     gGroupDataProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
     Credentials::SetGroupDataProvider(&gGroupDataProvider);
 
+    DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();
+    if (provider == nullptr)
+    {
+        ChipLogError(AppServer, "Failed to get the DeviceInstanceInfoProvifer.");
+        chipDie();
+    }
+
     static CodeDrivenDataModelDevices devices({
-        .storageDelegate                = *initParams.persistentStorageDelegate,                 //
-            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
-            .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
-            .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-            .fabricTable                = Server::GetInstance().GetFabricTable(),                //
-            .accessControl              = Server::GetInstance().GetAccessControl(),              //
-            .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
-            .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
-            .platformManager            = DeviceLayer::PlatformMgr(),                            //
-            .groupDataProvider          = gGroupDataProvider,                                    //
-            .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //
-            .dnssdServer                = DnssdServer::Instance(),                               //
+        .storageDelegate            = *initParams.persistentStorageDelegate,                 //
+        .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
+        .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
+        .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+        .fabricTable                = Server::GetInstance().GetFabricTable(),                //
+        .accessControl              = Server::GetInstance().GetAccessControl(),              //
+        .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
+        .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
+        .deviceInstanceInfoProvider = *provider,                                             //
+        .platformManager            = DeviceLayer::PlatformMgr(),                            //
+        .groupDataProvider          = gGroupDataProvider,                                    //
+        .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //
+        .dnssdServer                = DnssdServer::Instance(),                               //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+        .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
     });
 

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -296,10 +296,10 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
 {
     using namespace BasicInformation::Attributes;
 
-    // NOTE: this is NEVER nullptr, using pointer as we have seen converting to reference
-    //       costs some flash (even though code would be more readable that way...)
     auto * deviceInfoProvider = mDelegate->GetDeviceInstanceInfoProvider();
-    auto & configManager      = mDelegate->GetConfigurationManager();
+    VerifyOrReturnError(deviceInfoProvider != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    auto & configManager = mDelegate->GetConfigurationManager();
 
     switch (request.path.mAttributeId)
     {

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -107,12 +107,12 @@ constexpr size_t kMaxStringLength = std::max({
 
 /// Reads a single device info string. Separate function to optimize for flash cost
 /// as querying strings seems to be a frequent operation.
-CHIP_ERROR ReadConfigurationString(DeviceInstanceInfoProvider * deviceInfoProvider,
+CHIP_ERROR ReadConfigurationString(DeviceInstanceInfoProvider & deviceInfoProvider,
                                    CHIP_ERROR (DeviceInstanceInfoProvider::*getter)(char *, size_t), bool unimplementedAllowed,
                                    AttributeValueEncoder & encoder)
 {
     char buffer[kMaxStringLength + 1] = { 0 };
-    CHIP_ERROR status                 = ((deviceInfoProvider)->*(getter))(buffer, sizeof(buffer));
+    CHIP_ERROR status                 = ((deviceInfoProvider).*(getter))(buffer, sizeof(buffer));
     if (unimplementedAllowed)
     {
         status = ClearNullTerminatedStringWhenUnimplemented(status, buffer);
@@ -120,31 +120,31 @@ CHIP_ERROR ReadConfigurationString(DeviceInstanceInfoProvider * deviceInfoProvid
     return EncodeStringOnSuccess(status, encoder, buffer, kMaxStringLength);
 }
 
-inline CHIP_ERROR ReadVendorID(DeviceInstanceInfoProvider * deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadVendorID(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
 {
     uint16_t vendorId = 0;
-    ReturnErrorOnFailure(deviceInfoProvider->GetVendorId(vendorId));
+    ReturnErrorOnFailure(deviceInfoProvider.GetVendorId(vendorId));
     return aEncoder.Encode(vendorId);
 }
 
-inline CHIP_ERROR ReadProductID(DeviceInstanceInfoProvider * deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadProductID(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
 {
     uint16_t productId = 0;
-    ReturnErrorOnFailure(deviceInfoProvider->GetProductId(productId));
+    ReturnErrorOnFailure(deviceInfoProvider.GetProductId(productId));
     return aEncoder.Encode(productId);
 }
 
-inline CHIP_ERROR ReadLocalConfigDisabled(DeviceInstanceInfoProvider * deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadLocalConfigDisabled(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
 {
     bool localConfigDisabled = false;
-    ReturnErrorOnFailure(deviceInfoProvider->GetLocalConfigDisabled(localConfigDisabled));
+    ReturnErrorOnFailure(deviceInfoProvider.GetLocalConfigDisabled(localConfigDisabled));
     return aEncoder.Encode(localConfigDisabled);
 }
 
-inline CHIP_ERROR ReadHardwareVersion(DeviceInstanceInfoProvider * deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadHardwareVersion(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
 {
     uint16_t hardwareVersion = 0;
-    ReturnErrorOnFailure(deviceInfoProvider->GetHardwareVersion(hardwareVersion));
+    ReturnErrorOnFailure(deviceInfoProvider.GetHardwareVersion(hardwareVersion));
     return aEncoder.Encode(hardwareVersion);
 }
 
@@ -163,7 +163,7 @@ inline CHIP_ERROR ReadSoftwareVersionString(DeviceLayer::ConfigurationManager & 
     return aEncoder.Encode(CharSpan(softwareVersionString, strnlen(softwareVersionString, kMaxLen)));
 }
 
-inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider * deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
 {
     constexpr size_t kMaxLen        = DeviceLayer::ConfigurationManager::kMaxManufacturingDateLength;
     constexpr size_t kMaxDateLength = 8; // YYYYMMDD
@@ -174,7 +174,7 @@ inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider * deviceInfoP
     uint8_t manufacturingDayOfMonth;
     size_t totalManufacturingDateLen = 0;
     MutableCharSpan vendorSuffixSpan(manufacturingDateString + kMaxDateLength, sizeof(manufacturingDateString) - kMaxDateLength);
-    CHIP_ERROR status = deviceInfoProvider->GetManufacturingDate(manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
+    CHIP_ERROR status = deviceInfoProvider.GetManufacturingDate(manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
 
     // TODO: Remove defaulting once proper runtime defaulting of unimplemented factory data is done
     if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
@@ -192,7 +192,7 @@ inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider * deviceInfoP
              manufacturingDayOfMonth);
 
     totalManufacturingDateLen = kMaxDateLength;
-    status                    = deviceInfoProvider->GetManufacturingDateSuffix(vendorSuffixSpan);
+    status                    = deviceInfoProvider.GetManufacturingDateSuffix(vendorSuffixSpan);
     if (status == CHIP_NO_ERROR)
     {
         totalManufacturingDateLen += vendorSuffixSpan.size();
@@ -213,14 +213,14 @@ inline CHIP_ERROR ReadUniqueID(DeviceLayer::ConfigurationManager & configManager
     return EncodeStringOnSuccess(status, aEncoder, uniqueId, kMaxLen);
 }
 
-inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, DeviceInstanceInfoProvider * deviceInfoProvider)
+inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, DeviceInstanceInfoProvider & deviceInfoProvider)
 {
     BasicInformation::Structs::CapabilityMinimaStruct::Type capabilityMinima;
 
     // TODO: These values must be set from something based on the SDK impl, but there are no such constants today.
     constexpr uint16_t kMinCaseSessionsPerFabricMandatedBySpec = 3;
 
-    auto capabilityMinimasFromDeviceInfo = deviceInfoProvider->GetSupportedCapabilityMinimaValues();
+    auto capabilityMinimasFromDeviceInfo = deviceInfoProvider.GetSupportedCapabilityMinimaValues();
 
     capabilityMinima.caseSessionsPerFabric  = kMinCaseSessionsPerFabricMandatedBySpec;
     capabilityMinima.subscriptionsPerFabric = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric();
@@ -261,13 +261,13 @@ inline CHIP_ERROR ReadLocation(DeviceLayer::ConfigurationManager & configManager
     return aEncoder.Encode(countryCodeSpan);
 }
 
-inline CHIP_ERROR ReadProductAppearance(DeviceInstanceInfoProvider * deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadProductAppearance(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
 {
     ProductFinishEnum finish;
-    ReturnErrorOnFailure(deviceInfoProvider->GetProductFinish(&finish));
+    ReturnErrorOnFailure(deviceInfoProvider.GetProductFinish(&finish));
 
     ColorEnum color;
-    CHIP_ERROR colorStatus = deviceInfoProvider->GetProductPrimaryColor(&color);
+    CHIP_ERROR colorStatus = deviceInfoProvider.GetProductPrimaryColor(&color);
     if (colorStatus != CHIP_NO_ERROR && colorStatus != CHIP_ERROR_NOT_IMPLEMENTED)
     {
         return colorStatus;
@@ -296,10 +296,8 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
 {
     using namespace BasicInformation::Attributes;
 
-    auto * deviceInfoProvider = mClusterContext.deviceInstanceInfoProvider;
-    VerifyOrReturnError(deviceInfoProvider != nullptr, CHIP_ERROR_INCORRECT_STATE);
-
-    auto & configManager = mClusterContext.configurationManager;
+    auto & deviceInfoProvider = mClusterContext.deviceInstanceInfoProvider;
+    auto & configManager      = mClusterContext.configurationManager;
 
     switch (request.path.mAttributeId)
     {
@@ -403,11 +401,11 @@ DataModel::ActionReturnStatus BasicInformationCluster::WriteImpl(const DataModel
         return persistence.StoreString(request.path, mNodeLabel);
     }
     case LocalConfigDisabled::Id: {
-        auto * deviceInfoProvider = mClusterContext.deviceInstanceInfoProvider;
+        auto & deviceInfoProvider = mClusterContext.deviceInstanceInfoProvider;
         bool localConfigDisabled  = false;
-        ReturnErrorOnFailure(deviceInfoProvider->GetLocalConfigDisabled(localConfigDisabled));
+        ReturnErrorOnFailure(deviceInfoProvider.GetLocalConfigDisabled(localConfigDisabled));
         auto decodeStatus = persistence.DecodeAndStoreNativeEndianValue(request.path, decoder, localConfigDisabled);
-        ReturnErrorOnFailure(deviceInfoProvider->SetLocalConfigDisabled(localConfigDisabled));
+        ReturnErrorOnFailure(deviceInfoProvider.SetLocalConfigDisabled(localConfigDisabled));
         return decodeStatus;
     }
     default:
@@ -466,12 +464,9 @@ CHIP_ERROR BasicInformationCluster::Startup(ServerClusterContext & context)
     (void) persistence.LoadNativeEndianValue<bool>({ kRootEndpointId, BasicInformation::Id, Attributes::LocalConfigDisabled::Id },
                                                    localConfigDisabled, false);
 
-    if (mClusterContext.deviceInstanceInfoProvider != nullptr)
-    {
-        // Propagate the restored 'LocalConfigDisabled' state to the DeviceInstanceInfoProvider
-        // so the underlying platform layer is aware of the configuration.
-        ReturnErrorOnFailure(mClusterContext.deviceInstanceInfoProvider->SetLocalConfigDisabled(localConfigDisabled));
-    }
+    // Propagate the restored 'LocalConfigDisabled' state to the DeviceInstanceInfoProvider
+    // so the underlying platform layer is aware of the configuration.
+    ReturnErrorOnFailure(mClusterContext.deviceInstanceInfoProvider.SetLocalConfigDisabled(localConfigDisabled));
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -296,10 +296,10 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
 {
     using namespace BasicInformation::Attributes;
 
-    auto * deviceInfoProvider = mDelegate->GetDeviceInstanceInfoProvider();
+    auto * deviceInfoProvider = mClusterContext.deviceInstanceInfoProvider;
     VerifyOrReturnError(deviceInfoProvider != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    auto & configManager = mDelegate->GetConfigurationManager();
+    auto & configManager = mClusterContext.configurationManager;
 
     switch (request.path.mAttributeId)
     {
@@ -394,7 +394,7 @@ DataModel::ActionReturnStatus BasicInformationCluster::WriteImpl(const DataModel
         CharSpan location;
         ReturnErrorOnFailure(decoder.Decode(location));
         VerifyOrReturnError(location.size() == kExpectedFixedLocationLength, Protocols::InteractionModel::Status::ConstraintError);
-        return mDelegate->GetConfigurationManager().StoreCountryCode(location.data(), location.size());
+        return mClusterContext.configurationManager.StoreCountryCode(location.data(), location.size());
     }
     case NodeLabel::Id: {
         CharSpan label;
@@ -403,8 +403,8 @@ DataModel::ActionReturnStatus BasicInformationCluster::WriteImpl(const DataModel
         return persistence.StoreString(request.path, mNodeLabel);
     }
     case LocalConfigDisabled::Id: {
-        auto deviceInfoProvider  = mDelegate->GetDeviceInstanceInfoProvider();
-        bool localConfigDisabled = false;
+        auto * deviceInfoProvider = mClusterContext.deviceInstanceInfoProvider;
+        bool localConfigDisabled  = false;
         ReturnErrorOnFailure(deviceInfoProvider->GetLocalConfigDisabled(localConfigDisabled));
         auto decodeStatus = persistence.DecodeAndStoreNativeEndianValue(request.path, decoder, localConfigDisabled);
         ReturnErrorOnFailure(deviceInfoProvider->SetLocalConfigDisabled(localConfigDisabled));
@@ -443,9 +443,16 @@ CHIP_ERROR BasicInformationCluster::Attributes(const ConcreteClusterPath & path,
 CHIP_ERROR BasicInformationCluster::Startup(ServerClusterContext & context)
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
-    if (mDelegate->GetPlatformManager().GetDelegate() == nullptr)
+
+    // Register this cluster as the PlatformManager delegate to receive shutdown events.
+    //
+    // We only register if the PlatformManager does not currently have a delegate.
+    // This prevents the cluster from overwriting a delegate that may have been explicitly
+    // registered by the application logic. If a delegate is already present, this cluster
+    // will simply not intercept the shutdown signal via this mechanism.
+    if (mClusterContext.platformManager.GetDelegate() == nullptr)
     {
-        mDelegate->GetPlatformManager().SetDelegate(this);
+        mClusterContext.platformManager.SetDelegate(this);
     }
 
     AttributePersistence persistence(context.attributeStorage);
@@ -458,16 +465,22 @@ CHIP_ERROR BasicInformationCluster::Startup(ServerClusterContext & context)
     bool localConfigDisabled = false;
     (void) persistence.LoadNativeEndianValue<bool>({ kRootEndpointId, BasicInformation::Id, Attributes::LocalConfigDisabled::Id },
                                                    localConfigDisabled, false);
-    ReturnErrorOnFailure(mDelegate->GetDeviceInstanceInfoProvider()->SetLocalConfigDisabled(localConfigDisabled));
+
+    if (mClusterContext.deviceInstanceInfoProvider != nullptr)
+    {
+        // Propagate the restored 'LocalConfigDisabled' state to the DeviceInstanceInfoProvider
+        // so the underlying platform layer is aware of the configuration.
+        ReturnErrorOnFailure(mClusterContext.deviceInstanceInfoProvider->SetLocalConfigDisabled(localConfigDisabled));
+    }
 
     return CHIP_NO_ERROR;
 }
 
 void BasicInformationCluster::Shutdown(ClusterShutdownType shutdownType)
 {
-    if (mDelegate->GetPlatformManager().GetDelegate() == this)
+    if (mClusterContext.platformManager.GetDelegate() == this)
     {
-        mDelegate->GetPlatformManager().SetDelegate(nullptr);
+        mClusterContext.platformManager.SetDelegate(nullptr);
     }
     DefaultServerCluster::Shutdown(shutdownType);
 }

--- a/src/app/clusters/basic-information/BasicInformationCluster.h
+++ b/src/app/clusters/basic-information/BasicInformationCluster.h
@@ -38,13 +38,14 @@ namespace Clusters {
 class BasicInformationCluster : public DefaultServerCluster, public DeviceLayer::PlatformManagerDelegate
 {
 public:
-    class Delegate
+    // Define the Context struct with References
+    struct Context
     {
-    public:
-        virtual ~Delegate()                                                               = default;
-        virtual DeviceLayer::DeviceInstanceInfoProvider * GetDeviceInstanceInfoProvider() = 0;
-        virtual DeviceLayer::ConfigurationManager & GetConfigurationManager()             = 0;
-        virtual DeviceLayer::PlatformManager & GetPlatformManager()                       = 0;
+        // Using pointer as we have seen converting to reference
+        // costs some flash (even though code would be more readable that way...)
+        DeviceLayer::DeviceInstanceInfoProvider * deviceInstanceInfoProvider;
+        DeviceLayer::ConfigurationManager & configurationManager;
+        DeviceLayer::PlatformManager & platformManager;
     };
 
     using OptionalAttributesSet = chip::app::OptionalAttributeSet< //
@@ -62,9 +63,9 @@ public:
         BasicInformation::Attributes::UniqueID::Id //
         >;
 
-    BasicInformationCluster(OptionalAttributesSet optionalAttributeSet, Delegate * delegate) :
+    BasicInformationCluster(OptionalAttributesSet optionalAttributeSet, Context ctx) :
         DefaultServerCluster({ kRootEndpointId, BasicInformation::Id }), mEnabledOptionalAttributes(optionalAttributeSet),
-        mDelegate(delegate)
+        mClusterContext(ctx)
     {
         mEnabledOptionalAttributes
             .Set<BasicInformation::Attributes::UniqueID::Id>(); // Unless told otherwise, unique id is mandatory
@@ -82,7 +83,18 @@ public:
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
     // PlatformManagerDelegate
+    /**
+     * @brief Initialize the cluster
+     *
+     * This method attempts to register the cluster as the DeviceLayer::PlatformManagerDelegate
+     * to receive system shutdown events (OnShutDown).
+     * * NOTE: Registration is conditional. It will ONLY register this cluster as the delegate
+     * if the PlatformManager does not currently have a delegate set. If the application
+     * has already registered a delegate, this cluster will respect that configuration
+     * and will NOT overwrite it.
+     */
     void OnStartUp(uint32_t softwareVersion) override;
+
     void OnShutDown() override;
 
 private:
@@ -92,7 +104,7 @@ private:
     OptionalAttributesSet mEnabledOptionalAttributes;
 
     Storage::String<32> mNodeLabel;
-    Delegate * mDelegate;
+    Context mClusterContext;
 };
 
 } // namespace Clusters

--- a/src/app/clusters/basic-information/BasicInformationCluster.h
+++ b/src/app/clusters/basic-information/BasicInformationCluster.h
@@ -41,9 +41,7 @@ public:
     // Define the Context struct with References
     struct Context
     {
-        // Using pointer as we have seen converting to reference
-        // costs some flash (even though code would be more readable that way...)
-        DeviceLayer::DeviceInstanceInfoProvider * deviceInstanceInfoProvider;
+        DeviceLayer::DeviceInstanceInfoProvider & deviceInstanceInfoProvider;
         DeviceLayer::ConfigurationManager & configurationManager;
         DeviceLayer::PlatformManager & platformManager;
     };

--- a/src/app/clusters/basic-information/CodegenIntegration.cpp
+++ b/src/app/clusters/basic-information/CodegenIntegration.cpp
@@ -36,6 +36,21 @@ namespace {
 //   - we have a fixed config and it is endpoint 0 OR
 //   - we have a fully dynamic config
 
+class BasicInfoDelegate : public BasicInformationCluster::Delegate
+{
+public:
+    DeviceLayer::DeviceInstanceInfoProvider * GetDeviceInstanceInfoProvider() override
+    {
+        return DeviceLayer::GetDeviceInstanceInfoProvider();
+    }
+
+    DeviceLayer::ConfigurationManager & GetConfigurationManager() override { return DeviceLayer::ConfigurationMgr(); }
+
+    DeviceLayer::PlatformManager & GetPlatformManager() override { return DeviceLayer::PlatformMgr(); }
+};
+
+static BasicInfoDelegate gDelegate;
+
 static constexpr size_t kBasicInformationFixedClusterCount = BasicInformation::StaticApplicationConfig::kFixedClusterConfig.size();
 
 static_assert((kBasicInformationFixedClusterCount == 0) ||
@@ -59,7 +74,7 @@ public:
 
         BasicInformationCluster::OptionalAttributesSet optionalAttributeSet(optionalAttributeBits);
 
-        gServer.Create(optionalAttributeSet);
+        gServer.Create(optionalAttributeSet, &gDelegate);
 
         // This disabling of the unique id attribute is here only for test purposes. The uniqe id attribute
         // is mandatory, but was optional in previous versions. It is forced to be enabled in the basic information

--- a/src/app/clusters/basic-information/CodegenIntegration.cpp
+++ b/src/app/clusters/basic-information/CodegenIntegration.cpp
@@ -62,7 +62,7 @@ public:
         DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();
         VerifyOrDie(provider != nullptr);
 
-        BasicInformationCluster::Context context = { .deviceInstanceInfoProvider = *provider,
+        BasicInformationCluster::Context context = { .deviceInstanceInfoProvider = provider,
                                                      .configurationManager       = DeviceLayer::ConfigurationMgr(),
                                                      .platformManager            = DeviceLayer::PlatformMgr() };
         gServer.Create(optionalAttributeSet, context);

--- a/src/app/clusters/basic-information/CodegenIntegration.cpp
+++ b/src/app/clusters/basic-information/CodegenIntegration.cpp
@@ -62,7 +62,7 @@ public:
         DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();
         VerifyOrDie(provider != nullptr);
 
-        BasicInformationCluster::Context context = { .deviceInstanceInfoProvider = provider,
+        BasicInformationCluster::Context context = { .deviceInstanceInfoProvider = *provider,
                                                      .configurationManager       = DeviceLayer::ConfigurationMgr(),
                                                      .platformManager            = DeviceLayer::PlatformMgr() };
         gServer.Create(optionalAttributeSet, context);

--- a/src/app/clusters/basic-information/CodegenIntegration.cpp
+++ b/src/app/clusters/basic-information/CodegenIntegration.cpp
@@ -36,21 +36,6 @@ namespace {
 //   - we have a fixed config and it is endpoint 0 OR
 //   - we have a fully dynamic config
 
-class BasicInfoDelegate : public BasicInformationCluster::Delegate
-{
-public:
-    DeviceLayer::DeviceInstanceInfoProvider * GetDeviceInstanceInfoProvider() override
-    {
-        return DeviceLayer::GetDeviceInstanceInfoProvider();
-    }
-
-    DeviceLayer::ConfigurationManager & GetConfigurationManager() override { return DeviceLayer::ConfigurationMgr(); }
-
-    DeviceLayer::PlatformManager & GetPlatformManager() override { return DeviceLayer::PlatformMgr(); }
-};
-
-static BasicInfoDelegate gDelegate;
-
 static constexpr size_t kBasicInformationFixedClusterCount = BasicInformation::StaticApplicationConfig::kFixedClusterConfig.size();
 
 static_assert((kBasicInformationFixedClusterCount == 0) ||
@@ -74,7 +59,13 @@ public:
 
         BasicInformationCluster::OptionalAttributesSet optionalAttributeSet(optionalAttributeBits);
 
-        gServer.Create(optionalAttributeSet, &gDelegate);
+        DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();
+        VerifyOrDie(provider != nullptr);
+
+        BasicInformationCluster::Context context = { .deviceInstanceInfoProvider = *provider,
+                                                     .configurationManager       = DeviceLayer::ConfigurationMgr(),
+                                                     .platformManager            = DeviceLayer::PlatformMgr() };
+        gServer.Create(optionalAttributeSet, context);
 
         // This disabling of the unique id attribute is here only for test purposes. The uniqe id attribute
         // is mandatory, but was optional in previous versions. It is forced to be enabled in the basic information

--- a/src/app/clusters/basic-information/tests/BUILD.gn
+++ b/src/app/clusters/basic-information/tests/BUILD.gn
@@ -20,7 +20,8 @@ import("${chip_root}/build/chip/chip_test_suite.gni")
 chip_test_suite("tests") {
   output_name = "libTestBasicInformationCluster"
 
-  test_sources = [ "TestBasicInformationCluster.cpp",
+  test_sources = [
+    "TestBasicInformationCluster.cpp",
     "TestBasicInformationReadWrite.cpp",
   ]
 

--- a/src/app/clusters/basic-information/tests/BUILD.gn
+++ b/src/app/clusters/basic-information/tests/BUILD.gn
@@ -20,14 +20,9 @@ import("${chip_root}/build/chip/chip_test_suite.gni")
 chip_test_suite("tests") {
   output_name = "libTestBasicInformationCluster"
 
-  test_sources = [ "TestBasicInformationCluster.cpp" ]
-
-  # The following tests are excluded for NXP / FREERTOS
-  # because the ConfigurationManagerImpl is defined final
-  # and does not allow to override methods to provide mock values.
-  if (chip_device_platform != "nxp") {
-    test_sources += [ "TestBasicInformationReadWrite.cpp" ]
-  }
+  test_sources = [ "TestBasicInformationCluster.cpp",
+    "TestBasicInformationReadWrite.cpp",
+  ]
 
   cflags = [ "-Wconversion" ]
 

--- a/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
@@ -131,7 +131,6 @@ class MockDelegate : public BasicInformationCluster::Delegate
 {
 public:
     DeviceLayer::DeviceInstanceInfoProvider * GetDeviceInstanceInfoProvider() override { return &mDeviceInfoProvider; }
-    // You can stub these or mock them if needed for specific tests
     DeviceLayer::ConfigurationManager & GetConfigurationManager() override { return chip::DeviceLayer::ConfigurationMgr(); }
     DeviceLayer::PlatformManager & GetPlatformManager() override { return chip::DeviceLayer::PlatformMgr(); }
 

--- a/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
@@ -127,23 +127,17 @@ public:
 
     CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override { return CHIP_NO_ERROR; }
 };
-class MockDelegate : public BasicInformationCluster::Delegate
-{
-public:
-    DeviceLayer::DeviceInstanceInfoProvider * GetDeviceInstanceInfoProvider() override { return &mDeviceInfoProvider; }
-    DeviceLayer::ConfigurationManager & GetConfigurationManager() override { return chip::DeviceLayer::ConfigurationMgr(); }
-    DeviceLayer::PlatformManager & GetPlatformManager() override { return chip::DeviceLayer::PlatformMgr(); }
 
-private:
-    MockDeviceInstanceInfoProvider mDeviceInfoProvider;
-};
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestBasicInformationCluster : public ::testing::Test
 {
+    MockDeviceInstanceInfoProvider mDeviceInfoProvider;
+    BasicInformationCluster::Context mContext = { .deviceInstanceInfoProvider = &mDeviceInfoProvider,
+                                                  .configurationManager       = chip::DeviceLayer::ConfigurationMgr(),
+                                                  .platformManager            = chip::DeviceLayer::PlatformMgr() };
+
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
-
-    MockDelegate mDelegate;
 };
 
 TEST_F(TestBasicInformationCluster, TestAttributes)
@@ -152,7 +146,7 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
     // check without optional attributes
     {
         const BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
-        BasicInformationCluster cluster(optionalAttributeSet, &mDelegate);
+        BasicInformationCluster cluster(optionalAttributeSet, mContext);
 
         EXPECT_TRUE(Testing::IsAttributesListEqualTo(
             cluster,
@@ -170,7 +164,7 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
     // Check that disabling unique id works
     {
         const BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
-        BasicInformationCluster cluster(optionalAttributeSet, &mDelegate);
+        BasicInformationCluster cluster(optionalAttributeSet, mContext);
 
         // UniqueID is EXPLICITLY NOT SET
         cluster.OptionalAttributes() = BasicInformationCluster::OptionalAttributesSet();
@@ -208,7 +202,7 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
                                                                                         .Set<ProductAppearance::Id>()
                                                                                         .Set<UniqueID::Id>();
 
-        BasicInformationCluster cluster(optionalAttributeSet, &mDelegate);
+        BasicInformationCluster cluster(optionalAttributeSet, mContext);
 
         EXPECT_TRUE(Testing::IsAttributesListEqualTo(cluster,
 

--- a/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
@@ -132,7 +132,7 @@ public:
 struct TestBasicInformationCluster : public ::testing::Test
 {
     MockDeviceInstanceInfoProvider mDeviceInfoProvider;
-    BasicInformationCluster::Context mContext = { .deviceInstanceInfoProvider = &mDeviceInfoProvider,
+    BasicInformationCluster::Context mContext = { .deviceInstanceInfoProvider = mDeviceInfoProvider,
                                                   .configurationManager       = chip::DeviceLayer::ConfigurationMgr(),
                                                   .platformManager            = chip::DeviceLayer::PlatformMgr() };
 

--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -301,7 +301,7 @@ struct TestBasicInformationReadWrite : public ::testing::Test
     MockDeviceInstanceInfoProvider mDeviceInfoProvider;
     MockConfigurationManager mMockConfigurationManager;
     BasicInformationCluster::Context mContext = {
-        .deviceInstanceInfoProvider = &mDeviceInfoProvider,
+        .deviceInstanceInfoProvider = mDeviceInfoProvider,
         .configurationManager       = mMockConfigurationManager,
         .platformManager            = chip::DeviceLayer::PlatformMgr(),
     };

--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -168,19 +168,16 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion) override { return CHIP_NO_ERROR; }
-
     // ========================================================================
     // Stubs required to satisfy the ConfigurationManager Interface
     // ========================================================================
 
     CHIP_ERROR Init() override { return CHIP_NO_ERROR; }
 
-    // --- Missing Stubs (Fixes "abstract class" errors) ---
     CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan & buf) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
     CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-
+    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion) override { return CHIP_NO_ERROR; }
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
     CHIP_ERROR GetFirmwareBuildChipEpochTime(System::Clock::Seconds32 & buildTime) override
     {
@@ -216,6 +213,12 @@ public:
     CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
     CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
     CHIP_ERROR GetSecondaryPairingInstruction(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+#if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID)
+    CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+    CHIP_ERROR IncrementLifetimeCounter() override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+    CHIP_ERROR SetRotatingDeviceIdUniqueId(const ByteSpan & uniqueIdSpan) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+    CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+#endif
 
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override
     {
@@ -267,8 +270,6 @@ private:
     char mCountryCode[kCountryCodeLength + 1] = "XX";
 };
 
-static DeviceLayer::DeviceInstanceInfoProvider * sDeviceInstanceInfoProviderBackup = nullptr;
-
 class MockDelegate : public BasicInformationCluster::Delegate
 {
 public:
@@ -284,16 +285,19 @@ struct TestBasicInformationReadWrite : public ::testing::Test
     static void SetUpTestSuite()
     {
         ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
-#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+
+        // Back up any existing DeviceInstanceInfoProvider and install the mock provider. This is required on platforms that build
+        // all unit tests into a single binary(e.g. Nordic), where global DeviceLayer state persists across test suites.
+        // DeviceInstanceInfoProvider has no universal default and cannot be reliably reset via Init/Shutdown, so without this
+        // backup/restore the mock would leak into subsequent tests.
         sDeviceInstanceInfoProviderBackup = DeviceLayer::TestOnlyTryGetDeviceInstanceInfoProvider();
-#endif
     }
 
     static void TearDownTestSuite()
     {
         // For the DeviceInstanceInfoProvider there is no default instance. Restore the provider that was installed prior to this
         // test suite, if any.
-        if (sDeviceInstanceInfoProviderBackup)
+        if (sDeviceInstanceInfoProviderBackup != nullptr)
         {
             DeviceLayer::SetDeviceInstanceInfoProvider(sDeviceInstanceInfoProviderBackup);
         }
@@ -303,8 +307,11 @@ struct TestBasicInformationReadWrite : public ::testing::Test
 
     TestBasicInformationReadWrite() {}
     chip::Testing::TestServerClusterContext testContext;
+    static DeviceLayer::DeviceInstanceInfoProvider * sDeviceInstanceInfoProviderBackup;
     MockDelegate mDelegate;
 };
+
+DeviceLayer::DeviceInstanceInfoProvider * TestBasicInformationReadWrite::sDeviceInstanceInfoProviderBackup = nullptr;
 
 TEST_F(TestBasicInformationReadWrite, TestNodeLabelLoadAndSave)
 {

--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -145,10 +145,14 @@ private:
 static constexpr size_t kCountryCodeLength = 2;
 static constexpr const char * kUniqueId    = "TEST_UNIQUE_ID_12345";
 // Mock ConfigurationManager for testing
-class MockConfigurationManager : public chip::DeviceLayer::ConfigurationManagerImpl
+class MockConfigurationManager : public chip::DeviceLayer::ConfigurationManager
 {
 public:
+    // ========================================================================
+    // Methods used by the Test Logic
+    // ========================================================================
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kUniqueId); }
+
     CHIP_ERROR StoreCountryCode(const char * countryCode, size_t countryCodeLen) override
     {
         VerifyOrReturnError(countryCodeLen == kCountryCodeLength, CHIP_ERROR_INVALID_ARGUMENT);
@@ -164,13 +168,106 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    // The following methods does not have implementation on Linux, so we provide
-    // a stub that returns success.
     CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion) override { return CHIP_NO_ERROR; }
+
+    // ========================================================================
+    // Stubs required to satisfy the ConfigurationManager Interface
+    // ========================================================================
+
+    CHIP_ERROR Init() override { return CHIP_NO_ERROR; }
+
+    // --- Missing Stubs (Fixes "abstract class" errors) ---
+    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan & buf) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+    CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+
+    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+    CHIP_ERROR GetFirmwareBuildChipEpochTime(System::Clock::Seconds32 & buildTime) override
+    {
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
+
+    CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR StoreSoftwareVersion(uint32_t softwareVer) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR StoreHardwareVersion(uint16_t hardwareVer) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR StoreRegulatoryLocation(uint8_t location) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+
+    CHIP_ERROR GetFailSafeArmed(bool & val) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+    CHIP_ERROR SetFailSafeArmed(bool val) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+
+    CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) override
+    {
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
+
+    void RunUnitTests() override {}
+    bool IsFullyProvisioned() override { return false; }
+    void LogDeviceConfig() override {}
+
+    bool IsCommissionableDeviceTypeEnabled() override { return false; }
+    CHIP_ERROR GetDeviceTypeId(uint32_t & deviceType) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+    bool IsCommissionableDeviceNameEnabled() override { return false; }
+    CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+
+    CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+    CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+    CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+    CHIP_ERROR GetSecondaryPairingInstruction(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
+
+    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override
+    {
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
+    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetRebootCount(uint32_t & v) override
+    {
+        v = 0;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR StoreRebootCount(uint32_t) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR GetTotalOperationalHours(uint32_t & v) override
+    {
+        v = 0;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR StoreTotalOperationalHours(uint32_t) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR GetBootReason(uint32_t & v) override
+    {
+        v = 0;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR StoreBootReason(uint32_t) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR GetRegulatoryLocation(uint8_t & loc) override
+    {
+        loc = 0;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR GetLocationCapability(uint8_t & cap) override
+    {
+        cap = 0;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR GetConfigurationVersion(uint32_t & v) override
+    {
+        v = 1;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR StoreConfigurationVersion(uint32_t) override { return CHIP_NO_ERROR; }
+    bool CanFactoryReset() override { return false; }
+    void InitiateFactoryReset() override {}
 
 private:
     char mCountryCode[kCountryCodeLength + 1] = "XX";
 };
+
+static DeviceLayer::DeviceInstanceInfoProvider * sDeviceInstanceInfoProviderBackup = nullptr;
 
 class MockDelegate : public BasicInformationCluster::Delegate
 {
@@ -184,13 +281,19 @@ public:
 };
 struct TestBasicInformationReadWrite : public ::testing::Test
 {
-    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void SetUpTestSuite()
+    {
+        ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+        sDeviceInstanceInfoProviderBackup = DeviceLayer::TestOnlyTryGetDeviceInstanceInfoProvider();
+#endif
+    }
 
     static void TearDownTestSuite()
     {
         // For the DeviceInstanceInfoProvider there is no default instance. Restore the provider that was installed prior to this
         // test suite, if any.
-        if (sDeviceInstanceInfoProviderBackup != nullptr)
+        if (sDeviceInstanceInfoProviderBackup)
         {
             DeviceLayer::SetDeviceInstanceInfoProvider(sDeviceInstanceInfoProviderBackup);
         }

--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -269,17 +269,6 @@ public:
 private:
     char mCountryCode[kCountryCodeLength + 1] = "XX";
 };
-
-class MockDelegate : public BasicInformationCluster::Delegate
-{
-public:
-    DeviceLayer::DeviceInstanceInfoProvider * GetDeviceInstanceInfoProvider() override { return &mDeviceInfoProvider; }
-    DeviceLayer::ConfigurationManager & GetConfigurationManager() override { return mMockConfigurationManager; }
-    DeviceLayer::PlatformManager & GetPlatformManager() override { return chip::DeviceLayer::PlatformMgr(); }
-
-    MockConfigurationManager mMockConfigurationManager;
-    MockDeviceInstanceInfoProvider mDeviceInfoProvider;
-};
 struct TestBasicInformationReadWrite : public ::testing::Test
 {
     static void SetUpTestSuite()
@@ -308,7 +297,14 @@ struct TestBasicInformationReadWrite : public ::testing::Test
     TestBasicInformationReadWrite() {}
     chip::Testing::TestServerClusterContext testContext;
     static DeviceLayer::DeviceInstanceInfoProvider * sDeviceInstanceInfoProviderBackup;
-    MockDelegate mDelegate;
+    // Context
+    MockDeviceInstanceInfoProvider mDeviceInfoProvider;
+    MockConfigurationManager mMockConfigurationManager;
+    BasicInformationCluster::Context mContext = {
+        .deviceInstanceInfoProvider = &mDeviceInfoProvider,
+        .configurationManager       = mMockConfigurationManager,
+        .platformManager            = chip::DeviceLayer::PlatformMgr(),
+    };
 };
 
 DeviceLayer::DeviceInstanceInfoProvider * TestBasicInformationReadWrite::sDeviceInstanceInfoProviderBackup = nullptr;
@@ -316,7 +312,7 @@ DeviceLayer::DeviceInstanceInfoProvider * TestBasicInformationReadWrite::sDevice
 TEST_F(TestBasicInformationReadWrite, TestNodeLabelLoadAndSave)
 {
     const BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
-    BasicInformationCluster cluster(optionalAttributeSet, &mDelegate);
+    BasicInformationCluster cluster(optionalAttributeSet, mContext);
     ASSERT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
     chip::Testing::ClusterTester tester(cluster);
 
@@ -371,7 +367,7 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
 
     BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
     optionalAttributeSet.Set<Attributes::ManufacturingDate::Id>();
-    BasicInformationCluster cluster(optionalAttributeSet, &mDelegate);
+    BasicInformationCluster cluster(optionalAttributeSet, mContext);
     chip::Testing::ClusterTester tester(cluster);
 
     // VendorName
@@ -445,10 +441,10 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
     {
         char buf[32];
         CharSpan val(buf);
-        mDelegate.mDeviceInfoProvider.SetManufacturingDateSuffix("ABCDEFGH");
+        mDeviceInfoProvider.SetManufacturingDateSuffix("ABCDEFGH");
         ASSERT_EQ(tester.ReadAttribute(Attributes::ManufacturingDate::Id, val), CHIP_NO_ERROR);
         EXPECT_TRUE(val.data_equal("20230615ABCDEFGH"_span));
-        mDelegate.mDeviceInfoProvider.SetManufacturingDateSuffix(nullptr);
+        mDeviceInfoProvider.SetManufacturingDateSuffix(nullptr);
     }
 
     // UniqueID (Mandatory in Rev 4+, so if it fails, cluster rev must be < 4)
@@ -497,7 +493,7 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
 TEST_F(TestBasicInformationReadWrite, TestWriteNodeLabel)
 {
     const BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
-    BasicInformationCluster cluster(optionalAttributeSet, &mDelegate);
+    BasicInformationCluster cluster(optionalAttributeSet, mContext);
     ASSERT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
     chip::Testing::ClusterTester tester(cluster);
 
@@ -519,7 +515,7 @@ TEST_F(TestBasicInformationReadWrite, TestWriteNodeLabel)
 TEST_F(TestBasicInformationReadWrite, TestWriteLocation)
 {
     const BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
-    BasicInformationCluster cluster(optionalAttributeSet, &mDelegate);
+    BasicInformationCluster cluster(optionalAttributeSet, mContext);
     ASSERT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
     chip::Testing::ClusterTester tester(cluster);
 
@@ -553,7 +549,7 @@ TEST_F(TestBasicInformationReadWrite, TestWriteLocalConfigDisabled)
 
     BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
     optionalAttributeSet.Set<Attributes::LocalConfigDisabled::Id>();
-    BasicInformationCluster cluster(optionalAttributeSet, &mDelegate);
+    BasicInformationCluster cluster(optionalAttributeSet, mContext);
     ASSERT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
     chip::Testing::ClusterTester tester(cluster);
 


### PR DESCRIPTION
#### Summary

Refactors `BasicInformationCluster` to use dependency injection for platform services.

* Introduced `BasicInformationCluster::Context` to supply `DeviceInstanceInfoProvider`, `ConfigurationManager`, and `PlatformManager`.
* Removed direct calls to global singletons (e.g., `DeviceLayer::ConfigurationMgr()`) within the cluster logic to improve decoupling and testability.
* Updated `RootNodeDevice` and `CodegenIntegration` to inject dependencies using the existing global instances from the application main / registration points.
* Added logic to safely register the cluster as a `PlatformManager` delegate (only if a delegate is not already set).

#### Related issues

Fixes #42602

#### Testing

* Updated `TestBasicInformationCluster` and `TestBasicInformationReadWrite` to use the new `Context` structure with mock objects.
* Verified that existing tests pass with the new dependency injection model.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

* [x] PR title is
[[descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
* [x] Apply the
*[[“When in Rome…”](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)*
rule (coding style)
* [x] PR size is short
* [ ] Try to avoid "squashing" and "force-update" in commit history
* [x] CI time didn't increase
