### PR TITLE
Use dependency injection in `NetworkCommissioningCluster` cluster for global values

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
@@ -65,11 +65,11 @@ public:
     void UnRegister(CodeDrivenDataModelProvider & provider) override;
 
 protected:
+    Context mContext;
+
     LazyRegisteredServerCluster<Clusters::GeneralCommissioningCluster> mGeneralCommissioningCluster;
 
 private:
-    Context mContext;
-
     LazyRegisteredServerCluster<Clusters::BasicInformationCluster> mBasicInformationCluster;
     LazyRegisteredServerCluster<Clusters::AdministratorCommissioningWithBasicCommissioningWindowCluster>
         mAdministratorCommissioningCluster;

--- a/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.cpp
@@ -36,9 +36,9 @@ CHIP_ERROR WifiRootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataMod
 
     mNetworkCommissioningCluster.Create(endpointId, &mWifiContext.wifiDriver, mGeneralCommissioningCluster.Cluster(),
                                         NetworkCommissioningCluster::Context{
-                                            .failSafeContext     = mWifiContext.failSafeContext,
-                                            .platformManager         = mWifiContext.platformManager,
-                                            .deviceControlServer = mWifiContext.deviceControlServer,
+                                            .failSafeContext     = mContext.failSafeContext,
+                                            .platformManager     = mContext.platformManager,
+                                            .deviceControlServer = mContext.deviceControlServer,
                                         });
     ReturnErrorOnFailure(mNetworkCommissioningCluster.Cluster().Init());
     ReturnErrorOnFailure(provider.AddCluster(mNetworkCommissioningCluster.Registration()));

--- a/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.cpp
@@ -36,9 +36,9 @@ CHIP_ERROR WifiRootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataMod
 
     mNetworkCommissioningCluster.Create(endpointId, &mWifiContext.wifiDriver, mGeneralCommissioningCluster.Cluster(),
                                         NetworkCommissioningCluster::Context{
-                                            .failSafeContext     = mContext.failSafeContext,
-                                            .platformMgr         = mContext.platformManager,
-                                            .deviceControlServer = mContext.deviceControlServer,
+                                            .failSafeContext     = mWifiContext.failSafeContext,
+                                            .platformManager         = mWifiContext.platformManager,
+                                            .deviceControlServer = mWifiContext.deviceControlServer,
                                         });
     ReturnErrorOnFailure(mNetworkCommissioningCluster.Cluster().Init());
     ReturnErrorOnFailure(provider.AddCluster(mNetworkCommissioningCluster.Registration()));

--- a/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.cpp
@@ -34,8 +34,9 @@ CHIP_ERROR WifiRootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataMod
                                    BitFlags<WiFiNetworkDiagnostics::Feature>{});
     ReturnErrorOnFailure(provider.AddCluster(mWifiDiagnosticsCluster.Registration()));
 
-    mNetworkCommissioningCluster.Create(endpointId, &mWifiContext.wifiDriver, mGeneralCommissioningCluster.Cluster(),
+    mNetworkCommissioningCluster.Create(endpointId, &mWifiContext.wifiDriver,
                                         NetworkCommissioningCluster::Context{
+                                            .breadcrumbTracker   = mGeneralCommissioningCluster.Cluster(),
                                             .failSafeContext     = mContext.failSafeContext,
                                             .platformManager     = mContext.platformManager,
                                             .deviceControlServer = mContext.deviceControlServer,

--- a/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.cpp
@@ -34,7 +34,12 @@ CHIP_ERROR WifiRootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataMod
                                    BitFlags<WiFiNetworkDiagnostics::Feature>{});
     ReturnErrorOnFailure(provider.AddCluster(mWifiDiagnosticsCluster.Registration()));
 
-    mNetworkCommissioningCluster.Create(endpointId, &mWifiContext.wifiDriver, mGeneralCommissioningCluster.Cluster());
+    mNetworkCommissioningCluster.Create(endpointId, &mWifiContext.wifiDriver, mGeneralCommissioningCluster.Cluster(),
+                                        NetworkCommissioningCluster::Context{
+                                            .failSafeContext     = mContext.failSafeContext,
+                                            .platformMgr         = mContext.platformManager,
+                                            .deviceControlServer = mContext.deviceControlServer,
+                                        });
     ReturnErrorOnFailure(mNetworkCommissioningCluster.Cluster().Init());
     ReturnErrorOnFailure(provider.AddCluster(mNetworkCommissioningCluster.Registration()));
 

--- a/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.h
@@ -30,9 +30,6 @@ public:
     struct WifiContext
     {
         DeviceLayer::NetworkCommissioning::WiFiDriver & wifiDriver;
-        FailSafeContext & failSafeContext;
-        DeviceLayer::PlatformManager & platformManager;
-        DeviceLayer::DeviceControlServer & deviceControlServer;
     };
 
     WifiRootNodeDevice(const Context & context, const WifiContext & wifiContext) :

--- a/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.h
@@ -30,6 +30,9 @@ public:
     struct WifiContext
     {
         DeviceLayer::NetworkCommissioning::WiFiDriver & wifiDriver;
+        FailSafeContext & failSafeContext;
+        DeviceLayer::PlatformManager & platformManager;
+        DeviceLayer::DeviceControlServer & deviceControlServer;
     };
 
     WifiRootNodeDevice(const Context & context, const WifiContext & wifiContext) :

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -216,9 +216,6 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
         },
         WifiRootNodeDevice::WifiContext{
             .wifiDriver = sWiFiDriver,
-            .platformManager = DeviceLayer::PlatformMgr(),
-            .failSafeContext = Server::GetInstance().GetFailSafeContext(),
-            .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
         });
     err = gRootNodeDevice->Register(kRootEndpointId, dataModelProvider, kInvalidEndpointId);
     if (err != CHIP_NO_ERROR)

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -206,7 +206,7 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
                 .persistentStorage      = Server::GetInstance().GetPersistentStorage(),          //
                 .failSafeContext        = Server::GetInstance().GetFailSafeContext(),            //
                 .platformManager        = DeviceLayer::PlatformMgr(),                            //
