### PR TITLE
Thread: recover BLE-Thread test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:181
+            image: ghcr.io/project-chip/chip-build:183
             options: >-
                 --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
@@ -347,9 +347,6 @@ jobs:
                      "
 
             - name: Run BLE-Thread commissioning test
-              # Disabled due to flakyness. See:
-              # https://github.com/project-chip/connectedhomeip/issues/42869
-              if: false
               env:
                 # Disable TSAN bug reporting, as it reports tons of (hopefully) false positives.
                 # The reason for that is BlueZ and WPA supplicant integration which involves GIO

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -484,6 +484,7 @@ def cmd_run(context: click.Context, dry_run: bool, iterations: int,
                 index=0,
                 # Do not bring up the app interface link automatically when doing BLE-WiFi commissioning.
                 setup_app_link_up=not wifi_required,
+                add_ula=not thread_required,
                 # Change the app link name so the interface will be recognized as WiFi or Ethernet
                 # depending on the commissioning method used.
                 app_link_name='wlx-app' if wifi_required else 'eth-app'))
@@ -537,6 +538,8 @@ def cmd_run(context: click.Context, dry_run: bool, iterations: int,
                         test_end = time.monotonic()
                         log.info("%-30s - Completed in %0.2f seconds", test.name, test_end - test_start)
                 except Exception:
+                    if os.path.exists('thread.pcap'):
+                        os.system("echo 'base64 -d - >thread.pcap <<EOF' && base64 thread.pcap && echo EOF")
                     test_end = time.monotonic()
                     log.exception("%-30s - FAILED in %0.2f seconds", test.name, test_end - test_start)
                     observed_failures += 1


### PR DESCRIPTION
#### Summary

This commit recovers the BLE-Thread test to make sure Thread is not broken by new changes.

This commit added the parameter `add_ula` to control whether add ULA address in the isolated environment manually. This is because when using Thread Border Router, we expect the border router to add ULA address for its infrastructure link. This also updated the interface configuration for both *app* and *tool* to accept RAs to configure the SLAAC addresses.

This commit also adds Thread packet capturing so that if something went wrong, we could check the Thread traffic.

#### Related issues

This is for the flaky issue #42869.  There can be other causes. This commit focuses on fixing when the on-link address is not correctly handled. 

#### Testing

This commit is to fix the flaky test itself.