### PR TITLE
[TSTAT] Remove deprecated elements from TC-TSTAT-2.1

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
@@ -223,28 +223,8 @@ tests:
               minValue: -27315
               maxValue: 32767
 
-    - label: "Step 9: TH reads the PICoolingDemand attribute from the DUT"
-      PICS: TSTAT.S.A0007
-      command: "readAttribute"
-      attribute: "PICoolingDemand"
-      response:
-          constraints:
-              type: int8u
-              minValue: 0
-              maxValue: 100
-
-    - label: "Step 10: TH reads the PIHeatingDemand attribute from the DUT"
-      PICS: TSTAT.S.A0008
-      command: "readAttribute"
-      attribute: "PIHeatingDemand"
-      response:
-          constraints:
-              type: int8u
-              minValue: 0
-              maxValue: 100
-
     - label:
-          "Step 11: TH reads the LocalTemperatureCalibration attribute from the
+          "Step 9: TH reads the LocalTemperatureCalibration attribute from the
           DUT"
       PICS: TSTAT.S.A0010
       command: "readAttribute"
@@ -255,7 +235,7 @@ tests:
               minValue: -127
               maxValue: 127
 
-    - label: "Step 12a: TH reads attribute OccupiedCoolingSetpoint from the DUT"
+    - label: "Step 10a: TH reads attribute OccupiedCoolingSetpoint from the DUT"
       PICS: TSTAT.S.F01 && TSTAT.S.A0017 && TSTAT.S.A0018
       command: "readAttribute"
       attribute: "OccupiedCoolingSetpoint"
@@ -265,7 +245,7 @@ tests:
               minValue: MinCoolSetpointLimitValue
               maxValue: MaxCoolSetpointLimitValue
 
-    - label: "Step 12b: TH reads attribute OccupiedCoolingSetpoint from the DUT"
+    - label: "Step 10b: TH reads attribute OccupiedCoolingSetpoint from the DUT"
       PICS: TSTAT.S.F01 && !TSTAT.S.A0017 && !TSTAT.S.A0018
       command: "readAttribute"
       attribute: "OccupiedCoolingSetpoint"
@@ -276,7 +256,7 @@ tests:
               maxValue: 3200
 
     - label:
-          "Step 13a: TH reads attribute OccupiedHeatingSetpoint if TSTAT.S.F05
+          "Step 11a: TH reads attribute OccupiedHeatingSetpoint if TSTAT.S.F05
           feature is supported"
       PICS: TSTAT.S.F05 && TSTAT.S.F00
       command: "readAttribute"
@@ -287,7 +267,7 @@ tests:
               minValue: AbsMinCoolSetpointLimitStep5
               maxValue: OccupiedCoolingSetpointValue - MinSetpointDeadBandValue
 
-    - label: "Step 13b: TH reads attribute OccupiedHeatingSetpoint from the DUT"
+    - label: "Step 11b: TH reads attribute OccupiedHeatingSetpoint from the DUT"
       PICS: TSTAT.S.F00 && !TSTAT.S.F05
       command: "readAttribute"
       attribute: "OccupiedHeatingSetpoint"
@@ -298,7 +278,7 @@ tests:
               maxValue: 3000
 
     - label:
-          "Step 14a: TH reads UnoccupiedCoolingSetpoint attribute from the DUT"
+          "Step 12a: TH reads UnoccupiedCoolingSetpoint attribute from the DUT"
       PICS: TSTAT.S.F05 && TSTAT.S.A0013
       command: "readAttribute"
       attribute: "UnoccupiedCoolingSetpoint"
@@ -309,7 +289,7 @@ tests:
               maxValue: AbsMaxHeatValue
 
     - label:
-          "Step 14b: TH reads UnoccupiedCoolingSetpoint attribute from the DUT"
+          "Step 12b: TH reads UnoccupiedCoolingSetpoint attribute from the DUT"
       PICS: TSTAT.S.F01 && TSTAT.S.F02 && !TSTAT.S.F05
       command: "readAttribute"
       attribute: "UnoccupiedCoolingSetpoint"
