### PR TITLE
[Camera] Remove non-delegate APIs from CameraAVStreamManagementDelegate

### DIFF
--- a/examples/camera-app/camera-common/include/camera-avstream-controller/camera-avstream-controller.h
+++ b/examples/camera-app/camera-common/include/camera-avstream-controller/camera-avstream-controller.h
@@ -64,6 +64,18 @@ public:
     virtual void GetBandwidthForStreams(const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
                                         const Optional<DataModel::Nullable<uint16_t>> & audioStreamId,
                                         uint32_t & outBandwidthbps) = 0;
+
+    /**
+     * @brief Called by transports when they start using the corresponding audio and video streams.
+     *
+     */
+    virtual CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) = 0;
+
+    /**
+     * @brief Called by transports when they release the corresponding audio and video streams.
+     *
+     */
+    virtual CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) = 0;
 };
 
 } // namespace CameraAvStreamManagement

--- a/examples/camera-app/camera-common/include/camera-avstream-controller/camera-avstream-controller.h
+++ b/examples/camera-app/camera-common/include/camera-avstream-controller/camera-avstream-controller.h
@@ -69,13 +69,13 @@ public:
      * @brief Called by transports when they start using the corresponding audio and video streams.
      *
      */
-    virtual CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) = 0;
+    virtual CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamId, uint16_t videoStreamId) = 0;
 
     /**
      * @brief Called by transports when they release the corresponding audio and video streams.
      *
      */
-    virtual CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) = 0;
+    virtual CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamId, uint16_t videoStreamId) = 0;
 };
 
 } // namespace CameraAvStreamManagement

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -890,12 +890,12 @@ CameraAVStreamManager::PersistentAttributesLoadedCallback()
 }
 
 CHIP_ERROR
-CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID)
+CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamId, uint16_t videoStreamId)
 {
     // Update the available audio stream in the HAL
     for (AudioStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableAudioStreams())
     {
-        if (stream.audioStreamParams.audioStreamID == audioStreamID && stream.isAllocated)
+        if (stream.audioStreamParams.audioStreamID == audioStreamId && stream.isAllocated)
         {
             if (stream.audioStreamParams.referenceCount < UINT8_MAX)
             {
@@ -903,7 +903,7 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamI
             }
             else
             {
-                ChipLogError(Camera, "Attempted to increment audio stream %u ref count beyond max limit", audioStreamID);
+                ChipLogError(Camera, "Attempted to increment audio stream %u ref count beyond max limit", audioStreamId);
             }
         }
     }
@@ -911,7 +911,7 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamI
     // Update the available video stream in the HAL
     for (VideoStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableVideoStreams())
     {
-        if (stream.videoStreamParams.videoStreamID == videoStreamID && stream.isAllocated)
+        if (stream.videoStreamParams.videoStreamID == videoStreamId && stream.isAllocated)
         {
             if (stream.videoStreamParams.referenceCount < UINT8_MAX)
             {
@@ -919,34 +919,34 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamI
             }
             else
             {
-                ChipLogError(Camera, "Attempted to increment video stream %u ref count beyond max limit", videoStreamID);
+                ChipLogError(Camera, "Attempted to increment video stream %u ref count beyond max limit", videoStreamId);
             }
         }
     }
 
     // Update the counts in the SDK allocated stream attributes
-    if (GetCameraAVStreamManagementCluster()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ true) !=
+    if (GetCameraAVStreamManagementCluster()->UpdateAudioStreamRefCount(audioStreamId, /* shouldIncrement = */ true) !=
         CHIP_NO_ERROR)
     {
-        ChipLogError(Camera, "Failed to increment audio stream %u ref count in SDK", audioStreamID);
+        ChipLogError(Camera, "Failed to increment audio stream %u ref count in SDK", audioStreamId);
     }
 
-    if (GetCameraAVStreamManagementCluster()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ true) !=
+    if (GetCameraAVStreamManagementCluster()->UpdateVideoStreamRefCount(videoStreamId, /* shouldIncrement = */ true) !=
         CHIP_NO_ERROR)
     {
-        ChipLogError(Camera, "Failed to increment video stream %u ref count in SDK", videoStreamID);
+        ChipLogError(Camera, "Failed to increment video stream %u ref count in SDK", videoStreamId);
     }
 
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR
-CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID)
+CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamId, uint16_t videoStreamId)
 {
     // Update the available audio stream in the HAL
     for (AudioStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableAudioStreams())
     {
-        if (stream.audioStreamParams.audioStreamID == audioStreamID && stream.isAllocated)
+        if (stream.audioStreamParams.audioStreamID == audioStreamId && stream.isAllocated)
         {
             if (stream.audioStreamParams.referenceCount > 0)
             {
@@ -954,7 +954,7 @@ CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamI
             }
             else
             {
-                ChipLogError(Camera, "Attempted to decrement audio stream %u ref count when it was already 0", audioStreamID);
+                ChipLogError(Camera, "Attempted to decrement audio stream %u ref count when it was already 0", audioStreamId);
             }
         }
     }
@@ -962,7 +962,7 @@ CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamI
     // Update the available video stream in the HAL
     for (VideoStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableVideoStreams())
     {
-        if (stream.videoStreamParams.videoStreamID == videoStreamID && stream.isAllocated)
+        if (stream.videoStreamParams.videoStreamID == videoStreamId && stream.isAllocated)
         {
             if (stream.videoStreamParams.referenceCount > 0)
             {
@@ -970,22 +970,22 @@ CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamI
             }
             else
             {
-                ChipLogError(Camera, "Attempted to decrement video stream %u ref count when it was already 0", videoStreamID);
+                ChipLogError(Camera, "Attempted to decrement video stream %u ref count when it was already 0", videoStreamId);
             }
         }
     }
 
     // Update the counts in the SDK allocated stream attributes
-    if (GetCameraAVStreamManagementCluster()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ false) !=
+    if (GetCameraAVStreamManagementCluster()->UpdateAudioStreamRefCount(audioStreamId, /* shouldIncrement = */ false) !=
         CHIP_NO_ERROR)
     {
-        ChipLogError(Camera, "Failed to decrement audio stream %u ref count in SDK", audioStreamID);
+        ChipLogError(Camera, "Failed to decrement audio stream %u ref count in SDK", audioStreamId);
     }
 
-    if (GetCameraAVStreamManagementCluster()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ false) !=
+    if (GetCameraAVStreamManagementCluster()->UpdateVideoStreamRefCount(videoStreamId, /* shouldIncrement = */ false) !=
         CHIP_NO_ERROR)
     {
-        ChipLogError(Camera, "Failed to decrement video stream %u ref count in SDK", videoStreamID);
+        ChipLogError(Camera, "Failed to decrement video stream %u ref count in SDK", videoStreamId);
     }
 
     return CHIP_NO_ERROR;

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -1169,8 +1169,8 @@ CHIP_ERROR WebRTCProviderManager::AcquireAudioVideoStreams(uint16_t sessionId)
     }
 
     WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
