### PR TITLE
[Silabs] Bump matter_support to pickup rebuilt libs. Re-enable efr32 ci

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -18,7 +18,7 @@ on:
   push:
     branches:
       - master
-      - 'v*-branch'
+      - "v*-branch"
   pull_request:
   merge_group:
 
@@ -31,11 +31,7 @@ env:
 
 jobs:
   efr32:
-    # TODO: Re-enable these tests once the Silabs version of the DeviceInstanceInfoProvider is updated
-    # to support the latest changes with reporting device capability minima. 
-    # See [Issue #42709](https://github.com/project-chip/connectedhomeip/issues/42709)
     name: EFR32
-    if: false
 
     env:
       SILABS_BOARD: BRD4187C
@@ -69,7 +65,7 @@ jobs:
       #     scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs ./out/light-app BRD4187C --slc_generate --docker
       #     rm -rf ./out/
       - name: Build some BRD4187C variants (1)
-      # TODO #39216 : Deactivated Unit Testing (efr32-brd4187c-unit-test ) due to Pigweed incompatibility issues
+        # TODO #39216 : Deactivated Unit Testing (efr32-brd4187c-unit-test ) due to Pigweed incompatibility issues
         run: |
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \


### PR DESCRIPTION
#### Summary
Our provision librairies broke after #42355 because we inherit from the DeviceInstanceInfoProvider class which now implement new default methods.
The vtable wasn't matching our Libs anymore cause build failure.

Rebuild librairies with the latest CSA master development.

We will restructure the content of our library to avoid such issue in the future.

Now that the build are successful, we can re-enable our platform in the CI

#### Related issues
Fixes #42709

#### Testing
Build our lighting-app on MG24 using the rebuilt-libs. 
Provision factory data to the device
Commission the device with chip-tool using provisioned discriminator, pincode and certificates.

