### PR TITLE
Darwin: Cluster Extension templates

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRAttributeSpecifiedCheck-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeSpecifiedCheck-src.zapt
@@ -16,11 +16,13 @@ static BOOL AttributeIsSpecifiedIn{{asUpperCamelCase name preserveAcronyms=true}
     using namespace Clusters::{{asUpperCamelCase name}};
     switch (aAttributeId) {
         {{#zcl_attributes_server}}
+        {{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
         {{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
         case Attributes::{{asUpperCamelCase name}}::Id: {
             return YES;
         }
         {{/if}}
+        {{/unless}}
         {{/zcl_attributes_server}}
         default: {
             // Not a known {{asUpperCamelCase name preserveAcronyms=true}} attribute.

--- a/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
@@ -57,6 +57,7 @@ static id _Nullable DecodeAttributeValueFor{{asUpperCamelCase name preserveAcron
     switch (aAttributeId) {
         {{#zcl_attributes_server removeKeys='isOptional'}}
         {{#if clusterRef}}
+        {{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
         {{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
         case Attributes::{{asUpperCamelCase name}}::Id: {
             using TypeInfo = Attributes::{{asUpperCamelCase name}}::TypeInfo;
@@ -71,6 +72,7 @@ static id _Nullable DecodeAttributeValueFor{{asUpperCamelCase name preserveAcron
             return value;
         }
         {{/if}}
+        {{/unless}}
         {{/if}}
         {{/zcl_attributes_server}}
         default: {

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -5,6 +5,7 @@
 @implementation MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}}
 
 {{#zcl_commands}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase parent.name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandImpl"}}
@@ -24,15 +25,18 @@ MTR{{cluster}}Cluster{{command}}Params
 {{> commandImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}
+{{/unless}}
 {{/zcl_commands}}
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase parent.name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
 {{#if (or (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))
           (and (isSupported (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))
                (wasIntroducedBeforeRelease "267F4B03-3256-4056-A62D-5237640FDCFE" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))))}}
 {{> base_clusters_attribute_impl}}
 {{/if}}
+{{/unless}}
 {{/zcl_attributes_server}}
 
 @end

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} : MTRGenericBaseCluster
 
 {{#zcl_commands}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase parent.name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandDecl"}}
@@ -52,9 +53,11 @@ NS_ASSUME_NONNULL_BEGIN
 {{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}
+{{/unless}}
 {{/zcl_commands}}
 
 {{#zcl_attributes_server removeKeys='isOptional'}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase parent.name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 - (void)read{{>attribute}}With
@@ -75,6 +78,7 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 + (void) read{{>attribute}}WithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completion:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completion {{availability (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true) minimalRelease="267F4B03-3256-4056-A62D-5237640FDCFE" deprecationMessage="This attribute is deprecated"}};
 {{/if}}
 {{/if}}
+{{/unless}}
 {{/zcl_attributes_server}}
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Private.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Private.zapt
@@ -1,5 +1,6 @@
 {{> header excludeZapComment=true}}
 
+#import <Matter/MTRBaseClusters.h>
 #import <Matter/MTRCluster.h>
 #import <Matter/MTRClusterStateCacheContainer.h>
 #import <Matter/MTRDefines.h>
@@ -88,7 +89,7 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
  * Cluster {{name}}
  *    {{description}}
  */
-@interface MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} : MTRGenericBaseCluster
+@interface MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} (PrivateExtensions)
 
 {{#zcl_commands}}
 {{#if manufacturerCode}}
@@ -137,21 +138,6 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 {{/if}}
 {{/if}}
 {{/zcl_attributes_server}}
-
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} (Availability)
-
-/**
- * For all instance methods (reads, writes, commands) that take a completion,
- * the completion will be called on the provided queue.
- */
-- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
-                              endpointID:(NSNumber *)endpointID
-                                   queue:(dispatch_queue_t)queue;
 
 @end
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Private.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Private.zapt
@@ -81,4 +81,80 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 {{/if}}
 {{/zcl_clusters}}
 
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+
+/**
+ * Cluster {{name}}
+ *    {{description}}
+ */
+@interface MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} : MTRGenericBaseCluster
+
+{{#zcl_commands}}
+{{#if manufacturerCode}}
+{{#if (is_str_equal source 'client')}}
+{{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
+{{#*inline "commandDecl"}}
+{{#if (isSupported cluster command=command)}}
+/**
+ * Command {{name}}
+ *
+ * {{description}}
+ */
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField }}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion;
+{{#unless commandHasRequiredField}}
+- (void){{asLowerCamelCase name}}WithCompletion:({{>command_completion_type command=.}})completion;
+{{/unless}}
+{{/if}}
+{{/inline}}
+{{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
+                command=(asUpperCamelCase name preserveAcronyms=true)}}
+{{/if}}
+{{/if}}
+{{/zcl_commands}}
+
+{{#zcl_attributes_server removeKeys='isOptional'}}
+{{#if manufacturerCode}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
+- (void)read{{>attribute}}With
+{{~#if_is_fabric_scoped_struct type cluster=../name~}}
+  Params:(MTRReadParams * _Nullable)params completion:
+{{~else~}}
+  Completion:
+{{~/if_is_fabric_scoped_struct~}}
+(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completion;
+{{#if (or isWritableAttribute
+      (isInConfigList (concat (asUpperCamelCase parent.name) "::" label) "DarwinForceWritable"))}}
+- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name}})value completion:(MTRStatusCompletion)completion;
+- (void)write{{>attribute}}WithValue:({{asObjectiveCType type parent.name}})value params:(MTRWriteParams * _Nullable)params completion:(MTRStatusCompletion)completion;
+{{/if}}
+{{#if isReportableAttribute}}
+- (void) subscribe{{>attribute}}WithParams:(MTRSubscribeParams *)params
+subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))reportHandler;
++ (void) read{{>attribute}}WithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completion:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error))completion;
+{{/if}}
+{{/if}}
+{{/if}}
+{{/zcl_attributes_server}}
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+@interface MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} (Availability)
+
+/**
+ * For all instance methods (reads, writes, commands) that take a completion,
+ * the completion will be called on the provided queue.
+ */
+- (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue;
+
+@end
+{{/if}}
+{{/zcl_clusters}}
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/MTRClusterConstants.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterConstants.zapt
@@ -71,6 +71,7 @@ MTRClusterDescriptorAttributeDeviceTypeListID
 = {{asMEI manufacturerCode code}},
 {{/if}}
 {{/if}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../clusterName preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (and (wasIntroducedBeforeRelease "267F4B03-3256-4056-A62D-5237640FDCFE" (compatClusterNameRemapping ../clusterName) attribute=(compatAttributeNameRemapping ../clusterName label) isForIds=true)
            (isSupported (compatClusterNameRemapping ../clusterName) attribute=(compatAttributeNameRemapping ../clusterName label) isForIds=true))}}
 MTRCluster{{compatClusterNameRemapping ../clusterName}}Attribute{{compatAttributeNameRemapping ../clusterName label}}ID
@@ -81,6 +82,7 @@ MTRCluster{{compatClusterNameRemapping ../clusterName}}Attribute{{compatAttribut
 MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID,
 {{/if}}
 {{/if}}
+{{/unless}}
 {{#last}}
 
 {{/last}}
@@ -93,6 +95,7 @@ MTRClusterGlobalAttribute{{asUpperCamelCase label}}ID,
 // Cluster {{> cluster}} attributes
 {{/if}}
 {{/first}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../clusterName preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (and (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)
            (or clusterRef
                (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)))}}
@@ -103,14 +106,17 @@ MTRAttributeIDTypeCluster{{>cluster}}Attribute{{>attribute}}ID {{availability (a
 MTRAttributeIDTypeGlobalAttribute{{asUpperCamelCase label}}ID,
 {{/if}}
 {{/if}}
+{{/unless}}
 {{! Anything which has an old name, and the new name was introduced in the "27C5E231-9EB5-4932-B4C1-10D88419D9CB" release or later
     (or just after the "267F4B03-3256-4056-A62D-5237640FDCFE" release, but we don't have a good way to test for that),
     we need to generate the new-form id for the old name too, as long as it was not removed. }}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../clusterName preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (and (hasOldName (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)
            (not (wasIntroducedBeforeRelease "27C5E231-9EB5-4932-B4C1-10D88419D9CB" (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true))
            (isSupported (compatClusterNameRemapping ../clusterName) attribute=(compatAttributeNameRemapping ../clusterName label) isForIds=true))}}
 MTRAttributeIDTypeCluster{{compatClusterNameRemapping ../clusterName}}Attribute{{compatAttributeNameRemapping ../clusterName label}}ID {{availability (compatClusterNameRemapping ../clusterName) attribute=(compatAttributeNameRemapping ../clusterName label) isForIds=true minimalRelease="267F4B03-3256-4056-A62D-5237640FDCFE" deprecationMessage=(concat "Please use MTRAttributeIDType" (asUpperCamelCase ../clusterName preserveAcronyms=true) "Attribute" (asUpperCamelCase label preserveAcronyms=true) "ID")}} = MTRAttributeIDTypeCluster{{>cluster}}Attribute{{>attribute}}ID,
 {{/if}}
+{{/unless}}
 {{#last}}
 
 {{/last}}
@@ -140,12 +146,14 @@ typedef NS_ENUM(uint32_t, MTRCommandIDType) {
 {{/first}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandIdDecl"}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../clusterName preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (and (wasIntroducedBeforeRelease "267F4B03-3256-4056-A62D-5237640FDCFE" cluster command=command isForIds=true)
            (isSupported cluster command=command isForIds=true))}}
 MTRCluster{{cluster}}Command{{command}}ID
 {{availability cluster command=command deprecatedRelease="267F4B03-3256-4056-A62D-5237640FDCFE" deprecationMessage=(concat "Please use MTRCommandIDTypeCluster" (asUpperCamelCase ../clusterName preserveAcronyms=true) "Command" (asUpperCamelCase name preserveAcronyms=true) "ID") isForIds=true}}
 = {{asMEI manufacturerCode code}},
 {{/if}}
+{{/unless}}
 {{/inline}}
 {{> commandIdDecl cluster=(compatClusterNameRemapping ../clusterName)
                   command=(compatCommandNameRemapping ../clusterName name)}}
@@ -162,9 +170,11 @@ MTRCluster{{cluster}}Command{{command}}ID
 {{/first}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandIdDecl"}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../clusterName preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (isSupported cluster command=command isForIds=true)}}
 MTRCommandIDTypeCluster{{cluster}}Command{{command}}ID {{availability cluster command=command minimalRelease="267F4B03-3256-4056-A62D-5237640FDCFE" isForIds=true deprecationMessage=(concat "The " command " command will be removed")}} = {{asMEI manufacturerCode code}},
 {{/if}}
+{{/unless}}
 {{/inline}}
 {{> commandIdDecl cluster=(asUpperCamelCase ../clusterName preserveAcronyms=true)
                   command=(asUpperCamelCase name preserveAcronyms=true)}}
@@ -204,12 +214,14 @@ typedef NS_ENUM(uint32_t, MTREventIDType) {
 {{/if}}
 {{/if}}
 {{/first}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../clusterName preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (and (wasIntroducedBeforeRelease "267F4B03-3256-4056-A62D-5237640FDCFE" (compatClusterNameRemapping ../clusterName) event=(asUpperCamelCase name) isForIds=true)
            (isSupported (compatClusterNameRemapping ../clusterName) event=(asUpperCamelCase name) isForIds=true))}}
 MTRCluster{{compatClusterNameRemapping ../clusterName}}Event{{asUpperCamelCase name}}ID
 {{availability (compatClusterNameRemapping ../clusterName) event=(asUpperCamelCase name) deprecatedRelease="267F4B03-3256-4056-A62D-5237640FDCFE" deprecationMessage=(concat "Please use MTREventIDTypeCluster" (asUpperCamelCase ../clusterName preserveAcronyms=true) "Event" (asUpperCamelCase name preserveAcronyms=true) "ID") isForIds=true}}
 = {{asMEI manufacturerCode code}},
 {{/if}}
+{{/unless}}
 {{#last}}
 
 {{/last}}
@@ -222,9 +234,11 @@ MTRCluster{{compatClusterNameRemapping ../clusterName}}Event{{asUpperCamelCase n
 // Cluster {{>cluster}} events
 {{/if}}
 {{/first}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../clusterName preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true) isForIds=true)}}
 MTREventIDTypeCluster{{>cluster}}Event{{>event}}ID {{availability (asUpperCamelCase ../clusterName preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true) minimalRelease="267F4B03-3256-4056-A62D-5237640FDCFE" isForIds=true}} = {{asMEI manufacturerCode code}},
 {{/if}}
+{{/unless}}
 {{#last}}
 
 {{/last}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusterConstants_Private.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterConstants_Private.zapt
@@ -15,6 +15,16 @@ typedef NS_ENUM(uint32_t, MTRPrivateClusterIDType) {
 {{/if}}
 {{/if}}
 {{/zcl_clusters}}
+{{#zcl_clusters}}
+{{#if manufacturerCode}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+{{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
+{{~#*inline "cluster"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
+    MTRPrivateClusterIDType{{>cluster}}ID {{availability (asUpperCamelCase label preserveAcronyms=true) minimalRelease="267F4B03-3256-4056-A62D-5237640FDCFE" isForIds=true deprecationMessage=(concat "The " (asUpperCamelCase label preserveAcronyms=true) " cluster will be removed")}} = {{asMEI manufacturerCode code}},
+{{/if}}
+{{/if}}
+{{/if}}
+{{/zcl_clusters}}
 };
 
 #pragma mark - Private Attribute IDs
@@ -30,6 +40,25 @@ typedef NS_ENUM(uint32_t, MTRPrivateAttributeIDType) {
            (or clusterRef
                (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)))}}
     MTRPrivateAttributeIDTypeCluster{{>cluster}}Attribute{{>attribute}}ID {{availability (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) minimalRelease="267F4B03-3256-4056-A62D-5237640FDCFE" isForIds=true deprecationMessage=(concat "The " (asUpperCamelCase label preserveAcronyms=true) " attribute will be removed")}} = {{#if clusterRef}}{{asMEI manufacturerCode code}}{{else}}MTRAttributeIDTypeGlobalAttribute{{asUpperCamelCase label}}ID{{/if}},
+{{/if}}
+{{/zcl_attributes_server}}
+{{/inline}}
+
+{{> attributeIDs clusterName=label}}
+{{/if}}
+{{/zcl_clusters}}
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+{{#*inline "attributeIDs"}}
+{{#zcl_attributes_server}}
+{{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
+{{~#*inline "attribute"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
+{{#if manufacturerCode}}
+{{#if (and (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)
+           (or clusterRef
+               (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)))}}
+    MTRPrivateAttributeIDTypeCluster{{>cluster}}Attribute{{>attribute}}ID {{availability (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) minimalRelease="267F4B03-3256-4056-A62D-5237640FDCFE" isForIds=true deprecationMessage=(concat "The " (asUpperCamelCase label preserveAcronyms=true) " attribute will be removed")}} = {{#if clusterRef}}{{asMEI manufacturerCode code}}{{else}}MTRAttributeIDTypeGlobalAttribute{{asUpperCamelCase label}}ID{{/if}},
+{{/if}}
 {{/if}}
 {{/zcl_attributes_server}}
 {{/inline}}
@@ -57,6 +86,23 @@ typedef NS_ENUM(uint32_t, MTRPrivateCommandIDType) {
 {{> commandIDs clusterName=label}}
 {{/if}}
 {{/zcl_clusters}}
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+{{#*inline "commandIDs"}}
+{{#zcl_commands}}
+{{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
+{{~#*inline "command"}}{{asUpperCamelCase name preserveAcronyms=true}}{{/inline~}}
+{{#if manufacturerCode}}
+{{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true) isForIds=true)}}
+    MTRPrivateCommandIDTypeCluster{{>cluster}}Command{{>command}}ID {{availability (asUpperCamelCase ../clusterName preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true) minimalRelease="267F4B03-3256-4056-A62D-5237640FDCFE" isForIds=true deprecationMessage=(concat "The " (asUpperCamelCase name preserveAcronyms=true) " command will be removed")}} = {{asMEI manufacturerCode code}},
+{{/if}}
+{{/if}}
+{{/zcl_commands}}
+{{/inline}}
+
+{{> commandIDs clusterName=label}}
+{{/if}}
+{{/zcl_clusters}}
 };
 
 #pragma mark - Private Event IDs
@@ -70,6 +116,23 @@ typedef NS_ENUM(uint32_t, MTRPrivateEventIDType) {
 {{~#*inline "event"}}{{asUpperCamelCase name preserveAcronyms=true}}{{/inline~}}
 {{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true) isForIds=true)}}
     MTRPrivateEventIDTypeCluster{{>cluster}}Event{{>event}}ID {{availability (asUpperCamelCase ../clusterName preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true) minimalRelease="267F4B03-3256-4056-A62D-5237640FDCFE" isForIds=true}} = {{asMEI manufacturerCode code}},
+{{/if}}
+{{/zcl_events}}
+{{/inline}}
+
+{{> eventIDs clusterName=label}}
+{{/if}}
+{{/zcl_clusters}}
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+{{#*inline "eventIDs"}}
+{{#zcl_events}}
+{{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
+{{~#*inline "event"}}{{asUpperCamelCase name preserveAcronyms=true}}{{/inline~}}
+{{#if manufacturerCode}}
+{{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true) isForIds=true)}}
+    MTRPrivateEventIDTypeCluster{{>cluster}}Event{{>event}}ID {{availability (asUpperCamelCase ../clusterName preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true) minimalRelease="267F4B03-3256-4056-A62D-5237640FDCFE" isForIds=true}} = {{asMEI manufacturerCode code}},
+{{/if}}
 {{/if}}
 {{/zcl_events}}
 {{/inline}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusterConstants_Private.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterConstants_Private.zapt
@@ -15,16 +15,6 @@ typedef NS_ENUM(uint32_t, MTRPrivateClusterIDType) {
 {{/if}}
 {{/if}}
 {{/zcl_clusters}}
-{{#zcl_clusters}}
-{{#if manufacturerCode}}
-{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
-{{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
-{{~#*inline "cluster"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
-    MTRPrivateClusterIDType{{>cluster}}ID {{availability (asUpperCamelCase label preserveAcronyms=true) minimalRelease="267F4B03-3256-4056-A62D-5237640FDCFE" isForIds=true deprecationMessage=(concat "The " (asUpperCamelCase label preserveAcronyms=true) " cluster will be removed")}} = {{asMEI manufacturerCode code}},
-{{/if}}
-{{/if}}
-{{/if}}
-{{/zcl_clusters}}
 };
 
 #pragma mark - Private Attribute IDs

--- a/src/darwin/Framework/CHIP/templates/MTRClusterNames-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterNames-src.zapt
@@ -53,6 +53,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
 
 {{#*inline "attributeIDs"}}
 {{#zcl_attributes_server}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../clusterName preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
 {{~#*inline "attribute"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
 {{#first}}
@@ -68,6 +69,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
                 break;
 
 {{/if}}
+{{/unless}}
 {{/zcl_attributes_server}}
 {{/inline}}
 
@@ -110,6 +112,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
 
 {{#*inline "commandIDs"}}
 {{#zcl_commands}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../clusterName preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
 {{~#*inline "command"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
 {{#if (and (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) command=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)
@@ -119,6 +122,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
                 break;
 
 {{/if}}
+{{/unless}}
 {{/zcl_commands}}
 {{/inline}}
 
@@ -171,6 +175,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
 
 {{#*inline "eventIDs"}}
 {{#zcl_events}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase ../clusterName preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
 {{~#*inline "event"}}{{asUpperCamelCase name preserveAcronyms=true}}{{/inline~}}
 {{#first}}
@@ -184,6 +189,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
                 break;
 
 {{/if}}
+{{/unless}}
 {{/zcl_events}}
 {{/inline}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRClusterNames_Private-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterNames_Private-src.zapt
@@ -84,6 +84,48 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {{/if}}
 {{/if}}
 {{/zcl_clusters}}
+
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+{{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
+{{~#*inline "cluster"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
+        case MTRPrivateClusterIDType{{>cluster}}ID:
+
+            switch ((MTRPrivateAttributeIDType)attributeID) {
+
+{{#*inline "attributeIDs"}}
+{{#zcl_attributes_server}}
+{{#if manufacturerCode}}
+{{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
+{{~#*inline "attribute"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
+{{#first}}
+{{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) isForIds=true)}}
+// Cluster {{> cluster}} attributes
+{{/if}}
+{{/first}}
+{{#if (and (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) attribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)
+           (or clusterRef
+               (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)))}}
+            case MTRPrivateAttributeIDTypeCluster{{>cluster}}Attribute{{>attribute}}ID:
+                result = @"{{>attribute}}";
+                break;
+
+{{/if}}
+{{/if}}
+{{/zcl_attributes_server}}
+{{/inline}}
+
+{{> attributeIDs clusterName=label}}
+
+            default:
+                // Not a known {{asUpperCamelCase name preserveAcronyms=true}} attribute.
+                result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
+                break;
+        }
+        break;
+{{/if}}
+{{/if}}
+{{/zcl_clusters}}
         default:
            result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
            break;
@@ -118,6 +160,41 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
                 result = @"{{>command}}";
                 break;
 
+{{/if}}
+{{/zcl_commands}}
+{{/inline}}
+
+{{> commandIDs clusterName=label}}
+
+            default:
+                result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
+                break;
+        }
+        break;
+{{/if}}
+{{/if}}
+{{/zcl_clusters}}
+
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+{{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
+{{~#*inline "cluster"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
+        case MTRPrivateClusterIDType{{>cluster}}ID:
+
+            switch ((MTRPrivateCommandIDType)commandID) {
+
+{{#*inline "commandIDs"}}
+{{#zcl_commands}}
+{{#if manufacturerCode}}
+{{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
+{{~#*inline "command"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
+{{#if (and (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) command=(asUpperCamelCase label preserveAcronyms=true) isForIds=true)
+           (isStrEqual source ../../../source))}}
+            case MTRPrivateCommandIDTypeCluster{{>cluster}}Command{{>command}}ID:
+                result = @"{{>command}}";
+                break;
+
+{{/if}}
 {{/if}}
 {{/zcl_commands}}
 {{/inline}}
@@ -189,6 +266,45 @@ NSString * MTRPrivateEventNameForID(MTRClusterIDType clusterID, MTREventIDType e
 {{> eventIDs clusterName=label}}
 
 {{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
+            default:
+                result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
+                break;
+        }
+        break;
+{{/if}}
+{{/if}}
+{{/zcl_clusters}}
+
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+{{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
+{{~#*inline "cluster"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
+        case MTRPrivateClusterIDType{{>cluster}}ID:
+
+            switch ((MTRPrivateEventIDType)eventID) {
+
+{{#*inline "eventIDs"}}
+{{#zcl_events}}
+{{#if manufacturerCode}}
+{{~#*inline "cluster"}}{{asUpperCamelCase ../clusterName preserveAcronyms=true}}{{/inline~}}
+{{~#*inline "event"}}{{asUpperCamelCase name preserveAcronyms=true}}{{/inline~}}
+{{#first}}
+{{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) isForIds=true)}}
+// Cluster {{> cluster}} events
+{{/if}}
+{{/first}}
+{{#if (isSupported (asUpperCamelCase ../clusterName preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true) isForIds=true)}}
+            case MTRPrivateEventIDTypeCluster{{>cluster}}Event{{>event}}ID:
+                result = @"{{>event}}";
+                break;
+
+{{/if}}
+{{/if}}
+{{/zcl_events}}
+{{/inline}}
+
+{{> eventIDs clusterName=label}}
+
             default:
                 result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
                 break;

--- a/src/darwin/Framework/CHIP/templates/MTRClusterNames_Private-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterNames_Private-src.zapt
@@ -12,7 +12,7 @@ NSString * MTRPrivateClusterNameForID(MTRClusterIDType clusterID)
 {
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType)clusterID) {
+    switch ((MTRClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
@@ -40,7 +40,7 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType)clusterID) {
+    switch ((MTRClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
@@ -89,7 +89,7 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
 {{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
 {{~#*inline "cluster"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
-        case MTRPrivateClusterIDType{{>cluster}}ID:
+        case MTRClusterIDType{{>cluster}}ID:
 
             switch ((MTRPrivateAttributeIDType)attributeID) {
 
@@ -140,7 +140,7 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {{~#*inline "commandIDOutput"}}
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType)clusterID) {
+    switch ((MTRClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
@@ -179,7 +179,7 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
 {{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
 {{~#*inline "cluster"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
-        case MTRPrivateClusterIDType{{>cluster}}ID:
+        case MTRClusterIDType{{>cluster}}ID:
 
             switch ((MTRPrivateCommandIDType)commandID) {
 
@@ -233,7 +233,7 @@ NSString * MTRPrivateEventNameForID(MTRClusterIDType clusterID, MTREventIDType e
 {
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType)clusterID) {
+    switch ((MTRClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
@@ -279,7 +279,7 @@ NSString * MTRPrivateEventNameForID(MTRClusterIDType clusterID, MTREventIDType e
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
 {{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
 {{~#*inline "cluster"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
-        case MTRPrivateClusterIDType{{>cluster}}ID:
+        case MTRClusterIDType{{>cluster}}ID:
 
             switch ((MTRPrivateEventIDType)eventID) {
 

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -5,6 +5,7 @@
 @implementation MTRCluster{{asUpperCamelCase name preserveAcronyms=true}}
 
 {{#zcl_commands}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase parent.name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandImpl"}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
@@ -31,9 +32,11 @@ MTR{{cluster}}Cluster{{command}}Params
 {{> commandImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}
+{{/unless}}
 {{/zcl_commands}}
 
 {{#zcl_attributes_server}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase parent.name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{! This is used as the implementation for both the new-name and old-name bits, so check for both here. }}
 {{#if (and
         (or clusterRef
@@ -69,6 +72,7 @@ MTR{{cluster}}Cluster{{command}}Params
 {{/if}}
 
 {{/if}}
+{{/unless}}
 {{/zcl_attributes_server}}
 
 @end

--- a/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} : MTRGenericCluster
 
 {{#zcl_commands}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase parent.name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandDecl"}}
@@ -47,9 +48,11 @@ NS_ASSUME_NONNULL_BEGIN
 {{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}
+{{/unless}}
 {{/zcl_commands}}
 
 {{#zcl_attributes_server}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase parent.name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (and (or clusterRef
                (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true)))
            (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true)))}}
@@ -64,6 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params {{> availability}};
 {{/if}}
 {{/if}}
+{{/unless}}
 {{/zcl_attributes_server}}
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/templates/MTRClusters_Private.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_Private.zapt
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Cluster {{name}}
  *    {{description}}
  */
-@interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} : MTRGenericCluster
+@interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} (PrivateExtensions)
 
 {{#zcl_commands}}
 {{#if manufacturerCode}}
@@ -118,28 +118,6 @@ NS_ASSUME_NONNULL_BEGIN
 {{/if}}
 {{/if}}
 {{/zcl_attributes_server}}
-
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} (Availability)
-
-/**
-{{#zcl_commands}}
-{{#first}}
- * For all instance methods that take a completion (i.e. command invocations),
- * the completion will be called on the provided queue.
-{{/first}}
-{{else}}
- * The queue is currently unused, but may be used in the future for calling completions
- * for command invocations if commands are added to this cluster.
-{{/zcl_commands}}
- */
-- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
-                              endpointID:(NSNumber *)endpointID
-                                   queue:(dispatch_queue_t)queue;
 
 @end
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusters_Private.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_Private.zapt
@@ -9,15 +9,7 @@
 NS_ASSUME_NONNULL_BEGIN
 {{> placeholder_comment}}
 
-{{#zcl_clusters}}
-{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
-
-/**
- * Cluster {{name}}
- *    {{description}}
- */
-@interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} : MTRGenericCluster
-
+{{#*inline "commandDeclarations"}}
 {{#zcl_commands}}
 {{#if (is_str_equal source 'client')}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
@@ -30,7 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
 {{/if}}
 {{/zcl_commands}}
+{{/inline}}
 
+{{#*inline "attributeDeclarations"}}
 {{#zcl_attributes_server}}
 {{#if (and (or clusterRef
                (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true)))
@@ -41,6 +35,86 @@ NS_ASSUME_NONNULL_BEGIN
       (isInConfigList (concat (asUpperCamelCase parent.name) "::" label) "DarwinForceWritable"))}}
 - (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
 - (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params;
+{{/if}}
+{{/if}}
+{{/zcl_attributes_server}}
+{{/inline}}
+
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
+
+/**
+ * Cluster {{name}}
+ *    {{description}}
+ */
+@interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} : MTRGenericCluster
+
+{{> commandDeclarations}}
+
+{{> attributeDeclarations}}
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+@interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} (Availability)
+
+/**
+{{#zcl_commands}}
+{{#first}}
+ * For all instance methods that take a completion (i.e. command invocations),
+ * the completion will be called on the provided queue.
+{{/first}}
+{{else}}
+ * The queue is currently unused, but may be used in the future for calling completions
+ * for command invocations if commands are added to this cluster.
+{{/zcl_commands}}
+ */
+- (instancetype _Nullable)initWithDevice:(MTRDevice *)device
+                              endpointID:(NSNumber *)endpointID
+                                   queue:(dispatch_queue_t)queue;
+
+@end
+{{/if}}
+{{/zcl_clusters}}
+
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+
+/**
+ * Cluster {{name}}
+ *    {{description}}
+ */
+@interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} : MTRGenericCluster
+
+{{#zcl_commands}}
+{{#if manufacturerCode}}
+{{#if (is_str_equal source 'client')}}
+{{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
+{{#*inline "commandDecl"}}
+{{#if (isSupported cluster command=command)}}
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion;
+{{/if}}
+{{/inline}}
+{{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
+                command=(asUpperCamelCase name preserveAcronyms=true)}}
+{{/if}}
+{{/if}}
+{{/zcl_commands}}
+
+{{#zcl_attributes_server}}
+{{#if manufacturerCode}}
+{{#if (and (or clusterRef
+               (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true)))
+           (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true)))}}
+{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
+- (NSDictionary<NSString *, id> * _Nullable)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params;
+{{#if (or isWritableAttribute
+      (isInConfigList (concat (asUpperCamelCase parent.name) "::" label) "DarwinForceWritable"))}}
+- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
+- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params;
+{{/if}}
 {{/if}}
 {{/if}}
 {{/zcl_attributes_server}}

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
@@ -15,6 +15,7 @@ static void LogAndConvertDecodingError(CHIP_ERROR err, NSError * __autoreleasing
 
 {{#zcl_clusters}}
 {{#zcl_commands}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase parent.name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#*inline "completeImpl"}}
 {{#if (isSupported cluster command=command isForCommandPayload=true)}}
 @implementation MTR{{cluster}}Cluster{{command}}Params
@@ -186,6 +187,7 @@ static void LogAndConvertDecodingError(CHIP_ERROR err, NSError * __autoreleasing
                  command=(compatCommandNameRemapping parent.name name)
                  includeRenamedProperties=true}}
 {{/if}}
+{{/unless}}
 {{/zcl_commands}}
 {{/zcl_clusters}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#zcl_clusters}}
 {{#zcl_commands}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase parent.name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#*inline "completeDecl"}}
 {{#if (isSupported cluster command=command isForCommandPayload=true)}}
 
@@ -52,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
                  base="NSObject <NSCopying>"
                  includeInitWithResponseValue=true}}
 {{/if}}
+{{/unless}}
 {{/zcl_commands}}
 {{/zcl_clusters}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc_Private.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc_Private.zapt
@@ -55,4 +55,53 @@ NS_ASSUME_NONNULL_BEGIN
 {{/if}}
 {{/zcl_clusters}}
 
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+{{#zcl_commands}}
+{{#if manufacturerCode}}
+{{#*inline "completeDecl"}}
+{{#if (isSupported cluster command=command isForCommandPayload=true)}}
+
+@interface MTR{{cluster}}Cluster{{command}}Params : {{base}}
+{{#zcl_command_arguments}}
+
+{{#if (isSupported ../cluster command=../command commandField=(asStructPropertyName label))}}
+{{> struct_field_decl cluster=parent.parent.name originalCluster=parent.parent.name type=type label=label}};
+{{/if}}
+{{#*inline "oldNameFieldDecl"}}
+
+{{#if (isSupported ../cluster command=../command commandField=commandField)}}
+{{> struct_field_decl cluster=parent.parent.name originalCluster=parent.parent.name type=type label=commandField}};
+{{/if}}
+{{/inline}}
+{{#if (and includeRenamedProperties
+           (hasOldName ../cluster command=../command commandField=(asStructPropertyName label)))}}
+{{> oldNameFieldDecl commandField=(oldName ../cluster command=../command commandField=(asStructPropertyName label))}}
+{{/if}}
+{{/zcl_command_arguments}}
+{{> command_timed_invoke_properties}}
+{{> command_init_with_response_value_decl cluster=cluster command=command includeInitWithResponseValue=includeInitWithResponseValue}}
+@end
+{{/if}}
+{{/inline}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true))}}
+{{> completeDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
+                 command=(asUpperCamelCase name preserveAcronyms=true)
+                 includeRenamedProperties=false
+                 base="NSObject <NSCopying>"
+                 includeInitWithResponseValue=true}}
+{{> command_old_name_decl}}
+{{> command_deprecated_fields_decl cluster=(asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true)}}
+{{else}}
+{{> completeDecl cluster=(compatClusterNameRemapping parent.name)
+                 command=(compatCommandNameRemapping parent.name name)
+                 includeRenamedProperties=true
+                 base="NSObject <NSCopying>"
+                 includeInitWithResponseValue=true}}
+{{/if}}
+{{/if}}
+{{/zcl_commands}}
+{{/if}}
+{{/zcl_clusters}}
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloads_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloads_Internal.zapt
@@ -10,11 +10,13 @@ NS_ASSUME_NONNULL_BEGIN
 {{#zcl_clusters}}
 {{#unless (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
 {{#zcl_commands}}
+{{#unless (and manufacturerCode (isInConfigList (asUpperCamelCase parent.name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions"))}}
 {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true) isForCommandPayload=true)}}
 
 {{> command_internal_methods_decl categoryName="InternalMethods"}}
 
 {{/if}}
+{{/unless}}
 {{/zcl_commands}}
 {{/unless}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/config-data.yaml
+++ b/src/darwin/Framework/CHIP/templates/config-data.yaml
@@ -21,3 +21,6 @@ LegacyCommandsWithOnlyOptionalArguments:
 
 # Clusters that should have private headers/implementations generated.
 DarwinPrivateClusters: []
+
+# Clusters with private extensions that should have private headers/implementations generated.
+DarwinClustersWithPrivateExtensions: []

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters_Private.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters_Private.h
@@ -16,6 +16,7 @@
  */
 
 #import "MTRCommandPayloadsObjc_Private.h"
+#import <Matter/MTRBaseClusters.h>
 #import <Matter/MTRCluster.h>
 #import <Matter/MTRClusterStateCacheContainer.h>
 #import <Matter/MTRCommandPayloadsObjc.h>

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterNames_Private.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterNames_Private.mm
@@ -26,7 +26,7 @@ NSString * MTRPrivateClusterNameForID(MTRClusterIDType clusterID)
 {
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType) clusterID) {
+    switch ((MTRClusterIDType) clusterID) {
 
     default:
         result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
@@ -42,7 +42,7 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType) clusterID) {
+    switch ((MTRClusterIDType) clusterID) {
 
     default:
         result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
@@ -58,7 +58,7 @@ NSString * MTRPrivateRequestCommandNameForID(MTRClusterIDType clusterID, MTRComm
 {
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType) clusterID) {
+    switch ((MTRClusterIDType) clusterID) {
 
     default:
         result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
@@ -72,7 +72,7 @@ NSString * MTRPrivateResponseCommandNameForID(MTRClusterIDType clusterID, MTRCom
 {
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType) clusterID) {
+    switch ((MTRClusterIDType) clusterID) {
 
     default:
         result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
@@ -88,7 +88,7 @@ NSString * MTRPrivateEventNameForID(MTRClusterIDType clusterID, MTREventIDType e
 {
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType) clusterID) {
+    switch ((MTRClusterIDType) clusterID) {
 
     default:
         result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];


### PR DESCRIPTION
#### Summary

Conditionalize templates for cluster extensions.  Utilizes similar mutual exclusion technique to whole clusters, but also checks for the presence of `manufacturerCode` to discern which extensions are intended for public vs private generation.

#### Testing

1. add a cluster extension XML to `src/app/zap-templates/zcl/data-model/chip`
3. add a cluster extension XML filename to `src/app/zap-templates/zcl/zcl.json`
4. add the cluster extension parent cluster name (CamelCase) to `src/darwin/Framework/CHIP/templates/config-data.yaml`
5. `./scripts/tools/zap_regen_all.py --type specific`

Expected result:  cluster extension attributes/commands/events placed in Darwin `_Private` source files.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase