### PR TITLE
Running run_test_suite.py exclusively from python test env

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -46,6 +46,7 @@ jobs:
           chip_tool: ""
     env:
       BUILD_VARIANT: ${{matrix.build_variant}}
+      PYTHON_BUILD_VENV: out/venv
 
       # We can't use the pigweed clang to build the Darwin framework once we start using
       # Swift, because it does not handle CLANG_ENABLE_MODULES correctly.
@@ -119,9 +120,18 @@ jobs:
                 build \
                 --copy-artifacts-to objdir-clone \
              "
+      - name: Build Python
+        run: |
+            ./scripts/run_in_build_env.sh \
+               "./scripts/build_python.sh \
+                  --install_virtual_env out/venv \
+                  --include_pytest_deps yes \
+                  $([ "${DISABLE_CCACHE}" != "true" ] && echo --enable-ccache) \
+               "
+
       - name: Run Tests
         run: |
-          ./scripts/run_in_build_env.sh \
+          ./scripts/run_in_python_env.sh ${PYTHON_BUILD_VENV} \
           "./scripts/tests/run_test_suite.py \
              --runner darwin_framework_tool_python \
              --target-skip-glob '{TestAccessControlConstraints}' \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -367,7 +367,7 @@ jobs:
 
             - name: Run Tests using the python parser sending commands to chip-tool
               run: |
-                  ./scripts/run_in_build_env.sh \
+                  ./scripts/run_in_python_env.sh out/venv \
                   "./scripts/tests/run_test_suite.py \
                      --find-path $PWD/objdir-clone \
                      --find-path $PWD/scripts \
@@ -392,7 +392,7 @@ jobs:
 
             - name: Run purposeful failure tests using the python parser sending commands to chip-tool
               run: |
-                  ./scripts/run_in_build_env.sh \
+                  ./scripts/run_in_python_env.sh out/venv \
                   "./scripts/tests/run_test_suite.py \
                      --find-path $PWD/objdir-clone \
                      --find-path $PWD/scripts \
@@ -414,7 +414,7 @@ jobs:
                 # globals (glib internals) that TSAN does not understand...
                 TSAN_OPTIONS: report_bugs=0
               run: |
-                  ./scripts/run_in_build_env.sh \
+                  ./scripts/run_in_python_env.sh out/venv \
                   "./scripts/tests/run_test_suite.py \
                      --find-path $PWD/objdir-clone \
                      --find-path $PWD/scripts \
@@ -612,7 +612,7 @@ jobs:
               # Processes run as root are exempt from these restrictions.
               # For details, see https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy#macOS-considerations
               run: |
-                  sudo ./scripts/run_in_build_env.sh \
+                  sudo ./scripts/run_in_python_env.sh out/venv \
                   "./scripts/tests/run_test_suite.py \
                      --find-path $PWD/objdir-clone \
                      --find-path $PWD/scripts \
@@ -640,7 +640,7 @@ jobs:
               # Use sudo to avoid Local Network Privacy restrictions on macOS 15+.
               # See comment on earlier step about Local Network Privacy and root exemption.
               run: |
-                  sudo ./scripts/run_in_build_env.sh \
+                  sudo ./scripts/run_in_python_env.sh out/venv \
                   "./scripts/tests/run_test_suite.py \
                      --find-path $PWD/objdir-clone \
                      --find-path $PWD/scripts \

--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -52,6 +52,7 @@ _abspath() {
 
 CHIP_ROOT=$(_abspath "$(dirname "$0")/..")
 OUTPUT_ROOT="$CHIP_ROOT/out/coverage"
+PYTHON_TESTS_VENV="$CHIP_ROOT/out/venv"
 COVERAGE_ROOT="$OUTPUT_ROOT/coverage"
 SUPPORTED_CODE=(core clusters all)
 CODE="core"
@@ -196,7 +197,7 @@ if [ "$skip_gn" == false ]; then
     if [ "$ENABLE_YAML" == true ]; then
         ninja -C "$OUTPUT_ROOT"
 
-        scripts/run_in_build_env.sh \
+        scripts/run_in_python_env.sh \"$PYTHON_TESTS_VENV\" \
             "./scripts/tests/run_test_suite.py \
              --runner chip_tool_python \
              --exclude-tags MANUAL \

--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -197,7 +197,7 @@ if [ "$skip_gn" == false ]; then
     if [ "$ENABLE_YAML" == true ]; then
         ninja -C "$OUTPUT_ROOT"
 
-        scripts/run_in_python_env.sh \"$PYTHON_TESTS_VENV\" \
+        scripts/run_in_python_env.sh "$PYTHON_TESTS_VENV" \
             "./scripts/tests/run_test_suite.py \
              --runner chip_tool_python \
              --exclude-tags MANUAL \


### PR DESCRIPTION
#### Summary

Make sure the run_test_suite.py is always called only from python venv (The one we use for testing), never from 

#### Related issues

#### Testing

To make sure the run_test_suite.py successfully run from python venv
```
./scripts/run_in_python_env.sh out/venv "./scripts/tests/run_test_suite.py --runner chip_tool_python --chip-tool out/linux-x64-chip-tool/chip-tool --target TestOperationalState --log-level debug run --all-clusters-app out/linux-x64-all-clusters/chip-all-clusters-app --commissioning-method ble-wifi "
```

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
