### PR TITLE
[devcontainer] Add ssh, gpg and fish to development dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,9 +38,12 @@ RUN apt-get update \
         dialog \
         docker.io \
         emacs \
+        fish \
+        gnupg2 \
         icecc \
         iputils-ping \
         lsb-release \
+        openssh-client \
         sudo \
         valgrind \
         vim \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,17 +32,22 @@ ENV LANG=en_US.utf8
 RUN apt-get update \
     && apt-get install -y locales \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
-    && apt-get -fy install vim emacs sudo \
-    apt-utils dialog zsh \
-    lsb-release \
-    bash-completion \
-    valgrind \
-    docker.io \
-    iputils-ping \
-    icecc \
-    # emacs pulls in libgccjit0 -> libgcc-14-dev without libstdc++-14-dev which causes clang++ to fail \
-    # See-Also: https://bugs.launchpad.net/ubuntu/+source/llvm-defaults/+bug/2077130 \
-    libstdc++-14-dev \
+    && apt-get -fy install \
+        apt-utils \
+        bash-completion \
+        dialog \
+        docker.io \
+        emacs \
+        icecc \
+        iputils-ping \
+        lsb-release \
+        sudo \
+        valgrind \
+        vim \
+        zsh \
+        # emacs pulls in libgccjit0 -> libgcc-14-dev without libstdc++-14-dev which causes clang++ to fail \
+        # See-Also: https://bugs.launchpad.net/ubuntu/+source/llvm-defaults/+bug/2077130 \
+        libstdc++-14-dev \
     && :
 
 RUN (getent passwd $USER_UID && userdel -f $(getent passwd $USER_UID | cut -d: -f1) || true) \


### PR DESCRIPTION
#### Summary

Add a few development dependencies, which I use for development:
- fish – personal preference (zsh, and bash-completion is already there)
- gnupg2 – allows for signing commits from within the devcontainer
- openssh-client – allows for use of git+ssh for remotes

#### Related issues

None

#### Testing

Built the devcontainer locally, and used it to submit this PR.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
