### PR TITLE
[Silabs] Adds fix for use of proper macro during OT-CLI initialisation

### DIFF
--- a/examples/platform/silabs/MatterShell.cpp
+++ b/examples/platform/silabs/MatterShell.cpp
@@ -119,7 +119,7 @@ void startShellTask()
     // For now also register commands from shell_common (shell app).
     // TODO move at least OTCLI to default commands in lib/shell/commands
     cmd_misc_init();
-#ifndef SL_WIFI
+#ifdef SL_CATALOG_OPENTHREAD_CLI_PRESENT
     cmd_otcli_init();
 #endif
 


### PR DESCRIPTION
#### Summary
The change updates the MACRO for OT CLI to use the relevant `SL_CATALOG MACRO` instead of `SL_WIFI`, ensuring it is inclusive of non‑WiFi configurations rather than assuming they are THREAD.

#### Related issues

N/A

#### Testing

Since it is a build parameter change, just verified inclusion in the required board combination, during compilation.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