@@ -320,7 +300,7 @@ tests:
               maxValue: 3200
 
     - label:
-          "Step 15a: TH reads UnoccupiedHeatingSetpoint attribute from the DUT"
+          "Step 13a: TH reads UnoccupiedHeatingSetpoint attribute from the DUT"
       PICS: TSTAT.S.F00 && TSTAT.S.F02 && TSTAT.S.F05 && TSTAT.S.A0013
       command: "readAttribute"
       attribute: "UnoccupiedHeatingSetpoint"
@@ -332,7 +312,7 @@ tests:
                   UnoccupiedCoolingSetpointValue - MinSetpointDeadBandValue
 
     - label:
-          "Step 15b: TH reads UnoccupiedHeatingSetpoint attribute from the DUT"
+          "Step 13b: TH reads UnoccupiedHeatingSetpoint attribute from the DUT"
       PICS: TSTAT.S.F00 && TSTAT.S.F02 && !TSTAT.S.F05
       command: "readAttribute"
       attribute: "UnoccupiedHeatingSetpoint"
@@ -342,7 +322,7 @@ tests:
               minValue: 700
               maxValue: 3000
 
-    - label: "Step 16a: TH reads attribute from DUT: MinHeatSetpointLimit"
+    - label: "Step 14a: TH reads attribute from DUT: MinHeatSetpointLimit"
       PICS: TSTAT.S.A0015 && TSTAT.S.F05 && TSTAT.S.A0017 && TSTAT.S.A0019
       command: "readAttribute"
       attribute: "MinHeatSetpointLimit"
@@ -353,7 +333,7 @@ tests:
               maxValue: MinCoolSetpointLimitValue - MinSetpointDeadBandValue
 
     - label:
-          "Step 16b: TH reads MinHeatSetpointLimit attribute from Server DUT and
+          "Step 14b: TH reads MinHeatSetpointLimit attribute from Server DUT and
           verifies that the value is within range"
       command: "readAttribute"
       attribute: "MinHeatSetpointLimit"
@@ -366,7 +346,7 @@ tests:
 
     #Using hard coded values when optional attributes are not available
     - label:
-          "Step 16c: TH reads MinHeatSetpointLimit attribute from Server DUT and
+          "Step 14c: TH reads MinHeatSetpointLimit attribute from Server DUT and
           verifies that the value is within range"
       command: "readAttribute"
       attribute: "MinHeatSetpointLimit"
@@ -377,7 +357,7 @@ tests:
               minValue: 700
               maxValue: 3000
 
-    - label: "Step 17a: TH reads attribute MaxHeatSetpointLimit from the DUT"
+    - label: "Step 15a: TH reads attribute MaxHeatSetpointLimit from the DUT"
       PICS: TSTAT.S.A0016 && !TSTAT.S.F05
       command: "readAttribute"
       attribute: "MaxHeatSetpointLimit"
@@ -387,7 +367,7 @@ tests:
               minValue: 700
               maxValue: 3000
 
-    - label: "Step 17b: TH reads attribute from DUT: MaxHeatSetpointLimit"
+    - label: "Step 15b: TH reads attribute from DUT: MaxHeatSetpointLimit"
       PICS: TSTAT.S.A0016 && TSTAT.S.F05 && TSTAT.S.A0018
       command: "readAttribute"
       attribute: "MaxHeatSetpointLimit"
@@ -397,7 +377,7 @@ tests:
               minValue: 700
               maxValue: MaxCoolSetpointLimitValue - MinSetpointDeadBandValue
 
-    - label: "Step 18a: TH reads attribute MinCoolSetpointLimit from DUT"
+    - label: "Step 16a: TH reads attribute MinCoolSetpointLimit from DUT"
       PICS: TSTAT.S.A0017 && TSTAT.S.A0018 && TSTAT.S.A0005
       command: "readAttribute"
       attribute: "MinCoolSetpointLimit"
@@ -407,7 +387,7 @@ tests:
               minValue: AbsMinCoolSetpointLimitStep5
               maxValue: MaxCoolSetpointLimitValue
 
