### PR TITLE
[WebRTC] Parse and set ICE servers to PeerConnection

### DIFF
--- a/examples/camera-app/linux/include/webrtc-abstract.h
+++ b/examples/camera-app/linux/include/webrtc-abstract.h
@@ -49,6 +49,13 @@ struct ICECandidateInfo
     int mlineIndex;
 };
 
+struct ICEServerInfo
+{
+    std::vector<std::string> urls;
+    std::string username;
+    std::string credential;
+};
+
 using OnLocalDescriptionCallback = std::function<void(const std::string & sdp, SDPType type)>;
 using OnICECandidateCallback     = std::function<void(const ICECandidateInfo & candidateInfo)>;
 using OnConnectionStateCallback  = std::function<void(bool connected)>;
@@ -83,4 +90,4 @@ public:
     virtual int GetPayloadType(const std::string & sdp, SDPType type, const std::string & codec) { return -1; };
 };
 
-std::shared_ptr<WebRTCPeerConnection> CreateWebRTCPeerConnection();
+std::shared_ptr<WebRTCPeerConnection> CreateWebRTCPeerConnection(const std::vector<ICEServerInfo> & iceServers = {});

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -148,7 +148,7 @@ private:
     RequestArgs mRequestArgs;
     OnTransportLocalDescriptionCallback mOnLocalDescription = nullptr;
     OnTransportConnectionStateCallback mOnConnectionState   = nullptr;
-    std::vector<ICEServerInfo> mIceServers;
+    std::vector<ICEServerInfo> mICEServers;
 
     std::mutex mTrackStatusLock;
 };

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -101,6 +101,9 @@ public:
     // Adds audio track to the peerconnection with opus codec with default payload type as 111
     void AddAudioTrack(const std::string & audioMid = "audio", int payloadType = 111);
 
+    // Set ICE servers to use when creating the underlying PeerConnection. Call this before Start().
+    void SetICEServers(const std::vector<ICEServerInfo> & servers);
+
     std::shared_ptr<WebRTCPeerConnection> GetPeerConnection() { return mPeerConnection; }
 
     std::string GetLocalDescription() { return mLocalSdp; }
@@ -145,6 +148,7 @@ private:
     RequestArgs mRequestArgs;
     OnTransportLocalDescriptionCallback mOnLocalDescription = nullptr;
     OnTransportConnectionStateCallback mOnConnectionState   = nullptr;
+    std::vector<ICEServerInfo> mIceServers;
 
     std::mutex mTrackStatusLock;
 };

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -107,12 +107,12 @@ bool ValidateSdpFields(const std::string & sdp)
  * @brief Converts Matter ICE server structures to the internal ICEServerInfo format.
  *
  * @param matterIceServers The Matter protocol ICE server list
- * @return std::vector<ICEServerInfo> The converted ICE server info list
+ * @param[out] iceServers The converted ICE server info list
+ * @return CHIP_ERROR CHIP_NO_ERROR on success, or an error from iterator parsing
  */
 template <typename T>
-std::vector<ICEServerInfo> ConvertICEServers(const T & matterIceServers)
+CHIP_ERROR ConvertICEServers(const T & matterIceServers, std::vector<ICEServerInfo> & iceServers)
 {
-    std::vector<ICEServerInfo> iceServers;
     for (const auto & server : matterIceServers)
     {
         ICEServerInfo info;
@@ -121,6 +121,7 @@ std::vector<ICEServerInfo> ConvertICEServers(const T & matterIceServers)
         {
             info.urls.emplace_back(urlsIter.GetValue().data(), urlsIter.GetValue().size());
         }
+        ReturnErrorOnFailure(urlsIter.GetStatus());
         if (server.username.HasValue())
         {
             info.username = std::string(server.username.Value().data(), server.username.Value().size());
@@ -134,7 +135,7 @@ std::vector<ICEServerInfo> ConvertICEServers(const T & matterIceServers)
             iceServers.push_back(std::move(info));
         }
     }
-    return iceServers;
+    return CHIP_NO_ERROR;
 }
 
 } // namespace
@@ -245,7 +246,13 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
 
     if (args.iceServers.HasValue())
     {
-        transport->SetICEServers(ConvertICEServers(args.iceServers.Value()));
+        std::vector<ICEServerInfo> iceServers;
+        ReturnErrorOnFailure(ConvertICEServers(args.iceServers.Value(), iceServers));
+        transport->SetICEServers(iceServers);
+    }
+    else
+    {
+        ChipLogProgress(Camera, "No ICE servers provided; ICE negotiation will be limited to host candidates");
     }
 
     // Check resource availability before proceeding
@@ -459,7 +466,13 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
 
     if (args.iceServers.HasValue())
     {
-        transport->SetICEServers(ConvertICEServers(args.iceServers.Value()));
+        std::vector<ICEServerInfo> iceServers;
+        ReturnErrorOnFailure(ConvertICEServers(args.iceServers.Value(), iceServers));
+        transport->SetICEServers(iceServers);
+    }
+    else
+    {
+        ChipLogProgress(Camera, "No ICE servers provided; ICE negotiation will be limited to host candidates");
     }
 
     transport->Start();

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -103,6 +103,40 @@ bool ValidateSdpFields(const std::string & sdp)
     return true;
 }
 
