### PR TITLE
[NXP] Fix freertos NXP unit tests build error

### DIFF
--- a/config/nxp/chip-cmake-freertos/Kconfig.defaults
+++ b/config/nxp/chip-cmake-freertos/Kconfig.defaults
@@ -53,6 +53,9 @@ config CHIP_TASK_STACK_SIZE
 	default 13000 if CHIP_SE05X  # Increase is do to the additional middle-ware APDU buffers
 	default 10240
 
+ config CHIP_INET_ENABLE_TCP_ENDPOINT
+	default n
+
 config CHIP_TASK_PRIORITY
 	default 2
 

--- a/src/test_driver/nxp/Kconfig
+++ b/src/test_driver/nxp/Kconfig
@@ -18,7 +18,7 @@ mainmenu "NXP Matter Unit Test Application"
 if CHIP_NXP_PLATFORM_MCXW71 || CHIP_NXP_PLATFORM_MCXW72
 
 config gMainThreadStackSize_c
-	default 6144
+	default 15000
 
 endif # if CHIP_NXP_PLATFORM_MCXW71 || CHIP_NXP_PLATFORM_MCXW72
 

--- a/src/test_driver/nxp/src/main.cpp
+++ b/src/test_driver/nxp/src/main.cpp
@@ -35,16 +35,20 @@ using namespace ::chip::DeviceLayer;
 
 void test_task(void * pvParameters)
 {
-    chip::Platform::MemoryInit();
-    chip::DeviceLayer::PlatformManagerImpl().ServiceInit();
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
-    int status = chip::test::RunAllTests();
+    err = chip::Platform::MemoryInit();
+    assert(err == CHIP_NO_ERROR);
+
+    err = chip::DeviceLayer::PlatformManagerImpl().ServiceInit();
+    assert(err == CHIP_NO_ERROR);
+
+    chip::test::RunAllTests();
 }
 
 #if FSL_OSA_MAIN_FUNC_ENABLE
 extern "C" void main_task(void const * argument)
 {
-    TaskHandle_t taskHandle;
 #if CONFIG_ENABLE_PW_RPC
     chip::NXP::App::Rpc::Init();
 #endif


### PR DESCRIPTION
#### Summary

Fix build unit test errors due to wrong Kconfig value and increase main stask size for mcxw platforms

#### Testing

Local build passing for mcxw and rw61x, command used for rw61x:
west build -d ./build_matter_unit_test/ -b frdmrw612 ./src/test_driver/nxp

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