-    - label: "Step 18b: TH reads attribute MinCoolSetpointLimit from DUT"
+    - label: "Step 16b: TH reads attribute MinCoolSetpointLimit from DUT"
       PICS: TSTAT.S.A0017 && !TSTAT.S.A0018 && !TSTAT.S.A0005
       command: "readAttribute"
       attribute: "MinCoolSetpointLimit"
@@ -417,7 +397,7 @@ tests:
               minValue: 1600
               maxValue: 3200
 
-    - label: "Step 19: TH reads the MaxCoolSetpointLimit attribute from the DUT"
+    - label: "Step 17: TH reads the MaxCoolSetpointLimit attribute from the DUT"
       PICS: TSTAT.S.A0018 && TSTAT.S.A0006 && TSTAT.S.A0017
       command: "readAttribute"
       attribute: "MaxCoolSetpointLimit"
@@ -427,7 +407,7 @@ tests:
               minValue: MinCoolSetpointLimitValue
               maxValue: AbsMaxCoolSetpointLimitStep6
 
-    - label: "Step 20: TH reads the MinSetpointDeadBand attribute from the DUT"
+    - label: "Step 18: TH reads the MinSetpointDeadBand attribute from the DUT"
       PICS: TSTAT.S.F05
       command: "readAttribute"
       attribute: "MinSetpointDeadBand"
@@ -437,7 +417,7 @@ tests:
               minValue: 0
               maxValue: 127
 
-    - label: "Step 21: TH reads the RemoteSensing attribute from the DUT"
+    - label: "Step 19: TH reads the RemoteSensing attribute from the DUT"
       PICS: TSTAT.S.A001a
       command: "readAttribute"
       attribute: "RemoteSensing"
@@ -448,7 +428,7 @@ tests:
               maxValue: 7
 
     - label:
-          "Step 22: TH reads the ControlSequenceOfOperation attribute from the
+          "Step 20: TH reads the ControlSequenceOfOperation attribute from the
           DUT"
       PICS: TSTAT.S.A001b
       command: "readAttribute"
@@ -459,7 +439,7 @@ tests:
               minValue: 0
               maxValue: 5
 
-    - label: "Step 23: TH reads the SystemMode attribute from the DUT"
+    - label: "Step 21: TH reads the SystemMode attribute from the DUT"
       PICS: TSTAT.S.A001c
       command: "readAttribute"
       attribute: "SystemMode"
@@ -470,7 +450,7 @@ tests:
               maxValue: 9
 
     - label:
-          "Step 24: TH reads the ThermostatRunningMode attribute from the DUT"
+          "Step 22: TH reads the ThermostatRunningMode attribute from the DUT"
       PICS: TSTAT.S.A001e
       command: "readAttribute"
       attribute: "ThermostatRunningMode"
@@ -484,41 +464,8 @@ tests:
                       ThermostatRunningModeEnum.Heat(4),
                   ]
 
-    - label: "Step 25: TH reads the StartOfWeek attribute from the DUT"
-      PICS: TSTAT.S.F03
-      command: "readAttribute"
-      attribute: "StartOfWeek"
-      response:
-          constraints:
-              type: enum8
-              minValue: 0
-              maxValue: 6
-
     - label:
-          "Step 26: TH reads the NumberOfWeeklyTransitions attribute from the
-          DUT"
-      PICS: TSTAT.S.F03
-      command: "readAttribute"
-      attribute: "NumberOfWeeklyTransitions"
-      response:
-          constraints:
-              type: int8u
-              minValue: 0
-              maxValue: 255
-
-    - label:
-          "Step 27: TH reads the NumberOfDailyTransitions attribute from the DUT"
-      PICS: TSTAT.S.F03
-      command: "readAttribute"
-      attribute: "NumberOfDailyTransitions"
-      response:
-          constraints:
-              type: int8u
-              minValue: 0
-              maxValue: 255
-
-    - label:
-          "Step 28: TH reads the TemperatureSetpointHold attribute from the DUT"
+          "Step 23: TH reads the TemperatureSetpointHold attribute from the DUT"
       PICS: TSTAT.S.A0023
       command: "readAttribute"
       attribute: "TemperatureSetpointHold"
