### PR TITLE
[Camera] Fix camera app crashes on unexpected SDPs

### DIFF
--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -40,12 +40,20 @@ constexpr uint16_t kMaxConcurrentWebRTCSessions = 5;
 /**
  * @brief Validates that an SDP contains the minimum required fields for WebRTC.
  *
- * This function checks that the SDP has the necessary ICE and DTLS parameters
- * that are required by the underlying WebRTC library. Without these fields,
- * the library would throw an exception when trying to set the remote description.
+ * This function checks that the SDP has the mandatory session-level fields per RFC 8866
+ * plus the necessary ICE and DTLS parameters required by the underlying WebRTC library.
+ * Without these fields, the library would throw an exception when trying to set the
+ * remote description.
  *
- * Required fields:
+ * Required fields (per RFC 8866):
+ * - Version (v=)
+ * - Origin (o=)
+ * - Session name (s=)
+ * - Connection (c=)
+ * - Timing (t=)
  * - At least one media line (m=)
+ *
+ * Required fields (WebRTC-specific):
  * - ICE user fragment (a=ice-ufrag:)
  * - ICE password (a=ice-pwd:)
  * - DTLS fingerprint (a=fingerprint:)
@@ -68,7 +76,13 @@ bool ValidateSdpFields(const std::string & sdp)
     };
 
     // Define the list of required substrings and their corresponding descriptions for error logging.
+    // These include mandatory SDP session-level fields per RFC 8866 plus WebRTC-specific requirements.
     static const SdpRequirement kRequirements[] = {
+        { "v=", "version" },
+        { "o=", "origin" },
+        { "s=", "session name" },
+        { "c=", "connection" },
+        { "t=", "timing" },
         { "m=", "media line" },
         { "a=ice-ufrag:", "ICE user fragment" },
         { "a=ice-pwd:", "ICE password" },

--- a/src/controller/webrtc/WebRTCClient.cpp
+++ b/src/controller/webrtc/WebRTCClient.cpp
@@ -33,12 +33,20 @@ const char * GetPeerConnectionStateStr(rtc::PeerConnection::State state);
 /**
  * @brief Validates that an SDP contains the minimum required fields for WebRTC.
  *
- * This function checks that the SDP has the necessary ICE and DTLS parameters
- * that are required by the underlying WebRTC library. Without these fields,
- * the library would throw an exception when trying to set the remote description.
+ * This function checks that the SDP has the mandatory session-level fields per RFC 8866
+ * plus the necessary ICE and DTLS parameters required by the underlying WebRTC library.
+ * Without these fields, the library would throw an exception when trying to set the
+ * remote description.
  *
- * Required fields:
+ * Required fields (per RFC 8866):
+ * - Version (v=)
+ * - Origin (o=)
+ * - Session name (s=)
+ * - Connection (c=)
+ * - Timing (t=)
  * - At least one media line (m=)
+ *
+ * Required fields (WebRTC-specific):
  * - ICE user fragment (a=ice-ufrag:)
  * - ICE password (a=ice-pwd:)
  * - DTLS fingerprint (a=fingerprint:)
@@ -61,7 +69,13 @@ bool ValidateSdpFields(const std::string & sdp)
     };
 
     // Define the list of required substrings and their corresponding descriptions for error logging.
+    // These include mandatory SDP session-level fields per RFC 8866 plus WebRTC-specific requirements.
     static const SdpRequirement kRequirements[] = {
+        { "v=", "version" },
+        { "o=", "origin" },
+        { "s=", "session name" },
+        { "c=", "connection" },
+        { "t=", "timing" },
         { "m=", "media line" },
         { "a=ice-ufrag:", "ICE user fragment" },
         { "a=ice-pwd:", "ICE password" },


### PR DESCRIPTION
#### Summary

We need to validates that an SDP contains the minimum required fields for WebRTC before use.
This required by the underlying WebRTC library. Without this check, the library would throw an exception when trying to set the remote description.

#### Related issues

Fixes: #42247


#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
