### PR TITLE
Fix TCP reuse_addr

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -98,8 +98,7 @@ CHIP_ERROR TCPBase::Init(TcpListenParameters & params)
 
     if (params.IsServerListenEnabled())
     {
-        err = mListenSocket->Bind(params.GetAddressType(), Inet::IPAddress::Any, params.GetListenPort(),
-                                  params.GetInterfaceId().IsPresent());
+        err = mListenSocket->Bind(params.GetAddressType(), Inet::IPAddress::Any, params.GetListenPort(), true);
         SuccessOrExit(err);
 
         mListenSocket->mAppState            = reinterpret_cast<void *>(this);

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -98,7 +98,7 @@ CHIP_ERROR TCPBase::Init(TcpListenParameters & params)
 
     if (params.IsServerListenEnabled())
     {
-        err = mListenSocket->Bind(params.GetAddressType(), Inet::IPAddress::Any, params.GetListenPort(), true);
+        err = mListenSocket->Bind(params.GetAddressType(), Inet::IPAddress::Any, params.GetListenPort(), /* reuseAddr = */ true);
         SuccessOrExit(err);
 
         mListenSocket->mAppState            = reinterpret_cast<void *>(this);


### PR DESCRIPTION
#### Summary

A parameter in TCP Bind was not being used correctly.

in src/transport/raw/TCP.cpp lines 101-102:
err = mListenSocket->Bind(params.GetAddressType(), Inet::IPAddress::Any, params.GetListenPort(), 
                          params.GetInterfaceId().IsPresent());

The Bind() signature from src/inet/TCPEndPoint.h:
CHIP_ERROR Bind(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr = false);

The 4th parameter reuseAddr controls the SO_REUSEADDR socket option, which determines whether multiple sockets can bind to the same address/port combination. This seems to be unrelated to whether an interface ID is present.

https://csa-matter.slack.com/archives/C014G30SVV0/p1768880651520909

Some details from the slack discussion:

Yes, it does not seem right that the presence of the InterfaceId is being passed to the SO_REUSEADDR socket option. If I am not mistaken, the socket option is set so that the TCP server can bind again on a restart when the previous connection is in the TimedWait state. Looking back at that change, it seems it has been there from even earlier. The last change did not add that line, but moved it from another location.

Can't think of a scenario where we would need it to be false. Maybe some obscure security use-case, but in general I would think it should be true.
That also makes it moot to pass as an argument and could be hard-coded in TCPEndpoint.
I think, as a first order to fix the issue, we can change that arg to true.

#### Testing

All unit tests and example app test cases pass