### PR TITLE
Removed Linux Platform Connectivity Manager Implementation Unused 'WiFiNetworkScanned' Structure

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -191,18 +191,6 @@ public:
 private:
     // ===== Members that implement the ConnectivityManager abstract interface.
 
-    struct WiFiNetworkScanned
-    {
-        // The fields matches WiFiInterfaceScanResult::Type.
-        uint8_t ssid[Internal::kMaxWiFiSSIDLength];
-        uint8_t ssidLen;
-        uint8_t bssid[6];
-        int8_t rssi;
-        uint16_t frequencyBand;
-        uint8_t channel;
-        uint8_t security;
-    };
-
     CHIP_ERROR _Init();
     void _OnPlatformEvent(const ChipDeviceEvent * event);
 

--- a/src/platform/NuttX/ConnectivityManagerImpl.h
+++ b/src/platform/NuttX/ConnectivityManagerImpl.h
@@ -168,18 +168,6 @@ public:
 private:
     // ===== Members that implement the ConnectivityManager abstract interface.
 
-    struct WiFiNetworkScanned
-    {
-        // The fields matches WiFiInterfaceScanResult::Type.
-        uint8_t ssid[Internal::kMaxWiFiSSIDLength];
-        uint8_t ssidLen;
-        uint8_t bssid[6];
-        int8_t rssi;
-        uint16_t frequencyBand;
-        uint8_t channel;
-        uint8_t security;
-    };
-
     CHIP_ERROR _Init();
     void _OnPlatformEvent(const ChipDeviceEvent * event);
 

--- a/src/platform/webos/ConnectivityManagerImpl.h
+++ b/src/platform/webos/ConnectivityManagerImpl.h
@@ -191,18 +191,6 @@ public:
 private:
     // ===== Members that implement the ConnectivityManager abstract interface.
 
-    struct WiFiNetworkScanned
-    {
-        // The fields matches WiFiInterfaceScanResult::Type.
-        uint8_t ssid[Internal::kMaxWiFiSSIDLength];
-        uint8_t ssidLen;
-        uint8_t bssid[6];
-        int8_t rssi;
-        uint16_t frequencyBand;
-        uint8_t channel;
-        uint8_t security;
-    };
-
     CHIP_ERROR _Init();
     void _OnPlatformEvent(const ChipDeviceEvent * event);
 


### PR DESCRIPTION
#### Summary

This removes the entirely-unused `WiFiNetworkScanned` from the Linux platform _Connectivity Manager_ implementation.

#### Related issues

#42516

#### Testing

Successfully paired / commissioned an armvl-unknown-linux-gnu device using the iOS 26.2 Apple "Home" app.