### PR TITLE
Thread: require Thread enabled when using OpenThread Endpoint

### DIFF
--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -23,6 +23,10 @@ import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/platform/device.gni")
 import("system.gni")
 
+assert(
+    chip_enable_openthread || !chip_system_config_use_openthread_inet_endpoints,
+    "OpenThread Endpoint is only available when Thread is enabled")
+
 if (chip_system_config_use_lwip) {
   import("//build_overrides/lwip.gni")
 }


### PR DESCRIPTION
#### Summary

This commit adds a check to ensure OpenThread Endpoint is only enabled when Thread is enabled to prevent invalid configurations.

#### Related issues

Please see the discussion: https://github.com/project-chip/connectedhomeip/pull/42336#discussion_r2714938153

#### Testing

This only changes the build file, so it is going to be covered by existing build checks.