### PR TITLE
Remove unused params from HandleEndSession API

### DIFF
--- a/examples/camera-app/camera-common/include/transport/transport.h
+++ b/examples/camera-app/camera-common/include/transport/transport.h
@@ -23,6 +23,7 @@
 #include <lib/core/Optional.h>
 #include <lib/support/Span.h>
 #pragma once
+
 // Base class for media transports(WebRTC, PushAV)
 // Media Transports would implement this interface for the Media controller to
 // use.

--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -59,16 +59,13 @@ public:
     CHIP_ERROR HandleSolicitOffer(const OfferRequestArgs & args, WebRTCSessionStruct & outSession,
                                   bool & outDeferredOffer) override;
 
-    CHIP_ERROR
-    HandleProvideOffer(const ProvideOfferRequestArgs & args, WebRTCSessionStruct & outSession) override;
+    CHIP_ERROR HandleProvideOffer(const ProvideOfferRequestArgs & args, WebRTCSessionStruct & outSession) override;
 
     CHIP_ERROR HandleProvideAnswer(uint16_t sessionId, const std::string & sdpAnswer) override;
 
     CHIP_ERROR HandleProvideICECandidates(uint16_t sessionId, const std::vector<ICECandidateStruct> & candidates) override;
 
-    CHIP_ERROR HandleEndSession(uint16_t sessionId, WebRTCEndReasonEnum reasonCode,
-                                chip::app::DataModel::Nullable<uint16_t> videoStreamID,
-                                chip::app::DataModel::Nullable<uint16_t> audioStreamID) override;
+    CHIP_ERROR HandleEndSession(uint16_t sessionId, WebRTCEndReasonEnum reasonCode) override;
 
     CHIP_ERROR ValidateStreamUsage(StreamUsageEnum streamUsage,
                                    chip::Optional<chip::app::DataModel::Nullable<uint16_t>> & videoStreamId,

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -455,9 +455,7 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideICECandidates(uint16_t sessionId,
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEndReasonEnum reasonCode,
-                                                   DataModel::Nullable<uint16_t> videoStreamID,
-                                                   DataModel::Nullable<uint16_t> audioStreamID)
+CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEndReasonEnum reasonCode)
 {
     WebrtcTransport * transport = GetTransport(sessionId);
     if (transport == nullptr)

--- a/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.cpp
+++ b/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.cpp
@@ -537,7 +537,7 @@ WebRTCTransportProviderCluster::HandleSolicitOffer(CommandHandler & commandHandl
         }
     }
 
-    // ===== Cluster logic starts here =====
+    // ===== Cluster logic starts here (Effect on Receipt) =====
 
     Status status = CheckPrivacyModes("HandleSolicitOffer", req.streamUsage);
     if (status != Status::Success)
@@ -790,7 +790,7 @@ WebRTCTransportProviderCluster::HandleProvideOffer(CommandHandler & commandHandl
         }
     }
 
-    // ===== Cluster logic starts here =====
+    // ===== Cluster logic starts here (Effect on Receipt) =====
 
     // If WebRTCSessionID is not null:
     // - If it does not match a value in CurrentSessions: Respond with NOT_FOUND
@@ -1071,7 +1071,7 @@ WebRTCTransportProviderCluster::HandleEndSession(CommandHandler & commandHandler
     }
 
     // Delegate handles decrementing reference counts on video/audio streams if applicable.
-    CHIP_ERROR err = mDelegate.HandleEndSession(sessionId, reason, existingSession->videoStreamID, existingSession->audioStreamID);
+    CHIP_ERROR err = mDelegate.HandleEndSession(sessionId, reason);
 
     // Remove the session entry from CurrentSessions.
     RemoveSession(sessionId);

--- a/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.h
+++ b/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.h
@@ -182,16 +182,12 @@ public:
      *
      * @param[in] sessionId      The ID of the session to end.
      * @param[in] reasonCode     Reason for ending the session (e.g. normal closure, resource limit).
-     * @param[in] videoStreamID  The nullable ID of the video stream associated with the session.
-     * @param[in] audioStreamID  The nullable ID of the audio stream associated with the session.
      *
      * @return CHIP_ERROR
      *   - CHIP_NO_ERROR on success
      *   - Error if no matching session is found or some cleanup error occurs
      */
-    virtual CHIP_ERROR HandleEndSession(uint16_t sessionId, WebRTCEndReasonEnum reasonCode,
-                                        DataModel::Nullable<uint16_t> videoStreamID,
-                                        DataModel::Nullable<uint16_t> audioStreamID) = 0;
+    virtual CHIP_ERROR HandleEndSession(uint16_t sessionId, WebRTCEndReasonEnum reasonCode) = 0;
 
     /**
      * @brief Validates the requested stream usage against the camera's resource management

--- a/src/app/clusters/webrtc-transport-provider-server/tests/TestWebRTCTransportProviderCluster.cpp
+++ b/src/app/clusters/webrtc-transport-provider-server/tests/TestWebRTCTransportProviderCluster.cpp
@@ -72,11 +72,7 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR HandleEndSession(uint16_t sessionId, WebRTCEndReasonEnum reasonCode, DataModel::Nullable<uint16_t> videoStreamID,
-                                DataModel::Nullable<uint16_t> audioStreamID) override
-    {
-        return CHIP_NO_ERROR;
-    }
+    CHIP_ERROR HandleEndSession(uint16_t sessionId, WebRTCEndReasonEnum reasonCode) override { return CHIP_NO_ERROR; }
 
     CHIP_ERROR ValidateStreamUsage(StreamUsageEnum streamUsage, Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
                                    Optional<DataModel::Nullable<uint16_t>> & audioStreamId) override


### PR DESCRIPTION
#### Summary

The following two params are not used in HandleEndSession
```
chip::app::DataModel::Nullable<uint16_t> videoStreamID,
chip::app::DataModel::Nullable<uint16_t> audioStreamID)
```
                                
Remove unused params from HandleEndSession API

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
