### PR TITLE
  Add OTA image generation to the chip-cert-bins Docker build process to eliminate manual OTA image creation

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -303,7 +303,6 @@ RUN case ${TARGETPLATFORM} in \
     "linux/amd64" | "linux/arm64") \
     set -x \
     && cd out \
-    && ls -lh chip-ota-requestor-app \
     && ../src/app/ota_image_tool.py create \
        -v 0xDEAD \
        -p 0xBEEF \
@@ -312,8 +311,6 @@ RUN case ${TARGETPLATFORM} in \
        -da sha256 \
        chip-ota-requestor-app \
        ota-requestor-app.ota \
-    && echo "OTA image generated successfully for ${TARGETPLATFORM##*/}" \
-    && ls -lh ota-requestor-app.ota \
     ;; \
     *) ;; \
     esac

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -297,6 +297,42 @@ RUN case ${TARGETPLATFORM} in \
 
 RUN source scripts/activate.sh && scripts/build_python.sh -m platform -d true --enable_nfc true -i out/python_env
 
+# Generate OTA image from the built OTA requestor app
+# This creates ota-requestor-app.ota for OTA testing
+RUN case ${TARGETPLATFORM} in \
+    "linux/amd64") \
+    set -x \
+    && cd out \
+    && ls -lh chip-ota-requestor-app \
+    && ../src/app/ota_image_tool.py create \
+       -v 0xDEAD \
+       -p 0xBEEF \
+       -vn 2 \
+       -vs "2.0" \
+       -da sha256 \
+       chip-ota-requestor-app \
+       ota-requestor-app.ota \
+    && echo "OTA image generated successfully for amd64" \
+    && ls -lh ota-requestor-app.ota \
+    ;; \
+    "linux/arm64") \
+    set -x \
+    && cd out \
+    && ls -lh chip-ota-requestor-app \
+    && ../src/app/ota_image_tool.py create \
+       -v 0xDEAD \
+       -p 0xBEEF \
+       -vn 2 \
+       -vs "2.0" \
+       -da sha256 \
+       chip-ota-requestor-app \
+       ota-requestor-app.ota \
+    && echo "OTA image generated successfully for arm64" \
+    && ls -lh ota-requestor-app.ota \
+    ;; \
+    *) ;; \
+    esac
+
 # Stage 3: Copy relevant cert bins to a minimal image to reduce size.
 FROM ubuntu:24.04
 ENV TZ=Etc/UTC
@@ -342,6 +378,7 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-bridge-app apps/
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/thermostat-app apps/thermostat-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-ota-provider-app apps/chip-ota-provider-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-ota-requestor-app apps/chip-ota-requestor-app
+COPY --from=chip-build-cert-bins /root/connectedhomeip/out/ota-requestor-app.ota apps/ota-requestor-app.ota
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-lock-app apps/chip-lock-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-app1 apps/chip-app1
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/lit-icd-app apps/lit-icd-app

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -300,7 +300,7 @@ RUN source scripts/activate.sh && scripts/build_python.sh -m platform -d true --
 # Generate OTA image from the built OTA requestor app
 # This creates ota-requestor-app.ota for OTA testing
 RUN case ${TARGETPLATFORM} in \
-    "linux/amd64") \
+    "linux/amd64" | "linux/arm64") \
     set -x \
     && cd out \
     && ls -lh chip-ota-requestor-app \
@@ -312,22 +312,7 @@ RUN case ${TARGETPLATFORM} in \
        -da sha256 \
        chip-ota-requestor-app \
        ota-requestor-app.ota \
-    && echo "OTA image generated successfully for amd64" \
-    && ls -lh ota-requestor-app.ota \
-    ;; \
-    "linux/arm64") \
-    set -x \
-    && cd out \
-    && ls -lh chip-ota-requestor-app \
-    && ../src/app/ota_image_tool.py create \
-       -v 0xDEAD \
-       -p 0xBEEF \
-       -vn 2 \
-       -vs "2.0" \
-       -da sha256 \
-       chip-ota-requestor-app \
-       ota-requestor-app.ota \
-    && echo "OTA image generated successfully for arm64" \
+    && echo "OTA image generated successfully for ${TARGETPLATFORM##*/}" \
     && ls -lh ota-requestor-app.ota \
     ;; \
     *) ;; \


### PR DESCRIPTION
#### What changed

 Modified integrations/docker/images/chip-cert-bins/Dockerfile to automatically generate ota-requestor-app.ota during the build process

#### Related issues
https://github.com/project-chip/certification-tool/issues/852


#### Testing
Locally tested and the `ota-requestor-app.ota` file is available inside chip-cert-bins image
<img width="1432" height="121" alt="Screenshot 2026-01-30 at 09 29 41" src="https://github.com/user-attachments/assets/64947042-3d9b-4c9d-b969-a04f861eb881" />


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
