### PR TITLE
[Silabs] Handling the return values when shell is enabled

### DIFF
--- a/examples/lock-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/lock-app/silabs/src/EventHandlerLibShell.cpp
@@ -106,7 +106,7 @@ CHIP_ERROR AlarmEventHandler(int argc, char ** argv)
     data->eventId         = Events::DoorLockAlarm::Id;
     data->alarmCode       = static_cast<AlarmCodeEnum>(atoi(argv[0]));
 
-    DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
+    TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
 
     return CHIP_NO_ERROR;
 }
@@ -138,7 +138,7 @@ CHIP_ERROR DoorStateEventHandler(int argc, char ** argv)
     data->eventId             = Events::DoorStateChange::Id;
     data->doorState           = static_cast<DoorStateEnum>(atoi(argv[0]));
 
-    DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
+    TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
 
     return CHIP_NO_ERROR;
 }

--- a/examples/lock-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/lock-app/silabs/src/EventHandlerLibShell.cpp
@@ -106,9 +106,7 @@ CHIP_ERROR AlarmEventHandler(int argc, char ** argv)
     data->eventId         = Events::DoorLockAlarm::Id;
     data->alarmCode       = static_cast<AlarmCodeEnum>(atoi(argv[0]));
 
-    TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
-
-    return CHIP_NO_ERROR;
+    return DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
 }
 
 /********************************************************
@@ -138,9 +136,7 @@ CHIP_ERROR DoorStateEventHandler(int argc, char ** argv)
     data->eventId             = Events::DoorStateChange::Id;
     data->doorState           = static_cast<DoorStateEnum>(atoi(argv[0]));
 
-    TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
-
-    return CHIP_NO_ERROR;
+    return DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
 }
 
 /**

--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -109,9 +109,7 @@ CHIP_ERROR RefrigeratorAlarmSuppressHandler(int argc, char ** argv)
     data->eventState                  = RefrigeratorAlarm::Events::Notify::Fields::kMask;
     data->doorState                   = static_cast<AlarmBitmap>(0);
 
-    TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
-
-    return CHIP_NO_ERROR;
+    return DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
 }
 
 CHIP_ERROR RefrigeratorDoorEventHandler(int argc, char ** argv)
@@ -141,9 +139,7 @@ CHIP_ERROR RefrigeratorDoorEventHandler(int argc, char ** argv)
     data->eventState                  = RefrigeratorAlarm::Events::Notify::Fields::kState;
     data->doorState                   = static_cast<AlarmBitmap>(value);
 
-    TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
-
-    return CHIP_NO_ERROR;
+    return DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
 }
 
 /**

--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -94,8 +94,7 @@ CHIP_ERROR EventRefrigeratorAlarmCommandHandler(int argc, char ** argv)
     {
         return AlarmHelpHandler(argc, argv);
     }
-    sShellRefrigeratorEventAlarmDoorSubCommands.ExecCommand(argc, argv);
-    return CHIP_NO_ERROR;
+    return sShellRefrigeratorEventAlarmDoorSubCommands.ExecCommand(argc, argv);
 }
 
 CHIP_ERROR RefrigeratorAlarmSuppressHandler(int argc, char ** argv)
@@ -110,7 +109,7 @@ CHIP_ERROR RefrigeratorAlarmSuppressHandler(int argc, char ** argv)
     data->eventState                  = RefrigeratorAlarm::Events::Notify::Fields::kMask;
     data->doorState                   = static_cast<AlarmBitmap>(0);
 
-    DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
+    TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
 
     return CHIP_NO_ERROR;
 }
@@ -142,7 +141,7 @@ CHIP_ERROR RefrigeratorDoorEventHandler(int argc, char ** argv)
     data->eventState                  = RefrigeratorAlarm::Events::Notify::Fields::kState;
     data->doorState                   = static_cast<AlarmBitmap>(value);
 
-    DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
+    TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Summary
The silabs platform build was failing since errors weren't handled. 
Handling and returing the error code when needed.

#### Related issues
NA

#### Testing
Tested local build with the 917SoC and thread with shell enabled


