### PR TITLE
Update Ranges for CapabilityMinimaStruct to Follow Spec

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -58,6 +58,8 @@ namespace chip {
 namespace app {
 namespace {
 
+inline constexpr uint16_t kMaxNumSubscriptionsPerFabric = 10000;
+
 /**
  * Helper to handle wildcard events in the event path.
  *
@@ -2021,10 +2023,10 @@ bool InteractionModelEngine::HasActiveRead()
 uint16_t InteractionModelEngine::GetMinGuaranteedSubscriptionsPerFabric() const
 {
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
-    return UINT16_MAX;
+    return kMaxNumSubscriptionsPerFabric;
 #else
     return static_cast<uint16_t>(
-        std::min(GetReadHandlerPoolCapacityForSubscriptions() / GetConfigMaxFabrics(), static_cast<size_t>(UINT16_MAX)));
+        std::min(GetReadHandlerPoolCapacityForSubscriptions() / GetConfigMaxFabrics(), static_cast<size_t>(kMaxNumSubscriptionsPerFabric)));
 #endif
 }
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -2025,8 +2025,8 @@ uint16_t InteractionModelEngine::GetMinGuaranteedSubscriptionsPerFabric() const
 #if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
     return kMaxNumSubscriptionsPerFabric;
 #else
-    return static_cast<uint16_t>(
-        std::min(GetReadHandlerPoolCapacityForSubscriptions() / GetConfigMaxFabrics(), static_cast<size_t>(kMaxNumSubscriptionsPerFabric)));
+    return static_cast<uint16_t>(std::min(GetReadHandlerPoolCapacityForSubscriptions() / GetConfigMaxFabrics(),
+                                          static_cast<size_t>(kMaxNumSubscriptionsPerFabric)));
 #endif
 }
 

--- a/src/include/platform/DeviceInstanceInfoProvider.h
+++ b/src/include/platform/DeviceInstanceInfoProvider.h
@@ -277,12 +277,17 @@ public:
      */
     virtual DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues()
     {
-        static_assert(CHIP_IM_MAX_NUM_COMMAND_HANDLER >= 1 && CHIP_IM_MAX_NUM_COMMAND_HANDLER <= 10000, "CHIP_IM_MAX_NUM_COMMAND_HANDLER must be greater than or equal to 1 and less than or equal to 10000");
-        static_assert(CHIP_IM_MAX_NUM_WRITE_HANDLER >= 1 && CHIP_IM_MAX_NUM_WRITE_HANDLER <= 10000, "CHIP_IM_MAX_NUM_WRITE_HANDLER must be greater than or equal to 1 and less than or equal to 10000");
-        static_assert(CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS >= 9 && CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS <= 10000,
-                      "CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS must be greater than or equal to 9 and less than or equal to 10000");
-        static_assert(CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS >= 3 && CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS <= 10000,
-                      "CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS must be greater than or equal to 3 and less than or equal to 10000");
+        static_assert(CHIP_IM_MAX_NUM_COMMAND_HANDLER >= 1 && CHIP_IM_MAX_NUM_COMMAND_HANDLER <= 10000,
+                      "CHIP_IM_MAX_NUM_COMMAND_HANDLER must be greater than or equal to 1 and less than or equal to 10000");
+        static_assert(CHIP_IM_MAX_NUM_WRITE_HANDLER >= 1 && CHIP_IM_MAX_NUM_WRITE_HANDLER <= 10000,
+                      "CHIP_IM_MAX_NUM_WRITE_HANDLER must be greater than or equal to 1 and less than or equal to 10000");
+        static_assert(
+            CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS >= 9 && CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS <= 10000,
+            "CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS must be greater than or equal to 9 and less than or equal to 10000");
+        static_assert(CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS >= 3 &&
+                          CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS <= 10000,
+                      "CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS must be greater than or equal to 3 and less than or "
+                      "equal to 10000");
 
         return DeviceInfoCapabilityMinimas{ .simultaneousInvocationsSupported = CHIP_IM_MAX_NUM_COMMAND_HANDLER,
                                             .simultaneousWritesSupported      = CHIP_IM_MAX_NUM_WRITE_HANDLER,

--- a/src/include/platform/DeviceInstanceInfoProvider.h
+++ b/src/include/platform/DeviceInstanceInfoProvider.h
@@ -277,12 +277,12 @@ public:
      */
     virtual DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues()
     {
-        static_assert(CHIP_IM_MAX_NUM_COMMAND_HANDLER <= 10000, "CHIP_IM_MAX_NUM_COMMAND_HANDLER must be <= 10000");
-        static_assert(CHIP_IM_MAX_NUM_WRITE_HANDLER <= 10000, "CHIP_IM_MAX_NUM_WRITE_HANDLER must be <= 10000");
-        static_assert(CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS <= 10000,
-                      "CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS must be <= 10000");
-        static_assert(CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS <= 10000,
-                      "CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS must be <= 10000");
+        static_assert(CHIP_IM_MAX_NUM_COMMAND_HANDLER >= 1 && CHIP_IM_MAX_NUM_COMMAND_HANDLER <= 10000, "CHIP_IM_MAX_NUM_COMMAND_HANDLER must be greater than or equal to 1 and less than or equal to 10000");
+        static_assert(CHIP_IM_MAX_NUM_WRITE_HANDLER >= 1 && CHIP_IM_MAX_NUM_WRITE_HANDLER <= 10000, "CHIP_IM_MAX_NUM_WRITE_HANDLER must be greater than or equal to 1 and less than or equal to 10000");
+        static_assert(CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS >= 9 && CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS <= 10000,
+                      "CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS must be greater than or equal to 9 and less than or equal to 10000");
+        static_assert(CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS >= 3 && CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS <= 10000,
+                      "CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS must be greater than or equal to 3 and less than or equal to 10000");
 
         return DeviceInfoCapabilityMinimas{ .simultaneousInvocationsSupported = CHIP_IM_MAX_NUM_COMMAND_HANDLER,
                                             .simultaneousWritesSupported      = CHIP_IM_MAX_NUM_WRITE_HANDLER,


### PR DESCRIPTION
#### Summary

This PR updates the values returned and the checks on the ranges for values part of the capability minima struct to be in-line with ranges defined in spec. This adds a check to minimum values of ranges for values from the DeviceInstanceInfoProvider (previously only the maximum was checked), and changes the default return value of the number of subscriptions per fabric from UINT16_MAX (65535) to 10,000.

#### Testing

- Unit tests should still pass
