### PR TITLE
[config][common] Centralize Wi‑Fi kconfig definitions in common area to be reused across platforms

### DIFF
--- a/config/common/cmake/Kconfig
+++ b/config/common/cmake/Kconfig
@@ -656,7 +656,7 @@ config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
 		Specifies the maximum connection recovery jitter interval (in milliseconds).
 		Once the wait time reaches the current maximum value (defined by CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL),
 		a random jitter interval is added to it to avoid periodicity. The random jitter is selected
-		within range [-JITTER; +JITTER].
+		within a range of +/- the value of this option.
 
 # Platform additions and configuration
 

--- a/config/common/cmake/Kconfig
+++ b/config/common/cmake/Kconfig
@@ -625,6 +625,39 @@ config CHIP_ENABLE_WIFI_AP
       Enable Wi-Fi Access Point mode for SoftAP commissioning.
       This allows the device to create its own Wi-Fi network for onboarding.
 
+config CHIP_WIFI_CONNECTION_RECOVERY_MINIMUM_INTERVAL
+	int "Define the minimum connection recovery time interval in milliseconds"
+	depends on CHIP_WIFI
+	default 500
+	help
+		Specifies the minimum connection recovery interval (in milliseconds).
+
+config CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL
+	int "Define the maximum connection recovery time interval in milliseconds"
+	depends on CHIP_WIFI
+	default 3600000 # 1 hour
+	help
+		Specifies the maximum connection recovery interval (in milliseconds).
+
+config CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER
+	int "Define the maximum amount of connection recovery occurrences"
+	depends on CHIP_WIFI
+	default 0
+	help
+		Specifies the maximum number of connection recovery attempts.
+		If set to 0, no limitation is applied and attempts
+		to recover the connection are performed indefinitely.
+
+config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
+	int "Define the connection recovery jitter in milliseconds"
+	depends on CHIP_WIFI
+	default 2000
+	help
+		Specifies the maximum connection recovery jitter interval (in milliseconds).
+		Once the wait time reaches the current maximum value (defined by CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL),
+		a random jitter interval is added to it to avoid periodicity. The random jitter is selected
+		within range [-JITTER; +JITTER].
+
 # Platform additions and configuration
 
 config CHIP_SYSTEM_THREAD_LOCAL_STORAGE
@@ -727,5 +760,11 @@ config CHIP_INET_ENABLE_TCP_ENDPOINT
 	default y if CHIP_BUILD_TESTS
 	help
 	  Enable TCP endpoint support in the Matter Inet layer.
+
+config NETWORK_LAYER_BLE
+	bool "Should be replaced by CONFIG_BT. Keep it for backwards compatibility"
+	default y if BT
+	help
+		Will be deprecated once application files replace CONFIG_NETWORK_LAYER_BLE with CONFIG_BT
 
 endif # CHIP

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -220,39 +220,6 @@ endif # SOC_SERIES_NRF53X
 
 endif # CHIP_DFU_OVER_BT_SMP
 
-config CHIP_WIFI_CONNECTION_RECOVERY_MINIMUM_INTERVAL
-	int "Define the minimum connection recovery time interval in milliseconds"
-	depends on CHIP_WIFI
-	default 500
-	help
-	  Specifies the minimum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL
-	int "Define the maximum connection recovery time interval in milliseconds"
-	depends on CHIP_WIFI
-	default 3600000 # 1 hour
-	help
-	  Specifies the maximum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER
-	int "Define the maximum amount of connection recovery occurrences"
-	depends on CHIP_WIFI
-	default 0
-	help
-	  Specifies the maximum number of connection recovery attempts.
-	  If set to 0, no limitation is applied and attempts
-	  to recover the connection are performed indefinitely.
-
-config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
-	int "Define the connection recovery jitter in milliseconds"
-	depends on CHIP_WIFI
-	default 2000
-	help
-	  Specifies the maximum connection recovery jitter interval (in milliseconds).
-	  Once the wait time reaches the current maximum value (defined by CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL),
-	  a random jitter interval is added to it to avoid periodicity. The random jitter is selected
-	  within range [-JITTER; +JITTER].
-
 choice CHIP_LAST_FABRIC_REMOVED_ACTION
 	prompt "An action to perform after removing the last fabric"
 	default CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT

