### PR TITLE
GroupDataProvider: New Groupcast support.

### DIFF
--- a/src/app/clusters/groupcast/CodegenIntegration.cpp
+++ b/src/app/clusters/groupcast/CodegenIntegration.cpp
@@ -16,11 +16,13 @@
  */
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/clusters/groupcast/GroupcastCluster.h>
+#include <app/clusters/groupcast/GroupcastContext.h>
 #include <app/static-cluster-config/Groupcast.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <data-model-providers/codegen/ClusterIntegration.h>
 
+using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::Groupcast::Attributes;
@@ -47,8 +49,13 @@ public:
     ServerClusterRegistration & CreateRegistration(chip::EndpointId endpointId, unsigned clusterInstanceIndex,
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
-        // No optional attributes
-        gServer.Create();
+        Credentials::GroupDataProvider * groupDataProvider = Credentials::GetGroupDataProvider();
+        VerifyOrDie(groupDataProvider != nullptr); // we require app main to set this before cluster startup
+
+        gServer.Create(GroupcastContext{
+            .fabrics  = Server::GetInstance().GetFabricTable(),
+            .provider = *groupDataProvider,
+        });
         return gServer.Registration();
     }
 

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -19,6 +19,8 @@ constexpr DataModel::AcceptedCommandEntry kAcceptedCommands[] = {
 };
 } // namespace
 
+GroupcastCluster::GroupcastCluster() : DefaultServerCluster({ kRootEndpointId, Groupcast::Id }) {}
+
 GroupcastCluster::GroupcastCluster(BitFlags<Groupcast::Feature> features) :
     DefaultServerCluster({ kRootEndpointId, Groupcast::Id }), mLogic(features)
 {}
@@ -33,7 +35,7 @@ DataModel::ActionReturnStatus GroupcastCluster::ReadAttribute(const DataModel::R
     case Groupcast::Attributes::ClusterRevision::Id:
         return encoder.Encode(Groupcast::kRevision);
     case Groupcast::Attributes::Membership::Id:
-        return mLogic.ReadMembership(request.path.mEndpointId, encoder);
+        return mLogic.ReadMembership(request.subjectDescriptor, request.path.mEndpointId, encoder);
     case Groupcast::Attributes::MaxMembershipCount::Id:
         return mLogic.ReadMaxMembershipCount(request.path.mEndpointId, encoder);
     }

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -19,12 +19,6 @@ constexpr DataModel::AcceptedCommandEntry kAcceptedCommands[] = {
 };
 } // namespace
 
