### PR TITLE
Add connman glib D-Bus XML Interface Definitions and gn Build

### DIFF
--- a/src/platform/Linux/dbus/connman/BUILD.gn
+++ b/src/platform/Linux/dbus/connman/BUILD.gn
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/build/chip/linux/gdbus_library.gni")
+
+gdbus_library("connman") {
+  sources = [
+    "DBusConnManAgent.xml",
+    "DBusConnManManager.xml",
+    "DBusConnManService.xml",
+    "DBusConnManTechnology.xml",
+  ]
+
+  c_namespace = "ConnMan"
+  interface_prefix = "net.connman"
+  c_generate_object_manager = false
+  dbus_out_dir = "platform/Linux/dbus/connman"
+}

--- a/src/platform/Linux/dbus/connman/DBusConnManAgent.xml
+++ b/src/platform/Linux/dbus/connman/DBusConnManAgent.xml
@@ -1,0 +1,49 @@
+<!--
+Copyright (c) 2026 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+This file is constructed based on the connman D-Bus API exposed by the
+connman daemon. The full, documented list of supported methods and
+properties is available at:
+https://git.kernel.org/pub/scm/network/connman/connman.git/tree/doc/agent-api.txt.
+
+Please note that this file is not a complete representation of the
+connman D-Bus Agent API, but only includes the methods that are
+relevant for the connman integration with the Matter SDK.
+-->
+
+<!DOCTYPE node PUBLIC
+  "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<node>
+    <interface name="net.connman.Agent">
+
+        <!-- Methods -->
+
+        <method name="Cancel"/>
+        <method name="Release"/>
+        <method name="ReportError">
+          <arg name="service" type="o" direction="in"/>
+          <arg name="error"   type="s" direction="in"/>
+        </method>
+        <method name="RequestInput">
+          <arg name="service" type="o"     direction="in"/>
+          <arg name="fields"  type="a{sv}" direction="in"/>
+          <arg name="reply"   type="a{sv}" direction="out"/>
+        </method>
+    </interface>
+</node>

--- a/src/platform/Linux/dbus/connman/DBusConnManManager.xml
+++ b/src/platform/Linux/dbus/connman/DBusConnManManager.xml
@@ -1,0 +1,79 @@
+<!--
+Copyright (c) 2026 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+This file is constructed with:
+
+    $ dbus-send \-\-system \-\-print-reply \-\-dest=net.connman / \
+    org.freedesktop.DBus.Introspectable.Introspect
+
+based on the connman D-Bus API exposed by the connman daemon. The
+full, documented list of supported methods and properties is available
+at: https://git.kernel.org/pub/scm/network/connman/connman.git/tree/doc/manager-api.txt.
+
+Please note that this file is not a complete representation of the
+connman D-Bus Manager API, but only includes the methods that are
+relevant for the connman integration with the Matter SDK.
+-->
+
+<!DOCTYPE node PUBLIC
+  "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<node>
+    <interface name="net.connman.Manager">
+
+        <!-- Methods -->
+
+        <method name="GetProperties">
+            <arg name="properties" type="a{sv}" direction="out"/>
+        </method>
+        <method name="SetProperty">
+            <arg name="name" type="s" direction="in"/>
+            <arg name="value" type="v" direction="in"/>
+        </method>
+        <method name="GetTechnologies">
+            <arg name="technologies" type="a(oa{sv})" direction="out"/>
+        </method>
+        <method name="GetServices">
+            <arg name="services" type="a(oa{sv})" direction="out"/>
+        </method>
+        <method name="RegisterAgent">
+            <arg name="path" type="o" direction="in"/>
+        </method>
+        <method name="UnregisterAgent">
+            <arg name="path" type="o" direction="in"/>
+        </method>
+
+        <!-- Signals -->
+
+        <signal name="PropertyChanged">
+            <arg name="name" type="s"/>
+            <arg name="value" type="v"/>
+        </signal>
+        <signal name="TechnologyAdded">
+            <arg name="path" type="o"/>
+            <arg name="properties" type="a{sv}"/>
+        </signal>
+        <signal name="TechnologyRemoved">
+            <arg name="path" type="o"/>
+        </signal>
+        <signal name="ServicesChanged">
+            <arg name="changed" type="a(oa{sv})"/>
+            <arg name="removed" type="ao"/>
+        </signal>
+    </interface>
+</node>