-                .groupDataProvider      = gGropupDataProvider,                                   //
+                .groupDataProvider      = gGroupDataProvider,                                    //
                 .sessionManager         = Server::GetInstance().GetSecureSessionManager(),       //
                 .dnssdServer            = DnssdServer::Instance(),                               //
 
@@ -216,6 +216,9 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
         },
         WifiRootNodeDevice::WifiContext{
             .wifiDriver = sWiFiDriver,
+            .platformManager = DeviceLayer::PlatformMgr(),
+            .failSafeContext = Server::GetInstance().GetFailSafeContext(),
+            .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
         });
     err = gRootNodeDevice->Register(kRootEndpointId, dataModelProvider, kInvalidEndpointId);
     if (err != CHIP_NO_ERROR)

--- a/src/app/clusters/network-commissioning/CodegenInstance.h
+++ b/src/app/clusters/network-commissioning/CodegenInstance.h
@@ -45,9 +45,9 @@ public:
     /// Calls Shutdown on the cluster and unregisters the cluster from the CodegenDataModelProvider Registry
     void Shutdown();
 
-    Instance(EndpointId aEndpointId, WiFiDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker) {}
-    Instance(EndpointId aEndpointId, ThreadDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker) {}
-    Instance(EndpointId aEndpointId, EthernetDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker) {}
+    Instance(EndpointId aEndpointId, WiFiDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker, mContext) {}
+    Instance(EndpointId aEndpointId, ThreadDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker, mContext) {}
+    Instance(EndpointId aEndpointId, EthernetDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker, mContext) {}
 
 private:
     // Does the tracking via the public general commissioning cluster (if available)
@@ -58,6 +58,11 @@ private:
     };
 
     CodegenGeneralCommissioningBreadcrumbTracker mTracker;
+    NetworkCommissioningCluster::Context mContext{
+        .failSafeContext    = chip::Server::GetInstance().GetFailSafeContext(),
+        .platformMgr        = chip::DeviceLayer::PlatformMgr(),
+        .deviceControlServer = chip::DeviceLayer::DeviceControlServer::DeviceControlSvr(),
+    };
     RegisteredServerCluster<NetworkCommissioningCluster> mCluster;
 };
 

--- a/src/app/clusters/network-commissioning/CodegenInstance.h
+++ b/src/app/clusters/network-commissioning/CodegenInstance.h
@@ -61,7 +61,7 @@ private:
     CodegenGeneralCommissioningBreadcrumbTracker mTracker;
     NetworkCommissioningCluster::Context mContext{
         .failSafeContext     = Server::GetInstance().GetFailSafeContext(),
-        .platformMgr         = DeviceLayer::PlatformMgr(),
+        .platformManager         = DeviceLayer::PlatformMgr(),
         .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
     };
     RegisteredServerCluster<NetworkCommissioningCluster> mCluster;

--- a/src/app/clusters/network-commissioning/CodegenInstance.h
+++ b/src/app/clusters/network-commissioning/CodegenInstance.h
@@ -19,6 +19,7 @@
 #include "NetworkCommissioningCluster.h"
 
 #include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
+#include <app/server/Server.h>
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 
@@ -59,9 +60,9 @@ private:
 
     CodegenGeneralCommissioningBreadcrumbTracker mTracker;
     NetworkCommissioningCluster::Context mContext{
-        .failSafeContext    = chip::Server::GetInstance().GetFailSafeContext(),
-        .platformMgr        = chip::DeviceLayer::PlatformMgr(),
-        .deviceControlServer = chip::DeviceLayer::DeviceControlServer::DeviceControlSvr(),
+        .failSafeContext    = Server::GetInstance().GetFailSafeContext(),
+        .platformMgr        = DeviceLayer::PlatformMgr(),
+        .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
     };
     RegisteredServerCluster<NetworkCommissioningCluster> mCluster;
 };

--- a/src/app/clusters/network-commissioning/CodegenInstance.h
+++ b/src/app/clusters/network-commissioning/CodegenInstance.h
@@ -19,8 +19,8 @@
 #include "NetworkCommissioningCluster.h"
 
 #include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