@@ -529,7 +476,7 @@ tests:
               maxValue: 1
 
     - label:
-          "Step 29: TH reads the TemperatureSetpointHoldDuration attribute from
+          "Step 24: TH reads the TemperatureSetpointHoldDuration attribute from
           the DUT"
       PICS: TSTAT.S.A0024
       command: "readAttribute"
@@ -541,19 +488,7 @@ tests:
               maxValue: 1440
 
     - label:
-          "Step 30: TH reads the ThermostatProgrammingOperationMode attribute
-          from the DUT"
-      PICS: TSTAT.S.A0025
-      command: "readAttribute"
-      attribute: "ThermostatProgrammingOperationMode"
-      response:
-          constraints:
-              type: bitmap8
-              minValue: 0
-              maxValue: 7
-
-    - label:
-          "Step 31: TH reads the ThermostatRunningState attribute from the DUT"
+          "Step 25: TH reads the ThermostatRunningState attribute from the DUT"
       PICS: TSTAT.S.A0029
       command: "readAttribute"
       attribute: "ThermostatRunningState"
@@ -563,7 +498,7 @@ tests:
               minValue: 0
               maxValue: 127
 
-    - label: "Step 32: TH reads the SetpointChangeSource attribute from the DUT"
+    - label: "Step 26: TH reads the SetpointChangeSource attribute from the DUT"
       PICS: TSTAT.S.A0030
       command: "readAttribute"
       attribute: "SetpointChangeSource"
@@ -573,7 +508,7 @@ tests:
               minValue: 0
               maxValue: 2
 
-    - label: "Step 33: TH reads the SetpointChangeAmount attribute from the DUT"
+    - label: "Step 27: TH reads the SetpointChangeAmount attribute from the DUT"
       PICS: TSTAT.S.A0031
       command: "readAttribute"
       attribute: "SetpointChangeAmount"
@@ -584,7 +519,7 @@ tests:
               maxValue: 32767
 
     - label:
-          "Step 34: TH reads the SetpointChangeSourceTimestamp attribute from
+          "Step 28: TH reads the SetpointChangeSourceTimestamp attribute from
           the DUT"
       PICS: TSTAT.S.A0032
       command: "readAttribute"
@@ -593,67 +528,7 @@ tests:
           constraints:
               type: epoch_s
 
-    - label: "Step 35: TH reads the OccupiedSetback attribute from the DUT"
-      PICS: TSTAT.S.F04
-      command: "readAttribute"
-      attribute: "OccupiedSetback"
-      response:
-          constraints:
-              type: int8u
-              minValue: 0
-              maxValue: 255
-
-    - label: "Step 36: TH reads the OccupiedSetbackMin attribute from the DUT"
-      PICS: TSTAT.S.F04
-      command: "readAttribute"
-      attribute: "OccupiedSetbackMin"
-      response:
-          constraints:
-              type: int8u
-              minValue: 0
-              maxValue: 255
-
-    - label: "Step 37: TH reads the OccupiedSetbackMax attribute from the DUT"
-      PICS: TSTAT.S.F04
-      command: "readAttribute"
-      attribute: "OccupiedSetbackMax"
-      response:
-          constraints:
-              type: int8u
-              minValue: 0
-              maxValue: 255
-
-    - label: "Step 38: TH reads the UnoccupiedSetback attribute from the DUT"
-      PICS: TSTAT.S.F02 && TSTAT.S.F04
-      command: "readAttribute"
-      attribute: "UnoccupiedSetback"
-      response:
-          constraints:
-              type: int8u
-              minValue: 0
-              maxValue: 255
-
-    - label: "Step 39: TH reads the UnoccupiedSetbackMin attribute from the DUT"
-      PICS: TSTAT.S.F02 && TSTAT.S.F04
-      command: "readAttribute"
-      attribute: "UnoccupiedSetbackMin"
-      response:
-          constraints:
-              type: int8u
-              minValue: 0
-              maxValue: 255
-
-    - label: "Step 40: TH reads the UnoccupiedSetbackMax attribute from the DUT"
-      PICS: TSTAT.S.F02 && TSTAT.S.F04
-      command: "readAttribute"
-      attribute: "UnoccupiedSetbackMax"
-      response:
-          constraints:
-              type: int8u
-              minValue: 0
-              maxValue: 255
-
-    - label: "Step 41: TH reads the EmergencyHeatDelta attribute from the DUT"
+    - label: "Step 29: TH reads the EmergencyHeatDelta attribute from the DUT"
       PICS: TSTAT.S.A003a
       command: "readAttribute"
       attribute: "EmergencyHeatDelta"
