### PR TITLE
[BooleanStateConfiguration] Add per-attribute change callback functions.

### DIFF
--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
@@ -192,7 +192,8 @@ BooleanStateConfigurationCluster::InvokeCommand(const DataModel::InvokeRequest &
         bool generateEvent = false;
         if (mAlarmsActive.HasAny(alarmsToDisable))
         {
-            if (mDelegate != nullptr) {
+            if (mDelegate != nullptr)
+            {
                 VerifyOrReturnError(mDelegate->OnAlarmsActiveChanged(mAlarmsActive), Status::Failure);
             }
             mAlarmsActive.Clear(alarmsToDisable);
@@ -201,7 +202,8 @@ BooleanStateConfigurationCluster::InvokeCommand(const DataModel::InvokeRequest &
         }
         if (mAlarmsSuppressed.HasAny(alarmsToDisable))
         {
-            if (mDelegate != nullptr) {
+            if (mDelegate != nullptr)
+            {
                 VerifyOrReturnError(mDelegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed), Status::Failure);
             }
             mAlarmsSuppressed.Clear(alarmsToDisable);
@@ -308,7 +310,8 @@ void BooleanStateConfigurationCluster::GenerateSensorFault(SensorFaultBitMask fa
 
     if (mOptionalAttributes.IsSet(SensorFault::Id) && (mSensorFault != fault))
     {
-        if (mDelegate != nullptr) {
+        if (mDelegate != nullptr)
+        {
             TEMPORARY_RETURN_IGNORED mDelegate->OnSensorFaultChanged(mSensorFault);
         }
         mSensorFault = fault;
@@ -321,7 +324,8 @@ CHIP_ERROR BooleanStateConfigurationCluster::SetCurrentSensitivityLevel(uint8_t 
     VerifyOrReturnError(level < mSupportedSensitivityLevels, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     VerifyOrReturnError(mCurrentSensitivityLevel != level, CHIP_NO_ERROR);
 
-    if (mDelegate != nullptr) {
+    if (mDelegate != nullptr)
+    {
         VerifyOrReturnError(mDelegate->OnCurrentSensitivityLevelChanged(level), CHIP_ERROR_INCORRECT_STATE);
     }
     mCurrentSensitivityLevel = level;
@@ -341,7 +345,8 @@ Status BooleanStateConfigurationCluster::SetAlarmsActive(AlarmModeBitMask alarms
     // No change is a noop
     VerifyOrReturnError(mAlarmsActive != alarms, Status::Success);
 
-    if (mDelegate != nullptr) {
+    if (mDelegate != nullptr)
+    {
         VerifyOrReturnError(mDelegate->OnAlarmsActiveChanged(alarms), Status::Failure);
     }
     mAlarmsActive = alarms;
@@ -359,7 +364,8 @@ Status BooleanStateConfigurationCluster::SetAllEnabledAlarmsActive()
     // No change is a noop
     VerifyOrReturnError(mAlarmsActive != mAlarmsEnabled, Status::Success);
 
-    if (mDelegate != nullptr) {
+    if (mDelegate != nullptr)
+    {
         VerifyOrReturnError(mDelegate->OnAlarmsActiveChanged(mAlarmsEnabled), Status::Failure);
     }
     mAlarmsActive = mAlarmsEnabled;
@@ -375,7 +381,8 @@ void BooleanStateConfigurationCluster::ClearAllAlarms()
 
     if (mAlarmsActive.HasAny())
     {
-        if (mDelegate != nullptr) {
+        if (mDelegate != nullptr)
+        {
             TEMPORARY_RETURN_IGNORED mDelegate->OnAlarmsActiveChanged(BitMask<AlarmModeBitmap>());
         }
         mAlarmsActive.ClearAll();
@@ -383,7 +390,8 @@ void BooleanStateConfigurationCluster::ClearAllAlarms()
     }
     if (mAlarmsSuppressed.HasAny())
     {
-        if (mDelegate != nullptr) {
+        if (mDelegate != nullptr)
+        {
             TEMPORARY_RETURN_IGNORED mDelegate->OnAlarmsSuppressedChanged(BitMask<AlarmModeBitmap>());
         }
         mAlarmsSuppressed.ClearAll();
@@ -413,7 +421,8 @@ Status BooleanStateConfigurationCluster::SuppressAlarms(AlarmModeBitMask alarms)
         TEMPORARY_RETURN_IGNORED mDelegate->HandleSuppressAlarm(alarms);
     }
 
-    if (mDelegate != nullptr) {
+    if (mDelegate != nullptr)
+    {
         VerifyOrReturnError(mDelegate->OnAlarmsSuppressedChanged(alarms), Status::Failure);
     }
     mAlarmsSuppressed.Set(alarms);

--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
@@ -312,7 +312,7 @@ void BooleanStateConfigurationCluster::GenerateSensorFault(SensorFaultBitMask fa
             TEMPORARY_RETURN_IGNORED mDelegate->OnSensorFaultChanged(mSensorFault);
         }
         mSensorFault = fault;
-        NotifyAttributeChanged(SensorFault::Id);     
+        NotifyAttributeChanged(SensorFault::Id);
     }
 }
 
@@ -346,7 +346,7 @@ Status BooleanStateConfigurationCluster::SetAlarmsActive(AlarmModeBitMask alarms
     }
     mAlarmsActive = alarms;
     NotifyAttributeChanged(AlarmsActive::Id);
-    
+
     GenerateAlarmsStateChangedEvent();
 
     return Status::Success;
@@ -364,7 +364,7 @@ Status BooleanStateConfigurationCluster::SetAllEnabledAlarmsActive()
     }
     mAlarmsActive = mAlarmsEnabled;
     NotifyAttributeChanged(AlarmsActive::Id);
-    
+
     GenerateAlarmsStateChangedEvent();
     return Status::Success;
 }

--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
@@ -192,21 +192,25 @@ BooleanStateConfigurationCluster::InvokeCommand(const DataModel::InvokeRequest &
         bool generateEvent = false;
         if (mAlarmsActive.HasAny(alarmsToDisable))
         {
+            AlarmModeBitMask newActive = mAlarmsActive;
+            newActive.Clear(alarmsToDisable);
             if (mDelegate != nullptr)
             {
-                VerifyOrReturnError(mDelegate->OnAlarmsActiveChanged(mAlarmsActive), Status::Failure);
+                VerifyOrReturnError(mDelegate->OnAlarmsActiveChanged(newActive), Status::Failure);
             }
-            mAlarmsActive.Clear(alarmsToDisable);
+            mAlarmsActive = newActive;
             NotifyAttributeChanged(AlarmsActive::Id);
             generateEvent = true;
         }
         if (mAlarmsSuppressed.HasAny(alarmsToDisable))
         {
+            AlarmModeBitMask newSuppressed = mAlarmsSuppressed;
+            newSuppressed.Clear(alarmsToDisable);
             if (mDelegate != nullptr)
             {
-                VerifyOrReturnError(mDelegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed), Status::Failure);
+                VerifyOrReturnError(mDelegate->OnAlarmsSuppressedChanged(newSuppressed), Status::Failure);
             }
-            mAlarmsSuppressed.Clear(alarmsToDisable);
+            mAlarmsSuppressed = newSuppressed;
             NotifyAttributeChanged(AlarmsSuppressed::Id);
             generateEvent = true;
         }
@@ -312,7 +316,7 @@ void BooleanStateConfigurationCluster::GenerateSensorFault(SensorFaultBitMask fa
     {
         if (mDelegate != nullptr)
         {
-            TEMPORARY_RETURN_IGNORED mDelegate->OnSensorFaultChanged(mSensorFault);
+            TEMPORARY_RETURN_IGNORED mDelegate->OnSensorFaultChanged(fault);
         }
         mSensorFault = fault;
         NotifyAttributeChanged(SensorFault::Id);
@@ -414,18 +418,16 @@ Status BooleanStateConfigurationCluster::SuppressAlarms(AlarmModeBitMask alarms)
     // validate this is not a NOOP
     VerifyOrReturnError(!mAlarmsSuppressed.HasAll(alarms), Status::Success);
 
+    AlarmModeBitMask newAlarmsSuppressed = mAlarmsSuppressed;
+    newAlarmsSuppressed.Set(alarms);
     if (mDelegate != nullptr)
     {
         // TODO: To preserve original logic, we ignore error code from the
         //       delegate, however this feels off.
         TEMPORARY_RETURN_IGNORED mDelegate->HandleSuppressAlarm(alarms);
-    }
-
-    if (mDelegate != nullptr)
-    {
         VerifyOrReturnError(mDelegate->OnAlarmsSuppressedChanged(alarms), Status::Failure);
     }
-    mAlarmsSuppressed.Set(alarms);
+    mAlarmsSuppressed = newAlarmsSuppressed;
     NotifyAttributeChanged(AlarmsSuppressed::Id);
     GenerateAlarmsStateChangedEvent();
     return Status::Success;

--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
@@ -161,6 +161,10 @@ BooleanStateConfigurationCluster::InvokeCommand(const DataModel::InvokeRequest &
 
         if (mAlarmsEnabled != alarms)
         {
+            if (mDelegate != nullptr)
+            {
+                VerifyOrReturnError(mDelegate->OnAlarmsEnabledChanged(alarms), Status::Failure);
+            }
             mAlarmsEnabled = alarms;
 
             AlarmModeBitMask::IntegerType rawAlarmsEnabled = mAlarmsEnabled.Raw();
@@ -170,8 +174,7 @@ BooleanStateConfigurationCluster::InvokeCommand(const DataModel::InvokeRequest &
             {
                 ChipLogError(DataManagement, "Failed to persist alarms enabled: %" CHIP_ERROR_FORMAT, err.Format());
             }
-            NotifyAttributeChangedAndCallDelegate(AlarmsEnabled::Id,
-                                                  [this](auto * delegate) { delegate->OnAlarmsEnabledChanged(mAlarmsEnabled); });
+            NotifyAttributeChanged(AlarmsEnabled::Id);
         }
 
         if (mDelegate != nullptr)
@@ -189,16 +192,20 @@ BooleanStateConfigurationCluster::InvokeCommand(const DataModel::InvokeRequest &
         bool generateEvent = false;
         if (mAlarmsActive.HasAny(alarmsToDisable))
         {
+            if (mDelegate != nullptr) {
+                VerifyOrReturnError(mDelegate->OnAlarmsActiveChanged(mAlarmsActive), Status::Failure);
+            }
             mAlarmsActive.Clear(alarmsToDisable);
-            NotifyAttributeChangedAndCallDelegate(AlarmsActive::Id,
-                                                  [this](auto * delegate) { delegate->OnAlarmsActiveChanged(mAlarmsActive); });
+            NotifyAttributeChanged(AlarmsActive::Id);
             generateEvent = true;
         }
         if (mAlarmsSuppressed.HasAny(alarmsToDisable))
         {
+            if (mDelegate != nullptr) {
+                VerifyOrReturnError(mDelegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed), Status::Failure);
+            }
             mAlarmsSuppressed.Clear(alarmsToDisable);
-            NotifyAttributeChangedAndCallDelegate(
-                AlarmsSuppressed::Id, [this](auto * delegate) { delegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed); });
+            NotifyAttributeChanged(AlarmsSuppressed::Id);
             generateEvent = true;
         }
 
@@ -301,9 +308,11 @@ void BooleanStateConfigurationCluster::GenerateSensorFault(SensorFaultBitMask fa
 
     if (mOptionalAttributes.IsSet(SensorFault::Id) && (mSensorFault != fault))
     {
+        if (mDelegate != nullptr) {
+            TEMPORARY_RETURN_IGNORED mDelegate->OnSensorFaultChanged(mSensorFault);
+        }
         mSensorFault = fault;
-        NotifyAttributeChangedAndCallDelegate(SensorFault::Id,
-                                              [this](auto * delegate) { delegate->OnSensorFaultChanged(mSensorFault); });
+        NotifyAttributeChanged(SensorFault::Id);     
     }
 }
 
@@ -312,10 +321,11 @@ CHIP_ERROR BooleanStateConfigurationCluster::SetCurrentSensitivityLevel(uint8_t 
     VerifyOrReturnError(level < mSupportedSensitivityLevels, CHIP_IM_GLOBAL_STATUS(ConstraintError));
     VerifyOrReturnError(mCurrentSensitivityLevel != level, CHIP_NO_ERROR);
 
+    if (mDelegate != nullptr) {
+        VerifyOrReturnError(mDelegate->OnCurrentSensitivityLevelChanged(level), CHIP_ERROR_INCORRECT_STATE);
+    }
     mCurrentSensitivityLevel = level;
-    NotifyAttributeChangedAndCallDelegate(CurrentSensitivityLevel::Id, [this](auto * delegate) {
-        delegate->OnCurrentSensitivityLevelChanged(mCurrentSensitivityLevel);
-    });
+    NotifyAttributeChanged(CurrentSensitivityLevel::Id);
 
     // TODO: we should migrate this to not use `Safe` attribute persistence and use
     //       a common persistence layer.
@@ -331,9 +341,12 @@ Status BooleanStateConfigurationCluster::SetAlarmsActive(AlarmModeBitMask alarms
     // No change is a noop
     VerifyOrReturnError(mAlarmsActive != alarms, Status::Success);
 
+    if (mDelegate != nullptr) {
+        VerifyOrReturnError(mDelegate->OnAlarmsActiveChanged(alarms), Status::Failure);
+    }
     mAlarmsActive = alarms;
-    NotifyAttributeChangedAndCallDelegate(AlarmsActive::Id,
-                                          [this](auto * delegate) { delegate->OnAlarmsActiveChanged(mAlarmsActive); });
+    NotifyAttributeChanged(AlarmsActive::Id);
+    
     GenerateAlarmsStateChangedEvent();
 
     return Status::Success;
@@ -346,9 +359,12 @@ Status BooleanStateConfigurationCluster::SetAllEnabledAlarmsActive()
     // No change is a noop
     VerifyOrReturnError(mAlarmsActive != mAlarmsEnabled, Status::Success);
 
+    if (mDelegate != nullptr) {
+        VerifyOrReturnError(mDelegate->OnAlarmsActiveChanged(mAlarmsEnabled), Status::Failure);
+    }
     mAlarmsActive = mAlarmsEnabled;
-    NotifyAttributeChangedAndCallDelegate(AlarmsActive::Id,
-                                          [this](auto * delegate) { delegate->OnAlarmsActiveChanged(mAlarmsActive); });
+    NotifyAttributeChanged(AlarmsActive::Id);
+    
     GenerateAlarmsStateChangedEvent();
     return Status::Success;
 }
@@ -359,15 +375,19 @@ void BooleanStateConfigurationCluster::ClearAllAlarms()
 
     if (mAlarmsActive.HasAny())
     {
+        if (mDelegate != nullptr) {
+            TEMPORARY_RETURN_IGNORED mDelegate->OnAlarmsActiveChanged(BitMask<AlarmModeBitmap>());
+        }
         mAlarmsActive.ClearAll();
-        NotifyAttributeChangedAndCallDelegate(AlarmsActive::Id,
-                                              [this](auto * delegate) { delegate->OnAlarmsActiveChanged(mAlarmsActive); });
+        NotifyAttributeChanged(AlarmsActive::Id);
     }
     if (mAlarmsSuppressed.HasAny())
     {
+        if (mDelegate != nullptr) {
+            TEMPORARY_RETURN_IGNORED mDelegate->OnAlarmsSuppressedChanged(BitMask<AlarmModeBitmap>());
+        }
         mAlarmsSuppressed.ClearAll();
-        NotifyAttributeChangedAndCallDelegate(AlarmsSuppressed::Id,
-                                              [this](auto * delegate) { delegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed); });
+        NotifyAttributeChanged(AlarmsSuppressed::Id);
     }
 
     GenerateAlarmsStateChangedEvent();
@@ -393,9 +413,11 @@ Status BooleanStateConfigurationCluster::SuppressAlarms(AlarmModeBitMask alarms)
         TEMPORARY_RETURN_IGNORED mDelegate->HandleSuppressAlarm(alarms);
     }
 
+    if (mDelegate != nullptr) {
+        VerifyOrReturnError(mDelegate->OnAlarmsSuppressedChanged(alarms), Status::Failure);
+    }
     mAlarmsSuppressed.Set(alarms);
-    NotifyAttributeChangedAndCallDelegate(AlarmsSuppressed::Id,
-                                          [this](auto * delegate) { delegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed); });
+    NotifyAttributeChanged(AlarmsSuppressed::Id);
     GenerateAlarmsStateChangedEvent();
     return Status::Success;
 }

--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
@@ -197,8 +197,8 @@ BooleanStateConfigurationCluster::InvokeCommand(const DataModel::InvokeRequest &
         if (mAlarmsSuppressed.HasAny(alarmsToDisable))
         {
             mAlarmsSuppressed.Clear(alarmsToDisable);
-            NotifyAttributeChangedAndCallDelegate(AlarmsSuppressed::Id,
-                                                  [this](auto * delegate) { delegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed); });
+            NotifyAttributeChangedAndCallDelegate(
+                AlarmsSuppressed::Id, [this](auto * delegate) { delegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed); });
             generateEvent = true;
         }
 
@@ -313,8 +313,9 @@ CHIP_ERROR BooleanStateConfigurationCluster::SetCurrentSensitivityLevel(uint8_t 
     VerifyOrReturnError(mCurrentSensitivityLevel != level, CHIP_NO_ERROR);
 
     mCurrentSensitivityLevel = level;
-    NotifyAttributeChangedAndCallDelegate(CurrentSensitivityLevel::Id,
-                                          [this](auto * delegate) { delegate->OnCurrentSensitivityLevelChanged(mCurrentSensitivityLevel); });
+    NotifyAttributeChangedAndCallDelegate(CurrentSensitivityLevel::Id, [this](auto * delegate) {
+        delegate->OnCurrentSensitivityLevelChanged(mCurrentSensitivityLevel);
+    });
 
     // TODO: we should migrate this to not use `Safe` attribute persistence and use
     //       a common persistence layer.

--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
@@ -170,7 +170,11 @@ BooleanStateConfigurationCluster::InvokeCommand(const DataModel::InvokeRequest &
             {
                 ChipLogError(DataManagement, "Failed to persist alarms enabled: %" CHIP_ERROR_FORMAT, err.Format());
             }
-            OnClusterAttributeChanged(AlarmsEnabled::Id);
+            NotifyAttributeChanged(AlarmsEnabled::Id);
+            if (mDelegate != nullptr)
+            {
+                mDelegate->OnAlarmsEnabledChanged(mAlarmsEnabled);
+            }
         }
 
         if (mDelegate != nullptr)
@@ -189,13 +193,21 @@ BooleanStateConfigurationCluster::InvokeCommand(const DataModel::InvokeRequest &
         if (mAlarmsActive.HasAny(alarmsToDisable))
         {
             mAlarmsActive.Clear(alarmsToDisable);
-            OnClusterAttributeChanged(AlarmsActive::Id);
+            NotifyAttributeChanged(AlarmsActive::Id);
+            if (mDelegate != nullptr)
+            {
+                mDelegate->OnAlarmsActiveChanged(mAlarmsActive);
+            }
             generateEvent = true;
         }
         if (mAlarmsSuppressed.HasAny(alarmsToDisable))
         {
             mAlarmsSuppressed.Clear(alarmsToDisable);
-            OnClusterAttributeChanged(AlarmsSuppressed::Id);
+            NotifyAttributeChanged(AlarmsSuppressed::Id);
+            if (mDelegate != nullptr)
+            {
+                mDelegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed);
+            }
             generateEvent = true;
         }
 
@@ -299,7 +311,11 @@ void BooleanStateConfigurationCluster::GenerateSensorFault(SensorFaultBitMask fa
     if (mOptionalAttributes.IsSet(SensorFault::Id) && (mSensorFault != fault))
     {
         mSensorFault = fault;
-        OnClusterAttributeChanged(SensorFault::Id);
+        NotifyAttributeChanged(SensorFault::Id);
+        if (mDelegate != nullptr)
+        {
+            mDelegate->OnSensorFaultChanged(mSensorFault);
+        }
     }
 }
 
@@ -309,21 +325,16 @@ CHIP_ERROR BooleanStateConfigurationCluster::SetCurrentSensitivityLevel(uint8_t 
     VerifyOrReturnError(mCurrentSensitivityLevel != level, CHIP_NO_ERROR);
 
     mCurrentSensitivityLevel = level;
-    OnClusterAttributeChanged(CurrentSensitivityLevel::Id);
+    NotifyAttributeChanged(CurrentSensitivityLevel::Id);
+    if (mDelegate != nullptr)
+    {
+        mDelegate->OnCurrentSensitivityLevelChanged(mCurrentSensitivityLevel);
+    }
 
     // TODO: we should migrate this to not use `Safe` attribute persistence and use
     //       a common persistence layer.
     return GetSafeAttributePersistenceProvider()->WriteScalarValue(
         { mPath.mEndpointId, mPath.mClusterId, CurrentSensitivityLevel::Id }, level);
-}
-
-void BooleanStateConfigurationCluster::OnClusterAttributeChanged(AttributeId attributeId)
-{
-    NotifyAttributeChanged(attributeId);
-    if (mDelegate != nullptr)
-    {
-        mDelegate->OnAttributeChanged(attributeId, this);
-    }
 }
 
 Status BooleanStateConfigurationCluster::SetAlarmsActive(AlarmModeBitMask alarms)
@@ -335,7 +346,11 @@ Status BooleanStateConfigurationCluster::SetAlarmsActive(AlarmModeBitMask alarms
     VerifyOrReturnError(mAlarmsActive != alarms, Status::Success);
 
     mAlarmsActive = alarms;
-    OnClusterAttributeChanged(AlarmsActive::Id);
+    NotifyAttributeChanged(AlarmsActive::Id);
+    if (mDelegate != nullptr)
+    {
+        mDelegate->OnAlarmsActiveChanged(mAlarmsActive);
+    }
     GenerateAlarmsStateChangedEvent();
 
     return Status::Success;
@@ -349,7 +364,11 @@ Status BooleanStateConfigurationCluster::SetAllEnabledAlarmsActive()
     VerifyOrReturnError(mAlarmsActive != mAlarmsEnabled, Status::Success);
 
     mAlarmsActive = mAlarmsEnabled;
-    OnClusterAttributeChanged(AlarmsActive::Id);
+    NotifyAttributeChanged(AlarmsActive::Id);
+    if (mDelegate != nullptr)
+    {
+        mDelegate->OnAlarmsActiveChanged(mAlarmsActive);
+    }
     GenerateAlarmsStateChangedEvent();
     return Status::Success;
 }
@@ -361,12 +380,20 @@ void BooleanStateConfigurationCluster::ClearAllAlarms()
     if (mAlarmsActive.HasAny())
     {
         mAlarmsActive.ClearAll();
-        OnClusterAttributeChanged(AlarmsActive::Id);
+        NotifyAttributeChanged(AlarmsActive::Id);
+        if (mDelegate != nullptr)
+        {
+            mDelegate->OnAlarmsActiveChanged(mAlarmsActive);
+        }
     }
     if (mAlarmsSuppressed.HasAny())
     {
         mAlarmsSuppressed.ClearAll();
-        OnClusterAttributeChanged(AlarmsSuppressed::Id);
+        NotifyAttributeChanged(AlarmsSuppressed::Id);
+        if (mDelegate != nullptr)
+        {
+            mDelegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed);
+        }
     }
 
     GenerateAlarmsStateChangedEvent();
@@ -393,7 +420,11 @@ Status BooleanStateConfigurationCluster::SuppressAlarms(AlarmModeBitMask alarms)
     }
 
     mAlarmsSuppressed.Set(alarms);
-    OnClusterAttributeChanged(AlarmsSuppressed::Id);
+    NotifyAttributeChanged(AlarmsSuppressed::Id);
+    if (mDelegate != nullptr)
+    {
+        mDelegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed);
+    }
     GenerateAlarmsStateChangedEvent();
     return Status::Success;
 }

--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
@@ -170,11 +170,8 @@ BooleanStateConfigurationCluster::InvokeCommand(const DataModel::InvokeRequest &
             {
                 ChipLogError(DataManagement, "Failed to persist alarms enabled: %" CHIP_ERROR_FORMAT, err.Format());
             }
-            NotifyAttributeChanged(AlarmsEnabled::Id);
-            if (mDelegate != nullptr)
-            {
-                mDelegate->OnAlarmsEnabledChanged(mAlarmsEnabled);
-            }
+            NotifyAttributeChangedAndCallDelegate(AlarmsEnabled::Id,
+                                                  [this](auto * delegate) { delegate->OnAlarmsEnabledChanged(mAlarmsEnabled); });
         }
 
         if (mDelegate != nullptr)
@@ -193,21 +190,15 @@ BooleanStateConfigurationCluster::InvokeCommand(const DataModel::InvokeRequest &
         if (mAlarmsActive.HasAny(alarmsToDisable))
         {
             mAlarmsActive.Clear(alarmsToDisable);
-            NotifyAttributeChanged(AlarmsActive::Id);
-            if (mDelegate != nullptr)
-            {
-                mDelegate->OnAlarmsActiveChanged(mAlarmsActive);
-            }
+            NotifyAttributeChangedAndCallDelegate(AlarmsActive::Id,
+                                                  [this](auto * delegate) { delegate->OnAlarmsActiveChanged(mAlarmsActive); });
             generateEvent = true;
         }
         if (mAlarmsSuppressed.HasAny(alarmsToDisable))
         {
             mAlarmsSuppressed.Clear(alarmsToDisable);
-            NotifyAttributeChanged(AlarmsSuppressed::Id);
-            if (mDelegate != nullptr)
-            {
-                mDelegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed);
-            }
+            NotifyAttributeChangedAndCallDelegate(AlarmsSuppressed::Id,
+                                                  [this](auto * delegate) { delegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed); });
             generateEvent = true;
         }
 
@@ -311,11 +302,8 @@ void BooleanStateConfigurationCluster::GenerateSensorFault(SensorFaultBitMask fa
     if (mOptionalAttributes.IsSet(SensorFault::Id) && (mSensorFault != fault))
     {
         mSensorFault = fault;
-        NotifyAttributeChanged(SensorFault::Id);
-        if (mDelegate != nullptr)
-        {
-            mDelegate->OnSensorFaultChanged(mSensorFault);
-        }
+        NotifyAttributeChangedAndCallDelegate(SensorFault::Id,
+                                              [this](auto * delegate) { delegate->OnSensorFaultChanged(mSensorFault); });
     }
 }
 
@@ -325,11 +313,8 @@ CHIP_ERROR BooleanStateConfigurationCluster::SetCurrentSensitivityLevel(uint8_t 
     VerifyOrReturnError(mCurrentSensitivityLevel != level, CHIP_NO_ERROR);
 
     mCurrentSensitivityLevel = level;
-    NotifyAttributeChanged(CurrentSensitivityLevel::Id);
-    if (mDelegate != nullptr)
-    {
-        mDelegate->OnCurrentSensitivityLevelChanged(mCurrentSensitivityLevel);
-    }
+    NotifyAttributeChangedAndCallDelegate(CurrentSensitivityLevel::Id,
+                                          [this](auto * delegate) { delegate->OnCurrentSensitivityLevelChanged(mCurrentSensitivityLevel); });
 
     // TODO: we should migrate this to not use `Safe` attribute persistence and use
     //       a common persistence layer.
@@ -346,11 +331,8 @@ Status BooleanStateConfigurationCluster::SetAlarmsActive(AlarmModeBitMask alarms
     VerifyOrReturnError(mAlarmsActive != alarms, Status::Success);
 
     mAlarmsActive = alarms;
-    NotifyAttributeChanged(AlarmsActive::Id);
-    if (mDelegate != nullptr)
-    {
-        mDelegate->OnAlarmsActiveChanged(mAlarmsActive);
-    }
+    NotifyAttributeChangedAndCallDelegate(AlarmsActive::Id,
+                                          [this](auto * delegate) { delegate->OnAlarmsActiveChanged(mAlarmsActive); });
     GenerateAlarmsStateChangedEvent();
 
     return Status::Success;
@@ -364,11 +346,8 @@ Status BooleanStateConfigurationCluster::SetAllEnabledAlarmsActive()
     VerifyOrReturnError(mAlarmsActive != mAlarmsEnabled, Status::Success);
 
     mAlarmsActive = mAlarmsEnabled;
-    NotifyAttributeChanged(AlarmsActive::Id);
-    if (mDelegate != nullptr)
-    {
-        mDelegate->OnAlarmsActiveChanged(mAlarmsActive);
-    }
+    NotifyAttributeChangedAndCallDelegate(AlarmsActive::Id,
+                                          [this](auto * delegate) { delegate->OnAlarmsActiveChanged(mAlarmsActive); });
     GenerateAlarmsStateChangedEvent();
     return Status::Success;
 }
@@ -380,20 +359,14 @@ void BooleanStateConfigurationCluster::ClearAllAlarms()
     if (mAlarmsActive.HasAny())
     {
         mAlarmsActive.ClearAll();
-        NotifyAttributeChanged(AlarmsActive::Id);
-        if (mDelegate != nullptr)
-        {
-            mDelegate->OnAlarmsActiveChanged(mAlarmsActive);
-        }
+        NotifyAttributeChangedAndCallDelegate(AlarmsActive::Id,
+                                              [this](auto * delegate) { delegate->OnAlarmsActiveChanged(mAlarmsActive); });
     }
     if (mAlarmsSuppressed.HasAny())
     {
         mAlarmsSuppressed.ClearAll();
-        NotifyAttributeChanged(AlarmsSuppressed::Id);
-        if (mDelegate != nullptr)
-        {
-            mDelegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed);
-        }
+        NotifyAttributeChangedAndCallDelegate(AlarmsSuppressed::Id,
+                                              [this](auto * delegate) { delegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed); });
     }
 
     GenerateAlarmsStateChangedEvent();
@@ -420,11 +393,8 @@ Status BooleanStateConfigurationCluster::SuppressAlarms(AlarmModeBitMask alarms)
     }
 
     mAlarmsSuppressed.Set(alarms);
-    NotifyAttributeChanged(AlarmsSuppressed::Id);
-    if (mDelegate != nullptr)
-    {
-        mDelegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed);
-    }
+    NotifyAttributeChangedAndCallDelegate(AlarmsSuppressed::Id,
+                                          [this](auto * delegate) { delegate->OnAlarmsSuppressedChanged(mAlarmsSuppressed); });
     GenerateAlarmsStateChangedEvent();
     return Status::Success;
 }

--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h
@@ -133,19 +133,6 @@ private:
 
     void GenerateAlarmsStateChangedEvent();
 
-    /// Helper method to notify attribute change and call delegate callback
-    /// @tparam CallbackType The type of the callback function/lambda
-    /// @param attributeId The attribute ID that changed
-    /// @param callback A callable that takes the delegate pointer and calls the appropriate callback method
-    template <typename CallbackType>
-    void NotifyAttributeChangedAndCallDelegate(AttributeId attributeId, CallbackType && callback)
-    {
-        NotifyAttributeChanged(attributeId);
-        if (mDelegate != nullptr)
-        {
-            std::forward<CallbackType>(callback)(mDelegate);
-        }
-    }
 };
 
 } // namespace chip::app::Clusters

--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h
@@ -132,7 +132,6 @@ private:
     SensorFaultBitMask mSensorFault{ 0 };
 
     void GenerateAlarmsStateChangedEvent();
-
 };
 
 } // namespace chip::app::Clusters

