### PR TITLE
Move wpa_supplicant-specific Constants into the Source Implementation

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -82,6 +82,17 @@ using namespace ::chip::WiFiPAF;
 
 namespace chip {
 namespace DeviceLayer {
+namespace {
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+static constexpr char kWpaSupplicantServiceName[] = "fi.w1.wpa_supplicant1";
+static constexpr char kWpaSupplicantObjectPath[]  = "/fi/w1/wpa_supplicant1";
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+static constexpr char kWpaSupplicantBlobUnknown[] = "fi.w1.wpa_supplicant1.BlobUnknown";
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+
+} // namespace
 
 ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
 

--- a/src/platform/Linux/ConnectivityUtils.h
+++ b/src/platform/Linux/ConnectivityUtils.h
@@ -30,11 +30,8 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-static constexpr uint16_t kWiFi_BAND_2_4_GHZ      = 2400;
-static constexpr uint16_t kWiFi_BAND_5_0_GHZ      = 5000;
-static constexpr char kWpaSupplicantServiceName[] = "fi.w1.wpa_supplicant1";
-static constexpr char kWpaSupplicantObjectPath[]  = "/fi/w1/wpa_supplicant1";
-static constexpr char kWpaSupplicantBlobUnknown[] = "fi.w1.wpa_supplicant1.BlobUnknown";
+static constexpr uint16_t kWiFi_BAND_2_4_GHZ = 2400;
+static constexpr uint16_t kWiFi_BAND_5_0_GHZ = 5000;
 
 namespace ConnectivityUtils {
 


### PR DESCRIPTION
#### Summary

This moves `wpa_supplicant`-specific D-Bus interface constants into the source implementation.

The constants are not needed or used by any other translation unit within the Linux platform; consequently, they need not be in a header.

#### Related issues

#42516 

#### Testing

Successfully paired / commissioned an armvl-unknown-linux-gnu device using the iOS 26.2 Apple "Home" app.