-    return mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportAcquireAudioVideoStreams(args.audioStreamId,
-                                                                                              args.videoStreamId);
+    return mCameraDevice->GetCameraAVStreamMgmtController().OnTransportAcquireAudioVideoStreams(args.audioStreamId,
+                                                                                                args.videoStreamId);
 }
 
 CHIP_ERROR WebRTCProviderManager::ReleaseAudioVideoStreams(uint16_t sessionId)
@@ -1183,7 +1183,7 @@ CHIP_ERROR WebRTCProviderManager::ReleaseAudioVideoStreams(uint16_t sessionId)
     }
 
     WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
-    // TODO: Use passed in audio/video stream ids corresponding to a sessionId.
-    return mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportReleaseAudioVideoStreams(args.audioStreamId,
-                                                                                              args.videoStreamId);
+
+    return mCameraDevice->GetCameraAVStreamMgmtController().OnTransportReleaseAudioVideoStreams(args.audioStreamId,
+                                                                                                args.videoStreamId);
 }

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
@@ -331,18 +331,6 @@ public:
     virtual CHIP_ERROR PersistentAttributesLoadedCallback() = 0;
 
     /**
-     * @brief Called by transports when they start using the corresponding audio and video streams.
-     *
-     */
-    virtual CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) = 0;
-
-    /**
-     * @brief Called by transports when they release the corresponding audio and video streams.
-     *
-     */
-    virtual CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) = 0;
-
-    /**
      * @brief Provides read-only access to the list of currently allocated video streams.
      * This allows other components (like PushAVStreamTransportManager) to query
      * allocated stream parameters (e.g., for bandwidth calculation) without directly

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -230,16 +230,6 @@ public:
 
     CHIP_ERROR PersistentAttributesLoadedCallback() override { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) override
-    {
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) override
-    {
-        return CHIP_NO_ERROR;
-    }
-
     const std::vector<VideoStreamStruct> & GetAllocatedVideoStreams() const override { return *mAllocatedVideoStreams; }
 
     const std::vector<AudioStreamStruct> & GetAllocatedAudioStreams() const override { return *mAllocatedAudioStreams; }


### PR DESCRIPTION
#### Summary

The following two APIs are defined and used only within the application. They should be removed from CameraAVStreamManagementDelegate.

CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID);
CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID)

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