+/**
+ * @brief Converts Matter ICE server structures to the internal ICEServerInfo format.
+ *
+ * @param matterIceServers The Matter protocol ICE server list
+ * @return std::vector<ICEServerInfo> The converted ICE server info list
+ */
+template <typename T>
+std::vector<ICEServerInfo> ConvertICEServers(const T & matterIceServers)
+{
+    std::vector<ICEServerInfo> iceServers;
+    for (const auto & server : matterIceServers)
+    {
+        ICEServerInfo info;
+        auto urlsIter = server.URLs.begin();
+        while (urlsIter.Next())
+        {
+            info.urls.emplace_back(urlsIter.GetValue().data(), urlsIter.GetValue().size());
+        }
+        if (server.username.HasValue())
+        {
+            info.username = std::string(server.username.Value().data(), server.username.Value().size());
+        }
+        if (server.credential.HasValue())
+        {
+            info.credential = std::string(server.credential.Value().data(), server.credential.Value().size());
+        }
+        if (!info.urls.empty())
+        {
+            iceServers.push_back(std::move(info));
+        }
+    }
+    return iceServers;
+}
+
 } // namespace
 
 void WebRTCProviderManager::SetCameraDevice(CameraDeviceInterface * aCameraDevice)
@@ -207,6 +241,11 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
     {
         transport->sFrameConfig = args.sFrameConfig;
         ChipLogProgress(Camera, "SFrame encryption enabled for session %u", args.sessionId);
+    }
+
+    if (args.iceServers.HasValue())
+    {
+        transport->SetICEServers(ConvertICEServers(args.iceServers.Value()));
     }
 
     // Check resource availability before proceeding
@@ -416,6 +455,11 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
     {
         transport->sFrameConfig = args.sFrameConfig;
         ChipLogProgress(Camera, "SFrame encryption enabled for session %u", args.sessionId);
+    }
+
+    if (args.iceServers.HasValue())
+    {
+        transport->SetICEServers(ConvertICEServers(args.iceServers.Value()));
     }
 
     transport->Start();

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -281,10 +281,19 @@ private:
 class LibDataChannelPeerConnection : public WebRTCPeerConnection
 {
 public:
-    LibDataChannelPeerConnection()
+    LibDataChannelPeerConnection(const std::vector<ICEServerInfo> & servers = {})
     {
         rtc::Configuration config;
-        // config.iceServers.emplace_back("stun.l.google.com:19302");
+        for (const auto & server : servers)
+        {
+            for (const auto & url : server.urls)
+            {
+                rtc::IceServer iceServer(url);
+                iceServer.username = server.username;
+                iceServer.password = server.credential;
+                config.iceServers.push_back(iceServer);
+            }
+        }
         mPeerConnection = std::make_shared<rtc::PeerConnection>(config);
     }
 
@@ -455,7 +464,7 @@ private:
 
 } // namespace
 
-std::shared_ptr<WebRTCPeerConnection> CreateWebRTCPeerConnection()
+std::shared_ptr<WebRTCPeerConnection> CreateWebRTCPeerConnection(const std::vector<ICEServerInfo> & iceServers)
 {
-    return std::make_shared<LibDataChannelPeerConnection>();
+    return std::make_shared<LibDataChannelPeerConnection>(iceServers);
 }

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -64,7 +64,7 @@ void WebrtcTransport::SetRequestArgs(const RequestArgs & args)
 
 void WebrtcTransport::SetICEServers(const std::vector<ICEServerInfo> & servers)
 {
-    mIceServers = servers;
+    mICEServers = servers;
 }
 
 WebrtcTransport::RequestArgs & WebrtcTransport::GetRequestArgs()
@@ -200,7 +200,7 @@ void WebrtcTransport::Start()
         return;
     }
 
-    mPeerConnection = CreateWebRTCPeerConnection(mIceServers);
+    mPeerConnection = CreateWebRTCPeerConnection(mICEServers);
 
     mPeerConnection->SetCallbacks([this](const std::string & sdp, SDPType type) { this->OnLocalDescription(sdp, type); },
                                   [this](const ICECandidateInfo & candidateInfo) { this->OnICECandidate(candidateInfo); },

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -62,6 +62,11 @@ void WebrtcTransport::SetRequestArgs(const RequestArgs & args)
     mRequestArgs = args;
 }
 
+void WebrtcTransport::SetICEServers(const std::vector<ICEServerInfo> & servers)
+{
+    mIceServers = servers;
+}
+
 WebrtcTransport::RequestArgs & WebrtcTransport::GetRequestArgs()
 {
     return mRequestArgs;
@@ -195,7 +200,7 @@ void WebrtcTransport::Start()
         return;
     }
 
-    mPeerConnection = CreateWebRTCPeerConnection();
+    mPeerConnection = CreateWebRTCPeerConnection(mIceServers);
 
     mPeerConnection->SetCallbacks([this](const std::string & sdp, SDPType type) { this->OnLocalDescription(sdp, type); },
                                   [this](const ICECandidateInfo & candidateInfo) { this->OnICECandidate(candidateInfo); },


### PR DESCRIPTION
#### Summary

WebRTC peers behind NATs or firewalls often cannot establish direct connections. ICE servers (STUN/TURN) help discover public IP addresses and relay traffic when direct connectivity fails. The Matter WebRTC Transport Provider cluster allows clients to specify ICE servers in the SolicitOffer and ProvideOffer commands.

This change adds support for configuring ICE (Interactive Connectivity Establishment) servers in the WebRTC transport layer, enabling NAT traversal for camera streaming sessions.   

#### Related issues

Fixes: #41656

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
