### PR TITLE
Update ubuntu build version in cross compile docker image for gstreamer

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-182 : Gstreamer: install gstreamer1.0-plugins-good, gstreamer1.0-plugins-ugly for Camera app
+183 : Gstreamer: install gstreamer1.0-plugins-good, gstreamer1.0-plugins-ugly for cross compiling Camera app

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /opt
 RUN set -x \
   && git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools \
   # TODO: Remove experimental solution to create the sysroot file in cross-compile image
-  && echo 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-2025.07.10' > ensure_file.txt \
+  && echo 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-2026.01.28' > ensure_file.txt \
   && ./depot_tools/cipd ensure -ensure-file ensure_file.txt -root ./ \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/firmware \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/git-core \


### PR DESCRIPTION
#### Summary
Updated ubuntu build version in cross compile docker image to included gstreamer1.0-plugins-ugly
-  As RPI image didn't have the gstreamer plugin ugly codecs, audio and video stream failure happens for PAVST_2_12 and PAVST_2_13.


#### Related issues

Fixes #42925 
Fixes #42926 

#### Testing
```
# Build and run camera application
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debug/chip-camera-app

# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run Push AV TC
Example:
python3 src/python_testing/TC_PAVST_2_11.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1
```