### PR TITLE
Darwin: Avoid enum-compare-switch warning / error in extension template

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRClusterNames_Private-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterNames_Private-src.zapt
@@ -12,7 +12,7 @@ NSString * MTRPrivateClusterNameForID(MTRClusterIDType clusterID)
 {
     NSString * result = nil;
 
-    switch ((MTRClusterIDType)clusterID) {
+    switch ((MTRPrivateClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
@@ -40,7 +40,7 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {
     NSString * result = nil;
 
-    switch ((MTRClusterIDType)clusterID) {
+    switch ((MTRPrivateClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
@@ -140,7 +140,7 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {{~#*inline "commandIDOutput"}}
     NSString * result = nil;
 
-    switch ((MTRClusterIDType)clusterID) {
+    switch ((MTRPrivateClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
@@ -233,7 +233,7 @@ NSString * MTRPrivateEventNameForID(MTRClusterIDType clusterID, MTREventIDType e
 {
     NSString * result = nil;
 
-    switch ((MTRClusterIDType)clusterID) {
+    switch ((MTRPrivateClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterNames_Private.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterNames_Private.mm
@@ -26,7 +26,7 @@ NSString * MTRPrivateClusterNameForID(MTRClusterIDType clusterID)
 {
     NSString * result = nil;
 
-    switch ((MTRClusterIDType) clusterID) {
+    switch ((MTRPrivateClusterIDType) clusterID) {
 
     default:
         result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
@@ -42,7 +42,7 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {
     NSString * result = nil;
 
-    switch ((MTRClusterIDType) clusterID) {
+    switch ((MTRPrivateClusterIDType) clusterID) {
 
     default:
         result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
@@ -58,7 +58,7 @@ NSString * MTRPrivateRequestCommandNameForID(MTRClusterIDType clusterID, MTRComm
 {
     NSString * result = nil;
 
-    switch ((MTRClusterIDType) clusterID) {
+    switch ((MTRPrivateClusterIDType) clusterID) {
 
     default:
         result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
@@ -72,7 +72,7 @@ NSString * MTRPrivateResponseCommandNameForID(MTRClusterIDType clusterID, MTRCom
 {
     NSString * result = nil;
 
-    switch ((MTRClusterIDType) clusterID) {
+    switch ((MTRPrivateClusterIDType) clusterID) {
 
     default:
         result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
@@ -88,7 +88,7 @@ NSString * MTRPrivateEventNameForID(MTRClusterIDType clusterID, MTREventIDType e
 {
     NSString * result = nil;
 
-    switch ((MTRClusterIDType) clusterID) {
+    switch ((MTRPrivateClusterIDType) clusterID) {
 
     default:
         result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];


### PR DESCRIPTION
#### Summary

Fix a Darwin-only extension template to avoid warnings / errors due to comparing different enum types.

#### Testing

Tested locally with extensions.
