### PR TITLE
[CHIME] Update chime cluster and test scripts to reflect spec changes

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/chime-instance.h
+++ b/examples/all-clusters-app/all-clusters-common/include/chime-instance.h
@@ -39,7 +39,7 @@ public:
 
     CHIP_ERROR GetChimeIDByIndex(uint8_t chimeIndex, uint8_t & chimeID);
 
-    Protocols::InteractionModel::Status PlayChimeSound();
+    Protocols::InteractionModel::Status PlayChimeSound(uint8_t chimeID);
 
     ChimeCommandDelegate()  = default;
     ~ChimeCommandDelegate() = default;

--- a/examples/all-clusters-app/all-clusters-common/src/chime-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/chime-instance.cpp
@@ -58,7 +58,7 @@ CHIP_ERROR ChimeCommandDelegate::GetChimeIDByIndex(uint8_t chimeIndex, uint8_t &
     return CHIP_NO_ERROR;
 }
 
-Status ChimeCommandDelegate::PlayChimeSound()
+Status ChimeCommandDelegate::PlayChimeSound(uint8_t chimeID)
 {
     return Status::Success;
 }

--- a/examples/all-devices-app/all-devices-common/devices/chime/impl/LoggingChimeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/chime/impl/LoggingChimeDevice.cpp
@@ -52,17 +52,15 @@ CHIP_ERROR LoggingChimeDevice::GetChimeIDByIndex(uint8_t chimeIndex, uint8_t & c
     return CHIP_NO_ERROR;
 }
 