--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h
@@ -131,6 +131,20 @@ private:
     SensorFaultBitMask mSensorFault{ 0 };
 
     void GenerateAlarmsStateChangedEvent();
+
+    /// Helper method to notify attribute change and call delegate callback
+    /// @tparam CallbackType The type of the callback function/lambda
+    /// @param attributeId The attribute ID that changed
+    /// @param callback A callable that takes the delegate pointer and calls the appropriate callback method
+    template <typename CallbackType>
+    void NotifyAttributeChangedAndCallDelegate(AttributeId attributeId, CallbackType && callback)
+    {
+        NotifyAttributeChanged(attributeId);
+        if (mDelegate != nullptr)
+        {
+            callback(mDelegate);
+        }
+    }
 };
 
 } // namespace chip::app::Clusters

--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h
@@ -131,9 +131,6 @@ private:
     SensorFaultBitMask mSensorFault{ 0 };
 
     void GenerateAlarmsStateChangedEvent();
-
-    // Does NotifyAttributeChanged and also calls the delegate attribute changed callback
-    void OnClusterAttributeChanged(AttributeId attributeId);
 };
 
 } // namespace chip::app::Clusters

--- a/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h
+++ b/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h
@@ -23,6 +23,7 @@
 #include <lib/core/DataModelTypes.h>
 
 #include <cstdint>
