### PR TITLE
Prevent Fabric label Constraint errors

### DIFF
--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -330,7 +330,7 @@ class TC_RR_1_1(MatterBaseTest):
             client = client_by_name[client_name]
 
             # Send the UpdateLabel command
-            label = ("%d" % fabric.fabricIndex) * 32
+            label = "%d" % fabric.fabricIndex
             log.info("Step 2a: Setting fabric label on fabric %d to '%s' using client %s" %
                      (fabric.fabricIndex, label, client_name))
             await client.SendCommand(self.dut_node_id, 0, Clusters.OperationalCredentials.Commands.UpdateFabricLabel(label))

--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -322,8 +322,8 @@ class TC_RR_1_1(MatterBaseTest):
         local_session_id_by_client_name = {client.name: client.GetConnectedDeviceSync(
             self.dut_node_id).localSessionId for client in client_list}
 
-        # Step 2: Set the Label field for each fabric and BasicInformation.NodeLabel to 32 characters
-        log.info("Step 2: Setting the Label field for each fabric and BasicInformation.NodeLabel to 32 characters")
+        # Step 2: Set the Label field for each fabric and BasicInformation.NodeLabel the string fabric index
+        log.info("Step 2: Setting the Label field for each fabric and BasicInformation.NodeLabel to the string fabricIndex")
 
         for fabric in fabric_table:
             client_name = generate_controller_name(fabric.fabricIndex, 0)


### PR DESCRIPTION
#### Summary

The current logic generated 64 byte long labels with fabric index 10+ which produce a constraint error when executing the UpdateFabricLabel command. We do not need to fill 32 bytes, we just need a unique label, so use the fabric index itself as label

#### Testing

This is a test