### PR TITLE
[silabs in cloudbuild] Disable light RPC support/test from cloudbuild.

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -74,7 +74,6 @@ steps:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
               --target efr32-brd4187c-light
-              --target efr32-brd4187c-light-rpc
               --target efr32-brd4187c-lock-openthread-mtd
               --target efr32-brd4187c-lock-rpc-openthread-mtd
               build


### PR DESCRIPTION
#### Summary

This does not work because pw_sync not compiling.
This example pulls pw_tracing which needs pw_sync.

This is the minimal change for now - we could also update the lighting app (e.g. remove tracing) or figure out a way to have a pw_sync backend, however those are larger changes.

#### Testing

Trivial change. Cloudbuild not tested by CI.