+#include <utility>
 
 namespace chip::app::Clusters {
 
@@ -142,7 +143,7 @@ private:
         NotifyAttributeChanged(attributeId);
         if (mDelegate != nullptr)
         {
-            callback(mDelegate);
+            std::forward<CallbackType>(callback)(mDelegate);
         }
     }
 };

--- a/src/app/clusters/boolean-state-configuration-server/README.md
+++ b/src/app/clusters/boolean-state-configuration-server/README.md
@@ -13,8 +13,17 @@ The application interacts with the cluster via a
 `BooleanStateConfiguration::Delegate` instance:
 
 -   allows additional handling when commands are received
--   provides a post-attribute update callback, which can be used for example to
-    react to updates to the `CurrentSensitivityLevel` attribute.
+-   provides type-safe per-attribute change callbacks:
+    -   `OnCurrentSensitivityLevelChanged(uint8_t)` - called when
+        CurrentSensitivityLevel changes
+    -   `OnAlarmsActiveChanged(BitMask<AlarmModeBitmap>)` - called when
+        AlarmsActive changes
+    -   `OnAlarmsSuppressedChanged(BitMask<AlarmModeBitmap>)` - called when
+        AlarmsSuppressed changes
+    -   `OnAlarmsEnabledChanged(BitMask<AlarmModeBitmap>)` - called when
+        AlarmsEnabled changes
+    -   `OnSensorFaultChanged(BitMask<SensorFaultBitmap>)` - called when
+        SensorFault changes
 
 ## CodegenIntegration / updates from ember `PostAttributeChangeCallback`
 
