### PR TITLE
Add Gstreamer good and ugly plugins to dockerfile.

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -49,6 +49,8 @@ RUN set -x \
     git-lfs \
     gperf \
     gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-ugly \
     gstreamer1.0-tools \
     iproute2 \
     iwyu \

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-181 : Thread: install libevent for Thread Commissioner
+182 : Gstreamer: install gstreamer1.0-plugins-good, gstreamer1.0-plugins-ugly for Camera app

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/start-sysroot-vm.sh
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/start-sysroot-vm.sh
@@ -115,6 +115,8 @@ packages:
   - g++
   - gcc
   - gstreamer1.0-plugins-base
+  - gstreamer1.0-plugins-good
+  - gstreamer1.0-plugins-ugly
   - gstreamer1.0-tools
   - libavahi-client-dev
   - libavcodec-dev


### PR DESCRIPTION
#### Summary
Adding gstreamer1.0-plugins-good and gstreamer1.0-plugins-ugly for docker 
ugly - is needed for video test source (x264enc) dependency

#### Related issues
CI fails: https://github.com/project-chip/connectedhomeip/actions/runs/21373955203/job/61526943493?pr=42370
PR #42370 

#### Testing
`- CI build`
