### PR TITLE
Disable AVSM 2.18, 2.19 and 2.21 tests due to flakyness

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -11,15 +11,15 @@ not_automated:
       reason: Shared code for TC_AVSM, not a standalone test
     - name: TC_AVSM_2_18.py
       reason:
-          AVSM flaky tests. See:
+          AVSM flaky tests. See
           https://github.com/project-chip/connectedhomeip/issues/42871
     - name: TC_AVSM_2_19.py
       reason:
-          AVSM flaky tests. See:
+          AVSM flaky tests. See
           https://github.com/project-chip/connectedhomeip/issues/42871
     - name: TC_AVSM_2_21.py
       reason:
-          AVSM flaky tests. See:
+          AVSM flaky tests. See
           https://github.com/project-chip/connectedhomeip/issues/42871
     - name: TC_BRBINFO_3_1.py
       reason:

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -9,6 +9,18 @@ not_automated:
       reason: Code/Test not being used or not shared code for any other tests
     - name: TC_AVSMTestBase.py
       reason: Shared code for TC_AVSM, not a standalone test
+    - name: TC_AVSM_2_18.py
+      reason:
+          AVSM flaky tests. See:
+          https://github.com/project-chip/connectedhomeip/issues/42871
+    - name: TC_AVSM_2_19.py
+      reason:
+          AVSM flaky tests. See:
+          https://github.com/project-chip/connectedhomeip/issues/42871
+    - name: TC_AVSM_2_21.py
+      reason:
+          AVSM flaky tests. See:
+          https://github.com/project-chip/connectedhomeip/issues/42871
     - name: TC_BRBINFO_3_1.py
       reason:
           Attribute is not implemented in the bridge app. Same code as


### PR DESCRIPTION
#### Summary

AVSM tests are flaky. Reported in #42871

#### Testing

Trivial change, CI will validate.