@@ -28,7 +37,7 @@ Usage Notes:
 -   existing API was preserved in `CodegenIntegration.h` with the added
     requirement that the API calls _MUST_ be called only after server
     initialization (i.e. after the clusters have been created.)
--   The `Delegate` provides a `OnAttributeChanged` hook that is to be used to
-    react/detect when attributes change (e.g. when `CurrentSensitivityLevel::Id`
-    was updated). Use this instead of implementing functionality in
-    `PostAttributeChangeCallback`.
+-   The `Delegate` provides type-safe per-attribute change callbacks (e.g.
+    `OnCurrentSensitivityLevelChanged()`) that are called when attributes change
+    via WriteAttribute or InvokeCommand. Use these instead of implementing
+    functionality in `PostAttributeChangeCallback`.

--- a/src/app/clusters/boolean-state-configuration-server/README.md
+++ b/src/app/clusters/boolean-state-configuration-server/README.md
@@ -38,6 +38,8 @@ Usage Notes:
     requirement that the API calls _MUST_ be called only after server
     initialization (i.e. after the clusters have been created.)
 -   The `Delegate` provides type-safe per-attribute change callbacks (e.g.
-    `OnCurrentSensitivityLevelChanged()`) that are called when attributes change
-    via WriteAttribute or InvokeCommand. Use these instead of implementing
-    functionality in `PostAttributeChangeCallback`.
+    `OnCurrentSensitivityLevelChanged(uint8_t)`) that are called whenever the
+    corresponding attributes change, whether via attribute writes, command
+    handlers, or server APIs such as `SetAlarmsActive()` or
+    `GenerateSensorFault()`. Use these instead of implementing functionality in
+    `PostAttributeChangeCallback`.

