### PR TITLE
Add Public Platform Events for Commissioning Window Open / Closure

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -637,6 +637,8 @@ void CommissioningWindowManager::UpdateWindowStatus(CommissioningWindowStatusEnu
             app::ICDNotifier::GetInstance().NotifyActiveRequestWithdrawal(request);
         }
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
+        LogErrorOnFailure(DeviceLayer::DeviceControlServer::DeviceControlSvr().PostCommissioningWindowChangedEvent(mWindowStatus));
     }
 
     if (CommissioningWindowStatusForCluster() != oldClusterStatus)

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -25,6 +25,7 @@
 #pragma once
 #include <stdint.h>
 
+#include <clusters/AdministratorCommissioning/Enums.h>
 #include <inet/IPAddress.h>
 #include <lib/core/DataModelTypes.h>
 
@@ -541,7 +542,10 @@ struct ChipDeviceEvent final
         {
             InterfaceIpChangeType Type;
         } InterfaceIpAddressChanged;
-
+        struct
+        {
+            chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum status;
+        } CommissioningWindowStatusChanged;
         struct
         {
             uint64_t nodeId;

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -202,6 +202,11 @@ enum PublicEventTypes
     kInterfaceIpAddressChanged,
 
     /**
+     *  Indicates that there has been a change in the commissioning window status.
+     */
+    kCommissioningWindowStatusChanged,
+
+    /**
      * Commissioning has completed by a call to the general commissioning cluster command.
      */
     kCommissioningComplete,

--- a/src/include/platform/DeviceControlServer.h
+++ b/src/include/platform/DeviceControlServer.h
@@ -33,6 +33,14 @@ class DeviceControlServer final
 public:
     // ===== Members for internal use by other Device Layer components.
 
+    /**
+     *  Post an event that there was a change in the commissioning
+     *  window status.
+     *
+     *  @param[in]  status
+     *    The current commissioning window status.
+     */
+    CHIP_ERROR PostCommissioningWindowChangedEvent(app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum status);
     CHIP_ERROR PostCommissioningCompleteEvent(NodeId peerNodeId, FabricIndex accessingFabricIndex);
     CHIP_ERROR SetRegulatoryConfig(uint8_t location, const CharSpan & countryCode);
     CHIP_ERROR PostConnectedToOperationalNetworkEvent(ByteSpan networkID);

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -604,6 +604,7 @@ if (chip_device_platform != "none") {
 
     public_deps = [
       ":platform_base",
+      "${chip_root}/src/app/common:enums",
       "${chip_root}/src/app/common:ids",
       "${chip_root}/src/app/common:metadata",
       "${chip_root}/src/app/util:types",

--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -34,6 +34,15 @@ DeviceControlServer & DeviceControlServer::DeviceControlSvr()
     return sInstance;
 }
 
+CHIP_ERROR DeviceControlServer::PostCommissioningWindowChangedEvent(
+    app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum status)
+{
+    const ChipDeviceEvent event{ .Type                             = DeviceEventType::kCommissioningWindowStatusChanged,
+                                 .CommissioningWindowStatusChanged = { .status = status } };
+
+    return PlatformMgr().PostEvent(&event);
+}
+
 CHIP_ERROR DeviceControlServer::PostCommissioningCompleteEvent(NodeId peerNodeId, FabricIndex accessingFabricIndex)
 {
     ChipDeviceEvent event{


### PR DESCRIPTION
#### Summary

At present, there is not any way for a device product or platform to know whether a commissioning window has opened or closed.

For example, when the commissioning flow is set to `CommissioningFlow::kStandard`, a commissioning window automatically opens on Matter stack start-up. However, there are no events or call backs to the integrating product or platform that this has actually happened such that UI/UX feedback can be effected to indicate this.

Similarly, when the commissioning flow is set to `CommissioningFlow::kUserInitiated` the device product or platform can request a commissioning window be opened when a UI/UX event occurs and, in this case, it could synchronously effect a UI/UX change when the open request returns; however, to the extent the internal Matter process is asynchronous, there is, again, no precise indication the window is open that is accessible to integrating products and platforms.

However, on close, `kCommissioningComplete` or `kFailSafeTimerExpired` can be used as inexact proxies for window closure; however, those are more "success" or "failure" statuses and are related to but not directly correlated with window closure.

With that in mind, this adds a new public stack event to introduce platform or product visibility for commissioning window state changes.

#### Related issues

Fixes #42887

#### Testing

Successfully paired / commissioned an armvl-unknown-linux-gnu device using the iOS 26.2 Apple "Home" app.

Validated that a basic commissioning window opens and closes after five minutes with the commissioning flow is set to `CommissioningFlow::kStandard`. Both the open and close events are generated and received.

Validated that an enhanced commissioning window opens and closes after five minutes when the "Turn On Pairing" button is hit in the Apple iOS 26.2 "Home" app. Both the open and close events are generated and received.