-Protocols::InteractionModel::Status LoggingChimeDevice::PlayChimeSound()
+Protocols::InteractionModel::Status LoggingChimeDevice::PlayChimeSound(uint8_t chimeID)
 {
-    // Access the cluster to get the selected chime attribute
-    // Note: ChimeDevice exposes ChimeCluster() accessor
-    uint8_t selectedChime = ChimeCluster().GetSelectedChime();
+    // The chime ID to be played is provided to the app
 
     // Find the name
     CharSpan soundName = "Unknown"_span;
     for (const auto & sound : mSounds)
     {
-        if (sound.id == selectedChime)
+        if (sound.id == chimeID)
         {
             soundName = sound.name;
             break;

--- a/examples/all-devices-app/all-devices-common/devices/chime/impl/LoggingChimeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/chime/impl/LoggingChimeDevice.h
@@ -40,7 +40,7 @@ public:
     // ChimeDelegate
     CHIP_ERROR GetChimeSoundByIndex(uint8_t chimeIndex, uint8_t & chimeID, MutableCharSpan & name) override;
     CHIP_ERROR GetChimeIDByIndex(uint8_t chimeIndex, uint8_t & chimeID) override;
-    Protocols::InteractionModel::Status PlayChimeSound() override;
+    Protocols::InteractionModel::Status PlayChimeSound(uint8_t chimeID) override;
 
 private:
     DefaultTimerDelegate mTimerDelegate;

--- a/examples/camera-app/linux/include/clusters/chime/chime-manager.h
+++ b/examples/camera-app/linux/include/clusters/chime/chime-manager.h
@@ -33,7 +33,7 @@ public:
     CHIP_ERROR GetChimeSoundByIndex(uint8_t chimeIndex, uint8_t & chimeID, chip::MutableCharSpan & name) override;
     CHIP_ERROR GetChimeIDByIndex(uint8_t chimeIndex, uint8_t & chimeID) override;
 
-    chip::Protocols::InteractionModel::Status PlayChimeSound() override;
+    chip::Protocols::InteractionModel::Status PlayChimeSound(uint8_t chimeID) override;
 
 private:
     using ChimeSoundStructType = chip::app::Clusters::Chime::Structs::ChimeSoundStruct::Type;

--- a/examples/camera-app/linux/src/clusters/chime/chime-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/chime/chime-manager.cpp
@@ -49,7 +49,7 @@ CHIP_ERROR ChimeManager::GetChimeIDByIndex(uint8_t chimeIndex, uint8_t & chimeID
     return CHIP_NO_ERROR;
 }
 
-Protocols::InteractionModel::Status ChimeManager::PlayChimeSound()
+Protocols::InteractionModel::Status ChimeManager::PlayChimeSound(uint8_t chimeID)
 {
     // check if we are enabled
     if (!mChimeServer->GetEnabled())
@@ -57,10 +57,7 @@ Protocols::InteractionModel::Status ChimeManager::PlayChimeSound()
         return Protocols::InteractionModel::Status::Failure;
     }
 
-    // Get the Active Chime ID
-    auto selectedChime = mChimeServer->GetSelectedChime();
-
     // Play chime sound
-    ChipLogDetail(Camera, "Playing Chime with sound ID: %u", unsigned(selectedChime));
+    ChipLogDetail(Camera, "Playing Chime with sound ID: %u", unsigned(chimeID));
     return Protocols::InteractionModel::Status::Success;
 }

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -271,18 +271,18 @@ std::optional<DataModel::ActionReturnStatus> ChimeCluster::InvokeCommand(const D
     }
 }
 
-DataModel::ActionReturnStatus  ChimeCluster::HandlePlayChimeSound(CommandHandler & aHandler, const ConcreteCommandPath & aPath, 
+DataModel::ActionReturnStatus  ChimeCluster::HandlePlayChimeSound(CommandHandler & aHandler, const ConcreteCommandPath & aPath,
                                                                    const Commands::PlayChimeSound::DecodableType & commandData)
 {
     // Immediately return if we're not enabled
     //
-    if (!mEnabled) 
+    if (!mEnabled)
     {
         return Status::Success;
     }
 
     // If we have a provided Chime ID, ensure it is valid
-    // 
+    //
     uint8_t chimeIDToUse = mSelectedChime;
     if (commandData.chimeID.HasValue())
     {

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -22,9 +22,9 @@
 
 #include "ChimeCluster.h"
 
+#include <app/EventLogging.h>
 #include <app/SafeAttributePersistenceProvider.h>
 #include <app/server-cluster/AttributeListBuilder.h>
-#include <app/EventLogging.h>
 #include <clusters/Chime/Attributes.h>
 #include <clusters/Chime/Commands.h>
 #include <clusters/Chime/Events.h>
@@ -271,8 +271,8 @@ std::optional<DataModel::ActionReturnStatus> ChimeCluster::InvokeCommand(const D
     }
 }
 
-DataModel::ActionReturnStatus  ChimeCluster::HandlePlayChimeSound(CommandHandler & aHandler, const ConcreteCommandPath & aPath,
-                                                                   const Commands::PlayChimeSound::DecodableType & commandData)
+DataModel::ActionReturnStatus ChimeCluster::HandlePlayChimeSound(CommandHandler & aHandler, const ConcreteCommandPath & aPath,
+                                                                 const Commands::PlayChimeSound::DecodableType & commandData)
 {
     // Immediately return if we're not enabled
     //

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -24,8 +24,10 @@
 
 #include <app/SafeAttributePersistenceProvider.h>
 #include <app/server-cluster/AttributeListBuilder.h>
+#include <app/EventLogging.h>
 #include <clusters/Chime/Attributes.h>
 #include <clusters/Chime/Commands.h>
+#include <clusters/Chime/Events.h>
 #include <clusters/Chime/Metadata.h>
 #include <clusters/Chime/Structs.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -259,19 +261,60 @@ std::optional<DataModel::ActionReturnStatus> ChimeCluster::InvokeCommand(const D
     {
     case Commands::PlayChimeSound::Id: {
         ChipLogDetail(Zcl, "Chime: PlayChimeSound");
-        Status status = Status::Success;
 
-        // Only invoke the delegate if enabled, otherwise don't play a sound, and "silently" return
-        if (mEnabled)
-        {
-            // call the delegate to play the chime
-            status = mDelegate.PlayChimeSound();
-        }
-
-        return status;
+        Commands::PlayChimeSound::DecodableType commandData;
+        ReturnErrorOnFailure(commandData.Decode(input_arguments));
+        return HandlePlayChimeSound(*handler, request.path, commandData);
     }
     default:
         return Status::UnsupportedCommand;
+    }
+}
+
+DataModel::ActionReturnStatus  ChimeCluster::HandlePlayChimeSound(CommandHandler & aHandler, const ConcreteCommandPath & aPath, 
+                                                                   const Commands::PlayChimeSound::DecodableType & commandData)
+{
+    // Immediately return if we're not enabled
+    //
+    if (!mEnabled) 
+    {
+        return Status::Success;
+    }
+
+    // If we have a provided Chime ID, ensure it is valid
+    // 
+    uint8_t chimeIDToUse = mSelectedChime;
+    if (commandData.chimeID.HasValue())
+    {
+        if (!IsSupportedChimeID(commandData.chimeID.Value()))
+        {
+            ChipLogError(Zcl, "Chime: Unknown Chime ID provided to PlayChimeSound");
+            return Status::NotFound;
+        }
+
+        chimeIDToUse = commandData.chimeID.Value();
+    }
+
+    Status status = mDelegate.PlayChimeSound(chimeIDToUse);
+    if (status == Status::Success)
+    {
+        // Generate the event
+        GenerateChimeStartedPlayingEvent(chimeIDToUse);
+    }
+    return status;
+}
+
+void ChimeCluster::GenerateChimeStartedPlayingEvent(const uint8_t chimeID)
+{
+    Events::ChimeStartedPlaying::Type event;
+    EventNumber eventNumber;
+
+    event.chimeID = chimeID;
+
+    CHIP_ERROR err = LogEvent(event, GetPaths().data()->mEndpointId, eventNumber);
+    if (CHIP_NO_ERROR != err)
+    {
+        ChipLogError(Zcl, "Unable to generate ChimeStartedPlaying event");
     }
 }
 

--- a/src/app/clusters/chime-server/ChimeCluster.h
+++ b/src/app/clusters/chime-server/ChimeCluster.h
@@ -104,10 +104,10 @@ private:
     // Encodes all Installed Chime Sounds
     CHIP_ERROR EncodeSupportedChimeSounds(const AttributeValueEncoder::ListEncodeHelper & encoder);
 
-    DataModel::ActionReturnStatus HandlePlayChimeSound(CommandHandler & aHandler, const ConcreteCommandPath & aPath, 
+    DataModel::ActionReturnStatus HandlePlayChimeSound(CommandHandler & aHandler, const ConcreteCommandPath & aPath,
                                                        const Chime::Commands::PlayChimeSound::DecodableType & commandData);
 
-    void GenerateChimeStartedPlayingEvent(const uint8_t chimeID); 
+    void GenerateChimeStartedPlayingEvent(const uint8_t chimeID);
 };
 
 /** @brief

--- a/src/app/clusters/chime-server/ChimeCluster.h
+++ b/src/app/clusters/chime-server/ChimeCluster.h
@@ -103,6 +103,11 @@ private:
 
     // Encodes all Installed Chime Sounds
     CHIP_ERROR EncodeSupportedChimeSounds(const AttributeValueEncoder::ListEncodeHelper & encoder);
+
+    DataModel::ActionReturnStatus HandlePlayChimeSound(CommandHandler & aHandler, const ConcreteCommandPath & aPath, 
+                                                       const Chime::Commands::PlayChimeSound::DecodableType & commandData);
+
+    void GenerateChimeStartedPlayingEvent(const uint8_t chimeID); 
 };
 
 /** @brief
@@ -148,8 +153,9 @@ public:
      * @brief Delegate should implement a handler to play the currently active chime sound.
      * It should report Status::Success if successful and may
      * return other Status codes if it fails
+     * @param chimeID the identifier for the chime to be played
      */
-    virtual Protocols::InteractionModel::Status PlayChimeSound() = 0;
+    virtual Protocols::InteractionModel::Status PlayChimeSound(uint8_t chimeID) = 0;
 
 protected:
     friend class ChimeCluster;

--- a/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
+++ b/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
@@ -75,7 +75,7 @@ public:
         }
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
     }
-    Protocols::InteractionModel::Status PlayChimeSound() override
+    Protocols::InteractionModel::Status PlayChimeSound(uint8_t chimeID) override
     {
         playChimeSoundCalled = true;
         return playChimeSoundStatus;

--- a/src/python_testing/TC_CHIMETestBase.py
+++ b/src/python_testing/TC_CHIMETestBase.py
@@ -35,10 +35,11 @@ class CHIMETestBase:
 
         asserts.assert_equal(response, status, "Unexpected error returned")
 
-    async def send_play_chime_sound_command(self, endpoint, expected_status: Status = Status.Success):
+    async def send_play_chime_sound_command(self, endpoint, chimeID: int = None, expected_status: Status = Status.Success):
         try:
-            await self.send_single_cmd(cmd=Clusters.Chime.Commands.PlayChimeSound(),
-                                       endpoint=endpoint)
+            await self.send_single_cmd(cmd=Clusters.Chime.Commands.PlayChimeSound(
+                chimeID = chimeID),
+                endpoint=endpoint)
 
             asserts.assert_equal(expected_status, Status.Success)
 

--- a/src/python_testing/TC_CHIMETestBase.py
+++ b/src/python_testing/TC_CHIMETestBase.py
@@ -38,7 +38,7 @@ class CHIMETestBase:
     async def send_play_chime_sound_command(self, endpoint, chimeID: int = None, expected_status: Status = Status.Success):
         try:
             await self.send_single_cmd(cmd=Clusters.Chime.Commands.PlayChimeSound(
-                chimeID = chimeID),
+                chimeID=chimeID),
                 endpoint=endpoint)
 
             asserts.assert_equal(expected_status, Status.Success)

--- a/src/python_testing/TC_CHIME_2_5.py
+++ b/src/python_testing/TC_CHIME_2_5.py
@@ -62,7 +62,7 @@ from matter.testing.runner import TestStep, default_matter_test_main
 log = logging.getLogger(__name__)
 
 
-class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
+class TC_CHIME_2_5(MatterBaseTest, CHIMETestBase):
 
     def desc_TC_CHIME_2_5(self) -> str:
         return "[TC-CHIME-2.5] Verify functionality of the PlayChimeSound command-Release 1.5.1 or later"

--- a/src/python_testing/TC_CHIME_2_5.py
+++ b/src/python_testing/TC_CHIME_2_5.py
@@ -145,5 +145,6 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
             self.skip_step(5)
             self.skip_step(6)
 
+
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_CHIME_2_5.py
+++ b/src/python_testing/TC_CHIME_2_5.py
@@ -114,7 +114,7 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
                 log.info("CHIME 2_5: No response received for no chime sound played user prompt")
 
         self.step(4)
-        await self.write_chime_attribute_expect_success(endpoint, attributes.Enabled, True)  
+        await self.write_chime_attribute_expect_success(endpoint, attributes.Enabled, True)
 
         myChimeSounds = await self.read_chime_attribute_expect_success(endpoint, attributes.InstalledChimeSounds)
         mySelectedChime = await self.read_chime_attribute_expect_success(endpoint, attributes.SelectedChime)

--- a/src/python_testing/TC_CHIME_2_5.py
+++ b/src/python_testing/TC_CHIME_2_5.py
@@ -1,0 +1,149 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#     factory-reset: true
+#     quiet: true
+#   run2:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --device chime
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import logging
+
+from mobly import asserts
+from TC_CHIMETestBase import CHIMETestBase
+
+import matter.clusters as Clusters
+from matter.testing.decorators import has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.runner import TestStep, default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+
+class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
+
+    def desc_TC_CHIME_2_5(self) -> str:
+        return "[TC-CHIME-2.5] Verify functionality of the PlayChimeSound command-Release 1.5.1 or later"
+
+    def steps_TC_CHIME_2_5(self) -> list[TestStep]:
+        return [
+            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(2, "Set the enabled attribute to False"),
+            TestStep(3, "Send the PlayChimeSound command and verify that no chime sound is heard"),
+            TestStep(4, "Set the enabled attribute to True"),
+            TestStep(5, "Send the PlayChimeSound with a ChimeID field different to the currently SelectedChime"),
+            TestStep(6, "Verify that a chime appropriate to the provided ID is heard."),
+        ]
+
+    def pics_TC_CHIME_2_5(self) -> list[str]:
+        return [
+            "CHIME.S",
+        ]
+
+    @run_if_endpoint_matches(has_cluster(Clusters.Chime))
+    async def test_TC_CHIME_2_5(self):
+        cluster = Clusters.Objects.Chime
+        attributes = cluster.Attributes
+        endpoint = self.get_endpoint()
+        self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
+
+        # Pre-condition, make sure the ClusterRevision is at least 2
+        clusterRevision = await self.read_chime_attribute_expect_success(endpoint=endpoint, attribute=attributes.ClusterRevision)
+        if clusterRevision < 2:
+            log.info("Chime 2.5: skipping as cluster revision is less than 2")
+            self.mark_all_remaining_steps_skipped(6)
+            return
+
+        self.step(1)  # Already done, immediately go to step 2
+
+        self.step(2)
+        await self.write_chime_attribute_expect_success(endpoint, attributes.Enabled, False)
+
+        self.step(3)
+        await self.send_play_chime_sound_command(endpoint)
+        if not self.is_ci:
+            user_response = self.wait_for_user_input(prompt_msg="A chime sound should not have been played, is this correct? Enter 'y' or 'n'",
+                                                     prompt_msg_placeholder="y",
+                                                     default_value="y")
+            if user_response is not None:
+                log.info(f"CHIME 2_5: response '{user_response}' received on confirmation of no chime sound")
+                asserts.assert_equal(user_response.lower(), "y")
+            else:
+                log.info("CHIME 2_5: No response received for no chime sound played user prompt")
+
+        self.step(4)
+        await self.write_chime_attribute_expect_success(endpoint, attributes.Enabled, True)  
+
+        myChimeSounds = await self.read_chime_attribute_expect_success(endpoint, attributes.InstalledChimeSounds)
+        mySelectedChime = await self.read_chime_attribute_expect_success(endpoint, attributes.SelectedChime)
+        if len(myChimeSounds) > 1:
+            self.step(5)
+
+            newSelectedChime = mySelectedChime
+            for chime in myChimeSounds:
+                if chime.chimeID != mySelectedChime:
+                    newSelectedChime = chime.chimeID
+                    break
+
+            await self.send_play_chime_sound_command(endpoint, newSelectedChime)
+            if not self.is_ci:
+                self.step(6)
+                user_response = self.wait_for_user_input(prompt_msg="A chime sound should have just been played, is this correct? Enter 'y' or 'n'",
+                                                         prompt_msg_placeholder="y",
+                                                         default_value="y")
+                if user_response is not None:
+                    log.info(f"CHIME 2_5: response '{user_response}' received on confirmation of different chime sound")
+                    asserts.assert_equal(user_response.lower(), "y")
+                else:
+                    log.info("CHIME 2_5: No response received for different chime sound played user prompt")
+            else:
+                self.skip_step(6)
+
+        else:
+            self.skip_step(5)
+            self.skip_step(6)
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_CHIME_2_6.py
+++ b/src/python_testing/TC_CHIME_2_6.py
@@ -74,7 +74,7 @@ class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
             TestStep(2, "Establish a subscription to the ChimeStartedPlaying event"),
             TestStep(3, "Set the enabled attribute to True"),
             TestStep(4, "Read and save the value of the SelectedChime attribute in mySelectedChime"),
-            TestStep(5, "Send the PlayChimeSound command"), 
+            TestStep(5, "Send the PlayChimeSound command"),
             TestStep(6, "Verify reception of the ChimeStartedPlaying event"),
             TestStep(7, "Verify that the value of the ChimeID in the event is the same as the value of mySelectedChime"),
         ]

