### PR TITLE
Add Linux Platform Connectivity Manager Implementation Abstract Interfaces

### DIFF
--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -126,6 +126,8 @@ static_library("Linux") {
     "ConfigurationManagerImpl.h",
     "ConnectivityManagerImpl.cpp",
     "ConnectivityManagerImpl.h",
+    "ConnectivityManagerImpl_NetworkManagementInterface.h",
+    "ConnectivityManagerImpl_WiFiPafInterface.h",
     "ConnectivityUtils.cpp",
     "ConnectivityUtils.h",
     "DeviceInstanceInfoProviderImpl.cpp",

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementInterface.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementInterface.h
@@ -1,0 +1,702 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include <lib/core/CHIPError.h>
+#include <platform/CHIPDeviceEvent.h>
+#include <platform/ConnectivityManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ *  An abstract interface for controlling and interacting with network
+ *  management infrastructure on a Linux platform.
+ *
+ *  Concrete implementations are expected to provide the platform- and
+ *  driver-specific integration required to manage one or more
+ *  IP-bearing network interfaces, especially Wi-Fi but also
+ *  Ethernet. Thread, however, is excluded as it is managed through an
+ *  independent, parallel stack interface.
+ *
+ *  Implementations may include full-featured network management
+ *  software such as GNOME Network Manager or Connection Manager (also
+ *  known as connman) or may be Wi-Fi-specific backends such as iwd or
+ *  wpa_supplicant with adjunct handling for Ethernet, if any.
+ *
+ */
+class NetworkManagementInterface
+{
+public:
+    // Destruction
+
+    virtual ~NetworkManagementInterface(void) = default;
+
+    // Initialization
+
+    /**
+     *  @brief
+     *    Perform explicit class initialization.
+     *
+     *  This initializer is invoked during stack initialization and
+     *  should perform any actions necessary to support subsequent
+     *  observation, mutation, event handling, and worker operations
+     *  on the managed network interfaces.
+     *
+     *  @param[in]  inConnectivityManagerImpl
+     *    A reference to the mutable platform connectivity manager
+     *    implementation for which the concrete interface
+     *    implementation is being initialized.
+     *
+     */
+    virtual CHIP_ERROR Init(ConnectivityManagerImpl & inConnectivityManagerImpl) = 0;
+
+    // Observation
+
+    /**
+     *  @brief
+     *    Get the currently configured (provisioned) operational network.
+     *
+     *  This returns the currently configured network used for operational
+     *  connectivity (for example, the Wi-Fi network to which the device
+     *  will attempt to connect when Wi-Fi station mode is enabled).
+     *
+     *  @param[out]  outNetwork
+     *    A reference to the mutable network structure to populate on
+     *    success.
+     *
+     */
+    virtual CHIP_ERROR GetConfiguredNetwork(NetworkCommissioning::Network & outNetwork) = 0;
+
+    // Event Handling
+
+    /**
+     *  @brief
+     *    Handle a platform event.
+     *
+     *  This provides an opportunity for the concrete interface
+     *  implementation to handle a platform event.
+     *
+     *  @param[in]  inDeviceEvent
+     *    A reference to the immutable platform event to handle.
+     *
+     */
+    virtual void OnPlatformEvent(const ChipDeviceEvent & inDeviceEvent) = 0;
+
+    /**
+     *  @brief
+     *    Commit any network configuration to non-volatile storage
+     *    such that the configuration may be restored and connectivity
+     *    resumed across system restarts.
+     *
+     *  @sa ClearWiFiStationProvision
+     *
+     */
+    virtual CHIP_ERROR CommitConfig(void) = 0;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+    // Ethernet Control Plane Management
+
+    // Observation
+
+    /**
+     *  @brief
+     *    Return the Ethernet network interface name.
+     *
+     *  This returns, if available, the Ethernet station network
+     *  interface name for the implicit "main" or default Ethernet
+     *  network interface as a null-terminated C string.
+     *
+     *  The returned pointer follows the "Get" / "Create" or "Copy"
+     *  rule and is owned by the interface instance returning it. The
+     *  pointer is guaranteed to be valid for the lifetime of the
+     *  interface instance.
+     *
+     *  @retval
+     *    If present and known, the Ethernet network interface name
+     *    as an immutable, null-terminated C string; otherwise, null.
+     *
+     */
+    virtual const char * GetEthernetIfName(void) = 0;
+
+    // Worker
+
+    /**
+     *  @brief
+     *    Update cached Ethernet networking status.
+     *
+     *  Implementations should refresh any cached Ethernet link and IP
+     *  state used by the Connectivity Manager (for example, to drive
+     *  DeviceLayer events or diagnostic attributes).
+     *
+     *  This method is typically invoked from a platform work context
+     *  and should not block for extended periods.
+     *
+     */
+    virtual void UpdateEthernetNetworkingStatus(void) = 0;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    // Wi-Fi Control Plane Management
+
+    // Observation
+
+    /**
+     *  @brief
+     *    Return the Wi-Fi station network interface name.
+     *
+     *  This returns, if available, the Wi-Fi station network
+     *  interface name for the implicit "main" or default Wi-Fi
+     *  network interface as a null-terminated C string.
+     *
+     *  The returned pointer follows the "Get" / "Create" or "Copy"
+     *  rule and is owned by the interface instance returning it. The
+     *  pointer is guaranteed to be valid for the lifetime of the
+     *  interface instance.
+     *
+     *  @returns
+     *    If present and known, the Wi-Fi station network interface
+     *    name as an immutable, null-terminated C string; otherwise,
+     *    null.
+     *
+     */
+    virtual const char * GetWiFiIfName(void) = 0;
+
+    // Control
+
+    /**
+     *  @brief
+     *    Start Wi-Fi management in a non-concurrent mode.
+     *
+     *  Start the Wi-Fi management infrastructure in a mode that does
+     *  @b not permit concurrent Wi-Fi station and Bluetooth Low
+     *  Energy (BLE) functions, where the latter is being used as the
+     *  commissioning channel (if supported by the platform or
+     *  implementation), biasing towards Wi-Fi station functionality
+     *  only. Concrete implementations may interpret this as
+     *  "station-only" or as a reduced-feature startup used during
+     *  commissioning or early boot.
+     *
+     *  This may be invoked by the BLE engine subsystem when Wi-Fi is
+     *  enabled as an operational network and the
+     *  #CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+     *  configuration option is deasserted.
+     *
+     *  @sa IsWiFiManagementStarted
+     *  @sa StartWiFiManagement
+     *
+     */
+    virtual void StartNonConcurrentWiFiManagement(void) = 0;
+
+    /**
+     *  @brief
+     *    Start Wi-Fi management.
+     *
+     *  Start the Wi-Fi management infrastructure for the device.
+     *  This may include attaching to, configuring, or starting an
+     *  external network manager and establishing any required event
+     *  subscriptions.
+     *
+     *  @sa IsWiFiManagementStarted
+     *  @sa StartNonConcurrentWiFiManagement
+     *
+     */
+    virtual void StartWiFiManagement(void) = 0;
+
+    // Wi-Fi Station Control Plane Management
+
+    // Introspection
+
+    /**
+     *  @brief
+     *    Return whether the network management infrastructure for the
+     *    Wi-Fi network interface is started running.
+     *
+     *  @returns
+     *    True if the network management infrastructure for the Wi-Fi
+     *    network interface is started and running; otherwise, false.
+     *
+     *  @sa StartNonConcurrentWiFiManagement
+     *  @sa StartWiFiManagement
+     *
+     */
+    virtual bool IsWiFiManagementStarted(void) = 0;
+
+    /**
+     *  @brief
+     *    Return whether the Wi-Fi station network interface is
+     *    application-controlled.
+     *
+     *  This returns whether the Wi-Fi station network interface is
+     *  managed by the application rather than by the platform network
+     *  management infrastructure.
+     *
+     *  When true, the Connectivity Manager should avoid taking
+     *  autonomous actions that would conflict with application
+     *  control (for example, automatically enabling/disabling station
+     *  mode or initiating reconnect behavior).
+     *
+     *  @returns
+     *    True if the Wi-Fi station network interface is
+     *    application-controlled; otherwise, false.
+     *
+     *  @sa GetWiFiStationMode
+     *  @sa IsWiFiStationConnected
+     *  @sa IsWiFiStationEnabled
+     *  @sa IsWiFiStationProvisioned
+     *  @sa SetWiFiStationMode
+     *
+     */
+    virtual bool IsWiFiStationApplicationControlled(void) = 0;
+
+    /**
+     *  @brief
+     *    Return whether the Wi-Fi station network interface is
+     *    connected.
+     *
+     *  This returns whether the Wi-Fi station network interface is
+     *  connected, that is, whether it as been assigned a valid IPv4
+     *  and/or IPv6 address and is locally- and/or Internet-reachable.
+     *
+     *  @returns
+     *    True if the Wi-Fi station network interface is connected;
+     *    otherwise, false.
+     *
+     *  @sa IsWiFiStationApplicationControlled
+     *  @sa IsWiFiStationEnabled
+     *  @sa IsWiFiStationProvisioned
+     *
+     */
+    virtual bool IsWiFiStationConnected(void) = 0;
+
+    /**
+     *  @brief
+     *    Return whether the Wi-Fi station network interface is
+     *    enabled.
+     *
+     *  @returns
+     *    True if the Wi-Fi station network interface is enabled;
+     *    otherwise, false.
+     *
+     *  @sa GetWiFiStationMode
+     *  @sa IsWiFiStationApplicationControlled
+     *  @sa IsWiFiStationConnected
+     *  @sa IsWiFiStationProvisioned
+     *  @sa SetWiFiStationMode
+     *
+     */
+    virtual bool IsWiFiStationEnabled(void) = 0;
+
+    /**
+     *  @brief
+     *    Return whether the Wi-Fi station network interface is
+     *    provisioned.
+     *
+     *  Returns whether the Wi-Fi station network interface is
+     *  provisioned to connect to a particular Wi-Fi network when that
+     *  network is encountered through an active, directed or passive,
+     *  broadcast Wi-Fi network scan.
+     *
+     *  @returns
+     *    True if the Wi-Fi station network interface is provisioned;
+     *    otherwise, false.
+     *
+     *  @sa ClearWiFiStationProvision
+     *  @sa CommitConfig
+     *  @sa IsWiFiStationApplicationControlled
+     *  @sa IsWiFiStationConnected
+     *  @sa IsWiFiStationEnabled
+     *
+     */
+    virtual bool IsWiFiStationProvisioned(void) = 0;
+
+    // Observation
+
+    /**
+     *  @brief
+     *    Get the Wi-Fi access point Basic Service Set Identifier
+     *    (BSSID) the Wi-Fi station network interface is currently
+     *    associated with.
+     *
+     *  This specifically is the remote Wi-Fi access point Basic
+     *  Service Set Identifier (BSSID), not the Wi-Fi access point
+     *  Basic Service Set Identifier (BSSID) associated with any local
+     *  Wi-Fi access point used for the purposes of "Soft Access Point
+     *  (AP)" functionality.
+     *
+     *  @param[out]  outBssId
+     *    A reference to the mutable byte span into which the Wi-Fi
+     *    remote access point Basic Service Set Identifier (BSSID) the
+     *    Wi-Fi station network interface is currently associated
+     *    with, if any, is copied.
+     *
+     */
+    virtual CHIP_ERROR GetWiFiBssId(MutableByteSpan & outBssId) = 0;
+
+    /**
+     *  @brief
+     *    Get the Wi-Fi security type associated with the current link
+     *    between the station and remote access point.
+     *
+     *  @param[out]  outSecurityType
+     *    A reference to mutable storage for the Wi-Fi security type
+     *    associated with the current link between the station and
+     *    remote access point.
+     *
+     */
+    virtual CHIP_ERROR GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & outSecurityType) = 0;
+
+    /**
+     *  @brief
+     *    Get the current operational mode of the Wi-Fi station
+     *    network interface.
+     *
+     *  @returns
+     *    The current operational mode of the Wi-Fi station network
+     *    interface.
+     *
+     *  @sa IsWiFiStationApplicationControlled
+     *  @sa IsWiFiStationEnabled
+     *  @sa SetWiFiStationMode
+     *
+     */
+    virtual ConnectivityManager::WiFiStationMode GetWiFiStationMode(void) = 0;
+
+    /**
+     *  @brief
+     *    Get the Wi-Fi station reconnect interval.
+     *
+     *  Return the interval used by the Connectivity Manager and/or
+     *  the concrete implementation to throttle automatic reconnect
+     *  attempts when Wi-Fi station mode is enabled but the station is
+     *  not connected.
+     *
+     *  A value of 0 may be used to indicate that reconnect attempts
+     *  should occur without an additional software-imposed delay
+     *  beyond any delay inherent to the underlying network manager.
+     *
+     *  @returns
+     *    The reconnect interval as a System::Clock::Timeout.
+     *
+     *  @sa SetWiFiStationReconnectInterval
+     *
+     */
+    virtual System::Clock::Timeout GetWiFiStationReconnectInterval(void) = 0;
+
+    /**
+     *  @brief
+     *    Get the Wi-Fi specification or standard version associated
+     *    with the current link between the station and remote access
+     *    point.
+     *
+     *  @param[out]  outVersion
+     *    A reference to mutable storage for the Wi-Fi specification
+     *    or standard version associated with the current link between
+     *    the station and remote access point.
+     *
+     */
+    virtual CHIP_ERROR GetWiFiVersion(app::Clusters::WiFiNetworkDiagnostics::WiFiVersionEnum & outVersion) = 0;
+
+    // Mutation
+
+    /**
+     *  @brief
+     *    Set the current operational mode of the Wi-Fi station
+     *    network interface.
+     *
+     *  Request a change to the Wi-Fi station operational
+     *  mode. Concrete implementations should apply the requested mode
+     *  via the underlying network manager (or, if
+     *  application-controlled, update their internal state
+     *  accordingly).
+     *
+     *  @param[in]  inWiFiStationMode
+     *    A reference to the immutable Wi-Fi station
+     *    operational mode to set.
+     *
+     *  @sa GetWiFiStationMode
+     *  @sa IsWiFiStationApplicationControlled
+     *  @sa IsWiFiStationEnabled
+     *
+     */
+    virtual CHIP_ERROR SetWiFiStationMode(const ConnectivityManager::WiFiStationMode & inWiFiStationMode) = 0;
+
+    /**
+     *  @brief
+     *    Set the Wi-Fi station reconnect interval.
+     *
+     *  Set the interval used to throttle automatic reconnect attempts
+     *  while the Wi-Fi station operational mode is enabled and the
+     *  station is not connected.
+     *
+     *  Concrete implementations may apply this interval internally,
+     *  may forward it to an underlying network manager if supported,
+     *  or may treat it as a best-effort hint.
+     *
+     *  @param[in]  inInterval
+     *    A reference to the immutable Wi-Fi station reconnect
+     *    interval to set.
+     *
+     *  @sa GetWiFiStationReconnectInterval
+     *
+     */
+    virtual CHIP_ERROR SetWiFiStationReconnectInterval(const System::Clock::Timeout & inInterval) = 0;
+
+    // Worker
+
+    /**
+     *  @brief
+     *    Clear any provisioning or other non-volatile configuration
+     *    information associated with the current Wi-Fi station
+     *    network interface.
+     *
+     *  @sa CommitConfig
+     *  @sa IsWiFiStationProvisioned
+     *
+     */
+    virtual void ClearWiFiStationProvision(void) = 0;
+
+    /**
+     *  @brief
+     *    Asynchronously connect the Wi-Fi station network interface
+     *    to a Wi-Fi remote access point with preshared key (PSK)
+     *    security.
+     *
+     *  This attempts to connect the Wi-Fi station network interface
+     *  to the Wi-Fi remote access point with optional preshared key
+     *  (PSK) security with the Service Set Identifier (SSID) @a
+     *  inSsid using the optional PSK credential @a inCredentials.
+     *
+     *  @param[in]  inSsid
+     *    A byte span for the Service Set Identifier (SSID) of the
+     *    Wi-Fi remote access point to connect to. While @a inSsid is
+     *    required and is always specified by the caller, the
+     *    underlying Wi-Fi control plane may not yet be aware of this
+     *    network. Implementations may need to perform a scan to
+     *    discover the SSID and its associated BSSIDs before
+     *    attempting association.
+     *
+     *  @param[in]  inCredentials
+     *    An optional byte span for the preshared key (PSK)
+     *    credentials associated with @a inSsid, if any.
+     *
+     *  @param[in]  inConnectCallback
+     *    A pointer to the callback to invoke when the connection
+     *    completes, either on failure or success.
+     *
+     *  @sa ConnectWiFiNetworkWithPDCAsync
+     *  @sa IsWiFiStationConnected
+     *
+     */
+    virtual CHIP_ERROR
+    ConnectWiFiNetworkAsync(ByteSpan inSsid, ByteSpan inCredentials,
+                            NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback) = 0;
+
+    /**
+     *  @brief
+     *    Asynchronously connect the Wi-Fi station network interface
+     *    to a Wi-Fi remote access point with per-device credential
+     *    (PDC) certificate-based security.
+     *
+     *  This attempts to connect the Wi-Fi station network interface
+     *  to the Wi-Fi remote access point with per-device credential
+     *  (PDC) certificate-based security.
+     *
+     *  The concrete implementation is expected to use the provided
+     *  network identity and client identity material to perform a
+     *  certificate-based authentication exchange appropriate for the
+     *  underlying Wi-Fi security method (for example, EAP-TLS).
+     *
+     *  Unless otherwise specified by the concrete implementation,
+     *  this operation is asynchronous and may complete after this
+     *  method returns.
+     *
+     *  @param[in]  inSsid
+     *    A byte span for the Service Set Identifier (SSID) of the
+     *    Wi-Fi remote access point to connect to. While @a inSsid is
+     *    required and is always specified by the caller, the
+     *    underlying Wi-Fi control plane may not yet be aware of this
+     *    network. Implementations may need to perform a scan to
+     *    discover the SSID and its associated BSSIDs before
+     *    attempting association.
+     *
+     *  @param[in]  inNetworkIdentity
+     *    The network identity used to select the credential and/or
+     *    trust context for the target network.  This is typically an
+     *    identifier meaningful to the underlying control plane (for
+     *    example, an EAP "realm", an SSID-scoped identity label, or
+     *    other network-identifier string encoded as bytes).
+     *
+     *  @param[in]  inClientIdentity
+     *    The client identity presented by the device during
+     *    certificate-based authentication (for example, an EAP
+     *    identity / username, often encoded as a UTF-8 string).
+     *
+     *  @param[in]  inClientIdentityKeypair
+     *    A reference to the immutable client authentication keypair
+     *    associated with the device's per-device credential. The
+     *    concrete implementation should use the private key material
+     *    for client authentication (and may use the public key to
+     *    construct or validate associated certificate material).
+     *
+     *  @param[in]  inConnectCallback
+     *    A pointer to the callback to invoke when the connection
+     *    completes, either on failure or success.
+     *
+     *  @sa ConnectWiFiNetworkAsync
+     *  @sa IsWiFiStationConnected
+     *
+     */
+    virtual CHIP_ERROR
+    ConnectWiFiNetworkWithPDCAsync(ByteSpan inSsid, ByteSpan inNetworkIdentity, ByteSpan inClientIdentity,
+                                   const Crypto::P256Keypair & inClientIdentityKeypair,
+                                   NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * inConnectCallback) = 0;
+
+    /**
+     *  @brief
+     *    Asynchronously scan for a Wi-Fi remote access point.
+     *
+     *  This attempts to scan for the Wi-Fi remote access point with
+     *  the Service Set Identifier (SSID) @a inSsid.
+     *
+     *  @param[in]  inSsid
+     *    The byte span for the Service Set Identifier (SSID) of the
+     *    Wi-Fi remote access point to scan for.
+     *
+     *  @param[in]  inScanCallback
+     *    A pointer to the callback to invoke when the scan completes,
+     *    either on failure or success.
+     *
+     *  @sa ConnectWiFiNetworkAsync
+     *
+     */
+    virtual CHIP_ERROR StartWiFiScan(ByteSpan inSsid, NetworkCommissioning::WiFiDriver::ScanCallback * inScanCallback) = 0;
+
+    // Wi-Fi Soft Access Point (AP) Control Plane Management
+
+    // Observation
+
+    /**
+     *  @brief
+     *    Get the current operational mode of the local Wi-Fi access
+     *    point network interface.
+     *
+     *  @returns
+     *    The current operational mode of the local Wi-Fi access point
+     *    network interface.
+     *
+     *  @sa SetWiFiApMode
+     *
+     */
+    virtual ConnectivityManager::WiFiAPMode GetWiFiApMode(void) = 0;
+
+    // Mutation
+
+    /**
+     *  @brief
+     *    Set the current operational mode of the local Wi-Fi access
+     *    point network interface.
+     *
+     *  Request a change to the Wi-Fi local soft access point (AP)
+     *  operational mode. Concrete implementations should apply the
+     *  requested mode via the underlying network manager and/or
+     *  access point subsystem.
+     *
+     *  @param[in]  inWiFiApMode
+     *    A reference to the immutable W-Fi local soft access point
+     *    operational mode to set.
+     *
+     *  @sa GetWiFiApMode
+     *
+     */
+    virtual CHIP_ERROR SetWiFiApMode(const ConnectivityManager::WiFiAPMode & inWiFiApMode) = 0;
+
+    /**
+     *  @brief
+     *    Set the Wi-Fi local soft access point (AP) idle timeout used
+     *    for on-demand operation.
+     *
+     *  Set the amount of time the the Wi-Fi local soft access point
+     *  (AP) may remain idle (for example, with no associated
+     *  stations) before the implementation may automatically stop it
+     *  when operating in on-demand mode.
+     *
+     *  @param[in]  inTimeout
+     *    A reference to the immutable idle timeout to set.
+     *
+     */
+    virtual void SetWiFiApIdleTimeout(const System::Clock::Timeout & inTimeout) = 0;
+
+    // Control
+
+    /**
+     *  @brief
+     *    Demand-start the Wi-Fi local soft access point (AP) for
+     *    on-demand use.
+     *
+     *  Request that the Wi-Fi local soft access point (AP) be started
+     *  (or kept started) for commissioning or other on-demand
+     *  use. Implementations may start the the Wi-Fi local soft access
+     *  point (AP) immediately or schedule startup according to
+     *  platform constraints.
+     *
+     *  @sa MaintainOnDemandWiFiAp
+     *  @sa StopOnDemandWiFiAp
+     *
+     */
+    virtual void DemandStartWiFiAp(void) = 0;
+
+    /**
+     *  @brief
+     *    Stop the on-demand Wi-Fi local soft access point (AP).
+     *
+     *  Request that the the on-demand Wi-Fi local soft access point
+     *  (AP) be stopped if it was started for on-demand
+     *  use. Implementations should stop the on-demand Wi-Fi local
+     *  soft access point (AP) promptly, subject to platform
+     *  constraints.
+     *
+     *  @sa DemandStartWiFiAp
+     *  @sa MaintainOnDemandWiFiAp
+     */
+    virtual void StopOnDemandWiFiAp(void) = 0;
+
+    /**
+     *  @brief
+     *    Maintain the on-demand Wi-Fi local soft access point (AP).
+     *
+     *  Inform the implementation that on-demand on-demand Wi-Fi local
+     *  soft access point (AP) availability is still desired (for
+     *  example, due to ongoing commissioning).  Implementations may
+     *  use this as a keep-alive signal to reset or extend any idle
+     *  timeout configured via #SetWiFiApIdleTimeout.
+     *
+     *  @sa DemandStartWiFiAp
+     *  @sa StopOnDemandWiFiAp
+     *
+     */
+    virtual void MaintainOnDemandWiFiAp(void) = 0;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl_WiFiPafInterface.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_WiFiPafInterface.h
@@ -1,0 +1,327 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include <lib/core/CHIPError.h>
+#include <platform/CHIPDeviceEvent.h>
+#include <platform/ConnectivityManager.h>
+#include <system/SystemPacketBuffer.h>
+#include <wifipaf/WiFiPAFRole.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ *  An abstract interface for controlling and interacting with a Wi-Fi
+ *  Neighbor Awareness Networking (NAN) Unsynchronized Service
+ *  Discovery (USD) / Public Action Frame (PAF) Commissioning
+ *  Transport on a Linux platform.
+ *
+ *  Concrete implementations are expected to provide the platform- and
+ *  driver-specific integration required to publish and subscribe to
+ *  commissioning services and to exchange commissioning data over the
+ *  Wi-Fi NAN USD PAF transport.
+ *
+ */
+class WiFiPafInterface
+{
+public:
+    // Destruction
+
+    virtual ~WiFiPafInterface(void) = default;
+
+    // Initialization
+
+    /**
+     *  @brief
+     *    Perform explicit class initialization.
+     *
+     *  This initializer is invoked during stack initialization.  It
+     *  should perform any actions necessary to support subsequent
+     *  introspection, mutation, publish-and-subscribe, or data
+     *  transmission on the Wi-Fi Neighbor Awareness Networking (NAN)
+     *  Unsynchronized Service Discovery (USD) / Public Action Frame
+     *  (PAF) Commissioning Transport.
+     *
+     *  @param[in]  inConnectivityManagerImpl
+     *    A reference to the mutable platform connectivity manager
+     *    implementation for which the concrete interface
+     *    implementation is being initialized.
+     *
+     *  @sa WiFiPafShutdown
+     *
+     */
+    virtual CHIP_ERROR Init(ConnectivityManagerImpl & inConnectivityManagerImpl) = 0;
+
+    // Event Handling
+
+    /**
+     *  @brief
+     *    Handle a platform event.
+     *
+     *  This provides an opportunity for the concrete interface
+     *  implementation to handle a platform event.
+     *
+     *  @param[in]  inDeviceEvent
+     *    A reference to the immutable platform event to handle.
+     *
+     */
+    virtual void OnPlatformEvent(const ChipDeviceEvent & inDeviceEvent) = 0;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    // Wi-Fi Neighbor Awareness Networking (NAN) Unsynchronized
+    // Service Discovery (USD) / Public Action Frame (PAF)
+    // Commissioning Transport
+
+    // Initialization
+
+    /**
+     *  @brief
+     *    Perform explicit transport deinitialization.
+     *
+     *  This deinitializer is invoked at the termination of the Wi-Fi
+     *  Neighbor Awareness Networking (NAN) Unsynchronized Service
+     *  Discovery (USD) / Public Action Frame (PAF) Commissioning
+     *  Transport. This deinitializer should perform any actions
+     *  necessary to release resources associated with the Wi-Fi NAN
+     *  USD PAF Commissioning Transport.
+     *
+     *  @param[in]  inId
+     *    A reference to the immutable Wi-Fi NAN USD PAF publish or
+     *    subscribe identifier.
+     *
+     *  @param[in]  inWiFiPafRole
+     *    A reference to the immutable Wi-Fi NAN USD PAF role,
+     *    influencing whether the Wi-Fi NAN USD PAF Commissioning
+     *    Transport is deinitialized as a publisher or subscriber and
+     *    how @a inId is interpreted.
+     *
+     *  @sa WiFiPafShutdown
+     *
+     */
+    virtual CHIP_ERROR WiFiPafShutdown(const uint32_t & inId, const WiFiPAF::WiFiPafRole & inWiFiPafRole) = 0;
+
+    // Introspection
+
+    /**
+     *  @brief
+     *    Return whether the Wi-Fi NAN USD PAF Commissioning
+     *    Transport resource is available.
+     *
+     *  @returns
+     *    True if the Wi-Fi NAN USD PAF Commissioning Transport
+     *    resource is available; otherwise, false.
+     *
+     */
+    virtual bool IsWiFiPafResourceAvailable(void) const = 0;
+
+    // Mutation
+
+    /**
+     *  @brief
+     *    Set the Wi-Fi NAN USD PAF Commissioning Transport resource
+     *    availability.
+     *
+     *  @param[in]  inAvailable
+     *    A reference to an immutable Boolean indicating the Wi-Fi NAN
+     *    USD PAF Commissioning Transport resource availability to
+     *    set.
+     *
+     *  @sa IsWiFiPafResourceAvailable
+     *
+     */
+    virtual CHIP_ERROR WiFiPafSetResourceAvailable(const bool & inAvailable) = 0;
+
+    /**
+     *  @brief
+     *    Set the primary subscribe scan frequency.
+     *
+     *  Set the frequency, in megahertz (MHz), to be used by
+     *  subsequent #WiFiPafSubscribe operations when scanning for a
+     *  matching commissioning service.
+     *
+     *  If a concrete implementation supports multi-channel scanning,
+     *  it may treat this as the preferred or initial frequency. If
+     *  the implementation does not support an explicit frequency
+     *  selection, it may ignore this value.
+     *
+     *  @param[in]  inFrequency
+     *    A reference to the immutable frequency, in megahertz (MHz),
+     *    that should be used for subsequent subscribe operations.
+     *
+     *  @sa WiFiPafSubscribe
+     *  @sa WiFiPafCancelSubscribe
+     *  @sa WiFiPafCancelIncompleteSubscribe
+     *
+     */
+    virtual void WiFiPafSetSubscribeFreq(const uint16_t & inFrequency) = 0;
+
+    // Publish-and-subscribe
+
+    /**
+     *  @brief
+     *    Publish (advertise) a Wi-Fi NAN USD PAF commissioning
+     *    service.
+     *
+     *  Start advertising a commissioning service using the parameters
+     *  in @a inOutWiFiPafAdvertiseParams.
+     *
+     *  On success, the concrete implementation is expected to update
+     *  @a inOutWiFiPafAdvertiseParams with any fields produced by the
+     *  publish operation (for example, a publish identifier) so that
+     *  the caller can subsequently cancel the publish with
+     *  #WiFiPafCancelPublish.
+     *
+     *  @param[in,out]  inOutWiFiPafAdvertiseParams
+     *    A reference to the publish (advertise) parameters. This may
+     *    be updated by the implementation on success.
+     *
+     *  @sa WiFiPafCancelPublish
+     *
+     */
+    virtual CHIP_ERROR WiFiPafPublish(ConnectivityManager::WiFiPAFAdvertiseParam & inOutWiFiPafAdvertiseParams) = 0;
+
+    /**
+     *  @brief
+     *    Cancel a previously-started publish (advertise) operation.
+     *
+     *  Cancel the publish identified by @a inPublishId. The publish
+     *  identifier is expected to be the value returned by
+     *  #WiFiPafPublish (for example, via the publish parameters).
+     *
+     *  @param[in]  inPublishId
+     *    A reference to the immutable publish identifier returned by
+     *    #WiFiPafPublish on success to cancel.
+     *
+     *  @sa WiFiPafPublish
+     *
+     */
+    virtual CHIP_ERROR WiFiPafCancelPublish(const uint32_t & inPublishId) = 0;
+
+    /**
+     *  @brief
+     *    Subscribe to a Wi-Fi NAN USD PAF commissioning service.
+     *
+     *  Start a subscribe operation to discover a matching
+     *  commissioning service for @a inConnectionDiscriminator.
+     *
+     *  The concrete implementation is expected to notify the caller
+     *  of completion by invoking either @a onSuccessFunc or
+     *  @a onErrorFunc (with @a inContext passed through) according to
+     *  the underlying transport outcome.
+     *
+     *  Unless otherwise specified by the concrete implementation,
+     *  this operation is asynchronous and may complete after this
+     *  method returns.
+     *
+     *  @param[in]  inConnectionDiscriminator
+     *    A reference to the immutable commissioning discriminator
+     *    used to match the desired commissioning service.
+     *
+     *  @param[in]  inContext
+     *    An opaque caller-provided context pointer that will be
+     *    provided to the completion callbacks.
+     *
+     *  @param[in]  onSuccessFunc
+     *    The callback invoked on successful completion of the
+     *    subscribe operation.
+     *
+     *  @param[in]  onErrorFunc
+     *    The callback invoked if the subscribe operation fails.
+     *
+     *  @sa WiFiPafSetSubscribeFreq
+     *  @sa WiFiPafCancelSubscribe
+     *  @sa WiFiPafCancelIncompleteSubscribe
+     *
+     */
+    virtual CHIP_ERROR WiFiPafSubscribe(const uint16_t & inConnectionDiscriminator, void * inContext,
+                                        ConnectivityManager::OnConnectionCompleteFunct onSuccessFunc,
+                                        ConnectivityManager::OnConnectionErrorFunct onErrorFunc) = 0;
+    /**
+     *  @brief
+     *    Cancel a previously-started subscribe operation.
+     *
+     *  Cancel the subscribe identified by @a inSubscribeId. The
+     *  identifier is expected to be the value returned by
+     *  #WiFiPafSubscribe on success (as defined by the concrete
+     *  implementation).
+     *
+     *  @param[in]  inSubscribeId
+     *    A reference to the immutable subscribe identifier to cancel.
+     *
+     *  @sa WiFiPafSetSubscribeFreq
+     *  @sa WiFiPafSubscribe
+     *  @sa WiFiPafCancelIncompleteSubscribe
+     *
+     */
+    virtual CHIP_ERROR WiFiPafCancelSubscribe(const uint32_t & inSubscribeId) = 0;
+
+    /**
+     *  @brief
+     *    Cancel an in-progress subscribe operation that has not yet
+     *    produced a subscribe identifier.
+     *
+     *  Cancel any subscribe operation that is currently in progress
+     *  but for which the caller does not yet have a stable subscribe
+     *  identifier (for example, because subscription setup has not
+     *  completed, or the identifier is produced only at a later
+     *  stage).
+     *
+     *  @sa WiFiPafSetSubscribeFreq
+     *  @sa WiFiPafSubscribe
+     *  @sa WiFiPafCancelSubscribe
+     *
+     */
+    virtual CHIP_ERROR WiFiPafCancelIncompleteSubscribe(void) = 0;
+
+    // Data Transmission
+
+    /**
+     *  @brief
+     *    Send commissioning data over an established Wi-Fi NAN USD
+     *    PAF session.
+     *
+     *  Transmit the message contained in @a inOutMessageBuffer over the
+     *  Wi-Fi NAN USD PAF session identified by @a inWiFiPafSession.
+     *
+     *  Ownership of @a inOutMessageBuffer is transferred to the
+     *  implementation. On success, the implementation is expected to
+     *  consume the buffer. On failure, the implementation may either
+     *  consume the buffer or leave it unchanged; callers should treat
+     *  the buffer as moved-from after invoking this method.
+     *
+     *  @param[in]  inWiFiPafSession
+     *    A reference to the immutable session describing the Wi-Fi
+     *    NAN USD PAF peer and any session-specific addressing
+     *    required for transmission.
+     *
+     *  @param[in,out]  inMessageBuffer
+     *    The message payload to transmit.
+     *
+     */
+    virtual CHIP_ERROR WiFiPafSend(const WiFiPAF::WiFiPAFSession & inWiFiPafSession,
+                                   chip::System::PacketBufferHandle && inOutMessageBuffer) = 0;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip


### PR DESCRIPTION
#### Summary

This partially addresses #42516 by adding two new Linux platform-only abstract interfaces to the Linux platform _Connectivity Manager_ implementation stack:

1. `::chip::DeviceLayer::Internal::NetworkManagementInterface` _src/platform/Linux/ConnectivityManagerImpl_NetworkManagementInterface.h_:
    * An abstract interface for controlling and interacting with network management infrastructure on a Linux platform.
    *  Concrete implementations are expected to provide the platform- and driver-specific integration required to manage one or more IP-bearing network interfaces, especially Wi-Fi but also Ethernet. Thread, however, is excluded as it is managed through an independent, parallel stack interface.
    *  Implementations may include full-featured network management software such as GNOME Network Manager or Connection Manager (also known as connman) or may be Wi-Fi-specific backends such as iwd or wpa_supplicant with adjunct handling for Ethernet, if any.
3. `::chip::DeviceLayer::Internal::WiFiPafInterface` _src/platform/Linux/ConnectivityManagerImpl_WiFiPafInterface.h_:
    * An abstract interface for controlling and interacting with a Wi-Fi Neighbor Awareness Networking (NAN) Unsynchronized Service Discovery (USD) / Public Action Frame (PAF) Commissioning Transport on a  Linux platform.
    *  Concrete implementations are expected to provide the platform- and driver-specific integration required to publish and subscribe to commissioning services and to exchange commissioning data over the Wi-Fi NAN USD PAF transport.

In subsequent pull requests, with the addition of these two abstract interfaces, the Linux platform will support:

* ConnectivityManager (public CRTP interface)
    * ConnectivityManagerImpl (Linux platform implementation of public CRTP interface)
        * Internal::NetworkManagementInterface
            * `ConnectivityManagerImpl_NetworkManagementConnMan` _ConnectivityManagerImpl_NetworkManagementConnMan.h_
            * `ConnectivityManagerImpl_NetworkManagementWpaSupplicant` _ConnectivityManagerImpl_NetworkManagementWpaSupplicant.h_
        * Internal::WiFiPafInterface
            * `ConnectivityManagerImpl_WiFiPafNone` _ConnectivityManagerImpl_WiFiPafNone.h_
            * `ConnectivityManagerImpl_WiFiPafWpaSupplicant` _ConnectivityManagerImpl_WiFiPafWpaSupplicant.h_

**Q:** Why are these interfaces as they are?
**A:** Generally, an effort has been made to mirror and match the public, upstream CRTP interfaces where possible rather than vary them to, perhaps, "do things right" and create an impedance mismatch between the CRTP interfaces and the Linux abstract implementation interface.

**Q:** Why is this only being introduced in Linux?
**A:** Per #42516, while there is a long-term desire to mimic the abstract interface (non-CRTP) structure of the peer _Configuration Manager_, there is not a consensus that the "expense" of doing so for all Matter platforms is justified (though the expense should be no worse than for _Configuration Manager_). For Linux, the expense is minimal relative to system resources and the relative overhead of D-Bus IPC interactions for all forms of Linux network management and technology-specific backends.

**Q:** Why not just more CRTP, all the way down?
**A:** Per #42516, the eventual goal is to mirror the peer _Configuration Manager_ and to be able to add a `SetConnectivityMgr` where the _Connectivity Manager_ implementation can be completely out-of-tree and set at runtime, as the _Configuration Manager_ can today. More CRTP, all the way down, is counter to that goal.

#### Related issues

#42516

#### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.2 Apple "Home" app with a Connectivity Manager implementation using this infrastructure.