-#include <app/server/Server.h>
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
+#include <app/server/Server.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 
 namespace chip {
@@ -60,8 +60,8 @@ private:
 
     CodegenGeneralCommissioningBreadcrumbTracker mTracker;
     NetworkCommissioningCluster::Context mContext{
-        .failSafeContext    = Server::GetInstance().GetFailSafeContext(),
-        .platformMgr        = DeviceLayer::PlatformMgr(),
+        .failSafeContext     = Server::GetInstance().GetFailSafeContext(),
+        .platformMgr         = DeviceLayer::PlatformMgr(),
         .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
     };
     RegisteredServerCluster<NetworkCommissioningCluster> mCluster;

--- a/src/app/clusters/network-commissioning/CodegenInstance.h
+++ b/src/app/clusters/network-commissioning/CodegenInstance.h
@@ -46,9 +46,9 @@ public:
     /// Calls Shutdown on the cluster and unregisters the cluster from the CodegenDataModelProvider Registry
     void Shutdown();
 
-    Instance(EndpointId aEndpointId, WiFiDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker, mContext) {}
-    Instance(EndpointId aEndpointId, ThreadDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker, mContext) {}
-    Instance(EndpointId aEndpointId, EthernetDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mTracker, mContext) {}
+    Instance(EndpointId aEndpointId, WiFiDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mContext) {}
+    Instance(EndpointId aEndpointId, ThreadDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mContext) {}
+    Instance(EndpointId aEndpointId, EthernetDriver * apDelegate) : mCluster(aEndpointId, apDelegate, mContext) {}
 
 private:
     // Does the tracking via the public general commissioning cluster (if available)
@@ -60,8 +60,9 @@ private:
 
     CodegenGeneralCommissioningBreadcrumbTracker mTracker;
     NetworkCommissioningCluster::Context mContext{
+        .breadcrumbTracker   = mTracker,
         .failSafeContext     = Server::GetInstance().GetFailSafeContext(),
-        .platformManager         = DeviceLayer::PlatformMgr(),
+        .platformManager     = DeviceLayer::PlatformMgr(),
         .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
     };
     RegisteredServerCluster<NetworkCommissioningCluster> mCluster;

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -29,7 +29,6 @@
 #include <app/reporting/reporting.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <app/server-cluster/DefaultServerCluster.h>
-#include <app/server/Server.h>
 #include <clusters/NetworkCommissioning/AttributeIds.h>
 #include <clusters/NetworkCommissioning/CommandIds.h>
 #include <clusters/NetworkCommissioning/Commands.h>
@@ -46,8 +45,6 @@
 #include <optional>
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/ConnectivityManager.h>
-#include <platform/DeviceControlServer.h>
-#include <platform/PlatformManager.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 #include <protocols/interaction_model/StatusCode.h>
 #include <tracing/macros.h>

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -169,29 +169,26 @@ std::optional<ActionReturnStatus> EnsureFailsafeIsArmed(FailSafeContext & failSa
     (void) 0
 } // namespace
 
-NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, WiFiDriver * driver, BreadCrumbTracker & tracker,
-                                                         const Context & context) :
+NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, WiFiDriver * driver, const Context & context) :
     DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
     mEndpointId(endpointId), mFeatureFlags(WiFiFeatures(driver)), mpWirelessDriver(driver), mpBaseDriver(driver),
-    mBreadcrumbTracker(tracker), mClusterContext(context)
+    mClusterContext(context)
 {
     mpDriver.Set<WiFiDriver *>(driver);
 }
 
-NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, ThreadDriver * driver, BreadCrumbTracker & tracker,
-                                                         const Context & context) :
+NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, ThreadDriver * driver, const Context & context) :
     DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
     mEndpointId(endpointId), mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(driver), mpBaseDriver(driver),
-    mBreadcrumbTracker(tracker), mClusterContext(context)
+    mClusterContext(context)
 {
     mpDriver.Set<ThreadDriver *>(driver);
 }
 
-NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, EthernetDriver * driver,
-                                                         BreadCrumbTracker & tracker, const Context & context) :
+NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, EthernetDriver * driver, const Context & context) :
     DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
     mEndpointId(endpointId), mFeatureFlags(Feature::kEthernetNetworkInterface), mpWirelessDriver(nullptr), mpBaseDriver(driver),
-    mBreadcrumbTracker(tracker), mClusterContext(context)
+    mClusterContext(context)
 {}
 
 #if CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
