### PR TITLE
Fix bug about fail-safe timer re-arm when using non-concurrent mode.

### DIFF
--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -58,12 +58,6 @@ public:
     ByteSpan GetAttestationSignature() const { return ByteSpan(mAttestationSignature, mAttestationSignatureLen); }
     ByteSpan GetAttestationNonce() const { return ByteSpan(mAttestationNonce); }
 
-    bool IsConcurrentModeSupported() const
-    {
-        // If the 'SupportsConcurrentConnection' attribute was not found, concurrent commissioning is supported
-        return mParams.GetSupportsConcurrentConnection().ValueOr(true);
-    }
-
 protected:
     virtual void CleanupCommissioning();
     CommissioningStage GetNextCommissioningStage(CommissioningStage currentStage, CHIP_ERROR & lastErr);

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -60,9 +60,12 @@ public:
 
     bool IsConcurrentModeSupported() const
     {
-        if (mParams.GetSupportsConcurrentConnection().HasValue()) {
+        if (mParams.GetSupportsConcurrentConnection().HasValue())
+        {
             return mParams.GetSupportsConcurrentConnection().Value();
-        } else {
+        }
+        else
+        {
             // Attribute 'SupportsConcurrentConnection' was not found
             // The default value for this attribute is 'true'
             return true;

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -60,16 +60,8 @@ public:
 
     bool IsConcurrentModeSupported() const
     {
-        if (mParams.GetSupportsConcurrentConnection().HasValue())
-        {
-            return mParams.GetSupportsConcurrentConnection().Value();
-        }
-        else
-        {
-            // Attribute 'SupportsConcurrentConnection' was not found
-            // The default value for this attribute is 'true'
-            return true;
-        }
+        // If the 'SupportsConcurrentConnection' attribute was not found, concurrent commissioning is supported
+        return mParams.GetSupportsConcurrentConnection().ValueOr(true);
     }
 
 protected:

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -58,6 +58,17 @@ public:
     ByteSpan GetAttestationSignature() const { return ByteSpan(mAttestationSignature, mAttestationSignatureLen); }
     ByteSpan GetAttestationNonce() const { return ByteSpan(mAttestationNonce); }
 
+    bool IsConcurrentModeSupported() const
+    {
+        if (mParams.GetSupportsConcurrentConnection().HasValue()) {
+            return mParams.GetSupportsConcurrentConnection().Value();
+        } else {
+            // Attribute 'SupportsConcurrentConnection' was not found
+            // The default value for this attribute is 'true'
+            return true;
+        }
+    }
+
 protected:
     virtual void CleanupCommissioning();
     CommissioningStage GetNextCommissioningStage(CommissioningStage currentStage, CHIP_ERROR & lastErr);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2214,7 +2214,8 @@ void DeviceCommissioner::OnDeviceConnectionRetryFn(void * context, const ScopedN
 
     bool supportsConcurrent =
         self->mCommissioningDelegate->GetCommissioningParameters().GetSupportsConcurrentConnection().ValueOr(true);
-    if (!supportsConcurrent) {
+    if (!supportsConcurrent)
+    {
         // Concurrent mode not supported.
         // We are in operational phase so the commissioning channel is no more
         //  available and it is not possible to re-arm the fail-safe timer.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2212,6 +2212,13 @@ void DeviceCommissioner::OnDeviceConnectionRetryFn(void * context, const ScopedN
                 self->GetCommissioningStage() == CommissioningStage::kFindOperationalForCommissioningComplete);
     VerifyOrDie(self->mDeviceBeingCommissioned->GetDeviceId() == peerId.GetNodeId());
 
+    if (!self->mAutoCommissioner.IsConcurrentModeSupported()) {
+        // Concurrent mode not supported.
+        // We are in operational phase so the commissioning channel is no more
+        //  available and it is not possible to re-arm the fail-safe timer.
+        return;
+    }
+
     // We need to do the fail-safe arming over the PASE session.
     auto * commissioneeDevice = self->FindCommissioneeDevice(peerId.GetNodeId());
     if (!commissioneeDevice)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2212,8 +2212,9 @@ void DeviceCommissioner::OnDeviceConnectionRetryFn(void * context, const ScopedN
                 self->GetCommissioningStage() == CommissioningStage::kFindOperationalForCommissioningComplete);
     VerifyOrDie(self->mDeviceBeingCommissioned->GetDeviceId() == peerId.GetNodeId());
 
-    if (!self->mAutoCommissioner.IsConcurrentModeSupported())
-    {
+    bool supportsConcurrent =
+        self->mCommissioningDelegate->GetCommissioningParameters().GetSupportsConcurrentConnection().ValueOr(true);
+    if (!supportsConcurrent) {
         // Concurrent mode not supported.
         // We are in operational phase so the commissioning channel is no more
         //  available and it is not possible to re-arm the fail-safe timer.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2212,7 +2212,8 @@ void DeviceCommissioner::OnDeviceConnectionRetryFn(void * context, const ScopedN
                 self->GetCommissioningStage() == CommissioningStage::kFindOperationalForCommissioningComplete);
     VerifyOrDie(self->mDeviceBeingCommissioned->GetDeviceId() == peerId.GetNodeId());
 
-    if (!self->mAutoCommissioner.IsConcurrentModeSupported()) {
+    if (!self->mAutoCommissioner.IsConcurrentModeSupported())
+    {
         // Concurrent mode not supported.
         // We are in operational phase so the commissioning channel is no more
         //  available and it is not possible to re-arm the fail-safe timer.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2217,8 +2217,8 @@ void DeviceCommissioner::OnDeviceConnectionRetryFn(void * context, const ScopedN
     if (!supportsConcurrent)
     {
         // Concurrent mode not supported.
-        // We are in operational phase so the commissioning channel is no more
-        //  available and it is not possible to re-arm the fail-safe timer.
+        // We are in operational phase so the commissioning channel is not
+        // available anymore and it is not possible to re-arm the fail-safe timer.
         return;
     }
 


### PR DESCRIPTION
This PR is fixing a bug seen while testing NFC-based commissioning:

During my test, I have had a timeout during CASE. I have then seen that the Commissoner called some code to retry the operational DNS-SD discovery and it also sent a command to rearm the fail-safe timer of the Commissionee. This command was sent over NFC which is not expected since:
- NFC commissioning is by nature non-concurrent. 
- We are in the operational phase so the NFC commissioning channel is no more available.

In case of non-concurrent commissioning, it is not possible to re-arm the fail-safe timer during the operational phase so this failsafe re-arm should not be done in that case. I'm pushing an update to ensure that.

#### Testing
I have tested with the test TC_DD_3_23 that it solves the issue.

Here is the log showing the issue:
```
[MatterTest] 01-22 10:24:39.698 ERROR Timeout waiting for mDNS resolution. 
[MatterTest] 01-22 10:24:53.681 INFO Checking node lookup status for 50B1D679A16B09F0-0000000012344321 after 45014 ms 
[MatterTest] 01-22 10:24:53.682 ERROR OperationalSessionSetup[1:0000000012344321]: operational discovery failed: src/lib/address_resolve/AddressResolve_DefaultImpl.cpp:124: CHIP Error 0x00000032: Timeout 
[MatterTest] 01-22 10:24:53.682 INFO Retrying operational DNS-SD discovery. Attempts remaining: 2 
[MatterTest] 01-22 10:24:53.683 INFO Lookup started for 50B1D679A16B09F0-0000000012344321 
[MatterTest] 01-22 10:24:53.683 ERROR Session establishment failed for <0000000012344321, 1>, error: src/lib/address_resolve/AddressResolve_DefaultImpl.cpp:124: CHIP Error 0x00000032: Timeout.  Next retry expected to get a response to Sigma1 or fail within 60 seconds 
[MatterTest] 01-22 10:24:53.684 INFO Arming failsafe (120 seconds) 
[MatterTest] 01-22 10:24:53.685 INFO <<< [E:8733i S:13398 M:129114765] (S) Msg TX from 0000000000000000 to 0:FFFFFFFB00000000 [0000] [NFC:3840] --- Type 0001:08 (IM:InvokeCommandRequest) (B:65) 
[MatterTest] 01-22 10:24:53.685 ERROR SCardTransmit failed with error 0x0000000080100069 
[MatterTest] 01-22 10:24:53.686 ERROR Invalid NFC Type4 response 
[MatterTest] 01-22 10:24:53.686 INFO NFCBase::OnNfcTagError 
```
