### PR TITLE
Add test TC_DD_3_22

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
@@ -15,20 +15,20 @@
 name: 3.3.22 [TC-DD-3.22] NFC-based commissioning [DUT as Commissioner]
 
 PICS:
-  - MCORE.ROLE.COMMISSIONER
-  - MCORE.DD.NFC
-  - MCORE.DD.NTL
+    - MCORE.ROLE.COMMISSIONER
+    - MCORE.DD.NFC
+    - MCORE.DD.NTL
 
 config:
-  nodeId: 0x12344321
-  cluster: "Basic Information"
-  endpoint: 0
+    nodeId: 0x12344321
+    cluster: "Basic Information"
+    endpoint: 0
 
 tests:
-  - label: "Step 1: Commission DUT to TH"
-    cluster: "DelayCommands"
-    command: "WaitForCommissionee"
-    arguments:
-      values:
-        - name: "nodeId"
-          value: nodeId
+    - label: "Step 1: Commission DUT to TH"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId

--- a/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
@@ -26,7 +26,7 @@ config:
 
 tests:
   - label: "Step 1: Commission DUT to TH"
-    cluster: "Basic Information"
+    cluster: "DelayCommands"
     command: "WaitForCommissionee"
     arguments:
       values:

--- a/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 3.3.22 [TC-DD-3.22] NFC-based commissioning [DUT as Commissioner]
+
+PICS:
+  - MCORE.ROLE.COMMISSIONER
+  - MCORE.DD.NFC
+  - MCORE.DD.NTL
+
+config:
+  nodeId: 0x12344321
+  cluster: "Basic Information"
+  endpoint: 0
+
+tests:
+  - label: "Step 1: Commission DUT to TH"
+    cluster: "Basic Information"
+    command: "WaitForCommissionee"
+    arguments:
+      values:
+        - name: "nodeId"
+          value: nodeId


### PR DESCRIPTION
Add test TC_DD_3_22 checking NFC-based commissioning for DUT as Commissioner

Warning: This test should be executed with "nfc-thread" or "nfc-wifi" pairing mode.

#### Testing

Tested that the test is working as expected. Here is the log.
[UI_Test_Run_TC_DD_3_22_2026_01_25_00_27_05.log](https://github.com/user-attachments/files/25096283/UI_Test_Run_TC_DD_3_22_2026_01_25_00_27_05.log)
