### PR TITLE
Fix undefined reference in FaultInjectionOptions

### DIFF
--- a/src/inet/tests/TestInetCommonOptions.cpp
+++ b/src/inet/tests/TestInetCommonOptions.cpp
@@ -44,7 +44,9 @@ using namespace chip::Inet;
 // Global Variables
 
 NetworkOptions gNetworkOptions;
+#if defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
 FaultInjectionOptions gFaultInjectionOptions;
+#endif  // defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
 
 NetworkOptions::NetworkOptions()
 {

--- a/src/inet/tests/TestInetCommonOptions.cpp
+++ b/src/inet/tests/TestInetCommonOptions.cpp
@@ -46,7 +46,7 @@ using namespace chip::Inet;
 NetworkOptions gNetworkOptions;
 #if defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
 FaultInjectionOptions gFaultInjectionOptions;
-#endif  // defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
+#endif // defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
 
 NetworkOptions::NetworkOptions()
 {

--- a/src/inet/tests/TestInetCommonOptions.h
+++ b/src/inet/tests/TestInetCommonOptions.h
@@ -94,4 +94,4 @@ public:
 };
 
 extern FaultInjectionOptions gFaultInjectionOptions;
-#endif  // defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
+#endif // defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION

--- a/src/inet/tests/TestInetCommonOptions.h
+++ b/src/inet/tests/TestInetCommonOptions.h
@@ -76,6 +76,7 @@ public:
 
 extern NetworkOptions gNetworkOptions;
 
+#if defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
 /**
  * Handler for options that control fault injection testing behavior.
  */
@@ -93,3 +94,4 @@ public:
 };
 
 extern FaultInjectionOptions gFaultInjectionOptions;
+#endif  // defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION

--- a/src/inet/tests/TestSetupFaultInjectionPosix.cpp
+++ b/src/inet/tests/TestSetupFaultInjectionPosix.cpp
@@ -138,11 +138,13 @@ static bool PrintFaultInjectionMaxArgCbFn(nl::FaultInjection::Manager & mgr, nl:
 {
     const char * faultName = mgr.GetFaultNames()[aId];
 
+#if defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
     if (gFaultInjectionOptions.PrintFaultCounters && aFaultRecord->mNumArguments)
     {
         printf("FI_instance_params: %s_%s_s%" PRIu32 " maxArg: %" PRIi32 ";\n", mgr.GetName(), faultName,
                aFaultRecord->mNumTimesChecked, aFaultRecord->mArguments[0]);
     }
+#endif  // defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
 
     return false;
 }

--- a/src/inet/tests/TestSetupFaultInjectionPosix.cpp
+++ b/src/inet/tests/TestSetupFaultInjectionPosix.cpp
@@ -144,7 +144,7 @@ static bool PrintFaultInjectionMaxArgCbFn(nl::FaultInjection::Manager & mgr, nl:
         printf("FI_instance_params: %s_%s_s%" PRIu32 " maxArg: %" PRIi32 ";\n", mgr.GetName(), faultName,
                aFaultRecord->mNumTimesChecked, aFaultRecord->mArguments[0]);
     }
-#endif  // defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
+#endif // defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
 
     return false;
 }

--- a/src/inet/tests/inet-layer-test-tool.cpp
+++ b/src/inet/tests/inet-layer-test-tool.cpp
@@ -178,7 +178,9 @@ static OptionSet *       sToolOptionSets[] =
 {
     &sToolOptions,
     &gNetworkOptions,
+#if defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
     &gFaultInjectionOptions,
+#endif  // defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
     &sHelpOptions,
     nullptr
 };


### PR DESCRIPTION
#### Summary

If CHIP_WITH_NLFAULTINJECTION is not defined and the linker is passed --no-allow-shlib-undefined the build fails because FaultInjectionOptions::HandleOption is undefined:

ld: error: undefined reference: vtable for FaultInjectionOptions

#### Testing

Built without CHIP_WITH_NLFAULTINJECTION defined.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
