### PR TITLE
Added a parallel 'CHIP_DEVICE_CONFIG_ENABLE_ETHERNET' Preprocessor Symbol to gn Build

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -217,6 +217,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       device_layer_target_define = "LINUX"
       defines += [
         "CHIP_DEVICE_LAYER_TARGET=Linux",
+        "CHIP_DEVICE_CONFIG_ENABLE_ETHERNET=${chip_enable_ethernet}",
         "CHIP_DEVICE_CONFIG_ENABLE_WIFI=${chip_enable_wifi}",
       ]
     } else if (chip_device_platform == "tizen") {


### PR DESCRIPTION
#### Summary

This partially addresses #42516 by adding, for the Linux platform, a parallel `CHIP_DEVICE_CONFIG_ENABLE_ETHERNET` alongside `CHIP_DEVICE_CONFIG_ENABLE_WIFI`, with the former set by `chip_enable_ethernet` mirroring how the latter is set by `chip_enable_wifi`.

#### Related issues

#42516

#### Testing

Successfully paired / commissioned an armvl-unknown-linux-gnu device using the iOS 26.2 Apple "Home" app.