### PR TITLE
[Energy] EVSE code driven conversion #3

### DIFF
--- a/examples/evse-app/evse-common/include/EVSECallbacks.h
+++ b/examples/evse-app/evse-common/include/EVSECallbacks.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <clusters/EnergyEvse/Enums.h>
+
 namespace chip {
 namespace app {
 namespace Clusters {

--- a/examples/evse-app/evse-common/include/EnergyEvseDelegateImpl.h
+++ b/examples/evse-app/evse-common/include/EnergyEvseDelegateImpl.h
@@ -18,10 +18,10 @@
 
 #pragma once
 
-#include "app/clusters/energy-evse-server/energy-evse-server.h"
 #include <EVSECallbacks.h>
 #include <EnergyEvseTargetsStore.h>
 #include <EvseTargetsConfig.h>
+#include <app/clusters/energy-evse-server/EnergyEvseCluster.h>
 
 #include <app/util/config.h>
 #include <cstring>

--- a/examples/evse-app/evse-common/include/EnergyEvseDelegateImpl.h
+++ b/examples/evse-app/evse-common/include/EnergyEvseDelegateImpl.h
@@ -239,69 +239,56 @@ public:
     Status SendFaultEvent(FaultStateEnum newFaultState);
 
     // ------------------------------------------------------------------
-    // Get attribute methods
-    StateEnum GetState() override;
-    CHIP_ERROR SetState(StateEnum);
+    // Attribute change callbacks - called by cluster after attribute is updated
+    void OnStateChanged(StateEnum newValue) override;
+    void OnSupplyStateChanged(SupplyStateEnum newValue) override;
+    void OnFaultStateChanged(FaultStateEnum newValue) override;
+    void OnChargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue) override;
+    void OnDischargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue) override;
+    void OnCircuitCapacityChanged(int64_t newValue) override;
+    void OnMinimumChargeCurrentChanged(int64_t newValue) override;
+    void OnMaximumChargeCurrentChanged(int64_t newValue) override;
+    void OnMaximumDischargeCurrentChanged(int64_t newValue) override;
+    void OnUserMaximumChargeCurrentChanged(int64_t newValue) override;
+    void OnRandomizationDelayWindowChanged(uint32_t newValue) override;
+    void OnNextChargeStartTimeChanged(DataModel::Nullable<uint32_t> newValue) override;
+    void OnNextChargeTargetTimeChanged(DataModel::Nullable<uint32_t> newValue) override;
+    void OnNextChargeRequiredEnergyChanged(DataModel::Nullable<int64_t> newValue) override;
+    void OnNextChargeTargetSoCChanged(DataModel::Nullable<Percent> newValue) override;
+    void OnApproximateEVEfficiencyChanged(DataModel::Nullable<uint16_t> newValue) override;
+    void OnStateOfChargeChanged(DataModel::Nullable<Percent> newValue) override;
+    void OnBatteryCapacityChanged(DataModel::Nullable<int64_t> newValue) override;
+    void OnVehicleIDChanged(DataModel::Nullable<CharSpan> newValue) override;
+    void OnSessionIDChanged(DataModel::Nullable<uint32_t> newValue) override;
+    void OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue) override;
+    void OnSessionEnergyChargedChanged(DataModel::Nullable<int64_t> newValue) override;
+    void OnSessionEnergyDischargedChanged(DataModel::Nullable<int64_t> newValue) override;
 
-    SupplyStateEnum GetSupplyState() override;
-    CHIP_ERROR SetSupplyState(SupplyStateEnum);
-
-    FaultStateEnum GetFaultState() override;
-    CHIP_ERROR SetFaultState(FaultStateEnum);
-
-    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() override;
-    CHIP_ERROR SetChargingEnabledUntil(DataModel::Nullable<uint32_t>);
-
-    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() override;
-    CHIP_ERROR SetDischargingEnabledUntil(DataModel::Nullable<uint32_t>);
-
-    int64_t GetCircuitCapacity() override;
-    CHIP_ERROR SetCircuitCapacity(int64_t);
-
-    int64_t GetMinimumChargeCurrent() override;
-    CHIP_ERROR SetMinimumChargeCurrent(int64_t);
-
-    int64_t GetMaximumChargeCurrent() override;
-    CHIP_ERROR SetMaximumChargeCurrent(int64_t);
-
-    int64_t GetMaximumDischargeCurrent() override;
-    CHIP_ERROR SetMaximumDischargeCurrent(int64_t);
-
-    int64_t GetUserMaximumChargeCurrent() override;
-    CHIP_ERROR SetUserMaximumChargeCurrent(int64_t) override;
-
-    uint32_t GetRandomizationDelayWindow() override;
-    CHIP_ERROR SetRandomizationDelayWindow(uint32_t) override;
-
-    /* PREF attributes */
-    DataModel::Nullable<uint32_t> GetNextChargeStartTime() override;
-    CHIP_ERROR SetNextChargeStartTime(DataModel::Nullable<uint32_t> newNextChargeStartTimeUtc);
-
-    DataModel::Nullable<uint32_t> GetNextChargeTargetTime() override;
-    CHIP_ERROR SetNextChargeTargetTime(DataModel::Nullable<uint32_t> newNextChargeTargetTimeUtc);
-
-    DataModel::Nullable<int64_t> GetNextChargeRequiredEnergy() override;
-    CHIP_ERROR SetNextChargeRequiredEnergy(DataModel::Nullable<int64_t> newNextChargeRequiredEnergyMilliWattH);
-
-    DataModel::Nullable<Percent> GetNextChargeTargetSoC() override;
-    CHIP_ERROR SetNextChargeTargetSoC(DataModel::Nullable<Percent> newValue);
-
-    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() override;
-    CHIP_ERROR SetApproximateEVEfficiency(DataModel::Nullable<uint16_t>) override;
-
-    /* SOC attributes */
-    DataModel::Nullable<Percent> GetStateOfCharge() override;
-    CHIP_ERROR SetStateOfCharge(DataModel::Nullable<Percent>);
-    DataModel::Nullable<int64_t> GetBatteryCapacity() override;
-    CHIP_ERROR SetBatteryCapacity(DataModel::Nullable<int64_t>);
-
-    /* PNC attributes*/
-    DataModel::Nullable<CharSpan> GetVehicleID() override;
-    /* Session SESS attributes */
-    DataModel::Nullable<uint32_t> GetSessionID() override;
-    DataModel::Nullable<uint32_t> GetSessionDuration() override;
-    DataModel::Nullable<int64_t> GetSessionEnergyCharged() override;
-    DataModel::Nullable<int64_t> GetSessionEnergyDischarged() override;
+    // ------------------------------------------------------------------
+    // Local getters for internal delegate use
+    StateEnum GetState() const { return mState; }
+    SupplyStateEnum GetSupplyState() const { return mSupplyState; }
+    FaultStateEnum GetFaultState() const { return mFaultState; }
+    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() const { return mChargingEnabledUntil; }
+    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() const { return mDischargingEnabledUntil; }
+    int64_t GetCircuitCapacity() const { return mCircuitCapacity; }
+    int64_t GetMinimumChargeCurrent() const { return mMinimumChargeCurrent; }
+    int64_t GetMaximumChargeCurrent() const { return mMaximumChargeCurrent; }
+    int64_t GetMaximumDischargeCurrent() const { return mMaximumDischargeCurrent; }
+    int64_t GetUserMaximumChargeCurrent() const { return mUserMaximumChargeCurrent; }
+    uint32_t GetRandomizationDelayWindow() const { return mRandomizationDelayWindow; }
+    DataModel::Nullable<uint32_t> GetNextChargeStartTime() const { return mNextChargeStartTime; }
+    DataModel::Nullable<uint32_t> GetNextChargeTargetTime() const { return mNextChargeTargetTime; }
+    DataModel::Nullable<int64_t> GetNextChargeRequiredEnergy() const { return mNextChargeRequiredEnergy; }
+    DataModel::Nullable<Percent> GetNextChargeTargetSoC() const { return mNextChargeTargetSoC; }
+    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() const { return mApproximateEVEfficiency; }
+    DataModel::Nullable<Percent> GetStateOfCharge() const { return mStateOfCharge; }
+    DataModel::Nullable<int64_t> GetBatteryCapacity() const { return mBatteryCapacity; }
+    DataModel::Nullable<CharSpan> GetVehicleID() const { return mVehicleID; }
+    DataModel::Nullable<uint32_t> GetSessionID() const { return mSession.mSessionID; }
+    DataModel::Nullable<uint32_t> GetSessionDuration() const { return mSession.mSessionDuration; }
+    DataModel::Nullable<int64_t> GetSessionEnergyCharged() const { return mSession.mSessionEnergyCharged; }
+    DataModel::Nullable<int64_t> GetSessionEnergyDischarged() const { return mSession.mSessionEnergyDischarged; }
 
 private:
     /* Constants */

--- a/examples/evse-app/evse-common/include/EnergyEvseDelegateImpl.h
+++ b/examples/evse-app/evse-common/include/EnergyEvseDelegateImpl.h
@@ -266,35 +266,35 @@ public:
     void OnSessionEnergyDischargedChanged(DataModel::Nullable<int64_t> newValue) override;
 
     // ------------------------------------------------------------------
-    // Instance management for codegen approach
+    // Instance management for codegen integration
     void SetInstance(Instance * aInstance) { mInstance = aInstance; }
     Instance * GetInstance() { return mInstance; }
 
     // ------------------------------------------------------------------
     // Local getters for internal delegate use - delegates to cluster instance
-    StateEnum GetState() const { return mInstance->GetState(); }
-    SupplyStateEnum GetSupplyState() const { return mInstance->GetSupplyState(); }
-    FaultStateEnum GetFaultState() const { return mInstance->GetFaultState(); }
-    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() const { return mInstance->GetChargingEnabledUntil(); }
-    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() const { return mInstance->GetDischargingEnabledUntil(); }
-    int64_t GetCircuitCapacity() const { return mInstance->GetCircuitCapacity(); }
-    int64_t GetMinimumChargeCurrent() const { return mInstance->GetMinimumChargeCurrent(); }
-    int64_t GetMaximumChargeCurrent() const { return mInstance->GetMaximumChargeCurrent(); }
-    int64_t GetMaximumDischargeCurrent() const { return mInstance->GetMaximumDischargeCurrent(); }
-    int64_t GetUserMaximumChargeCurrent() const { return mInstance->GetUserMaximumChargeCurrent(); }
-    uint32_t GetRandomizationDelayWindow() const { return mInstance->GetRandomizationDelayWindow(); }
-    DataModel::Nullable<uint32_t> GetNextChargeStartTime() const { return mInstance->GetNextChargeStartTime(); }
-    DataModel::Nullable<uint32_t> GetNextChargeTargetTime() const { return mInstance->GetNextChargeTargetTime(); }
-    DataModel::Nullable<int64_t> GetNextChargeRequiredEnergy() const { return mInstance->GetNextChargeRequiredEnergy(); }
-    DataModel::Nullable<Percent> GetNextChargeTargetSoC() const { return mInstance->GetNextChargeTargetSoC(); }
-    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() const { return mInstance->GetApproximateEVEfficiency(); }
-    DataModel::Nullable<Percent> GetStateOfCharge() const { return mInstance->GetStateOfCharge(); }
-    DataModel::Nullable<int64_t> GetBatteryCapacity() const { return mInstance->GetBatteryCapacity(); }
-    DataModel::Nullable<CharSpan> GetVehicleID() const { return mInstance->GetVehicleID(); }
-    DataModel::Nullable<uint32_t> GetSessionID() const { return mInstance->GetSessionID(); }
-    DataModel::Nullable<uint32_t> GetSessionDuration() const { return mInstance->GetSessionDuration(); }
-    DataModel::Nullable<int64_t> GetSessionEnergyCharged() const { return mInstance->GetSessionEnergyCharged(); }
-    DataModel::Nullable<int64_t> GetSessionEnergyDischarged() const { return mInstance->GetSessionEnergyDischarged(); }
+    StateEnum GetState() const;
+    SupplyStateEnum GetSupplyState() const;
+    FaultStateEnum GetFaultState() const;
+    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() const;
+    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() const;
+    int64_t GetCircuitCapacity() const;
+    int64_t GetMinimumChargeCurrent() const;
+    int64_t GetMaximumChargeCurrent() const;
+    int64_t GetMaximumDischargeCurrent() const;
+    int64_t GetUserMaximumChargeCurrent() const;
+    uint32_t GetRandomizationDelayWindow() const;
+    DataModel::Nullable<uint32_t> GetNextChargeStartTime() const;
+    DataModel::Nullable<uint32_t> GetNextChargeTargetTime() const;
+    DataModel::Nullable<int64_t> GetNextChargeRequiredEnergy() const;
+    DataModel::Nullable<Percent> GetNextChargeTargetSoC() const;
+    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() const;
+    DataModel::Nullable<Percent> GetStateOfCharge() const;
+    DataModel::Nullable<int64_t> GetBatteryCapacity() const;
+    DataModel::Nullable<CharSpan> GetVehicleID() const;
+    DataModel::Nullable<uint32_t> GetSessionID() const;
+    DataModel::Nullable<uint32_t> GetSessionDuration() const;
+    DataModel::Nullable<int64_t> GetSessionEnergyCharged() const;
+    DataModel::Nullable<int64_t> GetSessionEnergyDischarged() const;
 
 private:
     /* Constants */

--- a/examples/evse-app/evse-common/include/EnergyEvseDelegateImpl.h
+++ b/examples/evse-app/evse-common/include/EnergyEvseDelegateImpl.h
@@ -21,6 +21,7 @@
 #include <EVSECallbacks.h>
 #include <EnergyEvseTargetsStore.h>
 #include <EvseTargetsConfig.h>
+#include <app/clusters/energy-evse-server/CodegenIntegration.h>
 #include <app/clusters/energy-evse-server/EnergyEvseCluster.h>
 
 #include <app/util/config.h>
@@ -239,7 +240,7 @@ public:
     Status SendFaultEvent(FaultStateEnum newFaultState);
 
     // ------------------------------------------------------------------
-    // Attribute change callbacks - called by cluster after attribute is updated
+    // Attribute methods - called by cluster to propagate attribute changes to the delegate
     void OnStateChanged(StateEnum newValue) override;
     void OnSupplyStateChanged(SupplyStateEnum newValue) override;
     void OnFaultStateChanged(FaultStateEnum newValue) override;
@@ -265,30 +266,35 @@ public:
     void OnSessionEnergyDischargedChanged(DataModel::Nullable<int64_t> newValue) override;
 
     // ------------------------------------------------------------------
-    // Local getters for internal delegate use
-    StateEnum GetState() const { return mState; }
-    SupplyStateEnum GetSupplyState() const { return mSupplyState; }
-    FaultStateEnum GetFaultState() const { return mFaultState; }
-    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() const { return mChargingEnabledUntil; }
-    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() const { return mDischargingEnabledUntil; }
-    int64_t GetCircuitCapacity() const { return mCircuitCapacity; }
-    int64_t GetMinimumChargeCurrent() const { return mMinimumChargeCurrent; }
-    int64_t GetMaximumChargeCurrent() const { return mMaximumChargeCurrent; }
-    int64_t GetMaximumDischargeCurrent() const { return mMaximumDischargeCurrent; }
-    int64_t GetUserMaximumChargeCurrent() const { return mUserMaximumChargeCurrent; }
-    uint32_t GetRandomizationDelayWindow() const { return mRandomizationDelayWindow; }
-    DataModel::Nullable<uint32_t> GetNextChargeStartTime() const { return mNextChargeStartTime; }
-    DataModel::Nullable<uint32_t> GetNextChargeTargetTime() const { return mNextChargeTargetTime; }
-    DataModel::Nullable<int64_t> GetNextChargeRequiredEnergy() const { return mNextChargeRequiredEnergy; }
-    DataModel::Nullable<Percent> GetNextChargeTargetSoC() const { return mNextChargeTargetSoC; }
-    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() const { return mApproximateEVEfficiency; }
-    DataModel::Nullable<Percent> GetStateOfCharge() const { return mStateOfCharge; }
-    DataModel::Nullable<int64_t> GetBatteryCapacity() const { return mBatteryCapacity; }
-    DataModel::Nullable<CharSpan> GetVehicleID() const { return mVehicleID; }
-    DataModel::Nullable<uint32_t> GetSessionID() const { return mSession.mSessionID; }
-    DataModel::Nullable<uint32_t> GetSessionDuration() const { return mSession.mSessionDuration; }
-    DataModel::Nullable<int64_t> GetSessionEnergyCharged() const { return mSession.mSessionEnergyCharged; }
-    DataModel::Nullable<int64_t> GetSessionEnergyDischarged() const { return mSession.mSessionEnergyDischarged; }
+    // Instance management for codegen approach
+    void SetInstance(Instance * aInstance) { mInstance = aInstance; }
+    Instance * GetInstance() { return mInstance; }
+
+    // ------------------------------------------------------------------
+    // Local getters for internal delegate use - delegates to cluster instance
+    StateEnum GetState() const { return mInstance->GetState(); }
+    SupplyStateEnum GetSupplyState() const { return mInstance->GetSupplyState(); }
+    FaultStateEnum GetFaultState() const { return mInstance->GetFaultState(); }
+    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() const { return mInstance->GetChargingEnabledUntil(); }
+    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() const { return mInstance->GetDischargingEnabledUntil(); }
+    int64_t GetCircuitCapacity() const { return mInstance->GetCircuitCapacity(); }
+    int64_t GetMinimumChargeCurrent() const { return mInstance->GetMinimumChargeCurrent(); }
+    int64_t GetMaximumChargeCurrent() const { return mInstance->GetMaximumChargeCurrent(); }
+    int64_t GetMaximumDischargeCurrent() const { return mInstance->GetMaximumDischargeCurrent(); }
+    int64_t GetUserMaximumChargeCurrent() const { return mInstance->GetUserMaximumChargeCurrent(); }
+    uint32_t GetRandomizationDelayWindow() const { return mInstance->GetRandomizationDelayWindow(); }
+    DataModel::Nullable<uint32_t> GetNextChargeStartTime() const { return mInstance->GetNextChargeStartTime(); }
+    DataModel::Nullable<uint32_t> GetNextChargeTargetTime() const { return mInstance->GetNextChargeTargetTime(); }
+    DataModel::Nullable<int64_t> GetNextChargeRequiredEnergy() const { return mInstance->GetNextChargeRequiredEnergy(); }
+    DataModel::Nullable<Percent> GetNextChargeTargetSoC() const { return mInstance->GetNextChargeTargetSoC(); }
+    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() const { return mInstance->GetApproximateEVEfficiency(); }
+    DataModel::Nullable<Percent> GetStateOfCharge() const { return mInstance->GetStateOfCharge(); }
+    DataModel::Nullable<int64_t> GetBatteryCapacity() const { return mInstance->GetBatteryCapacity(); }
+    DataModel::Nullable<CharSpan> GetVehicleID() const { return mInstance->GetVehicleID(); }
+    DataModel::Nullable<uint32_t> GetSessionID() const { return mInstance->GetSessionID(); }
+    DataModel::Nullable<uint32_t> GetSessionDuration() const { return mInstance->GetSessionDuration(); }
+    DataModel::Nullable<int64_t> GetSessionEnergyCharged() const { return mInstance->GetSessionEnergyCharged(); }
+    DataModel::Nullable<int64_t> GetSessionEnergyDischarged() const { return mInstance->GetSessionEnergyDischarged(); }
 
 private:
     /* Constants */
@@ -349,39 +355,18 @@ private:
      */
     static void EvseCheckTimerExpiry(System::Layer * systemLayer, void * delegate);
 
-    /* Attributes */
-    StateEnum mState             = StateEnum::kNotPluggedIn;
-    SupplyStateEnum mSupplyState = SupplyStateEnum::kDisabled;
-    FaultStateEnum mFaultState   = FaultStateEnum::kNoError;
-    DataModel::Nullable<uint32_t> mChargingEnabledUntil;    // TODO Default to 0 to indicate disabled
-    DataModel::Nullable<uint32_t> mDischargingEnabledUntil; // TODO Default to 0 to indicate disabled
-    int64_t mCircuitCapacity           = 0;
-    int64_t mMinimumChargeCurrent      = kDefaultMinChargeCurrent_mA;
-    int64_t mMaximumChargeCurrent      = 0;
-    int64_t mMaximumDischargeCurrent   = 0;
-    int64_t mUserMaximumChargeCurrent  = kDefaultUserMaximumChargeCurrent_mA; // TODO update spec
-    uint32_t mRandomizationDelayWindow = kDefaultRandomizationDelayWindow_sec;
-    /* PREF attributes */
-    DataModel::Nullable<uint32_t> mNextChargeStartTime;
-    DataModel::Nullable<uint32_t> mNextChargeTargetTime;
-    DataModel::Nullable<int64_t> mNextChargeRequiredEnergy;
-    DataModel::Nullable<Percent> mNextChargeTargetSoC;
-    DataModel::Nullable<uint16_t> mApproximateEVEfficiency;
+    /* Instance pointer for accessing cluster */
+    Instance * mInstance = nullptr;
 
-    /* SOC attributes */
-    DataModel::Nullable<Percent> mStateOfCharge;
-    DataModel::Nullable<int64_t> mBatteryCapacity;
-
-    /* PNC attributes*/
-    DataModel::Nullable<CharSpan> mVehicleID;
-    char mVehicleIDBuf[kMaxVehicleIDBufSize];
-
-    /* Session Object */
+    /* Session Object - delegate owns session state management */
     EvseSession mSession = EvseSession();
 
     /* Helper variables to hold meter val since last EnergyTransferStarted event */
-    int64_t mImportedMeterValueAtEnergyTransferStart; // Charging
-    int64_t mExportedMeterValueAtEnergyTransferStart; // Discharging
+    int64_t mImportedMeterValueAtEnergyTransferStart;
+    int64_t mExportedMeterValueAtEnergyTransferStart;
+
+    /* VehicleID buffer for delegate use */
+    char mVehicleIDBuf[kMaxVehicleIDBufSize];
 
     /* Targets Delegate */
     EvseTargetsDelegate * mEvseTargetsDelegate = nullptr;

--- a/examples/evse-app/evse-common/include/EnergyEvseDelegateImpl.h
+++ b/examples/evse-app/evse-common/include/EnergyEvseDelegateImpl.h
@@ -49,58 +49,56 @@ enum EVSEStateMachineEvent
 };
 
 /**
- * Helper class to handle all of the session related info
+ * Helper class to handle session timing and energy meter deltas.
+ * Session attribute values are stored in the cluster (EnergyEvseCluster) and
+ * updated through Instance setters. This class only tracks the internal
+ * computation state (start time, energy meter baselines).
  */
 class EvseSession
 {
 public:
     EvseSession() {}
+
     /**
-     * @brief This function records the start time and provided energy meter values as part of the new session.
+     * @brief Start a new session: assigns a session ID, resets duration/energy counters.
      *
-     * @param endpointId            - The endpoint to report the update on
+     * @param instance              - The cluster Instance to update attributes on
      * @param chargingMeterValue    - The current value of the energy meter (charging) in mWh
      * @param dischargingMeterValue - The current value of the energy meter (discharging) in mWh
      */
-    void StartSession(EndpointId endpointId, int64_t chargingMeterValue, int64_t dischargingMeterValue);
+    void StartSession(Instance * instance, int64_t chargingMeterValue, int64_t dischargingMeterValue);
 
     /**
-     * @brief This function updates the session information at the unplugged event
+     * @brief Stop the current session: recalculates duration and energy values.
      *
-     * @param endpointId            - The endpoint to report the update on
+     * @param instance              - The cluster Instance to update attributes on
      * @param chargingMeterValue    - The current value of the energy meter (charging) in mWh
      * @param dischargingMeterValue - The current value of the energy meter (discharging) in mWh
      */
-    void StopSession(EndpointId endpointId, int64_t chargingMeterValue, int64_t dischargingMeterValue);
+    void StopSession(Instance * instance, int64_t chargingMeterValue, int64_t dischargingMeterValue);
 
     /**
-     * @brief This function updates the session Duration to allow read attributes to return latest values
+     * @brief Recalculate session duration from start time to now.
      *
-     * @param endpointId            - The endpoint to report the update on
+     * @param instance - The cluster Instance to update attributes on
      */
-    void RecalculateSessionDuration(EndpointId endpointId);
+    void RecalculateSessionDuration(Instance * instance);
 
     /**
-     * @brief This function updates the EnergyCharged meter value
+     * @brief Update the session's charged energy delta.
      *
-     * @param endpointId            - The endpoint to report the update on
-     * @param chargingMeterValue    - The value of the energy meter (charging) in mWh
+     * @param instance           - The cluster Instance to update attributes on
+     * @param chargingMeterValue - The current value of the energy meter (charging) in mWh
      */
-    void UpdateEnergyCharged(EndpointId endpointId, int64_t chargingMeterValue);
+    void UpdateEnergyCharged(Instance * instance, int64_t chargingMeterValue);
 
     /**
-     * @brief This function updates the EnergyDischarged meter value
+     * @brief Update the session's discharged energy delta.
      *
-     * @param endpointId            - The endpoint to report the update on
-     * @param dischargingMeterValue - The value of the energy meter (discharging) in mWh
+     * @param instance              - The cluster Instance to update attributes on
+     * @param dischargingMeterValue - The current value of the energy meter (discharging) in mWh
      */
-    void UpdateEnergyDischarged(EndpointId endpointId, int64_t dischargingMeterValue);
-
-    /* Public members - represent attributes in the cluster */
-    DataModel::Nullable<uint32_t> mSessionID;
-    DataModel::Nullable<uint32_t> mSessionDuration;
-    DataModel::Nullable<int64_t> mSessionEnergyCharged;
-    DataModel::Nullable<int64_t> mSessionEnergyDischarged;
+    void UpdateEnergyDischarged(Instance * instance, int64_t dischargingMeterValue);
 
 private:
     uint32_t mStartTime                     = 0; // Epoch_s - 0 means it hasn't started yet

--- a/examples/evse-app/evse-common/src/EVSEManufacturerImpl.cpp
+++ b/examples/evse-app/evse-common/src/EVSEManufacturerImpl.cpp
@@ -343,6 +343,9 @@ CHIP_ERROR EVSEManufacturer::ComputeChargingSchedule()
     EnergyEvseDelegate * dg = mn->GetEvseDelegate();
     VerifyOrReturnError(dg != nullptr, CHIP_ERROR_UNINITIALIZED);
 
+    Instance * instance = dg->GetInstance();
+    VerifyOrReturnError(instance != nullptr, CHIP_ERROR_UNINITIALIZED);
+
     BitMask<EnergyEvse::TargetDayOfWeekBitmap> dayOfWeekMap = 0;
     ReturnErrorOnFailure(GetLocalDayOfWeekNow(dayOfWeekMap));
 
@@ -413,10 +416,10 @@ CHIP_ERROR EVSEManufacturer::ComputeChargingSchedule()
     }
 
     // Update the attributes to allow a UI to inform the user
-    TEMPORARY_RETURN_IGNORED dg->SetNextChargeStartTime(startTime_epoch_s);
-    TEMPORARY_RETURN_IGNORED dg->SetNextChargeTargetTime(targetTime_epoch_s);
-    TEMPORARY_RETURN_IGNORED dg->SetNextChargeRequiredEnergy(targetAddedEnergy_mWh);
-    TEMPORARY_RETURN_IGNORED dg->SetNextChargeTargetSoC(targetSoC);
+    TEMPORARY_RETURN_IGNORED instance->SetNextChargeStartTime(startTime_epoch_s);
+    TEMPORARY_RETURN_IGNORED instance->SetNextChargeTargetTime(targetTime_epoch_s);
+    TEMPORARY_RETURN_IGNORED instance->SetNextChargeRequiredEnergy(targetAddedEnergy_mWh);
+    TEMPORARY_RETURN_IGNORED instance->SetNextChargeTargetSoC(targetSoC);
 
     return err;
 }

--- a/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
@@ -21,6 +21,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/EventLogging.h>
 #include <app/SafeAttributePersistenceProvider.h>
+#include <app/clusters/energy-evse-server/energy-evse-server.h>
 #include <app/reporting/reporting.h>
 #include <platform/CHIPDeviceLayer.h>
 
@@ -1373,9 +1374,11 @@ Status EnergyEvseDelegate::SendEnergyTransferStartedEvent()
     GetEVSEEnergyMeterValue(ChargingDischargingType::kCharging, mImportedMeterValueAtEnergyTransferStart);
     event.maximumCurrent = mMaximumChargeCurrent;
 
+    Instance * instance = GetInstance();
+    VerifyOrReturnError(instance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
     /* For V2X we may switch between charging and discharging, but we don't
      * keep sending EnergyTransferStarted events */
-    if (GetInstance()->HasFeature(Feature::kV2x))
+    if (instance->HasFeature(Feature::kV2x))
     {
         /* Sample the energy meter for discharging */
         GetEVSEEnergyMeterValue(ChargingDischargingType::kDischarging, mExportedMeterValueAtEnergyTransferStart);
@@ -1416,7 +1419,10 @@ Status EnergyEvseDelegate::SendEnergyTransferStoppedEvent(EnergyTransferStoppedR
     GetEVSEEnergyMeterValue(ChargingDischargingType::kCharging, meterValueNow);
     event.energyTransferred = meterValueNow - mImportedMeterValueAtEnergyTransferStart;
 
-    if (GetInstance()->HasFeature(Feature::kV2x))
+    Instance * instance = GetInstance();
+    VerifyOrReturnError(instance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
+
+    if (instance->HasFeature(Feature::kV2x))
     {
         GetEVSEEnergyMeterValue(ChargingDischargingType::kDischarging, meterValueNow);
         event.energyDischarged.SetValue(mExportedMeterValueAtEnergyTransferStart - meterValueNow);

--- a/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
@@ -21,7 +21,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/EventLogging.h>
 #include <app/SafeAttributePersistenceProvider.h>
-#include <app/clusters/energy-evse-server/energy-evse-server.h>
+#include <app/clusters/energy-evse-server/CodegenIntegration.h>
 #include <app/reporting/reporting.h>
 #include <platform/CHIPDeviceLayer.h>
 
@@ -42,13 +42,16 @@ Status EnergyEvseDelegate::Disable()
 {
     ChipLogProgress(AppServer, "EnergyEvseDelegate::Disable()");
 
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     DataModel::Nullable<uint32_t> disableTime(0);
     /* update ChargingEnabledUntil & DischargingEnabledUntil to show 0 */
-    TEMPORARY_RETURN_IGNORED SetChargingEnabledUntil(disableTime);
-    TEMPORARY_RETURN_IGNORED SetDischargingEnabledUntil(disableTime);
+    TEMPORARY_RETURN_IGNORED instance->SetChargingEnabledUntil(disableTime);
+    TEMPORARY_RETURN_IGNORED instance->SetDischargingEnabledUntil(disableTime);
 
     /* update MinimumChargeCurrent & MaximumChargeCurrent to 0 */
-    TEMPORARY_RETURN_IGNORED SetMinimumChargeCurrent(0);
+    TEMPORARY_RETURN_IGNORED instance->SetMinimumChargeCurrent(0);
 
     mMaximumChargingCurrentLimitFromCommand = 0;
     ComputeMaxChargeCurrentLimit();
@@ -90,22 +93,24 @@ Status EnergyEvseDelegate::EnableCharging(const DataModel::Nullable<uint32_t> & 
         return Status::ConstraintError;
     }
 
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     if (chargingEnabledUntil.IsNull())
     {
         /* Charging enabled indefinitely */
         ChipLogProgress(AppServer, "Charging enabled indefinitely");
-        TEMPORARY_RETURN_IGNORED SetChargingEnabledUntil(chargingEnabledUntil);
     }
     else
     {
         /* check chargingEnabledUntil is in the future */
         ChipLogProgress(AppServer, "Charging enabled until: %lu", static_cast<long unsigned int>(chargingEnabledUntil.Value()));
-        TEMPORARY_RETURN_IGNORED SetChargingEnabledUntil(chargingEnabledUntil);
     }
+    TEMPORARY_RETURN_IGNORED instance->SetChargingEnabledUntil(chargingEnabledUntil);
 
     /* If it looks ok, store the min & max charging current */
     mMaximumChargingCurrentLimitFromCommand = maximumChargeCurrent;
-    TEMPORARY_RETURN_IGNORED SetMinimumChargeCurrent(minimumChargeCurrent);
+    TEMPORARY_RETURN_IGNORED instance->SetMinimumChargeCurrent(minimumChargeCurrent);
     // TODO persist these to KVS
 
     ComputeMaxChargeCurrentLimit();
@@ -130,18 +135,20 @@ Status EnergyEvseDelegate::EnableDischarging(const DataModel::Nullable<uint32_t>
         return Status::ConstraintError;
     }
 
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     if (dischargingEnabledUntil.IsNull())
     {
         /* Discharging enabled indefinitely */
         ChipLogProgress(AppServer, "Discharging enabled indefinitely");
-        TEMPORARY_RETURN_IGNORED SetDischargingEnabledUntil(dischargingEnabledUntil);
     }
     else
     {
         ChipLogProgress(AppServer, "Discharging enabled until: %lu",
                         static_cast<long unsigned int>(dischargingEnabledUntil.Value()));
-        TEMPORARY_RETURN_IGNORED SetDischargingEnabledUntil(dischargingEnabledUntil);
     }
+    TEMPORARY_RETURN_IGNORED instance->SetDischargingEnabledUntil(dischargingEnabledUntil);
 
     /* If it looks ok, store the max discharging current */
     mMaximumDischargingCurrentLimitFromCommand = maximumDischargeCurrent;
@@ -192,6 +199,11 @@ static bool IsTimeExpired(const DataModel::Nullable<uint32_t> & timeValue, uint3
  */
 void EnergyEvseDelegate::HandleEnabledStateExpiration(uint32_t matterEpochSeconds)
 {
+    Instance * instance = GetInstance();
+    if (instance == nullptr)
+    {
+        return;
+    }
 
     DataModel::Nullable<uint32_t> chargingEnabledUntil    = GetChargingEnabledUntil();
     DataModel::Nullable<uint32_t> dischargingEnabledUntil = GetDischargingEnabledUntil();
@@ -202,10 +214,10 @@ void EnergyEvseDelegate::HandleEnabledStateExpiration(uint32_t matterEpochSecond
     if (chargingExpired)
     {
         // set to zero to indicate disabled
-        TEMPORARY_RETURN_IGNORED SetChargingEnabledUntil(DataModel::Nullable<uint32_t>(0));
+        TEMPORARY_RETURN_IGNORED instance->SetChargingEnabledUntil(DataModel::Nullable<uint32_t>(0));
 
         // update MinimumChargeCurrent & MaximumChargeCurrent to 0
-        TEMPORARY_RETURN_IGNORED SetMinimumChargeCurrent(0);
+        TEMPORARY_RETURN_IGNORED instance->SetMinimumChargeCurrent(0);
 
         mMaximumChargingCurrentLimitFromCommand = 0;
         ComputeMaxChargeCurrentLimit();
@@ -213,7 +225,7 @@ void EnergyEvseDelegate::HandleEnabledStateExpiration(uint32_t matterEpochSecond
         // Change to discharging-only if discharging is still enabled
         if (!dischargingExpired)
         {
-            TEMPORARY_RETURN_IGNORED SetSupplyState(SupplyStateEnum::kDischargingEnabled);
+            TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDischargingEnabled);
         }
         else
         {
@@ -225,7 +237,7 @@ void EnergyEvseDelegate::HandleEnabledStateExpiration(uint32_t matterEpochSecond
     if (dischargingExpired)
     {
         // set to zero to indicate disabled
-        TEMPORARY_RETURN_IGNORED SetDischargingEnabledUntil(DataModel::Nullable<uint32_t>(0));
+        TEMPORARY_RETURN_IGNORED instance->SetDischargingEnabledUntil(DataModel::Nullable<uint32_t>(0));
 
         // update MaximumDischargeCurrent to 0
         mMaximumDischargingCurrentLimitFromCommand = 0;
@@ -234,7 +246,7 @@ void EnergyEvseDelegate::HandleEnabledStateExpiration(uint32_t matterEpochSecond
         // Change to charging-only if charging is still enabled
         if (!chargingExpired)
         {
-            TEMPORARY_RETURN_IGNORED SetSupplyState(SupplyStateEnum::kChargingEnabled);
+            TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kChargingEnabled);
         }
         else
         {
@@ -353,8 +365,11 @@ Status EnergyEvseDelegate::StartDiagnostics()
         return Status::Failure;
     }
 
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     // Update the SupplyState - this will automatically callback the Application StateChanged callback
-    TEMPORARY_RETURN_IGNORED SetSupplyState(SupplyStateEnum::kDisabledDiagnostics);
+    TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDisabledDiagnostics);
 
     return Status::Success;
 }
@@ -685,13 +700,16 @@ Status EnergyEvseDelegate::HwSetFault(FaultStateEnum newFaultState)
         return Status::Failure;
     }
 
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     /** Before we do anything we log the fault
      * any change in FaultState reports previous fault and new fault
      * and the state prior to the fault being raised */
     SendFaultEvent(newFaultState);
 
     /* Updated FaultState before we call into the handlers */
-    TEMPORARY_RETURN_IGNORED SetFaultState(newFaultState);
+    TEMPORARY_RETURN_IGNORED instance->SetFaultState(newFaultState);
 
     if (newFaultState == FaultStateEnum::kNoError)
     {
@@ -800,9 +818,12 @@ Status EnergyEvseDelegate::HwDiagnosticsComplete()
         return Status::Failure;
     }
 
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     /* Restore the SupplyState to Disabled (per spec) - client will need to
      * re-enable charging or discharging to get out of this state */
-    TEMPORARY_RETURN_IGNORED SetSupplyState(SupplyStateEnum::kDisabled);
+    TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDisabled);
 
     return Status::Success;
 }
@@ -868,13 +889,16 @@ Status EnergyEvseDelegate::HandleEVPluggedInEvent()
     /* check if we are already plugged in or not */
     if (mState == StateEnum::kNotPluggedIn)
     {
+        Instance * instance = GetInstance();
+        VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
         /* EV was not plugged in - start a new session */
         // TODO get energy meter readings - #35370
         mSession.StartSession(mEndpointId, 0, 0);
         SendEVConnectedEvent();
 
         /* Set the state to either PluggedInNoDemand or PluggedInDemand as indicated by mHwState */
-        TEMPORARY_RETURN_IGNORED SetState(mHwState);
+        TEMPORARY_RETURN_IGNORED instance->SetState(mHwState);
     }
     // else we are already plugged in - ignore
     return Status::Success;
@@ -882,6 +906,9 @@ Status EnergyEvseDelegate::HandleEVPluggedInEvent()
 
 Status EnergyEvseDelegate::HandleEVNotDetectedEvent()
 {
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     if (mState == StateEnum::kPluggedInCharging || mState == StateEnum::kPluggedInDischarging)
     {
         /*
@@ -894,12 +921,15 @@ Status EnergyEvseDelegate::HandleEVNotDetectedEvent()
     // TODO get energy meter readings - #35370
     mSession.StopSession(mEndpointId, 0, 0);
     SendEVNotDetectedEvent();
-    TEMPORARY_RETURN_IGNORED SetState(StateEnum::kNotPluggedIn);
+    TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kNotPluggedIn);
     return Status::Success;
 }
 
 Status EnergyEvseDelegate::HandleEVNoDemandEvent()
 {
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     if (mState == StateEnum::kPluggedInCharging || mState == StateEnum::kPluggedInDischarging)
     {
         /*
@@ -909,22 +939,25 @@ Status EnergyEvseDelegate::HandleEVNoDemandEvent()
         SendEnergyTransferStoppedEvent(EnergyTransferStoppedReasonEnum::kEVStopped);
     }
     /* We must still be plugged in to get here - so no need to check if we are plugged in! */
-    TEMPORARY_RETURN_IGNORED SetState(StateEnum::kPluggedInNoDemand);
+    TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInNoDemand);
     return Status::Success;
 }
 Status EnergyEvseDelegate::HandleEVDemandEvent()
 {
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     /* Check to see if the supply is enabled for charging / discharging*/
     switch (mSupplyState)
     {
     case SupplyStateEnum::kChargingEnabled:
         ComputeMaxChargeCurrentLimit();
-        TEMPORARY_RETURN_IGNORED SetState(StateEnum::kPluggedInCharging);
+        TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInCharging);
         SendEnergyTransferStartedEvent();
         break;
     case SupplyStateEnum::kDischargingEnabled:
         ComputeMaxDischargeCurrentLimit();
-        TEMPORARY_RETURN_IGNORED SetState(StateEnum::kPluggedInDischarging);
+        TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInDischarging);
         SendEnergyTransferStartedEvent();
         break;
     case SupplyStateEnum::kEnabled:
@@ -936,7 +969,7 @@ Status EnergyEvseDelegate::HandleEVDemandEvent()
         */
         ComputeMaxChargeCurrentLimit();
         ComputeMaxDischargeCurrentLimit();
-        TEMPORARY_RETURN_IGNORED SetState(StateEnum::kPluggedInCharging);
+        TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInCharging);
         SendEnergyTransferStartedEvent();
         break;
     case SupplyStateEnum::kDisabled:
@@ -944,7 +977,7 @@ Status EnergyEvseDelegate::HandleEVDemandEvent()
     case SupplyStateEnum::kDisabledDiagnostics:
         /* We must be plugged in, and the event is asking for demand
          * but we can't charge or discharge now - leave it as kPluggedInDemand */
-        TEMPORARY_RETURN_IGNORED SetState(StateEnum::kPluggedInDemand);
+        TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInDemand);
         break;
     case SupplyStateEnum::kUnknownEnumValue:
         ChipLogError(AppServer, "EVSE: HandleEVDemandEvent called in unexpected SupplyState");
@@ -980,18 +1013,21 @@ Status EnergyEvseDelegate::HandleChargingEnabledEvent()
         return status;
     }
 
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     switch (mSupplyState)
     {
     case SupplyStateEnum::kDisabled:
         // it was kDisabled, then the state becomes kChargingEnabled
-        TEMPORARY_RETURN_IGNORED SetSupplyState(SupplyStateEnum::kChargingEnabled);
+        TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kChargingEnabled);
         break;
     case SupplyStateEnum::kChargingEnabled:
         // No change
         break;
     case SupplyStateEnum::kDischargingEnabled:
         // If the SupplyState was already kDischargingEnabled the state becomes kEnabled
-        TEMPORARY_RETURN_IGNORED SetSupplyState(SupplyStateEnum::kEnabled);
+        TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kEnabled);
         break;
     case SupplyStateEnum::kDisabledError:
     case SupplyStateEnum::kDisabledDiagnostics:
@@ -1011,7 +1047,7 @@ Status EnergyEvseDelegate::HandleChargingEnabledEvent()
         break;
     case StateEnum::kPluggedInDemand:
         ComputeMaxChargeCurrentLimit();
-        TEMPORARY_RETURN_IGNORED SetState(StateEnum::kPluggedInCharging);
+        TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInCharging);
         SendEnergyTransferStartedEvent();
         break;
     case StateEnum::kPluggedInCharging:
@@ -1038,15 +1074,18 @@ Status EnergyEvseDelegate::HandleDischargingEnabledEvent()
         return status;
     }
 
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     switch (mSupplyState)
     {
     case SupplyStateEnum::kDisabled:
         // it was kDisabled, then the state becomes kDischargingEnabled
-        TEMPORARY_RETURN_IGNORED SetSupplyState(SupplyStateEnum::kDischargingEnabled);
+        TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDischargingEnabled);
         break;
     case SupplyStateEnum::kChargingEnabled:
         // If the SupplyState was already kChargingEnabled the state becomes kEnabled
-        TEMPORARY_RETURN_IGNORED SetSupplyState(SupplyStateEnum::kEnabled);
+        TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kEnabled);
         break;
     case SupplyStateEnum::kDischargingEnabled:
         // No change
@@ -1091,8 +1130,11 @@ Status EnergyEvseDelegate::HandleDisabledEvent()
         return status;
     }
 
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     /* update SupplyState to disabled */
-    TEMPORARY_RETURN_IGNORED SetSupplyState(SupplyStateEnum::kDisabled);
+    TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDisabled);
 
     switch (mState)
     {
@@ -1103,7 +1145,7 @@ Status EnergyEvseDelegate::HandleDisabledEvent()
     case StateEnum::kPluggedInCharging:
     case StateEnum::kPluggedInDischarging:
         SendEnergyTransferStoppedEvent(EnergyTransferStoppedReasonEnum::kEVSEStopped);
-        TEMPORARY_RETURN_IGNORED SetState(mHwState);
+        TEMPORARY_RETURN_IGNORED instance->SetState(mHwState);
         break;
     default:
         break;
@@ -1121,6 +1163,9 @@ Status EnergyEvseDelegate::HandleDisabledEvent()
 )*/
 Status EnergyEvseDelegate::HandleFaultRaised()
 {
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     /* Save the current State and SupplyState so we can restore them if the fault clears */
     if (mStateBeforeFault == StateEnum::kUnknownEnumValue)
     {
@@ -1135,8 +1180,8 @@ Status EnergyEvseDelegate::HandleFaultRaised()
     }
 
     /* Update State & SupplyState */
-    TEMPORARY_RETURN_IGNORED SetState(StateEnum::kFault);
-    TEMPORARY_RETURN_IGNORED SetSupplyState(SupplyStateEnum::kDisabledError);
+    TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kFault);
+    TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDisabledError);
 
     return Status::Success;
 }
@@ -1149,11 +1194,14 @@ Status EnergyEvseDelegate::HandleFaultCleared()
         return Status::Failure;
     }
 
+    Instance * instance = GetInstance();
+    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+
     /* Restore the State and SupplyState back to old values once all the faults have cleared
      * Changing the State should notify the application, so it can continue charging etc
      */
-    TEMPORARY_RETURN_IGNORED SetState(mStateBeforeFault);
-    TEMPORARY_RETURN_IGNORED SetSupplyState(mSupplyStateBeforeFault);
+    TEMPORARY_RETURN_IGNORED instance->SetState(mStateBeforeFault);
+    TEMPORARY_RETURN_IGNORED instance->SetSupplyState(mSupplyStateBeforeFault);
 
     /* put back the sentinel to catch new faults if more are raised */
     mStateBeforeFault       = StateEnum::kUnknownEnumValue;
@@ -1461,298 +1509,112 @@ Status EnergyEvseDelegate::SendFaultEvent(FaultStateEnum newFaultState)
 }
 
 /**
- * Attribute methods
+ * Attribute change callbacks - called by cluster after attribute is updated
  */
-/* State */
-StateEnum EnergyEvseDelegate::GetState()
-{
-    return mState;
-}
 
-CHIP_ERROR EnergyEvseDelegate::SetState(StateEnum newValue)
+void EnergyEvseDelegate::OnStateChanged(StateEnum newValue)
 {
-    StateEnum oldValue = mState;
-    if (newValue >= StateEnum::kUnknownEnumValue)
-    {
-        return CHIP_IM_GLOBAL_STATUS(ConstraintError);
-    }
-
     mState = newValue;
-    if (oldValue != mState)
-    {
-        ChipLogDetail(AppServer, "State updated to %d", static_cast<int>(mState));
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, State::Id);
-        NotifyApplicationStateChange();
-    }
-
-    return CHIP_NO_ERROR;
+    ChipLogDetail(AppServer, "State updated to %d", static_cast<int>(mState));
+    NotifyApplicationStateChange();
 }
 
-/* SupplyState */
-SupplyStateEnum EnergyEvseDelegate::GetSupplyState()
+void EnergyEvseDelegate::OnSupplyStateChanged(SupplyStateEnum newValue)
 {
-    return mSupplyState;
-}
-
-CHIP_ERROR EnergyEvseDelegate::SetSupplyState(SupplyStateEnum newValue)
-{
-    SupplyStateEnum oldValue = mSupplyState;
-
-    if (newValue >= SupplyStateEnum::kUnknownEnumValue)
-    {
-        return CHIP_IM_GLOBAL_STATUS(ConstraintError);
-    }
-
     mSupplyState = newValue;
-    if (oldValue != mSupplyState)
-    {
-        ChipLogDetail(AppServer, "SupplyState updated to %d", static_cast<int>(mSupplyState));
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, SupplyState::Id);
-        NotifyApplicationStateChange();
-    }
-    return CHIP_NO_ERROR;
+    ChipLogDetail(AppServer, "SupplyState updated to %d", static_cast<int>(mSupplyState));
+    NotifyApplicationStateChange();
 }
 
-/* FaultState */
-FaultStateEnum EnergyEvseDelegate::GetFaultState()
+void EnergyEvseDelegate::OnFaultStateChanged(FaultStateEnum newValue)
 {
-    return mFaultState;
-}
-
-CHIP_ERROR EnergyEvseDelegate::SetFaultState(FaultStateEnum newValue)
-{
-    FaultStateEnum oldValue = mFaultState;
-
-    if (newValue >= FaultStateEnum::kUnknownEnumValue)
-    {
-        return CHIP_IM_GLOBAL_STATUS(ConstraintError);
-    }
-
     mFaultState = newValue;
-    if (oldValue != mFaultState)
-    {
-        ChipLogDetail(AppServer, "FaultState updated to %d", static_cast<int>(mFaultState));
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, FaultState::Id);
-    }
-    return CHIP_NO_ERROR;
+    ChipLogDetail(AppServer, "FaultState updated to %d", static_cast<int>(mFaultState));
 }
 
-/* ChargingEnabledUntil */
-DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetChargingEnabledUntil()
+void EnergyEvseDelegate::OnChargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    return mChargingEnabledUntil;
-}
-
-CHIP_ERROR EnergyEvseDelegate::SetChargingEnabledUntil(DataModel::Nullable<uint32_t> newValue)
-{
-    DataModel::Nullable<uint32_t> oldValue = mChargingEnabledUntil;
-
     mChargingEnabledUntil = newValue;
-    if (oldValue != newValue)
+    if (newValue.IsNull())
     {
-        if (newValue.IsNull())
-        {
-            ChipLogDetail(AppServer, "ChargingEnabledUntil updated to Null");
-        }
-        else
-        {
-            ChipLogDetail(AppServer, "ChargingEnabledUntil updated to %lu",
-                          static_cast<unsigned long int>(mChargingEnabledUntil.Value()));
-        }
-
-        // Write new value to persistent storage.
-        ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, ChargingEnabledUntil::Id);
-        TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mChargingEnabledUntil);
-
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, ChargingEnabledUntil::Id);
+        ChipLogDetail(AppServer, "ChargingEnabledUntil updated to Null");
     }
-
-    return CHIP_NO_ERROR;
+    else
+    {
+        ChipLogDetail(AppServer, "ChargingEnabledUntil updated to %lu",
+                      static_cast<unsigned long int>(mChargingEnabledUntil.Value()));
+    }
+    // Write new value to persistent storage.
+    ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, ChargingEnabledUntil::Id);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mChargingEnabledUntil);
 }
 
-/* DischargingEnabledUntil */
-DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetDischargingEnabledUntil()
+void EnergyEvseDelegate::OnDischargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    return mDischargingEnabledUntil;
-}
-
-CHIP_ERROR EnergyEvseDelegate::SetDischargingEnabledUntil(DataModel::Nullable<uint32_t> newValue)
-{
-    DataModel::Nullable<uint32_t> oldValue = mDischargingEnabledUntil;
-
     mDischargingEnabledUntil = newValue;
-    if (oldValue != newValue)
+    if (newValue.IsNull())
     {
-        if (newValue.IsNull())
-        {
-            ChipLogDetail(AppServer, "DischargingEnabledUntil updated to Null");
-        }
-        else
-        {
-            ChipLogDetail(AppServer, "DischargingEnabledUntil updated to %lu",
-                          static_cast<unsigned long int>(mDischargingEnabledUntil.Value()));
-        }
-        // Write new value to persistent storage.
-        ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, DischargingEnabledUntil::Id);
-        TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mDischargingEnabledUntil);
-
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, DischargingEnabledUntil::Id);
+        ChipLogDetail(AppServer, "DischargingEnabledUntil updated to Null");
     }
-
-    return CHIP_NO_ERROR;
+    else
+    {
+        ChipLogDetail(AppServer, "DischargingEnabledUntil updated to %lu",
+                      static_cast<unsigned long int>(mDischargingEnabledUntil.Value()));
+    }
+    // Write new value to persistent storage.
+    ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, DischargingEnabledUntil::Id);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mDischargingEnabledUntil);
 }
 
-/* CircuitCapacity */
-int64_t EnergyEvseDelegate::GetCircuitCapacity()
+void EnergyEvseDelegate::OnCircuitCapacityChanged(int64_t newValue)
 {
-    return mCircuitCapacity;
-}
-
-CHIP_ERROR EnergyEvseDelegate::SetCircuitCapacity(int64_t newValue)
-{
-    int64_t oldValue = mCircuitCapacity;
-
-    if (newValue < 0)
-    {
-        return CHIP_IM_GLOBAL_STATUS(ConstraintError);
-    }
-
     mCircuitCapacity = newValue;
-    if (oldValue != mCircuitCapacity)
-    {
-        ChipLogDetail(AppServer, "CircuitCapacity updated to %ld", static_cast<long>(mCircuitCapacity));
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, CircuitCapacity::Id);
-    }
-    return CHIP_NO_ERROR;
+    ChipLogDetail(AppServer, "CircuitCapacity updated to %ld", static_cast<long>(mCircuitCapacity));
 }
 
-/* MinimumChargeCurrent */
-int64_t EnergyEvseDelegate::GetMinimumChargeCurrent()
+void EnergyEvseDelegate::OnMinimumChargeCurrentChanged(int64_t newValue)
 {
-    return mMinimumChargeCurrent;
-}
-
-CHIP_ERROR EnergyEvseDelegate::SetMinimumChargeCurrent(int64_t newValue)
-{
-    int64_t oldValue = mMinimumChargeCurrent;
-
-    if (newValue < 0)
-    {
-        return CHIP_IM_GLOBAL_STATUS(ConstraintError);
-    }
-
     mMinimumChargeCurrent = newValue;
-    if (oldValue != mMinimumChargeCurrent)
-    {
-        ChipLogDetail(AppServer, "MinimumChargeCurrent updated to %ld", static_cast<long>(mMinimumChargeCurrent));
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, MinimumChargeCurrent::Id);
-    }
-    return CHIP_NO_ERROR;
+    ChipLogDetail(AppServer, "MinimumChargeCurrent updated to %ld", static_cast<long>(mMinimumChargeCurrent));
 }
 
-/* MaximumChargeCurrent */
-int64_t EnergyEvseDelegate::GetMaximumChargeCurrent()
+void EnergyEvseDelegate::OnMaximumChargeCurrentChanged(int64_t newValue)
 {
-    return mMaximumChargeCurrent;
+    mMaximumChargeCurrent = newValue;
+    ChipLogDetail(AppServer, "MaximumChargeCurrent updated to %ld", static_cast<long>(mMaximumChargeCurrent));
 }
 
-/* MaximumDischargeCurrent */
-int64_t EnergyEvseDelegate::GetMaximumDischargeCurrent()
+void EnergyEvseDelegate::OnMaximumDischargeCurrentChanged(int64_t newValue)
 {
-    return mMaximumDischargeCurrent;
-}
-
-CHIP_ERROR EnergyEvseDelegate::SetMaximumDischargeCurrent(int64_t newValue)
-{
-    int64_t oldValue = mMaximumDischargeCurrent;
-
-    if (newValue < 0)
-    {
-        return CHIP_IM_GLOBAL_STATUS(ConstraintError);
-    }
-
     mMaximumDischargeCurrent = newValue;
-    if (oldValue != mMaximumDischargeCurrent)
-    {
-        ChipLogDetail(AppServer, "MaximumDischargeCurrent updated to %ld", static_cast<long>(mMaximumDischargeCurrent));
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, MaximumDischargeCurrent::Id);
-    }
-    return CHIP_NO_ERROR;
+    ChipLogDetail(AppServer, "MaximumDischargeCurrent updated to %ld", static_cast<long>(mMaximumDischargeCurrent));
 }
 
-/* UserMaximumChargeCurrent */
-int64_t EnergyEvseDelegate::GetUserMaximumChargeCurrent()
+void EnergyEvseDelegate::OnUserMaximumChargeCurrentChanged(int64_t newValue)
 {
-    return mUserMaximumChargeCurrent;
-}
-
-CHIP_ERROR EnergyEvseDelegate::SetUserMaximumChargeCurrent(int64_t newValue)
-{
-    if (newValue < 0)
-    {
-        return CHIP_IM_GLOBAL_STATUS(ConstraintError);
-    }
-
-    int64_t oldValue          = mUserMaximumChargeCurrent;
     mUserMaximumChargeCurrent = newValue;
-    if (oldValue != newValue)
-    {
-        ChipLogDetail(AppServer, "UserMaximumChargeCurrent updated to %ld", static_cast<long>(mUserMaximumChargeCurrent));
+    ChipLogDetail(AppServer, "UserMaximumChargeCurrent updated to %ld", static_cast<long>(mUserMaximumChargeCurrent));
 
-        ComputeMaxChargeCurrentLimit();
+    ComputeMaxChargeCurrentLimit();
 
-        // Write new value to persistent storage.
-        ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, UserMaximumChargeCurrent::Id);
-        TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mUserMaximumChargeCurrent);
-
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, UserMaximumChargeCurrent::Id);
-    }
-
-    return CHIP_NO_ERROR;
+    // Write new value to persistent storage.
+    ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, UserMaximumChargeCurrent::Id);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mUserMaximumChargeCurrent);
 }
 
-/* RandomizationDelayWindow */
-uint32_t EnergyEvseDelegate::GetRandomizationDelayWindow()
+void EnergyEvseDelegate::OnRandomizationDelayWindowChanged(uint32_t newValue)
 {
-    return mRandomizationDelayWindow;
-}
-
-CHIP_ERROR EnergyEvseDelegate::SetRandomizationDelayWindow(uint32_t newValue)
-{
-    uint32_t oldValue = mRandomizationDelayWindow;
-    if (newValue > kMaxRandomizationDelayWindowSec)
-    {
-        return CHIP_IM_GLOBAL_STATUS(ConstraintError);
-    }
-
     mRandomizationDelayWindow = newValue;
-    if (oldValue != newValue)
-    {
-        ChipLogDetail(AppServer, "RandomizationDelayWindow updated to %lu",
-                      static_cast<unsigned long int>(mRandomizationDelayWindow));
+    ChipLogDetail(AppServer, "RandomizationDelayWindow updated to %lu", static_cast<unsigned long int>(mRandomizationDelayWindow));
 
-        // Write new value to persistent storage.
-        ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, RandomizationDelayWindow::Id);
-        TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mRandomizationDelayWindow);
-
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, RandomizationDelayWindow::Id);
-    }
-    return CHIP_NO_ERROR;
+    // Write new value to persistent storage.
+    ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, RandomizationDelayWindow::Id);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mRandomizationDelayWindow);
 }
 
-/* PREF attributes */
-DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetNextChargeStartTime()
+void EnergyEvseDelegate::OnNextChargeStartTimeChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    return mNextChargeStartTime;
-}
-CHIP_ERROR EnergyEvseDelegate::SetNextChargeStartTime(DataModel::Nullable<uint32_t> newNextChargeStartTimeUtc)
-{
-    if (newNextChargeStartTimeUtc == mNextChargeStartTime)
-    {
-        return CHIP_NO_ERROR;
-    }
-
-    mNextChargeStartTime = newNextChargeStartTimeUtc;
+    mNextChargeStartTime = newValue;
     if (mNextChargeStartTime.IsNull())
     {
         ChipLogDetail(AppServer, "NextChargeStartTime updated to Null");
@@ -1762,24 +1624,11 @@ CHIP_ERROR EnergyEvseDelegate::SetNextChargeStartTime(DataModel::Nullable<uint32
         ChipLogDetail(AppServer, "NextChargeStartTime updated to %lu",
                       static_cast<unsigned long int>(mNextChargeStartTime.Value()));
     }
-
-    MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, NextChargeStartTime::Id);
-
-    return CHIP_NO_ERROR;
 }
 
-DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetNextChargeTargetTime()
+void EnergyEvseDelegate::OnNextChargeTargetTimeChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    return mNextChargeTargetTime;
-}
-CHIP_ERROR EnergyEvseDelegate::SetNextChargeTargetTime(DataModel::Nullable<uint32_t> newNextChargeTargetTimeUtc)
-{
-    if (newNextChargeTargetTimeUtc == mNextChargeTargetTime)
-    {
-        return CHIP_NO_ERROR;
-    }
-
-    mNextChargeTargetTime = newNextChargeTargetTimeUtc;
+    mNextChargeTargetTime = newValue;
     if (mNextChargeTargetTime.IsNull())
     {
         ChipLogDetail(AppServer, "NextChargeTargetTime updated to Null");
@@ -1789,24 +1638,11 @@ CHIP_ERROR EnergyEvseDelegate::SetNextChargeTargetTime(DataModel::Nullable<uint3
         ChipLogDetail(AppServer, "NextChargeTargetTime updated to %lu",
                       static_cast<unsigned long int>(mNextChargeTargetTime.Value()));
     }
-
-    MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, NextChargeTargetTime::Id);
-
-    return CHIP_NO_ERROR;
 }
 
-DataModel::Nullable<int64_t> EnergyEvseDelegate::GetNextChargeRequiredEnergy()
+void EnergyEvseDelegate::OnNextChargeRequiredEnergyChanged(DataModel::Nullable<int64_t> newValue)
 {
-    return mNextChargeRequiredEnergy;
-}
-CHIP_ERROR EnergyEvseDelegate::SetNextChargeRequiredEnergy(DataModel::Nullable<int64_t> newNextChargeRequiredEnergyMilliWattH)
-{
-    if (mNextChargeRequiredEnergy == newNextChargeRequiredEnergyMilliWattH)
-    {
-        return CHIP_NO_ERROR;
-    }
-
-    mNextChargeRequiredEnergy = newNextChargeRequiredEnergyMilliWattH;
+    mNextChargeRequiredEnergy = newValue;
     if (mNextChargeRequiredEnergy.IsNull())
     {
         ChipLogDetail(AppServer, "NextChargeRequiredEnergy updated to Null");
@@ -1815,142 +1651,135 @@ CHIP_ERROR EnergyEvseDelegate::SetNextChargeRequiredEnergy(DataModel::Nullable<i
     {
         ChipLogDetail(AppServer, "NextChargeRequiredEnergy updated to %ld", static_cast<long>(mNextChargeRequiredEnergy.Value()));
     }
-
-    MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, NextChargeRequiredEnergy::Id);
-
-    return CHIP_NO_ERROR;
 }
 
-DataModel::Nullable<Percent> EnergyEvseDelegate::GetNextChargeTargetSoC()
+void EnergyEvseDelegate::OnNextChargeTargetSoCChanged(DataModel::Nullable<Percent> newValue)
 {
-    return mNextChargeTargetSoC;
-}
-CHIP_ERROR EnergyEvseDelegate::SetNextChargeTargetSoC(DataModel::Nullable<Percent> newValue)
-{
-    DataModel::Nullable<Percent> oldValue = mNextChargeTargetSoC;
-
     mNextChargeTargetSoC = newValue;
-    if (oldValue != newValue)
+    if (newValue.IsNull())
     {
-        if (newValue.IsNull())
-        {
-            ChipLogDetail(AppServer, "NextChargeTargetSoC updated to Null");
-        }
-        else
-        {
-            ChipLogDetail(AppServer, "NextChargeTargetSoC updated to %d %%", mNextChargeTargetSoC.Value());
-        }
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, NextChargeTargetSoC::Id);
+        ChipLogDetail(AppServer, "NextChargeTargetSoC updated to Null");
     }
-    return CHIP_NO_ERROR;
+    else
+    {
+        ChipLogDetail(AppServer, "NextChargeTargetSoC updated to %d %%", mNextChargeTargetSoC.Value());
+    }
 }
 
-/* ApproximateEVEfficiency */
-DataModel::Nullable<uint16_t> EnergyEvseDelegate::GetApproximateEVEfficiency()
+void EnergyEvseDelegate::OnApproximateEVEfficiencyChanged(DataModel::Nullable<uint16_t> newValue)
 {
-    return mApproximateEVEfficiency;
-}
-
-CHIP_ERROR EnergyEvseDelegate::SetApproximateEVEfficiency(DataModel::Nullable<uint16_t> newValue)
-{
-    DataModel::Nullable<uint16_t> oldValue = mApproximateEVEfficiency;
-
     mApproximateEVEfficiency = newValue;
-    if (oldValue != newValue)
+    if (newValue.IsNull())
     {
-        if (newValue.IsNull())
-        {
-            ChipLogDetail(AppServer, "ApproximateEVEfficiency updated to Null");
-        }
-        else
-        {
-            ChipLogDetail(AppServer, "ApproximateEVEfficiency updated to %d", mApproximateEVEfficiency.Value());
-        }
-        // Write new value to persistent storage.
-        ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, ApproximateEVEfficiency::Id);
-        TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mApproximateEVEfficiency);
-
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, ApproximateEVEfficiency::Id);
+        ChipLogDetail(AppServer, "ApproximateEVEfficiency updated to Null");
     }
-
-    return CHIP_NO_ERROR;
+    else
+    {
+        ChipLogDetail(AppServer, "ApproximateEVEfficiency updated to %d", mApproximateEVEfficiency.Value());
+    }
+    // Write new value to persistent storage.
+    ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, ApproximateEVEfficiency::Id);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mApproximateEVEfficiency);
 }
 
-/* SOC attributes */
-DataModel::Nullable<Percent> EnergyEvseDelegate::GetStateOfCharge()
+void EnergyEvseDelegate::OnStateOfChargeChanged(DataModel::Nullable<Percent> newValue)
 {
-    return mStateOfCharge;
-}
-CHIP_ERROR EnergyEvseDelegate::SetStateOfCharge(DataModel::Nullable<Percent> newValue)
-{
-    DataModel::Nullable<Percent> oldValue = mStateOfCharge;
-
     mStateOfCharge = newValue;
-    if (oldValue != newValue)
+    if (newValue.IsNull())
     {
-        if (newValue.IsNull())
-        {
-            ChipLogDetail(AppServer, "StateOfCharge updated to Null");
-        }
-        else
-        {
-            ChipLogDetail(AppServer, "StateOfCharge updated to %d", mStateOfCharge.Value());
-        }
-
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, StateOfCharge::Id);
+        ChipLogDetail(AppServer, "StateOfCharge updated to Null");
     }
-
-    return CHIP_NO_ERROR;
+    else
+    {
+        ChipLogDetail(AppServer, "StateOfCharge updated to %d", mStateOfCharge.Value());
+    }
 }
 
-DataModel::Nullable<int64_t> EnergyEvseDelegate::GetBatteryCapacity()
+void EnergyEvseDelegate::OnBatteryCapacityChanged(DataModel::Nullable<int64_t> newValue)
 {
-    return mBatteryCapacity;
-}
-CHIP_ERROR EnergyEvseDelegate::SetBatteryCapacity(DataModel::Nullable<int64_t> newValue)
-{
-    DataModel::Nullable<int64_t> oldValue = mBatteryCapacity;
-
     mBatteryCapacity = newValue;
-    if (oldValue != newValue)
+    if (newValue.IsNull())
     {
-        if (newValue.IsNull())
-        {
-            ChipLogDetail(AppServer, "BatteryCapacity updated to Null");
-        }
-        else
-        {
-            ChipLogDetail(AppServer, "BatteryCapacity updated to %ld", static_cast<long>(mBatteryCapacity.Value()));
-        }
-
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, BatteryCapacity::Id);
+        ChipLogDetail(AppServer, "BatteryCapacity updated to Null");
     }
-
-    return CHIP_NO_ERROR;
+    else
+    {
+        ChipLogDetail(AppServer, "BatteryCapacity updated to %ld", static_cast<long>(mBatteryCapacity.Value()));
+    }
 }
 
-/* PNC attributes*/
-DataModel::Nullable<CharSpan> EnergyEvseDelegate::GetVehicleID()
+void EnergyEvseDelegate::OnVehicleIDChanged(DataModel::Nullable<CharSpan> newValue)
 {
-    return mVehicleID;
+    // Copy the value to local buffer
+    if (newValue.IsNull())
+    {
+        mVehicleID = DataModel::NullNullable;
+        ChipLogDetail(AppServer, "VehicleID updated to Null");
+    }
+    else
+    {
+        size_t len = std::min(newValue.Value().size(), sizeof(mVehicleIDBuf) - 1);
+        memcpy(mVehicleIDBuf, newValue.Value().data(), len);
+        mVehicleIDBuf[len] = '\0';
+        mVehicleID         = DataModel::MakeNullable(CharSpan(mVehicleIDBuf, len));
+        ChipLogDetail(AppServer, "VehicleID updated to %.*s", static_cast<int>(len), mVehicleIDBuf);
+    }
 }
 
-/* Session SESS attributes */
-DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetSessionID()
+void EnergyEvseDelegate::OnSessionIDChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    return mSession.mSessionID;
+    mSession.mSessionID = newValue;
+    if (newValue.IsNull())
+    {
+        ChipLogDetail(AppServer, "SessionID updated to Null");
+    }
+    else
+    {
+        ChipLogDetail(AppServer, "SessionID updated to %lu", static_cast<unsigned long int>(mSession.mSessionID.Value()));
+    }
+    // Write value to persistent storage.
+    ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, SessionID::Id);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mSession.mSessionID);
 }
-DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetSessionDuration()
+
+void EnergyEvseDelegate::OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    return mSession.mSessionDuration;
+    mSession.mSessionDuration = newValue;
+    if (newValue.IsNull())
+    {
+        ChipLogDetail(AppServer, "SessionDuration updated to Null");
+    }
+    else
+    {
+        ChipLogDetail(AppServer, "SessionDuration updated to %lu", static_cast<unsigned long int>(mSession.mSessionDuration.Value()));
+    }
 }
-DataModel::Nullable<int64_t> EnergyEvseDelegate::GetSessionEnergyCharged()
+
+void EnergyEvseDelegate::OnSessionEnergyChargedChanged(DataModel::Nullable<int64_t> newValue)
 {
-    return mSession.mSessionEnergyCharged;
+    mSession.mSessionEnergyCharged = newValue;
+    if (newValue.IsNull())
+    {
+        ChipLogDetail(AppServer, "SessionEnergyCharged updated to Null");
+    }
+    else
+    {
+        ChipLogDetail(AppServer, "SessionEnergyCharged updated to %ld", static_cast<long>(mSession.mSessionEnergyCharged.Value()));
+    }
 }
-DataModel::Nullable<int64_t> EnergyEvseDelegate::GetSessionEnergyDischarged()
+
+void EnergyEvseDelegate::OnSessionEnergyDischargedChanged(DataModel::Nullable<int64_t> newValue)
 {
-    return mSession.mSessionEnergyDischarged;
+    mSession.mSessionEnergyDischarged = newValue;
+    if (newValue.IsNull())
+    {
+        ChipLogDetail(AppServer, "SessionEnergyDischarged updated to Null");
+    }
+    else
+    {
+        ChipLogDetail(AppServer, "SessionEnergyDischarged updated to %ld",
+                      static_cast<long>(mSession.mSessionEnergyDischarged.Value()));
+    }
 }
 
 /**

--- a/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
@@ -1535,7 +1535,7 @@ void EnergyEvseDelegate::OnChargingEnabledUntilChanged(DataModel::Nullable<uint3
         ChipLogDetail(AppServer, "ChargingEnabledUntil updated to %lu", static_cast<unsigned long int>(newValue.Value()));
     }
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, ChargingEnabledUntil::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnDischargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue)
@@ -1549,7 +1549,7 @@ void EnergyEvseDelegate::OnDischargingEnabledUntilChanged(DataModel::Nullable<ui
         ChipLogDetail(AppServer, "DischargingEnabledUntil updated to %lu", static_cast<unsigned long int>(newValue.Value()));
     }
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, DischargingEnabledUntil::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnCircuitCapacityChanged(int64_t newValue)
@@ -1577,14 +1577,14 @@ void EnergyEvseDelegate::OnUserMaximumChargeCurrentChanged(int64_t newValue)
     ChipLogDetail(AppServer, "UserMaximumChargeCurrent updated to %ld", static_cast<long>(newValue));
     ComputeMaxChargeCurrentLimit();
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, UserMaximumChargeCurrent::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnRandomizationDelayWindowChanged(uint32_t newValue)
 {
     ChipLogDetail(AppServer, "RandomizationDelayWindow updated to %lu", static_cast<unsigned long int>(newValue));
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, RandomizationDelayWindow::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnNextChargeStartTimeChanged(DataModel::Nullable<uint32_t> newValue)
@@ -1646,7 +1646,7 @@ void EnergyEvseDelegate::OnApproximateEVEfficiencyChanged(DataModel::Nullable<ui
         ChipLogDetail(AppServer, "ApproximateEVEfficiency updated to %d", newValue.Value());
     }
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, ApproximateEVEfficiency::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnStateOfChargeChanged(DataModel::Nullable<Percent> newValue)
@@ -1698,7 +1698,7 @@ void EnergyEvseDelegate::OnSessionIDChanged(DataModel::Nullable<uint32_t> newVal
     }
     // Write value to persistent storage.
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, SessionID::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, mSession.mSessionID);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mSession.mSessionID);
 }
 
 void EnergyEvseDelegate::OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue)
@@ -1799,7 +1799,7 @@ void EvseSession::StartSession(EndpointId endpointId, int64_t chargingMeterValue
 
     // Write values to persistent storage.
     ConcreteAttributePath path = ConcreteAttributePath(endpointId, EnergyEvse::Id, SessionID::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, mSessionID);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mSessionID);
 
     // TODO persist mStartTime
     // TODO persist mSessionEnergyChargedAtStart

--- a/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
@@ -1535,7 +1535,7 @@ void EnergyEvseDelegate::OnChargingEnabledUntilChanged(DataModel::Nullable<uint3
         ChipLogDetail(AppServer, "ChargingEnabledUntil updated to %lu", static_cast<unsigned long int>(newValue.Value()));
     }
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, ChargingEnabledUntil::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, newValue);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnDischargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue)
@@ -1549,7 +1549,7 @@ void EnergyEvseDelegate::OnDischargingEnabledUntilChanged(DataModel::Nullable<ui
         ChipLogDetail(AppServer, "DischargingEnabledUntil updated to %lu", static_cast<unsigned long int>(newValue.Value()));
     }
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, DischargingEnabledUntil::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, newValue);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnCircuitCapacityChanged(int64_t newValue)
@@ -1577,14 +1577,14 @@ void EnergyEvseDelegate::OnUserMaximumChargeCurrentChanged(int64_t newValue)
     ChipLogDetail(AppServer, "UserMaximumChargeCurrent updated to %ld", static_cast<long>(newValue));
     ComputeMaxChargeCurrentLimit();
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, UserMaximumChargeCurrent::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, newValue);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnRandomizationDelayWindowChanged(uint32_t newValue)
 {
     ChipLogDetail(AppServer, "RandomizationDelayWindow updated to %lu", static_cast<unsigned long int>(newValue));
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, RandomizationDelayWindow::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, newValue);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnNextChargeStartTimeChanged(DataModel::Nullable<uint32_t> newValue)
@@ -1646,7 +1646,7 @@ void EnergyEvseDelegate::OnApproximateEVEfficiencyChanged(DataModel::Nullable<ui
         ChipLogDetail(AppServer, "ApproximateEVEfficiency updated to %d", newValue.Value());
     }
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, ApproximateEVEfficiency::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, newValue);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnStateOfChargeChanged(DataModel::Nullable<Percent> newValue)
@@ -1698,7 +1698,7 @@ void EnergyEvseDelegate::OnSessionIDChanged(DataModel::Nullable<uint32_t> newVal
     }
     // Write value to persistent storage.
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, SessionID::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mSession.mSessionID);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, mSession.mSessionID);
 }
 
 void EnergyEvseDelegate::OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue)
@@ -1799,7 +1799,7 @@ void EvseSession::StartSession(EndpointId endpointId, int64_t chargingMeterValue
 
     // Write values to persistent storage.
     ConcreteAttributePath path = ConcreteAttributePath(endpointId, EnergyEvse::Id, SessionID::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mSessionID);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, mSessionID);
 
     // TODO persist mStartTime
     // TODO persist mSessionEnergyChargedAtStart
@@ -1868,4 +1868,146 @@ void EvseSession::UpdateEnergyDischarged(EndpointId endpointId, int64_t discharg
 {
     mSessionEnergyDischarged = MakeNullable(dischargingMeterValue - mSessionEnergyDischargedAtStart);
     MatterReportingAttributeChangeCallback(endpointId, EnergyEvse::Id, SessionEnergyDischarged::Id);
+}
+
+// ------------------------------------------------------------------
+// Local getters for internal delegate use - delegates to cluster instance
+// ------------------------------------------------------------------
+
+StateEnum EnergyEvseDelegate::GetState() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetState();
+}
+
+SupplyStateEnum EnergyEvseDelegate::GetSupplyState() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetSupplyState();
+}
+
+FaultStateEnum EnergyEvseDelegate::GetFaultState() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetFaultState();
+}
+
+DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetChargingEnabledUntil() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetChargingEnabledUntil();
+}
+
+DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetDischargingEnabledUntil() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetDischargingEnabledUntil();
+}
+
+int64_t EnergyEvseDelegate::GetCircuitCapacity() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetCircuitCapacity();
+}
+
+int64_t EnergyEvseDelegate::GetMinimumChargeCurrent() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetMinimumChargeCurrent();
+}
+
+int64_t EnergyEvseDelegate::GetMaximumChargeCurrent() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetMaximumChargeCurrent();
+}
+
+int64_t EnergyEvseDelegate::GetMaximumDischargeCurrent() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetMaximumDischargeCurrent();
+}
+
+int64_t EnergyEvseDelegate::GetUserMaximumChargeCurrent() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetUserMaximumChargeCurrent();
+}
+
+uint32_t EnergyEvseDelegate::GetRandomizationDelayWindow() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetRandomizationDelayWindow();
+}
+
+DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetNextChargeStartTime() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetNextChargeStartTime();
+}
+
+DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetNextChargeTargetTime() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetNextChargeTargetTime();
+}
+
+DataModel::Nullable<int64_t> EnergyEvseDelegate::GetNextChargeRequiredEnergy() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetNextChargeRequiredEnergy();
+}
+
+DataModel::Nullable<Percent> EnergyEvseDelegate::GetNextChargeTargetSoC() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetNextChargeTargetSoC();
+}
+
+DataModel::Nullable<uint16_t> EnergyEvseDelegate::GetApproximateEVEfficiency() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetApproximateEVEfficiency();
+}
+
+DataModel::Nullable<Percent> EnergyEvseDelegate::GetStateOfCharge() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetStateOfCharge();
+}
+
+DataModel::Nullable<int64_t> EnergyEvseDelegate::GetBatteryCapacity() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetBatteryCapacity();
+}
+
+DataModel::Nullable<CharSpan> EnergyEvseDelegate::GetVehicleID() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetVehicleID();
+}
+
+DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetSessionID() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetSessionID();
+}
+
+DataModel::Nullable<uint32_t> EnergyEvseDelegate::GetSessionDuration() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetSessionDuration();
+}
+
+DataModel::Nullable<int64_t> EnergyEvseDelegate::GetSessionEnergyCharged() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetSessionEnergyCharged();
+}
+
+DataModel::Nullable<int64_t> EnergyEvseDelegate::GetSessionEnergyDischarged() const
+{
+    VerifyOrDie(mInstance != nullptr);
+    return mInstance->GetSessionEnergyDischarged();
 }

--- a/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
@@ -1751,7 +1751,8 @@ void EnergyEvseDelegate::OnSessionDurationChanged(DataModel::Nullable<uint32_t> 
     }
     else
     {
-        ChipLogDetail(AppServer, "SessionDuration updated to %lu", static_cast<unsigned long int>(mSession.mSessionDuration.Value()));
+        ChipLogDetail(AppServer, "SessionDuration updated to %lu",
+                      static_cast<unsigned long int>(mSession.mSessionDuration.Value()));
     }
 }
 

--- a/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
@@ -1480,7 +1480,7 @@ Status EnergyEvseDelegate::SendFaultEvent(FaultStateEnum newFaultState)
 
     VerifyOrReturnError(mInstance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
     event.sessionID               = mInstance->GetSessionID(); // Note here the event sessionID can be Null!
-    event.state                   = GetState();          // This is the state prior to the fault being raised
+    event.state                   = GetState();                // This is the state prior to the fault being raised
     event.faultStatePreviousState = GetFaultState();
     event.faultStateCurrentState  = newFaultState;
 
@@ -1841,7 +1841,8 @@ void EvseSession::UpdateEnergyCharged(Instance * instance, int64_t chargingMeter
 void EvseSession::UpdateEnergyDischarged(Instance * instance, int64_t dischargingMeterValue)
 {
     VerifyOrReturn(instance != nullptr);
-    TEMPORARY_RETURN_IGNORED instance->SetSessionEnergyDischarged(MakeNullable(dischargingMeterValue - mSessionEnergyDischargedAtStart));
+    TEMPORARY_RETURN_IGNORED instance->SetSessionEnergyDischarged(
+        MakeNullable(dischargingMeterValue - mSessionEnergyDischargedAtStart));
 }
 
 // ------------------------------------------------------------------

--- a/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
@@ -897,7 +897,7 @@ Status EnergyEvseDelegate::HandleEVPluggedInEvent()
 
         /* EV was not plugged in - start a new session */
         // TODO get energy meter readings - #35370
-        mSession.StartSession(mEndpointId, 0, 0);
+        mSession.StartSession(mInstance, 0, 0);
         SendEVConnectedEvent();
 
         /* Set the state to either PluggedInNoDemand or PluggedInDemand as indicated by mHwState */
@@ -922,7 +922,7 @@ Status EnergyEvseDelegate::HandleEVNotDetectedEvent()
     }
 
     // TODO get energy meter readings - #35370
-    mSession.StopSession(mEndpointId, 0, 0);
+    mSession.StopSession(mInstance, 0, 0);
     SendEVNotDetectedEvent();
     TEMPORARY_RETURN_IGNORED mInstance->SetState(StateEnum::kNotPluggedIn);
     return Status::Success;
@@ -938,7 +938,7 @@ Status EnergyEvseDelegate::HandleEVNoDemandEvent()
         /*
          * EV was transferring current - EV decided to stop
          */
-        mSession.RecalculateSessionDuration(mEndpointId);
+        mSession.RecalculateSessionDuration(mInstance);
         SendEnergyTransferStoppedEvent(EnergyTransferStoppedReasonEnum::kEVStopped);
     }
     /* We must still be plugged in to get here - so no need to check if we are plugged in! */
@@ -1358,13 +1358,11 @@ Status EnergyEvseDelegate::SendEVConnectedEvent()
     Events::EVConnected::Type event;
     EventNumber eventNumber;
 
-    if (mSession.mSessionID.IsNull())
-    {
-        ChipLogError(AppServer, "SessionID is Null");
-        return Status::Failure;
-    }
+    VerifyOrReturnError(mInstance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
+    DataModel::Nullable<uint32_t> sessionID = mInstance->GetSessionID();
+    VerifyOrReturnError(!sessionID.IsNull(), Status::Failure, ChipLogError(AppServer, "SessionID is Null"));
 
-    event.sessionID = mSession.mSessionID.Value();
+    event.sessionID = sessionID.Value();
 
     CHIP_ERROR err = LogEvent(event, mEndpointId, eventNumber);
     if (CHIP_NO_ERROR != err)
@@ -1380,17 +1378,15 @@ Status EnergyEvseDelegate::SendEVNotDetectedEvent()
     Events::EVNotDetected::Type event;
     EventNumber eventNumber;
 
-    if (mSession.mSessionID.IsNull())
-    {
-        ChipLogError(AppServer, "SessionID is Null");
-        return Status::Failure;
-    }
+    VerifyOrReturnError(mInstance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
+    DataModel::Nullable<uint32_t> sessionID = mInstance->GetSessionID();
+    VerifyOrReturnError(!sessionID.IsNull(), Status::Failure, ChipLogError(AppServer, "SessionID is Null"));
 
-    event.sessionID               = mSession.mSessionID.Value();
+    event.sessionID               = sessionID.Value();
     event.state                   = GetState();
-    event.sessionDuration         = mSession.mSessionDuration.Value();
-    event.sessionEnergyCharged    = mSession.mSessionEnergyCharged.Value();
-    event.sessionEnergyDischarged = MakeOptional(mSession.mSessionEnergyDischarged.Value());
+    event.sessionDuration         = mInstance->GetSessionDuration().Value();
+    event.sessionEnergyCharged    = mInstance->GetSessionEnergyCharged().Value();
+    event.sessionEnergyDischarged = MakeOptional(mInstance->GetSessionEnergyDischarged().Value());
 
     CHIP_ERROR err = LogEvent(event, mEndpointId, eventNumber);
     if (CHIP_NO_ERROR != err)
@@ -1406,20 +1402,17 @@ Status EnergyEvseDelegate::SendEnergyTransferStartedEvent()
     Events::EnergyTransferStarted::Type event;
     EventNumber eventNumber;
 
-    if (mSession.mSessionID.IsNull())
-    {
-        ChipLogError(AppServer, "SessionID is Null");
-        return Status::Failure;
-    }
+    VerifyOrReturnError(mInstance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
+    DataModel::Nullable<uint32_t> sessionID = mInstance->GetSessionID();
+    VerifyOrReturnError(!sessionID.IsNull(), Status::Failure, ChipLogError(AppServer, "SessionID is Null"));
 
-    event.sessionID = mSession.mSessionID.Value();
+    event.sessionID = sessionID.Value();
     event.state     = GetState();
 
     /* Sample the energy meter for charging */
     GetEVSEEnergyMeterValue(ChargingDischargingType::kCharging, mImportedMeterValueAtEnergyTransferStart);
     event.maximumCurrent = GetMaximumChargeCurrent();
 
-    VerifyOrReturnError(mInstance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
     /* For V2X we may switch between charging and discharging, but we don't
      * keep sending EnergyTransferStarted events */
     if (mInstance->HasFeature(Feature::kV2x))
@@ -1449,21 +1442,17 @@ Status EnergyEvseDelegate::SendEnergyTransferStoppedEvent(EnergyTransferStoppedR
     Events::EnergyTransferStopped::Type event;
     EventNumber eventNumber;
 
-    if (mSession.mSessionID.IsNull())
-    {
-        ChipLogError(AppServer, "SessionID is Null");
-        return Status::Failure;
-    }
+    VerifyOrReturnError(mInstance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
+    DataModel::Nullable<uint32_t> sessionID = mInstance->GetSessionID();
+    VerifyOrReturnError(!sessionID.IsNull(), Status::Failure, ChipLogError(AppServer, "SessionID is Null"));
 
-    event.sessionID       = mSession.mSessionID.Value();
+    event.sessionID       = sessionID.Value();
     event.state           = GetState();
     event.reason          = reason;
     int64_t meterValueNow = 0;
 
     GetEVSEEnergyMeterValue(ChargingDischargingType::kCharging, meterValueNow);
     event.energyTransferred = meterValueNow - mImportedMeterValueAtEnergyTransferStart;
-
-    VerifyOrReturnError(mInstance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
 
     if (mInstance->HasFeature(Feature::kV2x))
     {
@@ -1489,7 +1478,8 @@ Status EnergyEvseDelegate::SendFaultEvent(FaultStateEnum newFaultState)
     Events::Fault::Type event;
     EventNumber eventNumber;
 
-    event.sessionID               = mSession.mSessionID; // Note here the event sessionID can be Null!
+    VerifyOrReturnError(mInstance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
+    event.sessionID               = mInstance->GetSessionID(); // Note here the event sessionID can be Null!
     event.state                   = GetState();          // This is the state prior to the fault being raised
     event.faultStatePreviousState = GetFaultState();
     event.faultStateCurrentState  = newFaultState;
@@ -1687,58 +1677,52 @@ void EnergyEvseDelegate::OnVehicleIDChanged(DataModel::Nullable<CharSpan> newVal
 
 void EnergyEvseDelegate::OnSessionIDChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    mSession.mSessionID = newValue;
     if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "SessionID updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "SessionID updated to %lu", static_cast<unsigned long int>(mSession.mSessionID.Value()));
+        ChipLogDetail(AppServer, "SessionID updated to %lu", static_cast<unsigned long int>(newValue.Value()));
     }
     // Write value to persistent storage.
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, SessionID::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mSession.mSessionID);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    mSession.mSessionDuration = newValue;
     if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "SessionDuration updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "SessionDuration updated to %lu",
-                      static_cast<unsigned long int>(mSession.mSessionDuration.Value()));
+        ChipLogDetail(AppServer, "SessionDuration updated to %lu", static_cast<unsigned long int>(newValue.Value()));
     }
 }
 
 void EnergyEvseDelegate::OnSessionEnergyChargedChanged(DataModel::Nullable<int64_t> newValue)
 {
-    mSession.mSessionEnergyCharged = newValue;
     if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "SessionEnergyCharged updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "SessionEnergyCharged updated to %ld", static_cast<long>(mSession.mSessionEnergyCharged.Value()));
+        ChipLogDetail(AppServer, "SessionEnergyCharged updated to %ld", static_cast<long>(newValue.Value()));
     }
 }
 
 void EnergyEvseDelegate::OnSessionEnergyDischargedChanged(DataModel::Nullable<int64_t> newValue)
 {
-    mSession.mSessionEnergyDischarged = newValue;
     if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "SessionEnergyDischarged updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "SessionEnergyDischarged updated to %ld",
-                      static_cast<long>(mSession.mSessionEnergyDischarged.Value()));
+        ChipLogDetail(AppServer, "SessionEnergyDischarged updated to %ld", static_cast<long>(newValue.Value()));
     }
 }
 
@@ -1760,15 +1744,15 @@ bool EnergyEvseDelegate::IsEvsePluggedIn()
  * @param chargingMeterValue    - The current value of the energy meter (charging) in mWh
  * @param dischargingMeterValue - The current value of the energy meter (discharging) in mWh
  */
-void EvseSession::StartSession(EndpointId endpointId, int64_t chargingMeterValue, int64_t dischargingMeterValue)
+void EvseSession::StartSession(Instance * instance, int64_t chargingMeterValue, int64_t dischargingMeterValue)
 {
+    VerifyOrReturn(instance != nullptr);
+
     /* Get Timestamp */
     uint32_t matterEpochSeconds = 0;
     CHIP_ERROR err              = System::Clock::GetClock_MatterEpochS(matterEpochSeconds);
     if (err != CHIP_NO_ERROR)
     {
-        /* Note that the error will be also be logged inside GetErrorTS() -
-         * adding context here to help debugging */
         ChipLogError(AppServer, "EVSE: Unable to get current time when starting session - err:%" CHIP_ERROR_FORMAT, err.Format());
         return;
     }
@@ -1777,29 +1761,21 @@ void EvseSession::StartSession(EndpointId endpointId, int64_t chargingMeterValue
     mSessionEnergyChargedAtStart    = chargingMeterValue;
     mSessionEnergyDischargedAtStart = dischargingMeterValue;
 
-    if (mSessionID.IsNull())
+    // Compute next session ID
+    DataModel::Nullable<uint32_t> currentSessionID = instance->GetSessionID();
+    if (currentSessionID.IsNull())
     {
-        mSessionID = MakeNullable(static_cast<uint32_t>(0));
+        TEMPORARY_RETURN_IGNORED instance->SetSessionID(MakeNullable(static_cast<uint32_t>(0)));
     }
     else
     {
-        uint32_t sessionID = mSessionID.Value() + 1;
-        mSessionID         = MakeNullable(sessionID);
+        TEMPORARY_RETURN_IGNORED instance->SetSessionID(MakeNullable(currentSessionID.Value() + 1));
     }
 
-    /* Reset other session values */
-    mSessionDuration         = MakeNullable(static_cast<uint32_t>(0));
-    mSessionEnergyCharged    = MakeNullable(static_cast<int64_t>(0));
-    mSessionEnergyDischarged = MakeNullable(static_cast<int64_t>(0));
-
-    MatterReportingAttributeChangeCallback(endpointId, EnergyEvse::Id, SessionID::Id);
-    MatterReportingAttributeChangeCallback(endpointId, EnergyEvse::Id, SessionDuration::Id);
-    MatterReportingAttributeChangeCallback(endpointId, EnergyEvse::Id, SessionEnergyCharged::Id);
-    MatterReportingAttributeChangeCallback(endpointId, EnergyEvse::Id, SessionEnergyDischarged::Id);
-
-    // Write values to persistent storage.
-    ConcreteAttributePath path = ConcreteAttributePath(endpointId, EnergyEvse::Id, SessionID::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mSessionID);
+    // Reset session counters
+    TEMPORARY_RETURN_IGNORED instance->SetSessionDuration(MakeNullable(static_cast<uint32_t>(0)));
+    TEMPORARY_RETURN_IGNORED instance->SetSessionEnergyCharged(MakeNullable(static_cast<int64_t>(0)));
+    TEMPORARY_RETURN_IGNORED instance->SetSessionEnergyDischarged(MakeNullable(static_cast<int64_t>(0)));
 
     // TODO persist mStartTime
     // TODO persist mSessionEnergyChargedAtStart
@@ -1813,11 +1789,11 @@ void EvseSession::StartSession(EndpointId endpointId, int64_t chargingMeterValue
  * @param chargingMeterValue    - The current value of the energy meter (charging) in mWh
  * @param dischargingMeterValue - The current value of the energy meter (discharging) in mWh
  */
-void EvseSession::StopSession(EndpointId endpointId, int64_t chargingMeterValue, int64_t dischargingMeterValue)
+void EvseSession::StopSession(Instance * instance, int64_t chargingMeterValue, int64_t dischargingMeterValue)
 {
-    RecalculateSessionDuration(endpointId);
-    UpdateEnergyCharged(endpointId, chargingMeterValue);
-    UpdateEnergyDischarged(endpointId, dischargingMeterValue);
+    RecalculateSessionDuration(instance);
+    UpdateEnergyCharged(instance, chargingMeterValue);
+    UpdateEnergyDischarged(instance, dischargingMeterValue);
 }
 
 /*---------------------- EvseSession functions --------------------------*/
@@ -1827,23 +1803,21 @@ void EvseSession::StopSession(EndpointId endpointId, int64_t chargingMeterValue,
  *
  * @param endpointId            - The endpoint to report the update on
  */
-void EvseSession::RecalculateSessionDuration(EndpointId endpointId)
+void EvseSession::RecalculateSessionDuration(Instance * instance)
 {
-    /* Get Timestamp */
+    VerifyOrReturn(instance != nullptr);
+
     uint32_t matterEpochSeconds = 0;
     CHIP_ERROR err              = System::Clock::GetClock_MatterEpochS(matterEpochSeconds);
     if (err != CHIP_NO_ERROR)
     {
-        /* Note that the error will be also be logged inside GetErrorTS() -
-         * adding context here to help debugging */
         ChipLogError(AppServer, "EVSE: Unable to get current time when updating session duration - err:%" CHIP_ERROR_FORMAT,
                      err.Format());
         return;
     }
 
     uint32_t duration = matterEpochSeconds - mStartTime;
-    mSessionDuration  = MakeNullable(duration);
-    MatterReportingAttributeChangeCallback(endpointId, EnergyEvse::Id, SessionDuration::Id);
+    TEMPORARY_RETURN_IGNORED instance->SetSessionDuration(MakeNullable(duration));
 }
 
 /**
@@ -1852,10 +1826,10 @@ void EvseSession::RecalculateSessionDuration(EndpointId endpointId)
  * @param endpointId            - The endpoint to report the update on
  * @param chargingMeterValue    - The value of the energy meter (charging) in mWh
  */
-void EvseSession::UpdateEnergyCharged(EndpointId endpointId, int64_t chargingMeterValue)
+void EvseSession::UpdateEnergyCharged(Instance * instance, int64_t chargingMeterValue)
 {
-    mSessionEnergyCharged = MakeNullable(chargingMeterValue - mSessionEnergyChargedAtStart);
-    MatterReportingAttributeChangeCallback(endpointId, EnergyEvse::Id, SessionEnergyCharged::Id);
+    VerifyOrReturn(instance != nullptr);
+    TEMPORARY_RETURN_IGNORED instance->SetSessionEnergyCharged(MakeNullable(chargingMeterValue - mSessionEnergyChargedAtStart));
 }
 
 /**
@@ -1864,10 +1838,10 @@ void EvseSession::UpdateEnergyCharged(EndpointId endpointId, int64_t chargingMet
  * @param endpointId            - The endpoint to report the update on
  * @param dischargingMeterValue - The value of the energy meter (discharging) in mWh
  */
-void EvseSession::UpdateEnergyDischarged(EndpointId endpointId, int64_t dischargingMeterValue)
+void EvseSession::UpdateEnergyDischarged(Instance * instance, int64_t dischargingMeterValue)
 {
-    mSessionEnergyDischarged = MakeNullable(dischargingMeterValue - mSessionEnergyDischargedAtStart);
-    MatterReportingAttributeChangeCallback(endpointId, EnergyEvse::Id, SessionEnergyDischarged::Id);
+    VerifyOrReturn(instance != nullptr);
+    TEMPORARY_RETURN_IGNORED instance->SetSessionEnergyDischarged(MakeNullable(dischargingMeterValue - mSessionEnergyDischargedAtStart));
 }
 
 // ------------------------------------------------------------------

--- a/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseDelegateImpl.cpp
@@ -42,16 +42,15 @@ Status EnergyEvseDelegate::Disable()
 {
     ChipLogProgress(AppServer, "EnergyEvseDelegate::Disable()");
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
     DataModel::Nullable<uint32_t> disableTime(0);
     /* update ChargingEnabledUntil & DischargingEnabledUntil to show 0 */
-    TEMPORARY_RETURN_IGNORED instance->SetChargingEnabledUntil(disableTime);
-    TEMPORARY_RETURN_IGNORED instance->SetDischargingEnabledUntil(disableTime);
+    TEMPORARY_RETURN_IGNORED mInstance->SetChargingEnabledUntil(disableTime);
+    TEMPORARY_RETURN_IGNORED mInstance->SetDischargingEnabledUntil(disableTime);
 
     /* update MinimumChargeCurrent & MaximumChargeCurrent to 0 */
-    TEMPORARY_RETURN_IGNORED instance->SetMinimumChargeCurrent(0);
+    TEMPORARY_RETURN_IGNORED mInstance->SetMinimumChargeCurrent(0);
 
     mMaximumChargingCurrentLimitFromCommand = 0;
     ComputeMaxChargeCurrentLimit();
@@ -93,8 +92,7 @@ Status EnergyEvseDelegate::EnableCharging(const DataModel::Nullable<uint32_t> & 
         return Status::ConstraintError;
     }
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
     if (chargingEnabledUntil.IsNull())
     {
@@ -106,11 +104,11 @@ Status EnergyEvseDelegate::EnableCharging(const DataModel::Nullable<uint32_t> & 
         /* check chargingEnabledUntil is in the future */
         ChipLogProgress(AppServer, "Charging enabled until: %lu", static_cast<long unsigned int>(chargingEnabledUntil.Value()));
     }
-    TEMPORARY_RETURN_IGNORED instance->SetChargingEnabledUntil(chargingEnabledUntil);
+    TEMPORARY_RETURN_IGNORED mInstance->SetChargingEnabledUntil(chargingEnabledUntil);
 
     /* If it looks ok, store the min & max charging current */
     mMaximumChargingCurrentLimitFromCommand = maximumChargeCurrent;
-    TEMPORARY_RETURN_IGNORED instance->SetMinimumChargeCurrent(minimumChargeCurrent);
+    TEMPORARY_RETURN_IGNORED mInstance->SetMinimumChargeCurrent(minimumChargeCurrent);
     // TODO persist these to KVS
 
     ComputeMaxChargeCurrentLimit();
@@ -135,8 +133,7 @@ Status EnergyEvseDelegate::EnableDischarging(const DataModel::Nullable<uint32_t>
         return Status::ConstraintError;
     }
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
     if (dischargingEnabledUntil.IsNull())
     {
@@ -148,7 +145,7 @@ Status EnergyEvseDelegate::EnableDischarging(const DataModel::Nullable<uint32_t>
         ChipLogProgress(AppServer, "Discharging enabled until: %lu",
                         static_cast<long unsigned int>(dischargingEnabledUntil.Value()));
     }
-    TEMPORARY_RETURN_IGNORED instance->SetDischargingEnabledUntil(dischargingEnabledUntil);
+    TEMPORARY_RETURN_IGNORED mInstance->SetDischargingEnabledUntil(dischargingEnabledUntil);
 
     /* If it looks ok, store the max discharging current */
     mMaximumDischargingCurrentLimitFromCommand = maximumDischargeCurrent;
@@ -199,8 +196,7 @@ static bool IsTimeExpired(const DataModel::Nullable<uint32_t> & timeValue, uint3
  */
 void EnergyEvseDelegate::HandleEnabledStateExpiration(uint32_t matterEpochSeconds)
 {
-    Instance * instance = GetInstance();
-    if (instance == nullptr)
+    if (mInstance == nullptr)
     {
         return;
     }
@@ -214,10 +210,10 @@ void EnergyEvseDelegate::HandleEnabledStateExpiration(uint32_t matterEpochSecond
     if (chargingExpired)
     {
         // set to zero to indicate disabled
-        TEMPORARY_RETURN_IGNORED instance->SetChargingEnabledUntil(DataModel::Nullable<uint32_t>(0));
+        TEMPORARY_RETURN_IGNORED mInstance->SetChargingEnabledUntil(DataModel::Nullable<uint32_t>(0));
 
         // update MinimumChargeCurrent & MaximumChargeCurrent to 0
-        TEMPORARY_RETURN_IGNORED instance->SetMinimumChargeCurrent(0);
+        TEMPORARY_RETURN_IGNORED mInstance->SetMinimumChargeCurrent(0);
 
         mMaximumChargingCurrentLimitFromCommand = 0;
         ComputeMaxChargeCurrentLimit();
@@ -225,7 +221,7 @@ void EnergyEvseDelegate::HandleEnabledStateExpiration(uint32_t matterEpochSecond
         // Change to discharging-only if discharging is still enabled
         if (!dischargingExpired)
         {
-            TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDischargingEnabled);
+            TEMPORARY_RETURN_IGNORED mInstance->SetSupplyState(SupplyStateEnum::kDischargingEnabled);
         }
         else
         {
@@ -237,7 +233,7 @@ void EnergyEvseDelegate::HandleEnabledStateExpiration(uint32_t matterEpochSecond
     if (dischargingExpired)
     {
         // set to zero to indicate disabled
-        TEMPORARY_RETURN_IGNORED instance->SetDischargingEnabledUntil(DataModel::Nullable<uint32_t>(0));
+        TEMPORARY_RETURN_IGNORED mInstance->SetDischargingEnabledUntil(DataModel::Nullable<uint32_t>(0));
 
         // update MaximumDischargeCurrent to 0
         mMaximumDischargingCurrentLimitFromCommand = 0;
@@ -246,7 +242,7 @@ void EnergyEvseDelegate::HandleEnabledStateExpiration(uint32_t matterEpochSecond
         // Change to charging-only if charging is still enabled
         if (!chargingExpired)
         {
-            TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kChargingEnabled);
+            TEMPORARY_RETURN_IGNORED mInstance->SetSupplyState(SupplyStateEnum::kChargingEnabled);
         }
         else
         {
@@ -270,7 +266,8 @@ Status EnergyEvseDelegate::ScheduleCheckOnEnabledTimeout()
 {
     // Determine the relevant timeout based on current supply state
     DataModel::Nullable<uint32_t> enabledUntilTime;
-    switch (mSupplyState)
+    SupplyStateEnum currentSupplyState = GetSupplyState();
+    switch (currentSupplyState)
     {
     case SupplyStateEnum::kChargingEnabled:
         enabledUntilTime = GetChargingEnabledUntil();
@@ -320,11 +317,13 @@ Status EnergyEvseDelegate::ScheduleCheckOnEnabledTimeout()
     // Time has expired - handle expiration based on current state
     ChipLogDetail(AppServer, "EVSE enable time expired, processing expiration");
 
-    if (mSupplyState == SupplyStateEnum::kChargingEnabled || mSupplyState == SupplyStateEnum::kDischargingEnabled)
+    // Re-check supply state as it may have changed
+    SupplyStateEnum currentState = GetSupplyState();
+    if (currentState == SupplyStateEnum::kChargingEnabled || currentState == SupplyStateEnum::kDischargingEnabled)
     {
         Disable();
     }
-    else if (mSupplyState == SupplyStateEnum::kEnabled)
+    else if (currentState == SupplyStateEnum::kEnabled)
     {
         HandleEnabledStateExpiration(matterEpochSeconds);
         // Call ourselves again now that one of our 2 timers has expired
@@ -359,17 +358,16 @@ Status EnergyEvseDelegate::StartDiagnostics()
     /* For EVSE manufacturers to customize */
     ChipLogProgress(AppServer, "EnergyEvseDelegate::StartDiagnostics()");
 
-    if (mSupplyState != SupplyStateEnum::kDisabled)
+    if (GetSupplyState() != SupplyStateEnum::kDisabled)
     {
         ChipLogError(AppServer, "EVSE: cannot be put into diagnostics mode if it is not Disabled!");
         return Status::Failure;
     }
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
     // Update the SupplyState - this will automatically callback the Application StateChanged callback
-    TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDisabledDiagnostics);
+    TEMPORARY_RETURN_IGNORED mInstance->SetSupplyState(SupplyStateEnum::kDisabledDiagnostics);
 
     return Status::Success;
 }
@@ -559,8 +557,9 @@ Status EnergyEvseDelegate::HwSetCircuitCapacity(int64_t currentmA)
         return Status::ConstraintError;
     }
 
-    mCircuitCapacity = currentmA;
-    MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, CircuitCapacity::Id);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
+
+    TEMPORARY_RETURN_IGNORED mInstance->SetCircuitCapacity(currentmA);
 
     return ComputeMaxChargeCurrentLimit();
 }
@@ -694,14 +693,13 @@ Status EnergyEvseDelegate::HwSetFault(FaultStateEnum newFaultState)
 {
     ChipLogProgress(AppServer, "EnergyEvseDelegate::Fault()");
 
-    if (mFaultState == newFaultState)
+    if (GetFaultState() == newFaultState)
     {
         ChipLogError(AppServer, "No change in fault state, ignoring call");
         return Status::Failure;
     }
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
     /** Before we do anything we log the fault
      * any change in FaultState reports previous fault and new fault
@@ -709,7 +707,7 @@ Status EnergyEvseDelegate::HwSetFault(FaultStateEnum newFaultState)
     SendFaultEvent(newFaultState);
 
     /* Updated FaultState before we call into the handlers */
-    TEMPORARY_RETURN_IGNORED instance->SetFaultState(newFaultState);
+    TEMPORARY_RETURN_IGNORED mInstance->SetFaultState(newFaultState);
 
     if (newFaultState == FaultStateEnum::kNoError)
     {
@@ -754,8 +752,12 @@ Status EnergyEvseDelegate::HwSetRFID(ByteSpan uid)
  */
 Status EnergyEvseDelegate::HwSetVehicleID(const CharSpan & newValue)
 {
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
-    if ((!mVehicleID.IsNull() && newValue.data_equal(mVehicleID.Value())) || (mVehicleID.IsNull() && newValue.empty()))
+    DataModel::Nullable<CharSpan> currentVehicleID = mInstance->GetVehicleID();
+
+    if ((!currentVehicleID.IsNull() && newValue.data_equal(currentVehicleID.Value())) ||
+        (currentVehicleID.IsNull() && newValue.empty()))
     {
         // No change in VehicleID, nothing to do
         return Status::Success;
@@ -770,17 +772,16 @@ Status EnergyEvseDelegate::HwSetVehicleID(const CharSpan & newValue)
     // If the input is empty, treat it as a request to clear the vehicle ID
     if (newValue.empty())
     {
-        mVehicleID.SetNull();
+        TEMPORARY_RETURN_IGNORED mInstance->SetVehicleID(DataModel::NullNullable);
         ChipLogDetail(AppServer, "VehicleID cleared");
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, VehicleID::Id);
         return Status::Success;
     }
 
     memcpy(mVehicleIDBuf, newValue.data(), newValue.size());
-    mVehicleID = MakeNullable(CharSpan(mVehicleIDBuf, newValue.size()));
+    DataModel::Nullable<CharSpan> vehicleID = MakeNullable(CharSpan(mVehicleIDBuf, newValue.size()));
+    TEMPORARY_RETURN_IGNORED mInstance->SetVehicleID(vehicleID);
 
-    ChipLogDetail(AppServer, "VehicleID updated %s", NullTerminated(mVehicleID.Value()).c_str());
-    MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, VehicleID::Id);
+    ChipLogDetail(AppServer, "VehicleID updated %s", NullTerminated(vehicleID.Value()).c_str());
 
     return Status::Success;
 }
@@ -792,7 +793,11 @@ Status EnergyEvseDelegate::HwSetVehicleID(const CharSpan & newValue)
  */
 CHIP_ERROR EnergyEvseDelegate::HwGetVehicleID(DataModel::Nullable<MutableCharSpan> & outValue)
 {
-    if (mVehicleID.IsNull())
+    VerifyOrReturnError(mInstance != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    DataModel::Nullable<CharSpan> vehicleID = mInstance->GetVehicleID();
+
+    if (vehicleID.IsNull())
     {
         outValue.SetNull();
         return CHIP_NO_ERROR;
@@ -804,7 +809,7 @@ CHIP_ERROR EnergyEvseDelegate::HwGetVehicleID(DataModel::Nullable<MutableCharSpa
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    return CopyCharSpanToMutableCharSpan(mVehicleID.Value(), outValue.Value());
+    return CopyCharSpanToMutableCharSpan(vehicleID.Value(), outValue.Value());
 }
 
 /**
@@ -812,18 +817,17 @@ CHIP_ERROR EnergyEvseDelegate::HwGetVehicleID(DataModel::Nullable<MutableCharSpa
  */
 Status EnergyEvseDelegate::HwDiagnosticsComplete()
 {
-    if (mSupplyState != SupplyStateEnum::kDisabledDiagnostics)
+    if (GetSupplyState() != SupplyStateEnum::kDisabledDiagnostics)
     {
         ChipLogError(AppServer, "Incorrect state to be completing diagnostics");
         return Status::Failure;
     }
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
     /* Restore the SupplyState to Disabled (per spec) - client will need to
      * re-enable charging or discharging to get out of this state */
-    TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDisabled);
+    TEMPORARY_RETURN_IGNORED mInstance->SetSupplyState(SupplyStateEnum::kDisabled);
 
     return Status::Success;
 }
@@ -886,11 +890,10 @@ Status EnergyEvseDelegate::HandleStateMachineEvent(EVSEStateMachineEvent event)
 
 Status EnergyEvseDelegate::HandleEVPluggedInEvent()
 {
-    /* check if we are already plugged in or not */
-    if (mState == StateEnum::kNotPluggedIn)
+    StateEnum currentState = GetState();
+    if (currentState == StateEnum::kNotPluggedIn)
     {
-        Instance * instance = GetInstance();
-        VerifyOrReturnValue(instance != nullptr, Status::Failure);
+        VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
         /* EV was not plugged in - start a new session */
         // TODO get energy meter readings - #35370
@@ -898,7 +901,7 @@ Status EnergyEvseDelegate::HandleEVPluggedInEvent()
         SendEVConnectedEvent();
 
         /* Set the state to either PluggedInNoDemand or PluggedInDemand as indicated by mHwState */
-        TEMPORARY_RETURN_IGNORED instance->SetState(mHwState);
+        TEMPORARY_RETURN_IGNORED mInstance->SetState(mHwState);
     }
     // else we are already plugged in - ignore
     return Status::Success;
@@ -906,10 +909,10 @@ Status EnergyEvseDelegate::HandleEVPluggedInEvent()
 
 Status EnergyEvseDelegate::HandleEVNotDetectedEvent()
 {
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
-    if (mState == StateEnum::kPluggedInCharging || mState == StateEnum::kPluggedInDischarging)
+    StateEnum currentState = GetState();
+    if (currentState == StateEnum::kPluggedInCharging || currentState == StateEnum::kPluggedInDischarging)
     {
         /*
          * EV was transferring current - unusual to get to this case without
@@ -921,16 +924,16 @@ Status EnergyEvseDelegate::HandleEVNotDetectedEvent()
     // TODO get energy meter readings - #35370
     mSession.StopSession(mEndpointId, 0, 0);
     SendEVNotDetectedEvent();
-    TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kNotPluggedIn);
+    TEMPORARY_RETURN_IGNORED mInstance->SetState(StateEnum::kNotPluggedIn);
     return Status::Success;
 }
 
 Status EnergyEvseDelegate::HandleEVNoDemandEvent()
 {
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
-    if (mState == StateEnum::kPluggedInCharging || mState == StateEnum::kPluggedInDischarging)
+    StateEnum currentState = GetState();
+    if (currentState == StateEnum::kPluggedInCharging || currentState == StateEnum::kPluggedInDischarging)
     {
         /*
          * EV was transferring current - EV decided to stop
@@ -939,25 +942,25 @@ Status EnergyEvseDelegate::HandleEVNoDemandEvent()
         SendEnergyTransferStoppedEvent(EnergyTransferStoppedReasonEnum::kEVStopped);
     }
     /* We must still be plugged in to get here - so no need to check if we are plugged in! */
-    TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInNoDemand);
+    TEMPORARY_RETURN_IGNORED mInstance->SetState(StateEnum::kPluggedInNoDemand);
     return Status::Success;
 }
 Status EnergyEvseDelegate::HandleEVDemandEvent()
 {
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
     /* Check to see if the supply is enabled for charging / discharging*/
-    switch (mSupplyState)
+    SupplyStateEnum currentSupplyState = GetSupplyState();
+    switch (currentSupplyState)
     {
     case SupplyStateEnum::kChargingEnabled:
         ComputeMaxChargeCurrentLimit();
-        TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInCharging);
+        TEMPORARY_RETURN_IGNORED mInstance->SetState(StateEnum::kPluggedInCharging);
         SendEnergyTransferStartedEvent();
         break;
     case SupplyStateEnum::kDischargingEnabled:
         ComputeMaxDischargeCurrentLimit();
-        TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInDischarging);
+        TEMPORARY_RETURN_IGNORED mInstance->SetState(StateEnum::kPluggedInDischarging);
         SendEnergyTransferStartedEvent();
         break;
     case SupplyStateEnum::kEnabled:
@@ -969,7 +972,7 @@ Status EnergyEvseDelegate::HandleEVDemandEvent()
         */
         ComputeMaxChargeCurrentLimit();
         ComputeMaxDischargeCurrentLimit();
-        TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInCharging);
+        TEMPORARY_RETURN_IGNORED mInstance->SetState(StateEnum::kPluggedInCharging);
         SendEnergyTransferStartedEvent();
         break;
     case SupplyStateEnum::kDisabled:
@@ -977,7 +980,7 @@ Status EnergyEvseDelegate::HandleEVDemandEvent()
     case SupplyStateEnum::kDisabledDiagnostics:
         /* We must be plugged in, and the event is asking for demand
          * but we can't charge or discharge now - leave it as kPluggedInDemand */
-        TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInDemand);
+        TEMPORARY_RETURN_IGNORED mInstance->SetState(StateEnum::kPluggedInDemand);
         break;
     case SupplyStateEnum::kUnknownEnumValue:
         ChipLogError(AppServer, "EVSE: HandleEVDemandEvent called in unexpected SupplyState");
@@ -990,13 +993,13 @@ Status EnergyEvseDelegate::HandleEVDemandEvent()
 
 Status EnergyEvseDelegate::CheckFaultOrDiagnostic()
 {
-    if (mFaultState != FaultStateEnum::kNoError)
+    if (GetFaultState() != FaultStateEnum::kNoError)
     {
         ChipLogError(AppServer, "EVSE: Trying to handle command when fault is present");
         return Status::Failure;
     }
 
-    if (mSupplyState == SupplyStateEnum::kDisabledDiagnostics)
+    if (GetSupplyState() == SupplyStateEnum::kDisabledDiagnostics)
     {
         ChipLogError(AppServer, "EVSE: Trying to handle command when in diagnostics mode");
         return Status::Failure;
@@ -1013,21 +1016,21 @@ Status EnergyEvseDelegate::HandleChargingEnabledEvent()
         return status;
     }
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
-    switch (mSupplyState)
+    SupplyStateEnum currentSupplyState = GetSupplyState();
+    switch (currentSupplyState)
     {
     case SupplyStateEnum::kDisabled:
         // it was kDisabled, then the state becomes kChargingEnabled
-        TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kChargingEnabled);
+        TEMPORARY_RETURN_IGNORED mInstance->SetSupplyState(SupplyStateEnum::kChargingEnabled);
         break;
     case SupplyStateEnum::kChargingEnabled:
         // No change
         break;
     case SupplyStateEnum::kDischargingEnabled:
         // If the SupplyState was already kDischargingEnabled the state becomes kEnabled
-        TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kEnabled);
+        TEMPORARY_RETURN_IGNORED mInstance->SetSupplyState(SupplyStateEnum::kEnabled);
         break;
     case SupplyStateEnum::kDisabledError:
     case SupplyStateEnum::kDisabledDiagnostics:
@@ -1040,14 +1043,15 @@ Status EnergyEvseDelegate::HandleChargingEnabledEvent()
         return Status::Failure;
     }
 
-    switch (mState)
+    StateEnum currentState = GetState();
+    switch (currentState)
     {
     case StateEnum::kNotPluggedIn:
     case StateEnum::kPluggedInNoDemand:
         break;
     case StateEnum::kPluggedInDemand:
         ComputeMaxChargeCurrentLimit();
-        TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kPluggedInCharging);
+        TEMPORARY_RETURN_IGNORED mInstance->SetState(StateEnum::kPluggedInCharging);
         SendEnergyTransferStartedEvent();
         break;
     case StateEnum::kPluggedInCharging:
@@ -1074,18 +1078,18 @@ Status EnergyEvseDelegate::HandleDischargingEnabledEvent()
         return status;
     }
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
-    switch (mSupplyState)
+    SupplyStateEnum currentSupplyState = GetSupplyState();
+    switch (currentSupplyState)
     {
     case SupplyStateEnum::kDisabled:
         // it was kDisabled, then the state becomes kDischargingEnabled
-        TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDischargingEnabled);
+        TEMPORARY_RETURN_IGNORED mInstance->SetSupplyState(SupplyStateEnum::kDischargingEnabled);
         break;
     case SupplyStateEnum::kChargingEnabled:
         // If the SupplyState was already kChargingEnabled the state becomes kEnabled
-        TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kEnabled);
+        TEMPORARY_RETURN_IGNORED mInstance->SetSupplyState(SupplyStateEnum::kEnabled);
         break;
     case SupplyStateEnum::kDischargingEnabled:
         // No change
@@ -1101,7 +1105,8 @@ Status EnergyEvseDelegate::HandleDischargingEnabledEvent()
         return Status::Failure;
     }
 
-    switch (mState)
+    StateEnum currentState = GetState();
+    switch (currentState)
     {
     case StateEnum::kNotPluggedIn:
     case StateEnum::kPluggedInNoDemand:
@@ -1130,13 +1135,13 @@ Status EnergyEvseDelegate::HandleDisabledEvent()
         return status;
     }
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
     /* update SupplyState to disabled */
-    TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDisabled);
+    TEMPORARY_RETURN_IGNORED mInstance->SetSupplyState(SupplyStateEnum::kDisabled);
 
-    switch (mState)
+    StateEnum currentState = GetState();
+    switch (currentState)
     {
     case StateEnum::kNotPluggedIn:
     case StateEnum::kPluggedInNoDemand:
@@ -1145,7 +1150,7 @@ Status EnergyEvseDelegate::HandleDisabledEvent()
     case StateEnum::kPluggedInCharging:
     case StateEnum::kPluggedInDischarging:
         SendEnergyTransferStoppedEvent(EnergyTransferStoppedReasonEnum::kEVSEStopped);
-        TEMPORARY_RETURN_IGNORED instance->SetState(mHwState);
+        TEMPORARY_RETURN_IGNORED mInstance->SetState(mHwState);
         break;
     default:
         break;
@@ -1163,25 +1168,24 @@ Status EnergyEvseDelegate::HandleDisabledEvent()
 )*/
 Status EnergyEvseDelegate::HandleFaultRaised()
 {
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
     /* Save the current State and SupplyState so we can restore them if the fault clears */
     if (mStateBeforeFault == StateEnum::kUnknownEnumValue)
     {
         /* No existing fault - save this value to restore it later if it clears */
-        mStateBeforeFault = mState;
+        mStateBeforeFault = GetState();
     }
 
     if (mSupplyStateBeforeFault == SupplyStateEnum::kUnknownEnumValue)
     {
         /* No existing fault */
-        mSupplyStateBeforeFault = mSupplyState;
+        mSupplyStateBeforeFault = GetSupplyState();
     }
 
     /* Update State & SupplyState */
-    TEMPORARY_RETURN_IGNORED instance->SetState(StateEnum::kFault);
-    TEMPORARY_RETURN_IGNORED instance->SetSupplyState(SupplyStateEnum::kDisabledError);
+    TEMPORARY_RETURN_IGNORED mInstance->SetState(StateEnum::kFault);
+    TEMPORARY_RETURN_IGNORED mInstance->SetSupplyState(SupplyStateEnum::kDisabledError);
 
     return Status::Success;
 }
@@ -1194,14 +1198,13 @@ Status EnergyEvseDelegate::HandleFaultCleared()
         return Status::Failure;
     }
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnValue(instance != nullptr, Status::Failure);
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
     /* Restore the State and SupplyState back to old values once all the faults have cleared
      * Changing the State should notify the application, so it can continue charging etc
      */
-    TEMPORARY_RETURN_IGNORED instance->SetState(mStateBeforeFault);
-    TEMPORARY_RETURN_IGNORED instance->SetSupplyState(mSupplyStateBeforeFault);
+    TEMPORARY_RETURN_IGNORED mInstance->SetState(mStateBeforeFault);
+    TEMPORARY_RETURN_IGNORED mInstance->SetSupplyState(mSupplyStateBeforeFault);
 
     /* put back the sentinel to catch new faults if more are raised */
     mStateBeforeFault       = StateEnum::kUnknownEnumValue;
@@ -1223,25 +1226,22 @@ Status EnergyEvseDelegate::HandleFaultCleared()
  */
 Status EnergyEvseDelegate::ComputeMaxChargeCurrentLimit()
 {
-    int64_t oldValue;
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
-    oldValue                    = mActualChargingCurrentLimit;
+    int64_t oldValue            = mActualChargingCurrentLimit;
     mActualChargingCurrentLimit = mMaxHardwareChargeCurrentLimit;
-    mActualChargingCurrentLimit = std::min(mActualChargingCurrentLimit, mCircuitCapacity);
+    mActualChargingCurrentLimit = std::min(mActualChargingCurrentLimit, mInstance->GetCircuitCapacity());
     mActualChargingCurrentLimit = std::min(mActualChargingCurrentLimit, mCableAssemblyCurrentLimit);
     mActualChargingCurrentLimit = std::min(mActualChargingCurrentLimit, mMaximumChargingCurrentLimitFromCommand);
-    mActualChargingCurrentLimit = std::min(mActualChargingCurrentLimit, mUserMaximumChargeCurrent);
+    mActualChargingCurrentLimit = std::min(mActualChargingCurrentLimit, mInstance->GetUserMaximumChargeCurrent());
 
-    /* Set the actual max charging current attribute */
-    mMaximumChargeCurrent = mActualChargingCurrentLimit;
+    int64_t newMaximumChargeCurrent = mActualChargingCurrentLimit;
 
-    if (oldValue != mMaximumChargeCurrent)
+    if (oldValue != newMaximumChargeCurrent)
     {
-        ChipLogDetail(AppServer, "MaximumChargeCurrent updated to %ld", static_cast<long>(mMaximumChargeCurrent));
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, MaximumChargeCurrent::Id);
-
-        /* Call the EV Charger hardware current limit callback */
-        NotifyApplicationChargeCurrentLimitChange(mMaximumChargeCurrent);
+        ChipLogDetail(AppServer, "MaximumChargeCurrent updated to %ld", static_cast<long>(newMaximumChargeCurrent));
+        TEMPORARY_RETURN_IGNORED mInstance->SetMaximumChargeCurrent(newMaximumChargeCurrent);
+        NotifyApplicationChargeCurrentLimitChange(newMaximumChargeCurrent);
     }
     return Status::Success;
 }
@@ -1257,24 +1257,21 @@ Status EnergyEvseDelegate::ComputeMaxChargeCurrentLimit()
  */
 Status EnergyEvseDelegate::ComputeMaxDischargeCurrentLimit()
 {
-    int64_t oldValue;
+    VerifyOrReturnValue(mInstance != nullptr, Status::Failure);
 
-    oldValue                       = mActualDischargingCurrentLimit;
+    int64_t oldValue               = mActualDischargingCurrentLimit;
     mActualDischargingCurrentLimit = mMaxHardwareDischargeCurrentLimit;
-    mActualDischargingCurrentLimit = std::min(mActualDischargingCurrentLimit, mCircuitCapacity);
+    mActualDischargingCurrentLimit = std::min(mActualDischargingCurrentLimit, mInstance->GetCircuitCapacity());
     mActualDischargingCurrentLimit = std::min(mActualDischargingCurrentLimit, mCableAssemblyCurrentLimit);
     mActualDischargingCurrentLimit = std::min(mActualDischargingCurrentLimit, mMaximumDischargingCurrentLimitFromCommand);
 
-    /* Set the actual max discharging current attribute */
-    mMaximumDischargeCurrent = mActualDischargingCurrentLimit;
+    int64_t newMaximumDischargeCurrent = mActualDischargingCurrentLimit;
 
-    if (oldValue != mMaximumDischargeCurrent)
+    if (oldValue != newMaximumDischargeCurrent)
     {
-        ChipLogDetail(AppServer, "MaximumDischargeCurrent updated to %ld", static_cast<long>(mMaximumDischargeCurrent));
-        MatterReportingAttributeChangeCallback(mEndpointId, EnergyEvse::Id, MaximumDischargeCurrent::Id);
-
-        /* Call the EV Charger hardware current limit callback */
-        NotifyApplicationDischargeCurrentLimitChange(mMaximumDischargeCurrent);
+        ChipLogDetail(AppServer, "MaximumDischargeCurrent updated to %ld", static_cast<long>(newMaximumDischargeCurrent));
+        TEMPORARY_RETURN_IGNORED mInstance->SetMaximumDischargeCurrent(newMaximumDischargeCurrent);
+        NotifyApplicationDischargeCurrentLimitChange(newMaximumDischargeCurrent);
     }
     return Status::Success;
 }
@@ -1314,8 +1311,8 @@ Status EnergyEvseDelegate::NotifyApplicationStateChange()
     EVSECbInfo cbInfo;
 
     cbInfo.type                    = EVSECallbackType::StateChanged;
-    cbInfo.StateChange.state       = mState;
-    cbInfo.StateChange.supplyState = mSupplyState;
+    cbInfo.StateChange.state       = GetState();
+    cbInfo.StateChange.supplyState = GetSupplyState();
 
     if (mCallbacks.handler != nullptr)
     {
@@ -1390,7 +1387,7 @@ Status EnergyEvseDelegate::SendEVNotDetectedEvent()
     }
 
     event.sessionID               = mSession.mSessionID.Value();
-    event.state                   = mState;
+    event.state                   = GetState();
     event.sessionDuration         = mSession.mSessionDuration.Value();
     event.sessionEnergyCharged    = mSession.mSessionEnergyCharged.Value();
     event.sessionEnergyDischarged = MakeOptional(mSession.mSessionEnergyDischarged.Value());
@@ -1416,22 +1413,21 @@ Status EnergyEvseDelegate::SendEnergyTransferStartedEvent()
     }
 
     event.sessionID = mSession.mSessionID.Value();
-    event.state     = mState;
+    event.state     = GetState();
 
     /* Sample the energy meter for charging */
     GetEVSEEnergyMeterValue(ChargingDischargingType::kCharging, mImportedMeterValueAtEnergyTransferStart);
-    event.maximumCurrent = mMaximumChargeCurrent;
+    event.maximumCurrent = GetMaximumChargeCurrent();
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnError(instance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
+    VerifyOrReturnError(mInstance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
     /* For V2X we may switch between charging and discharging, but we don't
      * keep sending EnergyTransferStarted events */
-    if (instance->HasFeature(Feature::kV2x))
+    if (mInstance->HasFeature(Feature::kV2x))
     {
         /* Sample the energy meter for discharging */
         GetEVSEEnergyMeterValue(ChargingDischargingType::kDischarging, mExportedMeterValueAtEnergyTransferStart);
 
-        event.maximumDischargeCurrent.SetValue(mMaximumDischargeCurrent);
+        event.maximumDischargeCurrent.SetValue(GetMaximumDischargeCurrent());
     }
     else
     {
@@ -1460,17 +1456,16 @@ Status EnergyEvseDelegate::SendEnergyTransferStoppedEvent(EnergyTransferStoppedR
     }
 
     event.sessionID       = mSession.mSessionID.Value();
-    event.state           = mState;
+    event.state           = GetState();
     event.reason          = reason;
     int64_t meterValueNow = 0;
 
     GetEVSEEnergyMeterValue(ChargingDischargingType::kCharging, meterValueNow);
     event.energyTransferred = meterValueNow - mImportedMeterValueAtEnergyTransferStart;
 
-    Instance * instance = GetInstance();
-    VerifyOrReturnError(instance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
+    VerifyOrReturnError(mInstance != nullptr, Status::Failure, ChipLogError(AppServer, "Instance is Null"));
 
-    if (instance->HasFeature(Feature::kV2x))
+    if (mInstance->HasFeature(Feature::kV2x))
     {
         GetEVSEEnergyMeterValue(ChargingDischargingType::kDischarging, meterValueNow);
         event.energyDischarged.SetValue(mExportedMeterValueAtEnergyTransferStart - meterValueNow);
@@ -1495,8 +1490,8 @@ Status EnergyEvseDelegate::SendFaultEvent(FaultStateEnum newFaultState)
     EventNumber eventNumber;
 
     event.sessionID               = mSession.mSessionID; // Note here the event sessionID can be Null!
-    event.state                   = mState;              // This is the state prior to the fault being raised
-    event.faultStatePreviousState = mFaultState;
+    event.state                   = GetState();          // This is the state prior to the fault being raised
+    event.faultStatePreviousState = GetFaultState();
     event.faultStateCurrentState  = newFaultState;
 
     CHIP_ERROR err = LogEvent(event, mEndpointId, eventNumber);
@@ -1514,215 +1509,179 @@ Status EnergyEvseDelegate::SendFaultEvent(FaultStateEnum newFaultState)
 
 void EnergyEvseDelegate::OnStateChanged(StateEnum newValue)
 {
-    mState = newValue;
-    ChipLogDetail(AppServer, "State updated to %d", static_cast<int>(mState));
+    ChipLogDetail(AppServer, "State updated to %d", static_cast<int>(newValue));
     NotifyApplicationStateChange();
 }
 
 void EnergyEvseDelegate::OnSupplyStateChanged(SupplyStateEnum newValue)
 {
-    mSupplyState = newValue;
-    ChipLogDetail(AppServer, "SupplyState updated to %d", static_cast<int>(mSupplyState));
+    ChipLogDetail(AppServer, "SupplyState updated to %d", static_cast<int>(newValue));
     NotifyApplicationStateChange();
 }
 
 void EnergyEvseDelegate::OnFaultStateChanged(FaultStateEnum newValue)
 {
-    mFaultState = newValue;
-    ChipLogDetail(AppServer, "FaultState updated to %d", static_cast<int>(mFaultState));
+    ChipLogDetail(AppServer, "FaultState updated to %d", static_cast<int>(newValue));
 }
 
 void EnergyEvseDelegate::OnChargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    mChargingEnabledUntil = newValue;
     if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "ChargingEnabledUntil updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "ChargingEnabledUntil updated to %lu",
-                      static_cast<unsigned long int>(mChargingEnabledUntil.Value()));
+        ChipLogDetail(AppServer, "ChargingEnabledUntil updated to %lu", static_cast<unsigned long int>(newValue.Value()));
     }
-    // Write new value to persistent storage.
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, ChargingEnabledUntil::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mChargingEnabledUntil);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnDischargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    mDischargingEnabledUntil = newValue;
     if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "DischargingEnabledUntil updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "DischargingEnabledUntil updated to %lu",
-                      static_cast<unsigned long int>(mDischargingEnabledUntil.Value()));
+        ChipLogDetail(AppServer, "DischargingEnabledUntil updated to %lu", static_cast<unsigned long int>(newValue.Value()));
     }
-    // Write new value to persistent storage.
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, DischargingEnabledUntil::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mDischargingEnabledUntil);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnCircuitCapacityChanged(int64_t newValue)
 {
-    mCircuitCapacity = newValue;
-    ChipLogDetail(AppServer, "CircuitCapacity updated to %ld", static_cast<long>(mCircuitCapacity));
+    ChipLogDetail(AppServer, "CircuitCapacity updated to %ld", static_cast<long>(newValue));
 }
 
 void EnergyEvseDelegate::OnMinimumChargeCurrentChanged(int64_t newValue)
 {
-    mMinimumChargeCurrent = newValue;
-    ChipLogDetail(AppServer, "MinimumChargeCurrent updated to %ld", static_cast<long>(mMinimumChargeCurrent));
+    ChipLogDetail(AppServer, "MinimumChargeCurrent updated to %ld", static_cast<long>(newValue));
 }
 
 void EnergyEvseDelegate::OnMaximumChargeCurrentChanged(int64_t newValue)
 {
-    mMaximumChargeCurrent = newValue;
-    ChipLogDetail(AppServer, "MaximumChargeCurrent updated to %ld", static_cast<long>(mMaximumChargeCurrent));
+    ChipLogDetail(AppServer, "MaximumChargeCurrent updated to %ld", static_cast<long>(newValue));
 }
 
 void EnergyEvseDelegate::OnMaximumDischargeCurrentChanged(int64_t newValue)
 {
-    mMaximumDischargeCurrent = newValue;
-    ChipLogDetail(AppServer, "MaximumDischargeCurrent updated to %ld", static_cast<long>(mMaximumDischargeCurrent));
+    ChipLogDetail(AppServer, "MaximumDischargeCurrent updated to %ld", static_cast<long>(newValue));
 }
 
 void EnergyEvseDelegate::OnUserMaximumChargeCurrentChanged(int64_t newValue)
 {
-    mUserMaximumChargeCurrent = newValue;
-    ChipLogDetail(AppServer, "UserMaximumChargeCurrent updated to %ld", static_cast<long>(mUserMaximumChargeCurrent));
-
+    ChipLogDetail(AppServer, "UserMaximumChargeCurrent updated to %ld", static_cast<long>(newValue));
     ComputeMaxChargeCurrentLimit();
-
-    // Write new value to persistent storage.
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, UserMaximumChargeCurrent::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mUserMaximumChargeCurrent);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnRandomizationDelayWindowChanged(uint32_t newValue)
 {
-    mRandomizationDelayWindow = newValue;
-    ChipLogDetail(AppServer, "RandomizationDelayWindow updated to %lu", static_cast<unsigned long int>(mRandomizationDelayWindow));
-
-    // Write new value to persistent storage.
+    ChipLogDetail(AppServer, "RandomizationDelayWindow updated to %lu", static_cast<unsigned long int>(newValue));
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, RandomizationDelayWindow::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mRandomizationDelayWindow);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnNextChargeStartTimeChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    mNextChargeStartTime = newValue;
-    if (mNextChargeStartTime.IsNull())
+    if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "NextChargeStartTime updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "NextChargeStartTime updated to %lu",
-                      static_cast<unsigned long int>(mNextChargeStartTime.Value()));
+        ChipLogDetail(AppServer, "NextChargeStartTime updated to %lu", static_cast<unsigned long int>(newValue.Value()));
     }
 }
 
 void EnergyEvseDelegate::OnNextChargeTargetTimeChanged(DataModel::Nullable<uint32_t> newValue)
 {
-    mNextChargeTargetTime = newValue;
-    if (mNextChargeTargetTime.IsNull())
+    if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "NextChargeTargetTime updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "NextChargeTargetTime updated to %lu",
-                      static_cast<unsigned long int>(mNextChargeTargetTime.Value()));
+        ChipLogDetail(AppServer, "NextChargeTargetTime updated to %lu", static_cast<unsigned long int>(newValue.Value()));
     }
 }
 
 void EnergyEvseDelegate::OnNextChargeRequiredEnergyChanged(DataModel::Nullable<int64_t> newValue)
 {
-    mNextChargeRequiredEnergy = newValue;
-    if (mNextChargeRequiredEnergy.IsNull())
+    if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "NextChargeRequiredEnergy updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "NextChargeRequiredEnergy updated to %ld", static_cast<long>(mNextChargeRequiredEnergy.Value()));
+        ChipLogDetail(AppServer, "NextChargeRequiredEnergy updated to %ld", static_cast<long>(newValue.Value()));
     }
 }
 
 void EnergyEvseDelegate::OnNextChargeTargetSoCChanged(DataModel::Nullable<Percent> newValue)
 {
-    mNextChargeTargetSoC = newValue;
     if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "NextChargeTargetSoC updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "NextChargeTargetSoC updated to %d %%", mNextChargeTargetSoC.Value());
+        ChipLogDetail(AppServer, "NextChargeTargetSoC updated to %d %%", newValue.Value());
     }
 }
 
 void EnergyEvseDelegate::OnApproximateEVEfficiencyChanged(DataModel::Nullable<uint16_t> newValue)
 {
-    mApproximateEVEfficiency = newValue;
     if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "ApproximateEVEfficiency updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "ApproximateEVEfficiency updated to %d", mApproximateEVEfficiency.Value());
+        ChipLogDetail(AppServer, "ApproximateEVEfficiency updated to %d", newValue.Value());
     }
-    // Write new value to persistent storage.
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, ApproximateEVEfficiency::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mApproximateEVEfficiency);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, newValue);
 }
 
 void EnergyEvseDelegate::OnStateOfChargeChanged(DataModel::Nullable<Percent> newValue)
 {
-    mStateOfCharge = newValue;
     if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "StateOfCharge updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "StateOfCharge updated to %d", mStateOfCharge.Value());
+        ChipLogDetail(AppServer, "StateOfCharge updated to %d", newValue.Value());
     }
 }
 
 void EnergyEvseDelegate::OnBatteryCapacityChanged(DataModel::Nullable<int64_t> newValue)
 {
-    mBatteryCapacity = newValue;
     if (newValue.IsNull())
     {
         ChipLogDetail(AppServer, "BatteryCapacity updated to Null");
     }
     else
     {
-        ChipLogDetail(AppServer, "BatteryCapacity updated to %ld", static_cast<long>(mBatteryCapacity.Value()));
+        ChipLogDetail(AppServer, "BatteryCapacity updated to %ld", static_cast<long>(newValue.Value()));
     }
 }
 
 void EnergyEvseDelegate::OnVehicleIDChanged(DataModel::Nullable<CharSpan> newValue)
 {
-    // Copy the value to local buffer
     if (newValue.IsNull())
     {
-        mVehicleID = DataModel::NullNullable;
         ChipLogDetail(AppServer, "VehicleID updated to Null");
     }
     else
     {
-        size_t len = std::min(newValue.Value().size(), sizeof(mVehicleIDBuf) - 1);
-        memcpy(mVehicleIDBuf, newValue.Value().data(), len);
-        mVehicleIDBuf[len] = '\0';
-        mVehicleID         = DataModel::MakeNullable(CharSpan(mVehicleIDBuf, len));
-        ChipLogDetail(AppServer, "VehicleID updated to %.*s", static_cast<int>(len), mVehicleIDBuf);
+        ChipLogDetail(AppServer, "VehicleID updated to %.*s", static_cast<int>(newValue.Value().size()), newValue.Value().data());
     }
 }
 
@@ -1739,7 +1698,7 @@ void EnergyEvseDelegate::OnSessionIDChanged(DataModel::Nullable<uint32_t> newVal
     }
     // Write value to persistent storage.
     ConcreteAttributePath path = ConcreteAttributePath(mEndpointId, EnergyEvse::Id, SessionID::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mSession.mSessionID);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, mSession.mSessionID);
 }
 
 void EnergyEvseDelegate::OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue)
@@ -1789,8 +1748,9 @@ void EnergyEvseDelegate::OnSessionEnergyDischargedChanged(DataModel::Nullable<in
  */
 bool EnergyEvseDelegate::IsEvsePluggedIn()
 {
-    return (mState == StateEnum::kPluggedInCharging || mState == StateEnum::kPluggedInDemand ||
-            mState == StateEnum::kPluggedInDischarging || mState == StateEnum::kPluggedInNoDemand);
+    StateEnum currentState = GetState();
+    return (currentState == StateEnum::kPluggedInCharging || currentState == StateEnum::kPluggedInDemand ||
+            currentState == StateEnum::kPluggedInDischarging || currentState == StateEnum::kPluggedInNoDemand);
 }
 
 /**
@@ -1839,7 +1799,7 @@ void EvseSession::StartSession(EndpointId endpointId, int64_t chargingMeterValue
 
     // Write values to persistent storage.
     ConcreteAttributePath path = ConcreteAttributePath(endpointId, EnergyEvse::Id, SessionID::Id);
-    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(path, mSessionID);
+    TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider() -> WriteScalarValue(path, mSessionID);
 
     // TODO persist mStartTime
     // TODO persist mSessionEnergyChargedAtStart

--- a/examples/evse-app/evse-common/src/EnergyEvseEventTriggers.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseEventTriggers.cpp
@@ -52,8 +52,8 @@ EnergyEvseDelegate * GetEvseDelegate()
 
 void SetTestEventTrigger_BasicFunctionality()
 {
-    EnergyEvseDelegate * dg = GetEvseDelegate();
-    Instance * instance     = dg->GetInstance();
+    EnergyEvseDelegate * dg         = GetEvseDelegate();
+    EnergyEvse::Instance * instance = dg->GetInstance();
     VerifyOrDieWithMsg(instance != nullptr, AppServer, "EVSE Instance is null");
 
     sEVSETestEventSaveData.mOldMaxHardwareChargeCurrentLimit    = dg->HwGetMaxHardwareChargeCurrentLimit();
@@ -70,8 +70,8 @@ void SetTestEventTrigger_BasicFunctionality()
 }
 void SetTestEventTrigger_BasicFunctionalityClear()
 {
-    EnergyEvseDelegate * dg = GetEvseDelegate();
-    Instance * instance     = dg->GetInstance();
+    EnergyEvseDelegate * dg         = GetEvseDelegate();
+    EnergyEvse::Instance * instance = dg->GetInstance();
     VerifyOrDieWithMsg(instance != nullptr, AppServer, "EVSE Instance is null");
 
     dg->HwSetMaxHardwareChargeCurrentLimit(sEVSETestEventSaveData.mOldMaxHardwareChargeCurrentLimit);
@@ -149,8 +149,8 @@ void SetTestEventTrigger_EVSEDiagnosticsComplete()
 void SetTestEventTrigger_EVSESetSoCLow()
 {
     // Set SoC 20%, 70kWh BatterySize
-    EnergyEvseDelegate * dg = GetEvseDelegate();
-    Instance * instance     = dg->GetInstance();
+    EnergyEvseDelegate * dg         = GetEvseDelegate();
+    EnergyEvse::Instance * instance = dg->GetInstance();
     VerifyOrDieWithMsg(instance != nullptr, AppServer, "EVSE Instance is null");
 
     TEMPORARY_RETURN_IGNORED instance->SetStateOfCharge(DataModel::MakeNullable(static_cast<Percent>(20)));
@@ -159,8 +159,8 @@ void SetTestEventTrigger_EVSESetSoCLow()
 void SetTestEventTrigger_EVSESetSoCHigh()
 {
     // Set SoC 95%, 70kWh BatterySize
-    EnergyEvseDelegate * dg = GetEvseDelegate();
-    Instance * instance     = dg->GetInstance();
+    EnergyEvseDelegate * dg         = GetEvseDelegate();
+    EnergyEvse::Instance * instance = dg->GetInstance();
     VerifyOrDieWithMsg(instance != nullptr, AppServer, "EVSE Instance is null");
 
     TEMPORARY_RETURN_IGNORED instance->SetStateOfCharge(DataModel::MakeNullable(static_cast<Percent>(95)));
@@ -169,8 +169,8 @@ void SetTestEventTrigger_EVSESetSoCHigh()
 void SetTestEventTrigger_EVSESetSoCClear()
 {
     // Set SoC null, BatterySize null
-    EnergyEvseDelegate * dg = GetEvseDelegate();
-    Instance * instance     = dg->GetInstance();
+    EnergyEvseDelegate * dg         = GetEvseDelegate();
+    EnergyEvse::Instance * instance = dg->GetInstance();
     VerifyOrDieWithMsg(instance != nullptr, AppServer, "EVSE Instance is null");
 
     TEMPORARY_RETURN_IGNORED instance->SetStateOfCharge(DataModel::NullNullable);

--- a/examples/evse-app/evse-common/src/EnergyEvseEventTriggers.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseEventTriggers.cpp
@@ -18,6 +18,7 @@
 
 #include <EVSEManufacturerImpl.h>
 
+#include <app/clusters/energy-evse-server/CodegenIntegration.h>
 #include <app/clusters/energy-evse-server/EnergyEvseTestEventTriggerHandler.h>
 
 using namespace chip;
@@ -52,27 +53,31 @@ EnergyEvseDelegate * GetEvseDelegate()
 void SetTestEventTrigger_BasicFunctionality()
 {
     EnergyEvseDelegate * dg = GetEvseDelegate();
+    Instance * instance     = dg->GetInstance();
+    VerifyOrDieWithMsg(instance != nullptr, AppServer, "EVSE Instance is null");
 
     sEVSETestEventSaveData.mOldMaxHardwareChargeCurrentLimit    = dg->HwGetMaxHardwareChargeCurrentLimit();
     sEVSETestEventSaveData.mOldMaxHardwareDischargeCurrentLimit = dg->HwGetMaxHardwareDischargeCurrentLimit();
-    sEVSETestEventSaveData.mOldCircuitCapacity                  = dg->GetCircuitCapacity();
-    sEVSETestEventSaveData.mOldUserMaximumChargeCurrent         = dg->GetUserMaximumChargeCurrent();
+    sEVSETestEventSaveData.mOldCircuitCapacity                  = instance->GetCircuitCapacity();
+    sEVSETestEventSaveData.mOldUserMaximumChargeCurrent         = instance->GetUserMaximumChargeCurrent();
     sEVSETestEventSaveData.mOldHwStateBasic                     = dg->HwGetState();
 
     dg->HwSetMaxHardwareChargeCurrentLimit(32000);
     dg->HwSetMaxHardwareDischargeCurrentLimit(32000);
-    dg->HwSetCircuitCapacity(32000);
-    TEMPORARY_RETURN_IGNORED dg->SetUserMaximumChargeCurrent(32000);
+    TEMPORARY_RETURN_IGNORED instance->SetCircuitCapacity(32000);
+    TEMPORARY_RETURN_IGNORED instance->SetUserMaximumChargeCurrent(32000);
     dg->HwSetState(StateEnum::kNotPluggedIn);
 }
 void SetTestEventTrigger_BasicFunctionalityClear()
 {
     EnergyEvseDelegate * dg = GetEvseDelegate();
+    Instance * instance     = dg->GetInstance();
+    VerifyOrDieWithMsg(instance != nullptr, AppServer, "EVSE Instance is null");
 
     dg->HwSetMaxHardwareChargeCurrentLimit(sEVSETestEventSaveData.mOldMaxHardwareChargeCurrentLimit);
     dg->HwSetMaxHardwareDischargeCurrentLimit(sEVSETestEventSaveData.mOldMaxHardwareDischargeCurrentLimit);
-    dg->HwSetCircuitCapacity(sEVSETestEventSaveData.mOldCircuitCapacity);
-    TEMPORARY_RETURN_IGNORED dg->SetUserMaximumChargeCurrent(sEVSETestEventSaveData.mOldUserMaximumChargeCurrent);
+    TEMPORARY_RETURN_IGNORED instance->SetCircuitCapacity(sEVSETestEventSaveData.mOldCircuitCapacity);
+    TEMPORARY_RETURN_IGNORED instance->SetUserMaximumChargeCurrent(sEVSETestEventSaveData.mOldUserMaximumChargeCurrent);
     dg->HwSetState(sEVSETestEventSaveData.mOldHwStateBasic);
 }
 void SetTestEventTrigger_EVPluggedIn()
@@ -145,24 +150,31 @@ void SetTestEventTrigger_EVSESetSoCLow()
 {
     // Set SoC 20%, 70kWh BatterySize
     EnergyEvseDelegate * dg = GetEvseDelegate();
-    TEMPORARY_RETURN_IGNORED dg->SetStateOfCharge(20);
-    TEMPORARY_RETURN_IGNORED dg->SetBatteryCapacity(70000000);
+    Instance * instance     = dg->GetInstance();
+    VerifyOrDieWithMsg(instance != nullptr, AppServer, "EVSE Instance is null");
+
+    TEMPORARY_RETURN_IGNORED instance->SetStateOfCharge(DataModel::MakeNullable(static_cast<Percent>(20)));
+    TEMPORARY_RETURN_IGNORED instance->SetBatteryCapacity(DataModel::MakeNullable(static_cast<int64_t>(70000000)));
 }
 void SetTestEventTrigger_EVSESetSoCHigh()
 {
     // Set SoC 95%, 70kWh BatterySize
     EnergyEvseDelegate * dg = GetEvseDelegate();
-    TEMPORARY_RETURN_IGNORED dg->SetStateOfCharge(95);
-    TEMPORARY_RETURN_IGNORED dg->SetBatteryCapacity(70000000);
+    Instance * instance     = dg->GetInstance();
+    VerifyOrDieWithMsg(instance != nullptr, AppServer, "EVSE Instance is null");
+
+    TEMPORARY_RETURN_IGNORED instance->SetStateOfCharge(DataModel::MakeNullable(static_cast<Percent>(95)));
+    TEMPORARY_RETURN_IGNORED instance->SetBatteryCapacity(DataModel::MakeNullable(static_cast<int64_t>(70000000)));
 }
 void SetTestEventTrigger_EVSESetSoCClear()
 {
-    // Set SoC null, BatterySize nu;;
+    // Set SoC null, BatterySize null
     EnergyEvseDelegate * dg = GetEvseDelegate();
-    DataModel::Nullable<uint8_t> noSoC;
-    DataModel::Nullable<int64_t> noBatteryCapacity;
-    TEMPORARY_RETURN_IGNORED dg->SetStateOfCharge(noSoC);
-    TEMPORARY_RETURN_IGNORED dg->SetBatteryCapacity(noBatteryCapacity);
+    Instance * instance     = dg->GetInstance();
+    VerifyOrDieWithMsg(instance != nullptr, AppServer, "EVSE Instance is null");
+
+    TEMPORARY_RETURN_IGNORED instance->SetStateOfCharge(DataModel::NullNullable);
+    TEMPORARY_RETURN_IGNORED instance->SetBatteryCapacity(DataModel::NullNullable);
 }
 void SetTestEventTrigger_EVSESetVehicleID()
 {

--- a/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
@@ -123,6 +123,9 @@ CHIP_ERROR EnergyEvseInit(chip::EndpointId endpointId)
         return err;
     }
 
+    // Link the delegate to the instance for attribute access
+    gEvseDelegate->SetInstance(gEvseInstance.get());
+
     err = gEvseTargetsDelegate->LoadTargets();
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
@@ -308,7 +308,7 @@ void EvseApplicationInit()
 
 void EvseApplicationShutdown()
 {
-    ChipLogDetail(AppServer, "Energy Management App (EVSE): EvseApplicationShutdown()");
+    ChipLogDetail(AppServer, "Evse App: EvseApplicationShutdown()");
 
     /* Shutdown in reverse order that they were created */
     TEMPORARY_RETURN_IGNORED EVSEManufacturerShutdown();

--- a/examples/evse-app/evse-common/src/EnergyEvseManager.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseManager.cpp
@@ -42,70 +42,70 @@ CHIP_ERROR EnergyEvseManager::LoadPersistentAttributes()
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
 
-    // Restore ChargingEnabledUntil value
+    // Restore ChargingEnabledUntil value - via Instance (which owns the data)
     DataModel::Nullable<uint32_t> tempChargingEnabledUntil;
     err = aProvider->ReadScalarValue(ConcreteAttributePath(aEndpointId, EnergyEvse::Id, Attributes::ChargingEnabledUntil::Id),
                                      tempChargingEnabledUntil);
     if (err == CHIP_NO_ERROR)
     {
         ChipLogDetail(AppServer, "EVSE: successfully loaded ChargingEnabledUntil from NVM");
-        TEMPORARY_RETURN_IGNORED mDelegate->SetChargingEnabledUntil(tempChargingEnabledUntil);
+        TEMPORARY_RETURN_IGNORED SetChargingEnabledUntil(tempChargingEnabledUntil);
     }
     else
     {
         ChipLogError(AppServer, "EVSE: Unable to restore persisted ChargingEnabledUntil value");
     }
 
-    // Restore DischargingEnabledUntil value
+    // Restore DischargingEnabledUntil value - via Instance (which owns the data)
     DataModel::Nullable<uint32_t> tempDischargingEnabledUntil;
     err = aProvider->ReadScalarValue(ConcreteAttributePath(aEndpointId, EnergyEvse::Id, Attributes::DischargingEnabledUntil::Id),
                                      tempDischargingEnabledUntil);
     if (err == CHIP_NO_ERROR)
     {
         ChipLogDetail(AppServer, "EVSE: successfully loaded DischargingEnabledUntil from NVM");
-        TEMPORARY_RETURN_IGNORED mDelegate->SetDischargingEnabledUntil(tempDischargingEnabledUntil);
+        TEMPORARY_RETURN_IGNORED SetDischargingEnabledUntil(tempDischargingEnabledUntil);
     }
     else
     {
         ChipLogError(AppServer, "EVSE: Unable to restore persisted DischargingEnabledUntil value");
     }
 
-    // Restore UserMaximumChargeCurrent value
+    // Restore UserMaximumChargeCurrent value - via Instance (which owns the data)
     int64_t tempUserMaximumChargeCurrent;
     err = aProvider->ReadScalarValue(ConcreteAttributePath(aEndpointId, EnergyEvse::Id, Attributes::UserMaximumChargeCurrent::Id),
                                      tempUserMaximumChargeCurrent);
     if (err == CHIP_NO_ERROR)
     {
         ChipLogDetail(AppServer, "EVSE: successfully loaded UserMaximumChargeCurrent from NVM");
-        TEMPORARY_RETURN_IGNORED mDelegate->SetUserMaximumChargeCurrent(tempUserMaximumChargeCurrent);
+        TEMPORARY_RETURN_IGNORED SetUserMaximumChargeCurrent(tempUserMaximumChargeCurrent);
     }
     else
     {
         ChipLogError(AppServer, "EVSE: Unable to restore persisted UserMaximumChargeCurrent value");
     }
 
-    // Restore RandomizationDelayWindow value
+    // Restore RandomizationDelayWindow value - via Instance (which owns the data)
     uint32_t tempRandomizationDelayWindow;
     err = aProvider->ReadScalarValue(ConcreteAttributePath(aEndpointId, EnergyEvse::Id, Attributes::RandomizationDelayWindow::Id),
                                      tempRandomizationDelayWindow);
     if (err == CHIP_NO_ERROR)
     {
         ChipLogDetail(AppServer, "EVSE: successfully loaded RandomizationDelayWindow from NVM");
-        TEMPORARY_RETURN_IGNORED mDelegate->SetRandomizationDelayWindow(tempRandomizationDelayWindow);
+        TEMPORARY_RETURN_IGNORED SetRandomizationDelayWindow(tempRandomizationDelayWindow);
     }
     else
     {
         ChipLogError(AppServer, "EVSE: Unable to restore persisted RandomizationDelayWindow value");
     }
 
-    // Restore ApproximateEVEfficiency value
+    // Restore ApproximateEVEfficiency value - via Instance (which owns the data)
     DataModel::Nullable<uint16_t> tempApproxEVEfficiency;
     err = aProvider->ReadScalarValue(ConcreteAttributePath(aEndpointId, EnergyEvse::Id, Attributes::ApproximateEVEfficiency::Id),
                                      tempApproxEVEfficiency);
     if (err == CHIP_NO_ERROR)
     {
         ChipLogDetail(AppServer, "EVSE: successfully loaded ApproximateEVEfficiency from NVM");
-        TEMPORARY_RETURN_IGNORED mDelegate->SetApproximateEVEfficiency(tempApproxEVEfficiency);
+        TEMPORARY_RETURN_IGNORED SetApproximateEVEfficiency(tempApproxEVEfficiency);
     }
     else
     {

--- a/examples/evse-app/silabs/src/AppTask.cpp
+++ b/examples/evse-app/silabs/src/AppTask.cpp
@@ -137,7 +137,6 @@ void ApplicationShutdown()
 {
     chip::DeviceLayer::PlatformMgr().LockChipStack();
     EvseApplicationShutdown();
-
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 }
 

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/CodeDrivenCallback.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/CodeDrivenCallback.h
@@ -141,6 +141,10 @@ void MatterDeviceEnergyManagementClusterInitCallback(chip::EndpointId endpointId
 
 void MatterDeviceEnergyManagementClusterShutdownCallback(chip::EndpointId endpointId, MatterClusterShutdownType shutdownType);
 
+void MatterEnergyEvseClusterInitCallback(chip::EndpointId endpointId);
+
+void MatterEnergyEvseClusterShutdownCallback(chip::EndpointId endpointId, MatterClusterShutdownType shutdownType);
+
 void MatterPowerTopologyClusterInitCallback(chip::EndpointId endpointId);
 
 void MatterPowerTopologyClusterShutdownCallback(chip::EndpointId endpointId, MatterClusterShutdownType shutdownType);

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/CodeDrivenInitShutdown.cpp
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/CodeDrivenInitShutdown.cpp
@@ -115,6 +115,9 @@ void MatterClusterServerInitCallback(EndpointId endpoint, ClusterId clusterId)
     case app::Clusters::DeviceEnergyManagement::Id:
         MatterDeviceEnergyManagementClusterInitCallback(endpoint);
         break;
+    case app::Clusters::EnergyEvse::Id:
+        MatterEnergyEvseClusterInitCallback(endpoint);
+        break;
     case app::Clusters::PowerTopology::Id:
         MatterPowerTopologyClusterInitCallback(endpoint);
         break;
@@ -226,6 +229,9 @@ void MatterClusterServerShutdownCallback(EndpointId endpoint, ClusterId clusterI
         break;
     case app::Clusters::DeviceEnergyManagement::Id:
         MatterDeviceEnergyManagementClusterShutdownCallback(endpoint, shutdownType);
+        break;
+    case app::Clusters::EnergyEvse::Id:
+        MatterEnergyEvseClusterShutdownCallback(endpoint, shutdownType);
         break;
     case app::Clusters::PowerTopology::Id:
         MatterPowerTopologyClusterShutdownCallback(endpoint, shutdownType);

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -67,6 +67,7 @@ if (chip_build_tests) {
       "${chip_root}/src/app/clusters/electrical-energy-measurement-server/tests",
       "${chip_root}/src/app/clusters/electrical-power-measurement-server/tests",
       "${chip_root}/src/app/clusters/ethernet-network-diagnostics-server/tests",
+      "${chip_root}/src/app/clusters/energy-evse-server/tests",
       "${chip_root}/src/app/clusters/fixed-label-server/tests",
       "${chip_root}/src/app/clusters/general-commissioning-server/tests",
       "${chip_root}/src/app/clusters/general-diagnostics-server/tests",

--- a/src/app/clusters/energy-evse-server/BUILD.gn
+++ b/src/app/clusters/energy-evse-server/BUILD.gn
@@ -11,5 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-group("energy-evse-server") {
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+source_set("energy-evse-server") {
+  sources = [
+    "EnergyEvseCluster.cpp",
+    "EnergyEvseCluster.h",
+    "EnergyEvseDelegate.h",
+    "EnergyEvseTestEventTriggerHandler.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/app/data-model-provider",
+    "${chip_root}/src/app/server",
+    "${chip_root}/src/app/server-cluster",
+    "${chip_root}/zzz_generated/app-common/clusters/EnergyEvse",
+  ]
 }

--- a/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
+++ b/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
@@ -30,7 +30,6 @@ Instance::Instance(EndpointId aEndpointId, Delegate & aDelegate, Feature aFeatur
                    OptionalCommands aOptionalCmds) :
     mCluster(EnergyEvseCluster::Config(aEndpointId, aDelegate, aFeature, aOptionalAttrs, aOptionalCmds))
 {
-    aDelegate.SetInstance(this);
 }
 
 CHIP_ERROR Instance::Init()

--- a/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
+++ b/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
@@ -1,0 +1,85 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/energy-evse-server/CodegenIntegration.h>
+
+#include <app/util/generic-callbacks.h>
+#include <clusters/EnergyEvse/Metadata.h>
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
+#include <protocols/interaction_model/StatusCode.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace EnergyEvse {
+
+Instance::Instance(EndpointId aEndpointId, Delegate & aDelegate, Feature aFeature, OptionalAttributes aOptionalAttrs,
+                   OptionalCommands aOptionalCmds) :
+    mCluster(EnergyEvseCluster::Config(aEndpointId, aDelegate, aFeature, aOptionalAttrs, aOptionalCmds))
+{
+    aDelegate.SetInstance(this);
+}
+
+CHIP_ERROR Instance::Init()
+{
+    CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Register(mCluster.Registration());
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "Failed to register cluster %u/" ChipLogFormatMEI ": %" CHIP_ERROR_FORMAT,
+                     mCluster.Cluster().GetPaths()[0].mEndpointId, ChipLogValueMEI(EnergyEvse::Id), err.Format());
+    }
+    return err;
+}
+
+void Instance::Shutdown()
+{
+    CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&mCluster.Cluster());
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "Failed to unregister cluster %u/" ChipLogFormatMEI ": %" CHIP_ERROR_FORMAT,
+                     mCluster.Cluster().GetPaths()[0].mEndpointId, ChipLogValueMEI(EnergyEvse::Id), err.Format());
+    }
+}
+
+bool Instance::HasFeature(Feature aFeature) const
+{
+    return mCluster.Cluster().Features().Has(aFeature);
+}
+
+bool Instance::SupportsOptAttr(OptionalAttributes aOptionalAttrs) const
+{
+    return mCluster.Cluster().OptionalAttrs().Has(aOptionalAttrs);
+}
+
+bool Instance::SupportsOptCmd(OptionalCommands aOptionalCmds) const
+{
+    return mCluster.Cluster().OptionalCmds().Has(aOptionalCmds);
+}
+
+} // namespace EnergyEvse
+} // namespace Clusters
+} // namespace app
+} // namespace chip
+
+// The current implementation already manually instantiates and initializes the cluster, so no need for the codegen integration.
+void MatterEnergyEvseClusterInitCallback(chip::EndpointId) {}
+void MatterEnergyEvseClusterShutdownCallback(chip::EndpointId, MatterClusterShutdownType) {}
+
+// Legacy callback stubs
+void MatterEnergyEvsePluginServerInitCallback() {}
+void MatterEnergyEvsePluginServerShutdownCallback() {}

--- a/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
+++ b/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
@@ -71,6 +71,236 @@ bool Instance::SupportsOptCmd(OptionalCommands aOptionalCmds) const
     return mCluster.Cluster().OptionalCmds().Has(aOptionalCmds);
 }
 
+StateEnum Instance::GetState() const
+{
+    return mCluster.Cluster().GetState();
+}
+
+CHIP_ERROR Instance::SetState(StateEnum newValue)
+{
+    return mCluster.Cluster().SetState(newValue);
+}
+
+SupplyStateEnum Instance::GetSupplyState() const
+{
+    return mCluster.Cluster().GetSupplyState();
+}
+
+CHIP_ERROR Instance::SetSupplyState(SupplyStateEnum newValue)
+{
+    return mCluster.Cluster().SetSupplyState(newValue);
+}
+
+FaultStateEnum Instance::GetFaultState() const
+{
+    return mCluster.Cluster().GetFaultState();
+}
+
+CHIP_ERROR Instance::SetFaultState(FaultStateEnum newValue)
+{
+    return mCluster.Cluster().SetFaultState(newValue);
+}
+
+DataModel::Nullable<uint32_t> Instance::GetChargingEnabledUntil() const
+{
+    return mCluster.Cluster().GetChargingEnabledUntil();
+}
+
+CHIP_ERROR Instance::SetChargingEnabledUntil(DataModel::Nullable<uint32_t> newValue)
+{
+    return mCluster.Cluster().SetChargingEnabledUntil(newValue);
+}
+
+DataModel::Nullable<uint32_t> Instance::GetDischargingEnabledUntil() const
+{
+    return mCluster.Cluster().GetDischargingEnabledUntil();
+}
+
+CHIP_ERROR Instance::SetDischargingEnabledUntil(DataModel::Nullable<uint32_t> newValue)
+{
+    return mCluster.Cluster().SetDischargingEnabledUntil(newValue);
+}
+
+int64_t Instance::GetCircuitCapacity() const
+{
+    return mCluster.Cluster().GetCircuitCapacity();
+}
+
+CHIP_ERROR Instance::SetCircuitCapacity(int64_t newValue)
+{
+    return mCluster.Cluster().SetCircuitCapacity(newValue);
+}
+
+int64_t Instance::GetMinimumChargeCurrent() const
+{
+    return mCluster.Cluster().GetMinimumChargeCurrent();
+}
+
+CHIP_ERROR Instance::SetMinimumChargeCurrent(int64_t newValue)
+{
+    return mCluster.Cluster().SetMinimumChargeCurrent(newValue);
+}
+
+int64_t Instance::GetMaximumChargeCurrent() const
+{
+    return mCluster.Cluster().GetMaximumChargeCurrent();
+}
+
+CHIP_ERROR Instance::SetMaximumChargeCurrent(int64_t newValue)
+{
+    return mCluster.Cluster().SetMaximumChargeCurrent(newValue);
+}
+
+int64_t Instance::GetMaximumDischargeCurrent() const
+{
+    return mCluster.Cluster().GetMaximumDischargeCurrent();
+}
+
+CHIP_ERROR Instance::SetMaximumDischargeCurrent(int64_t newValue)
+{
+    return mCluster.Cluster().SetMaximumDischargeCurrent(newValue);
+}
+
+int64_t Instance::GetUserMaximumChargeCurrent() const
+{
+    return mCluster.Cluster().GetUserMaximumChargeCurrent();
+}
+
+CHIP_ERROR Instance::SetUserMaximumChargeCurrent(int64_t newValue)
+{
+    return mCluster.Cluster().SetUserMaximumChargeCurrent(newValue);
+}
+
+uint32_t Instance::GetRandomizationDelayWindow() const
+{
+    return mCluster.Cluster().GetRandomizationDelayWindow();
+}
+
+CHIP_ERROR Instance::SetRandomizationDelayWindow(uint32_t newValue)
+{
+    return mCluster.Cluster().SetRandomizationDelayWindow(newValue);
+}
+
+DataModel::Nullable<uint32_t> Instance::GetNextChargeStartTime() const
+{
+    return mCluster.Cluster().GetNextChargeStartTime();
+}
+
+CHIP_ERROR Instance::SetNextChargeStartTime(DataModel::Nullable<uint32_t> newValue)
+{
+    return mCluster.Cluster().SetNextChargeStartTime(newValue);
+}
+
+DataModel::Nullable<uint32_t> Instance::GetNextChargeTargetTime() const
+{
+    return mCluster.Cluster().GetNextChargeTargetTime();
+}
+
+CHIP_ERROR Instance::SetNextChargeTargetTime(DataModel::Nullable<uint32_t> newValue)
+{
+    return mCluster.Cluster().SetNextChargeTargetTime(newValue);
+}
+
+DataModel::Nullable<int64_t> Instance::GetNextChargeRequiredEnergy() const
+{
+    return mCluster.Cluster().GetNextChargeRequiredEnergy();
+}
+
+CHIP_ERROR Instance::SetNextChargeRequiredEnergy(DataModel::Nullable<int64_t> newValue)
+{
+    return mCluster.Cluster().SetNextChargeRequiredEnergy(newValue);
+}
+
+DataModel::Nullable<Percent> Instance::GetNextChargeTargetSoC() const
+{
+    return mCluster.Cluster().GetNextChargeTargetSoC();
+}
+
+CHIP_ERROR Instance::SetNextChargeTargetSoC(DataModel::Nullable<Percent> newValue)
+{
+    return mCluster.Cluster().SetNextChargeTargetSoC(newValue);
+}
+
+DataModel::Nullable<uint16_t> Instance::GetApproximateEVEfficiency() const
+{
+    return mCluster.Cluster().GetApproximateEVEfficiency();
+}
+
+CHIP_ERROR Instance::SetApproximateEVEfficiency(DataModel::Nullable<uint16_t> newValue)
+{
+    return mCluster.Cluster().SetApproximateEVEfficiency(newValue);
+}
+
+DataModel::Nullable<Percent> Instance::GetStateOfCharge() const
+{
+    return mCluster.Cluster().GetStateOfCharge();
+}
+
+CHIP_ERROR Instance::SetStateOfCharge(DataModel::Nullable<Percent> newValue)
+{
+    return mCluster.Cluster().SetStateOfCharge(newValue);
+}
+
+DataModel::Nullable<int64_t> Instance::GetBatteryCapacity() const
+{
+    return mCluster.Cluster().GetBatteryCapacity();
+}
+
+CHIP_ERROR Instance::SetBatteryCapacity(DataModel::Nullable<int64_t> newValue)
+{
+    return mCluster.Cluster().SetBatteryCapacity(newValue);
+}
+
+DataModel::Nullable<CharSpan> Instance::GetVehicleID() const
+{
+    return mCluster.Cluster().GetVehicleID();
+}
+
+CHIP_ERROR Instance::SetVehicleID(DataModel::Nullable<CharSpan> newValue)
+{
+    return mCluster.Cluster().SetVehicleID(newValue);
+}
+
+DataModel::Nullable<uint32_t> Instance::GetSessionID() const
+{
+    return mCluster.Cluster().GetSessionID();
+}
+
+CHIP_ERROR Instance::SetSessionID(DataModel::Nullable<uint32_t> newValue)
+{
+    return mCluster.Cluster().SetSessionID(newValue);
+}
+
+DataModel::Nullable<uint32_t> Instance::GetSessionDuration() const
+{
+    return mCluster.Cluster().GetSessionDuration();
+}
+
+CHIP_ERROR Instance::SetSessionDuration(DataModel::Nullable<uint32_t> newValue)
+{
+    return mCluster.Cluster().SetSessionDuration(newValue);
+}
+
+DataModel::Nullable<int64_t> Instance::GetSessionEnergyCharged() const
+{
+    return mCluster.Cluster().GetSessionEnergyCharged();
+}
+
+CHIP_ERROR Instance::SetSessionEnergyCharged(DataModel::Nullable<int64_t> newValue)
+{
+    return mCluster.Cluster().SetSessionEnergyCharged(newValue);
+}
+
+DataModel::Nullable<int64_t> Instance::GetSessionEnergyDischarged() const
+{
+    return mCluster.Cluster().GetSessionEnergyDischarged();
+}
+
+CHIP_ERROR Instance::SetSessionEnergyDischarged(DataModel::Nullable<int64_t> newValue)
+{
+    return mCluster.Cluster().SetSessionEnergyDischarged(newValue);
+}
+
 } // namespace EnergyEvse
 } // namespace Clusters
 } // namespace app

--- a/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
+++ b/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
@@ -29,8 +29,7 @@ namespace EnergyEvse {
 Instance::Instance(EndpointId aEndpointId, Delegate & aDelegate, Feature aFeature, OptionalAttributes aOptionalAttrs,
                    OptionalCommands aOptionalCmds) :
     mCluster(EnergyEvseCluster::Config(aEndpointId, aDelegate, aFeature, aOptionalAttrs, aOptionalCmds))
-{
-}
+{}
 
 CHIP_ERROR Instance::Init()
 {

--- a/src/app/clusters/energy-evse-server/CodegenIntegration.h
+++ b/src/app/clusters/energy-evse-server/CodegenIntegration.h
@@ -1,0 +1,50 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app/clusters/energy-evse-server/EnergyEvseCluster.h>
+#include <app/server-cluster/ServerClusterInterfaceRegistry.h>
+#include <lib/support/LinkedList.h>
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace EnergyEvse {
+
+class Instance
+{
+public:
+    Instance(EndpointId aEndpointId, Delegate & aDelegate, Feature aFeature, OptionalAttributes aOptionalAttrs,
+             OptionalCommands aOptionalCmds);
+
+    CHIP_ERROR Init();
+    void Shutdown();
+
+    bool HasFeature(Feature aFeature) const;
+    bool SupportsOptAttr(OptionalAttributes aOptionalAttrs) const;
+    bool SupportsOptCmd(OptionalCommands aOptionalCmds) const;
+
+private:
+    RegisteredServerCluster<EnergyEvseCluster> mCluster;
+};
+
+} // namespace EnergyEvse
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/energy-evse-server/CodegenIntegration.h
+++ b/src/app/clusters/energy-evse-server/CodegenIntegration.h
@@ -40,6 +40,76 @@ public:
     bool SupportsOptAttr(OptionalAttributes aOptionalAttrs) const;
     bool SupportsOptCmd(OptionalCommands aOptionalCmds) const;
 
+    // Attribute accessors - pass through to cluster
+    StateEnum GetState() const;
+    CHIP_ERROR SetState(StateEnum newValue);
+
+    SupplyStateEnum GetSupplyState() const;
+    CHIP_ERROR SetSupplyState(SupplyStateEnum newValue);
+
+    FaultStateEnum GetFaultState() const;
+    CHIP_ERROR SetFaultState(FaultStateEnum newValue);
+
+    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() const;
+    CHIP_ERROR SetChargingEnabledUntil(DataModel::Nullable<uint32_t> newValue);
+
+    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() const;
+    CHIP_ERROR SetDischargingEnabledUntil(DataModel::Nullable<uint32_t> newValue);
+
+    int64_t GetCircuitCapacity() const;
+    CHIP_ERROR SetCircuitCapacity(int64_t newValue);
+
+    int64_t GetMinimumChargeCurrent() const;
+    CHIP_ERROR SetMinimumChargeCurrent(int64_t newValue);
+
+    int64_t GetMaximumChargeCurrent() const;
+    CHIP_ERROR SetMaximumChargeCurrent(int64_t newValue);
+
+    int64_t GetMaximumDischargeCurrent() const;
+    CHIP_ERROR SetMaximumDischargeCurrent(int64_t newValue);
+
+    int64_t GetUserMaximumChargeCurrent() const;
+    CHIP_ERROR SetUserMaximumChargeCurrent(int64_t newValue);
+
+    uint32_t GetRandomizationDelayWindow() const;
+    CHIP_ERROR SetRandomizationDelayWindow(uint32_t newValue);
+
+    DataModel::Nullable<uint32_t> GetNextChargeStartTime() const;
+    CHIP_ERROR SetNextChargeStartTime(DataModel::Nullable<uint32_t> newValue);
+
+    DataModel::Nullable<uint32_t> GetNextChargeTargetTime() const;
+    CHIP_ERROR SetNextChargeTargetTime(DataModel::Nullable<uint32_t> newValue);
+
+    DataModel::Nullable<int64_t> GetNextChargeRequiredEnergy() const;
+    CHIP_ERROR SetNextChargeRequiredEnergy(DataModel::Nullable<int64_t> newValue);
+
+    DataModel::Nullable<Percent> GetNextChargeTargetSoC() const;
+    CHIP_ERROR SetNextChargeTargetSoC(DataModel::Nullable<Percent> newValue);
+
+    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() const;
+    CHIP_ERROR SetApproximateEVEfficiency(DataModel::Nullable<uint16_t> newValue);
+
+    DataModel::Nullable<Percent> GetStateOfCharge() const;
+    CHIP_ERROR SetStateOfCharge(DataModel::Nullable<Percent> newValue);
+
+    DataModel::Nullable<int64_t> GetBatteryCapacity() const;
+    CHIP_ERROR SetBatteryCapacity(DataModel::Nullable<int64_t> newValue);
+
+    DataModel::Nullable<CharSpan> GetVehicleID() const;
+    CHIP_ERROR SetVehicleID(DataModel::Nullable<CharSpan> newValue);
+
+    DataModel::Nullable<uint32_t> GetSessionID() const;
+    CHIP_ERROR SetSessionID(DataModel::Nullable<uint32_t> newValue);
+
+    DataModel::Nullable<uint32_t> GetSessionDuration() const;
+    CHIP_ERROR SetSessionDuration(DataModel::Nullable<uint32_t> newValue);
+
+    DataModel::Nullable<int64_t> GetSessionEnergyCharged() const;
+    CHIP_ERROR SetSessionEnergyCharged(DataModel::Nullable<int64_t> newValue);
+
+    DataModel::Nullable<int64_t> GetSessionEnergyDischarged() const;
+    CHIP_ERROR SetSessionEnergyDischarged(DataModel::Nullable<int64_t> newValue);
+
 private:
     RegisteredServerCluster<EnergyEvseCluster> mCluster;
 };

--- a/src/app/clusters/energy-evse-server/Constants.h
+++ b/src/app/clusters/energy-evse-server/Constants.h
@@ -19,11 +19,13 @@
 namespace chip::app::Clusters::EnergyEvse {
 
 constexpr int64_t kMinimumChargeCurrentLimit       = 0;
+constexpr int64_t kMinimumChargeCurrent            = 6000;  // 6A in mA, spec default
 constexpr uint32_t kMaxRandomizationDelayWindowSec = 86400;
 constexpr uint8_t kEvseTargetsMaxNumberOfDays      = 7;
 constexpr uint8_t kEvseTargetsMaxTargetsPerDay     = 10;
 constexpr uint16_t kMaxMinutesPastMidnight         = 1439; // 24*60 - 1, spec range 0..1439
 constexpr uint8_t kMaxTargetSoCPercent             = 100;
 constexpr uint8_t kDayOfWeekBitmapMask             = 0x7F; // bits 0-6 for 7 days
+constexpr size_t kMaxVehicleIDBufSize              = 32;
 
 } // namespace chip::app::Clusters::EnergyEvse

--- a/src/app/clusters/energy-evse-server/Constants.h
+++ b/src/app/clusters/energy-evse-server/Constants.h
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+
 namespace chip::app::Clusters::EnergyEvse {
 
 constexpr int64_t kMinimumChargeCurrentLimit       = 0;

--- a/src/app/clusters/energy-evse-server/Constants.h
+++ b/src/app/clusters/energy-evse-server/Constants.h
@@ -19,7 +19,7 @@
 namespace chip::app::Clusters::EnergyEvse {
 
 constexpr int64_t kMinimumChargeCurrentLimit       = 0;
-constexpr int64_t kMinimumChargeCurrent            = 6000;  // 6A in mA, spec default
+constexpr int64_t kMinimumChargeCurrent            = 6000; // 6A in mA, spec default
 constexpr uint32_t kMaxRandomizationDelayWindowSec = 86400;
 constexpr uint8_t kEvseTargetsMaxNumberOfDays      = 7;
 constexpr uint8_t kEvseTargetsMaxTargetsPerDay     = 10;

--- a/src/app/clusters/energy-evse-server/Constants.h
+++ b/src/app/clusters/energy-evse-server/Constants.h
@@ -22,5 +22,8 @@ constexpr int64_t kMinimumChargeCurrentLimit       = 0;
 constexpr uint32_t kMaxRandomizationDelayWindowSec = 86400;
 constexpr uint8_t kEvseTargetsMaxNumberOfDays      = 7;
 constexpr uint8_t kEvseTargetsMaxTargetsPerDay     = 10;
+constexpr uint16_t kMaxMinutesPastMidnight         = 1439; // 24*60 - 1, spec range 0..1439
+constexpr uint8_t kMaxTargetSoCPercent             = 100;
+constexpr uint8_t kDayOfWeekBitmapMask             = 0x7F; // bits 0-6 for 7 days
 
 } // namespace chip::app::Clusters::EnergyEvse

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
@@ -44,6 +44,238 @@ CHIP_ERROR EnergyEvseCluster::Startup(ServerClusterContext & context)
     return DefaultServerCluster::Startup(context);
 }
 
+CHIP_ERROR EnergyEvseCluster::SetState(StateEnum newValue)
+{
+    VerifyOrReturnError(mState != newValue, CHIP_NO_ERROR);
+    mState = newValue;
+    mDelegate.OnStateChanged(newValue);
+    NotifyAttributeChanged(State::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetSupplyState(SupplyStateEnum newValue)
+{
+    VerifyOrReturnError(mSupplyState != newValue, CHIP_NO_ERROR);
+    mSupplyState = newValue;
+    mDelegate.OnSupplyStateChanged(newValue);
+    NotifyAttributeChanged(SupplyState::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetFaultState(FaultStateEnum newValue)
+{
+    VerifyOrReturnError(mFaultState != newValue, CHIP_NO_ERROR);
+    mFaultState = newValue;
+    mDelegate.OnFaultStateChanged(newValue);
+    NotifyAttributeChanged(FaultState::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetChargingEnabledUntil(DataModel::Nullable<uint32_t> newValue)
+{
+    VerifyOrReturnError(mChargingEnabledUntil != newValue, CHIP_NO_ERROR);
+    mChargingEnabledUntil = newValue;
+    mDelegate.OnChargingEnabledUntilChanged(newValue);
+    NotifyAttributeChanged(ChargingEnabledUntil::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetDischargingEnabledUntil(DataModel::Nullable<uint32_t> newValue)
+{
+    VerifyOrReturnError(mDischargingEnabledUntil != newValue, CHIP_NO_ERROR);
+    mDischargingEnabledUntil = newValue;
+    mDelegate.OnDischargingEnabledUntilChanged(newValue);
+    NotifyAttributeChanged(DischargingEnabledUntil::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetCircuitCapacity(int64_t newValue)
+{
+    VerifyOrReturnError(mCircuitCapacity != newValue, CHIP_NO_ERROR);
+    mCircuitCapacity = newValue;
+    mDelegate.OnCircuitCapacityChanged(newValue);
+    NotifyAttributeChanged(CircuitCapacity::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetMinimumChargeCurrent(int64_t newValue)
+{
+    VerifyOrReturnError(mMinimumChargeCurrent != newValue, CHIP_NO_ERROR);
+    mMinimumChargeCurrent = newValue;
+    mDelegate.OnMinimumChargeCurrentChanged(newValue);
+    NotifyAttributeChanged(MinimumChargeCurrent::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetMaximumChargeCurrent(int64_t newValue)
+{
+    VerifyOrReturnError(mMaximumChargeCurrent != newValue, CHIP_NO_ERROR);
+    mMaximumChargeCurrent = newValue;
+    mDelegate.OnMaximumChargeCurrentChanged(newValue);
+    NotifyAttributeChanged(MaximumChargeCurrent::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetMaximumDischargeCurrent(int64_t newValue)
+{
+    VerifyOrReturnError(mMaximumDischargeCurrent != newValue, CHIP_NO_ERROR);
+    mMaximumDischargeCurrent = newValue;
+    mDelegate.OnMaximumDischargeCurrentChanged(newValue);
+    NotifyAttributeChanged(MaximumDischargeCurrent::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetUserMaximumChargeCurrent(int64_t newValue)
+{
+    VerifyOrReturnError(mUserMaximumChargeCurrent != newValue, CHIP_NO_ERROR);
+    mUserMaximumChargeCurrent = newValue;
+    mDelegate.OnUserMaximumChargeCurrentChanged(newValue);
+    NotifyAttributeChanged(UserMaximumChargeCurrent::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetRandomizationDelayWindow(uint32_t newValue)
+{
+    VerifyOrReturnError(mRandomizationDelayWindow != newValue, CHIP_NO_ERROR);
+    mRandomizationDelayWindow = newValue;
+    mDelegate.OnRandomizationDelayWindowChanged(newValue);
+    NotifyAttributeChanged(RandomizationDelayWindow::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetNextChargeStartTime(DataModel::Nullable<uint32_t> newValue)
+{
+    VerifyOrReturnError(mNextChargeStartTime != newValue, CHIP_NO_ERROR);
+    mNextChargeStartTime = newValue;
+    mDelegate.OnNextChargeStartTimeChanged(newValue);
+    NotifyAttributeChanged(NextChargeStartTime::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetNextChargeTargetTime(DataModel::Nullable<uint32_t> newValue)
+{
+    VerifyOrReturnError(mNextChargeTargetTime != newValue, CHIP_NO_ERROR);
+    mNextChargeTargetTime = newValue;
+    mDelegate.OnNextChargeTargetTimeChanged(newValue);
+    NotifyAttributeChanged(NextChargeTargetTime::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetNextChargeRequiredEnergy(DataModel::Nullable<int64_t> newValue)
+{
+    VerifyOrReturnError(mNextChargeRequiredEnergy != newValue, CHIP_NO_ERROR);
+    mNextChargeRequiredEnergy = newValue;
+    mDelegate.OnNextChargeRequiredEnergyChanged(newValue);
+    NotifyAttributeChanged(NextChargeRequiredEnergy::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetNextChargeTargetSoC(DataModel::Nullable<Percent> newValue)
+{
+    VerifyOrReturnError(mNextChargeTargetSoC != newValue, CHIP_NO_ERROR);
+    mNextChargeTargetSoC = newValue;
+    mDelegate.OnNextChargeTargetSoCChanged(newValue);
+    NotifyAttributeChanged(NextChargeTargetSoC::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetApproximateEVEfficiency(DataModel::Nullable<uint16_t> newValue)
+{
+    VerifyOrReturnError(mApproximateEVEfficiency != newValue, CHIP_NO_ERROR);
+    mApproximateEVEfficiency = newValue;
+    mDelegate.OnApproximateEVEfficiencyChanged(newValue);
+    NotifyAttributeChanged(ApproximateEVEfficiency::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetStateOfCharge(DataModel::Nullable<Percent> newValue)
+{
+    VerifyOrReturnError(mStateOfCharge != newValue, CHIP_NO_ERROR);
+    mStateOfCharge = newValue;
+    mDelegate.OnStateOfChargeChanged(newValue);
+    NotifyAttributeChanged(StateOfCharge::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetBatteryCapacity(DataModel::Nullable<int64_t> newValue)
+{
+    VerifyOrReturnError(mBatteryCapacity != newValue, CHIP_NO_ERROR);
+    mBatteryCapacity = newValue;
+    mDelegate.OnBatteryCapacityChanged(newValue);
+    NotifyAttributeChanged(BatteryCapacity::Id);
+    return CHIP_NO_ERROR;
+}
+
+DataModel::Nullable<CharSpan> EnergyEvseCluster::GetVehicleID() const
+{
+    if (mVehicleID.IsNull())
+    {
+        return DataModel::NullNullable;
+    }
+    return DataModel::MakeNullable(CharSpan(mVehicleIDBuffer, mVehicleID.Value().size()));
+}
+
+CHIP_ERROR EnergyEvseCluster::SetVehicleID(DataModel::Nullable<CharSpan> newValue)
+{
+    if (newValue.IsNull())
+    {
+        if (mVehicleID.IsNull())
+        {
+            return CHIP_NO_ERROR;
+        }
+        mVehicleID = DataModel::NullNullable;
+    }
+    else
+    {
+        VerifyOrReturnError(newValue.Value().size() <= kMaxVehicleIDBufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
+        if (!mVehicleID.IsNull() && newValue.Value().data_equal(mVehicleID.Value()))
+        {
+            return CHIP_NO_ERROR;
+        }
+        memcpy(mVehicleIDBuffer, newValue.Value().data(), newValue.Value().size());
+        mVehicleID = DataModel::MakeNullable(CharSpan(mVehicleIDBuffer, newValue.Value().size()));
+    }
+    mDelegate.OnVehicleIDChanged(mVehicleID);
+    NotifyAttributeChanged(VehicleID::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetSessionID(DataModel::Nullable<uint32_t> newValue)
+{
+    VerifyOrReturnError(mSessionID != newValue, CHIP_NO_ERROR);
+    mSessionID = newValue;
+    mDelegate.OnSessionIDChanged(newValue);
+    NotifyAttributeChanged(SessionID::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetSessionDuration(DataModel::Nullable<uint32_t> newValue)
+{
+    VerifyOrReturnError(mSessionDuration != newValue, CHIP_NO_ERROR);
+    mSessionDuration = newValue;
+    mDelegate.OnSessionDurationChanged(newValue);
+    NotifyAttributeChanged(SessionDuration::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetSessionEnergyCharged(DataModel::Nullable<int64_t> newValue)
+{
+    VerifyOrReturnError(mSessionEnergyCharged != newValue, CHIP_NO_ERROR);
+    mSessionEnergyCharged = newValue;
+    mDelegate.OnSessionEnergyChargedChanged(newValue);
+    NotifyAttributeChanged(SessionEnergyCharged::Id);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EnergyEvseCluster::SetSessionEnergyDischarged(DataModel::Nullable<int64_t> newValue)
+{
+    VerifyOrReturnError(mSessionEnergyDischarged != newValue, CHIP_NO_ERROR);
+    mSessionEnergyDischarged = newValue;
+    mDelegate.OnSessionEnergyDischargedChanged(newValue);
+    NotifyAttributeChanged(SessionEnergyDischarged::Id);
+    return CHIP_NO_ERROR;
+}
+
 DataModel::ActionReturnStatus EnergyEvseCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                                AttributeValueEncoder & encoder)
 {
@@ -54,51 +286,51 @@ DataModel::ActionReturnStatus EnergyEvseCluster::ReadAttribute(const DataModel::
     case ClusterRevision::Id:
         return encoder.Encode(kRevision);
     case State::Id:
-        return encoder.Encode(mDelegate.GetState());
+        return encoder.Encode(mState);
     case SupplyState::Id:
-        return encoder.Encode(mDelegate.GetSupplyState());
+        return encoder.Encode(mSupplyState);
     case FaultState::Id:
-        return encoder.Encode(mDelegate.GetFaultState());
+        return encoder.Encode(mFaultState);
     case ChargingEnabledUntil::Id:
-        return encoder.Encode(mDelegate.GetChargingEnabledUntil());
+        return encoder.Encode(mChargingEnabledUntil);
     case DischargingEnabledUntil::Id:
-        return encoder.Encode(mDelegate.GetDischargingEnabledUntil());
+        return encoder.Encode(mDischargingEnabledUntil);
     case CircuitCapacity::Id:
-        return encoder.Encode(mDelegate.GetCircuitCapacity());
+        return encoder.Encode(mCircuitCapacity);
     case MinimumChargeCurrent::Id:
-        return encoder.Encode(mDelegate.GetMinimumChargeCurrent());
+        return encoder.Encode(mMinimumChargeCurrent);
     case MaximumChargeCurrent::Id:
-        return encoder.Encode(mDelegate.GetMaximumChargeCurrent());
+        return encoder.Encode(mMaximumChargeCurrent);
     case MaximumDischargeCurrent::Id:
-        return encoder.Encode(mDelegate.GetMaximumDischargeCurrent());
+        return encoder.Encode(mMaximumDischargeCurrent);
     case UserMaximumChargeCurrent::Id:
-        return encoder.Encode(mDelegate.GetUserMaximumChargeCurrent());
+        return encoder.Encode(mUserMaximumChargeCurrent);
     case RandomizationDelayWindow::Id:
-        return encoder.Encode(mDelegate.GetRandomizationDelayWindow());
+        return encoder.Encode(mRandomizationDelayWindow);
     case NextChargeStartTime::Id:
-        return encoder.Encode(mDelegate.GetNextChargeStartTime());
+        return encoder.Encode(mNextChargeStartTime);
     case NextChargeTargetTime::Id:
-        return encoder.Encode(mDelegate.GetNextChargeTargetTime());
+        return encoder.Encode(mNextChargeTargetTime);
     case NextChargeRequiredEnergy::Id:
-        return encoder.Encode(mDelegate.GetNextChargeRequiredEnergy());
+        return encoder.Encode(mNextChargeRequiredEnergy);
     case NextChargeTargetSoC::Id:
-        return encoder.Encode(mDelegate.GetNextChargeTargetSoC());
+        return encoder.Encode(mNextChargeTargetSoC);
     case ApproximateEVEfficiency::Id:
-        return encoder.Encode(mDelegate.GetApproximateEVEfficiency());
+        return encoder.Encode(mApproximateEVEfficiency);
     case StateOfCharge::Id:
-        return encoder.Encode(mDelegate.GetStateOfCharge());
+        return encoder.Encode(mStateOfCharge);
     case BatteryCapacity::Id:
-        return encoder.Encode(mDelegate.GetBatteryCapacity());
+        return encoder.Encode(mBatteryCapacity);
     case VehicleID::Id:
-        return encoder.Encode(mDelegate.GetVehicleID());
+        return encoder.Encode(GetVehicleID());
     case SessionID::Id:
-        return encoder.Encode(mDelegate.GetSessionID());
+        return encoder.Encode(mSessionID);
     case SessionDuration::Id:
-        return encoder.Encode(mDelegate.GetSessionDuration());
+        return encoder.Encode(mSessionDuration);
     case SessionEnergyCharged::Id:
-        return encoder.Encode(mDelegate.GetSessionEnergyCharged());
+        return encoder.Encode(mSessionEnergyCharged);
     case SessionEnergyDischarged::Id:
-        return encoder.Encode(mDelegate.GetSessionEnergyDischarged());
+        return encoder.Encode(mSessionEnergyDischarged);
     default:
         return Status::UnsupportedAttribute;
     }
@@ -112,17 +344,20 @@ DataModel::ActionReturnStatus EnergyEvseCluster::WriteAttribute(const DataModel:
     case UserMaximumChargeCurrent::Id: {
         UserMaximumChargeCurrent::TypeInfo::DecodableType value;
         ReturnErrorOnFailure(decoder.Decode(value));
-        return mDelegate.SetUserMaximumChargeCurrent(value);
+        VerifyOrReturnValue(mUserMaximumChargeCurrent != value, ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
+        return SetUserMaximumChargeCurrent(value);
     }
     case RandomizationDelayWindow::Id: {
         RandomizationDelayWindow::TypeInfo::DecodableType value;
         ReturnErrorOnFailure(decoder.Decode(value));
-        return mDelegate.SetRandomizationDelayWindow(value);
+        VerifyOrReturnValue(mRandomizationDelayWindow != value, ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
+        return SetRandomizationDelayWindow(value);
     }
     case ApproximateEVEfficiency::Id: {
         ApproximateEVEfficiency::TypeInfo::DecodableType value;
         ReturnErrorOnFailure(decoder.Decode(value));
-        return mDelegate.SetApproximateEVEfficiency(value);
+        VerifyOrReturnValue(mApproximateEVEfficiency != value, ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
+        return SetApproximateEVEfficiency(value);
     }
     default:
         return Status::UnsupportedAttribute;

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
@@ -105,7 +105,7 @@ CHIP_ERROR EnergyEvseCluster::SetCircuitCapacity(int64_t newValue)
 CHIP_ERROR EnergyEvseCluster::SetMinimumChargeCurrent(int64_t newValue)
 {
     VerifyOrReturnError(mMinimumChargeCurrent != newValue, CHIP_NO_ERROR);
-    VerifyOrReturnError(mMinimumChargeCurrent >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    VerifyOrReturnError(newValue >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mMinimumChargeCurrent = newValue;
     mDelegate.OnMinimumChargeCurrentChanged(newValue);
     NotifyAttributeChanged(MinimumChargeCurrent::Id);
@@ -115,7 +115,7 @@ CHIP_ERROR EnergyEvseCluster::SetMinimumChargeCurrent(int64_t newValue)
 CHIP_ERROR EnergyEvseCluster::SetMaximumChargeCurrent(int64_t newValue)
 {
     VerifyOrReturnError(mMaximumChargeCurrent != newValue, CHIP_NO_ERROR);
-    VerifyOrReturnError(mMaximumChargeCurrent >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    VerifyOrReturnError(newValue >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mMaximumChargeCurrent = newValue;
     mDelegate.OnMaximumChargeCurrentChanged(newValue);
     NotifyAttributeChanged(MaximumChargeCurrent::Id);
@@ -125,7 +125,7 @@ CHIP_ERROR EnergyEvseCluster::SetMaximumChargeCurrent(int64_t newValue)
 CHIP_ERROR EnergyEvseCluster::SetMaximumDischargeCurrent(int64_t newValue)
 {
     VerifyOrReturnError(mMaximumDischargeCurrent != newValue, CHIP_NO_ERROR);
-    VerifyOrReturnError(mMaximumDischargeCurrent >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    VerifyOrReturnError(newValue >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mMaximumDischargeCurrent = newValue;
     mDelegate.OnMaximumDischargeCurrentChanged(newValue);
     NotifyAttributeChanged(MaximumDischargeCurrent::Id);

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
@@ -14,14 +14,10 @@
  *    limitations under the License.
  */
 
-#include "energy-evse-server.h"
-
-#include <app/AttributeAccessInterface.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
-#include <app/CommandHandlerInterfaceRegistry.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelEngine.h>
-#include <app/util/attribute-storage.h>
+#include <app/clusters/energy-evse-server/EnergyEvseCluster.h>
+#include <app/server-cluster/AttributeListBuilder.h>
 #include <clusters/EnergyEvse/Metadata.h>
 
 using namespace chip;
@@ -37,363 +33,247 @@ namespace app {
 namespace Clusters {
 namespace EnergyEvse {
 
-CHIP_ERROR Instance::Init()
+CHIP_ERROR EnergyEvseCluster::Startup(ServerClusterContext & context)
 {
-    ReturnErrorOnFailure(CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(this));
-    VerifyOrReturnError(AttributeAccessInterfaceRegistry::Instance().Register(this), CHIP_ERROR_INCORRECT_STATE);
-
-    return CHIP_NO_ERROR;
-}
-
-void Instance::Shutdown()
-{
-    TEMPORARY_RETURN_IGNORED CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(this);
-    AttributeAccessInterfaceRegistry::Instance().Unregister(this);
-}
-
-bool Instance::HasFeature(Feature aFeature) const
-{
-    return mFeature.Has(aFeature);
-}
-
-bool Instance::SupportsOptAttr(OptionalAttributes aOptionalAttrs) const
-{
-    return mOptionalAttrs.Has(aOptionalAttrs);
-}
-
-bool Instance::SupportsOptCmd(OptionalCommands aOptionalCmds) const
-{
-    return mOptionalCmds.Has(aOptionalCmds);
-}
-
-// AttributeAccessInterface
-CHIP_ERROR Instance::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
-{
-    switch (aPath.mAttributeId)
+    if (mDelegate.GetEndpointId() != mPath.mEndpointId)
     {
-    case State::Id:
-        return aEncoder.Encode(mDelegate.GetState());
-    case SupplyState::Id:
-        return aEncoder.Encode(mDelegate.GetSupplyState());
-    case FaultState::Id:
-        return aEncoder.Encode(mDelegate.GetFaultState());
-    case ChargingEnabledUntil::Id:
-        return aEncoder.Encode(mDelegate.GetChargingEnabledUntil());
-    case DischargingEnabledUntil::Id:
-        /* V2X */
-        return aEncoder.Encode(mDelegate.GetDischargingEnabledUntil());
-    case CircuitCapacity::Id:
-        return aEncoder.Encode(mDelegate.GetCircuitCapacity());
-    case MinimumChargeCurrent::Id:
-        return aEncoder.Encode(mDelegate.GetMinimumChargeCurrent());
-    case MaximumChargeCurrent::Id:
-        return aEncoder.Encode(mDelegate.GetMaximumChargeCurrent());
-    case MaximumDischargeCurrent::Id:
-        /* V2X */
-        return aEncoder.Encode(mDelegate.GetMaximumDischargeCurrent());
-
-    case UserMaximumChargeCurrent::Id:
-        return aEncoder.Encode(mDelegate.GetUserMaximumChargeCurrent());
-    case RandomizationDelayWindow::Id:
-        /* Optional */
-        return aEncoder.Encode(mDelegate.GetRandomizationDelayWindow());
-    /* PREF - ChargingPreferences attributes */
-    case NextChargeStartTime::Id:
-        return aEncoder.Encode(mDelegate.GetNextChargeStartTime());
-    case NextChargeTargetTime::Id:
-        return aEncoder.Encode(mDelegate.GetNextChargeTargetTime());
-    case NextChargeRequiredEnergy::Id:
-        return aEncoder.Encode(mDelegate.GetNextChargeRequiredEnergy());
-    case NextChargeTargetSoC::Id:
-        return aEncoder.Encode(mDelegate.GetNextChargeTargetSoC());
-    case ApproximateEVEfficiency::Id:
-        return aEncoder.Encode(mDelegate.GetApproximateEVEfficiency());
-    /* SOC attributes */
-    case StateOfCharge::Id:
-        return aEncoder.Encode(mDelegate.GetStateOfCharge());
-    case BatteryCapacity::Id:
-        return aEncoder.Encode(mDelegate.GetBatteryCapacity());
-    /* PNC attributes*/
-    case VehicleID::Id:
-        return aEncoder.Encode(mDelegate.GetVehicleID());
-    /* Session SESS attributes */
-    case SessionID::Id:
-        return aEncoder.Encode(mDelegate.GetSessionID());
-    case SessionDuration::Id:
-        return aEncoder.Encode(mDelegate.GetSessionDuration());
-    case SessionEnergyCharged::Id:
-        return aEncoder.Encode(mDelegate.GetSessionEnergyCharged());
-    case SessionEnergyDischarged::Id:
-        return aEncoder.Encode(mDelegate.GetSessionEnergyDischarged());
-
-    /* FeatureMap - is held locally */
-    case FeatureMap::Id:
-        return aEncoder.Encode(mFeature);
+        ChipLogError(Zcl, "EVSE: EndpointId mismatch - delegate has %d, cluster has %d", mDelegate.GetEndpointId(),
+                     mPath.mEndpointId);
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    /* Allow all other unhandled attributes to fall through to Ember */
-    return CHIP_NO_ERROR;
+    return DefaultServerCluster::Startup(context);
 }
 
-CHIP_ERROR Instance::Write(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder)
+DataModel::ActionReturnStatus EnergyEvseCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
+                                                               AttributeValueEncoder & encoder)
 {
-    switch (aPath.mAttributeId)
+    switch (request.path.mAttributeId)
+    {
+    case FeatureMap::Id:
+        return encoder.Encode(mFeatureFlags);
+    case ClusterRevision::Id:
+        return encoder.Encode(kRevision);
+    case State::Id:
+        return encoder.Encode(mDelegate.GetState());
+    case SupplyState::Id:
+        return encoder.Encode(mDelegate.GetSupplyState());
+    case FaultState::Id:
+        return encoder.Encode(mDelegate.GetFaultState());
+    case ChargingEnabledUntil::Id:
+        return encoder.Encode(mDelegate.GetChargingEnabledUntil());
+    case DischargingEnabledUntil::Id:
+        return encoder.Encode(mDelegate.GetDischargingEnabledUntil());
+    case CircuitCapacity::Id:
+        return encoder.Encode(mDelegate.GetCircuitCapacity());
+    case MinimumChargeCurrent::Id:
+        return encoder.Encode(mDelegate.GetMinimumChargeCurrent());
+    case MaximumChargeCurrent::Id:
+        return encoder.Encode(mDelegate.GetMaximumChargeCurrent());
+    case MaximumDischargeCurrent::Id:
+        return encoder.Encode(mDelegate.GetMaximumDischargeCurrent());
+    case UserMaximumChargeCurrent::Id:
+        return encoder.Encode(mDelegate.GetUserMaximumChargeCurrent());
+    case RandomizationDelayWindow::Id:
+        return encoder.Encode(mDelegate.GetRandomizationDelayWindow());
+    case NextChargeStartTime::Id:
+        return encoder.Encode(mDelegate.GetNextChargeStartTime());
+    case NextChargeTargetTime::Id:
+        return encoder.Encode(mDelegate.GetNextChargeTargetTime());
+    case NextChargeRequiredEnergy::Id:
+        return encoder.Encode(mDelegate.GetNextChargeRequiredEnergy());
+    case NextChargeTargetSoC::Id:
+        return encoder.Encode(mDelegate.GetNextChargeTargetSoC());
+    case ApproximateEVEfficiency::Id:
+        return encoder.Encode(mDelegate.GetApproximateEVEfficiency());
+    case StateOfCharge::Id:
+        return encoder.Encode(mDelegate.GetStateOfCharge());
+    case BatteryCapacity::Id:
+        return encoder.Encode(mDelegate.GetBatteryCapacity());
+    case VehicleID::Id:
+        return encoder.Encode(mDelegate.GetVehicleID());
+    case SessionID::Id:
+        return encoder.Encode(mDelegate.GetSessionID());
+    case SessionDuration::Id:
+        return encoder.Encode(mDelegate.GetSessionDuration());
+    case SessionEnergyCharged::Id:
+        return encoder.Encode(mDelegate.GetSessionEnergyCharged());
+    case SessionEnergyDischarged::Id:
+        return encoder.Encode(mDelegate.GetSessionEnergyDischarged());
+    default:
+        return Status::UnsupportedAttribute;
+    }
+}
+
+DataModel::ActionReturnStatus EnergyEvseCluster::WriteAttribute(const DataModel::WriteAttributeRequest & request,
+                                                                AttributeValueDecoder & decoder)
+{
+    switch (request.path.mAttributeId)
     {
     case UserMaximumChargeCurrent::Id: {
-        // Optional Attribute
-        if (!SupportsOptAttr(OptionalAttributes::kSupportsUserMaximumChargingCurrent))
-        {
-            return CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute);
-        }
-
-        int64_t newValue;
-        ReturnErrorOnFailure(aDecoder.Decode(newValue));
-        ReturnErrorOnFailure(mDelegate.SetUserMaximumChargeCurrent(newValue));
-        return CHIP_NO_ERROR;
+        UserMaximumChargeCurrent::TypeInfo::DecodableType value;
+        ReturnErrorOnFailure(decoder.Decode(value));
+        return mDelegate.SetUserMaximumChargeCurrent(value);
     }
     case RandomizationDelayWindow::Id: {
-        // Optional Attribute
-        if (!SupportsOptAttr(OptionalAttributes::kSupportsRandomizationWindow))
-        {
-            return CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute);
-        }
-        uint32_t newValue;
-        ReturnErrorOnFailure(aDecoder.Decode(newValue));
-        ReturnErrorOnFailure(mDelegate.SetRandomizationDelayWindow(newValue));
-        return CHIP_NO_ERROR;
+        RandomizationDelayWindow::TypeInfo::DecodableType value;
+        ReturnErrorOnFailure(decoder.Decode(value));
+        return mDelegate.SetRandomizationDelayWindow(value);
     }
     case ApproximateEVEfficiency::Id: {
-        // Optional Attribute if ChargingPreferences is supported
-        if ((!HasFeature(Feature::kChargingPreferences)) ||
-            (!SupportsOptAttr(OptionalAttributes::kSupportsApproximateEvEfficiency)))
-        {
-            return CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute);
-        }
-        uint16_t newValue;
-        ReturnErrorOnFailure(aDecoder.Decode(newValue));
-        ReturnErrorOnFailure(mDelegate.SetApproximateEVEfficiency(MakeNullable(newValue)));
-        return CHIP_NO_ERROR;
+        ApproximateEVEfficiency::TypeInfo::DecodableType value;
+        ReturnErrorOnFailure(decoder.Decode(value));
+        return mDelegate.SetApproximateEVEfficiency(value);
     }
-
     default:
-        // Unknown attribute; return error.  None of the other attributes for
-        // this cluster are writable, so should not be ending up in this code to
-        // start with.
-        return CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute);
+        return Status::UnsupportedAttribute;
+    }
+}
+std::optional<DataModel::ActionReturnStatus> EnergyEvseCluster::InvokeCommand(const DataModel::InvokeRequest & request,
+                                                                              TLV::TLVReader & input_arguments,
+                                                                              CommandHandler * handler)
+{
+    using namespace Commands;
+
+    switch (request.path.mCommandId)
+    {
+    case Disable::Id:
+        return HandleDisable(request, input_arguments, handler);
+    case EnableCharging::Id:
+        return HandleEnableCharging(request, input_arguments, handler);
+    case EnableDischarging::Id:
+        return HandleEnableDischarging(request, input_arguments, handler);
+    case StartDiagnostics::Id:
+        return HandleStartDiagnostics(request, input_arguments, handler);
+    case SetTargets::Id:
+        return HandleSetTargets(request, input_arguments, handler);
+    case GetTargets::Id:
+        return HandleGetTargets(request, input_arguments, handler);
+    case ClearTargets::Id:
+        return HandleClearTargets(request, input_arguments, handler);
+    default:
+        return Status::UnsupportedCommand;
     }
 }
 
-// CommandHandlerInterface
-CHIP_ERROR Instance::RetrieveAcceptedCommands(const ConcreteClusterPath & cluster,
-                                              ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder)
+CHIP_ERROR EnergyEvseCluster::Attributes(const ConcreteClusterPath & path,
+                                         ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
+{
+    AttributeListBuilder::OptionalAttributeEntry optionalAttributes[] = {
+        // V2x feature attributes
+        { mFeatureFlags.Has(Feature::kV2x), DischargingEnabledUntil::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kV2x), MaximumDischargeCurrent::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kV2x), SessionEnergyDischarged::kMetadataEntry },
+        // ChargingPreferences feature attributes
+        { mFeatureFlags.Has(Feature::kChargingPreferences), NextChargeStartTime::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kChargingPreferences), NextChargeTargetTime::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kChargingPreferences), NextChargeRequiredEnergy::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kChargingPreferences), NextChargeTargetSoC::kMetadataEntry },
+        { (mFeatureFlags.Has(Feature::kChargingPreferences) &&
+           mOptionalAttrs.Has(OptionalAttributes::kSupportsApproximateEvEfficiency)),
+          ApproximateEVEfficiency::kMetadataEntry },
+        // SoCReporting feature attributes
+        { mFeatureFlags.Has(Feature::kSoCReporting), StateOfCharge::kMetadataEntry },
+        { mFeatureFlags.Has(Feature::kSoCReporting), BatteryCapacity::kMetadataEntry },
+        // PlugAndCharge feature attribute
+        { mFeatureFlags.Has(Feature::kPlugAndCharge), VehicleID::kMetadataEntry },
+        // Optional attributes (not feature-based)
+        { mOptionalAttrs.Has(OptionalAttributes::kSupportsUserMaximumChargingCurrent), UserMaximumChargeCurrent::kMetadataEntry },
+        { mOptionalAttrs.Has(OptionalAttributes::kSupportsRandomizationWindow), RandomizationDelayWindow::kMetadataEntry },
+    };
+    AttributeListBuilder listBuilder(builder);
+    return listBuilder.Append(Span(Attributes::kMandatoryMetadata), Span(optionalAttributes));
+}
+
+CHIP_ERROR EnergyEvseCluster::AcceptedCommands(const ConcreteClusterPath & path,
+                                               ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder)
 {
     using namespace Commands;
-    ReturnErrorOnFailure(builder.EnsureAppendCapacity(kAcceptedCommandsCount));
-
     ReturnErrorOnFailure(builder.AppendElements({ Disable::kMetadataEntry, EnableCharging::kMetadataEntry }));
-
-    if (HasFeature(Feature::kV2x))
+    if (mFeatureFlags.Has(Feature::kV2x))
     {
-        ReturnErrorOnFailure(builder.Append(EnableDischarging::kMetadataEntry));
+        ReturnErrorOnFailure(builder.AppendElements({ EnableDischarging::kMetadataEntry }));
     }
-
-    if (HasFeature(Feature::kChargingPreferences))
+    if (mOptionalCmds.Has(OptionalCommands::kSupportsStartDiagnostics))
+    {
+        ReturnErrorOnFailure(builder.AppendElements({ StartDiagnostics::kMetadataEntry }));
+    }
+    if (mFeatureFlags.Has(Feature::kChargingPreferences))
     {
         ReturnErrorOnFailure(
             builder.AppendElements({ SetTargets::kMetadataEntry, GetTargets::kMetadataEntry, ClearTargets::kMetadataEntry }));
     }
 
-    if (SupportsOptCmd(OptionalCommands::kSupportsStartDiagnostics))
-    {
-        ReturnErrorOnFailure(builder.Append(StartDiagnostics::kMetadataEntry));
-    }
-
     return CHIP_NO_ERROR;
 }
 
-void Instance::InvokeCommand(HandlerContext & handlerContext)
+CHIP_ERROR EnergyEvseCluster::GeneratedCommands(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<CommandId> & builder)
 {
     using namespace Commands;
-
-    switch (handlerContext.mRequestPath.mCommandId)
+    if (mFeatureFlags.Has(Feature::kChargingPreferences))
     {
-    case Disable::Id:
-        HandleCommand<Disable::DecodableType>(
-            handlerContext, [this](HandlerContext & ctx, const auto & commandData) { HandleDisable(ctx, commandData); });
-        return;
-    case EnableCharging::Id:
-        HandleCommand<EnableCharging::DecodableType>(
-            handlerContext, [this](HandlerContext & ctx, const auto & commandData) { HandleEnableCharging(ctx, commandData); });
-        return;
-    case EnableDischarging::Id:
-        if (!HasFeature(Feature::kV2x))
-        {
-            handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, Status::UnsupportedCommand);
-        }
-        else
-        {
-            HandleCommand<EnableDischarging::DecodableType>(handlerContext, [this](HandlerContext & ctx, const auto & commandData) {
-                HandleEnableDischarging(ctx, commandData);
-            });
-        }
-        return;
-    case StartDiagnostics::Id:
-        if (!SupportsOptCmd(OptionalCommands::kSupportsStartDiagnostics))
-        {
-            handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, Status::UnsupportedCommand);
-        }
-        else
-        {
-            HandleCommand<StartDiagnostics::DecodableType>(handlerContext, [this](HandlerContext & ctx, const auto & commandData) {
-                HandleStartDiagnostics(ctx, commandData);
-            });
-        }
-        return;
-    case SetTargets::Id:
-        if (!HasFeature(Feature::kChargingPreferences))
-        {
-            handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, Status::UnsupportedCommand);
-        }
-        else
-        {
-            HandleCommand<SetTargets::DecodableType>(
-                handlerContext, [this](HandlerContext & ctx, const auto & commandData) { HandleSetTargets(ctx, commandData); });
-        }
-        return;
-    case GetTargets::Id:
-        if (!HasFeature(Feature::kChargingPreferences))
-        {
-            handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, Status::UnsupportedCommand);
-        }
-        else
-        {
-            HandleCommand<GetTargets::DecodableType>(
-                handlerContext, [this](HandlerContext & ctx, const auto & commandData) { HandleGetTargets(ctx, commandData); });
-        }
-        return;
-    case ClearTargets::Id:
-        if (!HasFeature(Feature::kChargingPreferences))
-        {
-            handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, Status::UnsupportedCommand);
-        }
-        else
-        {
-            HandleCommand<ClearTargets::DecodableType>(
-                handlerContext, [this](HandlerContext & ctx, const auto & commandData) { HandleClearTargets(ctx, commandData); });
-        }
-        return;
+        ReturnErrorOnFailure(builder.AppendElements({ GetTargetsResponse::Id }));
     }
+    return CHIP_NO_ERROR;
 }
 
-void Instance::HandleDisable(HandlerContext & ctx, const Commands::Disable::DecodableType & commandData)
+DataModel::ActionReturnStatus EnergyEvseCluster::HandleDisable(const DataModel::InvokeRequest & request,
+                                                               TLV::TLVReader & input_arguments, CommandHandler * handler)
 {
-    // No parameters for this command
-    // Call the delegate
-    Status status = mDelegate.Disable();
-
-    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
+    return mDelegate.Disable();
 }
 
-void Instance::HandleEnableCharging(HandlerContext & ctx, const Commands::EnableCharging::DecodableType & commandData)
+DataModel::ActionReturnStatus EnergyEvseCluster::HandleEnableCharging(const DataModel::InvokeRequest & request,
+                                                                      TLV::TLVReader & input_arguments, CommandHandler * handler)
 {
+    Commands::EnableCharging::DecodableType commandData;
+    ReturnErrorOnFailure(DataModel::Decode(input_arguments, commandData));
+
     auto & chargingEnabledUntil = commandData.chargingEnabledUntil;
     auto & minimumChargeCurrent = commandData.minimumChargeCurrent;
     auto & maximumChargeCurrent = commandData.maximumChargeCurrent;
 
-    if (minimumChargeCurrent < kMinimumChargeCurrentLimit)
-    {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
-        return;
-    }
+    VerifyOrReturnValue(minimumChargeCurrent >= kMinimumChargeCurrentLimit, Status::ConstraintError);
+    VerifyOrReturnValue(maximumChargeCurrent >= kMinimumChargeCurrentLimit, Status::ConstraintError);
+    VerifyOrReturnValue(minimumChargeCurrent <= maximumChargeCurrent, Status::ConstraintError);
 
-    if (maximumChargeCurrent < kMinimumChargeCurrentLimit)
-    {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
-        return;
-    }
-
-    if (minimumChargeCurrent > maximumChargeCurrent)
-    {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
-        return;
-    }
-
-    // Call the delegate
-    Status status = mDelegate.EnableCharging(chargingEnabledUntil, minimumChargeCurrent, maximumChargeCurrent);
-
-    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
+    return mDelegate.EnableCharging(chargingEnabledUntil, minimumChargeCurrent, maximumChargeCurrent);
 }
 
-void Instance::HandleEnableDischarging(HandlerContext & ctx, const Commands::EnableDischarging::DecodableType & commandData)
+DataModel::ActionReturnStatus EnergyEvseCluster::HandleEnableDischarging(const DataModel::InvokeRequest & request,
+                                                                         TLV::TLVReader & input_arguments, CommandHandler * handler)
 {
+    Commands::EnableDischarging::DecodableType commandData;
+    ReturnErrorOnFailure(DataModel::Decode(input_arguments, commandData));
 
     auto & dischargingEnabledUntil = commandData.dischargingEnabledUntil;
     auto & maximumDischargeCurrent = commandData.maximumDischargeCurrent;
 
-    if (maximumDischargeCurrent < kMinimumChargeCurrentLimit)
-    {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
-        return;
-    }
+    VerifyOrReturnValue(maximumDischargeCurrent >= kMinimumChargeCurrentLimit, Status::ConstraintError);
 
-    // Call the delegate
-    Status status = mDelegate.EnableDischarging(dischargingEnabledUntil, maximumDischargeCurrent);
-
-    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
+    return mDelegate.EnableDischarging(dischargingEnabledUntil, maximumDischargeCurrent);
 }
-void Instance::HandleStartDiagnostics(HandlerContext & ctx, const Commands::StartDiagnostics::DecodableType & commandData)
+
+DataModel::ActionReturnStatus EnergyEvseCluster::HandleStartDiagnostics(const DataModel::InvokeRequest & request,
+                                                                        TLV::TLVReader & input_arguments, CommandHandler * handler)
 {
-    // No parameters for this command
-    // Call the delegate
-    Status status = mDelegate.StartDiagnostics();
-
-    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
+    return mDelegate.StartDiagnostics();
 }
 
-void Instance::HandleSetTargets(HandlerContext & ctx, const Commands::SetTargets::DecodableType & commandData)
-{
-    // Call the delegate
-    auto & chargingTargetSchedules = commandData.chargingTargetSchedules;
-
-    Status status = ValidateTargets(chargingTargetSchedules);
-    if (status != Status::Success)
-    {
-        ChipLogError(AppServer, "SetTargets contained invalid data - Rejecting");
-    }
-    else
-    {
-        status = mDelegate.SetTargets(chargingTargetSchedules);
-    }
-
-    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
-}
-
-Status Instance::ValidateTargets(
+Status EnergyEvseCluster::ValidateTargets(
     const DataModel::DecodableList<Structs::ChargingTargetScheduleStruct::DecodableType> & chargingTargetSchedules)
 {
-    /* A) check that the targets are valid
-     *  1) each target must be within valid range (TargetTimeMinutesPastMidnight < 1440)
-     *  2) each target must be within valid range (TargetSoC percent 0 - 100)
-     *      If SOC feature not supported then this MUST be 100 or not present
-     *  3) each target must be within valid range (AddedEnergy >= 0)
-     * B) Day of Week is only allowed to be included once
-     */
-
     uint8_t dayOfWeekBitmap = 0;
 
     auto iter = chargingTargetSchedules.begin();
     while (iter.Next())
     {
         auto & entry    = iter.GetValue();
-        uint8_t bitmask = entry.dayOfWeekForSequence.GetField(static_cast<TargetDayOfWeekBitmap>(0x7F));
+        uint8_t bitmask = entry.dayOfWeekForSequence.GetField(static_cast<TargetDayOfWeekBitmap>(kDayOfWeekBitmapMask));
         ChipLogProgress(AppServer, "DayOfWeekForSequence = 0x%02x", bitmask);
 
-        if ((dayOfWeekBitmap & bitmask) != 0)
-        {
-            // A bit has already been set - Return ConstraintError
-            ChipLogError(AppServer, "DayOfWeekForSequence has a bit set which has already been set in another entry.");
-            return Status::ConstraintError;
-        }
-        dayOfWeekBitmap |= bitmask; // add this day Of week to the previously seen days
+        VerifyOrReturnValue((dayOfWeekBitmap & bitmask) == 0, Status::ConstraintError,
+                            ChipLogError(AppServer, "DayOfWeekForSequence bit already set"));
+        dayOfWeekBitmap |= bitmask;
 
         auto iterInner   = entry.chargingTargets.begin();
         uint8_t innerIdx = 0;
@@ -404,100 +284,75 @@ Status Instance::ValidateTargets(
             ChipLogProgress(AppServer, "[%d] MinutesPastMidnight : %d", innerIdx,
                             static_cast<short unsigned int>(minutesPastMidnight));
 
-            if (minutesPastMidnight > 1439)
+            VerifyOrReturnValue(minutesPastMidnight <= kMaxMinutesPastMidnight, Status::ConstraintError,
+                                ChipLogError(AppServer, "MinutesPastMidnight invalid: %d", static_cast<int>(minutesPastMidnight)));
+
+            if (mFeatureFlags.Has(Feature::kSoCReporting))
             {
-                ChipLogError(AppServer, "MinutesPastMidnight has invalid value (%d)", static_cast<int>(minutesPastMidnight));
-                return Status::ConstraintError;
+                VerifyOrReturnValue(targetStruct.targetSoC.HasValue(), Status::InvalidCommand,
+                                    ChipLogError(AppServer, "SoCReporting enabled but TargetSoC missing"));
+                VerifyOrReturnValue(
+                    targetStruct.targetSoC.Value() <= kMaxTargetSoCPercent, Status::ConstraintError,
+                    ChipLogError(AppServer, "TargetSoC invalid: %d", static_cast<int>(targetStruct.targetSoC.Value())));
+            }
+            else
+            {
+                VerifyOrReturnValue(!targetStruct.targetSoC.HasValue() || targetStruct.targetSoC.Value() == kMaxTargetSoCPercent,
+                                    Status::ConstraintError,
+                                    ChipLogError(AppServer, "TargetSoC must be 100 if SOC feature not supported"));
             }
 
-            // If SocReporting is supported, targetSoc must have a value in the range [0, 100]
-            if (HasFeature(Feature::kSoCReporting))
-            {
-                if (!targetStruct.targetSoC.HasValue())
-                {
-                    ChipLogError(AppServer, "kSoCReporting is supported but TargetSoC does not have a value");
-                    return Status::InvalidCommand;
-                }
+            VerifyOrReturnValue(targetStruct.targetSoC.HasValue() || targetStruct.addedEnergy.HasValue(), Status::Failure,
+                                ChipLogError(AppServer, "Must have one of AddedEnergy or TargetSoC"));
 
-                if (targetStruct.targetSoC.Value() > 100)
-                {
-                    ChipLogError(AppServer, "TargetSoC has invalid value (%d)", static_cast<int>(targetStruct.targetSoC.Value()));
-                    return Status::ConstraintError;
-                }
-            }
-            else if (targetStruct.targetSoC.HasValue() && targetStruct.targetSoC.Value() != 100)
-            {
-                // If SocReporting is not supported but targetSoc has a value, it must be 100
-                ChipLogError(AppServer, "TargetSoC has can only be 100%% if SOC feature is not supported");
-                return Status::ConstraintError;
-            }
-
-            // One or both of targetSoc and addedEnergy must be specified
-            if (!(targetStruct.targetSoC.HasValue()) && !(targetStruct.addedEnergy.HasValue()))
-            {
-                ChipLogError(AppServer, "Must have one of AddedEnergy or TargetSoC");
-                return Status::Failure;
-            }
-
-            // Validate the value of addedEnergy, if specified is >= 0
-            if (targetStruct.addedEnergy.HasValue() && targetStruct.addedEnergy.Value() < 0)
-            {
-                ChipLogError(AppServer, "AddedEnergy has invalid value (%ld)",
-                             static_cast<signed long int>(targetStruct.addedEnergy.Value()));
-                return Status::ConstraintError;
-            }
+            VerifyOrReturnValue(
+                !targetStruct.addedEnergy.HasValue() || targetStruct.addedEnergy.Value() >= 0, Status::ConstraintError,
+                ChipLogError(AppServer, "AddedEnergy invalid: %ld", static_cast<long>(targetStruct.addedEnergy.Value())));
             innerIdx++;
         }
 
-        if (innerIdx > kEvseTargetsMaxTargetsPerDay)
-        {
-            ChipLogError(AppServer, "Too many targets in a single ChargingTargetScheduleStruct (%d)", innerIdx);
-            return Status::ResourceExhausted;
-        }
-
-        if (iterInner.GetStatus() != CHIP_NO_ERROR)
-        {
-            return Status::InvalidCommand;
-        }
+        VerifyOrReturnValue(innerIdx <= kEvseTargetsMaxTargetsPerDay, Status::ResourceExhausted,
+                            ChipLogError(AppServer, "Too many targets: %d", innerIdx));
+        VerifyOrReturnValue(iterInner.GetStatus() == CHIP_NO_ERROR, Status::InvalidCommand);
     }
 
-    if (iter.GetStatus() != CHIP_NO_ERROR)
-    {
-        return Status::InvalidCommand;
-    }
+    VerifyOrReturnValue(iter.GetStatus() == CHIP_NO_ERROR, Status::InvalidCommand);
 
     return Status::Success;
 }
 
-void Instance::HandleGetTargets(HandlerContext & ctx, const Commands::GetTargets::DecodableType & commandData)
+DataModel::ActionReturnStatus EnergyEvseCluster::HandleSetTargets(const DataModel::InvokeRequest & request,
+                                                                  TLV::TLVReader & input_arguments, CommandHandler * handler)
 {
-    Commands::GetTargetsResponse::Type response;
+    Commands::SetTargets::DecodableType commandData;
+    ReturnErrorOnFailure(DataModel::Decode(input_arguments, commandData));
 
-    Status status = mDelegate.GetTargets(response.chargingTargetSchedules);
-    if (status != Status::Success)
-    {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
-        return;
-    }
+    auto & chargingTargetSchedules = commandData.chargingTargetSchedules;
 
-    ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
+    Status status = ValidateTargets(chargingTargetSchedules);
+    VerifyOrReturnValue(status == Status::Success, status, ChipLogError(AppServer, "SetTargets validation failed"));
+
+    return mDelegate.SetTargets(chargingTargetSchedules);
 }
 
-void Instance::HandleClearTargets(HandlerContext & ctx, const Commands::ClearTargets::DecodableType & commandData)
+DataModel::ActionReturnStatus EnergyEvseCluster::HandleGetTargets(const DataModel::InvokeRequest & request,
+                                                                  TLV::TLVReader & input_arguments, CommandHandler * handler)
 {
-    // Call the delegate
-    Status status = mDelegate.ClearTargets();
+    Commands::GetTargetsResponse::Type response;
+    Status status = mDelegate.GetTargets(response.chargingTargetSchedules);
+    VerifyOrReturnValue(status == Status::Success, status);
 
-    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
+    handler->AddResponse(request.path, response);
+    return Status::Success;
+}
+
+DataModel::ActionReturnStatus EnergyEvseCluster::HandleClearTargets(const DataModel::InvokeRequest & request,
+                                                                    TLV::TLVReader & input_arguments, CommandHandler * handler)
+{
+    return mDelegate.ClearTargets();
 }
 
 } // namespace EnergyEvse
 } // namespace Clusters
 } // namespace app
 } // namespace chip
-
-// -----------------------------------------------------------------------------
-// Plugin initialization
-
-void MatterEnergyEvsePluginServerInitCallback() {}
-void MatterEnergyEvsePluginServerShutdownCallback() {}

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
@@ -47,6 +47,7 @@ CHIP_ERROR EnergyEvseCluster::Startup(ServerClusterContext & context)
 CHIP_ERROR EnergyEvseCluster::SetState(StateEnum newValue)
 {
     VerifyOrReturnError(mState != newValue, CHIP_NO_ERROR);
+    VerifyOrReturnError(newValue < StateEnum::kUnknownEnumValue, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mState = newValue;
     mDelegate.OnStateChanged(newValue);
     NotifyAttributeChanged(State::Id);
@@ -56,6 +57,7 @@ CHIP_ERROR EnergyEvseCluster::SetState(StateEnum newValue)
 CHIP_ERROR EnergyEvseCluster::SetSupplyState(SupplyStateEnum newValue)
 {
     VerifyOrReturnError(mSupplyState != newValue, CHIP_NO_ERROR);
+    VerifyOrReturnError(newValue < SupplyStateEnum::kUnknownEnumValue, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mSupplyState = newValue;
     mDelegate.OnSupplyStateChanged(newValue);
     NotifyAttributeChanged(SupplyState::Id);
@@ -65,6 +67,7 @@ CHIP_ERROR EnergyEvseCluster::SetSupplyState(SupplyStateEnum newValue)
 CHIP_ERROR EnergyEvseCluster::SetFaultState(FaultStateEnum newValue)
 {
     VerifyOrReturnError(mFaultState != newValue, CHIP_NO_ERROR);
+    VerifyOrReturnError(newValue < FaultStateEnum::kUnknownEnumValue, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mFaultState = newValue;
     mDelegate.OnFaultStateChanged(newValue);
     NotifyAttributeChanged(FaultState::Id);
@@ -92,6 +95,7 @@ CHIP_ERROR EnergyEvseCluster::SetDischargingEnabledUntil(DataModel::Nullable<uin
 CHIP_ERROR EnergyEvseCluster::SetCircuitCapacity(int64_t newValue)
 {
     VerifyOrReturnError(mCircuitCapacity != newValue, CHIP_NO_ERROR);
+    VerifyOrReturnError(mCircuitCapacity >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mCircuitCapacity = newValue;
     mDelegate.OnCircuitCapacityChanged(newValue);
     NotifyAttributeChanged(CircuitCapacity::Id);
@@ -101,6 +105,7 @@ CHIP_ERROR EnergyEvseCluster::SetCircuitCapacity(int64_t newValue)
 CHIP_ERROR EnergyEvseCluster::SetMinimumChargeCurrent(int64_t newValue)
 {
     VerifyOrReturnError(mMinimumChargeCurrent != newValue, CHIP_NO_ERROR);
+    VerifyOrReturnError(mMinimumChargeCurrent >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mMinimumChargeCurrent = newValue;
     mDelegate.OnMinimumChargeCurrentChanged(newValue);
     NotifyAttributeChanged(MinimumChargeCurrent::Id);
@@ -110,6 +115,7 @@ CHIP_ERROR EnergyEvseCluster::SetMinimumChargeCurrent(int64_t newValue)
 CHIP_ERROR EnergyEvseCluster::SetMaximumChargeCurrent(int64_t newValue)
 {
     VerifyOrReturnError(mMaximumChargeCurrent != newValue, CHIP_NO_ERROR);
+    VerifyOrReturnError(mMaximumChargeCurrent >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mMaximumChargeCurrent = newValue;
     mDelegate.OnMaximumChargeCurrentChanged(newValue);
     NotifyAttributeChanged(MaximumChargeCurrent::Id);
@@ -119,6 +125,7 @@ CHIP_ERROR EnergyEvseCluster::SetMaximumChargeCurrent(int64_t newValue)
 CHIP_ERROR EnergyEvseCluster::SetMaximumDischargeCurrent(int64_t newValue)
 {
     VerifyOrReturnError(mMaximumDischargeCurrent != newValue, CHIP_NO_ERROR);
+    VerifyOrReturnError(mMaximumDischargeCurrent >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mMaximumDischargeCurrent = newValue;
     mDelegate.OnMaximumDischargeCurrentChanged(newValue);
     NotifyAttributeChanged(MaximumDischargeCurrent::Id);
@@ -128,6 +135,7 @@ CHIP_ERROR EnergyEvseCluster::SetMaximumDischargeCurrent(int64_t newValue)
 CHIP_ERROR EnergyEvseCluster::SetUserMaximumChargeCurrent(int64_t newValue)
 {
     VerifyOrReturnError(mUserMaximumChargeCurrent != newValue, CHIP_NO_ERROR);
+    VerifyOrReturnError(mUserMaximumChargeCurrent >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mUserMaximumChargeCurrent = newValue;
     mDelegate.OnUserMaximumChargeCurrentChanged(newValue);
     NotifyAttributeChanged(UserMaximumChargeCurrent::Id);
@@ -137,6 +145,7 @@ CHIP_ERROR EnergyEvseCluster::SetUserMaximumChargeCurrent(int64_t newValue)
 CHIP_ERROR EnergyEvseCluster::SetRandomizationDelayWindow(uint32_t newValue)
 {
     VerifyOrReturnError(mRandomizationDelayWindow != newValue, CHIP_NO_ERROR);
+    VerifyOrReturnError(mRandomizationDelayWindow <= kMaxRandomizationDelayWindowSec, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mRandomizationDelayWindow = newValue;
     mDelegate.OnRandomizationDelayWindowChanged(newValue);
     NotifyAttributeChanged(RandomizationDelayWindow::Id);

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
@@ -95,7 +95,7 @@ CHIP_ERROR EnergyEvseCluster::SetDischargingEnabledUntil(DataModel::Nullable<uin
 CHIP_ERROR EnergyEvseCluster::SetCircuitCapacity(int64_t newValue)
 {
     VerifyOrReturnError(mCircuitCapacity != newValue, CHIP_NO_ERROR);
-    VerifyOrReturnError(mCircuitCapacity >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    VerifyOrReturnError(newValue >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mCircuitCapacity = newValue;
     mDelegate.OnCircuitCapacityChanged(newValue);
     NotifyAttributeChanged(CircuitCapacity::Id);
@@ -135,7 +135,7 @@ CHIP_ERROR EnergyEvseCluster::SetMaximumDischargeCurrent(int64_t newValue)
 CHIP_ERROR EnergyEvseCluster::SetUserMaximumChargeCurrent(int64_t newValue)
 {
     VerifyOrReturnError(mUserMaximumChargeCurrent != newValue, CHIP_NO_ERROR);
-    VerifyOrReturnError(mUserMaximumChargeCurrent >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    VerifyOrReturnError(newValue >= 0, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mUserMaximumChargeCurrent = newValue;
     mDelegate.OnUserMaximumChargeCurrentChanged(newValue);
     NotifyAttributeChanged(UserMaximumChargeCurrent::Id);
@@ -145,7 +145,7 @@ CHIP_ERROR EnergyEvseCluster::SetUserMaximumChargeCurrent(int64_t newValue)
 CHIP_ERROR EnergyEvseCluster::SetRandomizationDelayWindow(uint32_t newValue)
 {
     VerifyOrReturnError(mRandomizationDelayWindow != newValue, CHIP_NO_ERROR);
-    VerifyOrReturnError(mRandomizationDelayWindow <= kMaxRandomizationDelayWindowSec, CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    VerifyOrReturnError(newValue <= kMaxRandomizationDelayWindowSec, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     mRandomizationDelayWindow = newValue;
     mDelegate.OnRandomizationDelayWindowChanged(newValue);
     NotifyAttributeChanged(RandomizationDelayWindow::Id);

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
@@ -260,7 +260,8 @@ CHIP_ERROR EnergyEvseCluster::SetSessionID(DataModel::Nullable<uint32_t> newValu
 
 CHIP_ERROR EnergyEvseCluster::SetSessionDuration(DataModel::Nullable<uint32_t> newValue)
 {
-    VerifyOrReturnError(mSessionDuration != newValue, CHIP_NO_ERROR);
+    // We do not check for equality here because the tests expect reports at session boundaries (start/stop) even when the value has
+    // not changed (e.g. energy stayed at 0 because no charging occurred).
     mSessionDuration = newValue;
     mDelegate.OnSessionDurationChanged(newValue);
     NotifyAttributeChanged(SessionDuration::Id);
@@ -269,7 +270,8 @@ CHIP_ERROR EnergyEvseCluster::SetSessionDuration(DataModel::Nullable<uint32_t> n
 
 CHIP_ERROR EnergyEvseCluster::SetSessionEnergyCharged(DataModel::Nullable<int64_t> newValue)
 {
-    VerifyOrReturnError(mSessionEnergyCharged != newValue, CHIP_NO_ERROR);
+    // We do not check for equality here because the tests expect reports at session boundaries (start/stop) even when the value has
+    // not changed (e.g. energy stayed at 0 because no charging occurred).
     mSessionEnergyCharged = newValue;
     mDelegate.OnSessionEnergyChargedChanged(newValue);
     NotifyAttributeChanged(SessionEnergyCharged::Id);
@@ -278,7 +280,8 @@ CHIP_ERROR EnergyEvseCluster::SetSessionEnergyCharged(DataModel::Nullable<int64_
 
 CHIP_ERROR EnergyEvseCluster::SetSessionEnergyDischarged(DataModel::Nullable<int64_t> newValue)
 {
-    VerifyOrReturnError(mSessionEnergyDischarged != newValue, CHIP_NO_ERROR);
+    // We do not check for equality here because the tests expect reports at session boundaries (start/stop) even when the value has
+    // not changed (e.g. energy stayed at 0 because no charging occurred).
     mSessionEnergyDischarged = newValue;
     mDelegate.OnSessionEnergyDischargedChanged(newValue);
     NotifyAttributeChanged(SessionEnergyDischarged::Id);

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
@@ -579,15 +579,16 @@ DataModel::ActionReturnStatus EnergyEvseCluster::HandleSetTargets(const DataMode
     return mDelegate.SetTargets(chargingTargetSchedules);
 }
 
-DataModel::ActionReturnStatus EnergyEvseCluster::HandleGetTargets(const DataModel::InvokeRequest & request,
-                                                                  TLV::TLVReader & input_arguments, CommandHandler * handler)
+std::optional<DataModel::ActionReturnStatus> EnergyEvseCluster::HandleGetTargets(const DataModel::InvokeRequest & request,
+                                                                                 TLV::TLVReader & input_arguments,
+                                                                                 CommandHandler * handler)
 {
     Commands::GetTargetsResponse::Type response;
     Status status = mDelegate.GetTargets(response.chargingTargetSchedules);
     VerifyOrReturnValue(status == Status::Success, status);
 
     handler->AddResponse(request.path, response);
-    return Status::Success;
+    return std::nullopt;
 }
 
 DataModel::ActionReturnStatus EnergyEvseCluster::HandleClearTargets(const DataModel::InvokeRequest & request,

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -63,8 +63,8 @@ public:
 
         Config(EndpointId aEndpointId, EnergyEvse::Delegate & aDelegate, BitMask<EnergyEvse::Feature> aFeature,
                BitMask<EnergyEvse::OptionalAttributes> aOptionalAttrs, BitMask<EnergyEvse::OptionalCommands> aOptionalCmds) :
-            endpointId(aEndpointId), delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds),
-            optionalAttrs(aOptionalAttrs)
+            endpointId(aEndpointId),
+            delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds), optionalAttrs(aOptionalAttrs)
         {}
     };
     // We don't want to allow the default constructor as this cluster requires a delegate to be set

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -81,6 +81,76 @@ public:
     const BitMask<EnergyEvse::OptionalAttributes> & OptionalAttrs() const { return mOptionalAttrs; }
     const BitMask<EnergyEvse::OptionalCommands> & OptionalCmds() const { return mOptionalCmds; }
 
+    // Attribute getters and setters - cluster owns the data
+    StateEnum GetState() const { return mState; }
+    CHIP_ERROR SetState(StateEnum newValue);
+
+    SupplyStateEnum GetSupplyState() const { return mSupplyState; }
+    CHIP_ERROR SetSupplyState(SupplyStateEnum newValue);
+
+    FaultStateEnum GetFaultState() const { return mFaultState; }
+    CHIP_ERROR SetFaultState(FaultStateEnum newValue);
+
+    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() const { return mChargingEnabledUntil; }
+    CHIP_ERROR SetChargingEnabledUntil(DataModel::Nullable<uint32_t> newValue);
+
+    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() const { return mDischargingEnabledUntil; }
+    CHIP_ERROR SetDischargingEnabledUntil(DataModel::Nullable<uint32_t> newValue);
+
+    int64_t GetCircuitCapacity() const { return mCircuitCapacity; }
+    CHIP_ERROR SetCircuitCapacity(int64_t newValue);
+
+    int64_t GetMinimumChargeCurrent() const { return mMinimumChargeCurrent; }
+    CHIP_ERROR SetMinimumChargeCurrent(int64_t newValue);
+
+    int64_t GetMaximumChargeCurrent() const { return mMaximumChargeCurrent; }
+    CHIP_ERROR SetMaximumChargeCurrent(int64_t newValue);
+
+    int64_t GetMaximumDischargeCurrent() const { return mMaximumDischargeCurrent; }
+    CHIP_ERROR SetMaximumDischargeCurrent(int64_t newValue);
+
+    int64_t GetUserMaximumChargeCurrent() const { return mUserMaximumChargeCurrent; }
+    CHIP_ERROR SetUserMaximumChargeCurrent(int64_t newValue);
+
+    uint32_t GetRandomizationDelayWindow() const { return mRandomizationDelayWindow; }
+    CHIP_ERROR SetRandomizationDelayWindow(uint32_t newValue);
+
+    DataModel::Nullable<uint32_t> GetNextChargeStartTime() const { return mNextChargeStartTime; }
+    CHIP_ERROR SetNextChargeStartTime(DataModel::Nullable<uint32_t> newValue);
+
+    DataModel::Nullable<uint32_t> GetNextChargeTargetTime() const { return mNextChargeTargetTime; }
+    CHIP_ERROR SetNextChargeTargetTime(DataModel::Nullable<uint32_t> newValue);
+
+    DataModel::Nullable<int64_t> GetNextChargeRequiredEnergy() const { return mNextChargeRequiredEnergy; }
+    CHIP_ERROR SetNextChargeRequiredEnergy(DataModel::Nullable<int64_t> newValue);
+
+    DataModel::Nullable<Percent> GetNextChargeTargetSoC() const { return mNextChargeTargetSoC; }
+    CHIP_ERROR SetNextChargeTargetSoC(DataModel::Nullable<Percent> newValue);
+
+    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() const { return mApproximateEVEfficiency; }
+    CHIP_ERROR SetApproximateEVEfficiency(DataModel::Nullable<uint16_t> newValue);
+
+    DataModel::Nullable<Percent> GetStateOfCharge() const { return mStateOfCharge; }
+    CHIP_ERROR SetStateOfCharge(DataModel::Nullable<Percent> newValue);
+
+    DataModel::Nullable<int64_t> GetBatteryCapacity() const { return mBatteryCapacity; }
+    CHIP_ERROR SetBatteryCapacity(DataModel::Nullable<int64_t> newValue);
+
+    DataModel::Nullable<CharSpan> GetVehicleID() const;
+    CHIP_ERROR SetVehicleID(DataModel::Nullable<CharSpan> newValue);
+
+    DataModel::Nullable<uint32_t> GetSessionID() const { return mSessionID; }
+    CHIP_ERROR SetSessionID(DataModel::Nullable<uint32_t> newValue);
+
+    DataModel::Nullable<uint32_t> GetSessionDuration() const { return mSessionDuration; }
+    CHIP_ERROR SetSessionDuration(DataModel::Nullable<uint32_t> newValue);
+
+    DataModel::Nullable<int64_t> GetSessionEnergyCharged() const { return mSessionEnergyCharged; }
+    CHIP_ERROR SetSessionEnergyCharged(DataModel::Nullable<int64_t> newValue);
+
+    DataModel::Nullable<int64_t> GetSessionEnergyDischarged() const { return mSessionEnergyDischarged; }
+    CHIP_ERROR SetSessionEnergyDischarged(DataModel::Nullable<int64_t> newValue);
+
     CHIP_ERROR Startup(ServerClusterContext & context) override;
 
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
@@ -118,6 +188,32 @@ private:
     const BitMask<EnergyEvse::Feature> mFeatureFlags;
     const BitMask<EnergyEvse::OptionalAttributes> mOptionalAttrs;
     const BitMask<EnergyEvse::OptionalCommands> mOptionalCmds;
+
+    // Attribute storage - cluster owns the data
+    StateEnum mState                                         = StateEnum::kNotPluggedIn;
+    SupplyStateEnum mSupplyState                             = SupplyStateEnum::kDisabled;
+    FaultStateEnum mFaultState                               = FaultStateEnum::kNoError;
+    DataModel::Nullable<uint32_t> mChargingEnabledUntil      = DataModel::NullNullable;
+    DataModel::Nullable<uint32_t> mDischargingEnabledUntil   = DataModel::NullNullable;
+    int64_t mCircuitCapacity                                 = 0;
+    int64_t mMinimumChargeCurrent                            = kMinimumChargeCurrent;
+    int64_t mMaximumChargeCurrent                            = 0;
+    int64_t mMaximumDischargeCurrent                         = 0;
+    int64_t mUserMaximumChargeCurrent                        = 0;
+    uint32_t mRandomizationDelayWindow                       = 600; // Default 600s per spec
+    DataModel::Nullable<uint32_t> mNextChargeStartTime       = DataModel::NullNullable;
+    DataModel::Nullable<uint32_t> mNextChargeTargetTime      = DataModel::NullNullable;
+    DataModel::Nullable<int64_t> mNextChargeRequiredEnergy   = DataModel::NullNullable;
+    DataModel::Nullable<Percent> mNextChargeTargetSoC        = DataModel::NullNullable;
+    DataModel::Nullable<uint16_t> mApproximateEVEfficiency   = DataModel::NullNullable;
+    DataModel::Nullable<Percent> mStateOfCharge              = DataModel::NullNullable;
+    DataModel::Nullable<int64_t> mBatteryCapacity            = DataModel::NullNullable;
+    char mVehicleIDBuffer[kMaxVehicleIDBufSize]              = { 0 };
+    DataModel::Nullable<CharSpan> mVehicleID                 = DataModel::NullNullable;
+    DataModel::Nullable<uint32_t> mSessionID                 = DataModel::NullNullable;
+    DataModel::Nullable<uint32_t> mSessionDuration           = DataModel::NullNullable;
+    DataModel::Nullable<int64_t> mSessionEnergyCharged       = DataModel::NullNullable;
+    DataModel::Nullable<int64_t> mSessionEnergyDischarged    = DataModel::NullNullable;
 };
 
 } // namespace EnergyEvse

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -63,8 +63,8 @@ public:
 
         Config(EndpointId aEndpointId, EnergyEvse::Delegate & aDelegate, BitMask<EnergyEvse::Feature> aFeature,
                BitMask<EnergyEvse::OptionalAttributes> aOptionalAttrs, BitMask<EnergyEvse::OptionalCommands> aOptionalCmds) :
-            endpointId(aEndpointId),
-            delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds), optionalAttrs(aOptionalAttrs)
+            endpointId(aEndpointId), delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds),
+            optionalAttrs(aOptionalAttrs)
         {}
     };
     // We don't want to allow the default constructor as this cluster requires a delegate to be set
@@ -176,8 +176,8 @@ private:
                                                          CommandHandler * handler);
     DataModel::ActionReturnStatus HandleSetTargets(const DataModel::InvokeRequest & request, TLV::TLVReader & input_arguments,
                                                    CommandHandler * handler);
-    DataModel::ActionReturnStatus HandleGetTargets(const DataModel::InvokeRequest & request, TLV::TLVReader & input_arguments,
-                                                   CommandHandler * handler);
+    std::optional<DataModel::ActionReturnStatus> HandleGetTargets(const DataModel::InvokeRequest & request,
+                                                                  TLV::TLVReader & input_arguments, CommandHandler * handler);
     DataModel::ActionReturnStatus HandleClearTargets(const DataModel::InvokeRequest & request, TLV::TLVReader & input_arguments,
                                                      CommandHandler * handler);
 

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -190,30 +190,30 @@ private:
     const BitMask<EnergyEvse::OptionalCommands> mOptionalCmds;
 
     // Attribute storage - cluster owns the data
-    StateEnum mState                                         = StateEnum::kNotPluggedIn;
-    SupplyStateEnum mSupplyState                             = SupplyStateEnum::kDisabled;
-    FaultStateEnum mFaultState                               = FaultStateEnum::kNoError;
-    DataModel::Nullable<uint32_t> mChargingEnabledUntil      = DataModel::NullNullable;
-    DataModel::Nullable<uint32_t> mDischargingEnabledUntil   = DataModel::NullNullable;
-    int64_t mCircuitCapacity                                 = 0;
-    int64_t mMinimumChargeCurrent                            = kMinimumChargeCurrent;
-    int64_t mMaximumChargeCurrent                            = 0;
-    int64_t mMaximumDischargeCurrent                         = 0;
-    int64_t mUserMaximumChargeCurrent                        = 0;
-    uint32_t mRandomizationDelayWindow                       = 600; // Default 600s per spec
-    DataModel::Nullable<uint32_t> mNextChargeStartTime       = DataModel::NullNullable;
-    DataModel::Nullable<uint32_t> mNextChargeTargetTime      = DataModel::NullNullable;
-    DataModel::Nullable<int64_t> mNextChargeRequiredEnergy   = DataModel::NullNullable;
-    DataModel::Nullable<Percent> mNextChargeTargetSoC        = DataModel::NullNullable;
-    DataModel::Nullable<uint16_t> mApproximateEVEfficiency   = DataModel::NullNullable;
-    DataModel::Nullable<Percent> mStateOfCharge              = DataModel::NullNullable;
-    DataModel::Nullable<int64_t> mBatteryCapacity            = DataModel::NullNullable;
-    char mVehicleIDBuffer[kMaxVehicleIDBufSize]              = { 0 };
-    DataModel::Nullable<CharSpan> mVehicleID                 = DataModel::NullNullable;
-    DataModel::Nullable<uint32_t> mSessionID                 = DataModel::NullNullable;
-    DataModel::Nullable<uint32_t> mSessionDuration           = DataModel::NullNullable;
-    DataModel::Nullable<int64_t> mSessionEnergyCharged       = DataModel::NullNullable;
-    DataModel::Nullable<int64_t> mSessionEnergyDischarged    = DataModel::NullNullable;
+    StateEnum mState                                       = StateEnum::kNotPluggedIn;
+    SupplyStateEnum mSupplyState                           = SupplyStateEnum::kDisabled;
+    FaultStateEnum mFaultState                             = FaultStateEnum::kNoError;
+    DataModel::Nullable<uint32_t> mChargingEnabledUntil    = DataModel::NullNullable;
+    DataModel::Nullable<uint32_t> mDischargingEnabledUntil = DataModel::NullNullable;
+    int64_t mCircuitCapacity                               = 0;
+    int64_t mMinimumChargeCurrent                          = kMinimumChargeCurrent;
+    int64_t mMaximumChargeCurrent                          = 0;
+    int64_t mMaximumDischargeCurrent                       = 0;
+    int64_t mUserMaximumChargeCurrent                      = 0;
+    uint32_t mRandomizationDelayWindow                     = 600; // Default 600s per spec
+    DataModel::Nullable<uint32_t> mNextChargeStartTime     = DataModel::NullNullable;
+    DataModel::Nullable<uint32_t> mNextChargeTargetTime    = DataModel::NullNullable;
+    DataModel::Nullable<int64_t> mNextChargeRequiredEnergy = DataModel::NullNullable;
+    DataModel::Nullable<Percent> mNextChargeTargetSoC      = DataModel::NullNullable;
+    DataModel::Nullable<uint16_t> mApproximateEVEfficiency = DataModel::NullNullable;
+    DataModel::Nullable<Percent> mStateOfCharge            = DataModel::NullNullable;
+    DataModel::Nullable<int64_t> mBatteryCapacity          = DataModel::NullNullable;
+    char mVehicleIDBuffer[kMaxVehicleIDBufSize]            = { 0 };
+    DataModel::Nullable<CharSpan> mVehicleID               = DataModel::NullNullable;
+    DataModel::Nullable<uint32_t> mSessionID               = DataModel::NullNullable;
+    DataModel::Nullable<uint32_t> mSessionDuration         = DataModel::NullNullable;
+    DataModel::Nullable<int64_t> mSessionEnergyCharged     = DataModel::NullNullable;
+    DataModel::Nullable<int64_t> mSessionEnergyDischarged  = DataModel::NullNullable;
 };
 
 } // namespace EnergyEvse

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -78,8 +78,8 @@ public:
     }
 
     const BitFlags<EnergyEvse::Feature> & Features() const { return mFeatureFlags; }
-    const BitMask<EnergyEvse::OptionalAttributes> & OptionalAttrs() const { return mOptionalAttrs; }
-    const BitMask<EnergyEvse::OptionalCommands> & OptionalCmds() const { return mOptionalCmds; }
+    const BitFlags<EnergyEvse::OptionalAttributes> & OptionalAttrs() const { return mOptionalAttrs; }
+    const BitFlags<EnergyEvse::OptionalCommands> & OptionalCmds() const { return mOptionalCmds; }
 
     // Attribute getters and setters - cluster owns the data
     StateEnum GetState() const { return mState; }
@@ -185,9 +185,9 @@ private:
     ValidateTargets(const DataModel::DecodableList<Structs::ChargingTargetScheduleStruct::DecodableType> & chargingTargetSchedules);
 
     EnergyEvse::Delegate & mDelegate;
-    const BitMask<EnergyEvse::Feature> mFeatureFlags;
-    const BitMask<EnergyEvse::OptionalAttributes> mOptionalAttrs;
-    const BitMask<EnergyEvse::OptionalCommands> mOptionalCmds;
+    const BitFlags<EnergyEvse::Feature> mFeatureFlags;
+    const BitFlags<EnergyEvse::OptionalAttributes> mOptionalAttrs;
+    const BitFlags<EnergyEvse::OptionalCommands> mOptionalCmds;
 
     // Attribute storage
     StateEnum mState                                       = StateEnum::kNotPluggedIn;

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -63,8 +63,8 @@ public:
 
         Config(EndpointId aEndpointId, EnergyEvse::Delegate & aDelegate, BitMask<EnergyEvse::Feature> aFeature,
                BitMask<EnergyEvse::OptionalAttributes> aOptionalAttrs, BitMask<EnergyEvse::OptionalCommands> aOptionalCmds) :
-            endpointId(aEndpointId), delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds),
-            optionalAttrs(aOptionalAttrs)
+            endpointId(aEndpointId),
+            delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds), optionalAttrs(aOptionalAttrs)
         {}
     };
     // We don't want to allow the default constructor as this cluster requires a delegate to be set
@@ -193,14 +193,14 @@ private:
     StateEnum mState                                       = StateEnum::kNotPluggedIn;
     SupplyStateEnum mSupplyState                           = SupplyStateEnum::kDisabled;
     FaultStateEnum mFaultState                             = FaultStateEnum::kNoError;
-    DataModel::Nullable<uint32_t> mChargingEnabledUntil    = DataModel::NullNullable;    // TODO Default to 0 to indicate disabled
-    DataModel::Nullable<uint32_t> mDischargingEnabledUntil = DataModel::NullNullable;    // TODO Default to 0 to indicate disabled
+    DataModel::Nullable<uint32_t> mChargingEnabledUntil    = DataModel::NullNullable; // TODO Default to 0 to indicate disabled
+    DataModel::Nullable<uint32_t> mDischargingEnabledUntil = DataModel::NullNullable; // TODO Default to 0 to indicate disabled
     int64_t mCircuitCapacity                               = 0;
     int64_t mMinimumChargeCurrent                          = kMinimumChargeCurrent;
     int64_t mMaximumChargeCurrent                          = 0;
     int64_t mMaximumDischargeCurrent                       = 0;
-    int64_t mUserMaximumChargeCurrent                      = 0;                           // TODO update spec
-    uint32_t mRandomizationDelayWindow                     = 600;                         // Default 600s per spec
+    int64_t mUserMaximumChargeCurrent                      = 0;   // TODO update spec
+    uint32_t mRandomizationDelayWindow                     = 600; // Default 600s per spec
     // PREF attributes
     DataModel::Nullable<uint32_t> mNextChargeStartTime     = DataModel::NullNullable;
     DataModel::Nullable<uint32_t> mNextChargeTargetTime    = DataModel::NullNullable;
@@ -208,16 +208,16 @@ private:
     DataModel::Nullable<Percent> mNextChargeTargetSoC      = DataModel::NullNullable;
     DataModel::Nullable<uint16_t> mApproximateEVEfficiency = DataModel::NullNullable;
     // SOC attributes
-    DataModel::Nullable<Percent> mStateOfCharge            = DataModel::NullNullable;
-    DataModel::Nullable<int64_t> mBatteryCapacity          = DataModel::NullNullable;
+    DataModel::Nullable<Percent> mStateOfCharge   = DataModel::NullNullable;
+    DataModel::Nullable<int64_t> mBatteryCapacity = DataModel::NullNullable;
     // PNC attributes
-    char mVehicleIDBuffer[kMaxVehicleIDBufSize]            = { 0 };
-    DataModel::Nullable<CharSpan> mVehicleID               = DataModel::NullNullable;
+    char mVehicleIDBuffer[kMaxVehicleIDBufSize] = { 0 };
+    DataModel::Nullable<CharSpan> mVehicleID    = DataModel::NullNullable;
     // Session attributes
-    DataModel::Nullable<uint32_t> mSessionID               = DataModel::NullNullable;
-    DataModel::Nullable<uint32_t> mSessionDuration         = DataModel::NullNullable;
-    DataModel::Nullable<int64_t> mSessionEnergyCharged     = DataModel::NullNullable;
-    DataModel::Nullable<int64_t> mSessionEnergyDischarged  = DataModel::NullNullable;
+    DataModel::Nullable<uint32_t> mSessionID              = DataModel::NullNullable;
+    DataModel::Nullable<uint32_t> mSessionDuration        = DataModel::NullNullable;
+    DataModel::Nullable<int64_t> mSessionEnergyCharged    = DataModel::NullNullable;
+    DataModel::Nullable<int64_t> mSessionEnergyDischarged = DataModel::NullNullable;
 };
 
 } // namespace EnergyEvse

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -44,21 +44,6 @@ enum class OptionalAttributes : uint32_t
     kSupportsApproximateEvEfficiency    = 0x4
 };
 
-enum class FeatureAttributes : uint32_t
-{
-    kDischargingEnabledUntil  = 0x1,   // V2x feature
-    kMaximumDischargeCurrent  = 0x2,   // V2x feature
-    kNextChargeStartTime      = 0x4,   // ChargingPreferences feature
-    kNextChargeTargetTime     = 0x8,   // ChargingPreferences feature
-    kNextChargeRequiredEnergy = 0x10,  // ChargingPreferences feature
-    kNextChargeTargetSoC      = 0x20,  // ChargingPreferences feature
-    kApproximateEvEfficiency  = 0x40,  // ChargingPreferences feature & kSupportsApproximateEvEfficiency
-    kStateOfCharge            = 0x80,  // SoCReporting feature
-    kBatteryCapacity          = 0x100, // SoCReporting feature
-    kVehicleID                = 0x200, // PlugAndCharge feature
-    kSessionEnergyDischarged  = 0x400  // V2x feature
-};
-
 enum class OptionalCommands : uint32_t
 {
     kSupportsStartDiagnostics = 0x1
@@ -78,8 +63,8 @@ public:
 
         Config(EndpointId aEndpointId, EnergyEvse::Delegate & aDelegate, BitMask<EnergyEvse::Feature> aFeature,
                BitMask<EnergyEvse::OptionalAttributes> aOptionalAttrs, BitMask<EnergyEvse::OptionalCommands> aOptionalCmds) :
-            endpointId(aEndpointId),
-            delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds), optionalAttrs(aOptionalAttrs)
+            endpointId(aEndpointId), delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds),
+            optionalAttrs(aOptionalAttrs)
         {}
     };
     // We don't want to allow the default constructor as this cluster requires a delegate to be set

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -63,8 +63,8 @@ public:
 
         Config(EndpointId aEndpointId, EnergyEvse::Delegate & aDelegate, BitMask<EnergyEvse::Feature> aFeature,
                BitMask<EnergyEvse::OptionalAttributes> aOptionalAttrs, BitMask<EnergyEvse::OptionalCommands> aOptionalCmds) :
-            endpointId(aEndpointId),
-            delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds), optionalAttrs(aOptionalAttrs)
+            endpointId(aEndpointId), delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds),
+            optionalAttrs(aOptionalAttrs)
         {}
     };
     // We don't want to allow the default constructor as this cluster requires a delegate to be set
@@ -199,7 +199,7 @@ private:
     int64_t mMinimumChargeCurrent                          = kMinimumChargeCurrent;
     int64_t mMaximumChargeCurrent                          = 0;
     int64_t mMaximumDischargeCurrent                       = 0;
-    int64_t mUserMaximumChargeCurrent                      = 0;   // TODO update spec
+    int64_t mUserMaximumChargeCurrent                      = 0;
     uint32_t mRandomizationDelayWindow                     = 600; // Default 600s per spec
     // PREF attributes
     DataModel::Nullable<uint32_t> mNextChargeStartTime     = DataModel::NullNullable;

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -18,13 +18,17 @@
 
 #pragma once
 
-#include <app-common/zap-generated/cluster-objects.h>
-#include <app/AttributeAccessInterface.h>
-#include <app/CommandHandlerInterface.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/MessageDef/StatusIB.h>
 #include <app/clusters/energy-evse-server/Constants.h>
 #include <app/clusters/energy-evse-server/EnergyEvseDelegate.h>
+#include <app/server-cluster/DefaultServerCluster.h>
+#include <app/server-cluster/OptionalAttributeSet.h>
+#include <clusters/EnergyEvse/Attributes.h>
+#include <clusters/EnergyEvse/Commands.h>
+#include <clusters/EnergyEvse/Enums.h>
+#include <clusters/EnergyEvse/Events.h>
+#include <clusters/EnergyEvse/Structs.h>
 #include <lib/core/CHIPError.h>
 #include <protocols/interaction_model/StatusCode.h>
 
@@ -40,63 +44,95 @@ enum class OptionalAttributes : uint32_t
     kSupportsApproximateEvEfficiency    = 0x4
 };
 
+enum class FeatureAttributes : uint32_t
+{
+    kDischargingEnabledUntil  = 0x1,   // V2x feature
+    kMaximumDischargeCurrent  = 0x2,   // V2x feature
+    kNextChargeStartTime      = 0x4,   // ChargingPreferences feature
+    kNextChargeTargetTime     = 0x8,   // ChargingPreferences feature
+    kNextChargeRequiredEnergy = 0x10,  // ChargingPreferences feature
+    kNextChargeTargetSoC      = 0x20,  // ChargingPreferences feature
+    kApproximateEvEfficiency  = 0x40,  // ChargingPreferences feature & kSupportsApproximateEvEfficiency
+    kStateOfCharge            = 0x80,  // SoCReporting feature
+    kBatteryCapacity          = 0x100, // SoCReporting feature
+    kVehicleID                = 0x200, // PlugAndCharge feature
+    kSessionEnergyDischarged  = 0x400  // V2x feature
+};
+
 enum class OptionalCommands : uint32_t
 {
     kSupportsStartDiagnostics = 0x1
 };
 
-class Instance : public AttributeAccessInterface, public CommandHandlerInterface
+class EnergyEvseCluster : public DefaultServerCluster
 {
+
 public:
-    Instance(EndpointId aEndpointId, Delegate & aDelegate, Feature aFeature, OptionalAttributes aOptionalAttrs,
-             OptionalCommands aOptionalCmds) :
-        AttributeAccessInterface(MakeOptional(aEndpointId), Id),
-        CommandHandlerInterface(MakeOptional(aEndpointId), Id), mDelegate(aDelegate), mFeature(aFeature),
-        mOptionalAttrs(aOptionalAttrs), mOptionalCmds(aOptionalCmds)
+    struct Config
     {
-        /* set the base class delegates endpointId */
-        mDelegate.SetEndpointId(aEndpointId);
-        mDelegate.SetInstance(this);
-    }
-    ~Instance()
+        EndpointId endpointId;
+        EnergyEvse::Delegate & delegate;
+        BitMask<EnergyEvse::Feature> feature;
+        BitMask<EnergyEvse::OptionalCommands> optionalCmds;
+        BitMask<EnergyEvse::OptionalAttributes> optionalAttrs;
+
+        Config(EndpointId aEndpointId, EnergyEvse::Delegate & aDelegate, BitMask<EnergyEvse::Feature> aFeature,
+               BitMask<EnergyEvse::OptionalAttributes> aOptionalAttrs, BitMask<EnergyEvse::OptionalCommands> aOptionalCmds) :
+            endpointId(aEndpointId),
+            delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds), optionalAttrs(aOptionalAttrs)
+        {}
+    };
+    // We don't want to allow the default constructor as this cluster requires a delegate to be set
+    EnergyEvseCluster() = delete;
+
+    EnergyEvseCluster(const Config & config) :
+        DefaultServerCluster({ config.endpointId, EnergyEvse::Id }), mDelegate(config.delegate), mFeatureFlags(config.feature),
+        mOptionalAttrs(config.optionalAttrs), mOptionalCmds(config.optionalCmds)
     {
-        mDelegate.SetInstance(nullptr);
-        Shutdown();
+        mDelegate.SetEndpointId(config.endpointId);
     }
 
-    CHIP_ERROR Init();
-    void Shutdown();
+    const BitFlags<EnergyEvse::Feature> & Features() const { return mFeatureFlags; }
+    const BitMask<EnergyEvse::OptionalAttributes> & OptionalAttrs() const { return mOptionalAttrs; }
+    const BitMask<EnergyEvse::OptionalCommands> & OptionalCmds() const { return mOptionalCmds; }
 
-    bool HasFeature(Feature aFeature) const;
-    bool SupportsOptAttr(OptionalAttributes aOptionalAttrs) const;
-    bool SupportsOptCmd(OptionalCommands aOptionalCmds) const;
+    CHIP_ERROR Startup(ServerClusterContext & context) override;
+
+    DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
+                                                AttributeValueEncoder & encoder) override;
+    DataModel::ActionReturnStatus WriteAttribute(const DataModel::WriteAttributeRequest & request,
+                                                 AttributeValueDecoder & decoder) override;
+
+    std::optional<DataModel::ActionReturnStatus> InvokeCommand(const DataModel::InvokeRequest & request,
+                                                               TLV::TLVReader & input_arguments, CommandHandler * handler) override;
+    CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
+    CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path,
+                                ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder) override;
+    CHIP_ERROR GeneratedCommands(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<CommandId> & builder) override;
 
 private:
-    Delegate & mDelegate;
-    BitMask<Feature> mFeature;
-    BitMask<OptionalAttributes> mOptionalAttrs;
-    BitMask<OptionalCommands> mOptionalCmds;
+    DataModel::ActionReturnStatus HandleDisable(const DataModel::InvokeRequest & request, TLV::TLVReader & input_arguments,
+                                                CommandHandler * handler);
+    DataModel::ActionReturnStatus HandleEnableCharging(const DataModel::InvokeRequest & request, TLV::TLVReader & input_arguments,
+                                                       CommandHandler * handler);
+    DataModel::ActionReturnStatus HandleEnableDischarging(const DataModel::InvokeRequest & request,
+                                                          TLV::TLVReader & input_arguments, CommandHandler * handler);
+    DataModel::ActionReturnStatus HandleStartDiagnostics(const DataModel::InvokeRequest & request, TLV::TLVReader & input_arguments,
+                                                         CommandHandler * handler);
+    DataModel::ActionReturnStatus HandleSetTargets(const DataModel::InvokeRequest & request, TLV::TLVReader & input_arguments,
+                                                   CommandHandler * handler);
+    DataModel::ActionReturnStatus HandleGetTargets(const DataModel::InvokeRequest & request, TLV::TLVReader & input_arguments,
+                                                   CommandHandler * handler);
+    DataModel::ActionReturnStatus HandleClearTargets(const DataModel::InvokeRequest & request, TLV::TLVReader & input_arguments,
+                                                     CommandHandler * handler);
 
-    // AttributeAccessInterface
-    CHIP_ERROR Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder) override;
-    CHIP_ERROR Write(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder) override;
-
-    // CommandHandlerInterface
-    void InvokeCommand(HandlerContext & handlerContext) override;
-    CHIP_ERROR RetrieveAcceptedCommands(const ConcreteClusterPath & cluster,
-                                        ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder) override;
-
-    void HandleDisable(HandlerContext & ctx, const Commands::Disable::DecodableType & commandData);
-    void HandleEnableCharging(HandlerContext & ctx, const Commands::EnableCharging::DecodableType & commandData);
-    void HandleEnableDischarging(HandlerContext & ctx, const Commands::EnableDischarging::DecodableType & commandData);
-    void HandleStartDiagnostics(HandlerContext & ctx, const Commands::StartDiagnostics::DecodableType & commandData);
-    void HandleSetTargets(HandlerContext & ctx, const Commands::SetTargets::DecodableType & commandData);
-    void HandleGetTargets(HandlerContext & ctx, const Commands::GetTargets::DecodableType & commandData);
-    void HandleClearTargets(HandlerContext & ctx, const Commands::ClearTargets::DecodableType & commandData);
-
-    // Check that the targets are valid
     Protocols::InteractionModel::Status
     ValidateTargets(const DataModel::DecodableList<Structs::ChargingTargetScheduleStruct::DecodableType> & chargingTargetSchedules);
+
+    EnergyEvse::Delegate & mDelegate;
+    const BitMask<EnergyEvse::Feature> mFeatureFlags;
+    const BitMask<EnergyEvse::OptionalAttributes> mOptionalAttrs;
+    const BitMask<EnergyEvse::OptionalCommands> mOptionalCmds;
 };
 
 } // namespace EnergyEvse

--- a/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseCluster.h
@@ -63,8 +63,8 @@ public:
 
         Config(EndpointId aEndpointId, EnergyEvse::Delegate & aDelegate, BitMask<EnergyEvse::Feature> aFeature,
                BitMask<EnergyEvse::OptionalAttributes> aOptionalAttrs, BitMask<EnergyEvse::OptionalCommands> aOptionalCmds) :
-            endpointId(aEndpointId),
-            delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds), optionalAttrs(aOptionalAttrs)
+            endpointId(aEndpointId), delegate(aDelegate), feature(aFeature), optionalCmds(aOptionalCmds),
+            optionalAttrs(aOptionalAttrs)
         {}
     };
     // We don't want to allow the default constructor as this cluster requires a delegate to be set
@@ -189,27 +189,31 @@ private:
     const BitMask<EnergyEvse::OptionalAttributes> mOptionalAttrs;
     const BitMask<EnergyEvse::OptionalCommands> mOptionalCmds;
 
-    // Attribute storage - cluster owns the data
+    // Attribute storage
     StateEnum mState                                       = StateEnum::kNotPluggedIn;
     SupplyStateEnum mSupplyState                           = SupplyStateEnum::kDisabled;
     FaultStateEnum mFaultState                             = FaultStateEnum::kNoError;
-    DataModel::Nullable<uint32_t> mChargingEnabledUntil    = DataModel::NullNullable;
-    DataModel::Nullable<uint32_t> mDischargingEnabledUntil = DataModel::NullNullable;
+    DataModel::Nullable<uint32_t> mChargingEnabledUntil    = DataModel::NullNullable;    // TODO Default to 0 to indicate disabled
+    DataModel::Nullable<uint32_t> mDischargingEnabledUntil = DataModel::NullNullable;    // TODO Default to 0 to indicate disabled
     int64_t mCircuitCapacity                               = 0;
     int64_t mMinimumChargeCurrent                          = kMinimumChargeCurrent;
     int64_t mMaximumChargeCurrent                          = 0;
     int64_t mMaximumDischargeCurrent                       = 0;
-    int64_t mUserMaximumChargeCurrent                      = 0;
-    uint32_t mRandomizationDelayWindow                     = 600; // Default 600s per spec
+    int64_t mUserMaximumChargeCurrent                      = 0;                           // TODO update spec
+    uint32_t mRandomizationDelayWindow                     = 600;                         // Default 600s per spec
+    // PREF attributes
     DataModel::Nullable<uint32_t> mNextChargeStartTime     = DataModel::NullNullable;
     DataModel::Nullable<uint32_t> mNextChargeTargetTime    = DataModel::NullNullable;
     DataModel::Nullable<int64_t> mNextChargeRequiredEnergy = DataModel::NullNullable;
     DataModel::Nullable<Percent> mNextChargeTargetSoC      = DataModel::NullNullable;
     DataModel::Nullable<uint16_t> mApproximateEVEfficiency = DataModel::NullNullable;
+    // SOC attributes
     DataModel::Nullable<Percent> mStateOfCharge            = DataModel::NullNullable;
     DataModel::Nullable<int64_t> mBatteryCapacity          = DataModel::NullNullable;
+    // PNC attributes
     char mVehicleIDBuffer[kMaxVehicleIDBufSize]            = { 0 };
     DataModel::Nullable<CharSpan> mVehicleID               = DataModel::NullNullable;
+    // Session attributes
     DataModel::Nullable<uint32_t> mSessionID               = DataModel::NullNullable;
     DataModel::Nullable<uint32_t> mSessionDuration         = DataModel::NullNullable;
     DataModel::Nullable<int64_t> mSessionEnergyCharged     = DataModel::NullNullable;

--- a/src/app/clusters/energy-evse-server/EnergyEvseDelegate.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseDelegate.h
@@ -108,29 +108,29 @@ public:
     // ------------------------------------------------------------------
     // Attribute change callbacks - called by cluster after attribute is updated
     // These allow the delegate to react to attribute changes (e.g., persist values, update app state)
-    virtual void OnStateChanged(StateEnum newValue)                                        = 0;
-    virtual void OnSupplyStateChanged(SupplyStateEnum newValue)                            = 0;
-    virtual void OnFaultStateChanged(FaultStateEnum newValue)                              = 0;
-    virtual void OnChargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue)     = 0;
-    virtual void OnDischargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue)  = 0;
-    virtual void OnCircuitCapacityChanged(int64_t newValue)                                = 0;
-    virtual void OnMinimumChargeCurrentChanged(int64_t newValue)                           = 0;
-    virtual void OnMaximumChargeCurrentChanged(int64_t newValue)                           = 0;
-    virtual void OnMaximumDischargeCurrentChanged(int64_t newValue)                        = 0;
-    virtual void OnUserMaximumChargeCurrentChanged(int64_t newValue)                       = 0;
-    virtual void OnRandomizationDelayWindowChanged(uint32_t newValue)                      = 0;
-    virtual void OnNextChargeStartTimeChanged(DataModel::Nullable<uint32_t> newValue)      = 0;
-    virtual void OnNextChargeTargetTimeChanged(DataModel::Nullable<uint32_t> newValue)     = 0;
-    virtual void OnNextChargeRequiredEnergyChanged(DataModel::Nullable<int64_t> newValue)  = 0;
-    virtual void OnNextChargeTargetSoCChanged(DataModel::Nullable<Percent> newValue)       = 0;
-    virtual void OnApproximateEVEfficiencyChanged(DataModel::Nullable<uint16_t> newValue)  = 0;
-    virtual void OnStateOfChargeChanged(DataModel::Nullable<Percent> newValue)             = 0;
-    virtual void OnBatteryCapacityChanged(DataModel::Nullable<int64_t> newValue)           = 0;
-    virtual void OnVehicleIDChanged(DataModel::Nullable<CharSpan> newValue)                = 0;
-    virtual void OnSessionIDChanged(DataModel::Nullable<uint32_t> newValue)                = 0;
-    virtual void OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue)          = 0;
-    virtual void OnSessionEnergyChargedChanged(DataModel::Nullable<int64_t> newValue)      = 0;
-    virtual void OnSessionEnergyDischargedChanged(DataModel::Nullable<int64_t> newValue)   = 0;
+    virtual void OnStateChanged(StateEnum newValue)                                       = 0;
+    virtual void OnSupplyStateChanged(SupplyStateEnum newValue)                           = 0;
+    virtual void OnFaultStateChanged(FaultStateEnum newValue)                             = 0;
+    virtual void OnChargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue)    = 0;
+    virtual void OnDischargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue) = 0;
+    virtual void OnCircuitCapacityChanged(int64_t newValue)                               = 0;
+    virtual void OnMinimumChargeCurrentChanged(int64_t newValue)                          = 0;
+    virtual void OnMaximumChargeCurrentChanged(int64_t newValue)                          = 0;
+    virtual void OnMaximumDischargeCurrentChanged(int64_t newValue)                       = 0;
+    virtual void OnUserMaximumChargeCurrentChanged(int64_t newValue)                      = 0;
+    virtual void OnRandomizationDelayWindowChanged(uint32_t newValue)                     = 0;
+    virtual void OnNextChargeStartTimeChanged(DataModel::Nullable<uint32_t> newValue)     = 0;
+    virtual void OnNextChargeTargetTimeChanged(DataModel::Nullable<uint32_t> newValue)    = 0;
+    virtual void OnNextChargeRequiredEnergyChanged(DataModel::Nullable<int64_t> newValue) = 0;
+    virtual void OnNextChargeTargetSoCChanged(DataModel::Nullable<Percent> newValue)      = 0;
+    virtual void OnApproximateEVEfficiencyChanged(DataModel::Nullable<uint16_t> newValue) = 0;
+    virtual void OnStateOfChargeChanged(DataModel::Nullable<Percent> newValue)            = 0;
+    virtual void OnBatteryCapacityChanged(DataModel::Nullable<int64_t> newValue)          = 0;
+    virtual void OnVehicleIDChanged(DataModel::Nullable<CharSpan> newValue)               = 0;
+    virtual void OnSessionIDChanged(DataModel::Nullable<uint32_t> newValue)               = 0;
+    virtual void OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue)         = 0;
+    virtual void OnSessionEnergyChargedChanged(DataModel::Nullable<int64_t> newValue)     = 0;
+    virtual void OnSessionEnergyDischargedChanged(DataModel::Nullable<int64_t> newValue)  = 0;
 
 protected:
     EndpointId mEndpointId = 0;

--- a/src/app/clusters/energy-evse-server/EnergyEvseDelegate.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseDelegate.h
@@ -106,43 +106,31 @@ public:
     virtual Protocols::InteractionModel::Status ClearTargets() = 0;
 
     // ------------------------------------------------------------------
-    // Get attribute methods
-    virtual StateEnum GetState()                                       = 0;
-    virtual SupplyStateEnum GetSupplyState()                           = 0;
-    virtual FaultStateEnum GetFaultState()                             = 0;
-    virtual DataModel::Nullable<uint32_t> GetChargingEnabledUntil()    = 0;
-    virtual DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() = 0;
-    virtual int64_t GetCircuitCapacity()                               = 0;
-    virtual int64_t GetMinimumChargeCurrent()                          = 0;
-    virtual int64_t GetMaximumChargeCurrent()                          = 0;
-    virtual int64_t GetMaximumDischargeCurrent()                       = 0;
-    virtual int64_t GetUserMaximumChargeCurrent()                      = 0;
-    virtual uint32_t GetRandomizationDelayWindow()                     = 0;
-    /* PREF attributes */
-    virtual DataModel::Nullable<uint32_t> GetNextChargeStartTime()     = 0;
-    virtual DataModel::Nullable<uint32_t> GetNextChargeTargetTime()    = 0;
-    virtual DataModel::Nullable<int64_t> GetNextChargeRequiredEnergy() = 0;
-    virtual DataModel::Nullable<Percent> GetNextChargeTargetSoC()      = 0;
-    virtual DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() = 0;
-
-    /* SOC attributes */
-    virtual DataModel::Nullable<Percent> GetStateOfCharge()   = 0;
-    virtual DataModel::Nullable<int64_t> GetBatteryCapacity() = 0;
-
-    /* PNC attributes*/
-    virtual DataModel::Nullable<CharSpan> GetVehicleID() = 0;
-
-    /* Session SESS attributes */
-    virtual DataModel::Nullable<uint32_t> GetSessionID()              = 0;
-    virtual DataModel::Nullable<uint32_t> GetSessionDuration()        = 0;
-    virtual DataModel::Nullable<int64_t> GetSessionEnergyCharged()    = 0;
-    virtual DataModel::Nullable<int64_t> GetSessionEnergyDischarged() = 0;
-
-    // ------------------------------------------------------------------
-    // Set attribute methods
-    virtual CHIP_ERROR SetUserMaximumChargeCurrent(int64_t aNewValue)                      = 0;
-    virtual CHIP_ERROR SetRandomizationDelayWindow(uint32_t aNewValue)                     = 0;
-    virtual CHIP_ERROR SetApproximateEVEfficiency(DataModel::Nullable<uint16_t> aNewValue) = 0;
+    // Attribute change callbacks - called by cluster after attribute is updated
+    // These allow the delegate to react to attribute changes (e.g., persist values, update app state)
+    virtual void OnStateChanged(StateEnum newValue)                                        = 0;
+    virtual void OnSupplyStateChanged(SupplyStateEnum newValue)                            = 0;
+    virtual void OnFaultStateChanged(FaultStateEnum newValue)                              = 0;
+    virtual void OnChargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue)     = 0;
+    virtual void OnDischargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue)  = 0;
+    virtual void OnCircuitCapacityChanged(int64_t newValue)                                = 0;
+    virtual void OnMinimumChargeCurrentChanged(int64_t newValue)                           = 0;
+    virtual void OnMaximumChargeCurrentChanged(int64_t newValue)                           = 0;
+    virtual void OnMaximumDischargeCurrentChanged(int64_t newValue)                        = 0;
+    virtual void OnUserMaximumChargeCurrentChanged(int64_t newValue)                       = 0;
+    virtual void OnRandomizationDelayWindowChanged(uint32_t newValue)                      = 0;
+    virtual void OnNextChargeStartTimeChanged(DataModel::Nullable<uint32_t> newValue)      = 0;
+    virtual void OnNextChargeTargetTimeChanged(DataModel::Nullable<uint32_t> newValue)     = 0;
+    virtual void OnNextChargeRequiredEnergyChanged(DataModel::Nullable<int64_t> newValue)  = 0;
+    virtual void OnNextChargeTargetSoCChanged(DataModel::Nullable<Percent> newValue)       = 0;
+    virtual void OnApproximateEVEfficiencyChanged(DataModel::Nullable<uint16_t> newValue)  = 0;
+    virtual void OnStateOfChargeChanged(DataModel::Nullable<Percent> newValue)             = 0;
+    virtual void OnBatteryCapacityChanged(DataModel::Nullable<int64_t> newValue)           = 0;
+    virtual void OnVehicleIDChanged(DataModel::Nullable<CharSpan> newValue)                = 0;
+    virtual void OnSessionIDChanged(DataModel::Nullable<uint32_t> newValue)                = 0;
+    virtual void OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue)          = 0;
+    virtual void OnSessionEnergyChargedChanged(DataModel::Nullable<int64_t> newValue)      = 0;
+    virtual void OnSessionEnergyDischargedChanged(DataModel::Nullable<int64_t> newValue)   = 0;
 
 protected:
     EndpointId mEndpointId = 0;

--- a/src/app/clusters/energy-evse-server/EnergyEvseDelegate.h
+++ b/src/app/clusters/energy-evse-server/EnergyEvseDelegate.h
@@ -32,7 +32,6 @@ namespace EnergyEvse {
 /** @brief
  *    Defines methods for implementing application-specific logic for the EVSE Management Cluster.
  */
-class Instance;
 
 class Delegate
 {
@@ -41,8 +40,6 @@ public:
 
     void SetEndpointId(EndpointId aEndpoint) { mEndpointId = aEndpoint; }
     EndpointId GetEndpointId() { return mEndpointId; }
-    void SetInstance(Instance * aInstance) { mInstance = aInstance; }
-    Instance * GetInstance() { return mInstance; }
 
     /**
      * @brief Delegate should implement a handler to disable the EVSE.
@@ -134,7 +131,6 @@ public:
 
 protected:
     EndpointId mEndpointId = 0;
-    Instance * mInstance   = nullptr;
 };
 
 } // namespace EnergyEvse

--- a/src/app/clusters/energy-evse-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/energy-evse-server/app_config_dependent_sources.cmake
@@ -16,9 +16,17 @@
 TARGET_SOURCES(
   ${APP_TARGET}
   PRIVATE
-    "${CLUSTER_DIR}/EnergyEvseTestEventTriggerHandler.h"
-    "${CLUSTER_DIR}/EnergyEvseCluster.cpp"
-    "${CLUSTER_DIR}/EnergyEvseCluster.h"
-    "${CLUSTER_DIR}/EnergyEvseDelegate.h"
+    "${CLUSTER_DIR}/CodegenIntegration.cpp"
+    "${CLUSTER_DIR}/CodegenIntegration.h"
     "${CLUSTER_DIR}/energy-evse-server.h"
+)
+
+# These are the things that BUILD.gn dependencies would pull
+TARGET_SOURCES(  
+  ${APP_TARGET}
+PRIVATE
+"${CLUSTER_DIR}/EnergyEvseTestEventTriggerHandler.h"
+"${CLUSTER_DIR}/EnergyEvseCluster.cpp"
+"${CLUSTER_DIR}/EnergyEvseCluster.h"
+"${CLUSTER_DIR}/EnergyEvseDelegate.h"
 )

--- a/src/app/clusters/energy-evse-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/energy-evse-server/app_config_dependent_sources.gni
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 app_config_dependent_sources = [
-  "EnergyEvseCluster.cpp",
-  "EnergyEvseCluster.h",
-  "EnergyEvseDelegate.h",
-  "EnergyEvseTestEventTriggerHandler.h",
+  "CodegenIntegration.cpp",
+  "CodegenIntegration.h",
   "energy-evse-server.h",
 ]

--- a/src/app/clusters/energy-evse-server/energy-evse-server.h
+++ b/src/app/clusters/energy-evse-server/energy-evse-server.h
@@ -18,5 +18,4 @@
 
 #pragma once
 
-#include <app/clusters/energy-evse-server/EnergyEvseCluster.h>
-#include <app/clusters/energy-evse-server/EnergyEvseDelegate.h>
+#include <app/clusters/energy-evse-server/CodegenIntegration.h>

--- a/src/app/clusters/energy-evse-server/tests/BUILD.gn
+++ b/src/app/clusters/energy-evse-server/tests/BUILD.gn
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "TestEnergyEvseCluster"
+
+  test_sources = [ "TestEnergyEvseCluster.cpp" ]
+
+  sources = [
+    "MockEvseDelegate.cpp",
+    "MockEvseDelegate.h",
+  ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/app/clusters/energy-evse-server",
+    "${chip_root}/src/app/data-model-provider/tests:encode-decode",
+    "${chip_root}/src/app/server-cluster/testing",
+    "${chip_root}/src/app/server-cluster/testing:testing",
+    "${chip_root}/src/lib/support",
+  ]
+}
+
+chip_test_suite("tests-backwards-compatibility") {
+  import(
+      "${chip_root}/src/app/clusters/energy-evse-server/app_config_dependent_sources.gni")
+
+  output_name = "TestEnergyEvseClusterBackwardsCompatibility"
+
+  test_sources = [ "TestEnergyEvseClusterBackwardsCompatibility.cpp" ]
+
+  # Prefix app_config_dependent_sources with "../" and add to the sources list
+  sources = [
+    "MockEvseDelegate.cpp",
+    "MockEvseDelegate.h",
+  ]
+  foreach(file, app_config_dependent_sources) {
+    sources += [ "../" + file ]
+  }
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/app/clusters/energy-evse-server",
+    "${chip_root}/src/app/data-model-provider/tests:encode-decode",
+    "${chip_root}/src/app/server-cluster/testing",
+    "${chip_root}/src/app/server-cluster/testing:testing",
+    "${chip_root}/src/data-model-providers/codegen/tests:mock_model",
+    "${chip_root}/src/lib/support",
+  ]
+}

--- a/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.cpp
+++ b/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.cpp
@@ -27,9 +27,12 @@ namespace EnergyEvse {
 
 Protocols::InteractionModel::Status MockEvseDelegate::Disable()
 {
-    mChargingEnabledUntil    = DataModel::Nullable<uint32_t>(0);
-    mDischargingEnabledUntil = DataModel::Nullable<uint32_t>(0);
-    mSupplyState             = SupplyStateEnum::kDisabled;
+    VerifyOrReturnValue(mCluster != nullptr, Protocols::InteractionModel::Status::Failure);
+
+    DataModel::Nullable<uint32_t> disableTime(0);
+    TEMPORARY_RETURN_IGNORED mCluster->SetChargingEnabledUntil(disableTime);
+    TEMPORARY_RETURN_IGNORED mCluster->SetDischargingEnabledUntil(disableTime);
+    TEMPORARY_RETURN_IGNORED mCluster->SetSupplyState(SupplyStateEnum::kDisabled);
     return Protocols::InteractionModel::Status::Success;
 }
 
@@ -37,14 +40,16 @@ Protocols::InteractionModel::Status MockEvseDelegate::EnableCharging(const DataM
                                                                      const int64_t & minimumChargeCurrent,
                                                                      const int64_t & maximumChargeCurrent)
 {
+    VerifyOrReturnValue(mCluster != nullptr, Protocols::InteractionModel::Status::Failure);
+
     // If there is currently an error present on the EVSE, return FAILURE
-    if (mFaultState != FaultStateEnum::kNoError)
+    if (mCluster->GetFaultState() != FaultStateEnum::kNoError)
     {
         return Protocols::InteractionModel::Status::Failure;
     }
 
     // If Diagnostics are currently active, return FAILURE
-    if (mSupplyState == SupplyStateEnum::kDisabledDiagnostics)
+    if (mCluster->GetSupplyState() == SupplyStateEnum::kDisabledDiagnostics)
     {
         return Protocols::InteractionModel::Status::Failure;
     }
@@ -52,22 +57,23 @@ Protocols::InteractionModel::Status MockEvseDelegate::EnableCharging(const DataM
     // Update SupplyState based on previous state:
     // - If previously Disabled -> ChargingEnabled
     // - If previously DischargingEnabled -> Enabled (both charging and discharging)
-    if (mSupplyState == SupplyStateEnum::kDisabled || mSupplyState == SupplyStateEnum::kDisabledError)
+    SupplyStateEnum currentSupplyState = mCluster->GetSupplyState();
+    if (currentSupplyState == SupplyStateEnum::kDisabled || currentSupplyState == SupplyStateEnum::kDisabledError)
     {
-        mSupplyState = SupplyStateEnum::kChargingEnabled;
+        TEMPORARY_RETURN_IGNORED mCluster->SetSupplyState(SupplyStateEnum::kChargingEnabled);
     }
-    else if (mSupplyState == SupplyStateEnum::kDischargingEnabled)
+    else if (currentSupplyState == SupplyStateEnum::kDischargingEnabled)
     {
-        mSupplyState = SupplyStateEnum::kEnabled;
+        TEMPORARY_RETURN_IGNORED mCluster->SetSupplyState(SupplyStateEnum::kEnabled);
     }
     // If already ChargingEnabled or Enabled, keep the current state
 
     // Update ChargingEnabledUntil to the provided timestamp (can be null for indefinite)
-    mChargingEnabledUntil = enableChargeTime;
+    TEMPORARY_RETURN_IGNORED mCluster->SetChargingEnabledUntil(enableChargeTime);
 
     // Store the charge current limits
-    mMinimumChargeCurrent = minimumChargeCurrent;
-    mMaximumChargeCurrent = maximumChargeCurrent;
+    TEMPORARY_RETURN_IGNORED mCluster->SetMinimumChargeCurrent(minimumChargeCurrent);
+    TEMPORARY_RETURN_IGNORED mCluster->SetMaximumChargeCurrent(maximumChargeCurrent);
 
     return Protocols::InteractionModel::Status::Success;
 }
@@ -75,14 +81,16 @@ Protocols::InteractionModel::Status MockEvseDelegate::EnableCharging(const DataM
 Protocols::InteractionModel::Status MockEvseDelegate::EnableDischarging(const DataModel::Nullable<uint32_t> & enableDischargeTime,
                                                                         const int64_t & maximumDischargeCurrent)
 {
+    VerifyOrReturnValue(mCluster != nullptr, Protocols::InteractionModel::Status::Failure);
+
     // If there is currently an error present on the EVSE, return FAILURE
-    if (mFaultState != FaultStateEnum::kNoError)
+    if (mCluster->GetFaultState() != FaultStateEnum::kNoError)
     {
         return Protocols::InteractionModel::Status::Failure;
     }
 
     // If Diagnostics are currently active, return FAILURE
-    if (mSupplyState == SupplyStateEnum::kDisabledDiagnostics)
+    if (mCluster->GetSupplyState() == SupplyStateEnum::kDisabledDiagnostics)
     {
         return Protocols::InteractionModel::Status::Failure;
     }
@@ -90,35 +98,38 @@ Protocols::InteractionModel::Status MockEvseDelegate::EnableDischarging(const Da
     // Update SupplyState based on previous state:
     // - If previously Disabled -> DischargingEnabled
     // - If previously ChargingEnabled -> Enabled (both charging and discharging)
-    if (mSupplyState == SupplyStateEnum::kDisabled || mSupplyState == SupplyStateEnum::kDisabledError)
+    SupplyStateEnum currentSupplyState = mCluster->GetSupplyState();
+    if (currentSupplyState == SupplyStateEnum::kDisabled || currentSupplyState == SupplyStateEnum::kDisabledError)
     {
-        mSupplyState = SupplyStateEnum::kDischargingEnabled;
+        TEMPORARY_RETURN_IGNORED mCluster->SetSupplyState(SupplyStateEnum::kDischargingEnabled);
     }
-    else if (mSupplyState == SupplyStateEnum::kChargingEnabled)
+    else if (currentSupplyState == SupplyStateEnum::kChargingEnabled)
     {
-        mSupplyState = SupplyStateEnum::kEnabled;
+        TEMPORARY_RETURN_IGNORED mCluster->SetSupplyState(SupplyStateEnum::kEnabled);
     }
     // If already DischargingEnabled or Enabled, keep the current state
 
     // Update DischargingEnabledUntil to the provided timestamp (can be null for indefinite)
-    mDischargingEnabledUntil = enableDischargeTime;
+    TEMPORARY_RETURN_IGNORED mCluster->SetDischargingEnabledUntil(enableDischargeTime);
 
     // Store the discharge current limit
-    mMaximumDischargeCurrent = maximumDischargeCurrent;
+    TEMPORARY_RETURN_IGNORED mCluster->SetMaximumDischargeCurrent(maximumDischargeCurrent);
 
     return Protocols::InteractionModel::Status::Success;
 }
 
 Protocols::InteractionModel::Status MockEvseDelegate::StartDiagnostics()
 {
+    VerifyOrReturnValue(mCluster != nullptr, Protocols::InteractionModel::Status::Failure);
+
     // EVSE SHALL enter Diagnostics state only if SupplyState is Disabled
-    if (mSupplyState != SupplyStateEnum::kDisabled)
+    if (mCluster->GetSupplyState() != SupplyStateEnum::kDisabled)
     {
         return Protocols::InteractionModel::Status::Failure;
     }
 
     // Set SupplyState to DisabledDiagnostics
-    mSupplyState = SupplyStateEnum::kDisabledDiagnostics;
+    TEMPORARY_RETURN_IGNORED mCluster->SetSupplyState(SupplyStateEnum::kDisabledDiagnostics);
 
     return Protocols::InteractionModel::Status::Success;
 }

--- a/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.cpp
+++ b/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.cpp
@@ -1,0 +1,236 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/energy-evse-server/tests/MockEvseDelegate.h>
+
+#include <app/clusters/energy-evse-server/Constants.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace EnergyEvse {
+
+Protocols::InteractionModel::Status MockEvseDelegate::Disable()
+{
+    mChargingEnabledUntil    = DataModel::Nullable<uint32_t>(0);
+    mDischargingEnabledUntil = DataModel::Nullable<uint32_t>(0);
+    mSupplyState             = SupplyStateEnum::kDisabled;
+    return Protocols::InteractionModel::Status::Success;
+}
+
+Protocols::InteractionModel::Status MockEvseDelegate::EnableCharging(const DataModel::Nullable<uint32_t> & enableChargeTime,
+                                                                     const int64_t & minimumChargeCurrent,
+                                                                     const int64_t & maximumChargeCurrent)
+{
+    // If there is currently an error present on the EVSE, return FAILURE
+    if (mFaultState != FaultStateEnum::kNoError)
+    {
+        return Protocols::InteractionModel::Status::Failure;
+    }
+
+    // If Diagnostics are currently active, return FAILURE
+    if (mSupplyState == SupplyStateEnum::kDisabledDiagnostics)
+    {
+        return Protocols::InteractionModel::Status::Failure;
+    }
+
+    // Update SupplyState based on previous state:
+    // - If previously Disabled -> ChargingEnabled
+    // - If previously DischargingEnabled -> Enabled (both charging and discharging)
+    if (mSupplyState == SupplyStateEnum::kDisabled || mSupplyState == SupplyStateEnum::kDisabledError)
+    {
+        mSupplyState = SupplyStateEnum::kChargingEnabled;
+    }
+    else if (mSupplyState == SupplyStateEnum::kDischargingEnabled)
+    {
+        mSupplyState = SupplyStateEnum::kEnabled;
+    }
+    // If already ChargingEnabled or Enabled, keep the current state
+
+    // Update ChargingEnabledUntil to the provided timestamp (can be null for indefinite)
+    mChargingEnabledUntil = enableChargeTime;
+
+    // Store the charge current limits
+    mMinimumChargeCurrent = minimumChargeCurrent;
+    mMaximumChargeCurrent = maximumChargeCurrent;
+
+    return Protocols::InteractionModel::Status::Success;
+}
+
+Protocols::InteractionModel::Status MockEvseDelegate::EnableDischarging(const DataModel::Nullable<uint32_t> & enableDischargeTime,
+                                                                        const int64_t & maximumDischargeCurrent)
+{
+    // If there is currently an error present on the EVSE, return FAILURE
+    if (mFaultState != FaultStateEnum::kNoError)
+    {
+        return Protocols::InteractionModel::Status::Failure;
+    }
+
+    // If Diagnostics are currently active, return FAILURE
+    if (mSupplyState == SupplyStateEnum::kDisabledDiagnostics)
+    {
+        return Protocols::InteractionModel::Status::Failure;
+    }
+
+    // Update SupplyState based on previous state:
+    // - If previously Disabled -> DischargingEnabled
+    // - If previously ChargingEnabled -> Enabled (both charging and discharging)
+    if (mSupplyState == SupplyStateEnum::kDisabled || mSupplyState == SupplyStateEnum::kDisabledError)
+    {
+        mSupplyState = SupplyStateEnum::kDischargingEnabled;
+    }
+    else if (mSupplyState == SupplyStateEnum::kChargingEnabled)
+    {
+        mSupplyState = SupplyStateEnum::kEnabled;
+    }
+    // If already DischargingEnabled or Enabled, keep the current state
+
+    // Update DischargingEnabledUntil to the provided timestamp (can be null for indefinite)
+    mDischargingEnabledUntil = enableDischargeTime;
+
+    // Store the discharge current limit
+    mMaximumDischargeCurrent = maximumDischargeCurrent;
+
+    return Protocols::InteractionModel::Status::Success;
+}
+
+Protocols::InteractionModel::Status MockEvseDelegate::StartDiagnostics()
+{
+    // EVSE SHALL enter Diagnostics state only if SupplyState is Disabled
+    if (mSupplyState != SupplyStateEnum::kDisabled)
+    {
+        return Protocols::InteractionModel::Status::Failure;
+    }
+
+    // Set SupplyState to DisabledDiagnostics
+    mSupplyState = SupplyStateEnum::kDisabledDiagnostics;
+
+    return Protocols::InteractionModel::Status::Success;
+}
+
+Protocols::InteractionModel::Status MockEvseDelegate::SetTargets(
+    const DataModel::DecodableList<Structs::ChargingTargetScheduleStruct::DecodableType> & chargingTargetSchedules)
+{
+    Structs::ChargingTargetStruct::Type tmpTargets[7][kMaxTargetsPerDay];
+    size_t tmpTargetsPerDay[7] = { 0 };
+    size_t newTargetsCount     = 0;
+    BitMask<TargetDayOfWeekBitmap> daysModified;
+
+    auto iter = chargingTargetSchedules.begin();
+    while (iter.Next())
+    {
+        auto & schedule = iter.GetValue();
+        daysModified.Set(schedule.dayOfWeekForSequence);
+
+        // For each day in the bitmask, collect targets into temp storage
+        for (uint8_t day = 0; day < 7; day++)
+        {
+            if (!schedule.dayOfWeekForSequence.Has(static_cast<TargetDayOfWeekBitmap>(1 << day)))
+            {
+                continue;
+            }
+
+            // Reset temp count for this day (replacing targets)
+            tmpTargetsPerDay[day] = 0;
+
+            auto targetsIter = schedule.chargingTargets.begin();
+            while (targetsIter.Next() && tmpTargetsPerDay[day] < kMaxTargetsPerDay)
+            {
+                if (newTargetsCount >= kMaxTotalTargets)
+                {
+                    return Protocols::InteractionModel::Status::ResourceExhausted;
+                }
+
+                auto & target                          = targetsIter.GetValue();
+                tmpTargets[day][tmpTargetsPerDay[day]] = target;
+                tmpTargetsPerDay[day]++;
+                newTargetsCount++;
+            }
+        }
+    }
+
+    mTotalTargetsCount = 0;
+    mDaysWithTargets   = 0;
+    for (uint8_t day = 0; day < 7; day++)
+    {
+        if (daysModified.Has(static_cast<TargetDayOfWeekBitmap>(1 << day)))
+        {
+            // This day was modified - use temp state
+            mTargetsPerDay[day] = tmpTargetsPerDay[day];
+            for (size_t i = 0; i < tmpTargetsPerDay[day]; i++)
+            {
+                mTargets[day][i] = tmpTargets[day][i];
+            }
+        }
+
+        // Recalculate totals for all days
+        mTotalTargetsCount += mTargetsPerDay[day];
+        if (mTargetsPerDay[day] > 0)
+        {
+            mDaysWithTargets |= static_cast<uint8_t>(1 << day);
+        }
+    }
+
+    return Protocols::InteractionModel::Status::Success;
+}
+
+Protocols::InteractionModel::Status MockEvseDelegate::LoadTargets()
+{
+    // In a real implementation, this would load from persistent storage
+    // For mock, targets are already in memory
+    return Protocols::InteractionModel::Status::Success;
+}
+
+Protocols::InteractionModel::Status
+MockEvseDelegate::GetTargets(DataModel::List<const Structs::ChargingTargetScheduleStruct::Type> & chargingTargetSchedules)
+{
+    // Build response from stored targets
+    size_t scheduleCount = 0;
+
+    for (uint8_t day = 0; day < 7; day++)
+    {
+        if (mTargetsPerDay[day] > 0)
+        {
+            mSchedules[scheduleCount].dayOfWeekForSequence = static_cast<TargetDayOfWeekBitmap>(1 << day);
+            mSchedules[scheduleCount].chargingTargets =
+                DataModel::List<const Structs::ChargingTargetStruct::Type>(mTargets[day], mTargetsPerDay[day]);
+            scheduleCount++;
+        }
+    }
+
+    chargingTargetSchedules = DataModel::List<const Structs::ChargingTargetScheduleStruct::Type>(mSchedules, scheduleCount);
+    return Protocols::InteractionModel::Status::Success;
+}
+
+Protocols::InteractionModel::Status MockEvseDelegate::ClearTargets()
+{
+    // Clear all stored targets
+    for (uint8_t day = 0; day < 7; day++)
+    {
+        mTargetsPerDay[day] = 0;
+    }
+    mTotalTargetsCount = 0;
+    mDaysWithTargets   = 0;
+
+    return Protocols::InteractionModel::Status::Success;
+}
+
+} // namespace EnergyEvse
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.h
+++ b/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.h
@@ -72,54 +72,52 @@ public:
     Protocols::InteractionModel::Status ClearTargets() override;
 
     // ------------------------------------------------------------------
-    // Attribute getters
-    StateEnum GetState() override { return mState; }
-    SupplyStateEnum GetSupplyState() override { return mSupplyState; }
-    FaultStateEnum GetFaultState() override { return mFaultState; }
-    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() override { return mChargingEnabledUntil; }
-    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() override { return mDischargingEnabledUntil; }
-    int64_t GetCircuitCapacity() override { return mCircuitCapacity; }
-    int64_t GetMinimumChargeCurrent() override { return mMinimumChargeCurrent; }
-    int64_t GetMaximumChargeCurrent() override { return mMaximumChargeCurrent; }
-    int64_t GetMaximumDischargeCurrent() override { return mMaximumDischargeCurrent; }
-    int64_t GetUserMaximumChargeCurrent() override { return mUserMaximumChargeCurrent; }
-    uint32_t GetRandomizationDelayWindow() override { return mRandomizationDelayWindow; }
-    DataModel::Nullable<uint32_t> GetNextChargeStartTime() override { return mNextChargeStartTime; }
-    DataModel::Nullable<uint32_t> GetNextChargeTargetTime() override { return mNextChargeTargetTime; }
-    DataModel::Nullable<int64_t> GetNextChargeRequiredEnergy() override { return mNextChargeRequiredEnergy; }
-    DataModel::Nullable<Percent> GetNextChargeTargetSoC() override { return mNextChargeTargetSoC; }
-    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() override { return mApproximateEVEfficiency; }
-    DataModel::Nullable<Percent> GetStateOfCharge() override { return mStateOfCharge; }
-    DataModel::Nullable<int64_t> GetBatteryCapacity() override { return mBatteryCapacity; }
-    DataModel::Nullable<CharSpan> GetVehicleID() override { return mVehicleID; }
-    DataModel::Nullable<uint32_t> GetSessionID() override { return mSessionID; }
-    DataModel::Nullable<uint32_t> GetSessionDuration() override { return mSessionDuration; }
-    DataModel::Nullable<int64_t> GetSessionEnergyCharged() override { return mSessionEnergyCharged; }
-    DataModel::Nullable<int64_t> GetSessionEnergyDischarged() override { return mSessionEnergyDischarged; }
+    // Attribute change callbacks (from Delegate interface)
+    void OnStateChanged(StateEnum newValue) override { mState = newValue; }
+    void OnSupplyStateChanged(SupplyStateEnum newValue) override { mSupplyState = newValue; }
+    void OnFaultStateChanged(FaultStateEnum newValue) override { mFaultState = newValue; }
+    void OnChargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue) override { mChargingEnabledUntil = newValue; }
+    void OnDischargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue) override { mDischargingEnabledUntil = newValue; }
+    void OnCircuitCapacityChanged(int64_t newValue) override { mCircuitCapacity = newValue; }
+    void OnMinimumChargeCurrentChanged(int64_t newValue) override { mMinimumChargeCurrent = newValue; }
+    void OnMaximumChargeCurrentChanged(int64_t newValue) override { mMaximumChargeCurrent = newValue; }
+    void OnMaximumDischargeCurrentChanged(int64_t newValue) override { mMaximumDischargeCurrent = newValue; }
+    void OnUserMaximumChargeCurrentChanged(int64_t newValue) override { mUserMaximumChargeCurrent = newValue; }
+    void OnRandomizationDelayWindowChanged(uint32_t newValue) override { mRandomizationDelayWindow = newValue; }
+    void OnNextChargeStartTimeChanged(DataModel::Nullable<uint32_t> newValue) override { mNextChargeStartTime = newValue; }
+    void OnNextChargeTargetTimeChanged(DataModel::Nullable<uint32_t> newValue) override { mNextChargeTargetTime = newValue; }
+    void OnNextChargeRequiredEnergyChanged(DataModel::Nullable<int64_t> newValue) override { mNextChargeRequiredEnergy = newValue; }
+    void OnNextChargeTargetSoCChanged(DataModel::Nullable<Percent> newValue) override { mNextChargeTargetSoC = newValue; }
+    void OnApproximateEVEfficiencyChanged(DataModel::Nullable<uint16_t> newValue) override { mApproximateEVEfficiency = newValue; }
+    void OnStateOfChargeChanged(DataModel::Nullable<Percent> newValue) override { mStateOfCharge = newValue; }
+    void OnBatteryCapacityChanged(DataModel::Nullable<int64_t> newValue) override { mBatteryCapacity = newValue; }
+    void OnVehicleIDChanged(DataModel::Nullable<CharSpan> newValue) override { mVehicleID = newValue; }
+    void OnSessionIDChanged(DataModel::Nullable<uint32_t> newValue) override { mSessionID = newValue; }
+    void OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue) override { mSessionDuration = newValue; }
+    void OnSessionEnergyChargedChanged(DataModel::Nullable<int64_t> newValue) override { mSessionEnergyCharged = newValue; }
+    void OnSessionEnergyDischargedChanged(DataModel::Nullable<int64_t> newValue) override { mSessionEnergyDischarged = newValue; }
 
     // ------------------------------------------------------------------
-    // Attribute setters (from Delegate interface)
-    CHIP_ERROR SetUserMaximumChargeCurrent(int64_t aNewValue) override
-    {
-        mUserMaximumChargeCurrent = aNewValue;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR SetRandomizationDelayWindow(uint32_t aNewValue) override
-    {
-        mRandomizationDelayWindow = aNewValue;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR SetApproximateEVEfficiency(DataModel::Nullable<uint16_t> aNewValue) override
-    {
-        mApproximateEVEfficiency = aNewValue;
-        return CHIP_NO_ERROR;
-    }
+    // Test helper getters (for accessing mock values - not for override)
+    StateEnum GetState() const { return mState; }
+    SupplyStateEnum GetSupplyState() const { return mSupplyState; }
+    FaultStateEnum GetFaultState() const { return mFaultState; }
+    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() const { return mChargingEnabledUntil; }
+    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() const { return mDischargingEnabledUntil; }
+    int64_t GetCircuitCapacity() const { return mCircuitCapacity; }
+    int64_t GetMinimumChargeCurrent() const { return mMinimumChargeCurrent; }
+    int64_t GetMaximumChargeCurrent() const { return mMaximumChargeCurrent; }
+    int64_t GetMaximumDischargeCurrent() const { return mMaximumDischargeCurrent; }
+    int64_t GetUserMaximumChargeCurrent() const { return mUserMaximumChargeCurrent; }
+    uint32_t GetRandomizationDelayWindow() const { return mRandomizationDelayWindow; }
+    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() const { return mApproximateEVEfficiency; }
+    DataModel::Nullable<Percent> GetStateOfCharge() const { return mStateOfCharge; }
+    DataModel::Nullable<int64_t> GetBatteryCapacity() const { return mBatteryCapacity; }
 
     // ------------------------------------------------------------------
-    // Test helper setters (for setting up test conditions)
-    void SetFaultState(FaultStateEnum aNewValue) { mFaultState = aNewValue; }
-    void SetSupplyState(SupplyStateEnum aNewValue) { mSupplyState = aNewValue; }
-    void SetState(StateEnum aNewValue) { mState = aNewValue; }
+    // Test helper setters (for setting up test state - not for override)
+    void SetFaultState(FaultStateEnum value) { mFaultState = value; }
+    void SetSupplyState(SupplyStateEnum value) { mSupplyState = value; }
 
     // ------------------------------------------------------------------
     // Test helper getters (for verifying targets state)

--- a/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.h
+++ b/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <app/clusters/energy-evse-server/EnergyEvseCluster.h>
 #include <app/clusters/energy-evse-server/EnergyEvseDelegate.h>
 
 namespace chip {
@@ -28,32 +29,10 @@ namespace EnergyEvse {
 class MockEvseDelegate : public Delegate
 {
 public:
-    // Mock test values - used for verification in tests
-    static constexpr StateEnum kMockState                   = StateEnum::kPluggedInNoDemand;
-    static constexpr SupplyStateEnum kMockSupplyState       = SupplyStateEnum::kChargingEnabled;
-    static constexpr FaultStateEnum kMockFaultState         = FaultStateEnum::kNoError;
-    static constexpr uint32_t kMockChargingEnabledUntil     = 1000;
-    static constexpr uint32_t kMockDischargingEnabledUntil  = 2000;
-    static constexpr int64_t kMockCircuitCapacity           = 32000;    // 32A in mA
-    static constexpr int64_t kMockMinimumChargeCurrent      = 6000;     // 6A in mA
-    static constexpr int64_t kMockMaximumChargeCurrent      = 32000;    // 32A in mA
-    static constexpr int64_t kMockMaximumDischargeCurrent   = 16000;    // 16A in mA (V2x)
-    static constexpr int64_t kMockUserMaximumChargeCurrent  = 24000;    // 24A in mA
-    static constexpr uint32_t kMockRandomizationDelayWindow = 600;      // 10 minutes
-    static constexpr uint32_t kMockNextChargeStartTime      = 3600;     // 1 hour from now
-    static constexpr uint32_t kMockNextChargeTargetTime     = 7200;     // 2 hours from now
-    static constexpr int64_t kMockNextChargeRequiredEnergy  = 20000000; // 20 kWh in mWh
-    static constexpr Percent kMockNextChargeTargetSoC       = 80;
-    static constexpr uint16_t kMockApproximateEVEfficiency  = 150; // 150 Wh/km
-    static constexpr Percent kMockStateOfCharge             = 45;
-    static constexpr int64_t kMockBatteryCapacity           = 60000000; // 60 kWh in mWh
-    static constexpr uint32_t kMockSessionID                = 12345;
-    static constexpr uint32_t kMockSessionDuration          = 1800;    // 30 minutes
-    static constexpr int64_t kMockSessionEnergyCharged      = 5000000; // 5 kWh in mWh
-    static constexpr int64_t kMockSessionEnergyDischarged   = 1000000; // 1 kWh in mWh
-
-    MockEvseDelegate()  = default;
+    MockEvseDelegate() : Delegate(), mCluster(nullptr) {}
     ~MockEvseDelegate() = default;
+
+    void SetCluster(EnergyEvseCluster & aCluster) { mCluster = &aCluster; }
 
     // ------------------------------------------------------------------
     // Command handlers (implementations in MockEvseDelegate.cpp)
@@ -72,52 +51,30 @@ public:
     Protocols::InteractionModel::Status ClearTargets() override;
 
     // ------------------------------------------------------------------
-    // Attribute change callbacks (from Delegate interface)
-    void OnStateChanged(StateEnum newValue) override { mState = newValue; }
-    void OnSupplyStateChanged(SupplyStateEnum newValue) override { mSupplyState = newValue; }
-    void OnFaultStateChanged(FaultStateEnum newValue) override { mFaultState = newValue; }
-    void OnChargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue) override { mChargingEnabledUntil = newValue; }
-    void OnDischargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue) override { mDischargingEnabledUntil = newValue; }
-    void OnCircuitCapacityChanged(int64_t newValue) override { mCircuitCapacity = newValue; }
-    void OnMinimumChargeCurrentChanged(int64_t newValue) override { mMinimumChargeCurrent = newValue; }
-    void OnMaximumChargeCurrentChanged(int64_t newValue) override { mMaximumChargeCurrent = newValue; }
-    void OnMaximumDischargeCurrentChanged(int64_t newValue) override { mMaximumDischargeCurrent = newValue; }
-    void OnUserMaximumChargeCurrentChanged(int64_t newValue) override { mUserMaximumChargeCurrent = newValue; }
-    void OnRandomizationDelayWindowChanged(uint32_t newValue) override { mRandomizationDelayWindow = newValue; }
-    void OnNextChargeStartTimeChanged(DataModel::Nullable<uint32_t> newValue) override { mNextChargeStartTime = newValue; }
-    void OnNextChargeTargetTimeChanged(DataModel::Nullable<uint32_t> newValue) override { mNextChargeTargetTime = newValue; }
-    void OnNextChargeRequiredEnergyChanged(DataModel::Nullable<int64_t> newValue) override { mNextChargeRequiredEnergy = newValue; }
-    void OnNextChargeTargetSoCChanged(DataModel::Nullable<Percent> newValue) override { mNextChargeTargetSoC = newValue; }
-    void OnApproximateEVEfficiencyChanged(DataModel::Nullable<uint16_t> newValue) override { mApproximateEVEfficiency = newValue; }
-    void OnStateOfChargeChanged(DataModel::Nullable<Percent> newValue) override { mStateOfCharge = newValue; }
-    void OnBatteryCapacityChanged(DataModel::Nullable<int64_t> newValue) override { mBatteryCapacity = newValue; }
-    void OnVehicleIDChanged(DataModel::Nullable<CharSpan> newValue) override { mVehicleID = newValue; }
-    void OnSessionIDChanged(DataModel::Nullable<uint32_t> newValue) override { mSessionID = newValue; }
-    void OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue) override { mSessionDuration = newValue; }
-    void OnSessionEnergyChargedChanged(DataModel::Nullable<int64_t> newValue) override { mSessionEnergyCharged = newValue; }
-    void OnSessionEnergyDischargedChanged(DataModel::Nullable<int64_t> newValue) override { mSessionEnergyDischarged = newValue; }
-
-    // ------------------------------------------------------------------
-    // Test helper getters (for accessing mock values - not for override)
-    StateEnum GetState() const { return mState; }
-    SupplyStateEnum GetSupplyState() const { return mSupplyState; }
-    FaultStateEnum GetFaultState() const { return mFaultState; }
-    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() const { return mChargingEnabledUntil; }
-    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() const { return mDischargingEnabledUntil; }
-    int64_t GetCircuitCapacity() const { return mCircuitCapacity; }
-    int64_t GetMinimumChargeCurrent() const { return mMinimumChargeCurrent; }
-    int64_t GetMaximumChargeCurrent() const { return mMaximumChargeCurrent; }
-    int64_t GetMaximumDischargeCurrent() const { return mMaximumDischargeCurrent; }
-    int64_t GetUserMaximumChargeCurrent() const { return mUserMaximumChargeCurrent; }
-    uint32_t GetRandomizationDelayWindow() const { return mRandomizationDelayWindow; }
-    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() const { return mApproximateEVEfficiency; }
-    DataModel::Nullable<Percent> GetStateOfCharge() const { return mStateOfCharge; }
-    DataModel::Nullable<int64_t> GetBatteryCapacity() const { return mBatteryCapacity; }
-
-    // ------------------------------------------------------------------
-    // Test helper setters (for setting up test state - not for override)
-    void SetFaultState(FaultStateEnum value) { mFaultState = value; }
-    void SetSupplyState(SupplyStateEnum value) { mSupplyState = value; }
+    // Attribute change callbacks (from Delegate interface) - empty implementations for mock
+    void OnStateChanged(StateEnum newValue) override {}
+    void OnSupplyStateChanged(SupplyStateEnum newValue) override {}
+    void OnFaultStateChanged(FaultStateEnum newValue) override {}
+    void OnChargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue) override {}
+    void OnDischargingEnabledUntilChanged(DataModel::Nullable<uint32_t> newValue) override {}
+    void OnCircuitCapacityChanged(int64_t newValue) override {}
+    void OnMinimumChargeCurrentChanged(int64_t newValue) override {}
+    void OnMaximumChargeCurrentChanged(int64_t newValue) override {}
+    void OnMaximumDischargeCurrentChanged(int64_t newValue) override {}
+    void OnUserMaximumChargeCurrentChanged(int64_t newValue) override {}
+    void OnRandomizationDelayWindowChanged(uint32_t newValue) override {}
+    void OnNextChargeStartTimeChanged(DataModel::Nullable<uint32_t> newValue) override {}
+    void OnNextChargeTargetTimeChanged(DataModel::Nullable<uint32_t> newValue) override {}
+    void OnNextChargeRequiredEnergyChanged(DataModel::Nullable<int64_t> newValue) override {}
+    void OnNextChargeTargetSoCChanged(DataModel::Nullable<Percent> newValue) override {}
+    void OnApproximateEVEfficiencyChanged(DataModel::Nullable<uint16_t> newValue) override {}
+    void OnStateOfChargeChanged(DataModel::Nullable<Percent> newValue) override {}
+    void OnBatteryCapacityChanged(DataModel::Nullable<int64_t> newValue) override {}
+    void OnVehicleIDChanged(DataModel::Nullable<CharSpan> newValue) override {}
+    void OnSessionIDChanged(DataModel::Nullable<uint32_t> newValue) override {}
+    void OnSessionDurationChanged(DataModel::Nullable<uint32_t> newValue) override {}
+    void OnSessionEnergyChargedChanged(DataModel::Nullable<int64_t> newValue) override {}
+    void OnSessionEnergyDischargedChanged(DataModel::Nullable<int64_t> newValue) override {}
 
     // ------------------------------------------------------------------
     // Test helper getters (for verifying targets state)
@@ -129,32 +86,7 @@ public:
     static constexpr size_t kMaxTotalTargets  = 70; // 7 days * 10 targets
 
 private:
-    // Member variables with default mock values
-    StateEnum mState                                       = kMockState;
-    SupplyStateEnum mSupplyState                           = kMockSupplyState;
-    FaultStateEnum mFaultState                             = kMockFaultState;
-    DataModel::Nullable<uint32_t> mChargingEnabledUntil    = DataModel::Nullable<uint32_t>(kMockChargingEnabledUntil);
-    DataModel::Nullable<uint32_t> mDischargingEnabledUntil = DataModel::Nullable<uint32_t>(kMockDischargingEnabledUntil);
-    int64_t mCircuitCapacity                               = kMockCircuitCapacity;
-    int64_t mMinimumChargeCurrent                          = kMockMinimumChargeCurrent;
-    int64_t mMaximumChargeCurrent                          = kMockMaximumChargeCurrent;
-    int64_t mMaximumDischargeCurrent                       = kMockMaximumDischargeCurrent;
-    int64_t mUserMaximumChargeCurrent                      = kMockUserMaximumChargeCurrent;
-    uint32_t mRandomizationDelayWindow                     = kMockRandomizationDelayWindow;
-    DataModel::Nullable<uint32_t> mNextChargeStartTime     = DataModel::Nullable<uint32_t>(kMockNextChargeStartTime);
-    DataModel::Nullable<uint32_t> mNextChargeTargetTime    = DataModel::Nullable<uint32_t>(kMockNextChargeTargetTime);
-    DataModel::Nullable<int64_t> mNextChargeRequiredEnergy = DataModel::Nullable<int64_t>(kMockNextChargeRequiredEnergy);
-    DataModel::Nullable<Percent> mNextChargeTargetSoC      = DataModel::Nullable<Percent>(kMockNextChargeTargetSoC);
-    DataModel::Nullable<uint16_t> mApproximateEVEfficiency = DataModel::Nullable<uint16_t>(kMockApproximateEVEfficiency);
-    DataModel::Nullable<Percent> mStateOfCharge            = DataModel::Nullable<Percent>(kMockStateOfCharge);
-    DataModel::Nullable<int64_t> mBatteryCapacity          = DataModel::Nullable<int64_t>(kMockBatteryCapacity);
-    static constexpr size_t kVehicleIdBufferSize           = 32;
-    char mVehicleIdBuffer[kVehicleIdBufferSize]            = "MOCK-VIN-12345";
-    DataModel::Nullable<CharSpan> mVehicleID           = DataModel::Nullable<CharSpan>(CharSpan::fromCharString(mVehicleIdBuffer));
-    DataModel::Nullable<uint32_t> mSessionID           = DataModel::Nullable<uint32_t>(kMockSessionID);
-    DataModel::Nullable<uint32_t> mSessionDuration     = DataModel::Nullable<uint32_t>(kMockSessionDuration);
-    DataModel::Nullable<int64_t> mSessionEnergyCharged = DataModel::Nullable<int64_t>(kMockSessionEnergyCharged);
-    DataModel::Nullable<int64_t> mSessionEnergyDischarged = DataModel::Nullable<int64_t>(kMockSessionEnergyDischarged);
+    EnergyEvseCluster * mCluster;
 
     // Targets storage
     size_t mTotalTargetsCount = 0;

--- a/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.h
+++ b/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.h
@@ -1,0 +1,170 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/energy-evse-server/EnergyEvseDelegate.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace EnergyEvse {
+
+class MockEvseDelegate : public Delegate
+{
+public:
+    // Mock test values - used for verification in tests
+    static constexpr StateEnum kMockState                   = StateEnum::kPluggedInNoDemand;
+    static constexpr SupplyStateEnum kMockSupplyState       = SupplyStateEnum::kChargingEnabled;
+    static constexpr FaultStateEnum kMockFaultState         = FaultStateEnum::kNoError;
+    static constexpr uint32_t kMockChargingEnabledUntil     = 1000;
+    static constexpr uint32_t kMockDischargingEnabledUntil  = 2000;
+    static constexpr int64_t kMockCircuitCapacity           = 32000;    // 32A in mA
+    static constexpr int64_t kMockMinimumChargeCurrent      = 6000;     // 6A in mA
+    static constexpr int64_t kMockMaximumChargeCurrent      = 32000;    // 32A in mA
+    static constexpr int64_t kMockMaximumDischargeCurrent   = 16000;    // 16A in mA (V2x)
+    static constexpr int64_t kMockUserMaximumChargeCurrent  = 24000;    // 24A in mA
+    static constexpr uint32_t kMockRandomizationDelayWindow = 600;      // 10 minutes
+    static constexpr uint32_t kMockNextChargeStartTime      = 3600;     // 1 hour from now
+    static constexpr uint32_t kMockNextChargeTargetTime     = 7200;     // 2 hours from now
+    static constexpr int64_t kMockNextChargeRequiredEnergy  = 20000000; // 20 kWh in mWh
+    static constexpr Percent kMockNextChargeTargetSoC       = 80;
+    static constexpr uint16_t kMockApproximateEVEfficiency  = 150; // 150 Wh/km
+    static constexpr Percent kMockStateOfCharge             = 45;
+    static constexpr int64_t kMockBatteryCapacity           = 60000000; // 60 kWh in mWh
+    static constexpr uint32_t kMockSessionID                = 12345;
+    static constexpr uint32_t kMockSessionDuration          = 1800;    // 30 minutes
+    static constexpr int64_t kMockSessionEnergyCharged      = 5000000; // 5 kWh in mWh
+    static constexpr int64_t kMockSessionEnergyDischarged   = 1000000; // 1 kWh in mWh
+
+    MockEvseDelegate()  = default;
+    ~MockEvseDelegate() = default;
+
+    // ------------------------------------------------------------------
+    // Command handlers (implementations in MockEvseDelegate.cpp)
+    Protocols::InteractionModel::Status Disable() override;
+    Protocols::InteractionModel::Status EnableCharging(const DataModel::Nullable<uint32_t> & enableChargeTime,
+                                                       const int64_t & minimumChargeCurrent,
+                                                       const int64_t & maximumChargeCurrent) override;
+    Protocols::InteractionModel::Status EnableDischarging(const DataModel::Nullable<uint32_t> & enableDischargeTime,
+                                                          const int64_t & maximumDischargeCurrent) override;
+    Protocols::InteractionModel::Status StartDiagnostics() override;
+    Protocols::InteractionModel::Status SetTargets(
+        const DataModel::DecodableList<Structs::ChargingTargetScheduleStruct::DecodableType> & chargingTargetSchedules) override;
+    Protocols::InteractionModel::Status LoadTargets() override;
+    Protocols::InteractionModel::Status
+    GetTargets(DataModel::List<const Structs::ChargingTargetScheduleStruct::Type> & chargingTargetSchedules) override;
+    Protocols::InteractionModel::Status ClearTargets() override;
+
+    // ------------------------------------------------------------------
+    // Attribute getters
+    StateEnum GetState() override { return mState; }
+    SupplyStateEnum GetSupplyState() override { return mSupplyState; }
+    FaultStateEnum GetFaultState() override { return mFaultState; }
+    DataModel::Nullable<uint32_t> GetChargingEnabledUntil() override { return mChargingEnabledUntil; }
+    DataModel::Nullable<uint32_t> GetDischargingEnabledUntil() override { return mDischargingEnabledUntil; }
+    int64_t GetCircuitCapacity() override { return mCircuitCapacity; }
+    int64_t GetMinimumChargeCurrent() override { return mMinimumChargeCurrent; }
+    int64_t GetMaximumChargeCurrent() override { return mMaximumChargeCurrent; }
+    int64_t GetMaximumDischargeCurrent() override { return mMaximumDischargeCurrent; }
+    int64_t GetUserMaximumChargeCurrent() override { return mUserMaximumChargeCurrent; }
+    uint32_t GetRandomizationDelayWindow() override { return mRandomizationDelayWindow; }
+    DataModel::Nullable<uint32_t> GetNextChargeStartTime() override { return mNextChargeStartTime; }
+    DataModel::Nullable<uint32_t> GetNextChargeTargetTime() override { return mNextChargeTargetTime; }
+    DataModel::Nullable<int64_t> GetNextChargeRequiredEnergy() override { return mNextChargeRequiredEnergy; }
+    DataModel::Nullable<Percent> GetNextChargeTargetSoC() override { return mNextChargeTargetSoC; }
+    DataModel::Nullable<uint16_t> GetApproximateEVEfficiency() override { return mApproximateEVEfficiency; }
+    DataModel::Nullable<Percent> GetStateOfCharge() override { return mStateOfCharge; }
+    DataModel::Nullable<int64_t> GetBatteryCapacity() override { return mBatteryCapacity; }
+    DataModel::Nullable<CharSpan> GetVehicleID() override { return mVehicleID; }
+    DataModel::Nullable<uint32_t> GetSessionID() override { return mSessionID; }
+    DataModel::Nullable<uint32_t> GetSessionDuration() override { return mSessionDuration; }
+    DataModel::Nullable<int64_t> GetSessionEnergyCharged() override { return mSessionEnergyCharged; }
+    DataModel::Nullable<int64_t> GetSessionEnergyDischarged() override { return mSessionEnergyDischarged; }
+
+    // ------------------------------------------------------------------
+    // Attribute setters (from Delegate interface)
+    CHIP_ERROR SetUserMaximumChargeCurrent(int64_t aNewValue) override
+    {
+        mUserMaximumChargeCurrent = aNewValue;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR SetRandomizationDelayWindow(uint32_t aNewValue) override
+    {
+        mRandomizationDelayWindow = aNewValue;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR SetApproximateEVEfficiency(DataModel::Nullable<uint16_t> aNewValue) override
+    {
+        mApproximateEVEfficiency = aNewValue;
+        return CHIP_NO_ERROR;
+    }
+
+    // ------------------------------------------------------------------
+    // Test helper setters (for setting up test conditions)
+    void SetFaultState(FaultStateEnum aNewValue) { mFaultState = aNewValue; }
+    void SetSupplyState(SupplyStateEnum aNewValue) { mSupplyState = aNewValue; }
+    void SetState(StateEnum aNewValue) { mState = aNewValue; }
+
+    // ------------------------------------------------------------------
+    // Test helper getters (for verifying targets state)
+    size_t GetTotalTargetsCount() const { return mTotalTargetsCount; }
+    uint8_t GetDaysWithTargets() const { return mDaysWithTargets; }
+
+    // Maximum targets per day and total (for mock purposes)
+    static constexpr size_t kMaxTargetsPerDay = 10;
+    static constexpr size_t kMaxTotalTargets  = 70; // 7 days * 10 targets
+
+private:
+    // Member variables with default mock values
+    StateEnum mState                                       = kMockState;
+    SupplyStateEnum mSupplyState                           = kMockSupplyState;
+    FaultStateEnum mFaultState                             = kMockFaultState;
+    DataModel::Nullable<uint32_t> mChargingEnabledUntil    = DataModel::Nullable<uint32_t>(kMockChargingEnabledUntil);
+    DataModel::Nullable<uint32_t> mDischargingEnabledUntil = DataModel::Nullable<uint32_t>(kMockDischargingEnabledUntil);
+    int64_t mCircuitCapacity                               = kMockCircuitCapacity;
+    int64_t mMinimumChargeCurrent                          = kMockMinimumChargeCurrent;
+    int64_t mMaximumChargeCurrent                          = kMockMaximumChargeCurrent;
+    int64_t mMaximumDischargeCurrent                       = kMockMaximumDischargeCurrent;
+    int64_t mUserMaximumChargeCurrent                      = kMockUserMaximumChargeCurrent;
+    uint32_t mRandomizationDelayWindow                     = kMockRandomizationDelayWindow;
+    DataModel::Nullable<uint32_t> mNextChargeStartTime     = DataModel::Nullable<uint32_t>(kMockNextChargeStartTime);
+    DataModel::Nullable<uint32_t> mNextChargeTargetTime    = DataModel::Nullable<uint32_t>(kMockNextChargeTargetTime);
+    DataModel::Nullable<int64_t> mNextChargeRequiredEnergy = DataModel::Nullable<int64_t>(kMockNextChargeRequiredEnergy);
+    DataModel::Nullable<Percent> mNextChargeTargetSoC      = DataModel::Nullable<Percent>(kMockNextChargeTargetSoC);
+    DataModel::Nullable<uint16_t> mApproximateEVEfficiency = DataModel::Nullable<uint16_t>(kMockApproximateEVEfficiency);
+    DataModel::Nullable<Percent> mStateOfCharge            = DataModel::Nullable<Percent>(kMockStateOfCharge);
+    DataModel::Nullable<int64_t> mBatteryCapacity          = DataModel::Nullable<int64_t>(kMockBatteryCapacity);
+    DataModel::Nullable<CharSpan> mVehicleID           = DataModel::Nullable<CharSpan>(CharSpan::fromCharString("MOCK-VIN-12345"));
+    DataModel::Nullable<uint32_t> mSessionID           = DataModel::Nullable<uint32_t>(kMockSessionID);
+    DataModel::Nullable<uint32_t> mSessionDuration     = DataModel::Nullable<uint32_t>(kMockSessionDuration);
+    DataModel::Nullable<int64_t> mSessionEnergyCharged = DataModel::Nullable<int64_t>(kMockSessionEnergyCharged);
+    DataModel::Nullable<int64_t> mSessionEnergyDischarged = DataModel::Nullable<int64_t>(kMockSessionEnergyDischarged);
+
+    // Targets storage
+    size_t mTotalTargetsCount = 0;
+    uint8_t mDaysWithTargets  = 0;                                      // Bitmask of days that have targets
+    Structs::ChargingTargetStruct::Type mTargets[7][kMaxTargetsPerDay]; // 7 days, up to kMaxTargetsPerDay each
+    size_t mTargetsPerDay[7] = { 0 };
+    Structs::ChargingTargetScheduleStruct::Type mSchedules[7]; // For GetTargets response
+};
+
+} // namespace EnergyEvse
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.h
+++ b/src/app/clusters/energy-evse-server/tests/MockEvseDelegate.h
@@ -148,7 +148,9 @@ private:
     DataModel::Nullable<uint16_t> mApproximateEVEfficiency = DataModel::Nullable<uint16_t>(kMockApproximateEVEfficiency);
     DataModel::Nullable<Percent> mStateOfCharge            = DataModel::Nullable<Percent>(kMockStateOfCharge);
     DataModel::Nullable<int64_t> mBatteryCapacity          = DataModel::Nullable<int64_t>(kMockBatteryCapacity);
-    DataModel::Nullable<CharSpan> mVehicleID           = DataModel::Nullable<CharSpan>(CharSpan::fromCharString("MOCK-VIN-12345"));
+    static constexpr size_t kVehicleIdBufferSize           = 32;
+    char mVehicleIdBuffer[kVehicleIdBufferSize]            = "MOCK-VIN-12345";
+    DataModel::Nullable<CharSpan> mVehicleID           = DataModel::Nullable<CharSpan>(CharSpan::fromCharString(mVehicleIdBuffer));
     DataModel::Nullable<uint32_t> mSessionID           = DataModel::Nullable<uint32_t>(kMockSessionID);
     DataModel::Nullable<uint32_t> mSessionDuration     = DataModel::Nullable<uint32_t>(kMockSessionDuration);
     DataModel::Nullable<int64_t> mSessionEnergyCharged = DataModel::Nullable<int64_t>(kMockSessionEnergyCharged);

--- a/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
@@ -1,0 +1,1058 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "clusters/EnergyEvse/Enums.h"
+#include "pw_unit_test/framework.h"
+#include <app/clusters/energy-evse-server/EnergyEvseCluster.h>
+#include <app/clusters/energy-evse-server/tests/MockEvseDelegate.h>
+#include <pw_unit_test/framework.h>
+
+#include <app/server-cluster/testing/ClusterTester.h>
+#include <app/server-cluster/testing/TestServerClusterContext.h>
+#include <app/server-cluster/testing/ValidateGlobalAttributes.h>
+#include <clusters/EnergyEvse/Attributes.h>
+#include <clusters/EnergyEvse/Commands.h>
+#include <clusters/EnergyEvse/Metadata.h>
+#include <system/SystemClock.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::EnergyEvse;
+using namespace chip::app::Clusters::EnergyEvse::Attributes;
+using namespace chip::app::Clusters::EnergyEvse::Commands;
+using namespace chip::Testing;
+
+using chip::Testing::IsAcceptedCommandsListEqualTo;
+using chip::Testing::IsAttributesListEqualTo;
+
+namespace {
+
+constexpr EndpointId kTestEndpointId = 1;
+
+struct TestEnergyEvseCluster : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+
+    void SetUp() override {}
+};
+
+// =============================================================================
+// Feature Tests
+// =============================================================================
+
+TEST_F(TestEnergyEvseCluster, TestFeatures)
+{
+
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    {
+        // Test with minimum features and no optional attributes
+        // ChargingPreferences feature is mandatory
+        BitMask<Feature> minimumFeatures(Feature::kChargingPreferences);
+        BitMask<OptionalAttributes> optionalAttributes;
+        BitMask<OptionalCommands> optionalCommands;
+
+        EnergyEvseCluster cluster(
+            EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, minimumFeatures, optionalAttributes, optionalCommands));
+        EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+        EXPECT_TRUE(IsAttributesListEqualTo(cluster,
+                                            {
+                                                State::kMetadataEntry,
+                                                SupplyState::kMetadataEntry,
+                                                FaultState::kMetadataEntry,
+                                                ChargingEnabledUntil::kMetadataEntry,
+                                                CircuitCapacity::kMetadataEntry,
+                                                MinimumChargeCurrent::kMetadataEntry,
+                                                MaximumChargeCurrent::kMetadataEntry,
+                                                NextChargeStartTime::kMetadataEntry,
+                                                NextChargeTargetTime::kMetadataEntry,
+                                                NextChargeRequiredEnergy::kMetadataEntry,
+                                                NextChargeTargetSoC::kMetadataEntry,
+                                                SessionID::kMetadataEntry,
+                                                SessionDuration::kMetadataEntry,
+                                                SessionEnergyCharged::kMetadataEntry,
+                                            }));
+
+        EXPECT_TRUE(IsAcceptedCommandsListEqualTo(
+            cluster,
+            {
+                { Disable::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { EnableCharging::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { SetTargets::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { GetTargets::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { ClearTargets::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+            }));
+
+        EXPECT_TRUE(IsGeneratedCommandsListEqualTo(cluster,
+                                                   {
+                                                       GetTargetsResponse::Id,
+                                                   }));
+    }
+    // Test with all features and no optional attributes & no optional commands
+    {
+        BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kV2x, Feature::kSoCReporting, Feature::kPlugAndCharge);
+        BitMask<OptionalAttributes> optionalAttributes;
+        BitMask<OptionalCommands> optionalCommands;
+
+        EnergyEvseCluster cluster(
+            EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+        EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+        EXPECT_TRUE(IsAttributesListEqualTo(cluster,
+                                            {
+                                                State::kMetadataEntry,
+                                                SupplyState::kMetadataEntry,
+                                                FaultState::kMetadataEntry,
+                                                ChargingEnabledUntil::kMetadataEntry,
+                                                DischargingEnabledUntil::kMetadataEntry,
+                                                CircuitCapacity::kMetadataEntry,
+                                                MinimumChargeCurrent::kMetadataEntry,
+                                                MaximumChargeCurrent::kMetadataEntry,
+                                                MaximumDischargeCurrent::kMetadataEntry,
+                                                NextChargeStartTime::kMetadataEntry,
+                                                NextChargeTargetTime::kMetadataEntry,
+                                                NextChargeRequiredEnergy::kMetadataEntry,
+                                                NextChargeTargetSoC::kMetadataEntry,
+                                                StateOfCharge::kMetadataEntry,
+                                                BatteryCapacity::kMetadataEntry,
+                                                VehicleID::kMetadataEntry,
+                                                SessionID::kMetadataEntry,
+                                                SessionDuration::kMetadataEntry,
+                                                SessionEnergyCharged::kMetadataEntry,
+                                                SessionEnergyDischarged::kMetadataEntry,
+                                            }));
+
+        EXPECT_TRUE(IsAcceptedCommandsListEqualTo(
+            cluster,
+            {
+                { Disable::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { EnableCharging::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { EnableDischarging::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { SetTargets::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { GetTargets::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { ClearTargets::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+            }));
+
+        EXPECT_TRUE(IsGeneratedCommandsListEqualTo(cluster,
+                                                   {
+                                                       GetTargetsResponse::Id,
+                                                   }));
+
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
+
+    // Test with all features and optional attributes & optional commands
+    {
+        BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kV2x, Feature::kSoCReporting, Feature::kPlugAndCharge);
+        BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
+                                                       OptionalAttributes::kSupportsRandomizationWindow,
+                                                       OptionalAttributes::kSupportsApproximateEvEfficiency);
+        BitMask<OptionalCommands> optionalCommands(OptionalCommands::kSupportsStartDiagnostics);
+
+        EnergyEvseCluster cluster(
+            EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+        EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+        EXPECT_TRUE(IsAttributesListEqualTo(cluster,
+                                            {
+                                                State::kMetadataEntry,
+                                                SupplyState::kMetadataEntry,
+                                                FaultState::kMetadataEntry,
+                                                ChargingEnabledUntil::kMetadataEntry,
+                                                DischargingEnabledUntil::kMetadataEntry,
+                                                CircuitCapacity::kMetadataEntry,
+                                                MinimumChargeCurrent::kMetadataEntry,
+                                                MaximumChargeCurrent::kMetadataEntry,
+                                                MaximumDischargeCurrent::kMetadataEntry,
+                                                NextChargeStartTime::kMetadataEntry,
+                                                NextChargeTargetTime::kMetadataEntry,
+                                                NextChargeRequiredEnergy::kMetadataEntry,
+                                                NextChargeTargetSoC::kMetadataEntry,
+                                                ApproximateEVEfficiency::kMetadataEntry,
+                                                StateOfCharge::kMetadataEntry,
+                                                BatteryCapacity::kMetadataEntry,
+                                                VehicleID::kMetadataEntry,
+                                                SessionID::kMetadataEntry,
+                                                SessionDuration::kMetadataEntry,
+                                                SessionEnergyCharged::kMetadataEntry,
+                                                SessionEnergyDischarged::kMetadataEntry,
+                                                UserMaximumChargeCurrent::kMetadataEntry,
+                                                RandomizationDelayWindow::kMetadataEntry,
+                                            }));
+
+        EXPECT_TRUE(IsAcceptedCommandsListEqualTo(
+            cluster,
+            {
+                { Disable::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { EnableCharging::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { EnableDischarging::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { StartDiagnostics::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { SetTargets::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { GetTargets::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+                { ClearTargets::Id,
+                  BitMask<chip::app::DataModel::CommandQualityFlags>(chip::app::DataModel::CommandQualityFlags::kTimed) },
+            }));
+
+        EXPECT_TRUE(IsGeneratedCommandsListEqualTo(cluster,
+                                                   {
+                                                       GetTargetsResponse::Id,
+                                                   }));
+
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
+}
+
+// =============================================================================
+// Startup Tests
+// =============================================================================
+
+TEST_F(TestEnergyEvseCluster, TestStartupFailsWithMismatchedEndpointId)
+{
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> noFeatures;
+    BitMask<OptionalAttributes> optionalAttributes;
+    BitMask<OptionalCommands> optionalCommands;
+
+    constexpr EndpointId kClusterEndpointId  = 1;
+    constexpr EndpointId kDelegateEndpointId = 2;
+
+    // Create cluster with one endpoint ID
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kClusterEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+
+    // Set delegate to a different endpoint ID
+    mockDelegate.SetEndpointId(kDelegateEndpointId);
+
+    // Startup should fail because endpoint IDs don't match
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_F(TestEnergyEvseCluster, TestStartupSucceedsWithMatchingEndpointId)
+{
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> noFeatures;
+    BitMask<OptionalAttributes> optionalAttributes;
+    BitMask<OptionalCommands> optionalCommands;
+    constexpr EndpointId kEndpointId = 1;
+
+    // Create cluster with endpoint ID
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+
+    // Delegate endpoint ID is set in constructor, so they should match
+    EXPECT_EQ(mockDelegate.GetEndpointId(), kEndpointId);
+
+    // Startup should succeed because endpoint IDs match
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// =============================================================================
+// Attribute Tests
+// =============================================================================
+
+TEST_F(TestEnergyEvseCluster, TestAttributesMinimalConfig)
+{
+    // Test with minimal configuration (no features, no optional attributes)
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> noFeatures;
+    BitMask<OptionalAttributes> optionalAttributes;
+    BitMask<OptionalCommands> optionalCommands;
+
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    EXPECT_TRUE(IsAttributesListEqualTo(cluster,
+                                        {
+                                            State::kMetadataEntry,
+                                            SupplyState::kMetadataEntry,
+                                            FaultState::kMetadataEntry,
+                                            ChargingEnabledUntil::kMetadataEntry,
+                                            CircuitCapacity::kMetadataEntry,
+                                            MinimumChargeCurrent::kMetadataEntry,
+                                            MaximumChargeCurrent::kMetadataEntry,
+                                            SessionID::kMetadataEntry,
+                                            SessionDuration::kMetadataEntry,
+                                            SessionEnergyCharged::kMetadataEntry,
+                                        }));
+
+    ClusterTester tester(cluster);
+
+    // Read mandatory attributes and verify values
+    StateEnum state = StateEnum::kUnknownEnumValue;
+    ASSERT_EQ(tester.ReadAttribute(State::Id, state), CHIP_NO_ERROR);
+    EXPECT_EQ(state, MockEvseDelegate::kMockState);
+
+    SupplyStateEnum supplyState = SupplyStateEnum::kUnknownEnumValue;
+    ASSERT_EQ(tester.ReadAttribute(SupplyState::Id, supplyState), CHIP_NO_ERROR);
+    EXPECT_EQ(supplyState, MockEvseDelegate::kMockSupplyState);
+
+    FaultStateEnum faultState = FaultStateEnum::kUnknownEnumValue;
+    ASSERT_EQ(tester.ReadAttribute(FaultState::Id, faultState), CHIP_NO_ERROR);
+    EXPECT_EQ(faultState, MockEvseDelegate::kMockFaultState);
+
+    DataModel::Nullable<uint32_t> chargingEnabledUntil;
+    ASSERT_EQ(tester.ReadAttribute(ChargingEnabledUntil::Id, chargingEnabledUntil), CHIP_NO_ERROR);
+    ASSERT_FALSE(chargingEnabledUntil.IsNull());
+    EXPECT_EQ(chargingEnabledUntil.Value(), MockEvseDelegate::kMockChargingEnabledUntil);
+
+    int64_t circuitCapacity = 0;
+    ASSERT_EQ(tester.ReadAttribute(CircuitCapacity::Id, circuitCapacity), CHIP_NO_ERROR);
+    EXPECT_EQ(circuitCapacity, MockEvseDelegate::kMockCircuitCapacity);
+
+    int64_t minimumChargeCurrent = 0;
+    ASSERT_EQ(tester.ReadAttribute(MinimumChargeCurrent::Id, minimumChargeCurrent), CHIP_NO_ERROR);
+    EXPECT_EQ(minimumChargeCurrent, MockEvseDelegate::kMockMinimumChargeCurrent);
+
+    int64_t maximumChargeCurrent = 0;
+    ASSERT_EQ(tester.ReadAttribute(MaximumChargeCurrent::Id, maximumChargeCurrent), CHIP_NO_ERROR);
+    EXPECT_EQ(maximumChargeCurrent, MockEvseDelegate::kMockMaximumChargeCurrent);
+
+    DataModel::Nullable<uint32_t> sessionID;
+    ASSERT_EQ(tester.ReadAttribute(SessionID::Id, sessionID), CHIP_NO_ERROR);
+    ASSERT_FALSE(sessionID.IsNull());
+    EXPECT_EQ(sessionID.Value(), MockEvseDelegate::kMockSessionID);
+
+    DataModel::Nullable<uint32_t> sessionDuration;
+    ASSERT_EQ(tester.ReadAttribute(SessionDuration::Id, sessionDuration), CHIP_NO_ERROR);
+    ASSERT_FALSE(sessionDuration.IsNull());
+    EXPECT_EQ(sessionDuration.Value(), MockEvseDelegate::kMockSessionDuration);
+
+    DataModel::Nullable<int64_t> sessionEnergyCharged;
+    ASSERT_EQ(tester.ReadAttribute(SessionEnergyCharged::Id, sessionEnergyCharged), CHIP_NO_ERROR);
+    ASSERT_FALSE(sessionEnergyCharged.IsNull());
+    EXPECT_EQ(sessionEnergyCharged.Value(), MockEvseDelegate::kMockSessionEnergyCharged);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestEnergyEvseCluster, TestAttributesFullConfig)
+{
+    // Test with all features and optional attributes
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kV2x, Feature::kSoCReporting, Feature::kPlugAndCharge);
+    BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
+                                                   OptionalAttributes::kSupportsRandomizationWindow,
+                                                   OptionalAttributes::kSupportsApproximateEvEfficiency);
+    BitMask<OptionalCommands> optionalCommands;
+
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+
+    // Read mandatory attributes
+    StateEnum state = StateEnum::kUnknownEnumValue;
+    ASSERT_EQ(tester.ReadAttribute(State::Id, state), CHIP_NO_ERROR);
+    EXPECT_EQ(state, MockEvseDelegate::kMockState);
+
+    SupplyStateEnum supplyState = SupplyStateEnum::kUnknownEnumValue;
+    ASSERT_EQ(tester.ReadAttribute(SupplyState::Id, supplyState), CHIP_NO_ERROR);
+    EXPECT_EQ(supplyState, MockEvseDelegate::kMockSupplyState);
+
+    FaultStateEnum faultState = FaultStateEnum::kUnknownEnumValue;
+    ASSERT_EQ(tester.ReadAttribute(FaultState::Id, faultState), CHIP_NO_ERROR);
+    EXPECT_EQ(faultState, MockEvseDelegate::kMockFaultState);
+
+    DataModel::Nullable<uint32_t> chargingEnabledUntil;
+    ASSERT_EQ(tester.ReadAttribute(ChargingEnabledUntil::Id, chargingEnabledUntil), CHIP_NO_ERROR);
+    ASSERT_FALSE(chargingEnabledUntil.IsNull());
+    EXPECT_EQ(chargingEnabledUntil.Value(), MockEvseDelegate::kMockChargingEnabledUntil);
+
+    int64_t circuitCapacity = 0;
+    ASSERT_EQ(tester.ReadAttribute(CircuitCapacity::Id, circuitCapacity), CHIP_NO_ERROR);
+    EXPECT_EQ(circuitCapacity, MockEvseDelegate::kMockCircuitCapacity);
+
+    int64_t minimumChargeCurrent = 0;
+    ASSERT_EQ(tester.ReadAttribute(MinimumChargeCurrent::Id, minimumChargeCurrent), CHIP_NO_ERROR);
+    EXPECT_EQ(minimumChargeCurrent, MockEvseDelegate::kMockMinimumChargeCurrent);
+
+    int64_t maximumChargeCurrent = 0;
+    ASSERT_EQ(tester.ReadAttribute(MaximumChargeCurrent::Id, maximumChargeCurrent), CHIP_NO_ERROR);
+    EXPECT_EQ(maximumChargeCurrent, MockEvseDelegate::kMockMaximumChargeCurrent);
+
+    // V2x feature attributes
+    DataModel::Nullable<uint32_t> dischargingEnabledUntil;
+    ASSERT_EQ(tester.ReadAttribute(DischargingEnabledUntil::Id, dischargingEnabledUntil), CHIP_NO_ERROR);
+    ASSERT_FALSE(dischargingEnabledUntil.IsNull());
+    EXPECT_EQ(dischargingEnabledUntil.Value(), MockEvseDelegate::kMockDischargingEnabledUntil);
+
+    int64_t maximumDischargeCurrent = 0;
+    ASSERT_EQ(tester.ReadAttribute(MaximumDischargeCurrent::Id, maximumDischargeCurrent), CHIP_NO_ERROR);
+    EXPECT_EQ(maximumDischargeCurrent, MockEvseDelegate::kMockMaximumDischargeCurrent);
+
+    DataModel::Nullable<int64_t> sessionEnergyDischarged;
+    ASSERT_EQ(tester.ReadAttribute(SessionEnergyDischarged::Id, sessionEnergyDischarged), CHIP_NO_ERROR);
+    ASSERT_FALSE(sessionEnergyDischarged.IsNull());
+    EXPECT_EQ(sessionEnergyDischarged.Value(), MockEvseDelegate::kMockSessionEnergyDischarged);
+
+    // ChargingPreferences feature attributes
+    DataModel::Nullable<uint32_t> nextChargeStartTime;
+    ASSERT_EQ(tester.ReadAttribute(NextChargeStartTime::Id, nextChargeStartTime), CHIP_NO_ERROR);
+    ASSERT_FALSE(nextChargeStartTime.IsNull());
+    EXPECT_EQ(nextChargeStartTime.Value(), MockEvseDelegate::kMockNextChargeStartTime);
+
+    DataModel::Nullable<uint32_t> nextChargeTargetTime;
+    ASSERT_EQ(tester.ReadAttribute(NextChargeTargetTime::Id, nextChargeTargetTime), CHIP_NO_ERROR);
+    ASSERT_FALSE(nextChargeTargetTime.IsNull());
+    EXPECT_EQ(nextChargeTargetTime.Value(), MockEvseDelegate::kMockNextChargeTargetTime);
+
+    DataModel::Nullable<int64_t> nextChargeRequiredEnergy;
+    ASSERT_EQ(tester.ReadAttribute(NextChargeRequiredEnergy::Id, nextChargeRequiredEnergy), CHIP_NO_ERROR);
+    ASSERT_FALSE(nextChargeRequiredEnergy.IsNull());
+    EXPECT_EQ(nextChargeRequiredEnergy.Value(), MockEvseDelegate::kMockNextChargeRequiredEnergy);
+
+    DataModel::Nullable<Percent> nextChargeTargetSoC;
+    ASSERT_EQ(tester.ReadAttribute(NextChargeTargetSoC::Id, nextChargeTargetSoC), CHIP_NO_ERROR);
+    ASSERT_FALSE(nextChargeTargetSoC.IsNull());
+    EXPECT_EQ(nextChargeTargetSoC.Value(), MockEvseDelegate::kMockNextChargeTargetSoC);
+
+    // SoCReporting feature attributes
+    DataModel::Nullable<Percent> stateOfCharge;
+    ASSERT_EQ(tester.ReadAttribute(StateOfCharge::Id, stateOfCharge), CHIP_NO_ERROR);
+    ASSERT_FALSE(stateOfCharge.IsNull());
+    EXPECT_EQ(stateOfCharge.Value(), MockEvseDelegate::kMockStateOfCharge);
+
+    DataModel::Nullable<int64_t> batteryCapacity;
+    ASSERT_EQ(tester.ReadAttribute(BatteryCapacity::Id, batteryCapacity), CHIP_NO_ERROR);
+    ASSERT_FALSE(batteryCapacity.IsNull());
+    EXPECT_EQ(batteryCapacity.Value(), MockEvseDelegate::kMockBatteryCapacity);
+
+    // PlugAndCharge feature attributes
+    DataModel::Nullable<CharSpan> vehicleID;
+    ASSERT_EQ(tester.ReadAttribute(VehicleID::Id, vehicleID), CHIP_NO_ERROR);
+    ASSERT_FALSE(vehicleID.IsNull());
+    EXPECT_TRUE(vehicleID.Value().data_equal(CharSpan::fromCharString("MOCK-VIN-12345")));
+
+    // Optional attributes
+    int64_t userMaximumChargeCurrent = 0;
+    ASSERT_EQ(tester.ReadAttribute(UserMaximumChargeCurrent::Id, userMaximumChargeCurrent), CHIP_NO_ERROR);
+    EXPECT_EQ(userMaximumChargeCurrent, MockEvseDelegate::kMockUserMaximumChargeCurrent);
+
+    uint32_t randomizationDelayWindow = 0;
+    ASSERT_EQ(tester.ReadAttribute(RandomizationDelayWindow::Id, randomizationDelayWindow), CHIP_NO_ERROR);
+    EXPECT_EQ(randomizationDelayWindow, MockEvseDelegate::kMockRandomizationDelayWindow);
+
+    DataModel::Nullable<uint16_t> approximateEVEfficiency;
+    ASSERT_EQ(tester.ReadAttribute(ApproximateEVEfficiency::Id, approximateEVEfficiency), CHIP_NO_ERROR);
+    ASSERT_FALSE(approximateEVEfficiency.IsNull());
+    EXPECT_EQ(approximateEVEfficiency.Value(), MockEvseDelegate::kMockApproximateEVEfficiency);
+
+    // Session attributes
+    DataModel::Nullable<uint32_t> sessionID;
+    ASSERT_EQ(tester.ReadAttribute(SessionID::Id, sessionID), CHIP_NO_ERROR);
+    ASSERT_FALSE(sessionID.IsNull());
+    EXPECT_EQ(sessionID.Value(), MockEvseDelegate::kMockSessionID);
+
+    DataModel::Nullable<uint32_t> sessionDuration;
+    ASSERT_EQ(tester.ReadAttribute(SessionDuration::Id, sessionDuration), CHIP_NO_ERROR);
+    ASSERT_FALSE(sessionDuration.IsNull());
+    EXPECT_EQ(sessionDuration.Value(), MockEvseDelegate::kMockSessionDuration);
+
+    DataModel::Nullable<int64_t> sessionEnergyCharged;
+    ASSERT_EQ(tester.ReadAttribute(SessionEnergyCharged::Id, sessionEnergyCharged), CHIP_NO_ERROR);
+    ASSERT_FALSE(sessionEnergyCharged.IsNull());
+    EXPECT_EQ(sessionEnergyCharged.Value(), MockEvseDelegate::kMockSessionEnergyCharged);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestEnergyEvseCluster, TestWriteAttributes)
+{
+    // Test writing to writable attributes
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kV2x, Feature::kSoCReporting, Feature::kPlugAndCharge);
+    BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
+                                                   OptionalAttributes::kSupportsRandomizationWindow,
+                                                   OptionalAttributes::kSupportsApproximateEvEfficiency);
+    BitMask<OptionalCommands> optionalCommands;
+
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+
+    // Test writing UserMaximumChargeCurrent
+    int64_t newUserMaximumChargeCurrent = 20000; // 20A in mA
+    EXPECT_TRUE(tester.WriteAttribute(UserMaximumChargeCurrent::Id, newUserMaximumChargeCurrent).IsSuccess());
+
+    // Read back and verify
+    int64_t readUserMaximumChargeCurrent = 0;
+    ASSERT_EQ(tester.ReadAttribute(UserMaximumChargeCurrent::Id, readUserMaximumChargeCurrent), CHIP_NO_ERROR);
+    EXPECT_EQ(readUserMaximumChargeCurrent, newUserMaximumChargeCurrent);
+
+    // Test writing RandomizationDelayWindow
+    uint32_t newRandomizationDelayWindow = 300; // 5 minutes
+    EXPECT_TRUE(tester.WriteAttribute(RandomizationDelayWindow::Id, newRandomizationDelayWindow).IsSuccess());
+
+    // Read back and verify
+    uint32_t readRandomizationDelayWindow = 0;
+    ASSERT_EQ(tester.ReadAttribute(RandomizationDelayWindow::Id, readRandomizationDelayWindow), CHIP_NO_ERROR);
+    EXPECT_EQ(readRandomizationDelayWindow, newRandomizationDelayWindow);
+
+    // Test writing ApproximateEVEfficiency
+    DataModel::Nullable<uint16_t> newApproximateEVEfficiency(200); // 200 Wh/km
+    EXPECT_TRUE(tester.WriteAttribute(ApproximateEVEfficiency::Id, newApproximateEVEfficiency).IsSuccess());
+
+    // Read back and verify
+    DataModel::Nullable<uint16_t> readApproximateEVEfficiency;
+    ASSERT_EQ(tester.ReadAttribute(ApproximateEVEfficiency::Id, readApproximateEVEfficiency), CHIP_NO_ERROR);
+    ASSERT_FALSE(readApproximateEVEfficiency.IsNull());
+    EXPECT_EQ(readApproximateEVEfficiency.Value(), 200);
+
+    // Test writing ApproximateEVEfficiency with null value
+    DataModel::Nullable<uint16_t> nullValue;
+    nullValue.SetNull();
+    EXPECT_TRUE(tester.WriteAttribute(ApproximateEVEfficiency::Id, nullValue).IsSuccess());
+
+    // Read back and verify it's null
+    DataModel::Nullable<uint16_t> readNullValue;
+    ASSERT_EQ(tester.ReadAttribute(ApproximateEVEfficiency::Id, readNullValue), CHIP_NO_ERROR);
+    EXPECT_TRUE(readNullValue.IsNull());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestEnergyEvseCluster, TestWriteReadOnlyAttributesFails)
+{
+    // Test that writing to read-only attributes fails with UnsupportedWrite
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kV2x, Feature::kSoCReporting, Feature::kPlugAndCharge);
+    BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
+                                                   OptionalAttributes::kSupportsRandomizationWindow,
+                                                   OptionalAttributes::kSupportsApproximateEvEfficiency);
+    BitMask<OptionalCommands> optionalCommands;
+
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+
+    // Test writing to State (read-only)
+    EXPECT_FALSE(tester.WriteAttribute(State::Id, StateEnum::kPluggedInCharging).IsSuccess());
+
+    // Test writing to SupplyState (read-only)
+    EXPECT_FALSE(tester.WriteAttribute(SupplyState::Id, SupplyStateEnum::kDisabled).IsSuccess());
+
+    // Test writing to FaultState (read-only)
+    EXPECT_FALSE(tester.WriteAttribute(FaultState::Id, FaultStateEnum::kGroundFault).IsSuccess());
+
+    // Test writing to ChargingEnabledUntil (read-only)
+    EXPECT_FALSE(tester.WriteAttribute(ChargingEnabledUntil::Id, DataModel::Nullable<uint32_t>(5000)).IsSuccess());
+
+    // Test writing to CircuitCapacity (read-only)
+    EXPECT_FALSE(tester.WriteAttribute(CircuitCapacity::Id, static_cast<int64_t>(50000)).IsSuccess());
+
+    // Test writing to MinimumChargeCurrent (read-only)
+    EXPECT_FALSE(tester.WriteAttribute(MinimumChargeCurrent::Id, static_cast<int64_t>(8000)).IsSuccess());
+
+    // Test writing to MaximumChargeCurrent (read-only)
+    EXPECT_FALSE(tester.WriteAttribute(MaximumChargeCurrent::Id, static_cast<int64_t>(40000)).IsSuccess());
+
+    // Test writing to SessionID (read-only)
+    EXPECT_FALSE(tester.WriteAttribute(SessionID::Id, DataModel::Nullable<uint32_t>(99999)).IsSuccess());
+
+    // Test writing to SessionDuration (read-only)
+    EXPECT_FALSE(tester.WriteAttribute(SessionDuration::Id, DataModel::Nullable<uint32_t>(9999)).IsSuccess());
+
+    // Test writing to SessionEnergyCharged (read-only)
+    EXPECT_FALSE(tester.WriteAttribute(SessionEnergyCharged::Id, DataModel::Nullable<int64_t>(99999999)).IsSuccess());
+
+    // Test writing to StateOfCharge (read-only, SoCReporting feature)
+    EXPECT_FALSE(tester.WriteAttribute(StateOfCharge::Id, DataModel::Nullable<Percent>(90)).IsSuccess());
+
+    // Test writing to BatteryCapacity (read-only, SoCReporting feature)
+    EXPECT_FALSE(tester.WriteAttribute(BatteryCapacity::Id, DataModel::Nullable<int64_t>(80000000)).IsSuccess());
+
+    // Test writing to VehicleID (read-only, PlugAndCharge feature)
+    EXPECT_FALSE(
+        tester.WriteAttribute(VehicleID::Id, DataModel::Nullable<CharSpan>(CharSpan::fromCharString("NEW-VIN"))).IsSuccess());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// =============================================================================
+// Disable Command Tests
+// =============================================================================
+
+TEST_F(TestEnergyEvseCluster, TestDisable)
+{
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> noFeatures;
+    BitMask<OptionalAttributes> optionalAttributes;
+    BitMask<OptionalCommands> optionalCommands;
+
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    Commands::Disable::Type command;
+    EXPECT_TRUE(tester.Invoke(Commands::Disable::Id, command).IsSuccess());
+
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabled);
+    EXPECT_EQ(mockDelegate.GetChargingEnabledUntil().Value(), 0u);
+    EXPECT_EQ(mockDelegate.GetDischargingEnabledUntil().Value(), 0u);
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// =============================================================================
+// EnableCharging Command Tests
+// =============================================================================
+
+TEST_F(TestEnergyEvseCluster, TestEnableCharging)
+{
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> noFeatures;
+    BitMask<OptionalAttributes> optionalAttributes;
+    BitMask<OptionalCommands> optionalCommands;
+
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    Commands::EnableCharging::Type command;
+
+    // --- Constraint error tests ---
+
+    // minimumChargeCurrent < 0 (below kMinimumChargeCurrentLimit)
+    command.chargingEnabledUntil = 5000;
+    command.minimumChargeCurrent = -1;
+    command.maximumChargeCurrent = 32000;
+    EXPECT_FALSE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
+
+    // maximumChargeCurrent < 0 (below kMinimumChargeCurrentLimit)
+    command.minimumChargeCurrent = 6000;
+    command.maximumChargeCurrent = -1;
+    EXPECT_FALSE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
+
+    // minimumChargeCurrent > maximumChargeCurrent
+    command.minimumChargeCurrent = 32000;
+    command.maximumChargeCurrent = 6000;
+    EXPECT_FALSE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
+
+    // --- Failure with FaultState ---
+
+    mockDelegate.SetFaultState(FaultStateEnum::kGroundFault);
+    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    command.chargingEnabledUntil = 5000;
+    command.minimumChargeCurrent = 6000;
+    command.maximumChargeCurrent = 32000;
+    EXPECT_FALSE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabled);
+
+    // --- Failure with DiagnosticsActive ---
+
+    mockDelegate.SetFaultState(FaultStateEnum::kNoError);
+    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabledDiagnostics);
+    EXPECT_FALSE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabledDiagnostics);
+
+    // --- Success from Disabled state -> ChargingEnabled ---
+
+    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    command.chargingEnabledUntil = 5000;
+    command.minimumChargeCurrent = 8000;
+    command.maximumChargeCurrent = 40000;
+    EXPECT_TRUE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
+    EXPECT_EQ(mockDelegate.GetChargingEnabledUntil().Value(), 5000u);
+    EXPECT_EQ(mockDelegate.GetMinimumChargeCurrent(), 8000);
+    EXPECT_EQ(mockDelegate.GetMaximumChargeCurrent(), 40000);
+
+    // --- Success from DisabledError state -> ChargingEnabled ---
+
+    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabledError);
+    command.chargingEnabledUntil = 6000;
+    command.minimumChargeCurrent = 6000;
+    command.maximumChargeCurrent = 32000;
+    EXPECT_TRUE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
+    EXPECT_EQ(mockDelegate.GetChargingEnabledUntil().Value(), 6000u);
+
+    // --- Success from DischargingEnabled state -> Enabled (both) ---
+
+    mockDelegate.SetSupplyState(SupplyStateEnum::kDischargingEnabled);
+    command.chargingEnabledUntil = 7000;
+    command.minimumChargeCurrent = 6000;
+    command.maximumChargeCurrent = 24000;
+    EXPECT_TRUE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kEnabled);
+    EXPECT_EQ(mockDelegate.GetChargingEnabledUntil().Value(), 7000u);
+
+    // --- Success with null timestamp (indefinite charging) ---
+
+    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    command.chargingEnabledUntil.SetNull();
+    command.minimumChargeCurrent = 6000;
+    command.maximumChargeCurrent = 32000;
+    EXPECT_TRUE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
+    EXPECT_TRUE(mockDelegate.GetChargingEnabledUntil().IsNull());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// =============================================================================
+// EnableDischarging Command Tests
+// =============================================================================
+
+TEST_F(TestEnergyEvseCluster, TestEnableDischarging)
+{
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> features(Feature::kV2x); // V2x feature enables discharging
+    BitMask<OptionalAttributes> optionalAttributes;
+    BitMask<OptionalCommands> optionalCommands;
+
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, features, optionalAttributes, optionalCommands));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    Commands::EnableDischarging::Type command;
+
+    // --- Constraint error test ---
+
+    // maximumDischargeCurrent < 0 (below kMinimumChargeCurrentLimit)
+    command.dischargingEnabledUntil = 5000;
+    command.maximumDischargeCurrent = -1;
+    EXPECT_FALSE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
+
+    // --- Failure with FaultState ---
+
+    mockDelegate.SetFaultState(FaultStateEnum::kGroundFault);
+    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    command.dischargingEnabledUntil = 5000;
+    command.maximumDischargeCurrent = 16000;
+    EXPECT_FALSE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabled);
+
+    // --- Failure with DiagnosticsActive ---
+
+    mockDelegate.SetFaultState(FaultStateEnum::kNoError);
+    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabledDiagnostics);
+    EXPECT_FALSE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabledDiagnostics);
+
+    // --- Success from Disabled state -> DischargingEnabled ---
+
+    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    command.dischargingEnabledUntil = 5000;
+    command.maximumDischargeCurrent = 16000;
+    EXPECT_TRUE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDischargingEnabled);
+    EXPECT_EQ(mockDelegate.GetDischargingEnabledUntil().Value(), 5000u);
+    EXPECT_EQ(mockDelegate.GetMaximumDischargeCurrent(), 16000);
+
+    // --- Success from DisabledError state -> DischargingEnabled ---
+
+    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabledError);
+    command.dischargingEnabledUntil = 6000;
+    command.maximumDischargeCurrent = 12000;
+    EXPECT_TRUE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDischargingEnabled);
+    EXPECT_EQ(mockDelegate.GetDischargingEnabledUntil().Value(), 6000u);
+
+    // --- Success from ChargingEnabled state -> Enabled (both) ---
+
+    mockDelegate.SetSupplyState(SupplyStateEnum::kChargingEnabled);
+    command.dischargingEnabledUntil = 7000;
+    command.maximumDischargeCurrent = 10000;
+    EXPECT_TRUE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kEnabled);
+    EXPECT_EQ(mockDelegate.GetDischargingEnabledUntil().Value(), 7000u);
+
+    // --- Success with null timestamp (indefinite discharging) ---
+
+    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    command.dischargingEnabledUntil.SetNull();
+    command.maximumDischargeCurrent = 16000;
+    EXPECT_TRUE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDischargingEnabled);
+    EXPECT_TRUE(mockDelegate.GetDischargingEnabledUntil().IsNull());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// =============================================================================
+// StartDiagnostics Command Tests
+// =============================================================================
+
+TEST_F(TestEnergyEvseCluster, TestStartDiagnostics)
+{
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> noFeatures;
+    BitMask<OptionalAttributes> optionalAttributes;
+    // Test with command supported
+    {
+        BitMask<OptionalCommands> optionalCommands(OptionalCommands::kSupportsStartDiagnostics);
+        EnergyEvseCluster cluster(
+            EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+
+        EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+        ClusterTester tester(cluster);
+        Commands::StartDiagnostics::Type command;
+
+        mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+        EXPECT_TRUE(tester.Invoke(Commands::StartDiagnostics::Id, command).IsSuccess());
+        EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabledDiagnostics);
+
+        // --- Failure with DiagnosticsActive ---
+
+        mockDelegate.SetSupplyState(SupplyStateEnum::kDisabledDiagnostics);
+        EXPECT_FALSE(tester.Invoke(Commands::StartDiagnostics::Id, command).IsSuccess());
+
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
+    // Test with command not supported
+    {
+        BitMask<OptionalCommands> optionalCommands;
+        EnergyEvseCluster cluster(
+            EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+        EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+        ClusterTester tester(cluster);
+        Commands::StartDiagnostics::Type command;
+
+        mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+        EXPECT_FALSE(tester.Invoke(Commands::StartDiagnostics::Id, command).IsSuccess());
+        EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabled);
+
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
+}
+
+// =============================================================================
+// SetTargets, GetTargets, ClearTargets Command Tests
+// =============================================================================
+
+TEST_F(TestEnergyEvseCluster, TestTargetsCommands)
+{
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    // ChargingPreferences feature is required for targets commands
+    // SoCReporting feature requires TargetSoC to be present
+    BitMask<Feature> features(Feature::kChargingPreferences, Feature::kSoCReporting);
+    BitMask<OptionalAttributes> optionalAttributes;
+    BitMask<OptionalCommands> optionalCommands;
+
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, features, optionalAttributes, optionalCommands));
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+
+    // --- Setup valid targets for Monday at 8:00 AM (480 minutes) ---
+
+    Structs::ChargingTargetStruct::Type mondayTarget;
+    mondayTarget.targetTimeMinutesPastMidnight = 480; // 8:00 AM
+    mondayTarget.targetSoC.SetValue(80);              // 80% SoC
+    mondayTarget.addedEnergy.SetValue(10000000);      // 10 kWh
+
+    Structs::ChargingTargetScheduleStruct::Type mondaySchedule;
+    mondaySchedule.dayOfWeekForSequence = BitMask<TargetDayOfWeekBitmap>(TargetDayOfWeekBitmap::kMonday);
+    mondaySchedule.chargingTargets      = DataModel::List<const Structs::ChargingTargetStruct::Type>(&mondayTarget, 1);
+
+    Commands::SetTargets::Type setTargetsCmd;
+    setTargetsCmd.chargingTargetSchedules = DataModel::List<const Structs::ChargingTargetScheduleStruct::Type>(&mondaySchedule, 1);
+
+    // --- Success: Set valid targets for Monday ---
+
+    EXPECT_TRUE(tester.Invoke(Commands::SetTargets::Id, setTargetsCmd).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetTotalTargetsCount(), 1u);
+    EXPECT_EQ(mockDelegate.GetDaysWithTargets(), static_cast<uint8_t>(TargetDayOfWeekBitmap::kMonday));
+
+    // --- ClearTargets: Verify targets are cleared ---
+
+    Commands::ClearTargets::Type clearTargetsCmd;
+    EXPECT_TRUE(tester.Invoke(Commands::ClearTargets::Id, clearTargetsCmd).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetTotalTargetsCount(), 0u);
+    EXPECT_EQ(mockDelegate.GetDaysWithTargets(), 0u);
+
+    // --- Constraint Error: MinutesPastMidnight > 1439 ---
+
+    Structs::ChargingTargetStruct::Type invalidTimeTarget;
+    invalidTimeTarget.targetTimeMinutesPastMidnight = 1440; // Invalid: max is 1439
+    invalidTimeTarget.targetSoC.SetValue(80);
+
+    Structs::ChargingTargetScheduleStruct::Type invalidTimeSchedule;
+    invalidTimeSchedule.dayOfWeekForSequence = BitMask<TargetDayOfWeekBitmap>(TargetDayOfWeekBitmap::kTuesday);
+    invalidTimeSchedule.chargingTargets      = DataModel::List<const Structs::ChargingTargetStruct::Type>(&invalidTimeTarget, 1);
+
+    setTargetsCmd.chargingTargetSchedules =
+        DataModel::List<const Structs::ChargingTargetScheduleStruct::Type>(&invalidTimeSchedule, 1);
+    EXPECT_FALSE(tester.Invoke(Commands::SetTargets::Id, setTargetsCmd).IsSuccess());
+
+    // --- Constraint Error: TargetSoC > 100 ---
+
+    Structs::ChargingTargetStruct::Type invalidSoCTarget;
+    invalidSoCTarget.targetTimeMinutesPastMidnight = 480;
+    invalidSoCTarget.targetSoC.SetValue(101); // Invalid: max is 100
+
+    Structs::ChargingTargetScheduleStruct::Type invalidSoCSchedule;
+    invalidSoCSchedule.dayOfWeekForSequence = BitMask<TargetDayOfWeekBitmap>(TargetDayOfWeekBitmap::kWednesday);
+    invalidSoCSchedule.chargingTargets      = DataModel::List<const Structs::ChargingTargetStruct::Type>(&invalidSoCTarget, 1);
+
+    setTargetsCmd.chargingTargetSchedules =
+        DataModel::List<const Structs::ChargingTargetScheduleStruct::Type>(&invalidSoCSchedule, 1);
+    EXPECT_FALSE(tester.Invoke(Commands::SetTargets::Id, setTargetsCmd).IsSuccess());
+
+    // --- Constraint Error: Duplicate day in multiple schedules ---
+
+    Structs::ChargingTargetStruct::Type target1, target2;
+    target1.targetTimeMinutesPastMidnight = 480;
+    target1.targetSoC.SetValue(80);
+    target2.targetTimeMinutesPastMidnight = 600;
+    target2.targetSoC.SetValue(90);
+
+    Structs::ChargingTargetScheduleStruct::Type schedules[2];
+    schedules[0].dayOfWeekForSequence = BitMask<TargetDayOfWeekBitmap>(TargetDayOfWeekBitmap::kThursday);
+    schedules[0].chargingTargets      = DataModel::List<const Structs::ChargingTargetStruct::Type>(&target1, 1);
+    schedules[1].dayOfWeekForSequence = BitMask<TargetDayOfWeekBitmap>(TargetDayOfWeekBitmap::kThursday); // Duplicate!
+    schedules[1].chargingTargets      = DataModel::List<const Structs::ChargingTargetStruct::Type>(&target2, 1);
+
+    setTargetsCmd.chargingTargetSchedules = DataModel::List<const Structs::ChargingTargetScheduleStruct::Type>(schedules, 2);
+    EXPECT_FALSE(tester.Invoke(Commands::SetTargets::Id, setTargetsCmd).IsSuccess());
+
+    // --- Success: Set targets for multiple days ---
+
+    Structs::ChargingTargetStruct::Type weekdayTarget;
+    weekdayTarget.targetTimeMinutesPastMidnight = 420; // 7:00 AM
+    weekdayTarget.targetSoC.SetValue(85);
+
+    Structs::ChargingTargetStruct::Type weekendTarget;
+    weekendTarget.targetTimeMinutesPastMidnight = 600; // 10:00 AM
+    weekendTarget.targetSoC.SetValue(100);
+
+    Structs::ChargingTargetScheduleStruct::Type multiDaySchedules[2];
+    // Monday through Friday
+    multiDaySchedules[0].dayOfWeekForSequence = BitMask<TargetDayOfWeekBitmap>(
+        TargetDayOfWeekBitmap::kMonday, TargetDayOfWeekBitmap::kTuesday, TargetDayOfWeekBitmap::kWednesday,
+        TargetDayOfWeekBitmap::kThursday, TargetDayOfWeekBitmap::kFriday);
+    multiDaySchedules[0].chargingTargets = DataModel::List<const Structs::ChargingTargetStruct::Type>(&weekdayTarget, 1);
+    // Saturday and Sunday
+    multiDaySchedules[1].dayOfWeekForSequence =
+        BitMask<TargetDayOfWeekBitmap>(TargetDayOfWeekBitmap::kSaturday, TargetDayOfWeekBitmap::kSunday);
+    multiDaySchedules[1].chargingTargets = DataModel::List<const Structs::ChargingTargetStruct::Type>(&weekendTarget, 1);
+
+    setTargetsCmd.chargingTargetSchedules =
+        DataModel::List<const Structs::ChargingTargetScheduleStruct::Type>(multiDaySchedules, 2);
+    EXPECT_TRUE(tester.Invoke(Commands::SetTargets::Id, setTargetsCmd).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetTotalTargetsCount(), 7u);  // 7 days, 1 target each
+    EXPECT_EQ(mockDelegate.GetDaysWithTargets(), 0x7Fu); // All 7 days
+
+    // --- Success: Replace targets for Saturday only ---
+
+    Structs::ChargingTargetStruct::Type newSaturdayTarget;
+    newSaturdayTarget.targetTimeMinutesPastMidnight = 720; // 12:00 PM
+    newSaturdayTarget.targetSoC.SetValue(50);
+
+    Structs::ChargingTargetScheduleStruct::Type saturdaySchedule;
+    saturdaySchedule.dayOfWeekForSequence = BitMask<TargetDayOfWeekBitmap>(TargetDayOfWeekBitmap::kSaturday);
+    saturdaySchedule.chargingTargets      = DataModel::List<const Structs::ChargingTargetStruct::Type>(&newSaturdayTarget, 1);
+
+    setTargetsCmd.chargingTargetSchedules =
+        DataModel::List<const Structs::ChargingTargetScheduleStruct::Type>(&saturdaySchedule, 1);
+    EXPECT_TRUE(tester.Invoke(Commands::SetTargets::Id, setTargetsCmd).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetTotalTargetsCount(), 7u);  // Still 7 targets
+    EXPECT_EQ(mockDelegate.GetDaysWithTargets(), 0x7Fu); // All 7 days still
+
+    // --- Success: Clear targets for Sunday by setting empty list ---
+
+    Structs::ChargingTargetScheduleStruct::Type emptySundaySchedule;
+    emptySundaySchedule.dayOfWeekForSequence = BitMask<TargetDayOfWeekBitmap>(TargetDayOfWeekBitmap::kSunday);
+    emptySundaySchedule.chargingTargets      = DataModel::List<const Structs::ChargingTargetStruct::Type>();
+
+    setTargetsCmd.chargingTargetSchedules =
+        DataModel::List<const Structs::ChargingTargetScheduleStruct::Type>(&emptySundaySchedule, 1);
+    EXPECT_TRUE(tester.Invoke(Commands::SetTargets::Id, setTargetsCmd).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetTotalTargetsCount(), 6u);  // 6 targets now
+    EXPECT_EQ(mockDelegate.GetDaysWithTargets(), 0x7Eu); // All except Sunday
+
+    // --- Final ClearTargets ---
+
+    EXPECT_TRUE(tester.Invoke(Commands::ClearTargets::Id, clearTargetsCmd).IsSuccess());
+    EXPECT_EQ(mockDelegate.GetTotalTargetsCount(), 0u);
+    EXPECT_EQ(mockDelegate.GetDaysWithTargets(), 0u);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+} // namespace

--- a/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
@@ -44,6 +44,30 @@ namespace {
 
 constexpr EndpointId kTestEndpointId = 1;
 
+// Mock test values - used for verification in tests
+constexpr StateEnum kMockState                   = StateEnum::kPluggedInNoDemand;
+constexpr SupplyStateEnum kMockSupplyState       = SupplyStateEnum::kChargingEnabled;
+constexpr FaultStateEnum kMockFaultState         = FaultStateEnum::kNoError;
+constexpr uint32_t kMockChargingEnabledUntil     = 1000;
+constexpr uint32_t kMockDischargingEnabledUntil  = 2000;
+constexpr int64_t kMockCircuitCapacity           = 32000;    // 32A in mA
+constexpr int64_t kMockMinimumChargeCurrent      = 6000;     // 6A in mA
+constexpr int64_t kMockMaximumChargeCurrent      = 32000;    // 32A in mA
+constexpr int64_t kMockMaximumDischargeCurrent   = 16000;    // 16A in mA (V2x)
+constexpr int64_t kMockUserMaximumChargeCurrent  = 24000;    // 24A in mA
+constexpr uint32_t kMockRandomizationDelayWindow = 600;      // 10 minutes
+constexpr uint32_t kMockNextChargeStartTime      = 3600;     // 1 hour from now
+constexpr uint32_t kMockNextChargeTargetTime     = 7200;     // 2 hours from now
+constexpr int64_t kMockNextChargeRequiredEnergy  = 20000000; // 20 kWh in mWh
+constexpr Percent kMockNextChargeTargetSoC       = 80;
+constexpr uint16_t kMockApproximateEVEfficiency  = 150; // 150 Wh/km
+constexpr Percent kMockStateOfCharge             = 45;
+constexpr int64_t kMockBatteryCapacity           = 60000000; // 60 kWh in mWh
+constexpr uint32_t kMockSessionID                = 12345;
+constexpr uint32_t kMockSessionDuration          = 1800;    // 30 minutes
+constexpr int64_t kMockSessionEnergyCharged      = 5000000; // 5 kWh in mWh
+constexpr int64_t kMockSessionEnergyDischarged   = 1000000; // 1 kWh in mWh
+
 struct TestEnergyEvseCluster : public ::testing::Test
 {
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
@@ -70,6 +94,7 @@ TEST_F(TestEnergyEvseCluster, TestFeatures)
 
         EnergyEvseCluster cluster(
             EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, minimumFeatures, optionalAttributes, optionalCommands));
+        mockDelegate.SetCluster(cluster);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
         EXPECT_TRUE(IsAttributesListEqualTo(cluster,
@@ -118,6 +143,7 @@ TEST_F(TestEnergyEvseCluster, TestFeatures)
 
         EnergyEvseCluster cluster(
             EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+        mockDelegate.SetCluster(cluster);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
         EXPECT_TRUE(IsAttributesListEqualTo(cluster,
@@ -179,6 +205,7 @@ TEST_F(TestEnergyEvseCluster, TestFeatures)
 
         EnergyEvseCluster cluster(
             EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+        mockDelegate.SetCluster(cluster);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
         EXPECT_TRUE(IsAttributesListEqualTo(cluster,
@@ -254,6 +281,7 @@ TEST_F(TestEnergyEvseCluster, TestStartupFailsWithMismatchedEndpointId)
     // Create cluster with one endpoint ID
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kClusterEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     // Set delegate to a different endpoint ID
     mockDelegate.SetEndpointId(kDelegateEndpointId);
@@ -274,6 +302,7 @@ TEST_F(TestEnergyEvseCluster, TestStartupSucceedsWithMatchingEndpointId)
     // Create cluster with endpoint ID
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     // Delegate endpoint ID is set in constructor, so they should match
     EXPECT_EQ(mockDelegate.GetEndpointId(), kEndpointId);
@@ -299,6 +328,7 @@ TEST_F(TestEnergyEvseCluster, TestAttributesMinimalConfig)
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
@@ -375,6 +405,7 @@ TEST_F(TestEnergyEvseCluster, TestAttributesFullConfig)
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
@@ -495,6 +526,7 @@ TEST_F(TestEnergyEvseCluster, TestWriteAttributes)
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
@@ -554,6 +586,7 @@ TEST_F(TestEnergyEvseCluster, TestWriteAttributesNotifiesChange)
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
@@ -601,6 +634,7 @@ TEST_F(TestEnergyEvseCluster, TestWriteReadOnlyAttributesFails)
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
@@ -666,6 +700,7 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetAttributes)
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
@@ -681,7 +716,7 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetAttributes)
     EXPECT_EQ(dirtyList[0].mAttributeId, State::Id);
 
     // Verify delegate callback was called
-    EXPECT_EQ(mockDelegate.GetState(), StateEnum::kPluggedInCharging);
+    EXPECT_EQ(cluster.GetState(), StateEnum::kPluggedInCharging);
 
     // Verify cluster stores the value
     StateEnum readState = StateEnum::kUnknownEnumValue;
@@ -694,7 +729,7 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetAttributes)
 
     EXPECT_EQ(dirtyList.size(), 1u);
     EXPECT_EQ(dirtyList[0].mAttributeId, SupplyState::Id);
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
 
     SupplyStateEnum readSupplyState = SupplyStateEnum::kUnknownEnumValue;
     ASSERT_EQ(tester.ReadAttribute(SupplyState::Id, readSupplyState), CHIP_NO_ERROR);
@@ -706,7 +741,7 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetAttributes)
 
     EXPECT_EQ(dirtyList.size(), 1u);
     EXPECT_EQ(dirtyList[0].mAttributeId, FaultState::Id);
-    EXPECT_EQ(mockDelegate.GetFaultState(), FaultStateEnum::kGroundFault);
+    EXPECT_EQ(cluster.GetFaultState(), FaultStateEnum::kGroundFault);
 
     // --- Test SetCircuitCapacity (read-only attribute) ---
     dirtyList.clear();
@@ -714,7 +749,7 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetAttributes)
 
     EXPECT_EQ(dirtyList.size(), 1u);
     EXPECT_EQ(dirtyList[0].mAttributeId, CircuitCapacity::Id);
-    EXPECT_EQ(mockDelegate.GetCircuitCapacity(), 48000);
+    EXPECT_EQ(cluster.GetCircuitCapacity(), 48000);
 
     int64_t readCircuitCapacity = 0;
     ASSERT_EQ(tester.ReadAttribute(CircuitCapacity::Id, readCircuitCapacity), CHIP_NO_ERROR);
@@ -726,7 +761,7 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetAttributes)
 
     EXPECT_EQ(dirtyList.size(), 1u);
     EXPECT_EQ(dirtyList[0].mAttributeId, MinimumChargeCurrent::Id);
-    EXPECT_EQ(mockDelegate.GetMinimumChargeCurrent(), 8000);
+    EXPECT_EQ(cluster.GetMinimumChargeCurrent(), 8000);
 
     // --- Test SetMaximumChargeCurrent (read-only attribute) ---
     dirtyList.clear();
@@ -734,7 +769,7 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetAttributes)
 
     EXPECT_EQ(dirtyList.size(), 1u);
     EXPECT_EQ(dirtyList[0].mAttributeId, MaximumChargeCurrent::Id);
-    EXPECT_EQ(mockDelegate.GetMaximumChargeCurrent(), 40000);
+    EXPECT_EQ(cluster.GetMaximumChargeCurrent(), 40000);
 
     // --- Test SetStateOfCharge (read-only attribute, SoCReporting feature) ---
     dirtyList.clear();
@@ -742,8 +777,8 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetAttributes)
 
     EXPECT_EQ(dirtyList.size(), 1u);
     EXPECT_EQ(dirtyList[0].mAttributeId, StateOfCharge::Id);
-    ASSERT_FALSE(mockDelegate.GetStateOfCharge().IsNull());
-    EXPECT_EQ(mockDelegate.GetStateOfCharge().Value(), 75);
+    ASSERT_FALSE(cluster.GetStateOfCharge().IsNull());
+    EXPECT_EQ(cluster.GetStateOfCharge().Value(), 75);
 
     // --- Test SetBatteryCapacity (read-only attribute, SoCReporting feature) ---
     dirtyList.clear();
@@ -751,8 +786,8 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetAttributes)
 
     EXPECT_EQ(dirtyList.size(), 1u);
     EXPECT_EQ(dirtyList[0].mAttributeId, BatteryCapacity::Id);
-    ASSERT_FALSE(mockDelegate.GetBatteryCapacity().IsNull());
-    EXPECT_EQ(mockDelegate.GetBatteryCapacity().Value(), 80000000);
+    ASSERT_FALSE(cluster.GetBatteryCapacity().IsNull());
+    EXPECT_EQ(cluster.GetBatteryCapacity().Value(), 80000000);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -768,6 +803,7 @@ TEST_F(TestEnergyEvseCluster, TestProgrammaticSetNoOpWhenSameValue)
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
@@ -836,6 +872,7 @@ TEST_F(TestEnergyEvseCluster, TestDisable)
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
@@ -843,9 +880,9 @@ TEST_F(TestEnergyEvseCluster, TestDisable)
     Commands::Disable::Type command;
     EXPECT_TRUE(tester.Invoke(Commands::Disable::Id, command).IsSuccess());
 
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabled);
-    EXPECT_EQ(mockDelegate.GetChargingEnabledUntil().Value(), 0u);
-    EXPECT_EQ(mockDelegate.GetDischargingEnabledUntil().Value(), 0u);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kDisabled);
+    EXPECT_EQ(cluster.GetChargingEnabledUntil().Value(), 0u);
+    EXPECT_EQ(cluster.GetDischargingEnabledUntil().Value(), 0u);
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
@@ -863,6 +900,7 @@ TEST_F(TestEnergyEvseCluster, TestEnableCharging)
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
@@ -889,62 +927,62 @@ TEST_F(TestEnergyEvseCluster, TestEnableCharging)
 
     // --- Failure with FaultState ---
 
-    mockDelegate.SetFaultState(FaultStateEnum::kGroundFault);
-    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    EXPECT_EQ(cluster.SetFaultState(FaultStateEnum::kGroundFault), CHIP_NO_ERROR);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabled), CHIP_NO_ERROR);
     command.chargingEnabledUntil = 5000;
     command.minimumChargeCurrent = 6000;
     command.maximumChargeCurrent = 32000;
     EXPECT_FALSE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabled);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kDisabled);
 
     // --- Failure with DiagnosticsActive ---
 
-    mockDelegate.SetFaultState(FaultStateEnum::kNoError);
-    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabledDiagnostics);
+    EXPECT_EQ(cluster.SetFaultState(FaultStateEnum::kNoError), CHIP_NO_ERROR);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabledDiagnostics), CHIP_NO_ERROR);
     EXPECT_FALSE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabledDiagnostics);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kDisabledDiagnostics);
 
     // --- Success from Disabled state -> ChargingEnabled ---
 
-    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabled), CHIP_NO_ERROR);
     command.chargingEnabledUntil = 5000;
     command.minimumChargeCurrent = 8000;
     command.maximumChargeCurrent = 40000;
     EXPECT_TRUE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
-    EXPECT_EQ(mockDelegate.GetChargingEnabledUntil().Value(), 5000u);
-    EXPECT_EQ(mockDelegate.GetMinimumChargeCurrent(), 8000);
-    EXPECT_EQ(mockDelegate.GetMaximumChargeCurrent(), 40000);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
+    EXPECT_EQ(cluster.GetChargingEnabledUntil().Value(), 5000u);
+    EXPECT_EQ(cluster.GetMinimumChargeCurrent(), 8000);
+    EXPECT_EQ(cluster.GetMaximumChargeCurrent(), 40000);
 
     // --- Success from DisabledError state -> ChargingEnabled ---
 
-    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabledError);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabledError), CHIP_NO_ERROR);
     command.chargingEnabledUntil = 6000;
     command.minimumChargeCurrent = 6000;
     command.maximumChargeCurrent = 32000;
     EXPECT_TRUE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
-    EXPECT_EQ(mockDelegate.GetChargingEnabledUntil().Value(), 6000u);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
+    EXPECT_EQ(cluster.GetChargingEnabledUntil().Value(), 6000u);
 
     // --- Success from DischargingEnabled state -> Enabled (both) ---
 
-    mockDelegate.SetSupplyState(SupplyStateEnum::kDischargingEnabled);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDischargingEnabled), CHIP_NO_ERROR);
     command.chargingEnabledUntil = 7000;
     command.minimumChargeCurrent = 6000;
     command.maximumChargeCurrent = 24000;
     EXPECT_TRUE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kEnabled);
-    EXPECT_EQ(mockDelegate.GetChargingEnabledUntil().Value(), 7000u);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kEnabled);
+    EXPECT_EQ(cluster.GetChargingEnabledUntil().Value(), 7000u);
 
     // --- Success with null timestamp (indefinite charging) ---
 
-    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabled), CHIP_NO_ERROR);
     command.chargingEnabledUntil.SetNull();
     command.minimumChargeCurrent = 6000;
     command.maximumChargeCurrent = 32000;
     EXPECT_TRUE(tester.Invoke(Commands::EnableCharging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
-    EXPECT_TRUE(mockDelegate.GetChargingEnabledUntil().IsNull());
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
+    EXPECT_TRUE(cluster.GetChargingEnabledUntil().IsNull());
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -963,6 +1001,7 @@ TEST_F(TestEnergyEvseCluster, TestEnableDischarging)
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, features, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
@@ -978,56 +1017,56 @@ TEST_F(TestEnergyEvseCluster, TestEnableDischarging)
 
     // --- Failure with FaultState ---
 
-    mockDelegate.SetFaultState(FaultStateEnum::kGroundFault);
-    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    EXPECT_EQ(cluster.SetFaultState(FaultStateEnum::kGroundFault), CHIP_NO_ERROR);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabled), CHIP_NO_ERROR);
     command.dischargingEnabledUntil = 5000;
     command.maximumDischargeCurrent = 16000;
     EXPECT_FALSE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabled);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kDisabled);
 
     // --- Failure with DiagnosticsActive ---
 
-    mockDelegate.SetFaultState(FaultStateEnum::kNoError);
-    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabledDiagnostics);
+    EXPECT_EQ(cluster.SetFaultState(FaultStateEnum::kNoError), CHIP_NO_ERROR);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabledDiagnostics), CHIP_NO_ERROR);
     EXPECT_FALSE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabledDiagnostics);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kDisabledDiagnostics);
 
     // --- Success from Disabled state -> DischargingEnabled ---
 
-    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabled), CHIP_NO_ERROR);
     command.dischargingEnabledUntil = 5000;
     command.maximumDischargeCurrent = 16000;
     EXPECT_TRUE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDischargingEnabled);
-    EXPECT_EQ(mockDelegate.GetDischargingEnabledUntil().Value(), 5000u);
-    EXPECT_EQ(mockDelegate.GetMaximumDischargeCurrent(), 16000);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kDischargingEnabled);
+    EXPECT_EQ(cluster.GetDischargingEnabledUntil().Value(), 5000u);
+    EXPECT_EQ(cluster.GetMaximumDischargeCurrent(), 16000);
 
     // --- Success from DisabledError state -> DischargingEnabled ---
 
-    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabledError);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabledError), CHIP_NO_ERROR);
     command.dischargingEnabledUntil = 6000;
     command.maximumDischargeCurrent = 12000;
     EXPECT_TRUE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDischargingEnabled);
-    EXPECT_EQ(mockDelegate.GetDischargingEnabledUntil().Value(), 6000u);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kDischargingEnabled);
+    EXPECT_EQ(cluster.GetDischargingEnabledUntil().Value(), 6000u);
 
     // --- Success from ChargingEnabled state -> Enabled (both) ---
 
-    mockDelegate.SetSupplyState(SupplyStateEnum::kChargingEnabled);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kChargingEnabled), CHIP_NO_ERROR);
     command.dischargingEnabledUntil = 7000;
     command.maximumDischargeCurrent = 10000;
     EXPECT_TRUE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kEnabled);
-    EXPECT_EQ(mockDelegate.GetDischargingEnabledUntil().Value(), 7000u);
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kEnabled);
+    EXPECT_EQ(cluster.GetDischargingEnabledUntil().Value(), 7000u);
 
     // --- Success with null timestamp (indefinite discharging) ---
 
-    mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabled), CHIP_NO_ERROR);
     command.dischargingEnabledUntil.SetNull();
     command.maximumDischargeCurrent = 16000;
     EXPECT_TRUE(tester.Invoke(Commands::EnableDischarging::Id, command).IsSuccess());
-    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDischargingEnabled);
-    EXPECT_TRUE(mockDelegate.GetDischargingEnabledUntil().IsNull());
+    EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kDischargingEnabled);
+    EXPECT_TRUE(cluster.GetDischargingEnabledUntil().IsNull());
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -1047,19 +1086,20 @@ TEST_F(TestEnergyEvseCluster, TestStartDiagnostics)
         BitMask<OptionalCommands> optionalCommands(OptionalCommands::kSupportsStartDiagnostics);
         EnergyEvseCluster cluster(
             EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+        mockDelegate.SetCluster(cluster);
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
         ClusterTester tester(cluster);
         Commands::StartDiagnostics::Type command;
 
-        mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+        EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabled), CHIP_NO_ERROR);
         EXPECT_TRUE(tester.Invoke(Commands::StartDiagnostics::Id, command).IsSuccess());
-        EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabledDiagnostics);
+        EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kDisabledDiagnostics);
 
         // --- Failure with DiagnosticsActive ---
 
-        mockDelegate.SetSupplyState(SupplyStateEnum::kDisabledDiagnostics);
+        EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabledDiagnostics), CHIP_NO_ERROR);
         EXPECT_FALSE(tester.Invoke(Commands::StartDiagnostics::Id, command).IsSuccess());
 
         cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -1069,14 +1109,15 @@ TEST_F(TestEnergyEvseCluster, TestStartDiagnostics)
         BitMask<OptionalCommands> optionalCommands;
         EnergyEvseCluster cluster(
             EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, noFeatures, optionalAttributes, optionalCommands));
+        mockDelegate.SetCluster(cluster);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
         ClusterTester tester(cluster);
         Commands::StartDiagnostics::Type command;
 
-        mockDelegate.SetSupplyState(SupplyStateEnum::kDisabled);
+        EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kDisabled), CHIP_NO_ERROR);
         EXPECT_FALSE(tester.Invoke(Commands::StartDiagnostics::Id, command).IsSuccess());
-        EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kDisabled);
+        EXPECT_EQ(cluster.GetSupplyState(), SupplyStateEnum::kDisabled);
 
         cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
     }
@@ -1098,6 +1139,7 @@ TEST_F(TestEnergyEvseCluster, TestTargetsCommands)
 
     EnergyEvseCluster cluster(
         EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, features, optionalAttributes, optionalCommands));
+    mockDelegate.SetCluster(cluster);
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
     ClusterTester tester(cluster);

--- a/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
@@ -44,30 +44,6 @@ namespace {
 
 constexpr EndpointId kTestEndpointId = 1;
 
-// Mock test values - used for verification in tests
-constexpr StateEnum kMockState                   = StateEnum::kPluggedInNoDemand;
-constexpr SupplyStateEnum kMockSupplyState       = SupplyStateEnum::kChargingEnabled;
-constexpr FaultStateEnum kMockFaultState         = FaultStateEnum::kNoError;
-constexpr uint32_t kMockChargingEnabledUntil     = 1000;
-constexpr uint32_t kMockDischargingEnabledUntil  = 2000;
-constexpr int64_t kMockCircuitCapacity           = 32000;    // 32A in mA
-constexpr int64_t kMockMinimumChargeCurrent      = 6000;     // 6A in mA
-constexpr int64_t kMockMaximumChargeCurrent      = 32000;    // 32A in mA
-constexpr int64_t kMockMaximumDischargeCurrent   = 16000;    // 16A in mA (V2x)
-constexpr int64_t kMockUserMaximumChargeCurrent  = 24000;    // 24A in mA
-constexpr uint32_t kMockRandomizationDelayWindow = 600;      // 10 minutes
-constexpr uint32_t kMockNextChargeStartTime      = 3600;     // 1 hour from now
-constexpr uint32_t kMockNextChargeTargetTime     = 7200;     // 2 hours from now
-constexpr int64_t kMockNextChargeRequiredEnergy  = 20000000; // 20 kWh in mWh
-constexpr Percent kMockNextChargeTargetSoC       = 80;
-constexpr uint16_t kMockApproximateEVEfficiency  = 150; // 150 Wh/km
-constexpr Percent kMockStateOfCharge             = 45;
-constexpr int64_t kMockBatteryCapacity           = 60000000; // 60 kWh in mWh
-constexpr uint32_t kMockSessionID                = 12345;
-constexpr uint32_t kMockSessionDuration          = 1800;    // 30 minutes
-constexpr int64_t kMockSessionEnergyCharged      = 5000000; // 5 kWh in mWh
-constexpr int64_t kMockSessionEnergyDischarged   = 1000000; // 1 kWh in mWh
-
 struct TestEnergyEvseCluster : public ::testing::Test
 {
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }

--- a/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
@@ -16,30 +16,10 @@
  *    limitations under the License.
  */
 
-/*
- *
- *    Copyright (c) 2025 Project CHIP Authors
- *    All rights reserved.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
-
 #include "clusters/EnergyEvse/Enums.h"
 #include "pw_unit_test/framework.h"
 #include <app/clusters/energy-evse-server/EnergyEvseCluster.h>
 #include <app/clusters/energy-evse-server/tests/MockEvseDelegate.h>
-#include <pw_unit_test/framework.h>
-
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>

--- a/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
@@ -134,6 +134,7 @@ TEST_F(TestEnergyEvseCluster, TestFeatures)
                                                    {
                                                        GetTargetsResponse::Id,
                                                    }));
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
     }
     // Test with all features and no optional attributes & no optional commands
     {

--- a/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
+++ b/src/app/clusters/energy-evse-server/tests/TestEnergyEvseCluster.cpp
@@ -18,6 +18,7 @@
 
 #include "clusters/EnergyEvse/Enums.h"
 #include "pw_unit_test/framework.h"
+#include <app/clusters/energy-evse-server/Constants.h>
 #include <app/clusters/energy-evse-server/EnergyEvseCluster.h>
 #include <app/clusters/energy-evse-server/tests/MockEvseDelegate.h>
 #include <app/server-cluster/testing/ClusterTester.h>
@@ -317,50 +318,46 @@ TEST_F(TestEnergyEvseCluster, TestAttributesMinimalConfig)
 
     ClusterTester tester(cluster);
 
-    // Read mandatory attributes and verify values
+    // Read mandatory attributes and verify values - cluster owns the data with defaults
     StateEnum state = StateEnum::kUnknownEnumValue;
     ASSERT_EQ(tester.ReadAttribute(State::Id, state), CHIP_NO_ERROR);
-    EXPECT_EQ(state, MockEvseDelegate::kMockState);
+    EXPECT_EQ(state, StateEnum::kNotPluggedIn); // Cluster default
 
     SupplyStateEnum supplyState = SupplyStateEnum::kUnknownEnumValue;
     ASSERT_EQ(tester.ReadAttribute(SupplyState::Id, supplyState), CHIP_NO_ERROR);
-    EXPECT_EQ(supplyState, MockEvseDelegate::kMockSupplyState);
+    EXPECT_EQ(supplyState, SupplyStateEnum::kDisabled); // Cluster default
 
     FaultStateEnum faultState = FaultStateEnum::kUnknownEnumValue;
     ASSERT_EQ(tester.ReadAttribute(FaultState::Id, faultState), CHIP_NO_ERROR);
-    EXPECT_EQ(faultState, MockEvseDelegate::kMockFaultState);
+    EXPECT_EQ(faultState, FaultStateEnum::kNoError); // Cluster default
 
     DataModel::Nullable<uint32_t> chargingEnabledUntil;
     ASSERT_EQ(tester.ReadAttribute(ChargingEnabledUntil::Id, chargingEnabledUntil), CHIP_NO_ERROR);
-    ASSERT_FALSE(chargingEnabledUntil.IsNull());
-    EXPECT_EQ(chargingEnabledUntil.Value(), MockEvseDelegate::kMockChargingEnabledUntil);
+    EXPECT_TRUE(chargingEnabledUntil.IsNull()); // Cluster default is null
 
-    int64_t circuitCapacity = 0;
+    int64_t circuitCapacity = -1;
     ASSERT_EQ(tester.ReadAttribute(CircuitCapacity::Id, circuitCapacity), CHIP_NO_ERROR);
-    EXPECT_EQ(circuitCapacity, MockEvseDelegate::kMockCircuitCapacity);
+    EXPECT_EQ(circuitCapacity, 0); // Cluster default
 
-    int64_t minimumChargeCurrent = 0;
+    int64_t minimumChargeCurrent = -1;
     ASSERT_EQ(tester.ReadAttribute(MinimumChargeCurrent::Id, minimumChargeCurrent), CHIP_NO_ERROR);
-    EXPECT_EQ(minimumChargeCurrent, MockEvseDelegate::kMockMinimumChargeCurrent);
+    EXPECT_EQ(minimumChargeCurrent, kMinimumChargeCurrent); // Cluster default (6000mA)
 
-    int64_t maximumChargeCurrent = 0;
+    int64_t maximumChargeCurrent = -1;
     ASSERT_EQ(tester.ReadAttribute(MaximumChargeCurrent::Id, maximumChargeCurrent), CHIP_NO_ERROR);
-    EXPECT_EQ(maximumChargeCurrent, MockEvseDelegate::kMockMaximumChargeCurrent);
+    EXPECT_EQ(maximumChargeCurrent, 0); // Cluster default
 
     DataModel::Nullable<uint32_t> sessionID;
     ASSERT_EQ(tester.ReadAttribute(SessionID::Id, sessionID), CHIP_NO_ERROR);
-    ASSERT_FALSE(sessionID.IsNull());
-    EXPECT_EQ(sessionID.Value(), MockEvseDelegate::kMockSessionID);
+    EXPECT_TRUE(sessionID.IsNull()); // Cluster default is null
 
     DataModel::Nullable<uint32_t> sessionDuration;
     ASSERT_EQ(tester.ReadAttribute(SessionDuration::Id, sessionDuration), CHIP_NO_ERROR);
-    ASSERT_FALSE(sessionDuration.IsNull());
-    EXPECT_EQ(sessionDuration.Value(), MockEvseDelegate::kMockSessionDuration);
+    EXPECT_TRUE(sessionDuration.IsNull()); // Cluster default is null
 
     DataModel::Nullable<int64_t> sessionEnergyCharged;
     ASSERT_EQ(tester.ReadAttribute(SessionEnergyCharged::Id, sessionEnergyCharged), CHIP_NO_ERROR);
-    ASSERT_FALSE(sessionEnergyCharged.IsNull());
-    EXPECT_EQ(sessionEnergyCharged.Value(), MockEvseDelegate::kMockSessionEnergyCharged);
+    EXPECT_TRUE(sessionEnergyCharged.IsNull()); // Cluster default is null
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -383,118 +380,104 @@ TEST_F(TestEnergyEvseCluster, TestAttributesFullConfig)
 
     ClusterTester tester(cluster);
 
-    // Read mandatory attributes
+    // Read mandatory attributes - cluster owns the data with defaults
     StateEnum state = StateEnum::kUnknownEnumValue;
     ASSERT_EQ(tester.ReadAttribute(State::Id, state), CHIP_NO_ERROR);
-    EXPECT_EQ(state, MockEvseDelegate::kMockState);
+    EXPECT_EQ(state, StateEnum::kNotPluggedIn); // Cluster default
 
     SupplyStateEnum supplyState = SupplyStateEnum::kUnknownEnumValue;
     ASSERT_EQ(tester.ReadAttribute(SupplyState::Id, supplyState), CHIP_NO_ERROR);
-    EXPECT_EQ(supplyState, MockEvseDelegate::kMockSupplyState);
+    EXPECT_EQ(supplyState, SupplyStateEnum::kDisabled); // Cluster default
 
     FaultStateEnum faultState = FaultStateEnum::kUnknownEnumValue;
     ASSERT_EQ(tester.ReadAttribute(FaultState::Id, faultState), CHIP_NO_ERROR);
-    EXPECT_EQ(faultState, MockEvseDelegate::kMockFaultState);
+    EXPECT_EQ(faultState, FaultStateEnum::kNoError); // Cluster default
 
     DataModel::Nullable<uint32_t> chargingEnabledUntil;
     ASSERT_EQ(tester.ReadAttribute(ChargingEnabledUntil::Id, chargingEnabledUntil), CHIP_NO_ERROR);
-    ASSERT_FALSE(chargingEnabledUntil.IsNull());
-    EXPECT_EQ(chargingEnabledUntil.Value(), MockEvseDelegate::kMockChargingEnabledUntil);
+    EXPECT_TRUE(chargingEnabledUntil.IsNull()); // Cluster default is null
 
-    int64_t circuitCapacity = 0;
+    int64_t circuitCapacity = -1;
     ASSERT_EQ(tester.ReadAttribute(CircuitCapacity::Id, circuitCapacity), CHIP_NO_ERROR);
-    EXPECT_EQ(circuitCapacity, MockEvseDelegate::kMockCircuitCapacity);
+    EXPECT_EQ(circuitCapacity, 0); // Cluster default
 
-    int64_t minimumChargeCurrent = 0;
+    int64_t minimumChargeCurrent = -1;
     ASSERT_EQ(tester.ReadAttribute(MinimumChargeCurrent::Id, minimumChargeCurrent), CHIP_NO_ERROR);
-    EXPECT_EQ(minimumChargeCurrent, MockEvseDelegate::kMockMinimumChargeCurrent);
+    EXPECT_EQ(minimumChargeCurrent, kMinimumChargeCurrent); // Cluster default (6000mA)
 
-    int64_t maximumChargeCurrent = 0;
+    int64_t maximumChargeCurrent = -1;
     ASSERT_EQ(tester.ReadAttribute(MaximumChargeCurrent::Id, maximumChargeCurrent), CHIP_NO_ERROR);
-    EXPECT_EQ(maximumChargeCurrent, MockEvseDelegate::kMockMaximumChargeCurrent);
+    EXPECT_EQ(maximumChargeCurrent, 0); // Cluster default
 
     // V2x feature attributes
     DataModel::Nullable<uint32_t> dischargingEnabledUntil;
     ASSERT_EQ(tester.ReadAttribute(DischargingEnabledUntil::Id, dischargingEnabledUntil), CHIP_NO_ERROR);
-    ASSERT_FALSE(dischargingEnabledUntil.IsNull());
-    EXPECT_EQ(dischargingEnabledUntil.Value(), MockEvseDelegate::kMockDischargingEnabledUntil);
+    EXPECT_TRUE(dischargingEnabledUntil.IsNull()); // Cluster default is null
 
-    int64_t maximumDischargeCurrent = 0;
+    int64_t maximumDischargeCurrent = -1;
     ASSERT_EQ(tester.ReadAttribute(MaximumDischargeCurrent::Id, maximumDischargeCurrent), CHIP_NO_ERROR);
-    EXPECT_EQ(maximumDischargeCurrent, MockEvseDelegate::kMockMaximumDischargeCurrent);
+    EXPECT_EQ(maximumDischargeCurrent, 0); // Cluster default
 
     DataModel::Nullable<int64_t> sessionEnergyDischarged;
     ASSERT_EQ(tester.ReadAttribute(SessionEnergyDischarged::Id, sessionEnergyDischarged), CHIP_NO_ERROR);
-    ASSERT_FALSE(sessionEnergyDischarged.IsNull());
-    EXPECT_EQ(sessionEnergyDischarged.Value(), MockEvseDelegate::kMockSessionEnergyDischarged);
+    EXPECT_TRUE(sessionEnergyDischarged.IsNull()); // Cluster default is null
 
     // ChargingPreferences feature attributes
     DataModel::Nullable<uint32_t> nextChargeStartTime;
     ASSERT_EQ(tester.ReadAttribute(NextChargeStartTime::Id, nextChargeStartTime), CHIP_NO_ERROR);
-    ASSERT_FALSE(nextChargeStartTime.IsNull());
-    EXPECT_EQ(nextChargeStartTime.Value(), MockEvseDelegate::kMockNextChargeStartTime);
+    EXPECT_TRUE(nextChargeStartTime.IsNull()); // Cluster default is null
 
     DataModel::Nullable<uint32_t> nextChargeTargetTime;
     ASSERT_EQ(tester.ReadAttribute(NextChargeTargetTime::Id, nextChargeTargetTime), CHIP_NO_ERROR);
-    ASSERT_FALSE(nextChargeTargetTime.IsNull());
-    EXPECT_EQ(nextChargeTargetTime.Value(), MockEvseDelegate::kMockNextChargeTargetTime);
+    EXPECT_TRUE(nextChargeTargetTime.IsNull()); // Cluster default is null
 
     DataModel::Nullable<int64_t> nextChargeRequiredEnergy;
     ASSERT_EQ(tester.ReadAttribute(NextChargeRequiredEnergy::Id, nextChargeRequiredEnergy), CHIP_NO_ERROR);
-    ASSERT_FALSE(nextChargeRequiredEnergy.IsNull());
-    EXPECT_EQ(nextChargeRequiredEnergy.Value(), MockEvseDelegate::kMockNextChargeRequiredEnergy);
+    EXPECT_TRUE(nextChargeRequiredEnergy.IsNull()); // Cluster default is null
 
     DataModel::Nullable<Percent> nextChargeTargetSoC;
     ASSERT_EQ(tester.ReadAttribute(NextChargeTargetSoC::Id, nextChargeTargetSoC), CHIP_NO_ERROR);
-    ASSERT_FALSE(nextChargeTargetSoC.IsNull());
-    EXPECT_EQ(nextChargeTargetSoC.Value(), MockEvseDelegate::kMockNextChargeTargetSoC);
+    EXPECT_TRUE(nextChargeTargetSoC.IsNull()); // Cluster default is null
 
     // SoCReporting feature attributes
     DataModel::Nullable<Percent> stateOfCharge;
     ASSERT_EQ(tester.ReadAttribute(StateOfCharge::Id, stateOfCharge), CHIP_NO_ERROR);
-    ASSERT_FALSE(stateOfCharge.IsNull());
-    EXPECT_EQ(stateOfCharge.Value(), MockEvseDelegate::kMockStateOfCharge);
+    EXPECT_TRUE(stateOfCharge.IsNull()); // Cluster default is null
 
     DataModel::Nullable<int64_t> batteryCapacity;
     ASSERT_EQ(tester.ReadAttribute(BatteryCapacity::Id, batteryCapacity), CHIP_NO_ERROR);
-    ASSERT_FALSE(batteryCapacity.IsNull());
-    EXPECT_EQ(batteryCapacity.Value(), MockEvseDelegate::kMockBatteryCapacity);
+    EXPECT_TRUE(batteryCapacity.IsNull()); // Cluster default is null
 
     // PlugAndCharge feature attributes
     DataModel::Nullable<CharSpan> vehicleID;
     ASSERT_EQ(tester.ReadAttribute(VehicleID::Id, vehicleID), CHIP_NO_ERROR);
-    ASSERT_FALSE(vehicleID.IsNull());
-    EXPECT_TRUE(vehicleID.Value().data_equal(CharSpan::fromCharString("MOCK-VIN-12345")));
+    EXPECT_TRUE(vehicleID.IsNull()); // Cluster default is null
 
-    // Optional attributes
-    int64_t userMaximumChargeCurrent = 0;
+    // Optional attributes - cluster owns the data with initial defaults
+    int64_t userMaximumChargeCurrent = -1;
     ASSERT_EQ(tester.ReadAttribute(UserMaximumChargeCurrent::Id, userMaximumChargeCurrent), CHIP_NO_ERROR);
-    EXPECT_EQ(userMaximumChargeCurrent, MockEvseDelegate::kMockUserMaximumChargeCurrent);
+    EXPECT_EQ(userMaximumChargeCurrent, 0); // Cluster's default initial value
 
     uint32_t randomizationDelayWindow = 0;
     ASSERT_EQ(tester.ReadAttribute(RandomizationDelayWindow::Id, randomizationDelayWindow), CHIP_NO_ERROR);
-    EXPECT_EQ(randomizationDelayWindow, MockEvseDelegate::kMockRandomizationDelayWindow);
+    EXPECT_EQ(randomizationDelayWindow, 600u); // Cluster's default initial value (600s per spec)
 
     DataModel::Nullable<uint16_t> approximateEVEfficiency;
     ASSERT_EQ(tester.ReadAttribute(ApproximateEVEfficiency::Id, approximateEVEfficiency), CHIP_NO_ERROR);
-    ASSERT_FALSE(approximateEVEfficiency.IsNull());
-    EXPECT_EQ(approximateEVEfficiency.Value(), MockEvseDelegate::kMockApproximateEVEfficiency);
+    EXPECT_TRUE(approximateEVEfficiency.IsNull()); // Cluster's default initial value is null
 
-    // Session attributes
+    // Session attributes - cluster owns the data with defaults
     DataModel::Nullable<uint32_t> sessionID;
     ASSERT_EQ(tester.ReadAttribute(SessionID::Id, sessionID), CHIP_NO_ERROR);
-    ASSERT_FALSE(sessionID.IsNull());
-    EXPECT_EQ(sessionID.Value(), MockEvseDelegate::kMockSessionID);
+    EXPECT_TRUE(sessionID.IsNull()); // Cluster default is null
 
     DataModel::Nullable<uint32_t> sessionDuration;
     ASSERT_EQ(tester.ReadAttribute(SessionDuration::Id, sessionDuration), CHIP_NO_ERROR);
-    ASSERT_FALSE(sessionDuration.IsNull());
-    EXPECT_EQ(sessionDuration.Value(), MockEvseDelegate::kMockSessionDuration);
+    EXPECT_TRUE(sessionDuration.IsNull()); // Cluster default is null
 
     DataModel::Nullable<int64_t> sessionEnergyCharged;
     ASSERT_EQ(tester.ReadAttribute(SessionEnergyCharged::Id, sessionEnergyCharged), CHIP_NO_ERROR);
-    ASSERT_FALSE(sessionEnergyCharged.IsNull());
-    EXPECT_EQ(sessionEnergyCharged.Value(), MockEvseDelegate::kMockSessionEnergyCharged);
+    EXPECT_TRUE(sessionEnergyCharged.IsNull()); // Cluster default is null
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -558,6 +541,53 @@ TEST_F(TestEnergyEvseCluster, TestWriteAttributes)
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
+TEST_F(TestEnergyEvseCluster, TestWriteAttributesNotifiesChange)
+{
+    // Test that writing to writable attributes generates attribute change notifications
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kV2x, Feature::kSoCReporting, Feature::kPlugAndCharge);
+    BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
+                                                   OptionalAttributes::kSupportsRandomizationWindow,
+                                                   OptionalAttributes::kSupportsApproximateEvEfficiency);
+    BitMask<OptionalCommands> optionalCommands;
+
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    auto & dirtyList = context.ChangeListener().DirtyList();
+
+    // --- Test UserMaximumChargeCurrent ---
+    dirtyList.clear();
+    EXPECT_TRUE(tester.WriteAttribute(UserMaximumChargeCurrent::Id, static_cast<int64_t>(20000)).IsSuccess());
+    EXPECT_EQ(dirtyList.size(), 1u);
+    EXPECT_EQ(dirtyList[0].mAttributeId, UserMaximumChargeCurrent::Id);
+
+    // --- Test RandomizationDelayWindow ---
+    dirtyList.clear();
+    EXPECT_TRUE(tester.WriteAttribute(RandomizationDelayWindow::Id, static_cast<uint32_t>(300)).IsSuccess());
+    EXPECT_EQ(dirtyList.size(), 1u);
+    EXPECT_EQ(dirtyList[0].mAttributeId, RandomizationDelayWindow::Id);
+
+    // --- Test ApproximateEVEfficiency ---
+    dirtyList.clear();
+    EXPECT_TRUE(tester.WriteAttribute(ApproximateEVEfficiency::Id, DataModel::Nullable<uint16_t>(200)).IsSuccess());
+    EXPECT_EQ(dirtyList.size(), 1u);
+    EXPECT_EQ(dirtyList[0].mAttributeId, ApproximateEVEfficiency::Id);
+
+    // Write same values again - should not generate notifications
+    dirtyList.clear();
+    EXPECT_TRUE(tester.WriteAttribute(UserMaximumChargeCurrent::Id, static_cast<int64_t>(20000)).IsSuccess());
+    EXPECT_TRUE(tester.WriteAttribute(RandomizationDelayWindow::Id, static_cast<uint32_t>(300)).IsSuccess());
+    EXPECT_TRUE(tester.WriteAttribute(ApproximateEVEfficiency::Id, DataModel::Nullable<uint16_t>(200)).IsSuccess());
+    EXPECT_TRUE(dirtyList.empty());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
 TEST_F(TestEnergyEvseCluster, TestWriteReadOnlyAttributesFails)
 {
     // Test that writing to read-only attributes fails with UnsupportedWrite
@@ -615,6 +645,179 @@ TEST_F(TestEnergyEvseCluster, TestWriteReadOnlyAttributesFails)
     // Test writing to VehicleID (read-only, PlugAndCharge feature)
     EXPECT_FALSE(
         tester.WriteAttribute(VehicleID::Id, DataModel::Nullable<CharSpan>(CharSpan::fromCharString("NEW-VIN"))).IsSuccess());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+// =============================================================================
+// Programmatic SetXxx() Method Tests
+// =============================================================================
+
+TEST_F(TestEnergyEvseCluster, TestProgrammaticSetAttributes)
+{
+    // Test setting attributes via cluster's SetXxx() methods (for read-only attributes)
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kV2x, Feature::kSoCReporting, Feature::kPlugAndCharge);
+    BitMask<OptionalAttributes> optionalAttributes(OptionalAttributes::kSupportsUserMaximumChargingCurrent,
+                                                   OptionalAttributes::kSupportsRandomizationWindow,
+                                                   OptionalAttributes::kSupportsApproximateEvEfficiency);
+    BitMask<OptionalCommands> optionalCommands;
+
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    ClusterTester tester(cluster);
+    auto & dirtyList = context.ChangeListener().DirtyList();
+
+    // --- Test SetState (read-only attribute) ---
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetState(StateEnum::kPluggedInCharging), CHIP_NO_ERROR);
+
+    // Verify notification was generated
+    EXPECT_EQ(dirtyList.size(), 1u);
+    EXPECT_EQ(dirtyList[0].mAttributeId, State::Id);
+
+    // Verify delegate callback was called
+    EXPECT_EQ(mockDelegate.GetState(), StateEnum::kPluggedInCharging);
+
+    // Verify cluster stores the value
+    StateEnum readState = StateEnum::kUnknownEnumValue;
+    ASSERT_EQ(tester.ReadAttribute(State::Id, readState), CHIP_NO_ERROR);
+    EXPECT_EQ(readState, StateEnum::kPluggedInCharging);
+
+    // --- Test SetSupplyState (read-only attribute) ---
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kChargingEnabled), CHIP_NO_ERROR);
+
+    EXPECT_EQ(dirtyList.size(), 1u);
+    EXPECT_EQ(dirtyList[0].mAttributeId, SupplyState::Id);
+    EXPECT_EQ(mockDelegate.GetSupplyState(), SupplyStateEnum::kChargingEnabled);
+
+    SupplyStateEnum readSupplyState = SupplyStateEnum::kUnknownEnumValue;
+    ASSERT_EQ(tester.ReadAttribute(SupplyState::Id, readSupplyState), CHIP_NO_ERROR);
+    EXPECT_EQ(readSupplyState, SupplyStateEnum::kChargingEnabled);
+
+    // --- Test SetFaultState (read-only attribute) ---
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetFaultState(FaultStateEnum::kGroundFault), CHIP_NO_ERROR);
+
+    EXPECT_EQ(dirtyList.size(), 1u);
+    EXPECT_EQ(dirtyList[0].mAttributeId, FaultState::Id);
+    EXPECT_EQ(mockDelegate.GetFaultState(), FaultStateEnum::kGroundFault);
+
+    // --- Test SetCircuitCapacity (read-only attribute) ---
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetCircuitCapacity(48000), CHIP_NO_ERROR);
+
+    EXPECT_EQ(dirtyList.size(), 1u);
+    EXPECT_EQ(dirtyList[0].mAttributeId, CircuitCapacity::Id);
+    EXPECT_EQ(mockDelegate.GetCircuitCapacity(), 48000);
+
+    int64_t readCircuitCapacity = 0;
+    ASSERT_EQ(tester.ReadAttribute(CircuitCapacity::Id, readCircuitCapacity), CHIP_NO_ERROR);
+    EXPECT_EQ(readCircuitCapacity, 48000);
+
+    // --- Test SetMinimumChargeCurrent (read-only attribute) ---
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetMinimumChargeCurrent(8000), CHIP_NO_ERROR);
+
+    EXPECT_EQ(dirtyList.size(), 1u);
+    EXPECT_EQ(dirtyList[0].mAttributeId, MinimumChargeCurrent::Id);
+    EXPECT_EQ(mockDelegate.GetMinimumChargeCurrent(), 8000);
+
+    // --- Test SetMaximumChargeCurrent (read-only attribute) ---
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetMaximumChargeCurrent(40000), CHIP_NO_ERROR);
+
+    EXPECT_EQ(dirtyList.size(), 1u);
+    EXPECT_EQ(dirtyList[0].mAttributeId, MaximumChargeCurrent::Id);
+    EXPECT_EQ(mockDelegate.GetMaximumChargeCurrent(), 40000);
+
+    // --- Test SetStateOfCharge (read-only attribute, SoCReporting feature) ---
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetStateOfCharge(DataModel::MakeNullable(static_cast<Percent>(75))), CHIP_NO_ERROR);
+
+    EXPECT_EQ(dirtyList.size(), 1u);
+    EXPECT_EQ(dirtyList[0].mAttributeId, StateOfCharge::Id);
+    ASSERT_FALSE(mockDelegate.GetStateOfCharge().IsNull());
+    EXPECT_EQ(mockDelegate.GetStateOfCharge().Value(), 75);
+
+    // --- Test SetBatteryCapacity (read-only attribute, SoCReporting feature) ---
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetBatteryCapacity(DataModel::MakeNullable(static_cast<int64_t>(80000000))), CHIP_NO_ERROR);
+
+    EXPECT_EQ(dirtyList.size(), 1u);
+    EXPECT_EQ(dirtyList[0].mAttributeId, BatteryCapacity::Id);
+    ASSERT_FALSE(mockDelegate.GetBatteryCapacity().IsNull());
+    EXPECT_EQ(mockDelegate.GetBatteryCapacity().Value(), 80000000);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestEnergyEvseCluster, TestProgrammaticSetNoOpWhenSameValue)
+{
+    // Test that setting the same value doesn't generate notifications (no-op behavior)
+    TestServerClusterContext context;
+    MockEvseDelegate mockDelegate;
+    BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kV2x, Feature::kSoCReporting, Feature::kPlugAndCharge);
+    BitMask<OptionalAttributes> optionalAttributes;
+    BitMask<OptionalCommands> optionalCommands;
+
+    EnergyEvseCluster cluster(
+        EnergyEvseCluster::Config(kTestEndpointId, mockDelegate, allFeatures, optionalAttributes, optionalCommands));
+
+    EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    auto & dirtyList = context.ChangeListener().DirtyList();
+
+    // First set to a specific value
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetState(StateEnum::kPluggedInDemand), CHIP_NO_ERROR);
+    EXPECT_EQ(dirtyList.size(), 1u);
+
+    // Set to the same value - should not generate notification
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetState(StateEnum::kPluggedInDemand), CHIP_NO_ERROR);
+    EXPECT_TRUE(dirtyList.empty());
+
+    // Same test for SupplyState
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kEnabled), CHIP_NO_ERROR);
+    EXPECT_EQ(dirtyList.size(), 1u);
+
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetSupplyState(SupplyStateEnum::kEnabled), CHIP_NO_ERROR);
+    EXPECT_TRUE(dirtyList.empty());
+
+    // Same test for CircuitCapacity
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetCircuitCapacity(32000), CHIP_NO_ERROR);
+    EXPECT_EQ(dirtyList.size(), 1u);
+
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetCircuitCapacity(32000), CHIP_NO_ERROR);
+    EXPECT_TRUE(dirtyList.empty());
+
+    // Same test for nullable attribute (StateOfCharge)
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetStateOfCharge(DataModel::MakeNullable(static_cast<Percent>(50))), CHIP_NO_ERROR);
+    EXPECT_EQ(dirtyList.size(), 1u);
+
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetStateOfCharge(DataModel::MakeNullable(static_cast<Percent>(50))), CHIP_NO_ERROR);
+    EXPECT_TRUE(dirtyList.empty());
+
+    // Test setting to null and then same null
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetStateOfCharge(DataModel::NullNullable), CHIP_NO_ERROR);
+    EXPECT_EQ(dirtyList.size(), 1u);
+
+    dirtyList.clear();
+    EXPECT_EQ(cluster.SetStateOfCharge(DataModel::NullNullable), CHIP_NO_ERROR);
+    EXPECT_TRUE(dirtyList.empty());
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/energy-evse-server/tests/TestEnergyEvseClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/energy-evse-server/tests/TestEnergyEvseClusterBackwardsCompatibility.cpp
@@ -1,0 +1,108 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/energy-evse-server/CodegenIntegration.h>
+#include <app/clusters/energy-evse-server/tests/MockEvseDelegate.h>
+#include <app/server-cluster/testing/TestServerClusterContext.h>
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
+#include <pw_unit_test/framework.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::EnergyEvse;
+using namespace chip::Testing;
+
+// Mock function for linking
+void InitDataModelHandler() {}
+
+namespace {
+
+constexpr EndpointId kTestEndpointId = 1;
+
+struct TestEvseClusterBackwardsCompatibility : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+
+    void SetUp() override {}
+
+    TestServerClusterContext mContext;
+};
+
+TEST_F(TestEvseClusterBackwardsCompatibility, TestInstanceLifecycle)
+{
+    // Test 1: Create Instance with all features
+    {
+        MockEvseDelegate mockDelegate;
+        BitMask<Feature> allFeatures(Feature::kChargingPreferences, Feature::kSoCReporting, Feature::kPlugAndCharge, Feature::kRfid,
+                                     Feature::kV2x);
+        BitMask<OptionalAttributes> optionalAttrs;
+        BitMask<OptionalCommands> optionalCmds;
+
+        Instance instance(kTestEndpointId, mockDelegate, allFeatures, optionalAttrs, optionalCmds);
+
+        // Test initialization (registration)
+        EXPECT_EQ(instance.Init(), CHIP_NO_ERROR);
+
+        // Verify cluster is registered in the registry
+        auto * registeredCluster =
+            CodegenDataModelProvider::Instance().Registry().Get(ConcreteClusterPath(kTestEndpointId, EnergyEvse::Id));
+        ASSERT_NE(registeredCluster, nullptr);
+
+        // Test feature checking
+        EXPECT_TRUE(instance.HasFeature(Feature::kChargingPreferences));
+        EXPECT_TRUE(instance.HasFeature(Feature::kSoCReporting));
+        EXPECT_TRUE(instance.HasFeature(Feature::kPlugAndCharge));
+        EXPECT_TRUE(instance.HasFeature(Feature::kRfid));
+        EXPECT_TRUE(instance.HasFeature(Feature::kV2x));
+
+        // Test shutdown (unregistration)
+        instance.Shutdown();
+
+        // Verify cluster is unregistered from the registry
+        auto * unregisteredCluster =
+            CodegenDataModelProvider::Instance().Registry().Get(ConcreteClusterPath(kTestEndpointId, EnergyEvse::Id));
+        EXPECT_EQ(unregisteredCluster, nullptr);
+    }
+
+    // Test 2: Instance with no features enabled
+    {
+        MockEvseDelegate mockDelegate;
+        BitMask<Feature> noFeatures;
+        BitMask<OptionalAttributes> optionalAttrs;
+        BitMask<OptionalCommands> optionalCmds;
+
+        Instance instance(kTestEndpointId, mockDelegate, noFeatures, optionalAttrs, optionalCmds);
+
+        // Test initialization
+        EXPECT_EQ(instance.Init(), CHIP_NO_ERROR);
+
+        // Verify no features are enabled
+        EXPECT_FALSE(instance.HasFeature(Feature::kChargingPreferences));
+        EXPECT_FALSE(instance.HasFeature(Feature::kSoCReporting));
+        EXPECT_FALSE(instance.HasFeature(Feature::kPlugAndCharge));
+        EXPECT_FALSE(instance.HasFeature(Feature::kRfid));
+        EXPECT_FALSE(instance.HasFeature(Feature::kV2x));
+
+        // Test shutdown
+        instance.Shutdown();
+    }
+}
+
+} // namespace

--- a/src/app/clusters/energy-evse-server/tests/TestEnergyEvseClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/energy-evse-server/tests/TestEnergyEvseClusterBackwardsCompatibility.cpp
@@ -39,10 +39,6 @@ struct TestEvseClusterBackwardsCompatibility : public ::testing::Test
 {
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
-
-    void SetUp() override {}
-
-    TestServerClusterContext mContext;
 };
 
 TEST_F(TestEvseClusterBackwardsCompatibility, TestInstanceLifecycle)

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -33,7 +33,6 @@ CommandHandlerInterfaceOnlyClusters:
     - Device Energy Management Mode
     - Dishwasher Mode
     - Electrical Energy Measurement
-    - Energy EVSE
     - Energy EVSE Mode
     - Joint Fabric Administrator
     - Laundry Washer Mode
@@ -128,6 +127,7 @@ CodeDrivenClusters:
     - Device Energy Management
     - Diagnostic Logs
     - Electrical Power Measurement
+    - Energy EVSE
     - Ethernet Network Diagnostics
     - Fixed Label
     - General Commissioning

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -10596,33 +10596,6 @@ Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
     return status;
 }
 
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<uint16_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::EnergyEvse::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
-{
-    using Traits = NumericAttributeTraits<uint16_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::EnergyEvse::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
-}
-
 } // namespace ClusterRevision
 
 } // namespace Attributes

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -1873,8 +1873,6 @@ namespace Attributes {
 
 namespace ClusterRevision {
 Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value); // int16u
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty);
 } // namespace ClusterRevision
 
 } // namespace Attributes


### PR DESCRIPTION
#### Summary

Moved the instance in codegen, removed AAI and CommandHandler and updated the EvseCluster to code driven.

Light changes in the EVSE app, such as nullptr checks.

Also added unit tests for the Evse Cluster.

#### Related issues

n/a

#### Testing

Local build and run of EVSE app.
Unit tests added.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
