### PR TITLE
Code driven OTA requestor cluster - Code moves

### DIFF
--- a/src/platform/bouffalolab/BL602/BUILD.gn
+++ b/src/platform/bouffalolab/BL602/BUILD.gn
@@ -42,13 +42,6 @@ static_library("BL602") {
     "../common/SystemTimeSupport.cpp",
   ]
 
-  if (chip_enable_ota_requestor) {
-    sources += [
-      "../common/OTAImageProcessorImpl.cpp",
-      "../common/OTAImageProcessorImpl.h",
-    ]
-  }
-
   if (chip_enable_ble) {
     sources += [
       "../common/BLEManagerImpl.cpp",
@@ -77,6 +70,13 @@ static_library("BL602") {
     "${chip_root}/src/lib/dnssd:platform_header",
     "${chip_root}/src/platform/logging:headers",
   ]
+
+  if (chip_enable_ota_requestor) {
+    sources += [
+      "../common/OTAImageProcessorImpl.cpp",
+      "../common/OTAImageProcessorImpl.h",
+    ]
+  }
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
 }

--- a/src/platform/bouffalolab/BL616/BUILD.gn
+++ b/src/platform/bouffalolab/BL616/BUILD.gn
@@ -41,10 +41,6 @@ static_library("BL616") {
     "../common/PlatformManagerImpl.cpp",
   ]
 
-  if (chip_enable_ota_requestor) {
-    sources += [ "../common/OTAImageProcessorImpl_bflb.cpp" ]
-  }
-
   if (chip_enable_ble) {
     sources += [
       "../common/BLEManagerImpl.cpp",
@@ -72,6 +68,10 @@ static_library("BL616") {
     "${chip_root}/src/credentials:credentials_header",
     "${chip_root}/src/platform/logging:headers",
   ]
+
+  if (chip_enable_ota_requestor) {
+    sources += [ "../common/OTAImageProcessorImpl_bflb.cpp" ]
+  }
 
   if (chip_enable_wifi) {
     sources += [

--- a/src/platform/bouffalolab/BL702/BUILD.gn
+++ b/src/platform/bouffalolab/BL702/BUILD.gn
@@ -44,13 +44,6 @@ static_library("BL702") {
     "../common/SystemTimeSupport.cpp",
   ]
 
-  if (chip_enable_ota_requestor) {
-    sources += [
-      "../common/OTAImageProcessorImpl.cpp",
-      "../common/OTAImageProcessorImpl.h",
-    ]
-  }
-
   if (chip_enable_ble) {
     sources += [
       "../common/BLEManagerImpl.cpp",
@@ -77,6 +70,13 @@ static_library("BL702") {
     "${chip_root}/src/credentials:credentials_header",
     "${chip_root}/src/platform/logging:headers",
   ]
+
+  if (chip_enable_ota_requestor) {
+    sources += [
+      "../common/OTAImageProcessorImpl.cpp",
+      "../common/OTAImageProcessorImpl.h",
+    ]
+  }
 
   if (chip_enable_wifi) {
     sources += [

--- a/src/platform/bouffalolab/BL702L/BUILD.gn
+++ b/src/platform/bouffalolab/BL702L/BUILD.gn
@@ -42,13 +42,6 @@ static_library("BL702L") {
     "../common/SystemTimeSupport.cpp",
   ]
 
-  if (chip_enable_ota_requestor) {
-    sources += [
-      "../common/OTAImageProcessorImpl.cpp",
-      "../common/OTAImageProcessorImpl.h",
-    ]
-  }
-
   if (chip_enable_ble) {
     sources += [
       "../common/BLEManagerImpl.cpp",
@@ -76,6 +69,13 @@ static_library("BL702L") {
     "${chip_root}/src/credentials:credentials_header",
     "${chip_root}/src/platform/logging:headers",
   ]
+
+  if (chip_enable_ota_requestor) {
+    sources += [
+      "../common/OTAImageProcessorImpl.cpp",
+      "../common/OTAImageProcessorImpl.h",
+    ]
+  }
 
   if (chip_enable_openthread) {
     # needed for MTD/FTD


### PR DESCRIPTION
#### Summary

Move some build source include checks in advance of making the OTA requestor code-driven. #41970 is the follow-up PR to make the cluster code-driven.

#### Related issues

#36538

#### Testing

Built the OTA requestor example app.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
