### PR TITLE
[1.4.2][Cherrypick] Matter Casting: fix init and memory issues (#42604)

### DIFF
--- a/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
@@ -78,5 +78,9 @@
 
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 
+#ifndef CHIP_DEVICE_LAYER_TARGET_DARWIN
+// Increase memory pools for better attribute reading performance
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 500 // Default is 15
 // Include the CHIPProjectConfig from platform implementation config
 #include <CHIPProjectConfig.h>
+#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DACProviderStub.java
@@ -17,6 +17,7 @@
 package com.matter.casting;
 
 import android.util.Base64;
+import android.util.Log;
 import com.matter.casting.support.DACProvider;
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
@@ -26,8 +27,11 @@ import java.security.Signature;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPrivateKeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
 
 public class DACProviderStub implements DACProvider {
+
+  private static final String TAG = DACProviderStub.class.getSimpleName();
 
   private String kDevelopmentDAC_Cert_FFF1_8001 =
       "MIIB5zCCAY6gAwIBAgIIac3xDenlTtEwCgYIKoZIzj0EAwIwPTElMCMGA1UEAwwcTWF0dGVyIERldiBQQUkgMHhGRkYxIG5vIFBJRDEUMBIGCisGAQQBgqJ8AgEMBEZGRjEwIBcNMjIwMjA1MDAwMDAwWhgPOTk5OTEyMzEyMzU5NTlaMFMxJTAjBgNVBAMMHE1hdHRlciBEZXYgREFDIDB4RkZGMS8weDgwMDExFDASBgorBgEEAYKifAIBDARGRkYxMRQwEgYKKwYBBAGConwCAgwEODAwMTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEY6xpNCkQoOVYj8b/Vrtj5i7M7LFI99TrA+5VJgFBV2fRalxmP3k+SRIyYLgpenzX58/HsxaznZjpDSk3dzjoKjYDBeMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMB0GA1UdDgQWBBSI3eezADgpMs/3NMBGJIEPRBaKbzAfBgNVHSMEGDAWgBRjVA5H9kscONE4hKRi0WwZXY/7PDAKBggqhkjOPQQDAgNHADBEAiABJ6J7S0RhDuL83E0reIVWNmC8D3bxchntagjfsrPBzQIga1ngr0Xz6yqFuRnTVzFSjGAoxBUjlUXhCOTlTnCXE1M=";
@@ -76,14 +80,24 @@ public class DACProviderStub implements DACProvider {
     try {
       byte[] privateKeyBytes = Base64.decode(kDevelopmentDAC_PrivateKey_FFF1_8001, Base64.DEFAULT);
 
-      AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance("EC");
-      algorithmParameters.init(new ECGenParameterSpec("secp256r1"));
-      ECParameterSpec parameterSpec = algorithmParameters.getParameterSpec(ECParameterSpec.class);
-      ECPrivateKeySpec ecPrivateKeySpec =
-          new ECPrivateKeySpec(new BigInteger(1, privateKeyBytes), parameterSpec);
-
+      PrivateKey privateKey = null;
       KeyFactory keyFactory = KeyFactory.getInstance("EC");
-      PrivateKey privateKey = keyFactory.generatePrivate(ecPrivateKeySpec);
+      // the format can be determined by the header in the private key file:
+      // -----BEGIN PRIVATE KEY----- - PKCS#8 format
+      // -----BEGIN EC PRIVATE KEY----- - SEC1/traditional EC format
+      try {
+        // Try PKCS#8 format first.
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKeyBytes);
+        privateKey = keyFactory.generatePrivate(keySpec);
+      } catch (java.security.spec.InvalidKeySpecException e) {
+        // Fallback to SEC1 format.
+        AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance("EC");
+        algorithmParameters.init(new ECGenParameterSpec("secp256r1"));
+        ECParameterSpec parameterSpec = algorithmParameters.getParameterSpec(ECParameterSpec.class);
+        ECPrivateKeySpec ecPrivateKeySpec =
+            new ECPrivateKeySpec(new BigInteger(1, privateKeyBytes), parameterSpec);
+        privateKey = keyFactory.generatePrivate(ecPrivateKeySpec);
+      }
 
       Signature signature = Signature.getInstance("SHA256withECDSA");
       signature.initSign(privateKey);
@@ -93,6 +107,7 @@ public class DACProviderStub implements DACProvider {
       return signature.sign();
 
     } catch (Exception e) {
+      Log.e(TAG, "SignWithDeviceAttestationKey failed", e);
       return null;
     }
   }

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -109,8 +109,11 @@
 
 #define CHIP_CONFIG_ENABLE_ACL_EXTENSIONS 1
 
+#ifndef CHIP_DEVICE_LAYER_TARGET_DARWIN
+// Increase memory pools for better attribute reading performance
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 500 // Default is 15
+
 // Include the CHIPProjectConfig from config/standalone
 // Add this at the end so that we can hit our #defines first
-#ifndef CHIP_DEVICE_LAYER_TARGET_DARWIN
 #include <CHIPProjectConfig.h>
 #endif // CHIP_DEVICE_LAYER_TARGET_DARWIN

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "core/CastingPlayer.h"
+#include <list>
 
 namespace matter {
 namespace casting {
@@ -40,9 +41,9 @@ public:
     CHIP_ERROR AddOrUpdate(core::CastingPlayer castingPlayer);
 
     /**
-     * @brief Reads and returns a vector of all CastingPlayers found in the cache
+     * @brief Reads and returns a list of all CastingPlayers found in the cache
      */
-    std::vector<core::CastingPlayer> ReadAll();
+    std::list<core::CastingPlayer> ReadAll();
 
     /**
      * @brief If castingPlayer is found in the cache, this will delete it. If it is not found, this method is a no-op
@@ -65,9 +66,9 @@ private:
     static CastingStore * _CastingStore;
 
     /**
-     * @brief Writes the vector of CastingPlayers to the cache. This method will overwrite any pre-existing cached data.
+     * @brief Writes the list of CastingPlayers to the cache. This method will overwrite any pre-existing cached data.
      */
-    CHIP_ERROR WriteAll(std::vector<core::CastingPlayer> castingPlayers);
+    CHIP_ERROR WriteAll(std::list<core::CastingPlayer> castingPlayers);
 
     enum CastingStoreTLVTag
     {

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -70,12 +70,20 @@ void ConfigurationManagerImpl::InitiateFactoryReset() {}
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    AndroidConfig::Key configKey{ AndroidConfig::kConfigNamespace_ChipCounters, key };
+
+    CHIP_ERROR err = ReadConfigValue(configKey, value);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+    return err;
 }
 
 CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    AndroidConfig::Key configKey{ AndroidConfig::kConfigNamespace_ChipCounters, key };
+    return WriteConfigValue(configKey, value);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool & val)

--- a/src/platform/android/java/chip/platform/NsdManagerServiceBrowser.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceBrowser.java
@@ -127,7 +127,11 @@ public class NsdManagerServiceBrowser implements ServiceBrowser {
       mainThreadHandler.removeCallbacksAndMessages(null);
     }
 
-    this.nsdManager.stopServiceDiscovery(discovery);
+    try {
+      this.nsdManager.stopServiceDiscovery(discovery);
+    } catch (Exception e) {
+      Log.e(TAG, "Exception in stopDiscover " + e, e);
+    }
   }
 
   public class NsdManagerDiscovery implements NsdManager.DiscoveryListener {


### PR DESCRIPTION
#### Summary

* Fix init and mem issues

(cherry picked from commit c37efec9db8b56546ecb7d99ed7e8b9f0093de03)

#### Testing

Tested with linux tv-app and tv-casting-app