### PR TITLE
[SILABS] Fix open network join failure on silabs platform

### DIFF
--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -474,7 +474,7 @@ sl_status_t SetWifiConfigurations()
             .security = security,
             .encryption = SL_WIFI_DEFAULT_ENCRYPTION,
             .client_options = SL_WIFI_JOIN_WITH_SCAN,
-            .credential_id = SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID,
+            .credential_id = (security == SL_WIFI_OPEN) ? SL_NET_NO_CREDENTIAL_ID : SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID,
         },
         .ip = {
             .mode = SL_IP_MANAGEMENT_DHCP,


### PR DESCRIPTION
#### Summary

When connecting to an open WiFi network (no password), the code in SetWifiConfigurations() always set credential_id = SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID, even for open networks.

According to the Silabs WiFi SDK documentation:
For open security mode (SL_WIFI_OPEN), credential_id must be set to SL_NET_NO_CREDENTIAL_ID (0)
Using a credential ID for open networks causes sl_net_set_profile to return SL_STATUS_INVALID_CONFIGURATION (0x23)

Fix Applied:
Conditionally set the credential ID

#### Related issues


#### Testing

Able to connect to open netwrok after this fix.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
