### PR TITLE
Fix failed fabric removal due to TLS enpoint's fabric index lookup failure

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tls-client-management-instance.cpp
@@ -400,7 +400,11 @@ void TlsClientManagementCommandDelegate::RemoveFabric(FabricIndex fabric)
     UniquePtr<GlobalEndpointData> globalData(New<GlobalEndpointData>(EndpointId(1)));
     VerifyOrReturn(globalData);
     ReturnOnFailure(globalData->Load(mStorage));
-    ReturnAndLogOnFailure(globalData->RemoveAll(*mStorage, fabric), Zcl, "Failure clearing TLS endpoint data for fabric");
+
+    // Not having endpoint data for a fabric is not an error; the fabric may never
+    // have had TLS endpoints provisioned.
+    ReturnAndLogOnFailure(globalData->RemoveAll(*mStorage, fabric).NoErrorIf(CHIP_ERROR_NOT_FOUND), Zcl,
+                          "Failure clearing TLS endpoint data for fabric");
 }
 
 CHIP_ERROR TlsClientManagementCommandDelegate::MutateEndpointReferenceCount(EndpointId matterEndpoint, FabricIndex fabric,


### PR DESCRIPTION
#### Summary
 
If no TLS endpoints were ever provisioned for a fabric, TlsClientManagementCommandDelegate::RemoveFabric, where GlobalEndpointData::RemoveAll will return CHIP_ERROR_NOT_FOUND.

We should not log error here to produce a confusing error log.  

#### Related issues

Fixes: #42266


#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
