### PR TITLE
[Tizen] Enable formatting errors as strings

### DIFF
--- a/src/platform/Tizen/CHIPPlatformConfig.h
+++ b/src/platform/Tizen/CHIPPlatformConfig.h
@@ -28,6 +28,9 @@
 
 #define CHIP_CONFIG_ABORT() abort()
 
+#define CHIP_CONFIG_ERROR_FORMAT_AS_STRING 1
+#define CHIP_CONFIG_ERROR_SOURCE 1
+
 // ==================== Security Adaptations ====================
 
 // ==================== General Configuration Overrides ====================


### PR DESCRIPTION
#### Summary

Showing the location of the error might be useful for debugging. Hence, enable it on Tizen by default (like on Linux and Darwin).

#### Testing

Tested locally that errors are show as expected:
```
INFO    [1770289359.917] [697:736] [DIS] Failed to resolve DNS-SD node: src/platform/Tizen/DnssdImpl.cpp:358: Platform Error 0xFE360005: Service not found
```
CI will verify potential build brakes.