### PR TITLE
Attempt to limit darwin errors due to async hooks.

### DIFF
--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -353,7 +353,7 @@ def main():
 
         # on 64 bit systems, allow maximum memory usage to go over 4GB (#15620)
         if sys.maxsize >= 2**32:
-            os.environ["NODE_OPTIONS"] = "--max-old-space-size=8192"
+            os.environ["NODE_OPTIONS"] = "--max-old-space-size=16384 --no-force-async-hooks-checks"
 
         # `zap-cli` may extract things into a temporary directory. ensure extraction
         # does not conflict.


### PR DESCRIPTION
#### Summary

Darwin occasionally gets a nodejs failure like:

```
INFO    Error: async hook stack has become corrupted (actual: 3651, expected: 3651)
INFO     1: 0x104fd9978 node::AsyncHooks::FailWithCorruptedAsyncStack(double) [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
INFO     2: 0x104f3e04a node::InternalCallbackScope::Close() [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
INFO     3: 0x104f3d793 node::InternalCallbackScope::Close() [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
INFO     4: 0x1050133e1 napi_create_async_work [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
INFO     5: 0x105d751e8 uv_random [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
INFO     6: 0x105d7ae6b uv_async_init [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
INFO     7: 0x105d913fa uv_free_interface_addresses [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
INFO     8: 0x105d7b838 uv_run [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
INFO     9: 0x104f3f363 node::SpinEventLoop(node::Environment*) [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
INFO    10: 0x1050c77a5 node::NodeMainInstance::Run() [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
INFO    11: 0x10500f643 node::Start(int, char**) [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
INFO    12: 0x20adc7781 
```

Attempt to avoid seeing this by increasing RAM and disabling async hook checks.

#### Testing

Ran zap-regen locally and it seemed fine.