### PR TITLE
Fix another undefined reference for FaultInjectionOptions 

### DIFF
--- a/src/inet/tests/TestInetCommonOptions.cpp
+++ b/src/inet/tests/TestInetCommonOptions.cpp
@@ -198,6 +198,7 @@ bool NetworkOptions::HandleOption(const char * progName, OptionSet * optSet, int
     return true;
 }
 
+#if defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
 FaultInjectionOptions::FaultInjectionOptions()
 {
     static OptionDef optionDefs[] = { { "faults", kArgumentRequired, kToolCommonOpt_FaultInjection },
@@ -238,7 +239,6 @@ FaultInjectionOptions::FaultInjectionOptions()
     ExtraCleanupTimeMsec = 0;
 }
 
-#if defined(CHIP_WITH_NLFAULTINJECTION) && CHIP_WITH_NLFAULTINJECTION
 bool FaultInjectionOptions::HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
 {
     using namespace nl::FaultInjection;


### PR DESCRIPTION
#### Summary

This is a follow-up to changes introduced in #42729. The `FaultInjectionOptions` class was put behind a macro, but the constructor function definition was not. Moving the function definition to be protected by the same preprocessor directive

#### Testing

- Unit tests should still pass
