### PR TITLE
Fix compilation error

### DIFF
--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -388,8 +388,10 @@ void ServiceEvents(uint32_t aSleepTimeMilliseconds)
             TEMPORARY_RETURN_IGNORED
             chip::DeviceLayer::PlatformMgr().ScheduleWork(
                 [](intptr_t) -> void {
-                TEMPORARY_RETURN_IGNORED
-                    chip::DeviceLayer::PlatformMgr().StopEventLoopTask(); }, (intptr_t) nullptr);
+                    TEMPORARY_RETURN_IGNORED
+                    chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+                },
+                (intptr_t) nullptr);
 #endif // CHIP_DEVICE_LAYER_TARGET_OPEN_IOT_SDK
             chip::DeviceLayer::PlatformMgr().RunEventLoop();
             sRemainingSystemLayerEventDelay = gNetworkOptions.EventDelay;

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -385,8 +385,11 @@ void ServiceEvents(uint32_t aSleepTimeMilliseconds)
             // We need to terminate event loop after performance single step.
             // Event loop processing work items until StopEventLoopTask is called.
             // Scheduling StopEventLoop task guarantees correct operation of the loop.
+            TEMPORARY_RETURN_IGNORED
             chip::DeviceLayer::PlatformMgr().ScheduleWork(
-                [](intptr_t) -> void { chip::DeviceLayer::PlatformMgr().StopEventLoopTask(); }, (intptr_t) nullptr);
+                [](intptr_t) -> void {
+                TEMPORARY_RETURN_IGNORED
+                    chip::DeviceLayer::PlatformMgr().StopEventLoopTask(); }, (intptr_t) nullptr);
 #endif // CHIP_DEVICE_LAYER_TARGET_OPEN_IOT_SDK
             chip::DeviceLayer::PlatformMgr().RunEventLoop();
             sRemainingSystemLayerEventDelay = gNetworkOptions.EventDelay;


### PR DESCRIPTION
#### Summary

Compilation error on MCXW72 if the fix is not used.


#### Testing

Successful compilation on MCXW72.

Build command:

`west build -d build_matter_unit_tests_w72/ -b frdmmcxw72 src/test_driver/nxp/ --force -DCONFIG_MCUX_COMPONENT_middleware.freertos-kernel.config=n -Dcore_id=cm33_core0 -DCONFIG_CHIP_CRYPTO_PSA=y -DCONFIG_CHIP_MBEDTLS_3X=y -DCONFIG_CHIP_CRYPTO_SPAKE2P_CUSTOM=y`
