### PR TITLE
Add app-ready-pattern for DUT app to signal AVSM persistence test scripts.

### DIFF
--- a/src/python_testing/TC_AVSM_2_18.py
+++ b/src/python_testing/TC_AVSM_2_18.py
@@ -22,6 +22,7 @@
 #   run1:
 #     app: ${CAMERA_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-ready-pattern: "APP STATUS: Starting event loop"
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network

--- a/src/python_testing/TC_AVSM_2_19.py
+++ b/src/python_testing/TC_AVSM_2_19.py
@@ -22,6 +22,7 @@
 #   run1:
 #     app: ${CAMERA_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-ready-pattern: "APP STATUS: Starting event loop"
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network

--- a/src/python_testing/TC_AVSM_2_20.py
+++ b/src/python_testing/TC_AVSM_2_20.py
@@ -22,6 +22,7 @@
 #   run1:
 #     app: ${CAMERA_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-ready-pattern: "APP STATUS: Starting event loop"
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network

--- a/src/python_testing/TC_AVSM_2_21.py
+++ b/src/python_testing/TC_AVSM_2_21.py
@@ -22,6 +22,7 @@
 #   run1:
 #     app: ${CAMERA_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-ready-pattern: "APP STATUS: Starting event loop"
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network


### PR DESCRIPTION
#### Summary
The app-ready-pattern signals the controller side test scripts to connect after the DUT is back up after a reboot.

#### Testing
CI validation

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
