### PR TITLE
[Silabs] Add option to enable a Watchdog for MGx families

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -274,6 +274,7 @@ CHIP_ERROR BaseApplication::Init()
         return err;
     }
 
+    GetPlatform().WatchdogInit();
     return err;
 }
 

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -385,8 +385,9 @@ extern "C" void vApplicationIdleHook(void)
 #endif // SL_CATALOG_SIMPLE_BUTTON_PRESENT
     SiWxPlatformInterface::sl_si91x_uart_power_requirement_handler();
 #endif
-
+#if SL_MATTER_DEBUG_WATCHDOG_ENABLE
     GetPlatform().WatchdogFeed();
+#endif // SL_MATTER_DEBUG_WATCHDOG_ENABLE
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -385,6 +385,8 @@ extern "C" void vApplicationIdleHook(void)
 #endif // SL_CATALOG_SIMPLE_BUTTON_PRESENT
     SiWxPlatformInterface::sl_si91x_uart_power_requirement_handler();
 #endif
+
+    GetPlatform().WatchdogFeed();
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -153,7 +153,6 @@ extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
     configASSERTNULL(NULL);
 }
 
-
 /*
  * Note: All our Fault handlers are defined naked functions so they don't modify the stack or registers we are trying to capture.
  * Because of that, C statements are not allowed in the fault handlers as it could lead to unpredictable behavior.

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -191,7 +191,7 @@ extern "C" __attribute__((naked)) void UsageFault_Handler(void)
 #if (__CORTEX_M >= 23U)
 extern "C" __attribute__((naked)) void SecureFault_Handler(void)
 {
-    faultId = 0x53464354; // 'SFCT'
+    faultId = 0x53434654; // 'SCFT'
     __asm volatile("b LogFault_Handler");
 }
 #endif // (__CORTEX_M >= 23U)

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -108,7 +108,9 @@ extern "C" void halInternalAssertFailed(const char * filename, int linenumber)
 #endif
 
 #if HARD_FAULT_LOG_ENABLE
-volatile uint32_t faultId = 0; // Variable to identify the fault handler
+// Identifier used by the various fault handlers to tag the fault type.
+// Note: This is read/written from exception/interrupt context.
+alignas(4) static volatile uint32_t faultId __asm__("faultId") = 0;
 
 /**
  * Log register contents to UART when a hard fault occurs.
@@ -151,6 +153,13 @@ extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
     configASSERTNULL(NULL);
 }
 
+
+/*
+ * Note: All our Fault handlers are defined naked functions so they don't modify the stack or registers we are trying to capture.
+ * Because of that, C statements are not allowed in the fault handlers as it could lead to unpredictable behavior.
+ * All the fault handlers are defined using inline assembly.
+ */
+
 /**
  * Log a fault to the debugHardfault function.
  * This function is called by the fault handlers to log the fault details.
@@ -158,49 +167,67 @@ extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
 
 extern "C" __attribute__((naked)) void LogFault_Handler(void)
 {
-    uint32_t * sp;
-    __asm volatile("tst lr, #4 \n"
-                   "ite eq \n"
-                   "mrseq %0, msp \n"
-                   "mrsne %0, psp \n"
-                   : "=r"(sp));
-    debugHardfault(sp);
+    __asm volatile("tst lr, #4       \n"
+                   "ite eq           \n"
+                   "mrseq r0, msp    \n"
+                   "mrsne r0, psp    \n"
+                   "b debugHardfault \n");
 }
 
 #ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 extern "C" __attribute__((naked)) void HardFault_Handler(void)
 {
-    faultId = 0x48415244; // 'HARD'
-    __asm volatile("b LogFault_Handler");
+    __asm volatile("ldr r0, =0x48415244 \n" // 'HARD'
+                   "ldr r1, =faultId    \n"
+                   "str r0, [r1]        \n"
+                   "b LogFault_Handler  \n");
 }
 extern "C" __attribute__((naked)) void mpu_fault_handler(void)
 {
-    faultId = 0x4D505546; // 'MPUF'
-    __asm volatile("b LogFault_Handler");
+    __asm volatile("ldr r0, =0x4D505546 \n" // 'MPUF'
+                   "ldr r1, =faultId    \n"
+                   "str r0, [r1]        \n"
+                   "b LogFault_Handler  \n");
 }
 extern "C" __attribute__((naked)) void BusFault_Handler(void)
 {
-    faultId = 0x42555346; // 'BUSF'
-    __asm volatile("b LogFault_Handler");
+    __asm volatile("ldr r0, =0x42555346 \n" // 'BUSF'
+                   "ldr r1, =faultId    \n"
+                   "str r0, [r1]        \n"
+                   "b LogFault_Handler  \n");
 }
 extern "C" __attribute__((naked)) void UsageFault_Handler(void)
 {
-    faultId = 0x55534654; // 'USFT'
-    __asm volatile("b LogFault_Handler");
+    __asm volatile("ldr r0, =0x55534654 \n" // 'USFT'
+                   "ldr r1, =faultId    \n"
+                   "str r0, [r1]        \n"
+                   "b LogFault_Handler  \n");
 }
 #if (__CORTEX_M >= 23U)
 extern "C" __attribute__((naked)) void SecureFault_Handler(void)
 {
-    faultId = 0x53434654; // 'SCFT'
-    __asm volatile("b LogFault_Handler");
+    __asm volatile("ldr r0, =0x53434654 \n" // 'SCFT'
+                   "ldr r1, =faultId    \n"
+                   "str r0, [r1]        \n"
+                   "b LogFault_Handler  \n");
 }
 #endif // (__CORTEX_M >= 23U)
 extern "C" __attribute__((naked)) void DebugMon_Handler(void)
 {
-    faultId = 0x44424D4E; // 'DBMN'
-    __asm volatile("b LogFault_Handler");
+    __asm volatile("ldr r0, =0x44424D4E \n" // 'DBMN'
+                   "ldr r1, =faultId    \n"
+                   "str r0, [r1]        \n"
+                   "b LogFault_Handler  \n");
 }
 #endif // !SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
+
+extern "C" __attribute__((naked)) void WDOG0_IRQHandler(void)
+{
+    __asm volatile("ldr r0, =0x57444F47 \n" // 'WDOG'
+                   "ldr r1, =faultId    \n"
+                   "str r0, [r1]        \n"
+                   "b LogFault_Handler  \n");
+}
 
 extern "C" void vApplicationMallocFailedHook(void)
 {
@@ -321,10 +348,4 @@ extern "C" void RAILCb_AssertFailed(RAIL_Handle_t railHandle, uint32_t errorCode
     chipAbort();
 }
 #endif // !defined(SLI_SI91X_MCU_INTERFACE) || !defined(SLI_SI91X_ENABLE_BLE)
-
-extern "C" void WDOG0_IRQHandler(void)
-{
-    faultId = 0x57444F47; // 'WDOG'
-    __asm volatile("b LogFault_Handler");
-}
 #endif // HARD_FAULT_LOG_ENABLE

--- a/src/platform/silabs/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/ConfigurationManagerImpl.cpp
@@ -300,6 +300,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
+    GetPlatform().WatchdogDisable();
     error = SilabsConfig::FactoryResetConfig();
     if (error != CHIP_NO_ERROR)
     {

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -311,8 +311,8 @@ void SilabsPlatform::WatchdogInit()
 {
     // Initialize WDOG with default configuration
     sl_hal_wdog_init_t wdogInit = SL_HAL_WDOG_INIT_DEFAULT;
-    wdogInit.reset_disable      = true;               // For debug, do not trigger a system reset on timeout
-    wdogInit.period_select      = SL_WDOG_PERIOD_32k; // Set timeout period. 1s with our default LF clock at 32.768kHz
+    wdogInit.reset_disable      = true;                // For debug, do not trigger a system reset on timeout
+    wdogInit.period_select      = SL_WDOG_PERIOD_128k; // Set timeout period. 4s with our default LF clock at 32.768kHz
 
     //  Initialize WDOG with our configuration
     sl_clock_manager_enable_bus_clock(SL_BUS_CLOCK_WDOG0);

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -312,7 +312,7 @@ void SilabsPlatform::WatchdogInit()
     // Initialize WDOG with default configuration
     sl_hal_wdog_init_t wdogInit = SL_HAL_WDOG_INIT_DEFAULT;
     wdogInit.reset_disable      = true;               // For debug, do not trigger a system reset on timeout
-    wdogInit.period_select      = SL_WDOG_PERIOD_16k; // Set timeout period
+    wdogInit.period_select      = SL_WDOG_PERIOD_32k; // Set timeout period. 1s with our default LF clock at 32.768kHz
 
     //  Initialize WDOG with our configuration
     sl_clock_manager_enable_bus_clock(SL_BUS_CLOCK_WDOG0);
@@ -322,6 +322,16 @@ void SilabsPlatform::WatchdogInit()
     sl_hal_wdog_clear_interrupts(WDOG0, WDOG_IF_TOUT);
     sl_hal_wdog_enable_interrupts(WDOG0, WDOG_IF_TOUT);
 
+    WatchdogEnable();
+}
+
+void SilabsPlatform::WatchdogFeed()
+{
+    sl_hal_wdog_feed(WDOG0);
+}
+
+void SilabsPlatform::WatchdogEnable()
+{
     // Enable NVIC interrupt for WDOG
     sl_interrupt_manager_clear_irq_pending(WDOG0_IRQn);
     sl_interrupt_manager_enable_irq(WDOG0_IRQn);
@@ -329,9 +339,10 @@ void SilabsPlatform::WatchdogInit()
     sl_hal_wdog_enable(WDOG0);
 }
 
-void SilabsPlatform::WatchdogFeed()
+void SilabsPlatform::WatchdogDisable()
 {
-    sl_hal_wdog_feed(WDOG0);
+    sl_hal_wdog_disable(WDOG0);
+    sl_interrupt_manager_disable_irq(WDOG0_IRQn);
 }
 #endif // SL_MATTER_DEBUG_WATCHDOG_ENABLE
 

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -15,18 +15,14 @@
  *    limitations under the License.
  */
 
