### PR TITLE
[Bugfix] Validate an ICAC is actually an ICAC in AddNOC/UpdateNOC 

### DIFF
--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -416,6 +416,10 @@ CHIP_ERROR FabricTable::VerifyCredentials(ByteSpan noc, ByteSpan icac, ByteSpan 
     if (!icac.empty())
     {
         ReturnErrorOnFailure(certificates.LoadCert(icac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)));
+        const ChipDN & icacSubjectDN = certificates.GetLastCert()[0].mSubjectDN;
+        CertType certType;
+        ReturnErrorOnFailure(icacSubjectDN.GetCertType(certType));
+        VerifyOrReturnError(certType == CertType::kICA, CHIP_ERROR_WRONG_CERT_DN);
     }
 
     ReturnErrorOnFailure(certificates.LoadCert(noc, BitFlags<CertDecodeFlags>(CertDecodeFlags::kGenerateTBSHash)));

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -595,10 +595,10 @@ TEST_F(TestFabricTable, TestSetLastKnownGoodTime)
     }
 }
 
-// This test validates that the ICAC is properly validated per the specification. In particular, an ICAC is identified by its
-// subject DN encoding exactly one matter-icac-id attribute and none of the prohibited attributes (such as matter-rcac-id).
-// Therefore passing a root certificate as the ICAC must be rejected.
-TEST_F(TestFabricTable, ShouldFailAddNocUpdateNocIfIcacIsNotIcac)
+//  This test validates that the ICAC is properly validated per the specification. In particular, an ICAC is identified by its
+//  subject DN encoding exactly one matter-icac-id attribute and none of the prohibited attributes (such as matter-rcac-id).
+//  Therefore passing a root certificate as the ICAC must be rejected.
+TEST_F(TestFabricTable, FailAddNocAndUpdateNocIfIcacSubjectDnIsInvalid)
 {
     chip::TestPersistentStorageDelegate storage;
 
@@ -616,8 +616,9 @@ TEST_F(TestFabricTable, ShouldFailAddNocUpdateNocIfIcacIsNotIcac)
     memcpy(opKeysSerialized.Bytes() + TestCerts::sTestCert_Node01_02_PublicKey.size(),
            TestCerts::sTestCert_Node01_02_PrivateKey.data(), TestCerts::sTestCert_Node01_02_PrivateKey.size());
 
-    // sTestCert_Node01_02_Chip is chained directly to sTestCert_Root01_Chip, with no ICAC in the chain. These tests intentionally
-    // pass the root certificate as the ICAC to verify compliant ICAC validation.
+    // sTestCert_Node01_02_Chip is chained directly to sTestCert_Root01_Chip, with no ICAC in the chain.
+    // These tests intentionally pass RCAC as the ICAC to verify that a certificate whose subject DN encodes matter-rcac-id and not
+    // matter-icac-id is rejected.
     ByteSpan rcacSpan(TestCerts::sTestCert_Root01_Chip);
     ByteSpan icacSpan(TestCerts::sTestCert_Root01_Chip);
     ByteSpan nocSpan(TestCerts::sTestCert_Node01_02_Chip);
@@ -626,7 +627,8 @@ TEST_F(TestFabricTable, ShouldFailAddNocUpdateNocIfIcacIsNotIcac)
                                               TestCerts::sTestCert_Node01_02_PrivateKey.size()));
     EXPECT_SUCCESS(opKey_Node01_02.Deserialize(opKeysSerialized));
 
-    // Test 1: AddNOC must reject a certificate that does not meet ICAC subject DN requirements.
+    // Test 1: AddNOC must reject a certificate presented as an ICAC whose subject DN encodes matter-rcac-id instead of
+    // matter-icac-id.
     {
         EXPECT_SUCCESS(fabricTable.AddNewPendingTrustedRootCert(rcacSpan));
 
@@ -637,9 +639,9 @@ TEST_F(TestFabricTable, ShouldFailAddNocUpdateNocIfIcacIsNotIcac)
         fabricTable.RevertPendingFabricData();
     }
 
-    // Test 2: UpdateNOC must reject a certificate that does not meet ICAC subject DN requirements.
+    // Test 2: UpdateNOC must reject a certificate presented as an ICAC whose subject DN encodes matter-rcac-id instead of
+    // matter-icac-id.
     {
-
         EXPECT_SUCCESS(fabricTable.AddNewPendingTrustedRootCert(rcacSpan));
         EXPECT_SUCCESS(fabricTable.AddNewPendingFabricWithProvidedOpKey(nocSpan, ByteSpan{}, VendorId::TestVendor1,
                                                                         &opKey_Node01_02,
@@ -654,6 +656,21 @@ TEST_F(TestFabricTable, ShouldFailAddNocUpdateNocIfIcacIsNotIcac)
         EXPECT_EQ(CHIP_ERROR_UNSUPPORTED_CERT_FORMAT,
                   fabricTable.UpdatePendingFabricWithOperationalKeystore(fabricIndex, nocSpan, icacSpan,
                                                                          FabricTable::AdvertiseIdentity::No));
+    }
+
+    // Test 3: Directly validate that the shared VerifyCredentials method used by both AddNOC and UpdateNOC rejects a certificate
+    // presented as an ICAC whose subject DN encodes matter-rcac-id instead of matter-icac-id.
+    {
+        Credentials::ValidationContext validContext;
+        CompressedFabricId compressedFabricId = kUndefinedCompressedFabricId;
+        NodeId nodeId                         = kUndefinedNodeId;
+        FabricId fabricId                     = kUndefinedFabricId;
+        Crypto::P256PublicKey nocPubKey;
+        Crypto::P256PublicKey rootPublicKey;
+
+        EXPECT_EQ(CHIP_ERROR_WRONG_CERT_DN,
+                  fabricTable.VerifyCredentials(nocSpan, icacSpan, rcacSpan, validContext, compressedFabricId, fabricId, nodeId,
+                                                nocPubKey, &rootPublicKey));
     }
 }
 

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -595,6 +595,68 @@ TEST_F(TestFabricTable, TestSetLastKnownGoodTime)
     }
 }
 