@@ -663,7 +538,7 @@ tests:
               minValue: 0
               maxValue: 255
 
-    - label: "Step 42: TH reads the ACType attribute from the DUT"
+    - label: "Step 30: TH reads the ACType attribute from the DUT"
       PICS: TSTAT.S.A0040
       command: "readAttribute"
       attribute: "ACType"
@@ -673,7 +548,7 @@ tests:
               minValue: 0
               maxValue: 4
 
-    - label: "Step 43: TH reads the ACCapacity attribute from the DUT"
+    - label: "Step 31: TH reads the ACCapacity attribute from the DUT"
       PICS: TSTAT.S.A0041
       command: "readAttribute"
       attribute: "ACCapacity"
@@ -683,7 +558,7 @@ tests:
               minValue: 0
               maxValue: 65535
 
-    - label: "Step 44: TH reads the ACRefrigerantType attribute from the DUT"
+    - label: "Step 32: TH reads the ACRefrigerantType attribute from the DUT"
       PICS: TSTAT.S.A0042
       command: "readAttribute"
       attribute: "ACRefrigerantType"
@@ -693,7 +568,7 @@ tests:
               minValue: 0
               maxValue: 3
 
-    - label: "Step 45: TH reads the ACCompressorType attribute from the DUT"
+    - label: "Step 33: TH reads the ACCompressorType attribute from the DUT"
       PICS: TSTAT.S.A0043
       command: "readAttribute"
       attribute: "ACCompressorType"
@@ -703,7 +578,7 @@ tests:
               minValue: 0
               maxValue: 3
 
-    - label: "Step 46: TH reads the ACErrorCode attribute from the DUT"
+    - label: "Step 34: TH reads the ACErrorCode attribute from the DUT"
       PICS: TSTAT.S.A0044
       command: "readAttribute"
       attribute: "ACErrorCode"
@@ -711,7 +586,7 @@ tests:
           constraints:
               type: bitmap32
 
-    - label: "Step 47: TH reads the ACLouverPosition attribute from the DUT"
+    - label: "Step 35: TH reads the ACLouverPosition attribute from the DUT"
       PICS: TSTAT.S.A0045
       command: "readAttribute"
       attribute: "ACLouverPosition"
@@ -721,7 +596,7 @@ tests:
               minValue: 1
               maxValue: 5
 
-    - label: "Step 48: TH reads the ACCoilTemperature attribute from the DUT"
+    - label: "Step 36: TH reads the ACCoilTemperature attribute from the DUT"
       PICS: TSTAT.S.A0046
       command: "readAttribute"
       attribute: "ACCoilTemperature"
@@ -731,7 +606,7 @@ tests:
               minValue: -27315
               maxValue: 32767
 
-    - label: "Step 49: TH reads the ACCapacityFormat attribute from the DUT"
+    - label: "Step 37: TH reads the ACCapacityFormat attribute from the DUT"
       PICS: TSTAT.S.A0047
       command: "readAttribute"
       attribute: "ACCapacityformat"
@@ -740,7 +615,7 @@ tests:
           constraints:
               type: enum8
 
-    - label: "Step 50: TH reads the PresetTypes attribute from the DUT"
+    - label: "Step 38: TH reads the PresetTypes attribute from the DUT"
       PICS: TSTAT.S.F08
       command: "readAttribute"
       attribute: "PresetTypes"
@@ -748,7 +623,7 @@ tests:
           constraints:
               type: list
 