-GroupcastCluster::GroupcastCluster() : DefaultServerCluster({ kRootEndpointId, Groupcast::Id }) {}
-
-GroupcastCluster::GroupcastCluster(BitFlags<Groupcast::Feature> features) :
-    DefaultServerCluster({ kRootEndpointId, Groupcast::Id }), mLogic(features)
-{}
-
 DataModel::ActionReturnStatus GroupcastCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                               AttributeValueEncoder & encoder)
 {
@@ -65,10 +59,16 @@ std::optional<DataModel::ActionReturnStatus> GroupcastCluster::InvokeCommand(con
     case Groupcast::Commands::LeaveGroup::Id: {
         Groupcast::Commands::LeaveGroup::DecodableType data;
         Groupcast::Commands::LeaveGroupResponse::Type response;
+        GroupcastLogic::EndpointList endpoints;
         ReturnErrorOnFailure(data.Decode(arguments, fabric_index));
-        TEMPORARY_RETURN_IGNORED mLogic.LeaveGroup(fabric_index, data, response);
-        handler->AddResponse(request.path, response);
-        return std::nullopt;
+        Protocols::InteractionModel::Status status = mLogic.LeaveGroup(fabric_index, data, endpoints);
+        if (Protocols::InteractionModel::Status::Success == status)
+        {
+            response.groupID   = data.groupID;
+            response.endpoints = DataModel::List<const chip::EndpointId>(endpoints.entries, endpoints.count);
+            handler->AddResponse(request.path, response);
+        }
+        return status;
     }
     case Groupcast::Commands::UpdateGroupKey::Id: {
         Groupcast::Commands::UpdateGroupKey::DecodableType data;

--- a/src/app/clusters/groupcast/GroupcastCluster.h
+++ b/src/app/clusters/groupcast/GroupcastCluster.h
@@ -31,6 +31,7 @@ namespace Clusters {
 class GroupcastCluster : public DefaultServerCluster
 {
 public:
+    GroupcastCluster();
     GroupcastCluster(BitFlags<Groupcast::Feature> features);
     virtual ~GroupcastCluster() {}
 

--- a/src/app/clusters/groupcast/GroupcastCluster.h
+++ b/src/app/clusters/groupcast/GroupcastCluster.h
@@ -31,8 +31,12 @@ namespace Clusters {
 class GroupcastCluster : public DefaultServerCluster
 {
 public:
-    GroupcastCluster();
-    GroupcastCluster(BitFlags<Groupcast::Feature> features);
+    GroupcastCluster(GroupcastContext && context) :
+        DefaultServerCluster({ kRootEndpointId, Groupcast::Id }), mContext(std::move(context)), mLogic(mContext)
+    {}
+    GroupcastCluster(GroupcastContext && context, BitFlags<Groupcast::Feature> features) :
+        DefaultServerCluster({ kRootEndpointId, Groupcast::Id }), mContext(std::move(context)), mLogic(mContext, features)
+    {}
     virtual ~GroupcastCluster() {}
 
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
@@ -44,6 +48,7 @@ public:
                                 ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder) override;
 
 private:
+    GroupcastContext mContext;
     GroupcastLogic mLogic;
 };
 

--- a/src/app/clusters/groupcast/GroupcastContext.h
+++ b/src/app/clusters/groupcast/GroupcastContext.h
@@ -1,0 +1,34 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/server/Server.h>
+#include <credentials/GroupDataProvider.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+
+struct GroupcastContext
+{
+    chip::FabricTable & fabrics;
+    chip::Credentials::GroupDataProvider & provider;
+};
+
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/groupcast/GroupcastLogic.cpp
+++ b/src/app/clusters/groupcast/GroupcastLogic.cpp
@@ -1,44 +1,232 @@
 #include "GroupcastLogic.h"
+#include <app/server/Server.h>
+#include <credentials/GroupDataProvider.h>
 
 namespace chip {
 namespace app {
 namespace Clusters {
 
-CHIP_ERROR GroupcastLogic::ReadMembership(EndpointId endpoint, AttributeValueEncoder & aEncoder)
+using GroupDataProvider = Credentials::GroupDataProvider;
+using GroupInfo         = Credentials::GroupDataProvider::GroupInfo;
+using GroupEndpoint     = Credentials::GroupDataProvider::GroupEndpoint;
+using GroupInfoIterator = Credentials::GroupDataProvider::GroupInfoIterator;
+using EndpointIterator  = Credentials::GroupDataProvider::EndpointIterator;
+
+CHIP_ERROR GroupcastLogic::ReadMembership(const chip::Access::SubjectDescriptor * subject, EndpointId endpoint,
+                                          AttributeValueEncoder & aEncoder)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    VerifyOrReturnError(nullptr != subject, CHIP_ERROR_INVALID_ARGUMENT);
+    FabricIndex fabric_index = subject->fabricIndex;
+
+    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
+    VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
+
+    EndpointId * endpoints = mEndpoints;
+
+    CHIP_ERROR err = aEncoder.EncodeList([fabric_index, groups, endpoints](const auto & encoder) -> CHIP_ERROR {
+        CHIP_ERROR status              = CHIP_NO_ERROR;
+        GroupInfoIterator * group_iter = groups->IterateGroupInfo(fabric_index);
+        VerifyOrReturnError(nullptr != group_iter, CHIP_ERROR_NO_MEMORY);
+
+        GroupInfo info;
+        while (group_iter->Next(info) && (CHIP_NO_ERROR == status))
+        {
+            // Group Key
+            KeysetId keyset_id = 0;
+            ReturnErrorOnFailure(groups->GetGroupKey(fabric_index, info.group_id, keyset_id));
+
+            // Endpoints
+            EndpointIterator * end_iter = groups->IterateEndpoints(fabric_index, info.group_id);
+            if (nullptr == end_iter)
+            {
+                status = CHIP_ERROR_NO_MEMORY;
+                break;
+            }
+
+            GroupEndpoint mapping;
+            size_t endpoint_count = 0;
+            while (end_iter->Next(mapping) && (CHIP_NO_ERROR == status))
+            {
+                endpoints[endpoint_count++] = mapping.endpoint_id;
+            }
+
+            Groupcast::Structs::MembershipStruct::Type group;
+            group.fabricIndex     = fabric_index;
+            group.groupID         = info.group_id;
+            group.keySetID        = keyset_id;
+            group.hasAuxiliaryACL = info.use_aux_acl;
+            group.endpoints       = DataModel::List<const chip::EndpointId>(endpoints, endpoint_count);
+            status                = encoder.Encode(group);
+            end_iter->Release();
+        }
+        group_iter->Release();
+
+        return status;
+    });
+
+    return err;
 }
 
 CHIP_ERROR GroupcastLogic::ReadMaxMembershipCount(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
+    VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
+    return aEncoder.Encode(kMaxMembershipCount);
 }
 
 CHIP_ERROR GroupcastLogic::JoinGroup(FabricIndex fabric_index, const Groupcast::Commands::JoinGroup::DecodableType & data)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
+    VerifyOrReturnValue(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
+
+    // The fabric cannot user more than half of the membership entries
+    GroupDataProvider::GroupInfo info;
+    CHIP_ERROR err = groups->GetGroupInfo(fabric_index, data.groupID, info);
+    VerifyOrReturnError(CHIP_ERROR_NOT_FOUND == err || CHIP_NO_ERROR == err, err);
+    // If the group is new, the fabric entries will increase
+    uint16_t new_count = (CHIP_ERROR_NOT_FOUND == err) ? info.count + 1 : info.count;
+    uint16_t limit     = static_cast<uint16_t>(kMaxMembershipCount / 2);
+    VerifyOrReturnError(new_count <= limit, CHIP_ERROR_NO_MEMORY);
+
+    // Key handing
+    if (data.key.HasValue())
+    {
+        // Create a new keyset
+        ReturnErrorOnFailure(SetKeySet(fabric_index, data.keySetID, data.key.Value()));
+    }
+    // Assign keyset to group
+    ReturnErrorOnFailure(groups->SetGroupKey(fabric_index, data.groupID, data.keySetID));
+
+    // Add/update entry in the group table
+    info.group_id    = data.groupID;
+    info.use_aux_acl = data.useAuxiliaryACL.HasValue() && data.useAuxiliaryACL.Value();
+    ReturnErrorOnFailure(groups->SetGroupInfo(fabric_index, info));
+
+    // Add Endpoints
+    auto iter          = data.endpoints.begin();
+    size_t group_count = 0;
+    while (iter.Next() && (group_count++ < kMaxCommandEndpoints))
+    {
+        ReturnErrorOnFailure(groups->AddEndpoint(fabric_index, data.groupID, iter.GetValue()));
+    }
+
+    // Join multicast
+    TEMPORARY_RETURN_IGNORED Server::GetInstance().GetTransportManager().MulticastGroupJoinLeave(
+        Transport::PeerAddress::Groupcast(), true);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR GroupcastLogic::LeaveGroup(FabricIndex fabric_index, const Groupcast::Commands::LeaveGroup::DecodableType & data,
                                       Groupcast::Commands::LeaveGroupResponse::Type & response)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
+    VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
+
+    size_t endpoint_count = 0;
+    if (data.endpoints.HasValue())
+    {
+        // Remove endpoints
+        auto iter = data.endpoints.Value().begin();
+        while (iter.Next() && (endpoint_count < kMaxCommandEndpoints))
+        {
+            auto endpoint_id = iter.GetValue();
+            if (groups->HasEndpoint(fabric_index, data.groupID, endpoint_id))
+            {
+                ReturnErrorOnFailure(groups->RemoveEndpoint(fabric_index, data.groupID, endpoint_id));
+                mEndpoints[endpoint_count++] = endpoint_id;
+            }
+        }
+    }
+    else
+    {
+        // Remove whole group
+        EndpointIterator * iter2 = groups->IterateEndpoints(fabric_index, data.groupID);
+        VerifyOrReturnError(nullptr != iter2, CHIP_ERROR_NO_MEMORY);
+        GroupEndpoint mapping;
+        while (iter2->Next(mapping) && (endpoint_count < kMaxMembershipEndpoints))
+        {
+            mEndpoints[endpoint_count++] = mapping.endpoint_id;
+        }
+        iter2->Release();
+        ReturnErrorOnFailure(groups->RemoveGroupInfo(fabric_index, data.groupID));
+    }
+
+    response.endpoints = DataModel::List<const chip::EndpointId>(mEndpoints, endpoint_count);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR GroupcastLogic::UpdateGroupKey(FabricIndex fabric_index, const Groupcast::Commands::UpdateGroupKey::DecodableType & data)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
+    VerifyOrReturnValue(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
+
+    // Key handing
+    if (data.key.HasValue())
+    {
+        // Create a new keyset
+        ReturnErrorOnFailure(SetKeySet(fabric_index, data.keySetID, data.key.Value()));
+    }
+    // Assign keyset to group
+    ReturnErrorOnFailure(groups->SetGroupKey(fabric_index, data.groupID, data.keySetID));
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR GroupcastLogic::ConfigureAuxiliaryACL(FabricIndex fabric_index,
                                                  const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
+    VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
+
+    // Get group info
+    GroupDataProvider::GroupInfo info;
+    ReturnErrorOnFailure(groups->GetGroupInfo(fabric_index, data.groupID, info));
+
+    // Update group info
+    info.use_aux_acl = data.useAuxiliaryACL;
+    ReturnErrorOnFailure(groups->SetGroupInfo(fabric_index, info));
+
+    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR GroupcastLogic::RegisterAccessControl(FabricIndex fabric_index, GroupId group_id)
+CHIP_ERROR GroupcastLogic::SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, const chip::ByteSpan & key)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
+    VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
+
+    GroupDataProvider::KeySet ks;
+
+    CHIP_ERROR err = groups->GetKeySet(fabric_index, static_cast<KeysetId>(keyset_id), ks);
+    if (CHIP_ERROR_NOT_FOUND == err)
+    {
+        // New key
+        const FabricInfo * fabric = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabric_index);
+        VerifyOrReturnValue(nullptr != fabric, CHIP_ERROR_INTERNAL);
+
+        ks.keyset_id     = static_cast<KeysetId>(keyset_id);
+        ks.policy        = GroupDataProvider::SecurityPolicy::kTrustFirst;
+        ks.num_keys_used = 1;
+
+        // Translate HEX key to binary
+        GroupDataProvider::EpochKey & epoch = ks.epoch_keys[0];
+        VerifyOrReturnValue(key.size() == 2 * GroupDataProvider::EpochKey::kLengthBytes, CHIP_ERROR_INTERNAL);
+        size_t key_size =
+            chip::Encoding::HexToBytes((char *) key.data(), key.size(), epoch.key, GroupDataProvider::EpochKey::kLengthBytes);
+        VerifyOrReturnValue(key_size == GroupDataProvider::EpochKey::kLengthBytes, CHIP_ERROR_INTERNAL);
+        {
+            // Get compressed fabric
+            uint8_t compressed_fabric_id_buffer[sizeof(uint64_t)];
+            MutableByteSpan compressed_fabric_id(compressed_fabric_id_buffer);
+            ReturnErrorOnFailure(fabric->GetCompressedFabricIdBytes(compressed_fabric_id));
+            // Set keys
+            err = groups->SetKeySet(fabric_index, compressed_fabric_id, ks);
+        }
+    }
+    else if (CHIP_NO_ERROR == err)
+    {
+        // Existing key
+        return CHIP_ERROR_DUPLICATE_KEY_ID;
+    }
+    return err;
 }
 
 } // namespace Clusters

--- a/src/app/clusters/groupcast/GroupcastLogic.cpp
+++ b/src/app/clusters/groupcast/GroupcastLogic.cpp
@@ -1,5 +1,5 @@
 #include "GroupcastLogic.h"
-#include <app/server/Server.h>
+#include <app/util/endpoint-config-api.h>
 #include <credentials/GroupDataProvider.h>
 
 namespace chip {
@@ -18,12 +18,10 @@ CHIP_ERROR GroupcastLogic::ReadMembership(const chip::Access::SubjectDescriptor 
     VerifyOrReturnError(nullptr != subject, CHIP_ERROR_INVALID_ARGUMENT);
     FabricIndex fabric_index = subject->fabricIndex;
 
-    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
-    VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
+    GroupDataProvider * groups = &Provider();
 
-    EndpointId * endpoints = mEndpoints;
-
-    CHIP_ERROR err = aEncoder.EncodeList([fabric_index, groups, endpoints](const auto & encoder) -> CHIP_ERROR {
+    CHIP_ERROR err = aEncoder.EncodeList([fabric_index, groups](const auto & encoder) -> CHIP_ERROR {
+        EndpointList endpoints;
         CHIP_ERROR status              = CHIP_NO_ERROR;
         GroupInfoIterator * group_iter = groups->IterateGroupInfo(fabric_index);
         VerifyOrReturnError(nullptr != group_iter, CHIP_ERROR_NO_MEMORY);
@@ -43,20 +41,30 @@ CHIP_ERROR GroupcastLogic::ReadMembership(const chip::Access::SubjectDescriptor 
                 break;
             }
 
+            // Return endpoints in kMaxMembershipEndpoints chunks or less
+            size_t group_total = end_iter->Count();
+            size_t group_count = 0;
+            size_t split_count = 0;
             GroupEndpoint mapping;
-            size_t endpoint_count = 0;
             while (end_iter->Next(mapping) && (CHIP_NO_ERROR == status))
             {
-                endpoints[endpoint_count++] = mapping.endpoint_id;
+                group_count++;
+                endpoints.entries[split_count++] = mapping.endpoint_id;
+                if ((group_count == group_total) || (split_count == kMaxMembershipEndpoints))
+                {
+                    Groupcast::Structs::MembershipStruct::Type group;
+                    group.fabricIndex     = fabric_index;
+                    group.groupID         = info.group_id;
+                    group.keySetID        = keyset_id;
+                    group.hasAuxiliaryACL = MakeOptional(info.flags & chip::to_underlying(GroupInfo::Flags::kHasAuxiliaryACL));
+                    group.mcastAddrPolicy = (info.flags & chip::to_underlying(GroupInfo::Flags::kMcastAddrPolicy)
+                                                 ? Groupcast::MulticastAddrPolicyEnum::kPerGroup
+                                                 : Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
+                    group.endpoints       = MakeOptional(DataModel::List<const chip::EndpointId>(endpoints.entries, split_count));
+                    status                = encoder.Encode(group);
+                    split_count           = 0;
+                }
             }
-
-            Groupcast::Structs::MembershipStruct::Type group;
-            group.fabricIndex     = fabric_index;
-            group.groupID         = info.group_id;
-            group.keySetID        = keyset_id;
-            group.hasAuxiliaryACL = info.use_aux_acl;
-            group.endpoints       = DataModel::List<const chip::EndpointId>(endpoints, endpoint_count);
-            status                = encoder.Encode(group);
             end_iter->Release();
         }
         group_iter->Release();
@@ -69,164 +77,281 @@ CHIP_ERROR GroupcastLogic::ReadMembership(const chip::Access::SubjectDescriptor 
 
 CHIP_ERROR GroupcastLogic::ReadMaxMembershipCount(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
-    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
-    VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
-    return aEncoder.Encode(kMaxMembershipCount);
+    GroupDataProvider & groups = Provider();
+    return aEncoder.Encode(groups.getMaxMembershipCount());
 }
 
-CHIP_ERROR GroupcastLogic::JoinGroup(FabricIndex fabric_index, const Groupcast::Commands::JoinGroup::DecodableType & data)
+Status GroupcastLogic::JoinGroup(FabricIndex fabric_index, const Groupcast::Commands::JoinGroup::DecodableType & data)
 {
-    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
-    VerifyOrReturnValue(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
+    GroupDataProvider & groups = Provider();
+    CHIP_ERROR err             = CHIP_NO_ERROR;
 
-    // The fabric cannot user more than half of the membership entries
+    // Check groupID
+    VerifyOrReturnError(data.groupID != kUndefinedGroupId, Status::ConstraintError);
+
+    // Check useAuxiliaryACL
+    if (data.useAuxiliaryACL.HasValue())
+    {
+        // AuxiliaryACL can only be present if LN feature is supported
+        VerifyOrReturnError(mFeatures.Has(Groupcast::Feature::kListener), Status::ConstraintError);
+    }
+
+    // Check endpoints
+    size_t endpoint_count = 0;
+    err                   = data.endpoints.ComputeSize(&endpoint_count);
+    VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
+    if (mFeatures.Has(Groupcast::Feature::kListener) && !mFeatures.Has(Groupcast::Feature::kSender))
+    {
+        // Listener only, endpoints cannot be empty
+        VerifyOrReturnError(endpoint_count > 0 && endpoint_count <= kMaxCommandEndpoints, Status::ConstraintError);
+    }
+    else if (!mFeatures.Has(Groupcast::Feature::kListener) && mFeatures.Has(Groupcast::Feature::kSender))
+    {
+        // Sender only, endpoints must be empty
+        VerifyOrReturnError(0 == endpoint_count, Status::ConstraintError);
+    }
+    // Verify endpoint values
+    {
+        auto iter = data.endpoints.begin();
+        while (iter.Next())
+        {
+            EndpointId ep = iter.GetValue();
+            VerifyOrReturnError((ep > 0) && (kInvalidEndpointId != ep), Status::ConstraintError);
+            // VerifyOrReturnError(nullptr != emberAfFindEndpointType(ep), Status::ConstraintError);
+        }
+    }
+
+    // Check fabric membership entries limit
     GroupDataProvider::GroupInfo info;
-    CHIP_ERROR err = groups->GetGroupInfo(fabric_index, data.groupID, info);
-    VerifyOrReturnError(CHIP_ERROR_NOT_FOUND == err || CHIP_NO_ERROR == err, err);
+    err = groups.GetGroupInfo(fabric_index, data.groupID, info);
+    VerifyOrReturnError(CHIP_ERROR_NOT_FOUND == err || CHIP_NO_ERROR == err, Status::Failure);
     // If the group is new, the fabric entries will increase
-    uint16_t new_count = (CHIP_ERROR_NOT_FOUND == err) ? info.count + 1 : info.count;
-    uint16_t limit     = static_cast<uint16_t>(kMaxMembershipCount / 2);
-    VerifyOrReturnError(new_count <= limit, CHIP_ERROR_NO_MEMORY);
+    uint16_t new_count              = (CHIP_ERROR_NOT_FOUND == err) ? info.count + 1 : info.count;
+    uint16_t max_fabric_memberships = static_cast<uint16_t>(groups.getMaxMembershipCount() / 2);
+    VerifyOrReturnError(new_count <= max_fabric_memberships, Status::ResourceExhausted);
 
-    // Key handing
+    // Key handling
     if (data.key.HasValue())
     {
         // Create a new keyset
-        ReturnErrorOnFailure(SetKeySet(fabric_index, data.keySetID, data.key.Value()));
+        Status stat = SetKeySet(fabric_index, data.keySetID, data.key.Value());
+        VerifyOrReturnError(Status::Success == stat, stat);
+    }
+    else
+    {
+        // The keyset must exist
+        GroupDataProvider::KeySet ks;
+        err = groups.GetKeySet(fabric_index, data.keySetID, ks);
+        VerifyOrReturnError(CHIP_NO_ERROR == err, Status::NotFound);
     }
     // Assign keyset to group
-    ReturnErrorOnFailure(groups->SetGroupKey(fabric_index, data.groupID, data.keySetID));
+    err = groups.SetGroupKey(fabric_index, data.groupID, data.keySetID);
+    VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
 
     // Add/update entry in the group table
-    info.group_id    = data.groupID;
-    info.use_aux_acl = data.useAuxiliaryACL.HasValue() && data.useAuxiliaryACL.Value();
-    ReturnErrorOnFailure(groups->SetGroupInfo(fabric_index, info));
-
-    // Add Endpoints
-    auto iter          = data.endpoints.begin();
-    size_t group_count = 0;
-    while (iter.Next() && (group_count++ < kMaxCommandEndpoints))
+    info.group_id = data.groupID;
+    info.flags    = 0;
+    if (data.useAuxiliaryACL.HasValue() && data.useAuxiliaryACL.Value())
     {
-        ReturnErrorOnFailure(groups->AddEndpoint(fabric_index, data.groupID, iter.GetValue()));
+        info.flags |= chip::to_underlying(GroupInfo::Flags::kHasAuxiliaryACL);
     }
 
-    // Join multicast
-    TEMPORARY_RETURN_IGNORED Server::GetInstance().GetTransportManager().MulticastGroupJoinLeave(
-        Transport::PeerAddress::Groupcast(), true);
-    return CHIP_NO_ERROR;
+    if (data.mcastAddrPolicy.HasValue() && (Groupcast::MulticastAddrPolicyEnum::kPerGroup == data.mcastAddrPolicy.Value()))
+    {
+        info.flags |= chip::to_underlying(GroupInfo::Flags::kMcastAddrPolicy);
+    }
+
+    err = groups.SetGroupInfo(fabric_index, info);
+    VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
+
+    if (data.replaceEndpoints.HasValue() && data.replaceEndpoints.Value())
+    {
+        // Replace endpoints
+        err = groups.RemoveEndpoints(fabric_index, data.groupID);
+        VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
+    }
+
+    // Add Endpoints
+    {
+        size_t group_count = 0;
+        auto iter          = data.endpoints.begin();
+        while (iter.Next() && (group_count++ < kMaxCommandEndpoints))
+        {
+            err = groups.AddEndpoint(fabric_index, data.groupID, iter.GetValue());
+            VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
+        }
+    }
+
+    return Status::Success;
 }
 
-CHIP_ERROR GroupcastLogic::LeaveGroup(FabricIndex fabric_index, const Groupcast::Commands::LeaveGroup::DecodableType & data,
-                                      Groupcast::Commands::LeaveGroupResponse::Type & response)
+Status GroupcastLogic::LeaveGroup(FabricIndex fabric_index, const Groupcast::Commands::LeaveGroup::DecodableType & data,
+                                  EndpointList & endpoints)
 {
-    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
-    VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
+    GroupDataProvider & groups = Provider();
+    Status err                 = Status::Success;
 
-    size_t endpoint_count = 0;
+    endpoints.count = 0;
+    if (kUndefinedGroupId == data.groupID)
+    {
+        // Apply changes to all groups
+        GroupInfoIterator * iter = groups.IterateGroupInfo(fabric_index);
+        VerifyOrReturnError(nullptr != iter, Status::ResourceExhausted);
+
+        GroupInfo info;
+        while (iter->Next(info) && (Status::Success == err))
+        {
+            err = RemoveGroup(fabric_index, info.group_id, data, endpoints);
+        }
+        iter->Release();
+    }
+    else
+    {
+        // Modify specific group
+        err = RemoveGroup(fabric_index, data.groupID, data, endpoints);
+    }
+
+    return err;
+}
+
+Status GroupcastLogic::UpdateGroupKey(FabricIndex fabric_index, const Groupcast::Commands::UpdateGroupKey::DecodableType & data)
+{
+    GroupDataProvider & groups = Provider();
+
+    // Key handling
+    if (data.key.HasValue())
+    {
+        // Create a new keyset
+        Status stat = SetKeySet(fabric_index, data.keySetID, data.key.Value());
+        VerifyOrReturnError(Status::Success == stat, stat);
+    }
+    // Assign keyset to group
+    CHIP_ERROR err = groups.SetGroupKey(fabric_index, data.groupID, data.keySetID);
+    return CHIP_NO_ERROR == err ? Status::Success : Status::Failure;
+}
+
+Status GroupcastLogic::ConfigureAuxiliaryACL(FabricIndex fabric_index,
+                                             const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data)
+{
+    GroupDataProvider & groups = Provider();
+    CHIP_ERROR err             = CHIP_NO_ERROR;
+
+    // Get group info
+    GroupDataProvider::GroupInfo info;
+    err = groups.GetGroupInfo(fabric_index, data.groupID, info);
+    VerifyOrReturnError(CHIP_NO_ERROR == err, Status::NotFound);
+
+    // Update group info
+    if (data.useAuxiliaryACL)
+    {
+        info.flags |= chip::to_underlying(GroupInfo::Flags::kHasAuxiliaryACL);
+    }
+    else
+    {
+        info.flags &= ~chip::to_underlying(GroupInfo::Flags::kHasAuxiliaryACL);
+    }
+    err = groups.SetGroupInfo(fabric_index, info);
+    VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
+
+    return Status::Success;
+}
+
+Status GroupcastLogic::SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, const chip::ByteSpan & key)
+{
+    GroupDataProvider & groups = Provider();
+    GroupDataProvider::KeySet ks;
+
+    CHIP_ERROR err = groups.GetKeySet(fabric_index, keyset_id, ks);
+    if (CHIP_ERROR_NOT_FOUND == err)
+    {
+        // New key
+        const FabricInfo * fabric = Fabrics().FindFabricWithIndex(fabric_index);
+        VerifyOrReturnValue(nullptr != fabric, Status::NotFound);
+
+        ks.keyset_id     = keyset_id;
+        ks.policy        = GroupDataProvider::SecurityPolicy::kTrustFirst;
+        ks.num_keys_used = 1;
+
+        GroupDataProvider::EpochKey & epoch = ks.epoch_keys[0];
+        VerifyOrReturnValue(key.size() == GroupDataProvider::EpochKey::kLengthBytes, Status::ConstraintError);
+        memcpy(epoch.key, key.data(), GroupDataProvider::EpochKey::kLengthBytes);
+
+        {
+            // Get compressed fabric
+            uint8_t compressed_fabric_id_buffer[sizeof(uint64_t)];
+            MutableByteSpan compressed_fabric_id(compressed_fabric_id_buffer);
+            err = fabric->GetCompressedFabricIdBytes(compressed_fabric_id);
+            VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
+            // Set keys
+            err = groups.SetKeySet(fabric_index, compressed_fabric_id, ks);
+            VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
+        }
+    }
+    else if (CHIP_NO_ERROR == err)
+    {
+        // Cannot set an existing key
+        return Status::AlreadyExists;
+    }
+    return Status::Success;
+}
+
+Status GroupcastLogic::RemoveGroup(FabricIndex fabric_index, GroupId group_id,
+                                   const Groupcast::Commands::LeaveGroup::DecodableType & data, EndpointList & endpoints)
+{
+    GroupDataProvider & groups = Provider();
+    Status stat                = Status::Success;
+
     if (data.endpoints.HasValue())
     {
         // Remove endpoints
         auto iter = data.endpoints.Value().begin();
-        while (iter.Next() && (endpoint_count < kMaxCommandEndpoints))
+        while (iter.Next() && (endpoints.count < kMaxCommandEndpoints))
         {
             auto endpoint_id = iter.GetValue();
-            if (groups->HasEndpoint(fabric_index, data.groupID, endpoint_id))
+            if (groups.HasEndpoint(fabric_index, group_id, endpoint_id))
             {
-                ReturnErrorOnFailure(groups->RemoveEndpoint(fabric_index, data.groupID, endpoint_id));
-                mEndpoints[endpoint_count++] = endpoint_id;
+                stat = RemoveGroupEndpoint(fabric_index, group_id, endpoint_id, endpoints);
+                VerifyOrReturnError(Status::Success == stat, stat);
             }
         }
     }
     else
     {
-        // Remove whole group
-        EndpointIterator * iter2 = groups->IterateEndpoints(fabric_index, data.groupID);
-        VerifyOrReturnError(nullptr != iter2, CHIP_ERROR_NO_MEMORY);
+        // Remove whole group (with all endpoints)
+        EndpointIterator * iter = groups.IterateEndpoints(fabric_index, data.groupID);
+        VerifyOrReturnError(nullptr != iter, Status::ResourceExhausted);
         GroupEndpoint mapping;
-        while (iter2->Next(mapping) && (endpoint_count < kMaxMembershipEndpoints))
+        while (iter->Next(mapping) && (endpoints.count < kMaxMembershipEndpoints))
         {
-            mEndpoints[endpoint_count++] = mapping.endpoint_id;
+            stat = RemoveGroupEndpoint(fabric_index, group_id, mapping.endpoint_id, endpoints);
+            VerifyOrReturnError(Status::Success == stat, stat);
         }
-        iter2->Release();
-        ReturnErrorOnFailure(groups->RemoveGroupInfo(fabric_index, data.groupID));
+        iter->Release();
+        CHIP_ERROR err = groups.RemoveGroupInfo(fabric_index, data.groupID);
+        VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
     }
 
-    response.endpoints = DataModel::List<const chip::EndpointId>(mEndpoints, endpoint_count);
-    return CHIP_NO_ERROR;
+    return Status::Success;
 }
 
-CHIP_ERROR GroupcastLogic::UpdateGroupKey(FabricIndex fabric_index, const Groupcast::Commands::UpdateGroupKey::DecodableType & data)
+Status GroupcastLogic::RemoveGroupEndpoint(FabricIndex fabric_index, GroupId group_id, EndpointId endpoint_id,
+                                           EndpointList & endpoints)
 {
-    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
-    VerifyOrReturnValue(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
+    GroupDataProvider & groups = Provider();
 
-    // Key handing
-    if (data.key.HasValue())
+    CHIP_ERROR err = groups.RemoveEndpoint(fabric_index, group_id, endpoint_id);
+    VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
+
+    bool found = false;
+    for (size_t i = 0; !found && i < endpoints.count; ++i)
     {
-        // Create a new keyset
-        ReturnErrorOnFailure(SetKeySet(fabric_index, data.keySetID, data.key.Value()));
+        found = (endpoints.entries[i] == endpoint_id);
     }
-    // Assign keyset to group
-    ReturnErrorOnFailure(groups->SetGroupKey(fabric_index, data.groupID, data.keySetID));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR GroupcastLogic::ConfigureAuxiliaryACL(FabricIndex fabric_index,
-                                                 const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data)
-{
-    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
-    VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
-
-    // Get group info
-    GroupDataProvider::GroupInfo info;
-    ReturnErrorOnFailure(groups->GetGroupInfo(fabric_index, data.groupID, info));
-
-    // Update group info
-    info.use_aux_acl = data.useAuxiliaryACL;
-    ReturnErrorOnFailure(groups->SetGroupInfo(fabric_index, info));
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR GroupcastLogic::SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, const chip::ByteSpan & key)
-{
-    GroupDataProvider * groups = Credentials::GetGroupDataProvider();
-    VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INCORRECT_STATE);
-
-    GroupDataProvider::KeySet ks;
-
-    CHIP_ERROR err = groups->GetKeySet(fabric_index, static_cast<KeysetId>(keyset_id), ks);
-    if (CHIP_ERROR_NOT_FOUND == err)
+    if (!found)
     {
-        // New key
-        const FabricInfo * fabric = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabric_index);
-        VerifyOrReturnValue(nullptr != fabric, CHIP_ERROR_INTERNAL);
-
-        ks.keyset_id     = static_cast<KeysetId>(keyset_id);
-        ks.policy        = GroupDataProvider::SecurityPolicy::kTrustFirst;
-        ks.num_keys_used = 1;
-
-        // Translate HEX key to binary
-        GroupDataProvider::EpochKey & epoch = ks.epoch_keys[0];
-        VerifyOrReturnValue(key.size() == 2 * GroupDataProvider::EpochKey::kLengthBytes, CHIP_ERROR_INTERNAL);
-        size_t key_size =
-            chip::Encoding::HexToBytes((char *) key.data(), key.size(), epoch.key, GroupDataProvider::EpochKey::kLengthBytes);
-        VerifyOrReturnValue(key_size == GroupDataProvider::EpochKey::kLengthBytes, CHIP_ERROR_INTERNAL);
-        {
-            // Get compressed fabric
-            uint8_t compressed_fabric_id_buffer[sizeof(uint64_t)];
-            MutableByteSpan compressed_fabric_id(compressed_fabric_id_buffer);
-            ReturnErrorOnFailure(fabric->GetCompressedFabricIdBytes(compressed_fabric_id));
-            // Set keys
-            err = groups->SetKeySet(fabric_index, compressed_fabric_id, ks);
-        }
+        endpoints.entries[endpoints.count++] = endpoint_id;
     }
-    else if (CHIP_NO_ERROR == err)
-    {
-        // Existing key
-        return CHIP_ERROR_DUPLICATE_KEY_ID;
-    }
-    return err;
+    return Status::Success;
 }
 
 } // namespace Clusters

--- a/src/app/clusters/groupcast/GroupcastLogic.h
+++ b/src/app/clusters/groupcast/GroupcastLogic.h
@@ -24,6 +24,7 @@
 #include <clusters/Groupcast/CommandIds.h>
 #include <clusters/Groupcast/Commands.h>
 #include <clusters/Groupcast/Enums.h>
+#include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 
@@ -37,10 +38,16 @@ namespace Clusters {
 class GroupcastLogic
 {
 public:
+    static constexpr uint16_t kMaxMembershipCount     = CHIP_CONFIG_MAX_GROUPCAST_MEMBERSHIP_COUNT;
+    static constexpr uint16_t kMaxMembershipEndpoints = 255;
+    static constexpr uint16_t kMaxCommandEndpoints    = 20;
+
+    GroupcastLogic() {}
     GroupcastLogic(BitFlags<Groupcast::Feature> features) : mFeatures(features) {}
     const BitFlags<Groupcast::Feature> & Features() const { return mFeatures; }
 
-    CHIP_ERROR ReadMembership(EndpointId endpoint, AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadMembership(const chip::Access::SubjectDescriptor * subject, EndpointId endpoint,
+                              AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadMaxMembershipCount(EndpointId endpoint, AttributeValueEncoder & aEncoder);
 
     CHIP_ERROR JoinGroup(FabricIndex fabric_index, const Groupcast::Commands::JoinGroup::DecodableType & data);
@@ -51,9 +58,10 @@ public:
                                      const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data);
 
 private:
-    CHIP_ERROR RegisterAccessControl(FabricIndex fabric_index, GroupId group_id);
+    CHIP_ERROR SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, const chip::ByteSpan & key);
 
     const BitFlags<Groupcast::Feature> mFeatures;
+    EndpointId mEndpoints[kMaxMembershipEndpoints];
 };
 
 } // namespace Clusters

--- a/src/app/clusters/groupcast/GroupcastLogic.h
+++ b/src/app/clusters/groupcast/GroupcastLogic.h
@@ -16,9 +16,10 @@
  */
 #pragma once
 
-#include <app/AttributeValueDecoder.h>
+#include "GroupcastContext.h"
 #include <app/AttributeValueEncoder.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
+#include <app/server/Server.h>
 #include <clusters/Groupcast/AttributeIds.h>
 #include <clusters/Groupcast/ClusterId.h>
 #include <clusters/Groupcast/CommandIds.h>
@@ -27,41 +28,55 @@
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {
 namespace app {
 namespace Clusters {
 
+using Status = chip::Protocols::InteractionModel::Status;
+
 /**
  * @brief Implements the Matter specifications for the Groupcast cluster
  */
+
 class GroupcastLogic
 {
 public:
-    static constexpr uint16_t kMaxMembershipCount     = CHIP_CONFIG_MAX_GROUPCAST_MEMBERSHIP_COUNT;
     static constexpr uint16_t kMaxMembershipEndpoints = 255;
     static constexpr uint16_t kMaxCommandEndpoints    = 20;
 
-    GroupcastLogic() {}
-    GroupcastLogic(BitFlags<Groupcast::Feature> features) : mFeatures(features) {}
+    struct EndpointList
+    {
+        EndpointId entries[kMaxMembershipEndpoints];
+        uint16_t count = 0;
+    };
+
+    GroupcastLogic(GroupcastContext & context) : mContext(context) {}
+    GroupcastLogic(GroupcastContext & context, BitFlags<Groupcast::Feature> features) : mContext(context), mFeatures(features) {}
     const BitFlags<Groupcast::Feature> & Features() const { return mFeatures; }
 
     CHIP_ERROR ReadMembership(const chip::Access::SubjectDescriptor * subject, EndpointId endpoint,
                               AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadMaxMembershipCount(EndpointId endpoint, AttributeValueEncoder & aEncoder);
 
-    CHIP_ERROR JoinGroup(FabricIndex fabric_index, const Groupcast::Commands::JoinGroup::DecodableType & data);
-    CHIP_ERROR LeaveGroup(FabricIndex fabric_index, const Groupcast::Commands::LeaveGroup::DecodableType & data,
-                          Groupcast::Commands::LeaveGroupResponse::Type & response);
-    CHIP_ERROR UpdateGroupKey(FabricIndex fabric_index, const Groupcast::Commands::UpdateGroupKey::DecodableType & data);
-    CHIP_ERROR ConfigureAuxiliaryACL(FabricIndex fabric_index,
-                                     const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data);
+    Status JoinGroup(FabricIndex fabric_index, const Groupcast::Commands::JoinGroup::DecodableType & data);
+    Status LeaveGroup(FabricIndex fabric_index, const Groupcast::Commands::LeaveGroup::DecodableType & data,
+                      EndpointList & endpoints);
+    Status UpdateGroupKey(FabricIndex fabric_index, const Groupcast::Commands::UpdateGroupKey::DecodableType & data);
+    Status ConfigureAuxiliaryACL(FabricIndex fabric_index, const Groupcast::Commands::ConfigureAuxiliaryACL::DecodableType & data);
 
 private:
-    CHIP_ERROR SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, const chip::ByteSpan & key);
+    Credentials::GroupDataProvider & Provider() { return mContext.provider; }
+    chip::FabricTable & Fabrics() { return mContext.fabrics; }
 
+    Status SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, const chip::ByteSpan & key);
+    Status RemoveGroup(FabricIndex fabric_index, GroupId group_id, const Groupcast::Commands::LeaveGroup::DecodableType & data,
+                       EndpointList & endpoints);
+    Status RemoveGroupEndpoint(FabricIndex fabric_index, GroupId group_id, EndpointId endpoint_id, EndpointList & endpoints);
+
+    GroupcastContext & mContext;
     const BitFlags<Groupcast::Feature> mFeatures;
-    EndpointId mEndpoints[kMaxMembershipEndpoints];
 };
 
 } // namespace Clusters

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -17,6 +17,7 @@
 
 #include <app/MessageDef/CommandDataIB.h>
 #include <app/clusters/groupcast/GroupcastCluster.h>
+#include <app/clusters/groupcast/GroupcastLogic.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
@@ -26,6 +27,7 @@
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
 #include <clusters/Groupcast/Enums.h>
 #include <clusters/Groupcast/Metadata.h>
+#include <credentials/GroupDataProviderImpl.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/BitFlags.h>
@@ -33,9 +35,15 @@
 #include <lib/support/ReadOnlyBuffer.h>
 #include <platform/NetworkCommissioning.h>
 
+#include <credentials/GroupDataProviderImpl.h>
+#include <crypto/DefaultSessionKeystore.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+
 namespace {
 
 using namespace chip;
+using namespace chip::Testing;
+using namespace chip::Credentials;
 using namespace chip::app::Clusters::Groupcast;
 using chip::Testing::IsAcceptedCommandsListEqualTo;
 using chip::Testing::IsAttributesListEqualTo;
@@ -43,19 +51,73 @@ using chip::Testing::IsAttributesListEqualTo;
 using chip::app::DataModel::AcceptedCommandEntry;
 using chip::app::DataModel::AttributeEntry;
 
+template <typename DecodableListType>
+CHIP_ERROR CountListElements(DecodableListType & list, size_t & count)
+{
+    count   = 0;
+    auto it = list.begin();
+    while (it.Next())
+    {
+        ++count;
+    }
+    // Return the iterator status to the caller for assertion
+    return it.GetStatus();
+}
+
+chip::FabricIndex kTestFabricIndex = Testing::kTestFabrixIndex;
+
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestGroupcastCluster : public ::testing::Test
 {
-    static void SetUpTestSuite() { ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR); }
-    static void TearDownTestSuite() { Platform::MemoryShutdown(); }
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+
+    TestServerClusterContext mTestContext;
+    Credentials::GroupDataProviderImpl mProvider;
+    Crypto::DefaultSessionKeystore mKeystore;
+    FabricTestFixture mFabricHelper{ &mTestContext.StorageDelegate() };
+    app::Clusters::GroupcastCluster mSender{ { mFabricHelper.GetFabricTable(), mProvider }, BitFlags<Feature>{ Feature::kSender } };
+    app::Clusters::GroupcastCluster mListener{ { mFabricHelper.GetFabricTable(), mProvider },
+                                               BitFlags<Feature>{ Feature::kListener } };
+
+    void SetUp() override
+    {
+        mProvider.SetStorageDelegate(&mTestContext.StorageDelegate());
+        mProvider.SetSessionKeystore(&mKeystore);
+        ASSERT_EQ(mProvider.Init(), CHIP_NO_ERROR);
+
+        ASSERT_EQ(mSender.Startup(mTestContext.Get()), CHIP_NO_ERROR);
+        ASSERT_EQ(mListener.Startup(mTestContext.Get()), CHIP_NO_ERROR);
+
+        CHIP_ERROR err = mFabricHelper.SetUpTestFabric(kTestFabricIndex);
+        ASSERT_EQ(err, CHIP_NO_ERROR);
+        Credentials::SetGroupDataProvider(&mProvider);
+    }
+
+    void TearDown() override
+    {
+        mSender.Shutdown(app::ClusterShutdownType::kClusterShutdown);
+        mListener.Shutdown(app::ClusterShutdownType::kClusterShutdown);
+        Credentials::SetGroupDataProvider(nullptr);
+        CHIP_ERROR err = mFabricHelper.TearDownTestFabric(kTestFabricIndex);
+        ASSERT_EQ(err, CHIP_NO_ERROR);
+        mProvider.Finish();
+    }
+
+    void AssertStatus(std::optional<app::DataModel::ActionReturnStatus> & status,
+                      const Protocols::InteractionModel::Status expected)
+    {
+        ASSERT_TRUE(status.has_value());
+        EXPECT_EQ(status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  expected);
+    }
 };
 
 TEST_F(TestGroupcastCluster, TestAttributes)
 {
-    app::Clusters::GroupcastCluster cluster(BitFlags<Feature>{ Feature::kSender });
     // Attributes
     {
-        ASSERT_TRUE(IsAttributesListEqualTo(cluster,
+        ASSERT_TRUE(IsAttributesListEqualTo(mSender,
                                             {
                                                 Attributes::Membership::kMetadataEntry,
                                                 Attributes::MaxMembershipCount::kMetadataEntry,
@@ -67,7 +129,7 @@ TEST_F(TestGroupcastCluster, TestAttributes)
 
     // Read attributes for expected values
     {
-        chip::Testing::ClusterTester tester(cluster);
+        chip::Testing::ClusterTester tester(mSender);
         uint16_t revision{};
         ASSERT_EQ(tester.ReadAttribute(Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
         ASSERT_EQ(revision, app::Clusters::Groupcast::kRevision);
@@ -81,8 +143,7 @@ TEST_F(TestGroupcastCluster, TestAttributes)
 
 TEST_F(TestGroupcastCluster, TestAcceptedCommands)
 {
-    app::Clusters::GroupcastCluster cluster(BitFlags<Feature>{ Feature::kListener });
-    ASSERT_TRUE(IsAcceptedCommandsListEqualTo(cluster,
+    ASSERT_TRUE(IsAcceptedCommandsListEqualTo(mListener,
                                               {
                                                   Commands::JoinGroup::kMetadataEntry,
                                                   Commands::LeaveGroup::kMetadataEntry,
@@ -91,29 +152,585 @@ TEST_F(TestGroupcastCluster, TestAcceptedCommands)
                                               }));
 }
 
+TEST_F(TestGroupcastCluster, TestReadMembership)
+{
+    static constexpr uint16_t kMaxEndpoints = app::Clusters::GroupcastLogic::kMaxCommandEndpoints;
+    static constexpr uint16_t kIntervals    = 15;
+    const uint8_t key[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+    const EndpointId kEndpoints[kIntervals][kMaxEndpoints] = {
+        { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 },
+        { 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40 },
+        { 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60 },
+        { 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80 },
+        { 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100 },
+        { 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120 },
+        { 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140 },
+        { 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160 },
+        { 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180 },
+        { 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200 },
+        { 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220 },
+        { 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240 },
+        { 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260 },
+        { 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280 },
+        { 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300 }
+    };
+    GroupId kGroup1 = 0xab01;
+    GroupId kGroup2 = 0xcd02;
+
+    chip::Testing::ClusterTester tester(mListener);
+    tester.SetFabricIndex(kTestFabricIndex);
+
+    // Join groups
+    {
+        Commands::JoinGroup::Type data;
+        data.groupID         = kGroup1;
+        data.keySetID        = 0xabcd;
+        data.key             = MakeOptional(ByteSpan(key));
+        data.useAuxiliaryACL = MakeOptional(true);
+        data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
+        data.endpoints       = chip::app::DataModel::List<const EndpointId>(kEndpoints[0], kMaxEndpoints);
+
+        auto result = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+        data.key.ClearValue();
+        for (int i = 1; i < kIntervals; i++)
+        {
+            data.endpoints = chip::app::DataModel::List<const EndpointId>(kEndpoints[i], kMaxEndpoints);
+            result         = tester.Invoke(Commands::JoinGroup::Id, data);
+            ASSERT_TRUE(result.status.has_value());
+            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                      Protocols::InteractionModel::Status::Success);
+        }
+        // Join group 2
+        data.groupID         = kGroup2;
+        data.useAuxiliaryACL = MakeOptional(false);
+        data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kPerGroup);
+        for (int i = 0; i < 2; i++)
+        {
+            data.endpoints = chip::app::DataModel::List<const EndpointId>(kEndpoints[i], kMaxEndpoints);
+            result         = tester.Invoke(Commands::JoinGroup::Id, data);
+            ASSERT_TRUE(result.status.has_value());
+            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                      Protocols::InteractionModel::Status::Success);
+        }
+    }
+
+    // Read Membership
+    {
+        app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+
+        size_t memershipCount = 0;
+        ASSERT_EQ(CountListElements(memberships, memershipCount), CHIP_NO_ERROR);
+        ASSERT_EQ(memershipCount, 3u); // Group1 [1..255], Group1 [256..300], Group2 [1..40]
+
+        GroupId expected_groups[]          = { kGroup1, kGroup1, kGroup2 };
+        GroupId expected_endpoint_counts[] = { 255, 45, 40 };
+        GroupId prev_group                 = kGroup1;
+        size_t i = 0, j = 0;
+        auto iter = memberships.begin();
+        while (iter.Next())
+        {
+            auto item             = iter.GetValue();
+            size_t endpoint_count = 0;
+            // Check group
+            ASSERT_EQ(item.groupID, expected_groups[i]);
+            ASSERT_TRUE(item.hasAuxiliaryACL.HasValue());
+            ASSERT_EQ(item.hasAuxiliaryACL.Value(), item.groupID == kGroup1);
+            ChipLogProgress(Crypto, "~~~ g:#%04x, a:%u, p:%u", (unsigned) item.groupID, (unsigned) item.hasAuxiliaryACL.Value(),
+                            (unsigned) item.mcastAddrPolicy);
+            ASSERT_EQ(item.mcastAddrPolicy,
+                      item.groupID == kGroup1 ? app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr
+                                              : app::Clusters::Groupcast::MulticastAddrPolicyEnum::kPerGroup);
+            // Check endpoint count
+            ASSERT_TRUE(item.endpoints.HasValue());
+            ASSERT_EQ(item.endpoints.Value().ComputeSize(&endpoint_count), CHIP_NO_ERROR);
+            ASSERT_EQ(endpoint_count, expected_endpoint_counts[i]);
+            // Check individual endpoints
+            if (item.groupID != prev_group)
+            {
+                // Reset endpoint idex for the new group
+                j = 0;
+            }
+            auto iter2 = item.endpoints.Value().begin();
+            while (iter2.Next())
+            {
+                EndpointId endpoint_id = iter2.GetValue();
+                EndpointId expected_id = kEndpoints[j / kMaxEndpoints][j % kMaxEndpoints];
+                ASSERT_EQ(endpoint_id, expected_id);
+                j++;
+            }
+            prev_group = item.groupID;
+            i++;
+        }
+    }
+}
+
 TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
 {
-    chip::Testing::TestServerClusterContext context;
-    app::Clusters::GroupcastCluster cluster(BitFlags<Feature>{ Feature::kListener });
-    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
-
-    // Form a valid JoinGroup command
-    const uint8_t keyData[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+    const uint8_t key[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
     const EndpointId kEndpoints[] = { 1 };
 
-    Commands::JoinGroup::Type cmdData;
-    cmdData.groupID         = 1;
-    cmdData.endpoints       = chip::app::DataModel::List<const EndpointId>(kEndpoints, MATTER_ARRAY_SIZE(kEndpoints));
-    cmdData.keySetID        = 0xAABB;
-    cmdData.key             = MakeOptional(ByteSpan(keyData));
-    cmdData.useAuxiliaryACL = MakeOptional(true);
+    Commands::JoinGroup::Type data;
+    data.groupID         = 1;
+    data.keySetID        = 0xabcd;
+    data.key             = MakeOptional(ByteSpan(key));
+    data.useAuxiliaryACL = MakeOptional(true);
+    data.endpoints       = chip::app::DataModel::List<const EndpointId>(kEndpoints, MATTER_ARRAY_SIZE(kEndpoints));
 
-    chip::Testing::MockCommandHandler cmdHandler;
-    chip::Testing::ClusterTester tester(cluster);
-    auto result = tester.Invoke(Commands::JoinGroup::Id, cmdData);
-    ASSERT_TRUE(result.status.has_value());
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-              Protocols::InteractionModel::Status::Failure);     // Currently expect Failure as JoinGroup command returns
-                                                                 // CHIP_ERROR_NOT_IMPLEMENTED
+    // Listener
+    {
+        chip::Testing::ClusterTester tester(mListener);
+        tester.SetFabricIndex(kTestFabricIndex);
+
+        // Join group: New keyset and key
+        auto result = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+
+        // Join group: Existing keyset and key (invalid)
+        data.groupID = 2;
+        result       = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::AlreadyExists);
+
+        // Join group: Existing keyset but no key
+        data.groupID = 2;
+        data.key.ClearValue();
+        result = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+
+        // Join group: Existing keyset but no key
+        data.groupID = 2;
+        data.key.ClearValue();
+        result = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+    }
+
+    // Sender
+    {
+        chip::Testing::ClusterTester tester(mSender);
+        tester.SetFabricIndex(kTestFabricIndex);
+        data.endpoints = chip::app::DataModel::List<const EndpointId>();
+
+        // Join group: UseAuxiliaryACL can't be set
+        auto result = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::ConstraintError);
+
+        // Join group: UseAuxiliaryACL unset
+        data.useAuxiliaryACL.ClearValue();
+        result = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+
+        // Join group: Non-empty endpoints
+        data.groupID   = 3;
+        data.endpoints = chip::app::DataModel::List<const EndpointId>(kEndpoints, MATTER_ARRAY_SIZE(kEndpoints));
+        result         = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::ConstraintError);
+    }
 }
+
+TEST_F(TestGroupcastCluster, TestLeaveGroup)
+{
+    static constexpr uint16_t kMaxEndpoints   = app::Clusters::GroupcastLogic::kMaxCommandEndpoints;
+    static constexpr uint16_t kIntervals      = 5;
+    static constexpr uint16_t kTotalEndpoints = kMaxEndpoints * kIntervals;
+    const uint8_t key[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+    const EndpointId kEndpoints[kIntervals][kMaxEndpoints] = {
+        { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 },
+        { 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40 },
+        { 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60 },
+        { 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80 },
+        { 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100 }
+    };
+    const EndpointId kLeaveEndpoints1[] = { 1, 23, 45, 56, 67, 78, 89, 100 };
+    const EndpointId kLeaveEndpoints2[] = { 3, 6, 29, 42, 48, 66, 76, 91 };
+
+    static const std::set<EndpointId> kRemoveSet1(std::begin(kLeaveEndpoints1), std::end(kLeaveEndpoints1));
+    static const std::set<EndpointId> kRemoveSet2(std::begin(kLeaveEndpoints2), std::end(kLeaveEndpoints2));
+
+    GroupId kGroup1 = 0xab01;
+    GroupId kGroup2 = kGroup1 + 1;
+
+    chip::Testing::ClusterTester tester(mListener);
+    tester.SetFabricIndex(kTestFabricIndex);
+
+    // Join grojups
+    {
+        // Group 1
+        Commands::JoinGroup::Type data;
+        data.groupID         = kGroup1;
+        data.keySetID        = 0xabcd;
+        data.key             = MakeOptional(ByteSpan(key));
+        data.useAuxiliaryACL = MakeOptional(true);
+        data.endpoints       = chip::app::DataModel::List<const EndpointId>(kEndpoints[0], kMaxEndpoints);
+
+        auto result = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+        data.key.ClearValue();
+        for (int i = 1; i < kIntervals; i++)
+        {
+            data.endpoints = chip::app::DataModel::List<const EndpointId>(kEndpoints[i], kMaxEndpoints);
+            result         = tester.Invoke(Commands::JoinGroup::Id, data);
+            ASSERT_TRUE(result.status.has_value());
+            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                      Protocols::InteractionModel::Status::Success);
+        }
+        // Group 2
+        data.groupID         = kGroup2;
+        data.useAuxiliaryACL = MakeOptional(false);
+        for (int i = 0; i < kIntervals; i++)
+        {
+            data.endpoints = chip::app::DataModel::List<const EndpointId>(kEndpoints[i], kMaxEndpoints);
+            result         = tester.Invoke(Commands::JoinGroup::Id, data);
+            ASSERT_TRUE(result.status.has_value());
+            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                      Protocols::InteractionModel::Status::Success);
+        }
+    }
+
+    // Read Membership
+    {
+        app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+
+        size_t memershipCount = 0;
+        ASSERT_EQ(CountListElements(memberships, memershipCount), CHIP_NO_ERROR);
+        ASSERT_EQ(memershipCount, 2u); // Group1 [1..255], Group1 [256..300], Group2 [1..40]
+
+        GroupId group_id = kGroup1;
+        auto iter        = memberships.begin();
+        while (iter.Next())
+        {
+            auto item = iter.GetValue();
+            ASSERT_EQ(item.groupID, group_id);
+            // Check the endpoints are still in the group
+            size_t found          = 0;
+            size_t endpoint_count = 0;
+            // Check endpoint count
+            ASSERT_TRUE(item.endpoints.HasValue());
+            ASSERT_EQ(item.endpoints.Value().ComputeSize(&endpoint_count), CHIP_NO_ERROR);
+            ASSERT_EQ(endpoint_count, kTotalEndpoints);
+            // Check endpoints are stil in the group
+            auto iter2 = item.endpoints.Value().begin();
+            while (iter2.Next())
+            {
+                if (kRemoveSet1.find(iter2.GetValue()) != kRemoveSet1.end())
+                {
+                    found++;
+                }
+            }
+            ASSERT_EQ(found, kRemoveSet1.size());
+            group_id++;
+        }
+    }
+
+    // LeaveGroup
+    {
+        Commands::LeaveGroup::Type data;
+
+        // Update existing key (invalid)
+        data.groupID = kGroup1;
+        data.endpoints =
+            MakeOptional(chip::app::DataModel::List<const EndpointId>(kLeaveEndpoints1, MATTER_ARRAY_SIZE(kLeaveEndpoints1)));
+        auto result = tester.Invoke(Commands::LeaveGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+    }
+
+    // Read Membership
+    {
+        app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+
+        size_t memershipCount = 0;
+        ASSERT_EQ(CountListElements(memberships, memershipCount), CHIP_NO_ERROR);
+        ASSERT_EQ(memershipCount, 2u); // Group1 [1..255], Group1 [256..300], Group2 [1..40]
+
+        GroupId group_id = kGroup1;
+        auto iter        = memberships.begin();
+        while (iter.Next())
+        {
+            auto item = iter.GetValue();
+            ASSERT_EQ(item.groupID, group_id);
+            // Check the endpoints are still in the group
+            size_t found          = 0;
+            size_t endpoint_count = 0;
+            // Check endpoint count
+
+            size_t expected_count = (kGroup1 == group_id) ? kTotalEndpoints - kRemoveSet1.size() : kTotalEndpoints;
+            ASSERT_TRUE(item.endpoints.HasValue());
+            ASSERT_EQ(item.endpoints.Value().ComputeSize(&endpoint_count), CHIP_NO_ERROR);
+            ASSERT_EQ(endpoint_count, expected_count);
+            // Check endpoints are stil in the group
+            auto iter2 = item.endpoints.Value().begin();
+            while (iter2.Next())
+            {
+                if (kRemoveSet1.find(iter2.GetValue()) != kRemoveSet1.end())
+                {
+                    found++;
+                }
+            }
+            // Endpoints removed from group 1, but not from group 2
+            ASSERT_EQ(found, kGroup1 == group_id ? 0 : kRemoveSet1.size());
+            group_id++;
+        }
+    }
+
+    // LeaveGroup (all)
+    {
+        Commands::LeaveGroup::Type data;
+
+        // Update existing key (invalid)
+        data.groupID = 0;
+        data.endpoints =
+            MakeOptional(chip::app::DataModel::List<const EndpointId>(kLeaveEndpoints2, MATTER_ARRAY_SIZE(kLeaveEndpoints2)));
+        auto result = tester.Invoke(Commands::LeaveGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+    }
+
+    // Read Membership
+    {
+        app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+
+        size_t memershipCount = 0;
+        ASSERT_EQ(CountListElements(memberships, memershipCount), CHIP_NO_ERROR);
+        ASSERT_EQ(memershipCount, 2u); // Group1 [1..255], Group1 [256..300], Group2 [1..40]
+
+        GroupId group_id = kGroup1;
+        auto iter        = memberships.begin();
+        while (iter.Next())
+        {
+            auto item = iter.GetValue();
+            ASSERT_EQ(item.groupID, group_id);
+            // Check the endpoints are still in the group
+            size_t found          = 0;
+            size_t endpoint_count = 0;
+            // Check endpoint count
+            size_t expected_count = (kGroup1 == group_id) ? kTotalEndpoints - kRemoveSet1.size() - kRemoveSet2.size()
+                                                          : kTotalEndpoints - kRemoveSet2.size();
+
+            ASSERT_TRUE(item.endpoints.HasValue());
+            ASSERT_EQ(item.endpoints.Value().ComputeSize(&endpoint_count), CHIP_NO_ERROR);
+            ASSERT_EQ(endpoint_count, expected_count);
+            // Check endpoints are stil in the group
+            auto iter2 = item.endpoints.Value().begin();
+            while (iter2.Next())
+            {
+                if (kRemoveSet2.find(iter2.GetValue()) != kRemoveSet2.end())
+                {
+                    found++;
+                }
+            }
+            // Endpoints removed from both all groups
+            ASSERT_EQ(found, static_cast<size_t>(0));
+            group_id++;
+        }
+    }
+}
+
+TEST_F(TestGroupcastCluster, TestUpdateGroupKey)
+{
+    const uint8_t key1[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+    const uint8_t key2[] = { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf };
+    const EndpointId kEndpoints[] = { 1 };
+    const KeysetId kKeyset1       = 0xabcd;
+    const KeysetId kKeyset2       = 0xcafe;
+
+    chip::Testing::ClusterTester tester(mListener);
+    tester.SetFabricIndex(kTestFabricIndex);
+
+    // Join groups
+    {
+        Commands::JoinGroup::Type data;
+        data.groupID         = 1;
+        data.keySetID        = kKeyset1;
+        data.key             = MakeOptional(ByteSpan(key1));
+        data.useAuxiliaryACL = MakeOptional(true);
+        data.endpoints       = chip::app::DataModel::List<const EndpointId>(kEndpoints, MATTER_ARRAY_SIZE(kEndpoints));
+
+        auto result = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+
+        data.groupID  = 2;
+        data.keySetID = kKeyset2;
+        data.key      = MakeOptional(ByteSpan(key2));
+        result        = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+    }
+
+    // Read Membership
+    {
+        app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+        GroupId group_id = 1;
+        auto iter        = memberships.begin();
+        while (iter.Next())
+        {
+            auto item            = iter.GetValue();
+            KeysetId expected_id = (1 == item.groupID) ? kKeyset1 : kKeyset2;
+            ASSERT_EQ(item.groupID, group_id);
+            ASSERT_EQ(item.keySetID, expected_id);
+            group_id++;
+        }
+    }
+
+    // Update
+    {
+        Commands::UpdateGroupKey::Type data;
+
+        // Update existing key (invalid)
+        data.groupID  = 2;
+        data.keySetID = kKeyset1;
+        data.key      = MakeOptional(ByteSpan(key1));
+
+        auto result = tester.Invoke(Commands::UpdateGroupKey::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::AlreadyExists);
+
+        // Update existing keyset (valid)
+        data.keySetID = kKeyset1;
+        data.key.ClearValue();
+        result = tester.Invoke(Commands::UpdateGroupKey::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+    }
+
+    // Read Membership
+    {
+        app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+        GroupId group_id = 1;
+        auto iter        = memberships.begin();
+        while (iter.Next())
+        {
+            auto item = iter.GetValue();
+            ASSERT_EQ(item.groupID, group_id);
+            ASSERT_EQ(item.keySetID, kKeyset1);
+            group_id++;
+        }
+    }
+}
+
+TEST_F(TestGroupcastCluster, TestConfigureAuxiliaryACL)
+{
+    const uint8_t key[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+    const EndpointId kEndpoints[] = { 1 };
+    const GroupId kGroupId        = 0xcafe;
+    const KeysetId kKeyset        = 0xabcd;
+
+    chip::Testing::ClusterTester tester(mListener);
+    tester.SetFabricIndex(kTestFabricIndex);
+
+    // Join group
+    {
+        Commands::JoinGroup::Type data;
+        data.groupID         = kGroupId;
+        data.keySetID        = kKeyset;
+        data.key             = MakeOptional(ByteSpan(key));
+        data.useAuxiliaryACL = MakeOptional(false);
+        data.endpoints       = chip::app::DataModel::List<const EndpointId>(kEndpoints, MATTER_ARRAY_SIZE(kEndpoints));
+
+        auto result = tester.Invoke(Commands::JoinGroup::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+    }
+
+    // Read Membership
+    {
+        app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+        auto iter = memberships.begin();
+        while (iter.Next())
+        {
+            auto item = iter.GetValue();
+            ASSERT_EQ(item.groupID, kGroupId);
+            ASSERT_EQ(item.keySetID, kKeyset);
+            ASSERT_TRUE(item.hasAuxiliaryACL.HasValue());
+            ASSERT_FALSE(item.hasAuxiliaryACL.Value());
+        }
+    }
+
+    // Update (false to true)
+    {
+        Commands::ConfigureAuxiliaryACL::Type data;
+        data.groupID         = kGroupId;
+        data.useAuxiliaryACL = true;
+
+        auto result = tester.Invoke(Commands::ConfigureAuxiliaryACL::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+    }
+
+    // Read Membership
+    {
+        app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+        auto iter = memberships.begin();
+        while (iter.Next())
+        {
+            auto item = iter.GetValue();
+            ASSERT_EQ(item.groupID, kGroupId);
+            ASSERT_EQ(item.keySetID, kKeyset);
+            ASSERT_TRUE(item.hasAuxiliaryACL.HasValue());
+            ASSERT_TRUE(item.hasAuxiliaryACL.Value());
+        }
+    }
+
+    // Update (true to false)
+    {
+        Commands::ConfigureAuxiliaryACL::Type data;
+        data.groupID         = kGroupId;
+        data.useAuxiliaryACL = false;
+
+        auto result = tester.Invoke(Commands::ConfigureAuxiliaryACL::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+    }
+
+    // Read Membership
+    {
+        app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
+        auto iter = memberships.begin();
+        while (iter.Next())
+        {
+            auto item = iter.GetValue();
+            ASSERT_EQ(item.groupID, kGroupId);
+            ASSERT_EQ(item.keySetID, kKeyset);
+            ASSERT_TRUE(item.hasAuxiliaryACL.HasValue());
+            ASSERT_FALSE(item.hasAuxiliaryACL.Value());
+        }
+    }
+}
+
 } // namespace

--- a/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
@@ -179,7 +179,12 @@ public:
     CHIP_ERROR RemoveEndpoint(FabricIndex, EndpointId) override { return CHIP_NO_ERROR; }
     GroupInfoIterator * IterateGroupInfo(FabricIndex) override { return nullptr; }
     EndpointIterator * IterateEndpoints(FabricIndex, std::optional<GroupId>) override { return nullptr; }
+    CHIP_ERROR SetGroupKey(FabricIndex fabric_index, GroupId group_id, KeysetId keyset_id) override { return CHIP_NO_ERROR; }
     CHIP_ERROR SetGroupKeyAt(FabricIndex, size_t, const GroupKey &) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR GetGroupKey(FabricIndex fabric_index, GroupId group_id, KeysetId & keyset_id) override
+    {
+        return CHIP_ERROR_NOT_FOUND;
+    }
     CHIP_ERROR GetGroupKeyAt(FabricIndex, size_t, GroupKey &) override { return CHIP_ERROR_NOT_FOUND; }
     CHIP_ERROR RemoveGroupKeyAt(FabricIndex, size_t) override { return CHIP_NO_ERROR; }
     CHIP_ERROR RemoveGroupKeys(FabricIndex) override { return CHIP_NO_ERROR; }

--- a/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
@@ -177,6 +177,7 @@ public:
     CHIP_ERROR AddEndpoint(FabricIndex, GroupId, EndpointId) override { return CHIP_NO_ERROR; }
     CHIP_ERROR RemoveEndpoint(FabricIndex, GroupId, EndpointId) override { return CHIP_NO_ERROR; }
     CHIP_ERROR RemoveEndpoint(FabricIndex, EndpointId) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR RemoveEndpoints(FabricIndex fabric_index, GroupId group_id) override { return CHIP_NO_ERROR; }
     GroupInfoIterator * IterateGroupInfo(FabricIndex) override { return nullptr; }
     EndpointIterator * IterateEndpoints(FabricIndex, std::optional<GroupId>) override { return nullptr; }
     CHIP_ERROR SetGroupKey(FabricIndex fabric_index, GroupId group_id, KeysetId keyset_id) override { return CHIP_NO_ERROR; }
@@ -197,6 +198,7 @@ public:
     CHIP_ERROR RemoveFabric(FabricIndex) override { return CHIP_NO_ERROR; }
     GroupSessionIterator * IterateGroupSessions(uint16_t) override { return nullptr; }
     Crypto::SymmetricKeyContext * GetKeyContext(FabricIndex, GroupId) override { return nullptr; }
+    uint16_t getMaxMembershipCount() override { return 0; }
 
     bool mHasEndpoint = true;
 };

--- a/src/app/zap_cluster_list.json
+++ b/src/app/zap_cluster_list.json
@@ -214,7 +214,7 @@
         "ELECTRICAL_GRID_CONDITIONS_CLUSTER": [
             "electrical-grid-conditions-server"
         ],
-        "GROUPCAST_CLUSTER": ["groupcast-server"],
+        "GROUPCAST_CLUSTER": ["groupcast"],
         "METER_IDENTIFICATION_CLUSTER": ["meter-identification-server"],
         "MICROWAVE_OVEN_MODE_CLUSTER": ["mode-base-server"],
         "DOOR_LOCK_CLUSTER": ["door-lock-server"],

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -44,12 +44,15 @@ public:
         GroupId group_id = kUndefinedGroupId;
         // Lastest group name written for a given GroupId on any Endpoint via the Groups cluster
         char name[kGroupNameMax + 1] = { 0 };
+        bool use_aux_acl             = false;
+        uint16_t count               = 0;
 
         GroupInfo() { SetName(nullptr); }
         GroupInfo(const char * groupName) { SetName(groupName); }
         GroupInfo(const CharSpan & groupName) { SetName(groupName); }
         GroupInfo(GroupId id, const char * groupName) : group_id(id) { SetName(groupName); }
         GroupInfo(GroupId id, const CharSpan & groupName) : group_id(id) { SetName(groupName); }
+        GroupInfo(GroupId id, bool aux_acl) : group_id(id), use_aux_acl(aux_acl) { SetName(nullptr); }
         void SetName(const char * groupName)
         {
             if (nullptr == groupName)
@@ -259,10 +262,12 @@ public:
     // Group-Key map
     //
 
-    virtual CHIP_ERROR SetGroupKeyAt(FabricIndex fabric_index, size_t index, const GroupKey & info) = 0;
-    virtual CHIP_ERROR GetGroupKeyAt(FabricIndex fabric_index, size_t index, GroupKey & info)       = 0;
-    virtual CHIP_ERROR RemoveGroupKeyAt(FabricIndex fabric_index, size_t index)                     = 0;
-    virtual CHIP_ERROR RemoveGroupKeys(FabricIndex fabric_index)                                    = 0;
+    virtual CHIP_ERROR SetGroupKey(FabricIndex fabric_index, GroupId group_id, KeysetId keyset_id)   = 0;
+    virtual CHIP_ERROR SetGroupKeyAt(FabricIndex fabric_index, size_t index, const GroupKey & info)  = 0;
+    virtual CHIP_ERROR GetGroupKey(FabricIndex fabric_index, GroupId group_id, KeysetId & keyset_id) = 0;
+    virtual CHIP_ERROR GetGroupKeyAt(FabricIndex fabric_index, size_t index, GroupKey & info)        = 0;
+    virtual CHIP_ERROR RemoveGroupKeyAt(FabricIndex fabric_index, size_t index)                      = 0;
+    virtual CHIP_ERROR RemoveGroupKeys(FabricIndex fabric_index)                                     = 0;
 
     /**
      *  Creates an iterator that may be used to obtain the list of (group, keyset) pairs associated with the given fabric.

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -39,20 +39,31 @@ public:
     struct GroupInfo
     {
         static constexpr size_t kGroupNameMax = CHIP_CONFIG_MAX_GROUP_NAME_LENGTH;
+        enum class Flags : uint8_t
+        {
+            kHasAuxiliaryACL = 0b00000001,
+            kMcastAddrPolicy = 0b00000010,
+        };
 
         // Identifies group within the scope of the given Fabric
         GroupId group_id = kUndefinedGroupId;
         // Lastest group name written for a given GroupId on any Endpoint via the Groups cluster
         char name[kGroupNameMax + 1] = { 0 };
-        bool use_aux_acl             = false;
+        uint8_t flags                = 0;
         uint16_t count               = 0;
 
         GroupInfo() { SetName(nullptr); }
+        GroupInfo(const GroupInfo & other) { Copy(other); }
         GroupInfo(const char * groupName) { SetName(groupName); }
         GroupInfo(const CharSpan & groupName) { SetName(groupName); }
-        GroupInfo(GroupId id, const char * groupName) : group_id(id) { SetName(groupName); }
-        GroupInfo(GroupId id, const CharSpan & groupName) : group_id(id) { SetName(groupName); }
-        GroupInfo(GroupId id, bool aux_acl) : group_id(id), use_aux_acl(aux_acl) { SetName(nullptr); }
+        GroupInfo(GroupId id, const char * groupName, uint8_t groupFlags = 0) : group_id(id), flags(groupFlags)
+        {
+            SetName(groupName);
+        }
+        GroupInfo(GroupId id, const CharSpan & groupName, uint8_t groupFlags = 0) : group_id(id), flags(groupFlags)
+        {
+            SetName(groupName);
+        }
         void SetName(const char * groupName)
         {
             if (nullptr == groupName)
@@ -75,9 +86,23 @@ public:
                 Platform::CopyString(name, groupName);
             }
         }
+        void Copy(const GroupInfo & other)
+        {
+            if (this != &other)
+            {
+                group_id = other.group_id;
+                flags    = other.flags;
+                SetName(other.name);
+            }
+        }
         bool operator==(const GroupInfo & other) const
         {
             return (this->group_id == other.group_id) && !strncmp(this->name, other.name, kGroupNameMax);
+        }
+        GroupInfo & operator=(const GroupInfo & other)
+        {
+            Copy(other);
+            return *this;
         }
     };
 
@@ -239,6 +264,7 @@ public:
     virtual CHIP_ERROR AddEndpoint(FabricIndex fabric_index, GroupId group_id, EndpointId endpoint_id)    = 0;
     virtual CHIP_ERROR RemoveEndpoint(FabricIndex fabric_index, GroupId group_id, EndpointId endpoint_id) = 0;
     virtual CHIP_ERROR RemoveEndpoint(FabricIndex fabric_index, EndpointId endpoint_id)                   = 0;
+    virtual CHIP_ERROR RemoveEndpoints(FabricIndex fabric_index, GroupId group_id)                        = 0;
     // Iterators
     /**
      *  Creates an iterator that may be used to obtain the list of groups associated with the given fabric.
@@ -320,6 +346,9 @@ public:
     // Listener
     void SetListener(GroupListener * listener) { mListener = listener; };
     void RemoveListener() { mListener = nullptr; };
+
+    // Groupcast MaxMembershipCount
+    virtual uint16_t getMaxMembershipCount() = 0;
 
 protected:
     void GroupAdded(FabricIndex fabric_index, const GroupInfo & new_group)

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -266,7 +266,7 @@ struct GroupData : public GroupDataProvider::GroupInfo, PersistableData<kPersist
     static constexpr TLV::Tag TagFirstEndpoint() { return TLV::ContextTag(2); }
     static constexpr TLV::Tag TagEndpointCount() { return TLV::ContextTag(3); }
     static constexpr TLV::Tag TagNext() { return TLV::ContextTag(4); }
-    static constexpr TLV::Tag TagHasAuxiliaryAcl() { return TLV::ContextTag(5); }
+    static constexpr TLV::Tag TagFlags() { return TLV::ContextTag(5); }
 
     chip::FabricIndex fabric_index  = kUndefinedFabricIndex;
     chip::EndpointId first_endpoint = kInvalidEndpointId;
@@ -293,7 +293,7 @@ struct GroupData : public GroupDataProvider::GroupInfo, PersistableData<kPersist
         first_endpoint = kInvalidEndpointId;
         endpoint_count = 0;
         next           = 0;
-        use_aux_acl    = false;
+        flags          = 0;
     }
 
     CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
@@ -306,7 +306,7 @@ struct GroupData : public GroupDataProvider::GroupInfo, PersistableData<kPersist
         ReturnErrorOnFailure(writer.Put(TagFirstEndpoint(), static_cast<uint16_t>(first_endpoint)));
         ReturnErrorOnFailure(writer.Put(TagEndpointCount(), static_cast<uint16_t>(endpoint_count)));
         ReturnErrorOnFailure(writer.Put(TagNext(), static_cast<uint16_t>(next)));
-        ReturnErrorOnFailure(writer.Put(TagHasAuxiliaryAcl(), static_cast<uint8_t>(use_aux_acl)));
+        ReturnErrorOnFailure(writer.Put(TagFlags(), static_cast<uint8_t>(flags)));
         return writer.EndContainer(container);
     }
 
@@ -332,13 +332,14 @@ struct GroupData : public GroupDataProvider::GroupInfo, PersistableData<kPersist
         // next
         ReturnErrorOnFailure(reader.Next(TagNext()));
         ReturnErrorOnFailure(reader.Get(next));
-        // use_aux_acl
-        CHIP_ERROR err = reader.Next(TagHasAuxiliaryAcl());
+        // Groupcast
+        CHIP_ERROR err = reader.Next(TagFlags());
         if (CHIP_NO_ERROR == err)
         {
-            uint8_t aux_acl = 0;
-            ReturnErrorOnFailure(reader.Get(aux_acl));
-            use_aux_acl = aux_acl;
+            // flags
+            uint8_t value = 0;
+            ReturnErrorOnFailure(reader.Get(value));
+            flags = value;
         }
         return reader.ExitContainer(container);
     }
@@ -868,15 +869,12 @@ CHIP_ERROR GroupDataProviderImpl::SetGroupInfo(chip::FabricIndex fabric_index, c
     if (group.Find(mStorage, fabric, info.group_id))
     {
         // Existing group_id
-        group.use_aux_acl = info.use_aux_acl;
-        group.SetName(info.name);
+        group.Copy(info);
         return group.Save(mStorage);
     }
 
     // New group_id
-    group.group_id    = info.group_id;
-    group.use_aux_acl = info.use_aux_acl;
-    group.SetName(info.name);
+    group.Copy(info);
     return SetGroupInfoAt(fabric_index, fabric.group_count, group);
 }
 
@@ -889,9 +887,7 @@ CHIP_ERROR GroupDataProviderImpl::GetGroupInfo(chip::FabricIndex fabric_index, c
     info.count = fabric.group_count;
     VerifyOrReturnError(group.Find(mStorage, fabric, group_id), CHIP_ERROR_NOT_FOUND);
 
-    info.group_id    = group.group_id;
-    info.use_aux_acl = group.use_aux_acl;
-    info.SetName(group.name);
+    info.Copy(group);
     return CHIP_NO_ERROR;
 }
 
@@ -921,10 +917,8 @@ CHIP_ERROR GroupDataProviderImpl::SetGroupInfoAt(chip::FabricIndex fabric_index,
     bool found = group.Find(mStorage, fabric, info.group_id);
     VerifyOrReturnError(!found || (group.index == index), CHIP_ERROR_DUPLICATE_KEY_ID);
 
-    group.group_id       = info.group_id;
-    group.use_aux_acl    = info.use_aux_acl;
+    group.Copy(info);
     group.endpoint_count = 0;
-    group.SetName(info.name);
 
     if (found)
     {
@@ -984,9 +978,7 @@ CHIP_ERROR GroupDataProviderImpl::GetGroupInfoAt(chip::FabricIndex fabric_index,
     VerifyOrReturnError(group.Get(mStorage, fabric, index), CHIP_ERROR_NOT_FOUND);
 
     // Target group found
-    info.group_id    = group.group_id;
-    info.use_aux_acl = group.use_aux_acl;
-    info.SetName(group.name);
+    info.Copy(group);
     return CHIP_NO_ERROR;
 }
 
@@ -1213,10 +1205,8 @@ bool GroupDataProviderImpl::GroupInfoIteratorImpl::Next(GroupInfo & output)
     VerifyOrReturnError(CHIP_NO_ERROR == err, false);
 
     mCount++;
-    mNextId            = group.next;
-    output.group_id    = group.group_id;
-    output.use_aux_acl = group.use_aux_acl;
-    output.SetName(group.name);
+    mNextId = group.next;
+    output.Copy(group);
     return true;
 }
 

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -75,8 +75,10 @@ public:
     // Group-Key map
     //
 
+    CHIP_ERROR SetGroupKey(FabricIndex fabric_index, GroupId group_id, KeysetId keyset_id) override;
     CHIP_ERROR SetGroupKeyAt(FabricIndex fabric_index, size_t index, const GroupKey & info) override;
     CHIP_ERROR GetGroupKeyAt(FabricIndex fabric_index, size_t index, GroupKey & info) override;
+    CHIP_ERROR GetGroupKey(FabricIndex fabric_index, GroupId group_id, KeysetId & keyset_id) override;
     CHIP_ERROR RemoveGroupKeyAt(FabricIndex fabric_index, size_t index) override;
     CHIP_ERROR RemoveGroupKeys(FabricIndex fabric_index) override;
     GroupKeyIterator * IterateGroupKeys(FabricIndex fabric_index) override;

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -27,7 +27,8 @@ namespace Credentials {
 class GroupDataProviderImpl : public GroupDataProvider
 {
 public:
-    static constexpr size_t kIteratorsMax = CHIP_CONFIG_MAX_GROUP_CONCURRENT_ITERATORS;
+    static constexpr size_t kIteratorsMax         = CHIP_CONFIG_MAX_GROUP_CONCURRENT_ITERATORS;
+    static constexpr uint16_t kMaxMembershipCount = 10;
 
     GroupDataProviderImpl() = default;
     GroupDataProviderImpl(uint16_t maxGroupsPerFabric, uint16_t maxGroupKeysPerFabric) :
@@ -67,6 +68,7 @@ public:
     CHIP_ERROR AddEndpoint(FabricIndex fabric_index, GroupId group_id, EndpointId endpoint_id) override;
     CHIP_ERROR RemoveEndpoint(FabricIndex fabric_index, GroupId group_id, EndpointId endpoint_id) override;
     CHIP_ERROR RemoveEndpoint(FabricIndex fabric_index, EndpointId endpoint_id) override;
+    CHIP_ERROR RemoveEndpoints(FabricIndex fabric_index, GroupId group_id) override;
     // Iterators
     GroupInfoIterator * IterateGroupInfo(FabricIndex fabric_index) override;
     EndpointIterator * IterateEndpoints(FabricIndex fabric_index, std::optional<GroupId> group_id = std::nullopt) override;
@@ -78,7 +80,6 @@ public:
     CHIP_ERROR SetGroupKey(FabricIndex fabric_index, GroupId group_id, KeysetId keyset_id) override;
     CHIP_ERROR SetGroupKeyAt(FabricIndex fabric_index, size_t index, const GroupKey & info) override;
     CHIP_ERROR GetGroupKeyAt(FabricIndex fabric_index, size_t index, GroupKey & info) override;
-    CHIP_ERROR GetGroupKey(FabricIndex fabric_index, GroupId group_id, KeysetId & keyset_id) override;
     CHIP_ERROR RemoveGroupKeyAt(FabricIndex fabric_index, size_t index) override;
     CHIP_ERROR RemoveGroupKeys(FabricIndex fabric_index) override;
     GroupKeyIterator * IterateGroupKeys(FabricIndex fabric_index) override;
@@ -90,6 +91,7 @@ public:
     CHIP_ERROR SetKeySet(FabricIndex fabric_index, const ByteSpan & compressed_fabric_id, const KeySet & keys) override;
     CHIP_ERROR GetKeySet(FabricIndex fabric_index, chip::KeysetId keyset_id, KeySet & keys) override;
     CHIP_ERROR RemoveKeySet(FabricIndex fabric_index, chip::KeysetId keyset_id) override;
+    CHIP_ERROR GetGroupKey(FabricIndex fabric_index, GroupId group_id, KeysetId & keyset_id) override;
     CHIP_ERROR GetIpkKeySet(FabricIndex fabric_index, KeySet & out_keyset) override;
     KeySetIterator * IterateKeySets(FabricIndex fabric_index) override;
 
@@ -99,6 +101,9 @@ public:
     // Decryption
     Crypto::SymmetricKeyContext * GetKeyContext(FabricIndex fabric_index, GroupId group_id) override;
     GroupSessionIterator * IterateGroupSessions(uint16_t session_id) override;
+
+    // Groupcast MaxMembershipCount
+    uint16_t getMaxMembershipCount() override { return kMaxMembershipCount; }
 
 protected:
     class GroupInfoIteratorImpl : public GroupInfoIterator
@@ -247,7 +252,6 @@ protected:
         GroupKeyContext mGroupKeyContext;
     };
 
-    CHIP_ERROR RemoveEndpoints(FabricIndex fabric_index, GroupId group_id);
     PersistentStorageDelegate * mStorage       = nullptr;
     Crypto::SessionKeystore * mSessionKeystore = nullptr;
     ObjectPool<GroupInfoIteratorImpl, kIteratorsMax> mGroupInfoIterators;

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -152,13 +152,13 @@ public:
     void OnGroupAdded(chip::FabricIndex fabric, const GroupInfo & new_group) override
     {
         fabric_index = fabric;
-        latest       = new_group;
+        latest.Copy(new_group);
         added_count++;
     }
     void OnGroupRemoved(chip::FabricIndex fabric, const GroupInfo & old_group) override
     {
         fabric_index = fabric;
-        latest       = old_group;
+        latest.Copy(old_group);
         removed_count++;
     }
 };

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -110,6 +110,7 @@ static const GroupInfo kGroupInfo3_2(kGroup2, "Group-3.2");
 static const GroupInfo kGroupInfo3_3(kGroup3, "Group-3.3");
 static const GroupInfo kGroupInfo3_4(kGroup4, "Group-3.4");
 static const GroupInfo kGroupInfo3_5(kGroup4, "Group-3.5");
+static const GroupInfo kGroupInfo3_6(kGroup4, "Group-3.5");
 
 static const GroupKey kGroup1Keyset0(kGroup1, kKeysetId0);
 static const GroupKey kGroup1Keyset1(kGroup1, kKeysetId1);
@@ -664,6 +665,13 @@ TEST_F(TestGroupDataProvider, TestGroupKeys)
     EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 0, pair), CHIP_NO_ERROR);
     EXPECT_EQ(pair, kGroup2Keyset0);
 
+    // Override first
+    EXPECT_EQ(provider->SetGroupKey(kFabric1, kGroup1, kKeysetId3), CHIP_NO_ERROR);
+    // Get First
+    KeysetId keyset_id = 0;
+    EXPECT_EQ(provider->GetGroupKey(kFabric1, kGroup1, keyset_id), CHIP_NO_ERROR);
+    EXPECT_EQ(keyset_id, kKeysetId3);
+
     // Remove Groups (remaining entries shift up)
 
     EXPECT_EQ(provider->RemoveGroupKeyAt(kFabric1, 2), CHIP_NO_ERROR);
@@ -675,7 +683,7 @@ TEST_F(TestGroupDataProvider, TestGroupKeys)
     EXPECT_EQ(provider->GetGroupKeyAt(kFabric1, 1, pair), CHIP_NO_ERROR);
     EXPECT_EQ(pair, kGroup1Keyset1);
     EXPECT_EQ(provider->GetGroupKeyAt(kFabric1, 0, pair), CHIP_NO_ERROR);
-    EXPECT_EQ(pair, kGroup1Keyset0);
+    EXPECT_EQ(pair, kGroup1Keyset3);
 
     EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupKeyAt(kFabric2, 3, pair));
     EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 2, pair), CHIP_NO_ERROR);
@@ -687,7 +695,7 @@ TEST_F(TestGroupDataProvider, TestGroupKeys)
 
     // Overwrite, (group_id, keyset_id) must be unique
 
-    EXPECT_EQ(CHIP_ERROR_DUPLICATE_KEY_ID, provider->SetGroupKeyAt(kFabric1, 2, kGroup1Keyset0));
+    EXPECT_EQ(CHIP_ERROR_DUPLICATE_KEY_ID, provider->SetGroupKeyAt(kFabric1, 2, kGroup1Keyset3));
     EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 2, kGroup3Keyset0), CHIP_NO_ERROR);
     EXPECT_EQ(CHIP_ERROR_DUPLICATE_KEY_ID, provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset2));
     EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 0, kGroup3Keyset1), CHIP_NO_ERROR);

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1113,15 +1113,6 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
- * @def CHIP_CONFIG_MAX_GROUPCAST_MEMBERSHIP_COUNT
- *
- * @brief Defines the max number of groupcast memberships per fabric
- */
-#ifndef CHIP_CONFIG_MAX_GROUPCAST_MEMBERSHIP_COUNT
-#define CHIP_CONFIG_MAX_GROUPCAST_MEMBERSHIP_COUNT 8
-#endif
-
-/**
  * @def CHIP_CONFIG_MAX_BINDING_ENTRIES_PER_FABRIC
  *
  * @brief Defines the number of binding entries per fabric.

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1113,6 +1113,15 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
+ * @def CHIP_CONFIG_MAX_GROUPCAST_MEMBERSHIP_COUNT
+ *
+ * @brief Defines the max number of groupcast memberships per fabric
+ */
+#ifndef CHIP_CONFIG_MAX_GROUPCAST_MEMBERSHIP_COUNT
+#define CHIP_CONFIG_MAX_GROUPCAST_MEMBERSHIP_COUNT 8
+#endif
+
+/**
  * @def CHIP_CONFIG_MAX_BINDING_ENTRIES_PER_FABRIC
  *
  * @brief Defines the number of binding entries per fabric.

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -244,7 +244,13 @@ public:
         return UDP(Inet::IPAddress::MakeIPv6PrefixMulticast(scope, prefixLength, prefix, groupId));
     }
 
-    static PeerAddress Groupcast() { return Multicast(0x00, 0xffff); }
+    static PeerAddress Groupcast()
+    {
+        constexpr uint8_t scope        = 0x05; // Site-Local
+        constexpr uint8_t prefixLength = 0x40; // 64-bit long network prefix field
+        // IANA assigned address
+        return UDP(Inet::IPAddress::MakeIPv6PrefixMulticast(scope, prefixLength, 0xff05000000000000, 0xfa));
+    }
 
 private:
     constexpr PeerAddress(uint16_t shortId) : mTransportType(Type::kNfc), mId{ .mNFCShortId = shortId } {}

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -244,6 +244,8 @@ public:
         return UDP(Inet::IPAddress::MakeIPv6PrefixMulticast(scope, prefixLength, prefix, groupId));
     }
 
+    static PeerAddress Groupcast() { return Multicast(0x00, 0xffff); }
+
 private:
     constexpr PeerAddress(uint16_t shortId) : mTransportType(Type::kNfc), mId{ .mNFCShortId = shortId } {}
 


### PR DESCRIPTION
#### Summary

Modifications on the existing `GroupDataProvider` to support the new `Groupcast` cluster.
* Methods added: `SetGroupKey`, `GetGroupKey`
* Method made public: `RemoveEndpoints`
* Added `use_aux_acl` flag to the persistent GroupData
* Groupcast cluster code updated to use the modified GroupDataProvider
* Added IANA-assigned multicast address to `PeerAddress`
* Tests added

#### Related issues

New Groupcast feature.

#### Testing

Groupcast commands executed successfully with two groups and up to 80 endpoints per group:
* JoinGroup
* LeaveGroup
* UpdateGroupKey
* ConfigureAuxiliaryACL

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
