### PR TITLE
Cherry-pick revision conformance

### DIFF
--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -28,7 +28,7 @@ import click
 import paths
 from lxml import etree
 
-from matter.testing.conformance import ConformanceDecision
+from matter.testing.conformance import EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, ConformanceDecision
 from matter.testing.spec_parsing import build_xml_clusters, build_xml_device_types
 
 logging.basicConfig(level=logging.DEBUG, format="[%(levelname)s] %(message)s")
@@ -413,10 +413,10 @@ def dump_ids_from_data_model_dirs():
         def device_type_support_str(d):
             logging.info(f"checking device type for {d.name} for {dir}")
             dt_server_mandatory = [id for id, requirement in d.server_clusters.items() if requirement.conformance(
-                [], 0, 0).decision == ConformanceDecision.MANDATORY]
+                EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision == ConformanceDecision.MANDATORY]
             server_provisional = [clusters[c].name for c in dt_server_mandatory if clusters[c].is_provisional]
             dt_client_mandatory = [id for id, requirement in d.client_clusters.items(
-            ) if requirement.conformance([], 0, 0).decision == ConformanceDecision.MANDATORY]
+            ) if requirement.conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision == ConformanceDecision.MANDATORY]
             client_provisional = [clusters[c].name for c in dt_client_mandatory if clusters[c].is_provisional]
             if server_provisional or client_provisional:
                 logging.info(

--- a/scripts/spec_xml/spec_revision_diff_summary.py
+++ b/scripts/spec_xml/spec_revision_diff_summary.py
@@ -22,7 +22,7 @@
 
 import click
 
-from matter.testing.conformance import ConformanceDecision
+from matter.testing.conformance import EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, ConformanceDecision
 from matter.testing.spec_parsing import PrebuiltDataModelDirectory, build_xml_clusters, build_xml_device_types
 
 
@@ -119,7 +119,7 @@ def diff_device_types(prior_revision: PrebuiltDataModelDirectory, new_revision: 
 
 
 def _get_provisional(items):
-    return [e.name for e in items if e.conformance(0, [], []).decision == ConformanceDecision.PROVISIONAL]
+    return [e.name for e in items if e.conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision == ConformanceDecision.PROVISIONAL]
 
 
 def get_all_provisional_clusters(new_revision: PrebuiltDataModelDirectory):

--- a/src/python_testing/MinimalRepresentation.py
+++ b/src/python_testing/MinimalRepresentation.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 
 from TC_DeviceConformance import DeviceConformanceTests
 
-from matter.testing.conformance import ConformanceDecision
+from matter.testing.conformance import ConformanceAssessmentData, ConformanceDecision
 from matter.testing.global_attribute_ids import GlobalAttributeIds
 from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 from matter.tlv import uint
@@ -62,12 +62,14 @@ class MinimalRepresentationChecker(DeviceConformanceTests):
                 all_command_list = cluster[GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID] + \
                     cluster[GlobalAttributeIds.GENERATED_COMMAND_LIST_ID]
                 accepted_command_list = cluster[GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID]
+                revision = cluster[GlobalAttributeIds.CLUSTER_REVISION_ID]
+                conformance_assessment_data = ConformanceAssessmentData(feature_map, attribute_list, all_command_list, revision)
 
                 # All optional features
                 feature_masks = [1 << i for i in range(32) if feature_map & (1 << i)]
                 for f in feature_masks:
                     xml_feature = self.xml_clusters[cluster_id].features[f]
-                    conformance_decision = xml_feature.conformance(feature_map, attribute_list, all_command_list)
+                    conformance_decision = xml_feature.conformance(conformance_assessment_data)
                     if conformance_decision == ConformanceDecision.OPTIONAL:
                         minimal.feature_masks.append(f)
 
@@ -79,7 +81,7 @@ class MinimalRepresentationChecker(DeviceConformanceTests):
                             minimal.attribute_ids.append(attribute_id)
                         continue
                     xml_attribute = self.xml_clusters[cluster_id].attributes[attribute_id]
-                    conformance_decision = xml_attribute.conformance(feature_map, attribute_list, all_command_list)
+                    conformance_decision = xml_attribute.conformance(conformance_assessment_data)
                     if conformance_decision == ConformanceDecision.OPTIONAL:
                         minimal.attribute_ids.append(attribute_id)
 
@@ -91,7 +93,7 @@ class MinimalRepresentationChecker(DeviceConformanceTests):
                             minimal.attribute_ids.append(command_id)
                         continue
                     xml_command = self.xml_clusters[cluster_id].accepted_commands[command_id]
-                    conformance_decision = xml_command.conformance(feature_map, attribute_list, all_command_list)
+                    conformance_decision = xml_command.conformance(conformance_assessment_data)
                     if conformance_decision == ConformanceDecision.OPTIONAL:
                         minimal.command_ids.append(command_id)
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/choice_conformance.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/choice_conformance.py
@@ -15,7 +15,7 @@
 #    limitations under the License.
 #
 
-from matter.testing.conformance import Choice, ConformanceDecisionWithChoice
+from matter.testing.conformance import Choice, ConformanceAssessmentData, ConformanceDecisionWithChoice
 from matter.testing.global_attribute_ids import GlobalAttributeIds
 from matter.testing.problem_notices import AttributePathLocation, ProblemNotice, ProblemSeverity
 from matter.testing.spec_parsing import XmlCluster
@@ -47,7 +47,7 @@ def _evaluate_choices(location: AttributePathLocation, counts: dict[Choice, int]
     return problems
 
 
-def evaluate_feature_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], feature_map: uint, attribute_list: list[uint], all_command_list: list[uint]) -> list[ChoiceConformanceProblemNotice]:
+def evaluate_feature_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], conformance_assessment_data: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
     all_features = [uint(1 << i) for i in range(32)]
     all_features = [f for f in all_features if f in xml_clusters[cluster_id].features.keys()]
 
@@ -55,36 +55,38 @@ def evaluate_feature_choice_conformance(endpoint_id: int, cluster_id: int, xml_c
     counts: dict[Choice, int] = {}
     for f in all_features:
         xml_feature = xml_clusters[cluster_id].features[f]
-        conformance_decision_with_choice = xml_feature.conformance(feature_map, attribute_list, all_command_list)
-        _add_to_counts_if_required(conformance_decision_with_choice, (feature_map & f) != 0, counts)
+        conformance_decision_with_choice = xml_feature.conformance(conformance_assessment_data)
+        _add_to_counts_if_required(conformance_decision_with_choice, (conformance_assessment_data.feature_map & f) != 0, counts)
 
     location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
                                      attribute_id=GlobalAttributeIds.FEATURE_MAP_ID)
     return _evaluate_choices(location, counts)
 
 
-def evaluate_attribute_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], feature_map: uint, attribute_list: list[uint], all_command_list: list[uint]) -> list[ChoiceConformanceProblemNotice]:
+def evaluate_attribute_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], conformance_assessment_data: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
     all_attributes = xml_clusters[cluster_id].attributes.keys()
 
     counts: dict[Choice, int] = {}
     for attribute_id in all_attributes:
         conformance_decision_with_choice = xml_clusters[cluster_id].attributes[attribute_id].conformance(
-            feature_map, attribute_list, all_command_list)
-        _add_to_counts_if_required(conformance_decision_with_choice, attribute_id in attribute_list, counts)
+            conformance_assessment_data)
+        _add_to_counts_if_required(conformance_decision_with_choice,
+                                   attribute_id in conformance_assessment_data.attribute_list, counts)
 
     location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
                                      attribute_id=GlobalAttributeIds.ATTRIBUTE_LIST_ID)
     return _evaluate_choices(location, counts)
 
 