--- a/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
+++ b/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
@@ -45,11 +45,11 @@ public:
     //  via WriteAttribute, InvokeCommand, or direct server APIs. Default implementations are empty
     //  override only the callbacks you need.
 
-    virtual void OnCurrentSensitivityLevelChanged(uint8_t newValue) {}
-    virtual void OnAlarmsActiveChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) {}
-    virtual void OnAlarmsSuppressedChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) {}
-    virtual void OnAlarmsEnabledChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) {}
-    virtual void OnSensorFaultChanged(chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> newValue) {}
+    virtual bool OnCurrentSensitivityLevelChanged(uint8_t newValue) { return true; }
+    virtual bool OnAlarmsActiveChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) { return true; }
+    virtual bool OnAlarmsSuppressedChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) { return true; }
+    virtual bool OnAlarmsEnabledChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) { return true; }
+    virtual bool OnSensorFaultChanged(chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> newValue) { return true; }
 };
 
 } // namespace BooleanStateConfiguration

--- a/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
+++ b/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
@@ -42,7 +42,7 @@ public:
     virtual CHIP_ERROR HandleEnableDisableAlarms(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> alarms) = 0;
 
     // These methods are called when the corresponding attributes are updated by the server, whether
-    //  via WriteAttribute, InvokeCommand, or direct server APIs. Default implementations are empty
+    //  via WriteAttribute, InvokeCommand, or direct server APIs. Default implementations return true;
     //  override only the callbacks you need.
 
     virtual bool OnCurrentSensitivityLevelChanged(uint8_t newValue) { return true; }

