### PR TITLE
Revert "Fix TCP reuse_addr (#42789)"

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -98,7 +98,8 @@ CHIP_ERROR TCPBase::Init(TcpListenParameters & params)
 
     if (params.IsServerListenEnabled())
     {
-        err = mListenSocket->Bind(params.GetAddressType(), Inet::IPAddress::Any, params.GetListenPort(), /* reuseAddr = */ true);
+        err = mListenSocket->Bind(params.GetAddressType(), Inet::IPAddress::Any, params.GetListenPort(),
+                                  params.GetInterfaceId().IsPresent());
         SuccessOrExit(err);
 
         mListenSocket->mAppState            = reinterpret_cast<void *>(this);


### PR DESCRIPTION
This reverts commit eb445a21270e6acb22f27319f45ae1544b1d2990.

#### Summary

TC_ACL_2_10 seems very flaky and this is the first PR that this shows up on master.

#### Testing

CI will check if ACL_2_10 now starts passing again ...