### PR TITLE
[Camera] Remove non-delegate APIs from CameraAVStreamManagementDelegate

### DIFF
--- a/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
@@ -90,16 +90,24 @@ public:
 
     CHIP_ERROR PersistentAttributesLoadedCallback() override;
 
-    CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) override;
-
-    CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) override;
-
     const std::vector<chip::app::Clusters::CameraAvStreamManagement::VideoStreamStruct> & GetAllocatedVideoStreams() const override;
 
     const std::vector<chip::app::Clusters::CameraAvStreamManagement::AudioStreamStruct> & GetAllocatedAudioStreams() const override;
 
     void GetBandwidthForStreams(const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
                                 const Optional<DataModel::Nullable<uint16_t>> & audioStreamId, uint32_t & outBandwidthbps) override;
+
+    /**
+     * @brief Called by transports when they start using the corresponding audio and video streams.
+     *
+     */
+    CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID);
+
+    /**
+     * @brief Called by transports when they release the corresponding audio and video streams.
+     *
+     */
+    CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID);
 
     CameraAVStreamManager()  = default;
     ~CameraAVStreamManager() = default;

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
@@ -331,18 +331,6 @@ public:
     virtual CHIP_ERROR PersistentAttributesLoadedCallback() = 0;
 
     /**
-     * @brief Called by transports when they start using the corresponding audio and video streams.
-     *
-     */
-    virtual CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) = 0;
-
-    /**
-     * @brief Called by transports when they release the corresponding audio and video streams.
-     *
-     */
-    virtual CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) = 0;
-
-    /**
      * @brief Provides read-only access to the list of currently allocated video streams.
      * This allows other components (like PushAVStreamTransportManager) to query
      * allocated stream parameters (e.g., for bandwidth calculation) without directly

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -230,16 +230,6 @@ public:
 
     CHIP_ERROR PersistentAttributesLoadedCallback() override { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) override
-    {
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) override
-    {
-        return CHIP_NO_ERROR;
-    }
-
     const std::vector<VideoStreamStruct> & GetAllocatedVideoStreams() const override { return *mAllocatedVideoStreams; }
 
     const std::vector<AudioStreamStruct> & GetAllocatedAudioStreams() const override { return *mAllocatedAudioStreams; }


### PR DESCRIPTION
#### Summary

The following two APIs are defined and used only within the application. They should be removed from CameraAVStreamManagementDelegate.

CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID);
CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID)

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