@@ -587,7 +584,7 @@ NetworkCommissioningCluster::HandleAddOrUpdateThreadNetwork(CommandHandler & han
 void NetworkCommissioningCluster::UpdateBreadcrumb(const Optional<uint64_t> & breadcrumb)
 {
     VerifyOrReturn(breadcrumb.HasValue());
-    mBreadcrumbTracker.SetBreadCrumb(breadcrumb.Value());
+    mClusterContext.breadcrumbTracker(breadcrumb.Value());
 }
 
 void NetworkCommissioningCluster::CommitSavedBreadcrumb()

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -581,7 +581,7 @@ NetworkCommissioningCluster::HandleAddOrUpdateThreadNetwork(CommandHandler & han
 void NetworkCommissioningCluster::UpdateBreadcrumb(const Optional<uint64_t> & breadcrumb)
 {
     VerifyOrReturn(breadcrumb.HasValue());
-    mClusterContext.breadcrumbTracker(breadcrumb.Value());
+    mClusterContext.breadcrumbTracker.SetBreadCrumb(breadcrumb.Value());
 }
 
 void NetworkCommissioningCluster::CommitSavedBreadcrumb()

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -200,7 +200,7 @@ NetworkCommissioningCluster::NetworkInstanceList NetworkCommissioningCluster::sI
 
 CHIP_ERROR NetworkCommissioningCluster::Init()
 {
-    ReturnErrorOnFailure(mClusterContext.platformMgr.AddEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this)));
+    ReturnErrorOnFailure(mClusterContext.platformManager.AddEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this)));
     ReturnErrorOnFailure(mpBaseDriver->Init(this));
     mLastNetworkingStatusValue.SetNull();
     mLastConnectErrorValue.SetNull();

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -164,23 +164,25 @@ std::optional<ActionReturnStatus> EnsureFailsafeIsArmed(FailSafeContext & failSa
 /// is not armed for the given fabric index.
 ///
 /// This just wraps EnsureFailsafeIsArmed with a one-liner for check & return.
-#define RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(failSafeContext, fabricIndex)                                                                     \
-    if (std::optional<ActionReturnStatus> status = EnsureFailsafeIsArmed(failSafeContext, fabricIndex); status.has_value())                         \
+#define RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(failSafeContext, fabricIndex)                                                    \
+    if (std::optional<ActionReturnStatus> status = EnsureFailsafeIsArmed(failSafeContext, fabricIndex); status.has_value())        \
     {                                                                                                                              \
         return status;                                                                                                             \
     }                                                                                                                              \
     (void) 0
 } // namespace
 
-NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, WiFiDriver * driver, BreadCrumbTracker & tracker, const Context & context) :
-    DefaultServerCluster({ endpointId, NetworkCommissioning::Id }), mEndpointId(endpointId), mFeatureFlags(WiFiFeatures(driver)),
-    mpWirelessDriver(driver), mpBaseDriver(driver), mBreadcrumbTracker(tracker), mClusterContext(context)
+NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, WiFiDriver * driver, BreadCrumbTracker & tracker,
+                                                         const Context & context) :
+    DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
+    mEndpointId(endpointId), mFeatureFlags(WiFiFeatures(driver)), mpWirelessDriver(driver), mpBaseDriver(driver),
+    mBreadcrumbTracker(tracker), mClusterContext(context)
 {
     mpDriver.Set<WiFiDriver *>(driver);
 }
 
-NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, ThreadDriver * driver,
-                                                         BreadCrumbTracker & tracker, const Context & context) :
+NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, ThreadDriver * driver, BreadCrumbTracker & tracker,
+                                                         const Context & context) :
     DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
     mEndpointId(endpointId), mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(driver), mpBaseDriver(driver),
     mBreadcrumbTracker(tracker), mClusterContext(context)

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -150,10 +150,8 @@ void FillDebugTextAndNetworkIndex(Commands::NetworkConfigResponse::Type & respon
     }
 }
 
-std::optional<ActionReturnStatus> EnsureFailsafeIsArmed(FabricIndex fabricIndex)
+std::optional<ActionReturnStatus> EnsureFailsafeIsArmed(FailSafeContext & failSafeContext, FabricIndex fabricIndex)
 {
-    auto & failSafeContext = chip::Server::GetInstance().GetFailSafeContext();
-
     if (!failSafeContext.IsFailSafeArmed(fabricIndex))
     {
         return Protocols::InteractionModel::Status::FailsafeRequired;
@@ -166,35 +164,35 @@ std::optional<ActionReturnStatus> EnsureFailsafeIsArmed(FabricIndex fabricIndex)
 /// is not armed for the given fabric index.
 ///
 /// This just wraps EnsureFailsafeIsArmed with a one-liner for check & return.
-#define RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(fabricIndex)                                                                     \
-    if (std::optional<ActionReturnStatus> status = EnsureFailsafeIsArmed(fabricIndex); status.has_value())                         \
+#define RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(failSafeContext, fabricIndex)                                                                     \
+    if (std::optional<ActionReturnStatus> status = EnsureFailsafeIsArmed(failSafeContext, fabricIndex); status.has_value())                         \
     {                                                                                                                              \
         return status;                                                                                                             \
     }                                                                                                                              \
     (void) 0
 } // namespace
 
-NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, WiFiDriver * driver, BreadCrumbTracker & tracker) :
+NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, WiFiDriver * driver, BreadCrumbTracker & tracker, const Context & context) :
     DefaultServerCluster({ endpointId, NetworkCommissioning::Id }), mEndpointId(endpointId), mFeatureFlags(WiFiFeatures(driver)),
-    mpWirelessDriver(driver), mpBaseDriver(driver), mBreadcrumbTracker(tracker)
+    mpWirelessDriver(driver), mpBaseDriver(driver), mBreadcrumbTracker(tracker), mClusterContext(context)
 {
     mpDriver.Set<WiFiDriver *>(driver);
 }
 
 NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, ThreadDriver * driver,
-                                                         BreadCrumbTracker & tracker) :
+                                                         BreadCrumbTracker & tracker, const Context & context) :
     DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
     mEndpointId(endpointId), mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(driver), mpBaseDriver(driver),
-    mBreadcrumbTracker(tracker)
+    mBreadcrumbTracker(tracker), mClusterContext(context)
 {
     mpDriver.Set<ThreadDriver *>(driver);
 }
 
 NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, EthernetDriver * driver,
