### PR TITLE
[Silabs] Fix WF200 NCP build when logging is disabled.

### DIFF
--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -394,9 +394,7 @@ extern "C" sl_status_t sl_wfx_host_process_event(sl_wfx_generic_message_t * even
         sl_wfx_exception_ind_t * firmware_exception = (sl_wfx_exception_ind_t *) event_payload;
         ChipLogError(DeviceLayer, "event: SL_WFX_EXCEPTION_IND_ID");
         ChipLogError(DeviceLayer, "firmware_exception->header.length: %d", firmware_exception->header.length);
-        // create a bytespan header.length with exception payload
-        ByteSpan exception_byte_span = ByteSpan((uint8_t *) firmware_exception, firmware_exception->header.length);
-        ChipLogByteSpan(DeviceLayer, exception_byte_span);
+        ChipLogByteSpan(DeviceLayer, ByteSpan((uint8_t *) firmware_exception, firmware_exception->header.length));
         break;
     }
     case SL_WFX_ERROR_IND_ID: {
@@ -404,9 +402,7 @@ extern "C" sl_status_t sl_wfx_host_process_event(sl_wfx_generic_message_t * even
         ChipLogError(DeviceLayer, "event: SL_WFX_ERROR_IND_ID");
         ChipLogError(DeviceLayer, "firmware_error->type: %lu", firmware_error->body.type);
         ChipLogError(DeviceLayer, "firmware_error->header.length: %d", firmware_error->header.length);
-        // create a bytespan header.length with error payload
-        ByteSpan error_byte_span = ByteSpan((uint8_t *) firmware_error, firmware_error->header.length);
-        ChipLogByteSpan(DeviceLayer, error_byte_span);
+        ChipLogByteSpan(DeviceLayer, ByteSpan((uint8_t *) firmware_error, firmware_error->header.length));
         break;
     }
     }


### PR DESCRIPTION
#### Summary
Avoid using local variable only for logging. Do the bytespan directly in the ChipLogByteSpan call

#### Related issues
n/a

#### Testing
Built an app with wf200 and no logging succesfully
`./scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs ./out/lighting_app BRD4187C --wifi wf200 chip_logging=false`