--- a/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
+++ b/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2023-2026 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,16 +18,14 @@
 
 #pragma once
 
-#include "clusters/BooleanStateConfiguration/Events.h"
-#include <app-common/zap-generated/cluster-enums.h>
+#include <clusters/BooleanStateConfiguration/Events.h>
+#include <clusters/BooleanStateConfiguration/Enums.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/BitMask.h>
 
 namespace chip {
 namespace app {
 namespace Clusters {
-
-class BooleanStateConfigurationCluster;
 
 namespace BooleanStateConfiguration {
 
@@ -46,21 +44,10 @@ public:
     // These methods are called when specific attributes are updated via WriteAttribute or InvokeCommand.
     // Default implementations are empty - override only the callbacks you need.
 
-    // TODO: If application want to return error on attribute change, should we have mechanism to fallback?
-
-    // Called when CurrentSensitivityLevel attribute changes
     virtual void OnCurrentSensitivityLevelChanged(uint8_t newValue) {}
-
-    // Called when AlarmsActive attribute changes
     virtual void OnAlarmsActiveChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) {}
-
-    // Called when AlarmsSuppressed attribute changes
     virtual void OnAlarmsSuppressedChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) {}
-
-    // Called when AlarmsEnabled attribute changes
     virtual void OnAlarmsEnabledChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) {}
-
-    // Called when SensorFault attribute changes
     virtual void OnSensorFaultChanged(chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> newValue) {}
 };
 

--- a/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
+++ b/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
@@ -41,8 +41,9 @@ public:
     virtual CHIP_ERROR HandleSuppressAlarm(BooleanStateConfiguration::AlarmModeBitmap alarmToSuppress)             = 0;
     virtual CHIP_ERROR HandleEnableDisableAlarms(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> alarms) = 0;
 
-    // These methods are called when specific attributes are updated via WriteAttribute or InvokeCommand.
-    // Default implementations are empty - override only the callbacks you need.
+    //These methods are called when the corresponding attributes are updated by the server, whether
+    // via WriteAttribute, InvokeCommand, or direct server APIs. Default implementations are empty
+    // override only the callbacks you need.
 
     virtual void OnCurrentSensitivityLevelChanged(uint8_t newValue) {}
     virtual void OnAlarmsActiveChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) {}

--- a/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
+++ b/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include <clusters/BooleanStateConfiguration/Events.h>
 #include <clusters/BooleanStateConfiguration/Enums.h>
+#include <clusters/BooleanStateConfiguration/Events.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/BitMask.h>
 

--- a/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
+++ b/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
@@ -43,12 +43,25 @@ public:
     virtual CHIP_ERROR HandleSuppressAlarm(BooleanStateConfiguration::AlarmModeBitmap alarmToSuppress)             = 0;
     virtual CHIP_ERROR HandleEnableDisableAlarms(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> alarms) = 0;
 
-    // Optional handler of when an attribute changed inside the cluster
-    // either as a result of a command or as a result of a attribute write.
-    //
-    // Callback will be called for boolean state configuration cluster attributes such as
-    // CurrentSensitivityLevel::Id, AlarmsActive::Id, AlarmsSuppressed::Id, AlarmsEnabled::Id and SensorFault::Id
-    virtual void OnAttributeChanged(AttributeId att, BooleanStateConfigurationCluster * cluster) {}
+    // These methods are called when specific attributes are updated via WriteAttribute or InvokeCommand.
+    // Default implementations are empty - override only the callbacks you need.
+
+    // TODO: If application want to return error on attribute change, should we have mechanism to fallback?
+
+    // Called when CurrentSensitivityLevel attribute changes
+    virtual void OnCurrentSensitivityLevelChanged(uint8_t newValue) {}
+
+    // Called when AlarmsActive attribute changes
+    virtual void OnAlarmsActiveChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) {}
+
+    // Called when AlarmsSuppressed attribute changes
+    virtual void OnAlarmsSuppressedChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) {}
+
+    // Called when AlarmsEnabled attribute changes
+    virtual void OnAlarmsEnabledChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) {}
+
+    // Called when SensorFault attribute changes
+    virtual void OnSensorFaultChanged(chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> newValue) {}
 };
 
 } // namespace BooleanStateConfiguration

--- a/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
+++ b/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h
@@ -41,9 +41,9 @@ public:
     virtual CHIP_ERROR HandleSuppressAlarm(BooleanStateConfiguration::AlarmModeBitmap alarmToSuppress)             = 0;
     virtual CHIP_ERROR HandleEnableDisableAlarms(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> alarms) = 0;
 
-    //These methods are called when the corresponding attributes are updated by the server, whether
-    // via WriteAttribute, InvokeCommand, or direct server APIs. Default implementations are empty
-    // override only the callbacks you need.
+    // These methods are called when the corresponding attributes are updated by the server, whether
+    //  via WriteAttribute, InvokeCommand, or direct server APIs. Default implementations are empty
+    //  override only the callbacks you need.
 
     virtual void OnCurrentSensitivityLevelChanged(uint8_t newValue) {}
     virtual void OnAlarmsActiveChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) {}

--- a/src/app/clusters/boolean-state-configuration-server/tests/TestBooleanStateConfigurationCluster.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/tests/TestBooleanStateConfigurationCluster.cpp
@@ -490,34 +490,39 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    void OnCurrentSensitivityLevelChanged(uint8_t newValue) override
+    bool OnCurrentSensitivityLevelChanged(uint8_t newValue) override
     {
         mCurrentSensitivityLevelCalled = true;
         mCurrentSensitivityLevelValue  = newValue;
+        return true;
     }
 
-    void OnAlarmsActiveChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) override
+    bool OnAlarmsActiveChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) override
     {
         mAlarmsActiveCalled = true;
         mAlarmsActiveValue  = newValue;
+        return true;
     }
 
-    void OnAlarmsSuppressedChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) override
+    bool OnAlarmsSuppressedChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) override
     {
         mAlarmsSuppressedCalled = true;
         mAlarmsSuppressedValue  = newValue;
+        return true;
     }
 