-                                                         BreadCrumbTracker & tracker) :
+                                                         BreadCrumbTracker & tracker, const Context & context) :
     DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
     mEndpointId(endpointId), mFeatureFlags(Feature::kEthernetNetworkInterface), mpWirelessDriver(nullptr), mpBaseDriver(driver),
-    mBreadcrumbTracker(tracker)
+    mBreadcrumbTracker(tracker), mClusterContext(context)
 {}
 
 #if CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
@@ -203,7 +201,7 @@ NetworkCommissioningCluster::NetworkInstanceList NetworkCommissioningCluster::sI
 
 CHIP_ERROR NetworkCommissioningCluster::Init()
 {
-    ReturnErrorOnFailure(DeviceLayer::PlatformMgrImpl().AddEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this)));
+    ReturnErrorOnFailure(mClusterContext.platformMgr.AddEventHandler(OnPlatformEventHandler, reinterpret_cast<intptr_t>(this)));
     ReturnErrorOnFailure(mpBaseDriver->Init(this));
     mLastNetworkingStatusValue.SetNull();
     mLastConnectErrorValue.SetNull();
@@ -378,7 +376,7 @@ NetworkCommissioningCluster::HandleAddOrUpdateWiFiNetwork(CommandHandler & handl
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
     MATTER_TRACE_SCOPE("HandleAddOrUpdateWiFiNetwork", "NetworkCommissioning");
 
-    RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(handler.GetAccessingFabricIndex());
+    RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(mClusterContext.failSafeContext, handler.GetAccessingFabricIndex());
 
     if (req.ssid.empty() || req.ssid.size() > DeviceLayer::Internal::kMaxWiFiSSIDLength)
     {
@@ -566,7 +564,7 @@ NetworkCommissioningCluster::HandleAddOrUpdateThreadNetwork(CommandHandler & han
 
     MATTER_TRACE_SCOPE("HandleAddOrUpdateThreadNetwork", "NetworkCommissioning");
 
-    RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(handler.GetAccessingFabricIndex());
+    RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(mClusterContext.failSafeContext, handler.GetAccessingFabricIndex());
 
     Commands::NetworkConfigResponse::Type response;
     DebugTextStorage debugTextBuffer;
@@ -607,7 +605,7 @@ NetworkCommissioningCluster::HandleRemoveNetwork(CommandHandler & handler, const
 {
     MATTER_TRACE_SCOPE("HandleRemoveNetwork", "NetworkCommissioning");
 
-    RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(handler.GetAccessingFabricIndex());
+    RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(mClusterContext.failSafeContext, handler.GetAccessingFabricIndex());
 
     Commands::NetworkConfigResponse::Type response;
     DebugTextStorage debugTextBuffer;
@@ -642,7 +640,7 @@ NetworkCommissioningCluster::HandleConnectNetwork(CommandHandler & handler, cons
         return Protocols::InteractionModel::Status::ConstraintError;
     }
 
-    RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(handler.GetAccessingFabricIndex());
+    RETURN_ERROR_STATUS_IF_FAILSAFE_NOT_ARMED(mClusterContext.failSafeContext, handler.GetAccessingFabricIndex());
 
     mConnectingNetworkIDLen = static_cast<uint8_t>(req.networkID.size());
     memcpy(mConnectingNetworkID, req.networkID.data(), mConnectingNetworkIDLen);
@@ -837,7 +835,7 @@ void NetworkCommissioningCluster::OnResult(Status commissioningError, CharSpan d
     }
     if (commissioningError == Status::kSuccess)
     {
-        TEMPORARY_RETURN_IGNORED DeviceLayer::DeviceControlServer::DeviceControlSvr().PostConnectedToOperationalNetworkEvent(
+        TEMPORARY_RETURN_IGNORED mClusterContext.deviceControlServer.PostConnectedToOperationalNetworkEvent(
             ByteSpan(mLastNetworkID, mLastNetworkIDLen));
         SetLastConnectErrorValue(NullNullable);
     }

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -170,25 +170,22 @@ std::optional<ActionReturnStatus> EnsureFailsafeIsArmed(FailSafeContext & failSa
 } // namespace
 
 NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, WiFiDriver * driver, const Context & context) :
-    DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
-    mEndpointId(endpointId), mFeatureFlags(WiFiFeatures(driver)), mpWirelessDriver(driver), mpBaseDriver(driver),
-    mClusterContext(context)
+    DefaultServerCluster({ endpointId, NetworkCommissioning::Id }), mEndpointId(endpointId), mFeatureFlags(WiFiFeatures(driver)),
+    mpWirelessDriver(driver), mpBaseDriver(driver), mClusterContext(context)
 {
     mpDriver.Set<WiFiDriver *>(driver);
 }
 
 NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, ThreadDriver * driver, const Context & context) :
-    DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
-    mEndpointId(endpointId), mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(driver), mpBaseDriver(driver),
-    mClusterContext(context)
+    DefaultServerCluster({ endpointId, NetworkCommissioning::Id }), mEndpointId(endpointId),
+    mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(driver), mpBaseDriver(driver), mClusterContext(context)
 {
     mpDriver.Set<ThreadDriver *>(driver);
 }
 
 NetworkCommissioningCluster::NetworkCommissioningCluster(EndpointId endpointId, EthernetDriver * driver, const Context & context) :
-    DefaultServerCluster({ endpointId, NetworkCommissioning::Id }),
-    mEndpointId(endpointId), mFeatureFlags(Feature::kEthernetNetworkInterface), mpWirelessDriver(nullptr), mpBaseDriver(driver),
-    mClusterContext(context)
+    DefaultServerCluster({ endpointId, NetworkCommissioning::Id }), mEndpointId(endpointId),
+    mFeatureFlags(Feature::kEthernetNetworkInterface), mpWirelessDriver(nullptr), mpBaseDriver(driver), mClusterContext(context)
 {}
 
 #if CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
@@ -73,17 +73,17 @@ public:
 
     struct Context
     {
+        BreadCrumbTracker & breadcrumbTracker;
         FailSafeContext & failSafeContext;
         DeviceLayer::PlatformManager & platformManager;
         DeviceLayer::DeviceControlServer & deviceControlServer;
     };
 
-    NetworkCommissioningCluster(EndpointId endpointId, WiFiDriver * driver, BreadCrumbTracker & tracker, const Context & context);
+    NetworkCommissioningCluster(EndpointId endpointId, WiFiDriver * driver, const Context & context);
 
-    NetworkCommissioningCluster(EndpointId endpointId, ThreadDriver * driver, BreadCrumbTracker & tracker, const Context & context);
+    NetworkCommissioningCluster(EndpointId endpointId, ThreadDriver * driver, const Context & context);
 
-    NetworkCommissioningCluster(EndpointId endpointId, EthernetDriver * driver, BreadCrumbTracker & tracker,
-                                const Context & context);
+    NetworkCommissioningCluster(EndpointId endpointId, EthernetDriver * driver, const Context & context);
 
     // Server cluster implementation
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
@@ -240,7 +240,6 @@ private:
     uint8_t mLastNetworkIDLen = 0;
     Optional<uint64_t> mCurrentOperationBreadcrumb;
     bool mScanningWasDirected = false;
-    BreadCrumbTracker & mBreadcrumbTracker;
     Context mClusterContext;
 
     void SetLastNetworkingStatusValue(NetworkCommissioning::Attributes::LastNetworkingStatus::TypeInfo::Type networkingStatusValue);

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
@@ -74,7 +74,7 @@ public:
     struct Context
     {
         FailSafeContext & failSafeContext;
-        DeviceLayer::PlatformManager & platformMgr;
+        DeviceLayer::PlatformManager & platformManager;
         DeviceLayer::DeviceControlServer & deviceControlServer;
     };
 

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
@@ -22,9 +22,11 @@
 #include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
 #include <app/data-model/Nullable.h>
+#include <app/FailSafeContext.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/NetworkCommissioning/Attributes.h>
 #include <clusters/NetworkCommissioning/Commands.h>
+#include <include/platform/DeviceControlServer.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/IntrusiveList.h>
 #include <lib/support/ThreadOperationalDataset.h>
@@ -69,11 +71,18 @@ public:
     using WiFiDriver     = DeviceLayer::NetworkCommissioning::WiFiDriver;
     using EthernetDriver = DeviceLayer::NetworkCommissioning::EthernetDriver;
 
-    NetworkCommissioningCluster(EndpointId endpointId, WiFiDriver * driver, BreadCrumbTracker & tracker);
+    struct Context
+    {
+        FailSafeContext & failSafeContext;
+        DeviceLayer::PlatformManager & platformMgr;
+        DeviceLayer::DeviceControlServer & deviceControlServer;
+    };
 
-    NetworkCommissioningCluster(EndpointId endpointId, ThreadDriver * driver, BreadCrumbTracker & tracker);
+    NetworkCommissioningCluster(EndpointId endpointId, WiFiDriver * driver, BreadCrumbTracker & tracker, const Context & context);
 
-    NetworkCommissioningCluster(EndpointId endpointId, EthernetDriver * driver, BreadCrumbTracker & tracker);
+    NetworkCommissioningCluster(EndpointId endpointId, ThreadDriver * driver, BreadCrumbTracker & tracker, const Context & context);
+
+    NetworkCommissioningCluster(EndpointId endpointId, EthernetDriver * driver, BreadCrumbTracker & tracker, const Context & context);
 
     // Server cluster implementation
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
@@ -231,6 +240,7 @@ private:
     Optional<uint64_t> mCurrentOperationBreadcrumb;
     bool mScanningWasDirected = false;
     BreadCrumbTracker & mBreadcrumbTracker;
+    Context mClusterContext;
 
     void SetLastNetworkingStatusValue(NetworkCommissioning::Attributes::LastNetworkingStatus::TypeInfo::Type networkingStatusValue);
     void SetLastConnectErrorValue(NetworkCommissioning::Attributes::LastConnectErrorValue::TypeInfo::Type connectErrorValue);

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
@@ -19,10 +19,10 @@
 #include <app/AttributeValueEncoder.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/FailSafeContext.h>
 #include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
 #include <app/data-model/Nullable.h>
-#include <app/FailSafeContext.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/NetworkCommissioning/Attributes.h>
 #include <clusters/NetworkCommissioning/Commands.h>
@@ -82,7 +82,8 @@ public:
 
     NetworkCommissioningCluster(EndpointId endpointId, ThreadDriver * driver, BreadCrumbTracker & tracker, const Context & context);
 
-    NetworkCommissioningCluster(EndpointId endpointId, EthernetDriver * driver, BreadCrumbTracker & tracker, const Context & context);
+    NetworkCommissioningCluster(EndpointId endpointId, EthernetDriver * driver, BreadCrumbTracker & tracker,
+                                const Context & context);
 
     // Server cluster implementation
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -19,6 +19,7 @@
 #include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
 #include <app/clusters/network-commissioning/NetworkCommissioningCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
+#include <app/server/Server.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
@@ -55,8 +56,14 @@ public:
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestNetworkCommissioningCluster : public ::testing::Test
 {
-    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
-    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+    static void SetUpTestSuite() { ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { Platform::MemoryShutdown(); }
+
+    NetworkCommissioningCluster::Context defaultContext{
+        .failSafeContext    = Server::GetInstance().GetFailSafeContext(),
+        .platformMgr        = DeviceLayer::PlatformMgr(),
+        .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
+    };
 };
 
 TEST_F(TestNetworkCommissioningCluster, TestAttributes)
@@ -65,7 +72,7 @@ TEST_F(TestNetworkCommissioningCluster, TestAttributes)
     {
         Testing::FakeWiFiDriver fakeWifiDriver;
 
-        NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, tracker);
+        NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, tracker, defaultContext);
 
         // NOTE: this is AWKWARD: we pass in a wifi driver, yet attributes are still depending
         //       on device enabling. Ideally we should not allow compiling odd things at all.
@@ -94,7 +101,7 @@ TEST_F(TestNetworkCommissioningCluster, TestNotifyOnEnableInterface)
 {
     Testing::FakeWiFiDriver fakeWifiDriver;
     NoopBreadcrumbTracker tracker;
-    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, tracker);
+    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, tracker, defaultContext);
 
     ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -19,11 +19,11 @@
 #include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
 #include <app/clusters/network-commissioning/NetworkCommissioningCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
-#include <app/server/Server.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
+#include <app/server/Server.h>
 #include <clusters/GeneralCommissioning/Attributes.h>
 #include <clusters/NetworkCommissioning/Commands.h>
 #include <clusters/NetworkCommissioning/Enums.h>
@@ -60,8 +60,8 @@ struct TestNetworkCommissioningCluster : public ::testing::Test
     static void TearDownTestSuite() { Platform::MemoryShutdown(); }
 
     NetworkCommissioningCluster::Context defaultContext{
-        .failSafeContext    = Server::GetInstance().GetFailSafeContext(),
-        .platformMgr        = DeviceLayer::PlatformMgr(),
+        .failSafeContext     = Server::GetInstance().GetFailSafeContext(),
+        .platformMgr         = DeviceLayer::PlatformMgr(),
         .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
     };
 };

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -61,7 +61,7 @@ struct TestNetworkCommissioningCluster : public ::testing::Test
 
     NetworkCommissioningCluster::Context defaultContext{
         .failSafeContext     = Server::GetInstance().GetFailSafeContext(),
-        .platformMgr         = DeviceLayer::PlatformMgr(),
+        .platformManager         = DeviceLayer::PlatformMgr(),
         .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
     };
 };

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -59,20 +59,21 @@ struct TestNetworkCommissioningCluster : public ::testing::Test
     static void SetUpTestSuite() { ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR); }
     static void TearDownTestSuite() { Platform::MemoryShutdown(); }
 