--- a/src/python_testing/TC_CHIME_2_6.py
+++ b/src/python_testing/TC_CHIME_2_6.py
@@ -56,8 +56,8 @@ from TC_CHIMETestBase import CHIMETestBase
 
 import matter.clusters as Clusters
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
-from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 
 log = logging.getLogger(__name__)

--- a/src/python_testing/TC_CHIME_2_6.py
+++ b/src/python_testing/TC_CHIME_2_6.py
@@ -63,7 +63,7 @@ from matter.testing.runner import TestStep, default_matter_test_main
 log = logging.getLogger(__name__)
 
 
-class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
+class TC_CHIME_2_6(MatterBaseTest, CHIMETestBase):
 
     def desc_TC_CHIME_2_6(self) -> str:
         return "[TC-CHIME-2.6] Verify the generation of the ChimeStartedPlaying Event"

--- a/src/python_testing/TC_CHIME_2_6.py
+++ b/src/python_testing/TC_CHIME_2_6.py
@@ -1,0 +1,137 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#     factory-reset: true
+#     quiet: true
+#   run2:
+#     app: ${ALL_DEVICES_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --device chime
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import logging
+
+from mobly import asserts
+from TC_CHIMETestBase import CHIMETestBase
+
+import matter.clusters as Clusters
+from matter.testing.decorators import has_cluster, run_if_endpoint_matches
+from matter.testing.matter_testing import MatterBaseTest
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.testing.runner import TestStep, default_matter_test_main
+
+log = logging.getLogger(__name__)
+
+
+class TC_CHIME_2_4(MatterBaseTest, CHIMETestBase):
+
+    def desc_TC_CHIME_2_6(self) -> str:
+        return "[TC-CHIME-2.6] Verify the generation of the ChimeStartedPlaying Event"
+
+    def steps_TC_CHIME_2_6(self) -> list[TestStep]:
+        return [
+            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(2, "Establish a subscription to the ChimeStartedPlaying event"),
+            TestStep(3, "Set the enabled attribute to True"),
+            TestStep(4, "Read and save the value of the SelectedChime attribute in mySelectedChime"),
+            TestStep(5, "Send the PlayChimeSound command"), 
+            TestStep(6, "Verify reception of the ChimeStartedPlaying event"),
+            TestStep(7, "Verify that the value of the ChimeID in the event is the same as the value of mySelectedChime"),
+        ]
+
+    def pics_TC_CHIME_2_6(self) -> list[str]:
+        return [
+            "CHIME.S",
+        ]
+
+    @run_if_endpoint_matches(has_cluster(Clusters.Chime))
+    async def test_TC_CHIME_2_6(self):
+        cluster = Clusters.Objects.Chime
+        attributes = cluster.Attributes
+        endpoint = self.get_endpoint()
+        self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
+
+        # Pre-condition, make sure the ClusterRevision is at least 2
+        clusterRevision = await self.read_chime_attribute_expect_success(endpoint=endpoint, attribute=attributes.ClusterRevision)
+        if clusterRevision < 2:
+            log.info("Chime 2.5: skipping as cluster revision is less than 2")
+            self.mark_all_remaining_steps_skipped(7)
+            return
+
+        self.step(1)  # Already done, immediately go to step 2
+
+        # TH establishes a subscription to all of the Events from the Cluster
+        self.step(2)
+        event_callback = EventSubscriptionHandler(expected_cluster=Clusters.Chime)
+        await event_callback.start(self.default_controller,
+                                   self.dut_node_id,
+                                   self.get_endpoint())
+
+        self.step(3)
+        await self.write_chime_attribute_expect_success(endpoint, attributes.Enabled, True)
+
+        self.step(4)
+        mySelectedChime = await self.read_chime_attribute_expect_success(endpoint, attributes.SelectedChime)
+
+        self.step(5)
+        await self.send_play_chime_sound_command(endpoint)
+        if not self.is_ci:
+            user_response = self.wait_for_user_input(prompt_msg="A chime sound should have been played, is this correct? Enter 'y' or 'n'",
+                                                     prompt_msg_placeholder="y",
+                                                     default_value="y")
+            if user_response is not None:
+                log.info(f"CHIME 2_6: response '{user_response}' received confirmation of chime sound")
+                asserts.assert_equal(user_response.lower(), "y")
+            else:
+                log.info("CHIME 2_6: No response received for chime sound played user prompt")
+
+        self.step(6)
+        event_data = event_callback.wait_for_event_report(Clusters.Chime.Events.ChimeStartedPlaying, timeout_sec=5)
+        log.info(f"Event data {event_data}")
+
+        self.step(7)
+        asserts.assert_equal(event_data.chimeID, mySelectedChime, "Unexpected value for ChimeID returned")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()


### PR DESCRIPTION
#### Summary

Chime cluster additions (per spec):
- new event for starting to play
- optional chime id provided to PlayChime

XML and codegen changes have already landed. This PR adds the cluster logic for the new event, and new command field, and updates the apps accordingly.  Also realized are new test cases 2_5 and 2_6.

#### Related issues

See also: https://github.com/CHIP-Specifications/chip-test-plans/pull/5763/

#### Testing

Using the python test runner execute all Chime tests, including the two new tests
Run all unit tests

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
