### PR TITLE
Add and Leverage 'WirelessSignalType' and 'WirelessSignal' Enumeration and Aggregate Type

### DIFF
--- a/src/app/clusters/network-commissioning/WifiScanResponse.cpp
+++ b/src/app/clusters/network-commissioning/WifiScanResponse.cpp
@@ -56,7 +56,10 @@ CHIP_ERROR WifiScanResponseToTLV::EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag
                 result.bssid    = ByteSpan(scanResponse.bssid, sizeof(scanResponse.bssid));
                 result.channel  = scanResponse.channel;
                 result.wiFiBand = scanResponse.wiFiBand;
-                result.rssi     = scanResponse.rssi;
+                if (scanResponse.signal.type == DeviceLayer::NetworkCommissioning::WirelessSignalType::kdBm)
+                    result.rssi = scanResponse.signal.strength;
+                else
+                    result.rssi = 0;
                 ReturnErrorOnFailure(DataModel::Encode(writer, TLV::AnonymousTag(), result));
 
                 ++networksEncoded;

--- a/src/app/clusters/network-commissioning/tests/TestWifiResponse.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestWifiResponse.cpp
@@ -89,34 +89,28 @@ TEST_F(TestWifiResponseEncoding, TestErrorEncode)
 
 TEST_F(TestWifiResponseEncoding, TestSuccessEncode)
 {
-    TestResponseIterator<3> fakeResponses{ WiFiScanResponse{
-                                               .security = BitFlags<WiFiSecurityBitmap>(WiFiSecurityBitmap::kWpa2Personal),
-                                               .ssid     = { 'f', 'o', 'o', 0 },
-                                               .ssidLen  = 3,
-                                               .bssid    = { '1', '2', '3', '4', 0 },
-                                               .channel  = 123,
-                                               .wiFiBand = WiFiBandEnum::k5g,
-                                               .rssi     = 10,
-                                           },
-                                           WiFiScanResponse{
-                                               .security = BitFlags<WiFiSecurityBitmap>(WiFiSecurityBitmap::kWpa2Personal),
-                                               .ssid     = { 'b', 'a', 'r', 0 },
-                                               .ssidLen  = 3,
-                                               .bssid    = { 'x', 'y', 'z', 0 },
-                                               .channel  = 321,
-                                               .wiFiBand = WiFiBandEnum::k2g4,
-                                               .rssi     = 20,
-                                           },
-                                           WiFiScanResponse{
-                                               .security = BitFlags<WiFiSecurityBitmap>(WiFiSecurityBitmap::kWpa2Personal),
-                                               .ssid     = { 'b', 'a', 0 },
-                                               .ssidLen  = 2,
-                                               .bssid    = { 'z', 'z', 'z', 0 },
-                                               .channel  = 100,
-                                               .wiFiBand = WiFiBandEnum::k2g4,
-                                               .rssi     = 15,
-                                           }
-
+    TestResponseIterator<3> fakeResponses{
+        WiFiScanResponse{ .security = BitFlags<WiFiSecurityBitmap>(WiFiSecurityBitmap::kWpa2Personal),
+                          .ssid     = { 'f', 'o', 'o', 0 },
+                          .ssidLen  = 3,
+                          .bssid    = { '1', '2', '3', '4', 0 },
+                          .channel  = 123,
+                          .wiFiBand = WiFiBandEnum::k5g,
+                          .signal   = { .type = WirelessSignalType::kdBm, .strength = 10 } },
+        WiFiScanResponse{ .security = BitFlags<WiFiSecurityBitmap>(WiFiSecurityBitmap::kWpa2Personal),
+                          .ssid     = { 'b', 'a', 'r', 0 },
+                          .ssidLen  = 3,
+                          .bssid    = { 'x', 'y', 'z', 0 },
+                          .channel  = 321,
+                          .wiFiBand = WiFiBandEnum::k2g4,
+                          .signal   = { .type = WirelessSignalType::kdBm, .strength = 20 } },
+        WiFiScanResponse{ .security = BitFlags<WiFiSecurityBitmap>(WiFiSecurityBitmap::kWpa2Personal),
+                          .ssid     = { 'b', 'a', 0 },
+                          .ssidLen  = 2,
+                          .bssid    = { 'z', 'z', 'z', 0 },
+                          .channel  = 100,
+                          .wiFiBand = WiFiBandEnum::k2g4,
+                          .signal   = { .type = WirelessSignalType::kdBm, .strength = 15 } }
     };
     WifiScanResponseToTLV encoder(NetworkCommissioningStatusEnum::kSuccess, ""_span, &fakeResponses);
 

--- a/src/include/platform/NetworkCommissioning.h
+++ b/src/include/platform/NetworkCommissioning.h
@@ -95,6 +95,28 @@ struct Network
 static_assert(sizeof(Network::networkID) <= std::numeric_limits<decltype(Network::networkIDLen)>::max(),
               "Max length of networkID ssid exceeds the limit of networkIDLen field");
 
+/**
+ *  Wireless signal strength assessment or measurement type.
+ */
+enum class WirelessSignalType
+{
+    /**
+     *  No signal strength information available.
+     */
+    kNone,
+
+    /**
+     *  Signal strength is quantitative, in dBm.
+     */
+    kdBm,
+
+    /**
+     *  Signal strength is qualitative, increasing from 0 (none/worst)
+     *  to 100 (best).
+     */
+    kQualitative
+};
+
 struct WiFiScanResponse
 {
 public:

--- a/src/include/platform/NetworkCommissioning.h
+++ b/src/include/platform/NetworkCommissioning.h
@@ -117,6 +117,26 @@ enum class WirelessSignalType
     kQualitative
 };
 
+/**
+ *  Wireless signal type and strength assessment.
+ */
+struct WirelessSignal
+{
+    /**
+     *  Wireless signal strength assessment or measurement type.
+     *
+     *  This determines how to interpret @a strength.
+     */
+    WirelessSignalType type;
+
+    /**
+     *  Wireless signal strength assessment or measurement.
+     *
+     *  This is interpretted based on @a type.
+     */
+    int8_t strength;
+};
+
 struct WiFiScanResponse
 {
 public:

--- a/src/include/platform/NetworkCommissioning.h
+++ b/src/include/platform/NetworkCommissioning.h
@@ -139,14 +139,13 @@ struct WirelessSignal
 
 struct WiFiScanResponse
 {
-public:
     chip::BitFlags<app::Clusters::NetworkCommissioning::WiFiSecurityBitmap> security;
     uint8_t ssid[DeviceLayer::Internal::kMaxWiFiSSIDLength];
     uint8_t ssidLen;
     uint8_t bssid[6];
     uint16_t channel;
     app::Clusters::NetworkCommissioning::WiFiBandEnum wiFiBand;
-    int8_t rssi;
+    WirelessSignal signal;
 };
 
 static_assert(sizeof(WiFiScanResponse::ssid) <= std::numeric_limits<decltype(WiFiScanResponse::ssidLen)>::max(),

--- a/src/platform/ASR/NetworkCommissioningDriver.h
+++ b/src/platform/ASR/NetworkCommissioningDriver.h
@@ -56,9 +56,10 @@ public:
         item.security.SetRaw(mpScanResults[mIternum].security);
         item.ssidLen = static_cast<uint8_t>(
             strnlen(reinterpret_cast<const char *>(mpScanResults[mIternum].ssid), chip::DeviceLayer::Internal::kMaxWiFiSSIDLength));
-        item.channel  = mpScanResults[mIternum].channel;
-        item.wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
-        item.rssi     = mpScanResults[mIternum].ap_power;
+        item.channel         = mpScanResults[mIternum].channel;
+        item.wiFiBand        = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
+        item.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        item.signal.strength = mpScanResults[mIternum].ap_power;
         memcpy(item.ssid, mpScanResults[mIternum].ssid, item.ssidLen);
         memcpy(item.bssid, mpScanResults[mIternum].bssid, 6);
 

--- a/src/platform/Ameba/NetworkCommissioningDriver.h
+++ b/src/platform/Ameba/NetworkCommissioningDriver.h
@@ -43,10 +43,11 @@ public:
 
         // copy the available information into WiFiScanResponse struct, which will be copied to the result to be sent
         item.security.SetRaw(mpScanResults[mIternum].security);
-        item.ssidLen  = mpScanResults[mIternum].SSID.len;
-        item.channel  = mpScanResults[mIternum].channel;
-        item.wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
-        item.rssi     = mpScanResults[mIternum].signal_strength;
+        item.ssidLen         = mpScanResults[mIternum].SSID.len;
+        item.channel         = mpScanResults[mIternum].channel;
+        item.wiFiBand        = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
+        item.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        item.signal.strength = mpScanResults[mIternum].signal_strength;
         memcpy(item.ssid, mpScanResults[mIternum].SSID.val, item.ssidLen);
         memcpy(item.bssid, mpScanResults[mIternum].BSSID.octet, 6);
 

--- a/src/platform/Beken/NetworkCommissioningDriver.h
+++ b/src/platform/Beken/NetworkCommissioningDriver.h
@@ -44,10 +44,11 @@ public:
         }
         uint8_t ssidlenth = strlen(mpScanResults->aps[mIternum].ssid);
         item.security.SetRaw(NC_SECURITYCONVERT(mpScanResults->aps[mIternum].security));
-        item.ssidLen  = ssidlenth;
-        item.channel  = mpScanResults->aps[mIternum].channel;
-        item.wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
-        item.rssi     = mpScanResults->aps[mIternum].rssi;
+        item.ssidLen         = ssidlenth;
+        item.channel         = mpScanResults->aps[mIternum].channel;
+        item.wiFiBand        = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
+        item.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        item.signal.strength = mpScanResults->aps[mIternum].rssi;
         memcpy(item.ssid, mpScanResults->aps[mIternum].ssid, ssidlenth);
         memcpy(item.bssid, mpScanResults->aps[mIternum].bssid, 6);
 

--- a/src/platform/Darwin/WiFi/NetworkCommissioningWiFiDriver.mm
+++ b/src/platform/Darwin/WiFi/NetworkCommissioningWiFiDriver.mm
@@ -75,7 +75,8 @@ private:
         destination.security = GetWiFiSecurity(source);
         destination.channel = static_cast<uint16_t>(source.wlanChannel.channelNumber);
         destination.wiFiBand = GetWiFiBand(source.wlanChannel);
-        destination.rssi = static_cast<int8_t>(source.rssiValue);
+        destination.signal.type = NetworkCommissioning::WirelessSignalType::kdBm;
+        destination.signal.strength = static_cast<int8_t>(source.rssiValue);
 
         NSData * ssidData = source.ssidData;
         destination.ssidLen = static_cast<uint8_t>(std::min(ssidData.length, DeviceLayer::Internal::kMaxWiFiSSIDLength));

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -80,9 +80,10 @@ private:
         static_assert(chip::DeviceLayer::Internal::kMaxWiFiSSIDLength <= UINT8_MAX, "SSID length might not fit in item.ssidLen");
         item.ssidLen = static_cast<uint8_t>(
             strnlen(reinterpret_cast<const char *>(ap_record.ssid), chip::DeviceLayer::Internal::kMaxWiFiSSIDLength));
-        item.channel  = ap_record.primary;
-        item.wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
-        item.rssi     = ap_record.rssi;
+        item.channel         = ap_record.primary;
+        item.wiFiBand        = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
+        item.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        item.signal.strength = ap_record.rssi;
         memcpy(item.ssid, ap_record.ssid, item.ssidLen);
         memcpy(item.bssid, ap_record.bssid, sizeof(item.bssid));
     }

--- a/src/platform/Infineon/PSOC6/NetworkCommissioningDriver.h
+++ b/src/platform/Infineon/PSOC6/NetworkCommissioningDriver.h
@@ -47,11 +47,12 @@ public:
         item.security.SetRaw(mpScanResults[mIternum].security);
         item.ssidLen =
             strnlen(reinterpret_cast<const char *>(mpScanResults[mIternum].SSID), chip::DeviceLayer::Internal::kMaxWiFiSSIDLength);
-        item.channel  = mpScanResults[mIternum].channel;
-        item.wiFiBand = (mpScanResults[mIternum].band == CY_WCM_WIFI_BAND_2_4GHZ)
-            ? chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4
-            : chip::DeviceLayer::NetworkCommissioning::WiFiBand::k5g;
-        item.rssi     = mpScanResults[mIternum].signal_strength;
+        item.channel         = mpScanResults[mIternum].channel;
+        item.wiFiBand        = (mpScanResults[mIternum].band == CY_WCM_WIFI_BAND_2_4GHZ)
+                   ? chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4
+                   : chip::DeviceLayer::NetworkCommissioning::WiFiBand::k5g;
+        item.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        item.signal.strength = mpScanResults[mIternum].signal_strength;
         memcpy(item.ssid, mpScanResults[mIternum].SSID, item.ssidLen);
         memcpy(item.bssid, mpScanResults[mIternum].BSSID, 6);
 

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -1498,18 +1498,19 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
     VerifyOrReturnError(bssidLen == kWiFiBSSIDLength, false);
     memcpy(result.ssid, ssidStr, ssidLen);
     memcpy(result.bssid, bssidBuf, bssidLen);
-    result.ssidLen = ssidLen;
+    result.ssidLen     = ssidLen;
+    result.signal.type = NetworkCommissioning::WirelessSignalType::kdBm;
     if (signal < INT8_MIN)
     {
-        result.rssi = INT8_MIN;
+        result.signal.strength = INT8_MIN;
     }
     else if (signal > INT8_MAX)
     {
-        result.rssi = INT8_MAX;
+        result.signal.strength = INT8_MAX;
     }
     else
     {
-        result.rssi = static_cast<uint8_t>(signal);
+        result.signal.strength = static_cast<uint8_t>(signal);
     }
 
     auto bandInfo   = GetBandAndChannelFromFrequency(frequency);

--- a/src/platform/NuttX/ConnectivityManagerImpl.cpp
+++ b/src/platform/NuttX/ConnectivityManagerImpl.cpp
@@ -1795,18 +1795,19 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
     VerifyOrReturnError(bssidLen == kWiFiBSSIDLength, false);
     memcpy(result.ssid, ssidStr, ssidLen);
     memcpy(result.bssid, bssidBuf, bssidLen);
-    result.ssidLen = ssidLen;
+    result.ssidLen     = ssidLen;
+    result.signal.type = NetworkCommissioning::WirelessSignalType::kdBm;
     if (signal < INT8_MIN)
     {
-        result.rssi = INT8_MIN;
+        result.signal.strength = INT8_MIN;
     }
     else if (signal > INT8_MAX)
     {
-        result.rssi = INT8_MAX;
+        result.signal.strength = INT8_MAX;
     }
     else
     {
-        result.rssi = static_cast<uint8_t>(signal);
+        result.signal.strength = static_cast<uint8_t>(signal);
     }
 
     auto bandInfo   = GetBandAndChannelFromFrequency(frequency);

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -417,7 +417,8 @@ bool WiFiManager::_FoundAPOnScanCb(wifi_manager_ap_h ap, void * userData)
     wifiErr = wifi_manager_ap_get_rssi(ap, &rssi);
     VerifyOrExit(wifiErr == WIFI_MANAGER_ERROR_NONE,
                  ChipLogError(DeviceLayer, "Fail: get rssi value [%s]", get_error_message(wifiErr)));
-    scannedAP.rssi = static_cast<int8_t>(rssi);
+    scannedAP.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+    scannedAP.signal.strength = static_cast<int8_t>(rssi);
 
     wifiErr = wifi_manager_ap_get_security_type(ap, &type);
     VerifyOrExit(wifiErr == WIFI_MANAGER_ERROR_NONE,

--- a/src/platform/Zephyr/wifi/WiFiManager.cpp
+++ b/src/platform/Zephyr/wifi/WiFiManager.cpp
@@ -77,10 +77,11 @@ NetworkCommissioning::WiFiScanResponse ToScanResponse(const wifi_scan_result * r
         // TODO: Distinguish WPA versions
         response.security.Set(result->security == WIFI_SECURITY_TYPE_PSK ? NetworkCommissioning::WiFiSecurity::kWpaPersonal
                                                                          : NetworkCommissioning::WiFiSecurity::kUnencrypted);
-        response.channel  = result->channel;
-        response.rssi     = result->rssi;
-        response.ssidLen  = result->ssid_length;
-        response.wiFiBand = ConvertBandEnum(result->band);
+        response.channel         = result->channel;
+        response.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        response.signal.strength = result->rssi;
+        response.ssidLen         = result->ssid_length;
+        response.wiFiBand        = ConvertBandEnum(result->band);
         memcpy(response.ssid, result->ssid, result->ssid_length);
         // TODO: MAC/BSSID is not filled by the Wi-Fi driver
         memcpy(response.bssid, result->mac, result->mac_length);

--- a/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.h
+++ b/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.h
@@ -44,12 +44,13 @@ public:
         }
 
         item.security.SetRaw(mpScanResults[mIternum].auth);
-        item.ssidLen  = mpScanResults[mIternum].ssid_len < chip::DeviceLayer::Internal::kMaxWiFiSSIDLength
-             ? mpScanResults[mIternum].ssid_len
-             : chip::DeviceLayer::Internal::kMaxWiFiSSIDLength;
-        item.channel  = mpScanResults[mIternum].channel;
-        item.wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
-        item.rssi     = mpScanResults[mIternum].rssi;
+        item.ssidLen         = mpScanResults[mIternum].ssid_len < chip::DeviceLayer::Internal::kMaxWiFiSSIDLength
+                    ? mpScanResults[mIternum].ssid_len
+                    : chip::DeviceLayer::Internal::kMaxWiFiSSIDLength;
+        item.channel         = mpScanResults[mIternum].channel;
+        item.wiFiBand        = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
+        item.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        item.signal.strength = mpScanResults[mIternum].rssi;
         memcpy(item.ssid, mpScanResults[mIternum].ssid, item.ssidLen);
         memcpy(item.bssid, mpScanResults[mIternum].bssid, 6);
 

--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.h
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.h
@@ -49,12 +49,13 @@ public:
         }
 
         item.security.SetRaw(mpScanResults[mIternum].auth);
-        item.ssidLen  = (uint32_t) (mpScanResults[mIternum].ssid_len) < chip::DeviceLayer::Internal::kMaxWiFiSSIDLength
-             ? mpScanResults[mIternum].ssid_len
-             : chip::DeviceLayer::Internal::kMaxWiFiSSIDLength;
-        item.channel  = mpScanResults[mIternum].channel;
-        item.wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
-        item.rssi     = mpScanResults[mIternum].rssi;
+        item.ssidLen         = (uint32_t) (mpScanResults[mIternum].ssid_len) < chip::DeviceLayer::Internal::kMaxWiFiSSIDLength
+                    ? mpScanResults[mIternum].ssid_len
+                    : chip::DeviceLayer::Internal::kMaxWiFiSSIDLength;
+        item.channel         = mpScanResults[mIternum].channel;
+        item.wiFiBand        = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
+        item.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        item.signal.strength = mpScanResults[mIternum].rssi;
         memcpy(item.ssid, mpScanResults[mIternum].ssid, item.ssidLen);
         memcpy(item.bssid, mpScanResults[mIternum].bssid, 6);
 

--- a/src/platform/bouffalolab/BL702/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL702/NetworkCommissioningDriver.cpp
@@ -266,10 +266,11 @@ void BLWiFiDriver::OnScanWiFiNetworkDone(void * opaque)
 
             p->security.SetRaw(pmsg->records[i].auth_mode);
             strncpy((char *) p->ssid, (const char *) pmsg->records[i].ssid, kMaxWiFiSSIDLength);
-            p->ssidLen  = strlen((char *) pmsg->records[i].ssid);
-            p->channel  = pmsg->records[i].channel;
-            p->wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
-            p->rssi     = pmsg->records[i].rssi;
+            p->ssidLen         = strlen((char *) pmsg->records[i].ssid);
+            p->channel         = pmsg->records[i].channel;
+            p->wiFiBand        = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
+            p->signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+            p->signal.strength = pmsg->records[i].rssi;
             memcpy(p->bssid, pmsg->records[i].bssid, 6);
 
             p++;

--- a/src/platform/mt793x/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/mt793x/NetworkCommissioningWiFiDriver.cpp
@@ -288,9 +288,10 @@ void GenioWiFiDriver::OnScanWiFiNetworkDone(wifi_scan_list_item_t * aScanResult)
             security = GetInstance().ConvertSecuritytype(aScanResult->auth_mode);
 
             scanResponse.security.Set(security);
-            scanResponse.channel = aScanResult->channel;
-            scanResponse.rssi    = aScanResult->rssi;
-            scanResponse.ssidLen = strnlen((char *) aScanResult->ssid, DeviceLayer::Internal::kMaxWiFiSSIDLength);
+            scanResponse.channel         = aScanResult->channel;
+            scanResponse.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+            scanResponse.signal.strength = aScanResult->rssi;
+            scanResponse.ssidLen         = strnlen((char *) aScanResult->ssid, DeviceLayer::Internal::kMaxWiFiSSIDLength);
             memcpy(scanResponse.ssid, aScanResult->ssid, scanResponse.ssidLen);
             memcpy(scanResponse.bssid, aScanResult->bssid, sizeof(scanResponse.bssid));
 

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -75,10 +75,11 @@ NetworkCommissioning::WiFiScanResponse ToScanResponse(const wifi_scan_result * r
         // TODO: Distinguish WPA versions
         response.security.Set(result->security == WIFI_SECURITY_TYPE_PSK ? NetworkCommissioning::WiFiSecurity::kWpaPersonal
                                                                          : NetworkCommissioning::WiFiSecurity::kUnencrypted);
-        response.channel  = result->channel;
-        response.rssi     = result->rssi;
-        response.ssidLen  = result->ssid_length;
-        response.wiFiBand = ConvertBandEnum(result->band);
+        response.channel         = result->channel;
+        response.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        response.signal.strength = result->rssi;
+        response.ssidLen         = result->ssid_length;
+        response.wiFiBand        = ConvertBandEnum(result->band);
         memcpy(response.ssid, result->ssid, result->ssid_length);
         // TODO: MAC/BSSID is not filled by the Wi-Fi driver
         memcpy(response.bssid, result->mac, result->mac_length);

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -430,7 +430,8 @@ int NXPWiFiDriver::ScanWiFINetworkDoneFromMatterTaskContext(unsigned int count)
         response.channel  = (uint16_t) res.channel;
         response.wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4; // TODO 5 GHz also possible, but results don't
                                                                                      // show this information
-        response.rssi = -static_cast<int8_t>(res.rssi);
+        response.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        response.signal.strength = -static_cast<int8_t>(res.rssi);
 
         response_list[valid] = response;
 

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -316,9 +316,10 @@ void SlWiFiDriver::OnScanWiFiNetworkDone(wfx_wifi_scan_result_t * aScanResult)
         NetworkCommissioning::WiFiScanResponse scanResponse = {};
 
         scanResponse.security.Set(nwDriver->ConvertSecuritytype(aScanResult->security));
-        scanResponse.channel = aScanResult->chan;
-        scanResponse.rssi    = aScanResult->rssi;
-        scanResponse.ssidLen = aScanResult->ssid_length;
+        scanResponse.channel         = aScanResult->chan;
+        scanResponse.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        scanResponse.signal.strength = aScanResult->rssi;
+        scanResponse.ssidLen         = aScanResult->ssid_length;
         memcpy(scanResponse.ssid, aScanResult->ssid, scanResponse.ssidLen);
         memcpy(scanResponse.bssid, aScanResult->bssid, sizeof(scanResponse.bssid));
         scanResponse.wiFiBand = aScanResult->wiFiBand;

--- a/src/platform/telink/wifi/3.3.99.0/WiFiManager.cpp
+++ b/src/platform/telink/wifi/3.3.99.0/WiFiManager.cpp
@@ -50,9 +50,10 @@ NetworkCommissioning::WiFiScanResponse ToScanResponse(const wifi_scan_result * r
         // TODO: Distinguish WPA versions
         response.security.Set(result->security == WIFI_SECURITY_TYPE_PSK ? NetworkCommissioning::WiFiSecurity::kWpaPersonal
                                                                          : NetworkCommissioning::WiFiSecurity::kUnencrypted);
-        response.channel = result->channel;
-        response.rssi    = result->rssi;
-        response.ssidLen = result->ssid_length;
+        response.channel         = result->channel;
+        response.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        response.signal.strength = result->rssi;
+        response.ssidLen         = result->ssid_length;
         memcpy(response.ssid, result->ssid, result->ssid_length);
         // TODO: MAC/BSSID is not filled by the Wi-Fi driver
         memcpy(response.bssid, result->mac, result->mac_length);

--- a/src/platform/telink/wifi/4.1.0.0/WiFiManager.cpp
+++ b/src/platform/telink/wifi/4.1.0.0/WiFiManager.cpp
@@ -58,10 +58,11 @@ NetworkCommissioning::WiFiScanResponse ToScanResponse(const wifi_scan_result * r
         // TODO: Distinguish WPA versions
         response.security.Set(result->security == WIFI_SECURITY_TYPE_PSK ? NetworkCommissioning::WiFiSecurity::kWpaPersonal
                                                                          : NetworkCommissioning::WiFiSecurity::kUnencrypted);
-        response.channel  = result->channel;
-        response.rssi     = result->rssi;
-        response.ssidLen  = result->ssid_length;
-        response.wiFiBand = ConvertBandEnum(result->band);
+        response.channel         = result->channel;
+        response.signal.type     = NetworkCommissioning::WirelessSignalType::kdBm;
+        response.signal.strength = result->rssi;
+        response.ssidLen         = result->ssid_length;
+        response.wiFiBand        = ConvertBandEnum(result->band);
         memcpy(response.ssid, result->ssid, result->ssid_length);
         // TODO: MAC/BSSID is not filled by the Wi-Fi driver
         memcpy(response.bssid, result->mac, result->mac_length);

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -2186,18 +2186,19 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
     VerifyOrReturnError(bssidLen == kWiFiBSSIDLength, false);
     memcpy(result.ssid, ssidStr, ssidLen);
     memcpy(result.bssid, bssidBuf, bssidLen);
-    result.ssidLen = ssidLen;
+    result.ssidLen     = ssidLen;
+    result.signal.type = NetworkCommissioning::WirelessSignalType::kdBm;
     if (signal < INT8_MIN)
     {
-        result.rssi = INT8_MIN;
+        result.signal.strength = INT8_MIN;
     }
     else if (signal > INT8_MAX)
     {
-        result.rssi = INT8_MAX;
+        result.signal.strength = INT8_MAX;
     }
     else
     {
-        result.rssi = static_cast<uint8_t>(signal);
+        result.signal.strength = static_cast<uint8_t>(signal);
     }
 
     auto bandInfo   = GetBandAndChannelFromFrequency(frequency);


### PR DESCRIPTION
#### Summary

This partially addresses #42516 by adding and leveraging a `WirelessSignalType` enumeration for a wireless signal strength assessment or measurement type and a `WirelessSignal` aggregate type for wireless signal type and strength assessment.

This supports, up to the internal interface of the _Network Commissioning_ cluster (which would / will require a specification change to accomodate propagation beyond that interface), network managers (such as connman) or wireless backends that make a wireless signal strength assessment using a qualitative, 0-100, assessment rather than a quantitative dBM measurement.

This has precedent with and echoes the Linux kernel header _include/net/cfg80211.h_:

```c
/**
 * enum cfg80211_signal_type - signal type
 *
 * @CFG80211_SIGNAL_TYPE_NONE: no signal strength information available
 * @CFG80211_SIGNAL_TYPE_MBM: signal strength in mBm (100*dBm)
 * @CFG80211_SIGNAL_TYPE_UNSPEC: signal strength, increasing from 0 through 100
 */
enum cfg80211_signal_type {
    CFG80211_SIGNAL_TYPE_NONE,
    CFG80211_SIGNAL_TYPE_MBM,
    CFG80211_SIGNAL_TYPE_UNSPEC,
};
```

#### Related issues

#42516 

#### Testing

Successfully paired / commissioned an armvl-unknown-linux-gnu device using the iOS 26.2 Apple "Home" app.