-    - label: "Step 51: TH reads the ScheduleTypes attribute from the DUT"
+    - label: "Step 39: TH reads the ScheduleTypes attribute from the DUT"
       PICS: TSTAT.S.F07
       command: "readAttribute"
       attribute: "ScheduleTypes"
@@ -756,7 +631,7 @@ tests:
           constraints:
               type: list
 
-    - label: "Step 52: TH reads the NumberOfPresets attribute from the DUT"
+    - label: "Step 40: TH reads the NumberOfPresets attribute from the DUT"
       PICS: TSTAT.S.F08
       command: "readAttribute"
       attribute: "NumberOfPresets"
@@ -764,7 +639,7 @@ tests:
           constraints:
               type: int8u
 
-    - label: "Step 53: TH reads the NumberOfSchedules attribute from the DUT"
+    - label: "Step 41: TH reads the NumberOfSchedules attribute from the DUT"
       PICS: TSTAT.S.F07
       command: "readAttribute"
       attribute: "NumberOfSchedules"
@@ -773,7 +648,7 @@ tests:
               type: int8u
 
     - label:
-          "Step 54: TH reads the NumberOfScheduleTransitions attribute from the
+          "Step 42: TH reads the NumberOfScheduleTransitions attribute from the
           DUT"
       PICS: TSTAT.S.F07
       command: "readAttribute"
@@ -783,7 +658,7 @@ tests:
               type: int8u
 
     - label:
-          "Step 55: TH reads the NumberOfScheduleTransitionPerDay attribute from
+          "Step 43: TH reads the NumberOfScheduleTransitionPerDay attribute from
           the DUT"
       PICS: TSTAT.S.F07
       command: "readAttribute"
@@ -792,7 +667,7 @@ tests:
           constraints:
               type: int8u
 
-    - label: "Step 56: TH reads the ActivePresetHandle attribute from the DUT"
+    - label: "Step 44: TH reads the ActivePresetHandle attribute from the DUT"
       PICS: TSTAT.S.F08
       command: "readAttribute"
       attribute: "ActivePresetHandle"
@@ -800,7 +675,7 @@ tests:
           constraints:
               type: octstr
 
-    - label: "Step 57: TH reads the ActiveScheduleHandle attribute from the DUT"
+    - label: "Step 45: TH reads the ActiveScheduleHandle attribute from the DUT"
       PICS: TSTAT.S.F07
       command: "readAttribute"
       attribute: "ActiveScheduleHandle"
@@ -808,7 +683,7 @@ tests:
           constraints:
               type: octstr
 
-    - label: "Step 58: TH reads the Presets attribute from the DUT"
+    - label: "Step 46: TH reads the Presets attribute from the DUT"
       PICS: TSTAT.S.F08
       command: "readAttribute"
       attribute: "Presets"
@@ -817,7 +692,7 @@ tests:
               type: list
               maxLength: NumberOfPresetsValue
 
-    - label: "Step 59: TH reads the Schedules attribute from the DUT"
+    - label: "Step 47: TH reads the Schedules attribute from the DUT"
       PICS: TSTAT.S.F07
       command: "readAttribute"
       attribute: "Schedules"
@@ -826,7 +701,7 @@ tests:
               type: list
 
     - label:
-          "Step 60: TH reads the SetpointHoldExpiryTimestamp attribute from the
+          "Step 48: TH reads the SetpointHoldExpiryTimestamp attribute from the
           DUT"
       PICS: TSTAT.S.A0052
       command: "readAttribute"


### PR DESCRIPTION
#### Summary

This PR updates the YAML script for TC-TSTAT-2.1 to remove the elements which have been deprecated in spec and removed from test plan

#### Related issues

Related spec PRs:
CHIP-Specifications/connectedhomeip-spec#12468
CHIP-Specifications/connectedhomeip-spec#12543
CHIP-Specifications/connectedhomeip-spec#12490
CHIP-Specifications/connectedhomeip-spec#10266

Related test plan PR:
https://github.com/CHIP-Specifications/chip-test-plans/pull/5818

#### Testing

Successfully pass CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
