### PR TITLE
Replace some TEMPORARY_RETURN_IGNORED with LogErrorOnFailure

### DIFF
--- a/src/app/clusters/groups-server/GroupsCluster.cpp
+++ b/src/app/clusters/groups-server/GroupsCluster.cpp
@@ -341,7 +341,7 @@ bool emberAfGroupsClusterRemoveAllGroupsCallback(app::CommandHandler * commandOb
     }
 #endif
 
-    TEMPORARY_RETURN_IGNORED provider->RemoveEndpoint(fabricIndex, commandPath.mEndpointId);
+    LogErrorOnFailure(provider->RemoveEndpoint(fabricIndex, commandPath.mEndpointId));
     status = Status::Success;
     MatterReportingAttributeChangeCallback(kRootEndpointId, GroupKeyManagement::Id, GroupKeyManagement::Attributes::GroupTable::Id);
 exit:

--- a/src/app/clusters/scenes-server/CodegenIntegration.cpp
+++ b/src/app/clusters/scenes-server/CodegenIntegration.cpp
@@ -167,7 +167,7 @@ void ScenesServer::GroupWillBeRemoved(FabricIndex aFabricIx, EndpointId aEndpoin
     ScenesManagementCluster * cluster = FindClusterOnEndpoint(aEndpointId);
     VerifyOrReturn(cluster != nullptr);
 
-    TEMPORARY_RETURN_IGNORED cluster->GroupWillBeRemoved(aFabricIx, aGroupId);
+    LogErrorOnFailure(cluster->GroupWillBeRemoved(aFabricIx, aGroupId));
 }
 
 void ScenesServer::MakeSceneInvalid(EndpointId aEndpointId, FabricIndex aFabricIx)
@@ -175,35 +175,35 @@ void ScenesServer::MakeSceneInvalid(EndpointId aEndpointId, FabricIndex aFabricI
     ScenesManagementCluster * cluster = FindClusterOnEndpoint(aEndpointId);
     VerifyOrReturn(cluster != nullptr);
 
-    TEMPORARY_RETURN_IGNORED cluster->MakeSceneInvalid(aFabricIx);
+    LogErrorOnFailure(cluster->MakeSceneInvalid(aFabricIx));
 }
 
 void ScenesServer::MakeSceneInvalidForAllFabrics(EndpointId aEndpointId)
 {
     ScenesManagementCluster * cluster = FindClusterOnEndpoint(aEndpointId);
     VerifyOrReturn(cluster != nullptr);
-    TEMPORARY_RETURN_IGNORED cluster->MakeSceneInvalidForAllFabrics();
+    LogErrorOnFailure(cluster->MakeSceneInvalidForAllFabrics());
 }
 
 void ScenesServer::StoreCurrentScene(FabricIndex aFabricIx, EndpointId aEndpointId, GroupId aGroupId, SceneId aSceneId)
 {
     ScenesManagementCluster * cluster = FindClusterOnEndpoint(aEndpointId);
     VerifyOrReturn(cluster != nullptr);
-    TEMPORARY_RETURN_IGNORED cluster->StoreCurrentScene(aFabricIx, aGroupId, aSceneId);
+    LogErrorOnFailure(cluster->StoreCurrentScene(aFabricIx, aGroupId, aSceneId));
 }
 
 void ScenesServer::RecallScene(FabricIndex aFabricIx, EndpointId aEndpointId, GroupId aGroupId, SceneId aSceneId)
 {
     ScenesManagementCluster * cluster = FindClusterOnEndpoint(aEndpointId);
     VerifyOrReturn(cluster != nullptr);
-    TEMPORARY_RETURN_IGNORED cluster->RecallScene(aFabricIx, aGroupId, aSceneId);
+    LogErrorOnFailure(cluster->RecallScene(aFabricIx, aGroupId, aSceneId));
 }
 
 void ScenesServer::RemoveFabric(EndpointId aEndpointId, FabricIndex aFabricIndex)
 {
     ScenesManagementCluster * cluster = FindClusterOnEndpoint(aEndpointId);
     VerifyOrReturn(cluster != nullptr);
-    TEMPORARY_RETURN_IGNORED cluster->RemoveFabric(aFabricIndex);
+    LogErrorOnFailure(cluster->RemoveFabric(aFabricIndex));
 }
 
 } // namespace chip::app::Clusters::ScenesManagement


### PR DESCRIPTION
#### Summary

We have potential failures that are never logged.
When changing clusters in #42886 it turns out that adding logging costs some flash.

Separating this change out to be able to compare flash changes separately. We likely want logging rather than "return ignored".

#### Testing

Generally a trivial change, CI will validate that nothing breaks (I don't expect anything to break really).