### PR TITLE
AVSUM: Use NotifyAttributeChanged instead of MatterReportingAttributeChangeCallback

### DIFF
--- a/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.cpp
+++ b/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.cpp
@@ -51,6 +51,7 @@ CHIP_ERROR CameraAvSettingsUserLevelManagementCluster::Startup(ServerClusterCont
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
 
+    mLogic.SetCluster(this);
     return mLogic.Startup();
 }
 /**

--- a/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.cpp
+++ b/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.cpp
@@ -51,7 +51,7 @@ CHIP_ERROR CameraAvSettingsUserLevelManagementCluster::Startup(ServerClusterCont
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
 
-    mLogic.SetCluster(this);
+    mLogic.SetMarkDirtyCallback([this](AttributeId attributeId) { MarkAttributeDirty(attributeId); });
     return mLogic.Startup();
 }
 /**

--- a/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.h
+++ b/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.h
@@ -213,6 +213,8 @@ public:
 
     CameraAvSettingsUserLevelMgmtServerLogic & GetLogic() { return mLogic; }
 
+    void MarkAttributeDirty(AttributeId attributeId) { NotifyAttributeChanged(attributeId); }
+
     void SetDelegate(CameraAvSettingsUserLevelManagementDelegate * delegate)
     {
         mLogic.SetDelegate(delegate);

--- a/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementLogic.cpp
+++ b/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementLogic.cpp
@@ -22,7 +22,6 @@
 #include <app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.h>
 #include <app/persistence/AttributePersistenceProvider.h>
 #include <app/persistence/AttributePersistenceProviderInstance.h>
-#include <app/reporting/reporting.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <app/util/util.h>
 #include <clusters/CameraAvSettingsUserLevelManagement/Metadata.h>
@@ -135,7 +134,10 @@ CHIP_ERROR CameraAvSettingsUserLevelMgmtServerLogic::Attributes(ReadOnlyBufferBu
 
 void CameraAvSettingsUserLevelMgmtServerLogic::MarkDirty(AttributeId aAttributeId)
 {
-    MatterReportingAttributeChangeCallback(mEndpointId, CameraAvSettingsUserLevelManagement::Id, aAttributeId);
+    if (mCluster != nullptr)
+    {
+        mCluster->MarkAttributeDirty(aAttributeId);
+    }
 }
 
 CHIP_ERROR CameraAvSettingsUserLevelMgmtServerLogic::StoreMPTZPosition(

--- a/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementLogic.cpp
+++ b/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementLogic.cpp
@@ -22,6 +22,7 @@
 #include <app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.h>
 #include <app/persistence/AttributePersistenceProvider.h>
 #include <app/persistence/AttributePersistenceProviderInstance.h>
+#include <app/reporting/reporting.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <app/util/util.h>
 #include <clusters/CameraAvSettingsUserLevelManagement/Metadata.h>
@@ -134,9 +135,9 @@ CHIP_ERROR CameraAvSettingsUserLevelMgmtServerLogic::Attributes(ReadOnlyBufferBu
 
 void CameraAvSettingsUserLevelMgmtServerLogic::MarkDirty(AttributeId aAttributeId)
 {
-    if (mCluster != nullptr)
+    if (mMarkDirtyCallback)
     {
-        mCluster->MarkAttributeDirty(aAttributeId);
+        mMarkDirtyCallback(aAttributeId);
     }
 }
 

--- a/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementLogic.h
+++ b/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementLogic.h
@@ -21,7 +21,6 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AttributeValueEncoder.h>
 #include <app/CommandHandler.h>
-#include <app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.h>
 #include <app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementConstants.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
 #include <app/data-model-provider/MetadataTypes.h>
@@ -35,6 +34,7 @@ namespace app {
 namespace Clusters {
 
 class CameraAvSettingsUserLevelManagementDelegate;
+class CameraAvSettingsUserLevelManagementCluster;
 
 class CameraAvSettingsUserLevelMgmtServerLogic : public CameraAvSettingsUserLevelManagement::PhysicalPTZCallback
 {
@@ -59,6 +59,8 @@ public:
             ChipLogError(Zcl, "CameraAVSettingsUserLevelManagement: Trying to set delegate to null");
         }
     }
+
+    void SetCluster(CameraAvSettingsUserLevelManagementCluster * cluster) { mCluster = cluster; }
 
     EndpointId mEndpointId = kInvalidEndpointId;
 
@@ -205,6 +207,7 @@ public:
 
 private:
     CameraAvSettingsUserLevelManagementDelegate * mDelegate = nullptr;
+    CameraAvSettingsUserLevelManagementCluster * mCluster   = nullptr;
 
     // Holding variables for values subject to successful physical movement
     Optional<int16_t> mTargetPan;

--- a/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementLogic.h
+++ b/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementLogic.h
@@ -21,11 +21,14 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AttributeValueEncoder.h>
 #include <app/CommandHandler.h>
+#include <app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.h>
 #include <app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementConstants.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <lib/support/ReadOnlyBuffer.h>
 #include <protocols/interaction_model/StatusCode.h>
+
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -34,7 +37,9 @@ namespace app {
 namespace Clusters {
 
 class CameraAvSettingsUserLevelManagementDelegate;
-class CameraAvSettingsUserLevelManagementCluster;
+
+// Callback type for notifying attribute changes
+using MarkDirtyCallback = std::function<void(AttributeId)>;
 
 class CameraAvSettingsUserLevelMgmtServerLogic : public CameraAvSettingsUserLevelManagement::PhysicalPTZCallback
 {
@@ -60,7 +65,7 @@ public:
         }
     }
 
-    void SetCluster(CameraAvSettingsUserLevelManagementCluster * cluster) { mCluster = cluster; }
+    void SetMarkDirtyCallback(MarkDirtyCallback callback) { mMarkDirtyCallback = std::move(callback); }
 
     EndpointId mEndpointId = kInvalidEndpointId;
 
@@ -207,7 +212,7 @@ public:
 
 private:
     CameraAvSettingsUserLevelManagementDelegate * mDelegate = nullptr;
-    CameraAvSettingsUserLevelManagementCluster * mCluster   = nullptr;
+    MarkDirtyCallback mMarkDirtyCallback;
 
     // Holding variables for values subject to successful physical movement
     Optional<int16_t> mTargetPan;


### PR DESCRIPTION


#### Summary

Replace legacy MatterReportingAttributeChangeCallback with NotifyAttributeChanged for CameraAvSettingsUserLevelMgmtServerLogic. 

This aligns with the code-driven cluster pattern where NotifyAttributeChanged properly increments the cluster data version and notifies through the ServerClusterContext.

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
