### PR TITLE
[Darwin] extract inline partials

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRClusters_Private.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_Private.zapt
@@ -9,37 +9,6 @@
 NS_ASSUME_NONNULL_BEGIN
 {{> placeholder_comment}}
 
-{{#*inline "commandDeclarations"}}
-{{#zcl_commands}}
-{{#if (is_str_equal source 'client')}}
-{{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
-{{#*inline "commandDecl"}}
-{{#if (isSupported cluster command=command)}}
-- (void){{asLowerCamelCase name}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion;
-{{/if}}
-{{/inline}}
-{{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
-                command=(asUpperCamelCase name preserveAcronyms=true)}}
-{{/if}}
-{{/zcl_commands}}
-{{/inline}}
-
-{{#*inline "attributeDeclarations"}}
-{{#zcl_attributes_server}}
-{{#if (and (or clusterRef
-               (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true)))
-           (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true)))}}
-{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
-- (NSDictionary<NSString *, id> * _Nullable)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params;
-{{#if (or isWritableAttribute
-      (isInConfigList (concat (asUpperCamelCase parent.name) "::" label) "DarwinForceWritable"))}}
-- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
-- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params;
-{{/if}}
-{{/if}}
-{{/zcl_attributes_server}}
-{{/inline}}
-
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
 

--- a/src/darwin/Framework/CHIP/templates/MTRClusters_Private.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_Private.zapt
@@ -57,36 +57,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} (PrivateExtensions)
 
-{{#zcl_commands}}
-{{#if manufacturerCode}}
-{{#if (is_str_equal source 'client')}}
-{{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
-{{#*inline "commandDecl"}}
-{{#if (isSupported cluster command=command)}}
-- (void){{asLowerCamelCase name}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion;
-{{/if}}
-{{/inline}}
-{{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
-                command=(asUpperCamelCase name preserveAcronyms=true)}}
-{{/if}}
-{{/if}}
-{{/zcl_commands}}
+{{> commandDeclarations manufacturerCodeOnly=true}}
 
-{{#zcl_attributes_server}}
-{{#if manufacturerCode}}
-{{#if (and (or clusterRef
-               (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true)))
-           (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true)))}}
-{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
-- (NSDictionary<NSString *, id> * _Nullable)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params;
-{{#if (or isWritableAttribute
-      (isInConfigList (concat (asUpperCamelCase parent.name) "::" label) "DarwinForceWritable"))}}
-- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
-- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params;
-{{/if}}
-{{/if}}
-{{/if}}
-{{/zcl_attributes_server}}
+{{> attributeDeclarations manufacturerCodeOnly=true}}
 
 @end
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/partials/attributeDeclarations.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/attributeDeclarations.zapt
@@ -1,0 +1,13 @@
+{{#zcl_attributes_server}}
+{{#if (and (or clusterRef
+               (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true)))
+           (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true)))}}
+{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
+- (NSDictionary<NSString *, id> * _Nullable)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params;
+{{#if (or isWritableAttribute
+      (isInConfigList (concat (asUpperCamelCase parent.name) "::" label) "DarwinForceWritable"))}}
+- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
+- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params;
+{{/if}}
+{{/if}}
+{{/zcl_attributes_server}}

--- a/src/darwin/Framework/CHIP/templates/partials/attributeDeclarations.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/attributeDeclarations.zapt
@@ -1,4 +1,6 @@
 {{#zcl_attributes_server}}
+{{! Only generate if: no filter set, or filter set and manufacturerCode present }}
+{{#if (or (not manufacturerCodeOnly) manufacturerCode)}}
 {{#if (and (or clusterRef
                (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true)))
            (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true)))}}
@@ -8,6 +10,7 @@
       (isInConfigList (concat (asUpperCamelCase parent.name) "::" label) "DarwinForceWritable"))}}
 - (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
 - (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params;
+{{/if}}
 {{/if}}
 {{/if}}
 {{/zcl_attributes_server}}

--- a/src/darwin/Framework/CHIP/templates/partials/commandDeclarations.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/commandDeclarations.zapt
@@ -1,0 +1,12 @@
+{{#zcl_commands}}
+{{#if (is_str_equal source 'client')}}
+{{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
+{{#*inline "commandDecl"}}
+{{#if (isSupported cluster command=command)}}
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion;
+{{/if}}
+{{/inline}}
+{{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
+                command=(asUpperCamelCase name preserveAcronyms=true)}}
+{{/if}}
+{{/zcl_commands}}

--- a/src/darwin/Framework/CHIP/templates/partials/commandDeclarations.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/commandDeclarations.zapt
@@ -1,5 +1,7 @@
 {{#zcl_commands}}
 {{#if (is_str_equal source 'client')}}
+{{! Only generate if: no filter set, or filter set and manufacturerCode present }}
+{{#if (or (not manufacturerCodeOnly) manufacturerCode)}}
 {{! Takes two arguments: cluster name and command name, plus the ambient state where the command is "this" }}
 {{#*inline "commandDecl"}}
 {{#if (isSupported cluster command=command)}}
@@ -8,5 +10,6 @@
 {{/inline}}
 {{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
                 command=(asUpperCamelCase name preserveAcronyms=true)}}
+{{/if}}
 {{/if}}
 {{/zcl_commands}}

--- a/src/darwin/Framework/CHIP/templates/templates.json
+++ b/src/darwin/Framework/CHIP/templates/templates.json
@@ -147,6 +147,14 @@
         {
             "name": "struct_old_name_variants",
             "path": "partials/struct_old_name_variants.zapt"
+        },
+        {
+            "name": "commandDeclarations",
+            "path": "partials/commandDeclarations.zapt"
+        },
+        {
+            "name": "attributeDeclarations",
+            "path": "partials/attributeDeclarations.zapt"
         }
     ],
     "templates": [


### PR DESCRIPTION
#### Summary

inline partials are only good within the block they are defined in.

#### Testing

`./scripts/tools/zap_regen_all.py --type all` with / without `UnitTesting` as a `DarwinPrivateCluster`.  Before fix, "with" case will generate an error due to the inlined partials.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
