### PR TITLE
TC_RR_1_1.py: Prevent generating too long FabricLabels

### DIFF
--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -330,7 +330,7 @@ class TC_RR_1_1(MatterBaseTest):
             client = client_by_name[client_name]
 
             # Send the UpdateLabel command
-            label = ("%d" % fabric.fabricIndex) * 32
+            label = (("%d." % fabric.fabricIndex) * 16)[:32]
             log.info("Step 2a: Setting fabric label on fabric %d to '%s' using client %s" %
                      (fabric.fabricIndex, label, client_name))
             await client.SendCommand(self.dut_node_id, 0, Clusters.OperationalCredentials.Commands.UpdateFabricLabel(label))


### PR DESCRIPTION
#### Summary

The former code generated 64 bytes labels when fabricIndex 10+ would have been existing. This code still ensures to have 32 chars but exactly and without collisions (1 and 11 or 111 would ed in the same string else)

#### Testing

Thsi is a test