### PR TITLE
Adds TXT record T key advertising to commissionable nodes if TCP is supported

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -307,7 +307,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     advertiseParameters.SetTCPSupportModes(mTCPServerEnabled ? chip::Dnssd::TCPModeAdvertise::kTCPClientServer
-                                                               : chip::Dnssd::TCPModeAdvertise::kTCPClient);
+                                                             : chip::Dnssd::TCPModeAdvertise::kTCPClient);
 #endif
 
     if (commissionableNode)

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -179,7 +179,7 @@ template <class AdvertisingParams>
 void DnssdServer::AddTCPKeyToAdvertisement(AdvertisingParams & advParams)
 {
     advParams.SetTCPSupportModes(mTCPServerEnabled ? chip::Dnssd::TCPModeAdvertise::kTCPClientServer
-                                                    : chip::Dnssd::TCPModeAdvertise::kTCPClient);
+                                                   : chip::Dnssd::TCPModeAdvertise::kTCPClient);
 }
 #endif
 

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -174,6 +174,15 @@ void DnssdServer::AddICDKeyToAdvertisement(AdvertisingParams & advParams)
 }
 #endif
 
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+template <class AdvertisingParams>
+void DnssdServer::AddTCPKeyToAdvertisement(AdvertisingParams & advParams)
+{
+    advParams.SetTCPSupportModes(mTCPServerEnabled ? chip::Dnssd::TCPModeAdvertise::kTCPClientServer
+                                                    : chip::Dnssd::TCPModeAdvertise::kTCPClient);
+}
+#endif
+
 void DnssdServer::GetPrimaryOrFallbackMACAddress(MutableByteSpan & mac)
 {
     if (ConfigurationMgr().GetPrimaryMACAddress(mac) != CHIP_NO_ERROR)
@@ -218,8 +227,7 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
 #endif
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-        advertiseParameters.SetTCPSupportModes(mTCPServerEnabled ? chip::Dnssd::TCPModeAdvertise::kTCPClientServer
-                                                                 : chip::Dnssd::TCPModeAdvertise::kTCPClient);
+        AddTCPKeyToAdvertisement(advertiseParameters);
 #endif
         auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
 
@@ -306,8 +314,7 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
 #endif
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    advertiseParameters.SetTCPSupportModes(mTCPServerEnabled ? chip::Dnssd::TCPModeAdvertise::kTCPClientServer
-                                                             : chip::Dnssd::TCPModeAdvertise::kTCPClient);
+    AddTCPKeyToAdvertisement(advertiseParameters);
 #endif
 
     if (commissionableNode)

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -305,6 +305,11 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
     AddICDKeyToAdvertisement(advertiseParameters);
 #endif
 
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    advertiseParameters.SetTCPSupportModes(mTCPServerEnabled ? chip::Dnssd::TCPModeAdvertise::kTCPClientServer
+                                                               : chip::Dnssd::TCPModeAdvertise::kTCPClient);
+#endif
+
     if (commissionableNode)
     {
         uint16_t discriminator = 0;

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -104,6 +104,9 @@ public:
 #endif
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    template <class AdvertisingParams>
+    void AddTCPKeyToAdvertisement(AdvertisingParams & advParams);
+
     void SetTCPServerEnabled(bool serverEnabled) { mTCPServerEnabled = serverEnabled; };
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 


### PR DESCRIPTION
#### Summary
Adds TXT record T key advertising to commissionable nodes if TCP is supported.

- At the moment, among other verifications, TC-SC-4.3 verifies T key presence if TCP is supported in an OPERATIONAL node, this is working correctly.

- T key verification in a COMMISSIONABLE node is done in TC-SC-4.1, which is currently failing when TCP is supported due to the T key not being present.

As per the spec and mentioned test plans dealing with the T key, if TCP is supported in the DUIT, then the T key must be included in the TXT record, this applies to both OPERATIONAL and COMMISSIONABLE nodes.

This PR fixes the issue of COMMISSIONABLE nodes not advertising the T key when TCP is supported. The fix is applied in the underlying DNS SD layer, impacting all apps.

#### Testing

Run TC-SC-4.1 with TCP support enabled
