### PR TITLE
[Darwin] Generated header tweaks

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -35,6 +35,7 @@
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"
 #import "zap-generated/MTRCommandPayloads_Internal.h"
+#import "zap-generated/MTRCommandPayloads_Private.h"
 
 #import "app/ConcreteAttributePath.h"
 #import "app/ConcreteCommandPath.h"

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -36,6 +36,7 @@
 #import "MTRUnfairLock.h"
 #import "MTRUtilities.h"
 #import "zap-generated/MTRCommandPayloads_Internal.h"
+#import "zap-generated/MTRCommandPayloads_Private.h"
 
 #import "lib/core/CHIPError.h"
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -30,6 +30,7 @@
 #import "MTRSetupPayload_Internal.h"
 #import "MTRUtilities.h"
 #import "zap-generated/MTRCommandPayloads_Internal.h"
+#import "zap-generated/MTRCommandPayloads_Private.h"
 
 #include <lib/core/DataModelTypes.h>
 

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -43,6 +43,7 @@
 #import "MTRUnfairLock.h"
 #import "MTRUtilities.h"
 #import "zap-generated/MTRCommandPayloads_Internal.h"
+#import "zap-generated/MTRCommandPayloads_Private.h"
 
 #import "lib/core/CHIPError.h"
 #import "lib/core/DataModelTypes.h"

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -418,7 +418,7 @@
 		9BD2142B2F21653B0044946F /* MTRBaseClusters_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BD214282F21653B0044946F /* MTRBaseClusters_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9BD214302F21666E0044946F /* MTRClusters_Private.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9BD2142D2F21666E0044946F /* MTRClusters_Private.mm */; };
 		9BD214312F21666E0044946F /* MTRCommandPayloadsObjc_Private.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9BD2142F2F21666E0044946F /* MTRCommandPayloadsObjc_Private.mm */; };
-		9BD214322F21666E0044946F /* MTRCommandPayloads_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BD2142E2F21666E0044946F /* MTRCommandPayloads_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9BD214322F21666E0044946F /* MTRCommandPayloads_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BD2142E2F21666E0044946F /* MTRCommandPayloads_Private.h */; };
 		9BD214332F21666E0044946F /* MTRClusters_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BD2142C2F21666E0044946F /* MTRClusters_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9BDA2A062C5D9AF800A32BDD /* MTRDevice_Concrete.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9BDA2A052C5D9AF800A32BDD /* MTRDevice_Concrete.mm */; };
 		9BDA2A082C5D9AFB00A32BDD /* MTRDevice_Concrete.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BDA2A072C5D9AFB00A32BDD /* MTRDevice_Concrete.h */; };


### PR DESCRIPTION
#### Summary
- **Fix `MTRCommandPayloads_Private.h` visibility**
- **Additional command payload imports**

The name of `MTRCommandPayloads_Private.h` is a bit of a misnomer:  it should have `_Internal.h` / `Project` visibility.

A renaming is probably in order to avoid future confusion but that will come in a later PR.

#### Testing

- Tested that codegen of `src/darwin/Framework/CHIP/zap-generated` files does not change existing files:
`./scripts/tools/zap_regen_all.py --type specific`

- Tested that generated code builds in Matter.framework:
`xcodebuild -project src/darwin/Framework/Matter.xcodeproj -scheme "Matter Framework"`

Both of the above steps should be tested with an empty `DarwinPrivateClusters` array and with it containing `UnitTesting`.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

