### PR TITLE
[v1.5 cherrypick] Disable kotlin static code analysis

### DIFF
--- a/.github/workflows/kotlin-style.yaml
+++ b/.github/workflows/kotlin-style.yaml
@@ -13,8 +13,11 @@ concurrency:
 
 
 jobs:
+
+  # This test is currently disabled due to Issue #41932
   detekt:
     name: Static code analysis
+    if: false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
#### Summary

This cherrypicks #41933 - detekt is currently broken

#### Testing

Clean cherrypick.