-    NetworkCommissioningCluster::Context defaultContext{
+    inline static NoopBreadcrumbTracker tracker;
+    inline static NetworkCommissioningCluster::Context defaultContext{
+        .breadcrumbTracker   = tracker,
         .failSafeContext     = Server::GetInstance().GetFailSafeContext(),
-        .platformManager         = DeviceLayer::PlatformMgr(),
+        .platformManager     = DeviceLayer::PlatformMgr(),
         .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
     };
 };
 
 TEST_F(TestNetworkCommissioningCluster, TestAttributes)
 {
-    NoopBreadcrumbTracker tracker;
     {
         Testing::FakeWiFiDriver fakeWifiDriver;
 
-        NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, tracker, defaultContext);
+        NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, defaultContext);
 
         // NOTE: this is AWKWARD: we pass in a wifi driver, yet attributes are still depending
         //       on device enabling. Ideally we should not allow compiling odd things at all.
@@ -100,8 +101,7 @@ TEST_F(TestNetworkCommissioningCluster, TestAttributes)
 TEST_F(TestNetworkCommissioningCluster, TestNotifyOnEnableInterface)
 {
     Testing::FakeWiFiDriver fakeWifiDriver;
-    NoopBreadcrumbTracker tracker;
-    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, tracker, defaultContext);
+    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver, defaultContext);
 
     ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningClusterEthernet.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningClusterEthernet.cpp