+// This test validates that the ICAC is properly validated per the specification. In particular, an ICAC is identified by its
+// subject DN encoding exactly one matter-icac-id attribute and none of the prohibited attributes (such as matter-rcac-id).
+// Therefore passing a root certificate as the ICAC must be rejected.
+TEST_F(TestFabricTable, ShouldFailAddNocUpdateNocIfIcacIsNotIcac)
+{
+    chip::TestPersistentStorageDelegate storage;
+
+    // Initialize a fabric table.
+    ScopedFabricTable fabricTableHolder;
+    EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
+    FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
+
+    Crypto::P256SerializedKeypair opKeysSerialized;
+    FabricIndex fabricIndex;
+    static Crypto::P256Keypair opKey_Node01_02;
+
+    memcpy(opKeysSerialized.Bytes(), TestCerts::sTestCert_Node01_02_PublicKey.data(),
+           TestCerts::sTestCert_Node01_02_PublicKey.size());
+    memcpy(opKeysSerialized.Bytes() + TestCerts::sTestCert_Node01_02_PublicKey.size(),
+           TestCerts::sTestCert_Node01_02_PrivateKey.data(), TestCerts::sTestCert_Node01_02_PrivateKey.size());
+
+    // sTestCert_Node01_02_Chip is chained directly to sTestCert_Root01_Chip, with no ICAC in the chain. These tests intentionally
+    // pass the root certificate as the ICAC to verify compliant ICAC validation.
+    ByteSpan rcacSpan(TestCerts::sTestCert_Root01_Chip);
+    ByteSpan icacSpan(TestCerts::sTestCert_Root01_Chip);
+    ByteSpan nocSpan(TestCerts::sTestCert_Node01_02_Chip);
+
+    EXPECT_SUCCESS(opKeysSerialized.SetLength(TestCerts::sTestCert_Node01_02_PublicKey.size() +
+                                              TestCerts::sTestCert_Node01_02_PrivateKey.size()));
+    EXPECT_SUCCESS(opKey_Node01_02.Deserialize(opKeysSerialized));
+
+    // Test 1: AddNOC must reject a certificate that does not meet ICAC subject DN requirements.
+    {
+        EXPECT_SUCCESS(fabricTable.AddNewPendingTrustedRootCert(rcacSpan));
+
+        EXPECT_EQ(CHIP_ERROR_UNSUPPORTED_CERT_FORMAT,
+                  fabricTable.AddNewPendingFabricWithProvidedOpKey(nocSpan, icacSpan, VendorId::TestVendor1, &opKey_Node01_02,
+                                                                   /*isExistingOpKeyExternallyOwned =*/true, &fabricIndex));
+        // Clean up pending state
+        fabricTable.RevertPendingFabricData();
+    }
+
+    // Test 2: UpdateNOC must reject a certificate that does not meet ICAC subject DN requirements.
+    {
+
+        EXPECT_SUCCESS(fabricTable.AddNewPendingTrustedRootCert(rcacSpan));
+        EXPECT_SUCCESS(fabricTable.AddNewPendingFabricWithProvidedOpKey(nocSpan, ByteSpan{}, VendorId::TestVendor1,
+                                                                        &opKey_Node01_02,
+                                                                        /*isExistingOpKeyExternallyOwned =*/true, &fabricIndex));
+        EXPECT_SUCCESS(fabricTable.CommitPendingFabricData());
+
+        uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
+        MutableByteSpan csrSpan{ csrBuf };
+        EXPECT_SUCCESS(
+            fabricTable.AllocatePendingOperationalKey(chip::MakeOptional(static_cast<FabricIndex>(fabricIndex)), csrSpan));
+
+        EXPECT_EQ(CHIP_ERROR_UNSUPPORTED_CERT_FORMAT,
+                  fabricTable.UpdatePendingFabricWithOperationalKeystore(fabricIndex, nocSpan, icacSpan,
+                                                                         FabricTable::AdvertiseIdentity::No));
+    }
+}
+
 // Test adding 2 fabrics, updating 1, removing 1
 TEST_F(TestFabricTable, TestBasicAddNocUpdateNocFlow)
 {


### PR DESCRIPTION
#### Summary

- Fixes https://github.com/project-chip/connectedhomeip/issues/42479

- before this fix, it was possible to present a RCAC as an ICAC in a call to AddNOC or UpdateNOC.
- This PR adds validation that a certificate passed as ICAC is actually an ICAC by calling `ChipDN::GetCertType` which validates that it contains the correct Subject DN; `matter-icac-id` only and none of the forbidden subject DNs.

#### Testing

Added Unit Test

