### PR TITLE
Consolidate cleanup sites to use the shared CleanupSession

### DIFF
--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -138,6 +138,8 @@ private:
     void OnLocalDescription(const std::string & sdp, SDPType type, const uint16_t sessionId);
     void OnConnectionStateChanged(bool connected, const uint16_t sessionId);
 
+    void CleanupSession(uint16_t sessionId);
+
     WebrtcTransport * GetTransport(uint16_t sessionId);
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnConnectedCallback;

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -949,12 +949,6 @@ void WebRTCProviderManager::CleanupSession(uint16_t sessionId)
     // Remove from session maps
     mSessionIdMap.erase(ScopedNodeId(args.peerNodeId, args.fabricIndex));
 
-    // Remove from current sessions list in the WebRTC Transport Provider
-    if (mWebRTCTransportProvider != nullptr)
-    {
-        mWebRTCTransportProvider->RemoveSession(sessionId);
-    }
-
     // Finally, remove and destroy the transport
     mWebrtcTransportMap.erase(sessionId);
 

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -529,25 +529,9 @@ CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEnd
         ChipLogError(Camera, "Session ID %u does not match the current sessions", sessionId);
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    if (transport != nullptr)
-    {
-        ChipLogProgress(Camera, "Delete Webrtc Transport for the session: %u", sessionId);
 
-        // Release the Video and Audio Streams from the CameraAVStreamManagement
-        // cluster and update the reference counts.
-        // TODO: Lookup the sessionID to get the Video/Audio StreamID
-        TEMPORARY_RETURN_IGNORED ReleaseAudioVideoStreams(sessionId);
-
-        UnregisterWebrtcTransport(sessionId);
-        mWebrtcTransportMap.erase(sessionId);
-        WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
-        mSessionIdMap.erase(ScopedNodeId(args.peerNodeId, args.fabricIndex));
-    }
-
-    if (transport->ClosePeerConnection())
-    {
-        ChipLogProgress(Camera, "Closing peer connection: %u", sessionId);
-    }
+    ChipLogProgress(Camera, "EndSession for session: %u", sessionId);
+    CleanupSession(sessionId);
 
     return CHIP_NO_ERROR;
 }
@@ -919,18 +903,7 @@ void WebRTCProviderManager::OnDeviceConnected(void * context, Messaging::Exchang
         }
 
         err = self->SendEndCommand(exchangeMgr, sessionHandle, sessionId, endReason);
-        // Release the Video and Audio Streams from the CameraAVStreamManagement
-        // cluster and update the reference counts.
-        TEMPORARY_RETURN_IGNORED self->ReleaseAudioVideoStreams(sessionId);
-        self->UnregisterWebrtcTransport(sessionId);
-        WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
-        self->mSessionIdMap.erase(ScopedNodeId(args.peerNodeId, args.fabricIndex));
-
-        transport->MoveToState(WebrtcTransport::State::Idle);
-
-        // remove from current sessions list
-        self->mWebRTCTransportProvider->RemoveSession(sessionId);
-        self->mWebrtcTransportMap.erase(sessionId);
+        self->CleanupSession(sessionId);
         break;
     }
     default:
