### PR TITLE
Update zap arguments in `generate.py` to support retries and update darwin-specific arguments.

### DIFF
--- a/build/chip/chip_codegen.gni
+++ b/build/chip/chip_codegen.gni
@@ -172,15 +172,38 @@ template("_chip_build_time_zapgen") {
       "--output-dir",
       rebase_path(target_gen_dir) + "/zapgen/" + _output_subdir,
 
-      # TODO: lock file support should be removed as this serializes zap
-      # (slower), however this is currently done because on Darwin zap startup
-      # may conflict and error out with:
-      #    Error: EEXIST: file already exists, mkdir '/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pkg/465fcc8a6282e28dc7a166859d5814d34e2fb94249a72fa9229033b5b32dff1a'
-      "--lock-file",
-      rebase_path("${root_out_dir}/zap_gen.lock"),
       "--parallel",
-      _idl_file,
     ]
+
+    if (current_os == "mac") {
+      args += [
+        # TODO: Retries are not ideal, however darwin fails with errors like:
+        #   INFO    Error: async hook stack has become corrupted (actual: 27947, expected: 27947)
+        #   INFO     1: 0x10049e978 node::AsyncHooks::FailWithCorruptedAsyncStack(double) [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
+        #   INFO     2: 0x10040304a node::InternalCallbackScope::Close() [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
+        #   INFO     3: 0x100402793 node::InternalCallbackScope::Close() [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
+        #   INFO     4: 0x1004d83e1 napi_create_async_work [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
+        #   INFO     5: 0x10123a1e8 uv_random [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
+        #   INFO     6: 0x10123fe6b uv_async_init [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
+        #   INFO     7: 0x1012563fa uv_free_interface_addresses [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
+        #   INFO     8: 0x101240838 uv_run [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
+        #   INFO     9: 0x100404363 node::SpinEventLoop(node::Environment*) [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
+        #   INFO    10: 0x10058c7a5 node::NodeMainInstance::Run() [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
+        #   INFO    11: 0x1004d4643 node::Start(int, char**) [/Users/runner/work/connectedhomeip/connectedhomeip/.environment/cipd/packages/zap/zap-cli]
+        #   INFO    12: 0x206195781
+        "--retries",
+        "3",
+
+        # TODO: lock file support should be removed as this serializes zap
+        # (slower), however this is currently done because on Darwin zap startup
+        # may conflict and error out with:
+        #    Error: EEXIST: file already exists, mkdir '/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pkg/465fcc8a6282e28dc7a166859d5814d34e2fb94249a72fa9229033b5b32dff1a'
+        "--lock-file",
+        rebase_path("${root_out_dir}/zap_gen.lock"),
+      ]
+    }
+
+    args += [ _idl_file ]
 
     inputs = [
       _idl_file,

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -248,6 +248,7 @@ def runGeneration(cmdLineArgs):
     for i in range(cmdLineArgs.retries):
         try:
             tool.run('generate', *args)
+            break
         except subprocess.CalledProcessError:
             if i < cmdLineArgs.retries - 1:
                 log.exception("Failure to generate, retrying (%d retries left)", cmdLineArgs.retries - i - 1)

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -252,6 +252,8 @@ def runGeneration(cmdLineArgs):
             if i < cmdLineArgs.retries - 1:
                 log.exception("Failure to generate, retrying (%d retries left)", cmdLineArgs.retries - i - 1)
                 continue
+            if cmdLineArgs.retries > 1:
+                log.error("Zap execution failure after %d retries", cmdLineArgs.retries)
             raise
 
     if cmdLineArgs.matter_file_name:

--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -44,6 +44,7 @@ class CmdLineArgs:
     templateFile: str
     outputDir: str
     runBootstrap: bool
+    retries: int
     parallel: bool = True
     prettify_output: bool = True
     version_check: bool = True
@@ -146,6 +147,7 @@ def runArgumentsParser() -> CmdLineArgs:
     parser.add_argument('--version-check', action='store_true')
     parser.add_argument('--no-version-check',
                         action='store_false', dest='version_check')
+    parser.add_argument('--retries', help='Retry running zap-cli in case of failure', default=1, type=int)
     parser.add_argument('--keep-output-dir', action='store_true',
                         help='Keep any created output directory. Useful for temporary directories.')
     parser.set_defaults(parallel=True)
@@ -191,6 +193,7 @@ def runArgumentsParser() -> CmdLineArgs:
         lock_file=args.lock_file,
         delete_output_dir=delete_output_dir,
         matter_file_name=matter_file_name,
+        retries=args.retries,
     )
 
 
@@ -242,7 +245,14 @@ def runGeneration(cmdLineArgs):
         # Parallel-compatible runs will need separate state
         args.append('--tempState')
 
-    tool.run('generate', *args)
+    for i in range(cmdLineArgs.retries):
+        try:
+            tool.run('generate', *args)
+        except subprocess.CalledProcessError:
+            if i < cmdLineArgs.retries - 1:
+                log.exception("Failure to generate, retrying (%d retries left)", cmdLineArgs.retries - i - 1)
+                continue
+            raise
 
     if cmdLineArgs.matter_file_name:
         matter_name = cmdLineArgs.matter_file_name


### PR DESCRIPTION
#### Summary

- Add support for `--retries` in generate.py
- Use this option for darwin and also isolate the other darwin-required option in codegen.gni

#### Testing

Ran generate.py locally while creating errors in a json file and noticed we retry. It also generates correctly if files are ok. I used something like:

```
watchexec --watch src/app "./scripts/run_in_build_env.sh './scripts/tools/zap/generate.py -t src/app/zap-templates/matter-idl-client.json -m src/controller/data_model/controller-clusters.matter --retries 3'"
```