--- a/config/nxp/chip-cmake-freertos/Kconfig
+++ b/config/nxp/chip-cmake-freertos/Kconfig
@@ -119,12 +119,16 @@ config CHIP_USE_GENERATED_CONFIG
 	help
 		Use the generated macro configs for CHIP configuration.
 
+# Define BT config for FreeRTOS compatibility with Zephyr (already defined in Zephyr module)
+# to enable shared code and Kconfig across both platforms.
 config BT
 	bool "Enable BLE"
 	default y
 	help
 		Enable BLE support.
 
+# Define NET_L2_OPENTHREAD config for FreeRTOS compatibility with Zephyr (already defined in Zephyr module)
+# to enable shared code and Kconfig across both platforms.
 config NET_L2_OPENTHREAD
 	bool "Enable Thread support"
 	default n
@@ -137,39 +141,6 @@ config CHIP_DEVICE_USE_ZEPHYR_BLE
 	default y if CHIP_NXP_PLATFORM_RW61X || CHIP_NXP_PLATFORM_RT1060 || CHIP_NXP_PLATFORM_RT1170
 	help
 		Use Zephyr implementation for BLE manager.
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MINIMUM_INTERVAL
-	int "Define the minimum connection recovery time interval in milliseconds"
-	depends on CHIP_WIFI
-	default 500
-	help
-		Specifies the minimum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL
-	int "Define the maximum connection recovery time interval in milliseconds"
-	depends on CHIP_WIFI
-	default 3600000 # 1 hour
-	help
-		Specifies the maximum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER
-	int "Define the maximum amount of connection recovery occurrences"
-	depends on CHIP_WIFI
-	default 0
-	help
-		Specifies the maximum number of connection recovery attempts.
-		If set to 0, no limitation is applied and attempts
-		to recover the connection are performed indefinitely.
-
-config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
-	int "Define the connection recovery jitter in milliseconds"
-	depends on CHIP_WIFI
-	default 2000
-	help
-		Specifies the maximum connection recovery jitter interval (in milliseconds).
-		Once the wait time reaches the current maximum value (defined by CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL),
-		a random jitter interval is added to it to avoid periodicity. The random jitter is selected
-		within range [-JITTER; +JITTER].
 
 # Secure Element Configurations
 
@@ -230,19 +201,7 @@ config CHIP_SE05X_DEVICE_ATTESTATION
 
 endif # CHIP_SE05X
 
-# Thread network features
-
-if NET_L2_OPENTHREAD
-
-endif # NET_L2_OPENTHREAD
-
 # App specific
-
-config NETWORK_LAYER_BLE
-	bool "Should be replaced by CONFIG_BT. Keep it for backwards compatibility"
-	default y if BT
-	help
-		Will be deprecated once application files replace CONFIG_NETWORK_LAYER_BLE with CONFIG_BT
 
 config OPERATIONAL_KEYSTORE
 	bool "Use custom implementation of operational keystore"
@@ -324,6 +283,8 @@ config NXP_CUSTOM_UNIT_TESTS_DIR
 
 endif # CHIP_BUILD_TESTS
 
+# Define Debug config for FreeRTOS compatibility with Zephyr (already defined in Zephyr module)
+# to enable shared code and Kconfig across both platforms.
 config DEBUG
 	bool "Build Matter stack with debugging enabled"
 	help

--- a/config/nxp/chip-module/Kconfig.features
+++ b/config/nxp/chip-module/Kconfig.features
@@ -39,39 +39,6 @@ config CHIP_WIFI
 	imply NET_STATISTICS_IPV6
 	imply NET_STATISTICS_USER_API
 