-    void OnAlarmsEnabledChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) override
+    bool OnAlarmsEnabledChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) override
     {
         mAlarmsEnabledCalled = true;
         mAlarmsEnabledValue  = newValue;
+        return true;
     }
 
-    void OnSensorFaultChanged(chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> newValue) override
+    bool OnSensorFaultChanged(chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> newValue) override
     {
         mSensorFaultCalled = true;
         mSensorFaultValue  = newValue;
+        return true;
     }
 
     // Reset all flags
@@ -685,28 +690,6 @@ TEST_F(TestBooleanStateConfigurationCluster, TestTypeSafeDelegateCallbacks)
         // Verify callback was called
         EXPECT_TRUE(delegate.WasAlarmsSuppressedCalled());
         EXPECT_TRUE(delegate.GetAlarmsSuppressedValue().Has(AlarmModeBitmap::kVisual));
-
-        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
-    }
-
-    // Test SensorFault callback via GenerateSensorFault
-    {
-        delegate.Reset();
-        auto config = DefaultConfig();
-        BooleanStateConfigurationCluster cluster(
-            kTestEndpointId, {}, { BooleanStateConfigurationCluster::OptionalAttributesSet().Set<Attributes::SensorFault::Id>() },
-            config);
-        cluster.SetDelegate(&delegate);
-        ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
-
-        // Generate sensor fault
-        chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> fault;
-        fault.Set(BooleanStateConfiguration::SensorFaultBitmap::kGeneralFault);
-        cluster.GenerateSensorFault(fault);
-
-        // Verify callback was called
-        EXPECT_TRUE(delegate.WasSensorFaultCalled());
-        EXPECT_TRUE(delegate.GetSensorFaultValue().Has(BooleanStateConfiguration::SensorFaultBitmap::kGeneralFault));
 
         cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
     }

--- a/src/app/clusters/boolean-state-configuration-server/tests/TestBooleanStateConfigurationCluster.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/tests/TestBooleanStateConfigurationCluster.cpp
@@ -19,6 +19,7 @@
 #include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/SafeAttributePersistenceProvider.h>
 #include <app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h>
