### PR TITLE
[Camera] Triggers SendingICECandidates when local ICE gathering completes

### DIFF
--- a/examples/camera-app/linux/include/webrtc-abstract.h
+++ b/examples/camera-app/linux/include/webrtc-abstract.h
@@ -53,6 +53,7 @@ using OnLocalDescriptionCallback = std::function<void(const std::string & sdp, S
 using OnICECandidateCallback     = std::function<void(const ICECandidateInfo & candidateInfo)>;
 using OnConnectionStateCallback  = std::function<void(bool connected)>;
 using OnTrackCallback            = std::function<void(std::shared_ptr<WebRTCTrack> track)>;
+using OnGatheringStateCallback   = std::function<void(bool gatheringComplete)>;
 
 // Abstract track interface
 class WebRTCTrack
@@ -73,7 +74,8 @@ public:
     virtual ~WebRTCPeerConnection() = default;
 
     virtual void SetCallbacks(OnLocalDescriptionCallback onLocalDescription, OnICECandidateCallback onICECandidate,
-                              OnConnectionStateCallback onConnectionState, OnTrackCallback onTrack)              = 0;
+                              OnConnectionStateCallback onConnectionState, OnTrackCallback onTrack,
+                              OnGatheringStateCallback onGatheringState)                                         = 0;
     virtual void Close()                                                                                         = 0;
     virtual void CreateOffer()                                                                                   = 0;
     virtual void CreateAnswer()                                                                                  = 0;

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -27,8 +27,9 @@
 #include <string>
 #include <vector>
 
-using OnTransportLocalDescriptionCallback = std::function<void(const std::string & sdp, SDPType type, const int16_t sessionId)>;
-using OnTransportConnectionStateCallback  = std::function<void(bool connected, const int16_t sessionId)>;
+using OnTransportLocalDescriptionCallback = std::function<void(const std::string & sdp, SDPType type, const uint16_t sessionId)>;
+using OnTransportConnectionStateCallback  = std::function<void(bool connected, const uint16_t sessionId)>;
+using OnTransportGatheringStateCallback   = std::function<void(bool gatheringComplete, const uint16_t sessionId)>;
 
 // Derived class for WebRTC transport
 class WebrtcTransport : public Transport
@@ -67,7 +68,8 @@ public:
 
     ~WebrtcTransport();
 
-    void SetCallbacks(OnTransportLocalDescriptionCallback onLocalDescription, OnTransportConnectionStateCallback onConnectionState);
+    void SetCallbacks(OnTransportLocalDescriptionCallback onLocalDescription, OnTransportConnectionStateCallback onConnectionState,
+                      OnTransportGatheringStateCallback onGatheringState);
 
     void MoveToState(const State targetState);
     const char * GetStateStr() const;
@@ -145,6 +147,7 @@ private:
     RequestArgs mRequestArgs;
     OnTransportLocalDescriptionCallback mOnLocalDescription = nullptr;
     OnTransportConnectionStateCallback mOnConnectionState   = nullptr;
+    OnTransportGatheringStateCallback mOnGatheringState     = nullptr;
 
     std::mutex mTrackStatusLock;
 };

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -289,7 +289,8 @@ public:
     }
 
     void SetCallbacks(OnLocalDescriptionCallback onLocalDescription, OnICECandidateCallback onICECandidate,
-                      OnConnectionStateCallback onConnectionState, OnTrackCallback onTrack) override
+                      OnConnectionStateCallback onConnectionState, OnTrackCallback onTrack,
+                      OnGatheringStateCallback onGatheringState) override
     {
         mPeerConnection->onLocalDescription([onLocalDescription, onICECandidate](rtc::Description desc) {
             // First, notify about the local description
@@ -339,8 +340,13 @@ public:
             }
         });
 
-        mPeerConnection->onGatheringStateChange([](rtc::PeerConnection::GatheringState state) {
+        mPeerConnection->onGatheringStateChange([onGatheringState](rtc::PeerConnection::GatheringState state) {
             ChipLogProgress(Camera, "[PeerConnection Gathering State: %s]", GetGatheringStateStr(state));
+            if (onGatheringState)
+            {
+                bool complete = (state == rtc::PeerConnection::GatheringState::Complete);
+                onGatheringState(complete);
+            }
         });
 
         mPeerConnection->onTrack(

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -51,10 +51,12 @@ WebrtcTransport::~WebrtcTransport()
 }
 
 void WebrtcTransport::SetCallbacks(OnTransportLocalDescriptionCallback onLocalDescription,
-                                   OnTransportConnectionStateCallback onConnectionState)
+                                   OnTransportConnectionStateCallback onConnectionState,
+                                   OnTransportGatheringStateCallback onGatheringState)
 {
     mOnLocalDescription = onLocalDescription;
     mOnConnectionState  = onConnectionState;
+    mOnGatheringState   = onGatheringState;
 }
 
 void WebrtcTransport::SetRequestArgs(const RequestArgs & args)
@@ -200,7 +202,13 @@ void WebrtcTransport::Start()
     mPeerConnection->SetCallbacks([this](const std::string & sdp, SDPType type) { this->OnLocalDescription(sdp, type); },
                                   [this](const ICECandidateInfo & candidateInfo) { this->OnICECandidate(candidateInfo); },
                                   [this](bool connected) { this->OnConnectionStateChanged(connected); },
-                                  [this](std::shared_ptr<WebRTCTrack> track) { this->OnTrack(track); });
+                                  [this](std::shared_ptr<WebRTCTrack> track) { this->OnTrack(track); },
+                                  [this](bool gatheringComplete) {
+                                      if (mOnGatheringState)
+                                      {
+                                          mOnGatheringState(gatheringComplete, mRequestArgs.sessionId);
+                                      }
+                                  });
 }
 
 void WebrtcTransport::Stop()


### PR DESCRIPTION
#### Summary

When the controller sends all ICE candidates bundled in the SDP offer (non-trickle ICE), the camera-app never receives separate ProvideICECandidates calls that would trigger the transition to SendingICECandidates state. As a result, the locally gathered ICE candidates are never sent back to the controller, breaking the connection.                                                                                                                                                                
                                                                                                                                                                              
This PR adds a gathering state callback that triggers SendingICECandidates when local ICE gathering completes, ensuring candidates are sent regardless of how the remote offer was delivered.                                                                                                                                                        
                         
#### Related issues

Fixes: #41660

#### Testing

Validate by CI 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
