### PR TITLE
Resolve failure reading NumberOfPresets for Silabs thermostat app

### DIFF
--- a/examples/thermostat/silabs/BUILD.gn
+++ b/examples/thermostat/silabs/BUILD.gn
@@ -32,6 +32,7 @@ if (chip_enable_pw_rpc) {
 assert(current_os == "freertos")
 
 silabs_project_dir = "${chip_root}/examples/thermostat/silabs"
+thermostat_common_dir = "${chip_root}/examples/thermostat/thermostat-common"
 examples_common_plat_dir = "${chip_root}/examples/platform/silabs"
 
 if (wifi_soc) {
@@ -104,11 +105,15 @@ if (wifi_soc) {
 
 silabs_executable("thermostat_app") {
   output_name = "matter-silabs-thermostat-example.out"
-  include_dirs = [ "include" ]
+  include_dirs = [
+    "include",
+    "${thermostat_common_dir}/include",
+  ]
   defines = []
 
   sources = [
     "${examples_common_plat_dir}/main.cpp",
+    "${thermostat_common_dir}/src/thermostat-delegate-impl.cpp",
     "src/AppTask.cpp",
     "src/DataModelCallbacks.cpp",
     "src/SensorManager.cpp",

--- a/examples/thermostat/silabs/src/DataModelCallbacks.cpp
+++ b/examples/thermostat/silabs/src/DataModelCallbacks.cpp
@@ -28,8 +28,6 @@
 #include <app/ConcreteAttributePath.h>
 #include <lib/support/logging/CHIPLogging.h>
 
-#include "sl_component_catalog.h"
-
 #ifdef SL_MATTER_ENABLE_AWS
 #include "MatterAwsControl.h"
 #endif // SL_MATTER_ENABLE_AWS

--- a/examples/thermostat/silabs/src/DataModelCallbacks.cpp
+++ b/examples/thermostat/silabs/src/DataModelCallbacks.cpp
@@ -29,10 +29,6 @@
 #include <lib/support/logging/CHIPLogging.h>
 
 #include "sl_component_catalog.h"
-#ifndef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
-#include "thermostat-delegate-impl.h"
-#include <app/clusters/thermostat-server/thermostat-server.h>
-#endif // !SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
 
 #ifdef SL_MATTER_ENABLE_AWS
 #include "MatterAwsControl.h"
@@ -61,13 +57,3 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 #endif // SL_MATTER_ENABLE_AWS
     }
 }
-
-#ifndef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
-using namespace chip::app::Clusters::Thermostat;
-
-void emberAfThermostatClusterInitCallback(chip::EndpointId endpoint)
-{
-    auto & delegate = ThermostatDelegate::GetInstance();
-    SetDefaultDelegate(endpoint, &delegate);
-}
-#endif // !SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT

--- a/examples/thermostat/silabs/src/DataModelCallbacks.cpp
+++ b/examples/thermostat/silabs/src/DataModelCallbacks.cpp
@@ -28,6 +28,12 @@
 #include <app/ConcreteAttributePath.h>
 #include <lib/support/logging/CHIPLogging.h>
 
+#include "sl_component_catalog.h"
+#ifndef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
+#include "thermostat-delegate-impl.h"
+#include <app/clusters/thermostat-server/thermostat-server.h>
+#endif // !SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
+
 #ifdef SL_MATTER_ENABLE_AWS
 #include "MatterAwsControl.h"
 #endif // SL_MATTER_ENABLE_AWS
@@ -55,3 +61,13 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 #endif // SL_MATTER_ENABLE_AWS
     }
 }
+
+#ifndef SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT
+using namespace chip::app::Clusters::Thermostat;
+
+void emberAfThermostatClusterInitCallback(chip::EndpointId endpoint)
+{
+    auto & delegate = ThermostatDelegate::GetInstance();
+    SetDefaultDelegate(endpoint, &delegate);
+}
+#endif // !SL_CATALOG_ZIGBEE_ZCL_FRAMEWORK_CORE_PRESENT

--- a/examples/thermostat/silabs/src/TemperatureManager.cpp
+++ b/examples/thermostat/silabs/src/TemperatureManager.cpp
@@ -25,7 +25,9 @@
 #include "AppConfig.h"
 #include "AppEvent.h"
 #include "AppTask.h"
+#include "thermostat-delegate-impl.h"
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/clusters/thermostat-server/thermostat-server.h>
 
 /**********************************************************
  * Defines and Constants
@@ -180,4 +182,10 @@ int8_t TemperatureManager::GetHeatingSetPoint()
 int8_t TemperatureManager::GetCoolingSetPoint()
 {
     return mCoolingCelsiusSetPoint;
+}
+
+void emberAfThermostatClusterInitCallback(chip::EndpointId endpoint)
+{
+    auto & delegate = ThermostatDelegate::GetInstance();
+    SetDefaultDelegate(endpoint, &delegate);
 }


### PR DESCRIPTION
#### Summary
Seeing failure when reading NumberOfPresets attribute in thermostat app. This is because app enables the presets feature but never registers a ThermostatDelegate to provide preset data.

Add the thermostat-common delegate implementation to the Silabs build and register it in emberAfThermostatClusterInitCallback, matching the Linux thermostat example.

See related matter_sdk PR: https://github.com/SiliconLabsSoftware/matter_sdk/pull/800

#### Related issues
[MATTER-5838](https://jira.silabs.com/browse/MATTER-5838)

#### Testing
During development: 
Verified that `mattertool thermostat read number-of-presets 25127 1` returned `NumberOfPresets: 5` rather than failure when building in matter_sdk and in matter_extension

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