--- a/src/platform/Linux/dbus/connman/DBusConnManService.xml
+++ b/src/platform/Linux/dbus/connman/DBusConnManService.xml
@@ -1,0 +1,68 @@
+<!--
+Copyright (c) 2026 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+This file is constructed with:
+
+    $ dbus-send \-\-system \-\-print-reply \-\-dest=net.connman \
+    /net/connman/service/wifi_0004f33c0f8b_74657374_managed_psk \
+    org.freedesktop.DBus.Introspectable.Introspect
+
+(where "/net/connman/service/wifi_0004f33c0f8b_74657374_managed_psk"
+can be any supported connman service D-Bus object path) based on the
+connman D-Bus API exposed by the connman daemon. The full, documented
+list of supported methods and properties is available at:
+https://git.kernel.org/pub/scm/network/connman/connman.git/tree/doc/service-api.txt.
+
+Please note that this file is not a complete representation of the
+connman D-Bus Service API, but only includes the methods that are
+relevant for the connman integration with the Matter SDK.
+-->
+
+<!DOCTYPE node PUBLIC
+  "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<node>
+    <interface name="net.connman.Service">
+
+        <!-- Methods -->
+
+        <method name="SetProperty">
+            <arg name="name" type="s" direction="in"/>
+            <arg name="value" type="v" direction="in"/>
+        </method>
+        <method name="ClearProperty">
+            <arg name="name" type="s" direction="in"/>
+        </method>
+        <method name="Connect"/>
+        <method name="Disconnect"/>
+        <method name="Remove"/>
+        <method name="MoveBefore">
+            <arg name="service" type="o" direction="in"/>
+        </method>
+        <method name="MoveAfter">
+            <arg name="service" type="o" direction="in"/>
+        </method>
+
+        <!-- Signals -->
+
+        <signal name="PropertyChanged">
+            <arg name="name" type="s"/>
+            <arg name="value" type="v"/>
+        </signal>
+    </interface>
+</node>

--- a/src/platform/Linux/dbus/connman/DBusConnManTechnology.xml
+++ b/src/platform/Linux/dbus/connman/DBusConnManTechnology.xml
@@ -1,0 +1,56 @@
+<!--
+Copyright (c) 2026 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+This file is constructed with:
+
+    $ dbus-send \-\-system \-\-print-reply \-\-dest=net.connman \
+    /net/connman/technology/wifi \
+    org.freedesktop.DBus.Introspectable.Introspect
+
+(where "/net/connman/technology/wifi" can be any supported connman
+technology D-Bus object path) based on the connman D-Bus API exposed
+by the connman daemon. The full, documented list of supported methods
+and properties is available at:
+https://git.kernel.org/pub/scm/network/connman/connman.git/tree/doc/technology-api.txt.
+
+Please note that this file is not a complete representation of the
+connman D-Bus Technology API, but only includes the methods that are
+relevant for the connman integration with the Matter SDK.
+-->
+
+<!DOCTYPE node PUBLIC
+  "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<node>
+    <interface name="net.connman.Technology">
+
+        <!-- Methods -->
+
+        <method name="SetProperty"><arg name="name" type="s" direction="in"/>
+            <arg name="value" type="v" direction="in"/>
+        </method>
+        <method name="Scan"/>
+
+        <!-- Signals -->
+
+        <signal name="PropertyChanged">
+            <arg name="name" type="s"/>
+            <arg name="value" type="v"/>
+        </signal>
+    </interface>
+</node>


### PR DESCRIPTION
#### Summary

This partially addresses #42516 by adding glib D-Bus XML interface definitions and the peer gn build for the third-party, open source _Connection Manager_ (also known as, _connman_) network manager:

* Agent
* Manager
* Service
* Technology

D-Bus interfaces (or at least the subsets thereof necessary for Matter stack integration).

#### Related issues

#42516 

#### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.2 Apple "Home" app with a _Connectivity Manager_ implementation using this infrastructure.