@@ -61,7 +61,7 @@ struct TestNetworkCommissioningClusterEthernet : public ::testing::Test
     inline static NetworkCommissioningCluster::Context defaultContext{
         .breadcrumbTracker   = tracker,
         .failSafeContext     = Server::GetInstance().GetFailSafeContext(),
-        .platformManager         = DeviceLayer::PlatformMgr(),
+        .platformManager     = DeviceLayer::PlatformMgr(),
         .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
     };
 };

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningClusterEthernet.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningClusterEthernet.cpp
@@ -57,7 +57,9 @@ struct TestNetworkCommissioningClusterEthernet : public ::testing::Test
     static void SetUpTestSuite() { ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR); }
     static void TearDownTestSuite() { Platform::MemoryShutdown(); }
 
-    NetworkCommissioningCluster::Context defaultContext{
+    inline static NoopBreadcrumbTracker tracker;
+    inline static NetworkCommissioningCluster::Context defaultContext{
+        .breadcrumbTracker   = tracker,
         .failSafeContext     = Server::GetInstance().GetFailSafeContext(),
         .platformManager         = DeviceLayer::PlatformMgr(),
         .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
@@ -66,10 +68,9 @@ struct TestNetworkCommissioningClusterEthernet : public ::testing::Test
 
 TEST_F(TestNetworkCommissioningClusterEthernet, TestAttributes)
 {
-    NoopBreadcrumbTracker tracker;
     Testing::FakeEthernetDriver fakeEthernetDriver;
     ByteSpan testInterfaceName(Uint8::from_const_char("eth0_test"), 9);
-    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeEthernetDriver, tracker, defaultContext);
+    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeEthernetDriver, defaultContext);
     chip::Testing::ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Init(), CHIP_NO_ERROR);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningClusterEthernet.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningClusterEthernet.cpp
