### PR TITLE
Apply suggestion for crash in ServiceNaming logging

### DIFF
--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -35,8 +35,11 @@ CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, const PeerId & peer
     NodeId nodeId               = peerId.GetNodeId();
     CompressedFabricId fabricId = peerId.GetCompressedFabricId();
 
-    snprintf(buffer, bufferLen, "%016" PRIX64 "-%016" PRIX64, fabricId, nodeId);
-
+    int ret = snprintf(buffer, bufferLen, "%016" PRIX64 "-%016" PRIX64, fabricId, nodeId);
+    if (ret < 0 || static_cast<size_t>(ret) >= bufferLen)
+    {
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
     return CHIP_NO_ERROR;
 }
 

--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -20,6 +20,7 @@
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/StringBuilder.h>
 
 #include <cstdio>
 #include <inttypes.h>
@@ -35,11 +36,10 @@ CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, const PeerId & peer
     NodeId nodeId               = peerId.GetNodeId();
     CompressedFabricId fabricId = peerId.GetCompressedFabricId();
 
-    int ret = snprintf(buffer, bufferLen, "%016" PRIX64 "-%016" PRIX64, fabricId, nodeId);
-    if (ret < 0 || static_cast<size_t>(ret) >= bufferLen)
-    {
-        return CHIP_ERROR_BUFFER_TOO_SMALL;
-    }
+    StringBuilderBase builder(buffer, bufferLen);
+    builder.AddFormat("%016" PRIX64 "-%016" PRIX64, fabricId, nodeId);
+
+    VerifyOrReturnError(builder.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
     return CHIP_NO_ERROR;
 }
 

--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -35,8 +35,7 @@ CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, const PeerId & peer
     NodeId nodeId               = peerId.GetNodeId();
     CompressedFabricId fabricId = peerId.GetCompressedFabricId();
 
-    snprintf(buffer, bufferLen, "%08" PRIX32 "%08" PRIX32 "-%08" PRIX32 "%08" PRIX32, static_cast<uint32_t>(fabricId >> 32),
-             static_cast<uint32_t>(fabricId), static_cast<uint32_t>(nodeId >> 32), static_cast<uint32_t>(nodeId));
+    snprintf(buffer, bufferLen, "%016" PRIX64 "-%016" PRIX64, fabricId, nodeId);
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Summary
```
*AI-generated analysis and fix proposal (Powered by Gemini CLI). Manual review and verification required.*

## Crash Analysis Result
The crash is an EXC_BREAKPOINT (SIGTRAP) with a BUG IN CLIENT OF LIBMALLOC: memory corruption of free block termination reason. This indicates heap corruption. The crash occurs in the Matter framework when trying to allocate an NSString from a C string. The call originates in -[MTRDeviceConnectivityMonitor initWithCompressedFabricID:nodeID:], which constructs a service instance name.

The root cause appears to be a subtle bug in the chip::Dnssd::MakeInstanceName function in connectedhomeip/src/lib/dnssd/ServiceNaming.cpp. This function uses a complex and potentially unsafe snprintf format string to construct the instance name from 64-bit fabric and node IDs by splitting them into 32-bit components. This approach can be fragile and may lead to memory corruption if not handled perfectly by the compiler and standard library on a specific platform.

==Call Chain==
2.  [NSString stringWithUTF8String:] is called from -[MTRDeviceConnectivityMonitor initWithCompressedFabricID:nodeID:] in the Matter framework.
3.  -[MTRDeviceConnectivityMonitor initWithCompressedFabricID:nodeID:] calls chip::Dnssd::MakeInstanceName to create a C-string representation of the service name.
4.  chip::Dnssd::MakeInstanceName uses snprintf with a complex format string to build the name. The potential misuse or misinterpretation of this format string is the likely source of memory corruption that leads to the crash.

## Code Fix Proposal
===diff start===
--- a/connectedhomeip/src/lib/dnssd/ServiceNaming.cpp
+++ b/connectedhomeip/src/lib/dnssd/ServiceNaming.cpp
@@ -35,9 +35,8 @@
     NodeId nodeId               = peerId.GetNodeId();
     CompressedFabricId fabricId = peerId.GetCompressedFabricId();
 
-    snprintf(buffer, bufferLen, "%08" PRIX32 "%08" PRIX32 "-%08" PRIX32 "%08" PRIX32, static_cast<uint32_t>(fabricId >> 32),
-             static_cast<uint32_t>(fabricId), static_cast<uint32_t>(nodeId >> 32), static_cast<uint32_t>(nodeId));
+    snprintf(
+        buffer, bufferLen, "%016" PRIX64 "-%016" PRIX64, fabricId, nodeId);
 
     return CHIP_NO_ERROR;
 }

===diff end===

## Code Fix Explanation
The proposed fix simplifies the snprintf call within the MakeInstanceName function. The original implementation was manually splitting 64-bit fabricId and nodeId values into high and low 32-bit parts and using a complex format string with four PRIX32 macros. This approach is unnecessarily complex and can be a source of subtle bugs.

The fix replaces this with a much cleaner and more robust single snprintf call that uses the correct PRIX64 format specifier to directly print the 64-bit fabricId and nodeId. This change produces the exact same output string format but in a safer, more readable, and more standard way, eliminating the potential for memory corruption caused by the complex formatting.
```
#### Testing

Ran Testing on Devices manually, CI covers this as well

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