+#include <app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
@@ -467,6 +468,246 @@ TEST_F(TestBooleanStateConfigurationCluster, TestAlarmsEnabledPersistence)
         BooleanStateConfigurationCluster::AlarmModeBitMask alarmsEnabled;
         EXPECT_EQ(tester.ReadAttribute(Attributes::AlarmsEnabled::Id, alarmsEnabled), Protocols::InteractionModel::Status::Success);
         EXPECT_EQ(alarmsEnabled.Raw(), 0); // Should be default, as storage is empty.
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
+}
+
+// Test delegate class to verify attribute change callbacks
+class TestDelegate : public BooleanStateConfiguration::Delegate
+{
+public:
+    CHIP_ERROR HandleSuppressAlarm(BooleanStateConfiguration::AlarmModeBitmap alarmToSuppress) override
+    {
+        mSuppressAlarmCalled = true;
+        mSuppressAlarmValue  = alarmToSuppress;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR HandleEnableDisableAlarms(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> alarms) override
+    {
+        mEnableDisableAlarmsCalled = true;
+        mEnableDisableAlarmsValue  = alarms;
+        return CHIP_NO_ERROR;
+    }
+
+    void OnCurrentSensitivityLevelChanged(uint8_t newValue) override
+    {
+        mCurrentSensitivityLevelCalled = true;
+        mCurrentSensitivityLevelValue  = newValue;
+    }
+
+    void OnAlarmsActiveChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) override
+    {
+        mAlarmsActiveCalled = true;
+        mAlarmsActiveValue  = newValue;
+    }
+
+    void OnAlarmsSuppressedChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) override
+    {
+        mAlarmsSuppressedCalled = true;
+        mAlarmsSuppressedValue  = newValue;
+    }
+
+    void OnAlarmsEnabledChanged(chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> newValue) override
+    {
+        mAlarmsEnabledCalled = true;
+        mAlarmsEnabledValue  = newValue;
+    }
+
+    void OnSensorFaultChanged(chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> newValue) override
+    {
+        mSensorFaultCalled = true;
+        mSensorFaultValue  = newValue;
+    }
+
+    // Reset all flags
+    void Reset()
+    {
+        mCurrentSensitivityLevelCalled = false;
+        mAlarmsActiveCalled            = false;
+        mAlarmsSuppressedCalled        = false;
+        mAlarmsEnabledCalled           = false;
+        mSensorFaultCalled             = false;
+        mSuppressAlarmCalled           = false;
+        mEnableDisableAlarmsCalled     = false;
+    }
+
+    // Getters for test verification
+    bool WasCurrentSensitivityLevelCalled() const { return mCurrentSensitivityLevelCalled; }
+    uint8_t GetCurrentSensitivityLevelValue() const { return mCurrentSensitivityLevelValue; }
+
+    bool WasAlarmsActiveCalled() const { return mAlarmsActiveCalled; }
+    chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> GetAlarmsActiveValue() const { return mAlarmsActiveValue; }
+
+    bool WasAlarmsSuppressedCalled() const { return mAlarmsSuppressedCalled; }
+    chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> GetAlarmsSuppressedValue() const { return mAlarmsSuppressedValue; }
+
+    bool WasAlarmsEnabledCalled() const { return mAlarmsEnabledCalled; }
+    chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> GetAlarmsEnabledValue() const { return mAlarmsEnabledValue; }
+
+    bool WasSensorFaultCalled() const { return mSensorFaultCalled; }
+    chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> GetSensorFaultValue() const { return mSensorFaultValue; }
+
+private:
+    bool mCurrentSensitivityLevelCalled = false;
+    uint8_t mCurrentSensitivityLevelValue{};
+
+    bool mAlarmsActiveCalled = false;
+    chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> mAlarmsActiveValue{};
+
+    bool mAlarmsSuppressedCalled = false;
+    chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> mAlarmsSuppressedValue{};
+
+    bool mAlarmsEnabledCalled = false;
+    chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> mAlarmsEnabledValue{};
+
+    bool mSensorFaultCalled = false;
+    chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> mSensorFaultValue{};
+
+    bool mSuppressAlarmCalled = false;
+    BooleanStateConfiguration::AlarmModeBitmap mSuppressAlarmValue{};
+
+    bool mEnableDisableAlarmsCalled = false;
+    chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> mEnableDisableAlarmsValue{};
+};
+
+TEST_F(TestBooleanStateConfigurationCluster, TestTypeSafeDelegateCallbacks)
+{
+    TestServerClusterContext context;
+    ScopedSafeAttributePersistence persistence(context);
+    TestDelegate delegate;
+
+    // Test CurrentSensitivityLevel callback via WriteAttribute
+    {
+        auto config = DefaultConfig().WithSupportedSensitivityLevels(10);
+        BooleanStateConfigurationCluster cluster(kTestEndpointId, Feature::kSensitivityLevel, {}, config);
+        cluster.SetDelegate(&delegate);
+        ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+        ClusterTester tester(cluster);
+
+        // Write a new sensitivity level
+        uint8_t newLevel = 5;
+        EXPECT_EQ(tester.WriteAttribute(Attributes::CurrentSensitivityLevel::Id, newLevel),
+                  Protocols::InteractionModel::Status::Success);
+
+        // Verify callback was called with correct value
+        EXPECT_TRUE(delegate.WasCurrentSensitivityLevelCalled());
+        EXPECT_EQ(delegate.GetCurrentSensitivityLevelValue(), newLevel);
+
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
+
+    // Test AlarmsEnabled callback via InvokeCommand (EnableDisableAlarm)
+    {
+        delegate.Reset();
+        auto config = DefaultConfig().AddAlarmsSupported(AlarmModeBitmap::kVisual).AddAlarmsSupported(AlarmModeBitmap::kAudible);
+        BooleanStateConfigurationCluster cluster(
+            kTestEndpointId, { Feature::kVisual, Feature::kAudible },
+            { BooleanStateConfigurationCluster::OptionalAttributesSet().Set<Attributes::AlarmsEnabled::Id>() }, config);
+        cluster.SetDelegate(&delegate);
+        ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+        ClusterTester tester(cluster);
+
+        // Invoke EnableDisableAlarm command
+        Commands::EnableDisableAlarm::Type request;
+        request.alarmsToEnableDisable.Set(AlarmModeBitmap::kVisual);
+        request.alarmsToEnableDisable.Set(AlarmModeBitmap::kAudible);
+
+        auto result = tester.Invoke(request);
+        EXPECT_TRUE(result.IsSuccess());
+
+        // Verify AlarmsEnabled callback was called
+        EXPECT_TRUE(delegate.WasAlarmsEnabledCalled());
+        EXPECT_TRUE(delegate.GetAlarmsEnabledValue().Has(AlarmModeBitmap::kVisual));
+        EXPECT_TRUE(delegate.GetAlarmsEnabledValue().Has(AlarmModeBitmap::kAudible));
+
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
+
+    // Test AlarmsActive callback via SetAlarmsActive
+    {
+        delegate.Reset();
+        auto config = DefaultConfig().AddAlarmsSupported(AlarmModeBitmap::kVisual);
+        BooleanStateConfigurationCluster cluster(
+            kTestEndpointId, BitMask<Feature>(Feature::kVisual),
+            { BooleanStateConfigurationCluster::OptionalAttributesSet().Set<Attributes::AlarmsEnabled::Id>() }, config);
+        cluster.SetDelegate(&delegate);
+        ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+        // Enable alarms first
+        Commands::EnableDisableAlarm::Type enableRequest;
+        enableRequest.alarmsToEnableDisable.Set(AlarmModeBitmap::kVisual);
+        ClusterTester tester(cluster);
+        EXPECT_TRUE(tester.Invoke(enableRequest).IsSuccess());
+
+        delegate.Reset();
+
+        // Set alarms active
+        chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> alarmsToSet;
+        alarmsToSet.Set(AlarmModeBitmap::kVisual);
+        EXPECT_EQ(cluster.SetAlarmsActive(alarmsToSet), Protocols::InteractionModel::Status::Success);
+
+        // Verify callback was called
+        EXPECT_TRUE(delegate.WasAlarmsActiveCalled());
+        EXPECT_TRUE(delegate.GetAlarmsActiveValue().Has(AlarmModeBitmap::kVisual));
+
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
+
+    // Test AlarmsSuppressed callback via SuppressAlarm command
+    {
+        delegate.Reset();
+        auto config = DefaultConfig().AddAlarmsSupported(AlarmModeBitmap::kVisual);
+        BooleanStateConfigurationCluster cluster(
+            kTestEndpointId, { Feature::kVisual, Feature::kAlarmSuppress },
+            { BooleanStateConfigurationCluster::OptionalAttributesSet().Set<Attributes::AlarmsEnabled::Id>() }, config);
+        cluster.SetDelegate(&delegate);
+        ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+        ClusterTester tester(cluster);
+
+        // Enable and activate alarms first
+        Commands::EnableDisableAlarm::Type enableRequest;
+        enableRequest.alarmsToEnableDisable.Set(AlarmModeBitmap::kVisual);
+        EXPECT_TRUE(tester.Invoke(enableRequest).IsSuccess());
+
+        chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> alarmsToSet;
+        alarmsToSet.Set(AlarmModeBitmap::kVisual);
+        cluster.SetAlarmsActive(alarmsToSet);
+
+        delegate.Reset();
+
+        // Suppress alarms
+        Commands::SuppressAlarm::Type suppressRequest;
+        suppressRequest.alarmsToSuppress.Set(AlarmModeBitmap::kVisual);
+        auto result = tester.Invoke(suppressRequest);
+        EXPECT_TRUE(result.IsSuccess());
+
+        // Verify callback was called
+        EXPECT_TRUE(delegate.WasAlarmsSuppressedCalled());
+        EXPECT_TRUE(delegate.GetAlarmsSuppressedValue().Has(AlarmModeBitmap::kVisual));
+
+        cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
+
+    // Test SensorFault callback via GenerateSensorFault
+    {
+        delegate.Reset();
+        auto config = DefaultConfig();
+        BooleanStateConfigurationCluster cluster(
+            kTestEndpointId, {}, { BooleanStateConfigurationCluster::OptionalAttributesSet().Set<Attributes::SensorFault::Id>() },
+            config);
+        cluster.SetDelegate(&delegate);
+        ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+        // Generate sensor fault
+        chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> fault;
+        fault.Set(BooleanStateConfiguration::SensorFaultBitmap::kGeneralFault);
+        cluster.GenerateSensorFault(fault);
+
+        // Verify callback was called
+        EXPECT_TRUE(delegate.WasSensorFaultCalled());
+        EXPECT_TRUE(delegate.GetSensorFaultValue().Has(BooleanStateConfiguration::SensorFaultBitmap::kGeneralFault));
+
         cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
     }
 }

--- a/src/app/clusters/boolean-state-configuration-server/tests/TestBooleanStateConfigurationCluster.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/tests/TestBooleanStateConfigurationCluster.cpp
@@ -564,7 +564,7 @@ private:
     bool mSensorFaultCalled = false;
     chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> mSensorFaultValue{};
 
-    bool mSuppressAlarmCalled = false;
+    bool mSuppressAlarmCalled                                      = false;
     BooleanStateConfiguration::AlarmModeBitmap mSuppressAlarmValue = BooleanStateConfiguration::AlarmModeBitmap::kVisual;
 
     bool mEnableDisableAlarmsCalled = false;

--- a/src/app/clusters/boolean-state-configuration-server/tests/TestBooleanStateConfigurationCluster.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/tests/TestBooleanStateConfigurationCluster.cpp
@@ -565,7 +565,7 @@ private:
     chip::BitMask<BooleanStateConfiguration::SensorFaultBitmap> mSensorFaultValue{};
 
     bool mSuppressAlarmCalled = false;
-    BooleanStateConfiguration::AlarmModeBitmap mSuppressAlarmValue{};
+    BooleanStateConfiguration::AlarmModeBitmap mSuppressAlarmValue = BooleanStateConfiguration::AlarmModeBitmap::kVisual;
 
     bool mEnableDisableAlarmsCalled = false;
     chip::BitMask<BooleanStateConfiguration::AlarmModeBitmap> mEnableDisableAlarmsValue{};


### PR DESCRIPTION
#### Summary

Application should get the attribute change callback whenever there is a change to an attribute via WriteAttribute or InvokeCommand.
This PR adds per attribute change callback with type-safety using delegates.

#### Related issues

NA

#### Testing

Added tests to verify that callbacks are being called with correct value.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