@@ -19,12 +19,12 @@
 #include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
 #include <app/clusters/network-commissioning/NetworkCommissioningCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
-#include <app/server/Server.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
+#include <app/server/Server.h>
 #include <clusters/GeneralCommissioning/Attributes.h>
 #include <clusters/NetworkCommissioning/Commands.h>
 #include <clusters/NetworkCommissioning/Enums.h>
@@ -58,8 +58,8 @@ struct TestNetworkCommissioningClusterEthernet : public ::testing::Test
     static void TearDownTestSuite() { Platform::MemoryShutdown(); }
 
     NetworkCommissioningCluster::Context defaultContext{
-        .failSafeContext    = Server::GetInstance().GetFailSafeContext(),
-        .platformMgr        = DeviceLayer::PlatformMgr(),
+        .failSafeContext     = Server::GetInstance().GetFailSafeContext(),
+        .platformMgr         = DeviceLayer::PlatformMgr(),
         .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
     };
 };

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningClusterEthernet.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningClusterEthernet.cpp
@@ -59,7 +59,7 @@ struct TestNetworkCommissioningClusterEthernet : public ::testing::Test
 
     NetworkCommissioningCluster::Context defaultContext{
         .failSafeContext     = Server::GetInstance().GetFailSafeContext(),
-        .platformMgr         = DeviceLayer::PlatformMgr(),
+        .platformManager         = DeviceLayer::PlatformMgr(),
         .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
     };
 };

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningClusterEthernet.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningClusterEthernet.cpp
@@ -19,6 +19,7 @@
 #include <app/clusters/general-commissioning-server/BreadCrumbTracker.h>
 #include <app/clusters/network-commissioning/NetworkCommissioningCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
+#include <app/server/Server.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
 #include <app/server-cluster/testing/ClusterTester.h>
@@ -53,8 +54,14 @@ public:
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestNetworkCommissioningClusterEthernet : public ::testing::Test
 {
-    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
-    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+    static void SetUpTestSuite() { ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { Platform::MemoryShutdown(); }
+
+    NetworkCommissioningCluster::Context defaultContext{
+        .failSafeContext    = Server::GetInstance().GetFailSafeContext(),
+        .platformMgr        = DeviceLayer::PlatformMgr(),
+        .deviceControlServer = DeviceLayer::DeviceControlServer::DeviceControlSvr(),
+    };
 };
 
 TEST_F(TestNetworkCommissioningClusterEthernet, TestAttributes)
@@ -62,7 +69,7 @@ TEST_F(TestNetworkCommissioningClusterEthernet, TestAttributes)
     NoopBreadcrumbTracker tracker;
     Testing::FakeEthernetDriver fakeEthernetDriver;
     ByteSpan testInterfaceName(Uint8::from_const_char("eth0_test"), 9);
-    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeEthernetDriver, tracker);
+    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeEthernetDriver, tracker, defaultContext);
     chip::Testing::ClusterTester tester(cluster);
     ASSERT_EQ(cluster.Init(), CHIP_NO_ERROR);
     ASSERT_EQ(cluster.Startup(tester.GetServerClusterContext()), CHIP_NO_ERROR);


### PR DESCRIPTION
#### Summary

This PR removes all direct uses of these global values in the `NetworkCommissioning` cluster
- `Server::GetInstance().GetFailSafeContext()`
- `chip::DeviceLayer::PlatformMgr()`
- `chip::DeviceLayer::DeviceControlServer::DeviceControlSvr()`

The PR also moves the `mBreadcrumbTracker` field in `NetworkCommissioningCluster` into the `mClusterContext` field and makes the `context` field in `RootNodeDevice` protected, to be used in `WifiRootNodeDevice`, and fixes a small typo (I don't understand how did checks pass with that typo though).

#### Related issues

Fixes: #42629 

#### Testing

Green CI

