### PR TITLE
[build_examples.py] fix unified build variant detection

### DIFF
--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -84,7 +84,8 @@ class Context:
                 logging.error(f"Target '{target}' could not be found. Nothing executed for it")
                 continue
 
-            if found_choice.isUnifiedBuild(found_choice.modifiers):
+            parts = found_choice.StringIntoTargetParts(target)
+            if parts and found_choice.isUnifiedBuild(parts):
                 # we want to ensure identical settings across builds. For now ensure that
                 # variants are identical
                 variants = '-'.join([x.name for x in found_choice.modifiers])

--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -84,7 +84,7 @@ class Context:
                 logging.error(f"Target '{target}' could not be found. Nothing executed for it")
                 continue
 
-            if found_choice.isUnifiedBuild:
+            if found_choice.isUnifiedBuild(found_choice.modifiers):
                 # we want to ensure identical settings across builds. For now ensure that
                 # variants are identical
                 variants = '-'.join([x.name for x in found_choice.modifiers])

--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -88,7 +88,8 @@ class Context:
             if parts and found_choice.isUnifiedBuild(parts):
                 # we want to ensure identical settings across builds. For now ensure that
                 # variants are identical
-                variants = '-'.join([x.name for x in found_choice.modifiers])
+                actual_modifiers = {x.name for x in found_choice.modifiers}
+                variants = '-'.join([x.name for x in parts if x.name in actual_modifiers])
                 if unified_variants is None:
                     unified_variants = variants
                 elif unified_variants != variants:


### PR DESCRIPTION
#### Summary

`isUnifiedBuild` was used as a property instead of as a function, so it would always be true (since the member exists as a function). This resulted in always trying to validate unified build variants and cloud integration smoketest would fail validation.

Changes:
  - correctly pick only the sub-parts of the build for validating variants (previously we were picking up ALL variants)
  - correctly use isUnifiedBuilds on these parts


#### Testing

- Ran smoke-test yaml command as `gen` and it worked
- Ran unified build as in tests.yaml and it worked
- Ran with `unified-clang` and `unified-clang-ipv6only` build and it failed as expected