-#include "sl_clock_manager.h"
-#include "sl_hal_wdog.h"
 #include <em_device.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
 #if defined(_SILICON_LABS_32B_SERIES_2)
-#include "em_cmu.h"
 #include "em_msc.h"
 #include "em_rmu.h"
 #elif defined(_SILICON_LABS_32B_SERIES_3)
 #include "sl_hal_emu.h"
-#include "sl_hal_wdog.h"
 #include "sl_se_manager.h"
 #include "sl_se_manager_types.h"
 #include <sl_se_manager_extmem.h>
@@ -36,6 +32,11 @@
 #if defined(SL_CATALOG_CUSTOM_MAIN_PRESENT)
 #include "sl_system_kernel.h"
 #endif
+
+#if SL_MATTER_DEBUG_WATCHDOG_ENABLE
+#include "sl_clock_manager.h"
+#include "sl_hal_wdog.h"
+#endif // SL_MATTER_DEBUG_WATCHDOG_ENABLE
 
 #ifdef ENABLE_WSTK_LEDS
 extern "C" {

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -85,6 +85,11 @@ public:
      */
     CHIP_ERROR NvmInit();
 
+#if SL_MATTER_DEBUG_WATCHDOG_ENABLE
+    void WatchdogInit();
+    void WatchdogFeed();
+#endif
+
 private:
     friend SilabsPlatform & GetPlatform(void);
 

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -88,6 +88,8 @@ public:
 #if SL_MATTER_DEBUG_WATCHDOG_ENABLE
     void WatchdogInit();
     void WatchdogFeed();
+    void WatchdogEnable();
+    void WatchdogDisable();
 #endif
 
 private:

--- a/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
@@ -68,6 +68,8 @@ public:
     // Watchdog
     virtual void WatchdogInit(){};
     virtual void WatchdogFeed(){};
+    virtual void WatchdogEnable(){};
+    virtual void WatchdogDisable(){};
 
     /**
      * @brief Function trigger the platform to execute a software reset.

--- a/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
@@ -65,6 +65,10 @@ public:
     virtual CHIP_ERROR FlashErasePage(uint32_t addr) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     virtual CHIP_ERROR FlashWritePage(uint32_t addr, const uint8_t * data, size_t size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
+    // Watchdog
+    virtual void WatchdogInit(){};
+    virtual void WatchdogFeed(){};
+
     /**
      * @brief Function trigger the platform to execute a software reset.
      *              Anything after this function will not be executed since the device will reboot.

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -963,8 +963,8 @@ template("efr32_sdk") {
       ]
     }
 
-    if (sl_matter_debug_watchdog_enable){
-      sources += ["${efr32_sdk_root}/platform/peripheral/src/sl_hal_wdog.c"]
+    if (sl_matter_debug_watchdog_enable) {
+      sources += [ "${efr32_sdk_root}/platform/peripheral/src/sl_hal_wdog.c" ]
     }
 
     # COS and SWO sources files for when we use generate with slc

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -747,7 +747,6 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform/peripheral/src/sl_hal_gpio.c",
       "${efr32_sdk_root}/platform/peripheral/src/sl_hal_sysrtc.c",
       "${efr32_sdk_root}/platform/peripheral/src/sl_hal_system.c",
-      "${efr32_sdk_root}/platform/peripheral/src/sl_hal_wdog.c",
       "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c",
       "${efr32_sdk_root}/platform/radio/rail_lib/plugin/rail_util_power_manager_init/sl_rail_util_power_manager_init.c",
       "${efr32_sdk_root}/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.c",
@@ -962,6 +961,10 @@ template("efr32_sdk") {
       sources += [
         "${efr32_sdk_root}/util/plugin/plugin-common/fem-control/fem-control.c",
       ]
+    }
+
+    if (sl_matter_debug_watchdog_enable){
+      sources += ["${efr32_sdk_root}/platform/peripheral/src/sl_hal_wdog.c"]
     }
 
     # COS and SWO sources files for when we use generate with slc

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -96,6 +96,9 @@ declare_args() {
 
   # Enable Multi-PAN support for Matter over Thread devices
   sl_openthread_multi_pan_enable = false
+
+  # Enable a Watchdog with debug features to catch software hangs
+  sl_matter_debug_watchdog_enable = false
 }
 
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
@@ -623,6 +626,12 @@ template("efr32_sdk") {
       }
     }
 
+    if (sl_matter_debug_watchdog_enable) {
+      defines += [ "SL_MATTER_DEBUG_WATCHDOG_ENABLE=1" ]
+    } else {
+      defines += [ "SL_MATTER_DEBUG_WATCHDOG_ENABLE=0" ]
+    }
+
     if (chip_build_libshell) {  # matter shell
       defines += [
         "ENABLE_CHIP_SHELL",
@@ -738,6 +747,7 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform/peripheral/src/sl_hal_gpio.c",
       "${efr32_sdk_root}/platform/peripheral/src/sl_hal_sysrtc.c",
       "${efr32_sdk_root}/platform/peripheral/src/sl_hal_system.c",
+      "${efr32_sdk_root}/platform/peripheral/src/sl_hal_wdog.c",
       "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c",
       "${efr32_sdk_root}/platform/radio/rail_lib/plugin/rail_util_power_manager_init/sl_rail_util_power_manager_init.c",
       "${efr32_sdk_root}/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.c",


### PR DESCRIPTION
#### Summary
- Add option to Enable/Configure a Watchdog peripheral for MGx families.  This allows user to catch device hangs and provide some diagnostic through our fault handler.
- This debug watchdog can be enabled with `sl_matter_debug_watchdog_enable` gn argument
- Add a faultId for each Fault Handler to facilitate debugging and log parsing.

#### Related issues
N/A

#### Testing
Enable the watchdog with `sl_matter_debug_watchdog_enable=true` on EFR32MG26. And implement a purposely faulty code that hang the device. Watchdog starves and `WDOG0_IRQHandler` is called. Validate logs as printed by `debugHardfault`

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