-config CHIP_WIFI_CONNECTION_RECOVERY_MINIMUM_INTERVAL
-	int "Define the minimum connection recovery time interval in milliseconds"
-	depends on CHIP_WIFI
-	default 500
-	help
-	  Specifies the minimum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL
-	int "Define the maximum connection recovery time interval in milliseconds"
-	depends on CHIP_WIFI
-	default 3600000 # 1 hour
-	help
-	  Specifies the maximum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER
-	int "Define the maximum amount of connection recovery occurrences"
-	depends on CHIP_WIFI
-	default 0
-	help
-	  Specifies the maximum number of connection recovery attempts.
-	  If set to 0, no limitation is applied and attempts
-	  to recover the connection are performed indefinitely.
-
-config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
-	int "Define the connection recovery jitter in milliseconds"
-	depends on CHIP_WIFI
-	default 2000
-	help
-	  Specifies the maximum connection recovery jitter interval (in milliseconds).
-	  Once the wait time reaches the current maximum value (defined by CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL),
-	  a random jitter interval is added to it to avoid periodicity. The random jitter is selected
-	  within range [-JITTER; +JITTER].
-
 # See config/common/cmake/Kconfig for full definition
 config CHIP_ETHERNET
 	default n

--- a/config/silabs/Kconfig
+++ b/config/silabs/Kconfig
@@ -289,39 +289,6 @@ config CHIP_MEMORY_PROFILING
 	help
 	  Enables features for tracking memory usage in Matter.
 
-config CHIP_WIFI_CONNECTION_RECOVERY_MINIMUM_INTERVAL
-	int "Define the minimum connection recovery time interval in milliseconds"
-	depends on CHIP_WIFI
-	default 500
-	help
-	  Specifies the minimum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL
-	int "Define the maximum connection recovery time interval in milliseconds"
-	depends on CHIP_WIFI
-	default 3600000 # 1 hour
-	help
-	  Specifies the maximum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER
-	int "Define the maximum amount of connection recovery occurrences"
-	depends on CHIP_WIFI
-	default 0
-	help
-	  Specifies the maximum number of connection recovery attempts.
-	  If set to 0, no limitation is applied and attempts
-	  to recover the connection are performed indefinitely.
-
-config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
-	int "Define the connection recovery jitter in milliseconds"
-	depends on CHIP_WIFI
-	default 2000
-	help
-	  Specifies the maximum connection recovery jitter interval (in milliseconds).
-	  Once the wait time reaches the current maximum value (defined by CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL),
-	  a random jitter interval is added to it to avoid periodicity. The random jitter is selected
-	  within range [-JITTER; +JITTER].
-
 choice CHIP_LAST_FABRIC_REMOVED_ACTION
 	prompt "An action to perform after removing the last fabric"
 	default CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -424,39 +424,6 @@ config DEFAULT_WIFI_PASSWORD
       The password for the default WiFi network.
       This option is for testing only and should be disabled in production releases.
 
-config CHIP_WIFI_CONNECTION_RECOVERY_MINIMUM_INTERVAL
-    int "Define the minimum connection recovery time interval in milliseconds"
-    depends on CHIP_WIFI
-    default 500
-    help
-      Specifies the minimum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL
-    int "Define the maximum connection recovery time interval in milliseconds"
-    depends on CHIP_WIFI
-    default 3600000 # 1 hour
-    help
-      Specifies the maximum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER
-    int "Define the maximum amount of connection recovery occurrences"
-    depends on CHIP_WIFI
-    default 0
-    help
-      Specifies the maximum number of connection recovery attempts.
-      If set to 0, no limitation is applied and attempts
-      to recover the connection are performed indefinitely.
-
-config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
-    int "Define the connection recovery jitter in milliseconds"
-    depends on CHIP_WIFI
-    default 2000
-    help
-      Specifies the maximum connection recovery jitter interval (in milliseconds).
-      Once the wait time reaches the current maximum value (defined by CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL),
-      a random jitter interval is added to it to avoid periodicity. The random jitter is selected
-      within range [-JITTER; +JITTER].
-
 config NET_MGMT_EVENT_STACK_SIZE
     default 2048
 


### PR DESCRIPTION
#### Summary

This PR is part of Issue #42453. It focuses on removing duplicated Wi‑Fi‑related Kconfig definitions that were scattered across platform‑specific directories, and consolidating them into a single shared location: `config/common/cmake/Kconfig`.

#### Related issues

Issue #42453

#### Testing

Tested with building NXP Zephyr application with Wi-Fi enabled by default:

"west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr"
