### PR TITLE
Disable CADMIN 1.27 and 1.28 in CI

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -13,6 +13,14 @@ not_automated:
       reason:
           Attribute is not implemented in the bridge app. Same code as
           BINFO-3.1, which is run in the CI
+    - name: TC_CADMIN_1_27.py
+      reason:
+          Flaky, see
+          https://github.com/project-chip/connectedhomeip/issues/41813
+    - name: TC_CADMIN_1_28.py
+      reason:
+          Flaky, see
+          https://github.com/project-chip/connectedhomeip/issues/41813
     - name: TC_CNET_4_2.py
       reason: It has no CI execution block, it not executed in CI
     - name: TC_CNET_4_1.py


### PR DESCRIPTION
#### Summary

TC_CADMIN_1_27 and TC_CADMIN_1_28 have been failing inconsistently on CI for a long time. This PR adds them to the ignore list for CI automation. We still need to fix these tests, but this will eliminate the impact on CI for now. 

#### Related issues

#41813

#### Testing

Validate that these are skipped in CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
