### PR TITLE
Exit command causing hard fault on Silabs devices

### DIFF
--- a/examples/platform/silabs/syscalls_stubs.cpp
+++ b/examples/platform/silabs/syscalls_stubs.cpp
@@ -30,6 +30,8 @@
 #include <string.h>
 #include <sys/stat.h>
 
+#include <em_device.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -235,6 +237,23 @@ int __attribute__((weak)) _write(int file, const char * ptr, int len)
     return len;
 }
 #endif // SILABS_LOG_OUT_UART
+
+/**************************************************************************
+ * @brief
+ *  Override exit to prevent hard fault
+ *
+ * @param[in] status
+ *  Exit status (not used).
+ **************************************************************************/
+void __attribute__((weak)) exit(int status)
+{
+    (void) status;
+    _write(0, "exit not supported, resetting system...\r\n", 42);
+    NVIC_SystemReset();
+    while (1)
+    {
+    } // Unreachable, satisfies noreturn attribute
+}
 
 #ifdef __cplusplus
 }

--- a/examples/platform/silabs/syscalls_stubs.cpp
+++ b/examples/platform/silabs/syscalls_stubs.cpp
@@ -248,7 +248,8 @@ int __attribute__((weak)) _write(int file, const char * ptr, int len)
 void __attribute__((weak)) exit(int status)
 {
     (void) status;
-    _write(0, "exit not supported, resetting system...\r\n", 42);
+    static const char kExitMessage[] = "exit not supported, resetting system...\r\n";
+    _write(0, kExitMessage, sizeof(kExitMessage) - 1);
     NVIC_SystemReset();
     while (1)
     {


### PR DESCRIPTION
#### Summary
Sending exit commands causes hard fault
Disable exit command and print unsupported message

See related matter_sdk PR: https://github.com/SiliconLabsSoftware/matter_sdk/pull/779

#### Related issues
[MATTER-5715
](https://jira.silabs.com/browse/MATTER-5715)

#### Testing
Local testing of lighting and closure app in extension and sdk

On exit call, system prints 

> exit not supported, resetting system...

then calls NVIC_SystemReset to factory reset the board and prevent hard fault

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
