### PR TITLE
[Silabs] 917SoC platform specific fixes

### DIFF
--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -165,13 +165,19 @@ static osThreadId_t sUartTaskHandle;
 constexpr uint32_t kUartTaskSize = 1024;
 static uint8_t uartStack[kUartTaskSize];
 static osThread_t sUartTaskControlBlock;
-constexpr osThreadAttr_t kUartTaskAttr = { .name       = "UART",
-                                           .attr_bits  = osThreadDetached,
-                                           .cb_mem     = &sUartTaskControlBlock,
-                                           .cb_size    = osThreadCbSize,
-                                           .stack_mem  = uartStack,
-                                           .stack_size = kUartTaskSize,
-                                           .priority   = osPriorityRealtime6 }; // Must be above Matter Task priority
+constexpr osThreadAttr_t kUartTaskAttr = {
+    .name       = "UART",
+    .attr_bits  = osThreadDetached,
+    .cb_mem     = &sUartTaskControlBlock,
+    .cb_size    = osThreadCbSize,
+    .stack_mem  = uartStack,
+    .stack_size = kUartTaskSize,
+#if SLI_SI91X_MCU_INTERFACE
+    .priority = osPriorityBelowNormal, // for SOC, must be below Matter Task priority
+#else
+    .priority = osPriorityRealtime6, // Must be above Matter Task priority
+#endif // SLI_SI91X_MCU_INTERFACE
+}; // Must be above Matter Task priority
 
 static uint32_t sMissedLogCount = 0; // Count of logs that were not sent to the UART due to queue full
 

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -177,7 +177,7 @@ constexpr osThreadAttr_t kUartTaskAttr = {
 #else
     .priority = osPriorityRealtime6, // Must be above Matter Task priority
 #endif // SLI_SI91X_MCU_INTERFACE
-}; // Must be above Matter Task priority
+};     // Must be above Matter Task priority
 
 static uint32_t sMissedLogCount = 0; // Count of logs that were not sent to the UART due to queue full
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -118,7 +118,12 @@ const sl_wifi_device_configuration_t config = {
     .boot_option = LOAD_NWP_FW,
     .mac_address = NULL,
     .band        = SL_SI91X_WIFI_BAND_2_4GHZ,
-    .region_code = REGION_CODE,
+    .region_code =
+#ifndef SL_SI91X_ACX_MODULE
+        REGION_CODE,
+#else
+        IGNORE_REGION,
+#endif
     .boot_config = { .oper_mode = SL_SI91X_CLIENT_MODE,
                      .coex_mode = SL_SI91X_WLAN_BLE_MODE,
                      .feature_bit_map =


### PR DESCRIPTION
#### Summary
Couple of 917SoC platform fixes

1. During sl_net_init with the module board, an error is thrown as expected. The module board only accepts IGNORE_REGION; if any other region is specified, it triggers this error by design. Hence hardcoding, IGNORE_REGION as the default parameter in the region option, so that it cannot be modified by the users as well.
2. During the UART refactoring https://github.com/project-chip/connectedhomeip/pull/40396/files, the UART task priority was moved to osPriorityRealtime6 for both 917SoC and EFR devices. With 917SoC UART we have seen delay with the TX which blocks the thread if the priority is higher than the Matter task. There was a delay in the matter task like movement of color control hue. Hence reducing it below the matter thread priority.


#### Related issues
NA

#### Testing
Tested with 917SoC