-def evaluate_command_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], feature_map: uint, attribute_list: list[uint], all_command_list: list[uint]) -> list[ChoiceConformanceProblemNotice]:
+def evaluate_command_choice_conformance(endpoint_id: int, cluster_id: int, xml_clusters: dict[int, XmlCluster], conformance_assessment_data: ConformanceAssessmentData) -> list[ChoiceConformanceProblemNotice]:
     all_commands = xml_clusters[cluster_id].accepted_commands.keys()
 
     counts: dict[Choice, int] = {}
     for command_id in all_commands:
         conformance_decision_with_choice = xml_clusters[cluster_id].accepted_commands[command_id].conformance(
-            feature_map, attribute_list, all_command_list)
-        _add_to_counts_if_required(conformance_decision_with_choice, command_id in all_command_list, counts)
+            conformance_assessment_data)
+        _add_to_counts_if_required(conformance_decision_with_choice,
+                                   command_id in conformance_assessment_data.all_command_list, counts)
 
     location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
                                      attribute_id=GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/conformance.py
@@ -33,6 +33,7 @@ should be present on a device based on the device's implemented features, attrib
 commands.
 """
 
+import operator
 import xml.etree.ElementTree as ElementTree
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -52,11 +53,13 @@ AND_TERM = 'andTerm'
 OR_TERM = 'orTerm'
 NOT_TERM = 'notTerm'
 GREATER_TERM = 'greaterTerm'
+GREATER_EQUAL_TERM = 'greaterOrEqualTerm'
 FEATURE_TAG = 'feature'
 ATTRIBUTE_TAG = 'attribute'
 COMMAND_TAG = 'command'
 CONDITION_TAG = 'condition'
 LITERAL_TAG = 'literal'
+REVISION_TAG = 'revision'
 ZIGBEE_CONDITION = 'zigbee'
 
 
@@ -225,19 +228,46 @@ class provisional(Conformance):
         return 'P'
 
 
-class literal(Conformance):
+class ValueConformance(Conformance):
+    def __call__(self, conformance_assessment_data: ConformanceAssessmentData):
+        # This should never be called
+        raise ConformanceException('Value conformance function should not be called - this is simply a value holder')
+
+    def get_value(self, conformance_assessment_data: ConformanceAssessmentData) -> int:
+        raise ConformanceException('Base get_value function should not be called directly')
+
+
+class literal(ValueConformance):
     def __init__(self, value: str):
         # base=0 allows automatic detection of number format from string prefix:
         # "10" -> 10 (decimal), "0x10" -> 16 (hex), "0o10" -> 8 (octal), "0b10" -> 2 (binary)
         # This is needed because XML literal values can be in different formats
         self.value = int(value, 0)
 
-    def __call__(self, conformance_assessment_data: ConformanceAssessmentData):
-        # This should never be called
-        raise ConformanceException('Literal conformance function should not be called - this is simply a value holder')
-
     def __str__(self):
         return str(self.value)
+
+    def get_value(self, conformance_assessment_data: ConformanceAssessmentData) -> int:
+        return self.value
+
+
+class revision(ValueConformance):
+    def __init__(self, value: str):
+        self.value: Optional[int]
+        if value.lower() == 'current':
+            self.value = None
+        else:
+            self.value = int(value, 0)
+
+    def __str__(self):
+        if self.value is None:
+            return "Rev"
+        return f'v{str(self.value)}'
+
+    def get_value(self, conformance_assessment_data: ConformanceAssessmentData) -> int:
+        if self.value is None:
+            return conformance_assessment_data.cluster_revision
+        return self.value
 
 
 # Conformance options that apply regardless of the element set of the cluster or device
@@ -426,24 +456,50 @@ class or_operation(Conformance):
         return f'({" | ".join(op_strs)})'
 
 
-class greater_operation(Conformance):
-    def _type_ok(self, op: Conformance):
-        return type(op) == attribute or type(op) == literal
+class ArithmeticConformance(Conformance):
+    ''' Base class for arithmetic operations - do not use directly.'''
+
+    def _type_ok(self, op1: Conformance, op2: Conformance):
+        def _is_valid_operand(op: Conformance) -> bool:
+            return issubclass(type(op), ValueConformance) or type(op) == attribute
+        return _is_valid_operand(op1) and _is_valid_operand(op2)
 
     def __init__(self, op1: Conformance, op2: Conformance):
-        if not self._type_ok(op1) or not self._type_ok(op2):
-            raise ConformanceException('Arithmetic operations can only have attribute or literal value children')
+        if not self._type_ok(op1, op2):
+            raise ConformanceException('Arithmetic operations can only have attribute + literal or revision children')
         self.op1 = op1
         self.op2 = op2
+        self.operator = operator.gt
+        self.opstr = "???"
 
     def __call__(self, conformance_assessment_data: ConformanceAssessmentData) -> ConformanceDecisionWithChoice:
+        # If there are any non-value ops, return optional, as it represents an attribute comparison and we don't have the data
+        # for that currently.
         # For now, this is fully optional, need to implement this properly later, but it requires access to the actual attribute values
         # We need to reach into the attribute, but can't use it directly because the attribute callable is an EXISTENCE check and
         # the arithmetic functions require a value.
+        if hasattr(self.op1, 'get_value') and hasattr(self.op2, 'get_value'):
+            if self.operator(self.op1.get_value(conformance_assessment_data), self.op2.get_value(conformance_assessment_data)):
+                return ConformanceDecisionWithChoice(ConformanceDecision.MANDATORY)
+            return ConformanceDecisionWithChoice(ConformanceDecision.NOT_APPLICABLE)
         return ConformanceDecisionWithChoice(ConformanceDecision.OPTIONAL)
 
     def __str__(self):
-        return f'{str(self.op1)} > {str(self.op2)}'
+        return f'{str(self.op1)} {self.opstr} {str(self.op2)}'
+
+
+class greater_operation(ArithmeticConformance):
+    def __init__(self, op1: Conformance, op2: Conformance):
+        super().__init__(op1, op2)
+        self.operator = operator.gt
+        self.opstr = '>'
+
+
+class greater_equal_operation(ArithmeticConformance):
+    def __init__(self, op1: Conformance, op2: Conformance):
+        super().__init__(op1, op2)
+        self.operator = operator.ge
+        self.opstr = '>='
 
 
 class otherwise(Conformance):
@@ -514,9 +570,14 @@ def parse_basic_callable_from_xml(element: ElementTree.Element) -> Conformance:
                 raise ConformanceException(
                     f"Literal tag missing 'value' attribute: {ElementTree.tostring(element, encoding='unicode').strip()}")
             return literal(literal_value)
-        else:
-            raise BasicConformanceException(
-                f'parse_basic_callable_from_xml called for unknown element {str(element.tag)} {str(element.attrib)}')
+        if element.tag == REVISION_TAG:
+            value = element.get('value')
+            if value is None:
+                raise ConformanceException(
+                    f"Revision tag missing 'value' attribute: {ElementTree.tostring(element, encoding='unicode').strip()}")
+            return revision(value)
+        raise BasicConformanceException(
+            f'parse_basic_callable_from_xml called for unknown element {str(element.tag)} {str(element.attrib)}')
 
 
 def parse_wrapper_callable_from_xml(element: ElementTree.Element, ops: list[Conformance]) -> Conformance:
@@ -569,8 +630,11 @@ def parse_wrapper_callable_from_xml(element: ElementTree.Element, ops: list[Conf
         if len(ops) != 2:
             raise ConformanceException(f'Greater than term found with more than two subelements {list(element)}')
         return greater_operation(ops[0], ops[1])
-    else:
-        raise ConformanceException(f'Unexpected conformance tag with children {element}')
+    if element.tag == GREATER_EQUAL_TERM:
+        if len(ops) != 2:
+            raise ConformanceException(f'Greater than term found with more than two subelements {list(element)}')
+        return greater_equal_operation(ops[0], ops[1])
+    raise ConformanceException(f'Unexpected conformance tag with children {element}')
 
 
 def parse_device_type_callable_from_xml(element: ElementTree.Element) -> Conformance:

--- a/src/python_testing/test_testing/DeviceConformanceTests.py
+++ b/src/python_testing/test_testing/DeviceConformanceTests.py
@@ -22,7 +22,7 @@ import matter.clusters as Clusters
 from matter.testing.basic_composition import BasicCompositionTests
 from matter.testing.choice_conformance import (evaluate_attribute_choice_conformance, evaluate_command_choice_conformance,
                                                evaluate_feature_choice_conformance)
-from matter.testing.conformance import conformance_allowed
+from matter.testing.conformance import EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, ConformanceAssessmentData, conformance_allowed
 from matter.testing.global_attribute_ids import (ClusterIdType, DeviceTypeIdType, GlobalAttributeIds, cluster_id_type,
                                                  device_type_id_type, is_valid_device_type_id)
 from matter.testing.problem_notices import (AttributePathLocation, ClusterPathLocation, CommandPathLocation, DeviceTypePathLocation,
@@ -161,6 +161,8 @@ class DeviceConformanceTests(BasicCompositionTests):
                 attribute_list = cluster[GlobalAttributeIds.ATTRIBUTE_LIST_ID]
                 all_command_list = cluster[GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID] + \
                     cluster[GlobalAttributeIds.GENERATED_COMMAND_LIST_ID]
+                revision = cluster[GlobalAttributeIds.CLUSTER_REVISION_ID]
+                cluster_info = ConformanceAssessmentData(feature_map, attribute_list, all_command_list, revision)
 
                 # Feature conformance checking
                 location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id,
@@ -179,12 +181,12 @@ class DeviceConformanceTests(BasicCompositionTests):
                                      problem=f'Unknown feature with mask 0x{f:02x} (feature bit {f.bit_length() - 1})')
                         continue
                     xml_feature = self.xml_clusters[cluster_id].features[f]
-                    conformance_decision_with_choice = xml_feature.conformance(feature_map, attribute_list, all_command_list)
+                    conformance_decision_with_choice = xml_feature.conformance(cluster_info)
                     if not conformance_allowed(conformance_decision_with_choice, allow_provisional):
                         record_error(location=location,
                                      problem=f'Disallowed feature with mask 0x{f:02x} (feature bit {f.bit_length() - 1})')
                 for feature_mask, xml_feature in self.xml_clusters[cluster_id].features.items():
-                    conformance_decision_with_choice = xml_feature.conformance(feature_map, attribute_list, all_command_list)
+                    conformance_decision_with_choice = xml_feature.conformance(cluster_info)
                     if conformance_decision_with_choice.is_mandatory() and feature_mask not in feature_masks:
                         record_error(
                             location=location, problem=f'Required feature with mask 0x{feature_mask:02x} (feature bit {feature_mask.bit_length() - 1}) is not present in feature map. {conformance_str(xml_feature.conformance, feature_map, self.xml_clusters[cluster_id].features)}')
@@ -200,7 +202,7 @@ class DeviceConformanceTests(BasicCompositionTests):
                             record_error(location=location, problem='Standard attribute found on device, but not in spec')
                         continue
                     xml_attribute = self.xml_clusters[cluster_id].attributes[attribute_id]
-                    conformance_decision_with_choice = xml_attribute.conformance(feature_map, attribute_list, all_command_list)
+                    conformance_decision_with_choice = xml_attribute.conformance(cluster_info)
                     if not conformance_allowed(conformance_decision_with_choice, allow_provisional):
                         location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id, attribute_id=attribute_id)
                         record_error(
@@ -208,8 +210,8 @@ class DeviceConformanceTests(BasicCompositionTests):
                 for attribute_id, xml_attribute in self.xml_clusters[cluster_id].attributes.items():
                     if cluster_id in ignore_attributes and attribute_id in ignore_attributes[cluster_id]:
                         continue
-                    conformance_decision_with_choice = xml_attribute.conformance(feature_map, attribute_list, all_command_list)
-                    if conformance_decision_with_choice.is_mandatory() and attribute_id not in cluster.keys():
+                    conformance_decision_with_choice = xml_attribute.conformance(cluster_info)
+                    if conformance_decision_with_choice.is_mandatory() and attribute_id not in cluster:
                         location = AttributePathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id, attribute_id=attribute_id)
                         record_error(
                             location=location, problem=f'Attribute 0x{attribute_id:02x} is required, but is not present on the DUT. {conformance_str(xml_attribute.conformance, feature_map, self.xml_clusters[cluster_id].features)}')
@@ -226,12 +228,12 @@ class DeviceConformanceTests(BasicCompositionTests):
                                 record_error(location=location, problem='Standard command found on device, but not in spec')
                             continue
                         xml_command = xml_commands_dict[command_id]
-                        conformance_decision_with_choice = xml_command.conformance(feature_map, attribute_list, all_command_list)
+                        conformance_decision_with_choice = xml_command.conformance(cluster_info)
                         if not conformance_allowed(conformance_decision_with_choice, allow_provisional):
                             record_error(
                                 location=location, problem=f'Command 0x{command_id:02x} is included, but disallowed by conformance. {conformance_str(xml_command.conformance, feature_map, self.xml_clusters[cluster_id].features)}')
                     for command_id, xml_command in xml_commands_dict.items():
-                        conformance_decision_with_choice = xml_command.conformance(feature_map, attribute_list, all_command_list)
+                        conformance_decision_with_choice = xml_command.conformance(cluster_info)
                         if conformance_decision_with_choice.is_mandatory() and command_id not in command_list:
                             location = CommandPathLocation(endpoint_id=endpoint_id, cluster_id=cluster_id, command_id=command_id)
                             record_error(
@@ -242,11 +244,11 @@ class DeviceConformanceTests(BasicCompositionTests):
                 check_spec_conformance_for_commands(CommandType.GENERATED)
 
                 feature_choice_problems = evaluate_feature_choice_conformance(
-                    endpoint_id, cluster_id, self.xml_clusters, feature_map, attribute_list, all_command_list)
+                    endpoint_id, cluster_id, self.xml_clusters, cluster_info)
                 attribute_choice_problems = evaluate_attribute_choice_conformance(
-                    endpoint_id, cluster_id, self.xml_clusters, feature_map, attribute_list, all_command_list)
+                    endpoint_id, cluster_id, self.xml_clusters, cluster_info)
                 command_choice_problem = evaluate_command_choice_conformance(
-                    endpoint_id, cluster_id, self.xml_clusters, feature_map, attribute_list, all_command_list)
+                    endpoint_id, cluster_id, self.xml_clusters, cluster_info)
 
                 if feature_choice_problems or attribute_choice_problems or command_choice_problem:
                     success = False
@@ -380,7 +382,7 @@ class DeviceConformanceTests(BasicCompositionTests):
                 # TODO: check client clusters too?
                 for cluster_id, cluster_requirement in xml_device.server_clusters.items():
                     # Device type cluster conformances do not include any conformances based on cluster elements
-                    conformance_decision_with_choice = cluster_requirement.conformance(0, [], [])
+                    conformance_decision_with_choice = cluster_requirement.conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES)
                     location = DeviceTypePathLocation(device_type_id=device_type_id, cluster_id=cluster_id)
                     if conformance_decision_with_choice.is_mandatory() and cluster_id not in server_clusters:
                         record_error(location=location,
@@ -396,9 +398,9 @@ class DeviceConformanceTests(BasicCompositionTests):
                         # Optional cluster not on this endpoint
                         continue
 
-                    def check_feature_overrides(cluster_requirement: XmlDeviceTypeClusterRequirements, feature_map, attribute_list, cmd_list):
+                    def check_feature_overrides(cluster_requirement: XmlDeviceTypeClusterRequirements, cluster_info: ConformanceAssessmentData):
                         for mask, conformance in cluster_requirement.feature_overrides.items():
-                            conformance_decision_with_choice = conformance(feature_map, attribute_list, cmd_list)
+                            conformance_decision_with_choice = conformance(cluster_info)
                             if conformance_decision_with_choice.is_mandatory() and ((feature_map & mask) == 0):
                                 record_error(
                                     location=location, problem=f"Feature bit {mask.bit_length() - 1} in cluster {cluster_requirement.name} is required by element override for device type {xml_device.name}, but is not present in the feature map")
@@ -406,9 +408,9 @@ class DeviceConformanceTests(BasicCompositionTests):
                                 record_error(
                                     location=location, problem=f"Feature bit {mask.bit_length() - 1} in cluster {cluster_requirement.name} is disallowed by element override for device type {xml_device.name}, but is present in the feature map")
 
-                    def check_attribute_overrides(cluster_requirement: XmlDeviceTypeClusterRequirements, feature_map: int, attribute_list: list[int], cmd_list: list[int]) -> None:
+                    def check_attribute_overrides(cluster_requirement: XmlDeviceTypeClusterRequirements, cluster_info: ConformanceAssessmentData) -> None:
                         for id, conformance in cluster_requirement.attribute_overrides.items():
-                            conformance_decision_with_choice = conformance(feature_map, attribute_list, cmd_list)
+                            conformance_decision_with_choice = conformance(cluster_info)
                             if conformance_decision_with_choice.is_mandatory() and id not in attribute_list:
                                 record_error(
                                     location=location, problem=f"Attribute {id} in cluster {cluster_requirement.name} is required by element override for device type {xml_device.name}, but is not present in the attribute list")
@@ -420,9 +422,9 @@ class DeviceConformanceTests(BasicCompositionTests):
                                 record_error(
                                     location=location, problem=f"Attribute {id} in cluster {cluster_requirement.name} is disallowed by element override for device type {xml_device.name}, but is present in the attribute list")
 
-                    def check_command_overrides(cluster_requirement: XmlDeviceTypeClusterRequirements, feature_map: int, attribute_list: list[int], cmd_list: list[int]):
+                    def check_command_overrides(cluster_requirement: XmlDeviceTypeClusterRequirements, cluster_info: ConformanceAssessmentData):
                         for id, conformance in cluster_requirement.command_overrides.items():
-                            conformance_decision_with_choice = conformance(feature_map, attribute_list, cmd_list)
+                            conformance_decision_with_choice = conformance(cluster_info)
                             if conformance_decision_with_choice.is_mandatory() and id not in cmd_list:
                                 record_error(
                                     location=location, problem=f"Command {id} in cluster {cluster_requirement.name} is required by element override for device type {xml_device.name}, but is not present in the cmd list")
@@ -434,10 +436,12 @@ class DeviceConformanceTests(BasicCompositionTests):
                     feature_map = endpoint[cluster][cluster.Attributes.FeatureMap]
                     attribute_list = endpoint[cluster][cluster.Attributes.AttributeList]
                     cmd_list = endpoint[cluster][cluster.Attributes.AcceptedCommandList]
+                    revision = endpoint[cluster][cluster.Attributes.ClusterRevision]
+                    cluster_info = ConformanceAssessmentData(feature_map, attribute_list, cmd_list, revision)
 
-                    check_feature_overrides(cluster_requirement, feature_map, attribute_list, cmd_list)
-                    check_attribute_overrides(cluster_requirement, feature_map, attribute_list, cmd_list)
-                    check_command_overrides(cluster_requirement, feature_map, attribute_list, cmd_list)
+                    check_feature_overrides(cluster_requirement, cluster_info)
+                    check_attribute_overrides(cluster_requirement, cluster_info)
+                    check_command_overrides(cluster_requirement, cluster_info)
 
                 # If we want to check for extra clusters on the endpoint, we need to know the entire set of clusters in all the device type
                 # lists across all the device types on the endpoint.

--- a/src/python_testing/test_testing/TestChoiceConformanceSupport.py
+++ b/src/python_testing/test_testing/TestChoiceConformanceSupport.py
@@ -23,6 +23,7 @@ from mobly import asserts
 
 from matter.testing.choice_conformance import (evaluate_attribute_choice_conformance, evaluate_command_choice_conformance,
                                                evaluate_feature_choice_conformance)
+from matter.testing.conformance import ConformanceAssessmentData
 from matter.testing.matter_testing import MatterBaseTest, default_matter_test_main
 from matter.testing.problem_notices import ProblemNotice
 from matter.testing.spec_parsing import XmlCluster, add_cluster_data_from_xml
@@ -195,17 +196,21 @@ class TestConformanceSupport(MatterBaseTest):
             return feature_map
 
         for combo, expected_failures in self.all_id_combos:
-            problems = evaluate_feature_choice_conformance(0, 1, self.clusters, make_feature_map(combo), [], [])
+            info = ConformanceAssessmentData(feature_map=make_feature_map(
+                combo), attribute_list=[], all_command_list=[], cluster_revision=1)
+            problems = evaluate_feature_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 
     def test_attributes(self):
         for combo, expected_failures in self.all_id_combos:
-            problems = evaluate_attribute_choice_conformance(0, 1, self.clusters, 0, list(combo), [])
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=list(combo), all_command_list=[], cluster_revision=1)
+            problems = evaluate_attribute_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 
     def test_commands(self):
         for combo, expected_failures in self.all_id_combos:
-            problems = evaluate_command_choice_conformance(0, 1, self.clusters, 0, [], list(combo))
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=[], all_command_list=list(combo), cluster_revision=1)
+            problems = evaluate_command_choice_conformance(0, 1, self.clusters, info)
             self._evaluate_problems(problems, expected_failures)
 
 

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -654,40 +654,33 @@ class TestConformanceSupport(MatterBaseTest):
                 asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.PROVISIONAL)
         asserts.assert_equal(str(xml_callable), 'AB & !CD, P')
 
-    def test_conformance_greater(self):
-        # AB, [CD]
-        xml = ('<mandatoryConform>'
-               '<greaterTerm>'
-               '<attribute name="attr1" />'
-               '<literal value="1" />'
-               '</greaterTerm>'
-               '</mandatoryConform>')
+    def _test_conformance_arithmetic(self, term: str, symbol: str):
+        def create_xml(xml_mid: str) -> str:
+            return ('<mandatoryConform>'
+                    f'<{term}>'
+                    f'{xml_mid}'
+                    f'</{term}>'
+                    '</mandatoryConform>')
+        xml = create_xml(('<attribute name="attr1" />'
+                          '<literal value="1" />'))
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         # TODO: switch this to check greater than once the update to the base is done (#33422)
         asserts.assert_equal(xml_callable(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision, ConformanceDecision.OPTIONAL)
-        asserts.assert_equal(str(xml_callable), 'attr1 > 1')
+        asserts.assert_equal(str(xml_callable), f'attr1 {symbol} 1')
 
         # Ensure that we can only have greater terms with exactly 2 value
-        xml = ('<mandatoryConform>'
-               '<greaterTerm>'
-               '<attribute name="attr1" />'
-               '<attribute name="attr2" />'
-               '<literal value="1" />'
-               '</greaterTerm>'
-               '</mandatoryConform>')
+        xml = create_xml(('<attribute name="attr1" />'
+                          '<attribute name="attr2" />'
+                          '<literal value="1" />'))
         et = ElementTree.fromstring(xml)
         try:
             xml_callable = parse_callable_from_xml(et, self.params)
-            asserts.fail("Incorrectly parsed bad greaterTerm XML with > 2 values")
+            asserts.fail(f"Incorrectly parsed bad {term} XML with > 2 values")
         except ConformanceException:
             pass
 
-        xml = ('<mandatoryConform>'
-               '<greaterTerm>'
-               '<attribute name="attr1" />'
-               '</greaterTerm>'
-               '</mandatoryConform>')
+        xml = create_xml(('<attribute name="attr1" />'))
         et = ElementTree.fromstring(xml)
         try:
             xml_callable = parse_callable_from_xml(et, self.params)
@@ -696,18 +689,88 @@ class TestConformanceSupport(MatterBaseTest):
             pass
 
         # Only attributes and literals allowed because arithmetic operations require values
-        xml = ('<mandatoryConform>'
-               '<greaterTerm>'
-               '<feature name="AB" />'
-               '<literal value="1" />'
-               '</greaterTerm>'
-               '</mandatoryConform>')
+        xml = create_xml(('<feature name="AB" />'
+                          '<literal value="1" />'))
         et = ElementTree.fromstring(xml)
         try:
             xml_callable = parse_callable_from_xml(et, self.params)
-            asserts.fail("Incorrectly parsed greater term with feature value")
+            asserts.fail(f"Incorrectly parsed {term} with feature value")
         except ConformanceException:
             pass
+
+    def test_conformance_greater(self):
+        self._test_conformance_arithmetic('greaterTerm', '>')
+
+    def test_conformance_greater_or_equal(self):
+        self._test_conformance_arithmetic('greaterOrEqualTerm', '>=')
+
+    def test_revision(self):
+        def create_xml(revision: int) -> str:
+            return ('<mandatoryConform>'
+                    '<greaterOrEqualTerm>'
+                    '<revision value="current"/>'
+                    f'<revision value="{revision}"/>'
+                    '</greaterOrEqualTerm>'
+                    '</mandatoryConform>')
+
+        conformance_assessment_data = EMPTY_CLUSTER_GLOBAL_ATTRIBUTES
+
+        xml = create_xml(2)
+        et = ElementTree.fromstring(xml)
+        xml_callable = parse_callable_from_xml(et, self.params)
+        asserts.assert_equal(str(xml_callable), 'Rev >= v2')
+
+        conformance_assessment_data.cluster_revision = 1
+        asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.NOT_APPLICABLE)
+        conformance_assessment_data.cluster_revision = 2
+        asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.MANDATORY)
+        conformance_assessment_data.cluster_revision = 3
+        asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.MANDATORY)
+
+        xml = create_xml(5)
+        et = ElementTree.fromstring(xml)
+        xml_callable = parse_callable_from_xml(et, self.params)
+        asserts.assert_equal(str(xml_callable), 'Rev >= v5')
+
+        conformance_assessment_data.cluster_revision = 1
+        asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.NOT_APPLICABLE)
+        conformance_assessment_data.cluster_revision = 2
+        asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.NOT_APPLICABLE)
+        conformance_assessment_data.cluster_revision = 4
+        asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.NOT_APPLICABLE)
+        conformance_assessment_data.cluster_revision = 5
+        asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.MANDATORY)
+        conformance_assessment_data.cluster_revision = 6
+        asserts.assert_equal(xml_callable(conformance_assessment_data).decision, ConformanceDecision.MANDATORY)
+
+        too_many_terms = ('<mandatoryConform>'
+                          '<greaterOrEqualTerm>'
+                          '<revision value="current"/>'
+                          '<revision value="2"/>'
+                          '<revision value="2"/>'
+                          '</greaterOrEqualTerm>'
+                          '</mandatoryConform>')
+        et = ElementTree.fromstring(too_many_terms)
+        with asserts.assert_raises(ConformanceException):
+            xml_callable = parse_callable_from_xml(et, self.params)
+
+        too_few_terms_current = ('<mandatoryConform>'
+                                 '<greaterOrEqualTerm>'
+                                 '<revision value="current"/>'
+                                 '</greaterOrEqualTerm>'
+                                 '</mandatoryConform>')
+        et = ElementTree.fromstring(too_few_terms_current)
+        with asserts.assert_raises(ConformanceException):
+            xml_callable = parse_callable_from_xml(et, self.params)
+
+        too_few_terms_value = ('<mandatoryConform>'
+                               '<greaterOrEqualTerm>'
+                               '<revision value="2"/>'
+                               '</greaterOrEqualTerm>'
+                               '</mandatoryConform>')
+        et = ElementTree.fromstring(too_few_terms_value)
+        with asserts.assert_raises(ConformanceException):
+            xml_callable = parse_callable_from_xml(et, self.params)
 
     def test_basic_conformance(self):
         basic_test('<mandatoryConform />', mandatory)

--- a/src/python_testing/test_testing/TestConformanceSupport.py
+++ b/src/python_testing/test_testing/TestConformanceSupport.py
@@ -20,9 +20,10 @@ from typing import Callable
 
 from mobly import asserts
 
-from matter.testing.conformance import (Choice, Conformance, ConformanceDecision, ConformanceException, ConformanceParseParameters,
-                                        deprecated, disallowed, mandatory, optional, parse_basic_callable_from_xml,
-                                        parse_callable_from_xml, provisional, zigbee)
+from matter.testing.conformance import (EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, Choice, Conformance, ConformanceAssessmentData,
+                                        ConformanceDecision, ConformanceException, ConformanceParseParameters, deprecated,
+                                        disallowed, mandatory, optional, parse_basic_callable_from_xml, parse_callable_from_xml,
+                                        provisional, zigbee)
 from matter.testing.matter_testing import MatterBaseTest, default_matter_test_main
 from matter.tlv import uint
 
@@ -61,7 +62,8 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.MANDATORY)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
+            asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
         asserts.assert_equal(str(xml_callable), 'M')
 
     def test_conformance_optional(self):
@@ -69,7 +71,8 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.OPTIONAL)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
+            asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         asserts.assert_equal(str(xml_callable), 'O')
 
     def test_conformance_disallowed(self):
@@ -77,14 +80,16 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.DISALLOWED)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
+            asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.DISALLOWED)
         asserts.assert_equal(str(xml_callable), 'X')
 
         xml = '<deprecateConform />'
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.DISALLOWED)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
+            asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.DISALLOWED)
         asserts.assert_equal(str(xml_callable), 'D')
 
     def test_conformance_provisional(self):
@@ -92,7 +97,8 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.PROVISIONAL)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
+            asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.PROVISIONAL)
         asserts.assert_equal(str(xml_callable), 'P')
 
     def test_conformance_zigbee(self):
@@ -100,7 +106,8 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for f in self.feature_maps:
-            asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
+            asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'Zigbee')
 
     def test_conformance_mandatory_on_condition(self):
@@ -110,10 +117,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'AB')
 
         xml = ('<mandatoryConform>'
@@ -122,10 +130,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_cd[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'CD')
 
         # single attribute mandatory
@@ -135,10 +144,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr1[i]:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'attr1')
 
         xml = ('<mandatoryConform>'
@@ -147,10 +157,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr2[i]:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'attr2')
 
         # test command in optional and in boolean - this is the same as attribute essentially, so testing every permutation is overkill
@@ -163,10 +174,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[AB]')
 
         xml = ('<optionalConform>'
@@ -175,10 +187,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_cd[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[CD]')
 
         # single attribute optional
@@ -188,10 +201,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr1[i]:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[attr1]')
 
         xml = ('<optionalConform>'
@@ -200,10 +214,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr2[i]:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[attr2]')
 
         # single command optional
@@ -213,10 +228,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, c in enumerate(self.cmd_lists):
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=[], all_command_list=c, cluster_revision=1)
             if self.has_cmd1[i]:
-                asserts.assert_equal(xml_callable(0x00, [], c).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
-                asserts.assert_equal(xml_callable(0x00, [], c).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[cmd1]')
 
         xml = ('<optionalConform>'
@@ -225,10 +241,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, c in enumerate(self.cmd_lists):
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=[], all_command_list=c, cluster_revision=1)
             if self.has_cmd2[i]:
-                asserts.assert_equal(xml_callable(0x00, [], c).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
-                asserts.assert_equal(xml_callable(0x00, [], c).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[cmd2]')
 
     def test_conformance_not_term_mandatory(self):
@@ -241,10 +258,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not self.has_ab[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '!AB')
 
         xml = ('<mandatoryConform>'
@@ -255,10 +273,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not self.has_cd[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '!CD')
 
         # single attribute not mandatory
@@ -270,10 +289,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if not self.has_attr1[i]:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '!attr1')
 
         xml = ('<mandatoryConform>'
@@ -284,10 +304,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if not self.has_attr2[i]:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '!attr2')
 
     def test_conformance_not_term_optional(self):
@@ -300,10 +321,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not self.has_ab[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[!AB]')
 
         xml = ('<optionalConform>'
@@ -314,10 +336,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not self.has_cd[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[!CD]')
 
     def test_conformance_and_term(self):
@@ -331,10 +354,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i] and self.has_cd[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'AB & CD')
 
         # and term for attributes only
@@ -347,10 +371,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr1[i] and self.has_attr2[i]:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'attr1 & attr2')
 
         # and term for feature and attribute
@@ -364,10 +389,11 @@ class TestConformanceSupport(MatterBaseTest):
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
+                info = ConformanceAssessmentData(feature_map=f, attribute_list=a, all_command_list=[], cluster_revision=1)
                 if self.has_ab[i] and self.has_attr2[j]:
-                    asserts.assert_equal(xml_callable(f, a, []).decision, ConformanceDecision.MANDATORY)
+                    asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
                 else:
-                    asserts.assert_equal(xml_callable(f, a, []).decision, ConformanceDecision.NOT_APPLICABLE)
+                    asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'AB & attr2')
 
     def test_conformance_or_term(self):
@@ -381,10 +407,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i] or self.has_cd[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'AB | CD')
 
         # or term attribute only
@@ -397,10 +424,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, a in enumerate(self.attribute_lists):
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=a, all_command_list=[], cluster_revision=1)
             if self.has_attr1[i] or self.has_attr2[i]:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(0x00, a, []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'attr1 | attr2')
 
         # or term feature and attribute
@@ -414,10 +442,11 @@ class TestConformanceSupport(MatterBaseTest):
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
+                info = ConformanceAssessmentData(feature_map=f, attribute_list=a, all_command_list=[], cluster_revision=1)
                 if self.has_ab[i] or self.has_attr2[j]:
-                    asserts.assert_equal(xml_callable(f, a, []).decision, ConformanceDecision.MANDATORY)
+                    asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
                 else:
-                    asserts.assert_equal(xml_callable(f, a, []).decision, ConformanceDecision.NOT_APPLICABLE)
+                    asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'AB | attr2')
 
     def test_conformance_and_term_with_not(self):
@@ -433,10 +462,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not self.has_ab[i] and self.has_cd[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[!AB & CD]')
 
     def test_conformance_or_term_with_not(self):
@@ -452,10 +482,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i] or not self.has_cd[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'AB | !CD')
 
         # not around or term with
@@ -470,10 +501,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if not (self.has_ab[i] or self.has_cd[i]):
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[!(AB | CD)]')
 
     def test_conformance_and_term_with_three_terms(self):
@@ -489,11 +521,14 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         # no features
-        asserts.assert_equal(xml_callable(0x00, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+        info = ConformanceAssessmentData(feature_map=0, attribute_list=[], all_command_list=[], cluster_revision=1)
+        asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         # one feature
-        asserts.assert_equal(xml_callable(0x01, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+        info = ConformanceAssessmentData(feature_map=0x01, attribute_list=[], all_command_list=[], cluster_revision=1)
+        asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         # all features
-        asserts.assert_equal(xml_callable(0x07, [], []).decision, ConformanceDecision.OPTIONAL)
+        info = ConformanceAssessmentData(feature_map=0x07, attribute_list=[], all_command_list=[], cluster_revision=1)
+        asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         asserts.assert_equal(str(xml_callable), '[AB & CD & EF]')
 
         # and term with one of each
@@ -509,10 +544,11 @@ class TestConformanceSupport(MatterBaseTest):
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
                 for k, c in enumerate(self.cmd_lists):
+                    info = ConformanceAssessmentData(feature_map=f, attribute_list=a, all_command_list=c, cluster_revision=1)
                     if self.has_ab[i] and self.has_attr1[j] and self.has_cmd1[k]:
-                        asserts.assert_equal(xml_callable(f, a, c).decision, ConformanceDecision.OPTIONAL)
+                        asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
                     else:
-                        asserts.assert_equal(xml_callable(f, a, c).decision, ConformanceDecision.NOT_APPLICABLE)
+                        asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[AB & attr1 & cmd1]')
 
     def test_conformance_or_term_with_three_terms(self):
@@ -527,11 +563,14 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         # no features
-        asserts.assert_equal(xml_callable(0x00, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+        info = ConformanceAssessmentData(feature_map=0x00, attribute_list=[], all_command_list=[], cluster_revision=1)
+        asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         # one feature
-        asserts.assert_equal(xml_callable(0x01, [], []).decision, ConformanceDecision.OPTIONAL)
+        info = ConformanceAssessmentData(feature_map=0x01, attribute_list=[], all_command_list=[], cluster_revision=1)
+        asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         # all features
-        asserts.assert_equal(xml_callable(0x07, [], []).decision, ConformanceDecision.OPTIONAL)
+        info = ConformanceAssessmentData(feature_map=0x07, attribute_list=[], all_command_list=[], cluster_revision=1)
+        asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         asserts.assert_equal(str(xml_callable), '[AB | CD | EF]')
 
         # or term with one of each
@@ -547,10 +586,11 @@ class TestConformanceSupport(MatterBaseTest):
         for i, f in enumerate(self.feature_maps):
             for j, a in enumerate(self.attribute_lists):
                 for k, c in enumerate(self.cmd_lists):
+                    info = ConformanceAssessmentData(feature_map=f, attribute_list=a, all_command_list=c, cluster_revision=1)
                     if self.has_ab[i] or self.has_attr1[j] or self.has_cmd1[k]:
-                        asserts.assert_equal(xml_callable(f, a, c).decision, ConformanceDecision.OPTIONAL)
+                        asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
                     else:
-                        asserts.assert_equal(xml_callable(f, a, c).decision, ConformanceDecision.NOT_APPLICABLE)
+                        asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), '[AB | attr1 | cmd1]')
 
     def test_conformance_otherwise(self):
@@ -564,10 +604,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
         asserts.assert_equal(str(xml_callable), 'AB, O')
 
         # AB, [CD]
@@ -582,12 +623,13 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             elif self.has_cd[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.OPTIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.OPTIONAL)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.NOT_APPLICABLE)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.NOT_APPLICABLE)
         asserts.assert_equal(str(xml_callable), 'AB, [CD]')
 
         # AB & !CD, P
@@ -605,10 +647,11 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         for i, f in enumerate(self.feature_maps):
+            info = ConformanceAssessmentData(feature_map=f, attribute_list=[], all_command_list=[], cluster_revision=1)
             if self.has_ab[i] and not self.has_cd[i]:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.MANDATORY)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.MANDATORY)
             else:
-                asserts.assert_equal(xml_callable(f, [], []).decision, ConformanceDecision.PROVISIONAL)
+                asserts.assert_equal(xml_callable(info).decision, ConformanceDecision.PROVISIONAL)
         asserts.assert_equal(str(xml_callable), 'AB & !CD, P')
 
     def test_conformance_greater(self):
@@ -622,7 +665,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         # TODO: switch this to check greater than once the update to the base is done (#33422)
-        asserts.assert_equal(xml_callable(0x00, [], []).decision, ConformanceDecision.OPTIONAL)
+        asserts.assert_equal(xml_callable(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision, ConformanceDecision.OPTIONAL)
         asserts.assert_equal(str(xml_callable), 'attr1 > 1')
 
         # Ensure that we can only have greater terms with exactly 2 value
@@ -707,7 +750,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         asserts.assert_equal(str(xml_callable), 'Zigbee', msg)
-        asserts.assert_equal(xml_callable(0, [], []).decision, ConformanceDecision.NOT_APPLICABLE, msg)
+        asserts.assert_equal(xml_callable(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision, ConformanceDecision.NOT_APPLICABLE, msg)
 
         xml = ('<optionalConform>'
                '<condition name="zigbee" />'
@@ -716,7 +759,7 @@ class TestConformanceSupport(MatterBaseTest):
         xml_callable = parse_callable_from_xml(et, self.params)
         # expect no exception here
         asserts.assert_equal(str(xml_callable), '[Zigbee]', msg)
-        asserts.assert_equal(xml_callable(0, [], []).decision, ConformanceDecision.NOT_APPLICABLE, msg)
+        asserts.assert_equal(xml_callable(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision, ConformanceDecision.NOT_APPLICABLE, msg)
 
         # otherwise conforms are allowed
         xml = ('<otherwiseConform>'
@@ -727,7 +770,7 @@ class TestConformanceSupport(MatterBaseTest):
         xml_callable = parse_callable_from_xml(et, self.params)
         # expect no exception here
         asserts.assert_equal(str(xml_callable), 'Zigbee, P', msg)
-        asserts.assert_equal(xml_callable(0, [], []).decision, ConformanceDecision.PROVISIONAL, msg)
+        asserts.assert_equal(xml_callable(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision, ConformanceDecision.PROVISIONAL, msg)
 
         # TODO: adjust conformance call function to accept a list of conditions and evaluate based on that
         xml = ('<mandatoryConform>'
@@ -738,7 +781,7 @@ class TestConformanceSupport(MatterBaseTest):
         asserts.assert_equal(str(xml_callable), 'CD', msg)
         # Device conditions are always optional (at least for now), even though we didn't pass in anything
         # to indicate whether or not this conditions is enabled
-        asserts.assert_equal(xml_callable(0, [], []).decision, ConformanceDecision.OPTIONAL)
+        asserts.assert_equal(xml_callable(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision, ConformanceDecision.OPTIONAL)
 
         xml = ('<otherwiseConform>'
                '<feature name="CD" />'
@@ -747,7 +790,7 @@ class TestConformanceSupport(MatterBaseTest):
         et = ElementTree.fromstring(xml)
         xml_callable = parse_callable_from_xml(et, self.params)
         asserts.assert_equal(str(xml_callable), 'CD, testy', msg)
-        asserts.assert_equal(xml_callable(0, [], []).decision, ConformanceDecision.OPTIONAL)
+        asserts.assert_equal(xml_callable(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision, ConformanceDecision.OPTIONAL)
 
     def check_good_choice(self, xml: str, conformance_str: str) -> Conformance:
         et = ElementTree.fromstring(xml)
@@ -756,7 +799,9 @@ class TestConformanceSupport(MatterBaseTest):
         return xml_callable
 
     def check_decision(self, more_expected: bool, conformance: Conformance, feature_map: uint, attr_list: list[uint], cmd_list: list[uint]):
-        decision = conformance(feature_map, attr_list, cmd_list)
+        info = ConformanceAssessmentData(feature_map=feature_map, attribute_list=attr_list,
+                                         all_command_list=cmd_list, cluster_revision=1)
+        decision = conformance(info)
         asserts.assert_true(decision.choice, 'Expected choice conformance on decision, but did not get one')
         asserts.assert_equal(decision.choice.marker, 'a', 'Unexpected conformance string returned')
         asserts.assert_equal(decision.choice.more, more_expected, "Unexpected more on choice")
@@ -800,21 +845,24 @@ class TestConformanceSupport(MatterBaseTest):
                    '<feature name="AB" />'
                    '</optionalConform>')
             conformance = self.check_good_choice(xml, f'[AB].{suffix}')
-            asserts.assert_equal(conformance(0, [], []).decision, ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
+            asserts.assert_equal(conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision,
+                                 ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             self.check_decision(more, conformance, AB, [], [])
 
             xml = (f'<optionalConform {xml_attrs}>'
                    '<attribute name="attr1" />'
                    '</optionalConform>')
             conformance = self.check_good_choice(xml, f'[attr1].{suffix}')
-            asserts.assert_equal(conformance(0, [], []).decision, ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
+            asserts.assert_equal(conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision,
+                                 ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             self.check_decision(more, conformance, 0, attr1, [])
 
             xml = (f'<optionalConform {xml_attrs}>'
                    '<command name="cmd1" />'
                    '</optionalConform>')
             conformance = self.check_good_choice(xml, f'[cmd1].{suffix}')
-            asserts.assert_equal(conformance(0, [], []).decision, ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
+            asserts.assert_equal(conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision,
+                                 ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             self.check_decision(more, conformance, 0, [], cmd1)
 
             xml = (f'<optionalConform {xml_attrs}>'
@@ -824,7 +872,8 @@ class TestConformanceSupport(MatterBaseTest):
                    '</orTerm>'
                    '</optionalConform>')
             conformance = self.check_good_choice(xml, f'[AB | CD].{suffix}')
-            asserts.assert_equal(conformance(0, [], []).decision, ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
+            asserts.assert_equal(conformance(ConformanceAssessmentData(feature_map=0, attribute_list=[], all_command_list=[], cluster_revision=1)).decision,
+                                 ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             self.check_decision(more, conformance, AB, [], [])
 
             xml = (f'<optionalConform {xml_attrs}>'
@@ -833,7 +882,8 @@ class TestConformanceSupport(MatterBaseTest):
                    '</notTerm>'
                    '</optionalConform>')
             conformance = self.check_good_choice(xml, f'[!attr1].{suffix}')
-            asserts.assert_equal(conformance(0, attr1, []).decision, ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
+            asserts.assert_equal(conformance(ConformanceAssessmentData(feature_map=0, attribute_list=attr1, all_command_list=[], cluster_revision=1)).decision,
+                                 ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             self.check_decision(more, conformance, 0, [], [])
 
             xml = ('<otherwiseConform>'
@@ -847,11 +897,13 @@ class TestConformanceSupport(MatterBaseTest):
             # with no features or attributes, this should end up as O.a, so there should be a choice
             self.check_decision(more, conformance, 0, [], [])
             # when we have this attribute, we should not have a choice
-            asserts.assert_equal(conformance(0, attr1, []).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
-            asserts.assert_equal(conformance(0, attr1, []).choice, None, 'Unexpected choice in conformance')
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=attr1, all_command_list=[], cluster_revision=1)
+            asserts.assert_equal(conformance(info).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
+            asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
             # when we have only this feature, we should not have a choice
-            asserts.assert_equal(conformance(AB, [], []).decision, ConformanceDecision.OPTIONAL, 'Unexpected conformance')
-            asserts.assert_equal(conformance(AB, [], []).choice, None, 'Unexpected choice in conformance')
+            info = ConformanceAssessmentData(feature_map=AB, attribute_list=[], all_command_list=[], cluster_revision=1)
+            asserts.assert_equal(conformance(info).decision, ConformanceDecision.OPTIONAL, 'Unexpected conformance')
+            asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
 
             # - multiple in otherwise [AB].a, [CD].b
             xml = ('<otherwiseConform>'
@@ -864,22 +916,26 @@ class TestConformanceSupport(MatterBaseTest):
                    '</optionalConform>'
                    '</otherwiseConform>')
             conformance = self.check_good_choice(xml, f'attr1, [AB].{suffix}, [CD].b')
-            asserts.assert_equal(conformance(0, [], []).decision, ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
+            asserts.assert_equal(conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES).decision,
+                                 ConformanceDecision.NOT_APPLICABLE, msg_not_applicable)
             # when we have this attribute, we should not have a choice
-            asserts.assert_equal(conformance(0, attr1, []).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
-            asserts.assert_equal(conformance(0, attr1, []).choice, None, 'Unexpected choice in conformance')
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=attr1, all_command_list=[], cluster_revision=1)
+            asserts.assert_equal(conformance(info).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
+            asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
             # When it's just AB, we should have a choice
             self.check_decision(more, conformance, AB, [], [])
             # When we have both the attribute and AB, we should not have a choice
-            asserts.assert_equal(conformance(0, attr1, []).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
-            asserts.assert_equal(conformance(0, attr1, []).choice, None, 'Unexpected choice in conformance')
+            info = ConformanceAssessmentData(feature_map=0, attribute_list=attr1, all_command_list=[], cluster_revision=1)
+            asserts.assert_equal(conformance(info).decision, ConformanceDecision.MANDATORY, 'Unexpected conformance')
+            asserts.assert_equal(conformance(info).choice, None, 'Unexpected choice in conformance')
             # When we have AB and CD, we should be using the AB choice
             CD = self.feature_names_to_bits['CD']
             ABCD = AB | CD
             self.check_decision(more, conformance, ABCD, [], [])
             # When we just have CD, we still have a choice, but the string should be b
-            asserts.assert_equal(conformance(CD, [], []).decision, ConformanceDecision.OPTIONAL, 'Unexpected conformance')
-            asserts.assert_equal(conformance(CD, [], []).choice, Choice('b', False), 'Unexpected choice in conformance')
+            info = ConformanceAssessmentData(feature_map=CD, attribute_list=[], all_command_list=[], cluster_revision=1)
+            asserts.assert_equal(conformance(info).decision, ConformanceDecision.OPTIONAL, 'Unexpected conformance')
+            asserts.assert_equal(conformance(info).choice, Choice('b', False), 'Unexpected choice in conformance')
 
             # Ones that should throw exceptions
 

--- a/src/python_testing/test_testing/TestSpecParsingDeviceType.py
+++ b/src/python_testing/test_testing/TestSpecParsingDeviceType.py
@@ -23,7 +23,7 @@ from jinja2 import Template
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.testing.conformance import conformance_allowed
+from matter.testing.conformance import EMPTY_CLUSTER_GLOBAL_ATTRIBUTES, conformance_allowed
 from matter.testing.matter_testing import MatterBaseTest, default_matter_test_main
 from matter.testing.spec_parsing import (PrebuiltDataModelDirectory, XmlDeviceType, build_xml_clusters, build_xml_device_types,
                                          parse_single_device_type)
@@ -452,8 +452,8 @@ class TestSpecParsingDeviceType(MatterBaseTest):
             expected_problems = 0
             self.create_good_device(id)
             for cluster_id, cluster in dt.server_clusters.items():
-                if not conformance_allowed(cluster.conformance(0, [], []), False):
-                    self.test.endpoints[1][Clusters.Descriptor][Clusters.Descriptor.Attributes.ServerList].append(cluster_id)
+                if not conformance_allowed(cluster.conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES), False):
+                    self.endpoints[1][Clusters.Descriptor][Clusters.Descriptor.Attributes.ServerList].append(cluster_id)
                     expected_problems += 1
             if expected_problems == 0:
                 continue

--- a/src/python_testing/test_testing/TestSpecParsingDeviceType.py
+++ b/src/python_testing/test_testing/TestSpecParsingDeviceType.py
@@ -453,7 +453,7 @@ class TestSpecParsingDeviceType(MatterBaseTest):
             self.create_good_device(id)
             for cluster_id, cluster in dt.server_clusters.items():
                 if not conformance_allowed(cluster.conformance(EMPTY_CLUSTER_GLOBAL_ATTRIBUTES), False):
-                    self.endpoints[1][Clusters.Descriptor][Clusters.Descriptor.Attributes.ServerList].append(cluster_id)
+                    self.test.endpoints[1][Clusters.Descriptor][Clusters.Descriptor.Attributes.ServerList].append(cluster_id)
                     expected_problems += 1
             if expected_problems == 0:
                 continue

--- a/src/python_testing/test_testing/TestSpecParsingSelection.py
+++ b/src/python_testing/test_testing/TestSpecParsingSelection.py
@@ -20,7 +20,7 @@ from DeviceConformanceTests import DeviceConformanceTests
 from mobly import asserts, signals
 
 import matter.clusters as Clusters
-from matter.testing.conformance import ConformanceDecision, ConformanceException
+from matter.testing.conformance import ConformanceAssessmentData, ConformanceDecision, ConformanceException
 from matter.testing.global_attribute_ids import is_standard_attribute_id
 from matter.testing.matter_testing import MatterBaseTest, default_matter_test_main
 from matter.testing.spec_parsing import PrebuiltDataModelDirectory, build_xml_clusters, dm_from_spec_version
@@ -94,13 +94,14 @@ class TestSpecParsingSelection(MatterBaseTest, DeviceConformanceTests):
             spec_attributes = xml_clusters[cluster.id].attributes
             spec_accepted_commands = xml_clusters[cluster.id].accepted_commands
             spec_generated_commands = xml_clusters[cluster.id].generated_commands
+            info = ConformanceAssessmentData(feature_map=feature_map, attribute_list=[], all_command_list=[], cluster_revision=1)
             # Build just the lists - basic composition checks the wildcard against the lists, conformance just uses lists
             attributes = [id for id, a in spec_attributes.items() if a.conformance(
-                feature_map, [], []).decision == ConformanceDecision.MANDATORY]
+                info).decision == ConformanceDecision.MANDATORY]
             accepted_commands = [id for id, c in spec_accepted_commands.items() if c.conformance(
-                feature_map, [], []).decision == ConformanceDecision.MANDATORY]
+                info).decision == ConformanceDecision.MANDATORY]
             generated_commands = [id for id, c in spec_generated_commands.items() if c.conformance(
-                feature_map, [], []).decision == ConformanceDecision.MANDATORY]
+                info).decision == ConformanceDecision.MANDATORY]
             attr = cluster.Attributes
 
             resp = {}


### PR DESCRIPTION
#### Summary

Cherry pick of two revision conformance PRs to 1.5. Used to support 1.5.1 data model files, which use these conformances.

#### Related issues
https://github.com/project-chip/connectedhomeip/pull/42661
https://github.com/project-chip/connectedhomeip/pull/42553

#### Testing

Unit tests of these functions are available in the TestSpecParsing* and Test*Conformance tests.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
