### PR TITLE
Re-enable TC_AVSM 2.18, 2.19, 2.21 test scripts in CI

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -9,18 +9,6 @@ not_automated:
       reason: Code/Test not being used or not shared code for any other tests
     - name: TC_AVSMTestBase.py
       reason: Shared code for TC_AVSM, not a standalone test
-    - name: TC_AVSM_2_18.py
-      reason:
-          AVSM flaky tests. See
-          https://github.com/project-chip/connectedhomeip/issues/42871
-    - name: TC_AVSM_2_19.py
-      reason:
-          AVSM flaky tests. See
-          https://github.com/project-chip/connectedhomeip/issues/42871
-    - name: TC_AVSM_2_21.py
-      reason:
-          AVSM flaky tests. See
-          https://github.com/project-chip/connectedhomeip/issues/42871
     - name: TC_BRBINFO_3_1.py
       reason:
           Attribute is not implemented in the bridge app. Same code as


### PR DESCRIPTION
#### Summary
The fix for resolving the flakiness has already merged in https://github.com/project-chip/connectedhomeip/pull/42883

#### Related issues

#### Testing
CI validation

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
