### PR TITLE
Thread: use `tmp` path in isolation environment

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -312,6 +312,7 @@ jobs:
                    -DCMAKE_BUILD_TYPE=Debug \
                    -DOTBR_BORDER_ROUTING=ON \
                    -DOTBR_MDNS=openthread \
+                   -DOT_POSIX_SETTINGS_PATH='\"tmp\"' \
                    -DOT_FIREWALL=OFF \
                    -DOT_LOG_LEVEL=INFO \
                    -DOT_TREL=OFF \

--- a/scripts/tests/chiptest/linux.py
+++ b/scripts/tests/chiptest/linux.py
@@ -69,13 +69,6 @@ def ensure_private_state():
         log.error("Are you using --privileged if running in docker?")
         sys.exit(1)
 
-    # TODO remove this mount once otbr-agent doesn't require it anymore
-    log.debug("Remounting /var/lib/thread")
-    if subprocess.run(["mount", "-t", "tmpfs", "tmpfs", "/var/lib/thread"]).returncode != 0:
-        log.error("Failed to mount /var/lib/thread as a temporary filesystem")
-        log.error("Are you using --privileged if running in docker?")
-        sys.exit(1)
-
 
 class IsolatedNetworkNamespace:
     """Helper class to create and remove network namespaces for tests."""


### PR DESCRIPTION
#### Summary

This commit changes the OpenThread Border Router settings path to a `tmp` so that the `/var/lib/thread` is not required.

#### Related issues

This was recently reported due to merge of #42336.

#### Testing

The BLE-Thread test case will cover the change.