@@ -949,6 +922,43 @@ void WebRTCProviderManager::OnDeviceConnectionFailure(void * context, const Scop
     LogErrorOnFailure(err);
     WebRTCProviderManager * self = reinterpret_cast<WebRTCProviderManager *>(context);
     VerifyOrReturn(self != nullptr, ChipLogError(Camera, "OnDeviceConnectionFailure: context is null"));
+}
+
+void WebRTCProviderManager::CleanupSession(uint16_t sessionId)
+{
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
+    {
+        ChipLogProgress(Camera, "Transport not found for session %u; session may have already been cleaned up", sessionId);
+        return;
+    }
+
+    // Release the Video and Audio Streams from the CameraAVStreamManagement
+    // cluster and update the reference counts.
+    TEMPORARY_RETURN_IGNORED ReleaseAudioVideoStreams(sessionId);
+
+    // Capture args before cleanup in case the transport is invalidated
+    WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
+
+    // Unregister the transport from the media controller
+    UnregisterWebrtcTransport(sessionId);
+
+    // Close the peer connection
+    transport->ClosePeerConnection();
+
+    // Remove from session maps
+    mSessionIdMap.erase(ScopedNodeId(args.peerNodeId, args.fabricIndex));
+
+    // Remove from current sessions list in the WebRTC Transport Provider
+    if (mWebRTCTransportProvider != nullptr)
+    {
+        mWebRTCTransportProvider->RemoveSession(sessionId);
+    }
+
+    // Finally, remove and destroy the transport
+    mWebrtcTransportMap.erase(sessionId);
+
+    ChipLogProgress(Camera, "Session %u cleanup completed", sessionId);
 }
 
 WebrtcTransport * WebRTCProviderManager::GetTransport(uint16_t sessionId)
@@ -1070,42 +1080,8 @@ void WebRTCProviderManager::OnConnectionStateChanged(bool connected, const uint1
         // Safe to capture 'this' by value: WebRTCProviderManager is a member of the global CameraDevice
         // object which has static storage duration and lives for the entire program lifetime.
         TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() {
-            WebrtcTransport * transport = GetTransport(sessionId);
-            if (transport == nullptr)
-            {
-                ChipLogProgress(Camera,
-                                "Transport not found for session %u during disconnect; session may have already been cleaned up",
-                                sessionId);
-                return;
-            }
-
-            // Connection was closed/disconnected by the peer - clean up the session
             ChipLogProgress(Camera, "Peer connection closed for session %u, cleaning up resources", sessionId);
-
-            // Release the Video and Audio Streams from the CameraAVStreamManagement
-            // cluster and update the reference counts.
-            TEMPORARY_RETURN_IGNORED ReleaseAudioVideoStreams(sessionId);
-
-            // Capture args before unregistering in case the transport is invalidated
-            WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
-
-            // Unregister the transport from the media controller
-            UnregisterWebrtcTransport(sessionId);
-
-            // Remove from session maps
-            mSessionIdMap.erase(ScopedNodeId(args.peerNodeId, args.fabricIndex));
-
-            // Remove from current sessions list in the WebRTC Transport Provider
-            // This MUST be called on the Matter thread with the stack lock held
-            if (mWebRTCTransportProvider != nullptr)
-            {
-                mWebRTCTransportProvider->RemoveSession(sessionId);
-            }
-
-            // Finally, remove and destroy the transport
-            mWebrtcTransportMap.erase(sessionId);
-
-            ChipLogProgress(Camera, "Session %u cleanup completed", sessionId);
+            CleanupSession(sessionId);
         });
     }
 }

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -1076,6 +1076,13 @@ void WebRTCProviderManager::OnConnectionStateChanged(bool connected, const uint1
         TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() {
             ChipLogProgress(Camera, "Peer connection closed for session %u, cleaning up resources", sessionId);
             CleanupSession(sessionId);
+
+            // Remove from current sessions list in the WebRTC Transport Provider
+            // This MUST be called on the Matter thread with the stack lock held
+            if (mWebRTCTransportProvider != nullptr)
+            {
+                mWebRTCTransportProvider->RemoveSession(sessionId);
+            }
         });
     }
 }

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -530,7 +530,7 @@ CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEnd
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    ChipLogProgress(Camera, "EndSession for session: %u", sessionId);
+    ChipLogProgress(Camera, "EndSession for session: %u, reason: %u", sessionId, static_cast<unsigned>(reasonCode));
     CleanupSession(sessionId);
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Summary

This block of session cleanup logic is very similar to the logic within the lambda in OnConnectionStateChanged and also has significant overlap with HandleEndSession and the kEnd case in OnDeviceConnected. To improve maintainability and ensure consistent cleanup behavior,  refactoring this logic into a single private helper function. This function could then be called from all these locations, reducing code duplication.

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
