### PR TITLE
Add step to build linux tool artefacts (chip-tool, RPC console) to chef cloudbuild trigger

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -27,11 +27,10 @@ steps:
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
-      # TODO: Revert the below change once trigger is verified.
           - >-
               pip install esp-idf-kconfig==2.5.0 &&
               perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt &&
-              ./examples/chef/chef.py --build_all --build_include "linux_x86-rootnode_dimmablelight"
+              ./examples/chef/chef.py --build_all --build_exclude "noip|icd"
       id: CompileAll
       waitFor:
           - Bootstrap

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -27,10 +27,11 @@ steps:
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
+      # TODO: Revert the below change once trigger is verified.
           - >-
               pip install esp-idf-kconfig==2.5.0 &&
               perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt &&
-              ./examples/chef/chef.py --build_all --build_exclude "noip|icd"
+              ./examples/chef/chef.py --build_all --build_include "linux_x86-rootnode_dimmablelight"
       id: CompileAll
       waitFor:
           - Bootstrap
@@ -58,6 +59,25 @@ steps:
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
+          - >-
+              ./scripts/build/build_examples.py
+              --enable-flashbundle
+              --target linux-x64-chip-tool-ipv6only
+              --target linux-x64-rpc-console
+              build
+              --create-archives /workspace/artifacts/
+      entrypoint: ./scripts/run_in_build_env.sh
+      volumes:
+          - name: pwenv
+            path: /pwenv
+      id: LinuxTools
+      waitFor:
+          - CompileICD
+
+    - name: "ghcr.io/project-chip/chip-build-vscode:177"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
           - ./examples/chef/chef.py --build_all --build_include
             linux_arm64_ipv6only.*noip
       # Temporarely allow failure since this is known to fail:
@@ -68,7 +88,7 @@ steps:
       allowFailure: true
       id: CompileNoip
       waitFor:
-          - CompileICD
+          - LinuxTools
       entrypoint: ./scripts/run_in_build_env.sh
       volumes:
           - name: pwenv


### PR DESCRIPTION
#### Summary

Build Linux binaries `chip-tool` and `rpc-console` to the chef cloudbuild trigger.

#### Testing

Ran cloudbuild trigger.