### PR TITLE
CodegenIntegration.h needs to be in app_config_dependent_sources.gni

### DIFF
--- a/src/app/clusters/tls-client-management-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/tls-client-management-server/app_config_dependent_sources.gni
@@ -15,4 +15,3 @@ app_config_dependent_sources = [
   "CodegenIntegration.cpp",
   "CodegenIntegration.h",
 ]
-

--- a/src/app/clusters/tls-client-management-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/tls-client-management-server/app_config_dependent_sources.gni
@@ -11,4 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-app_config_dependent_sources = [ "CodegenIntegration.cpp" ]
+app_config_dependent_sources = [
+  "CodegenIntegration.cpp",
+  "CodegenIntegration.h",
+]
+


### PR DESCRIPTION
#### Summary

According to the [writing_clusters.md:150-153], app_config_dependent_sources.gni should contain CodegenIntegration.cpp and "any other helper/compatibility layers (e.g. [CodegenIntegration.h] if applicable)". Since this header provides the public API for application configuration, it qualifies as a necessary compatibility layer.

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
