### PR TITLE
Add transport sink state reset and PTS offset handling

### DIFF
--- a/examples/camera-app/camera-common/include/media-controller/media-controller.h
+++ b/examples/camera-app/camera-common/include/media-controller/media-controller.h
@@ -52,4 +52,7 @@ public:
     virtual void DistributeVideo(const uint8_t * data, size_t size, uint16_t videoStreamID, int64_t timestamp) = 0;
     virtual void DistributeAudio(const uint8_t * data, size_t size, uint16_t audioStreamID, int64_t timestamp) = 0;
     virtual void SetPreRollLength(Transport * transport, uint16_t PreRollBufferLength)                         = 0;
+    // Reset the transport's sink state (before starting transmission)
+    // Call when transport wants data: pushav at clip record start, live stream at registration.
+    virtual void ResetTransportSinkState(Transport * transport) = 0;
 };

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -321,8 +321,8 @@ public:
     CameraError StopAudioPlaybackStream();
 
     // Timestamp handling for video and audio streams
-    std::map<uint16_t, int64_t> mVideoStreamFirstPts;
-    std::map<uint16_t, int64_t> mAudioStreamFirstPts;
+    std::map<uint16_t, int64_t> mVideoStreamPtsOffsetMs;
+    std::map<uint16_t, int64_t> mAudioStreamPtsOffsetMs;
 
 private:
     int videoDeviceFd            = -1;

--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -119,6 +119,9 @@ public:
 
     void RecordingStreamPrivacyModeChanged(bool privacyModeEnabled);
 
+    // Method to reset transport sink state - called by transports when starting transmission
+    void ResetTransportSinkStateForTransport(PushAVTransport * transport);
+
 private:
     MediaController * mMediaController                         = nullptr;
     CameraDeviceInterface * mCameraDevice                      = nullptr;

--- a/examples/camera-app/linux/include/media-controller/default-media-controller.h
+++ b/examples/camera-app/linux/include/media-controller/default-media-controller.h
@@ -48,6 +48,8 @@ public:
     // Get transport registered for a specific stream ID
     Transport * GetTransportForVideoStream(uint16_t videoStreamID) override;
     Transport * GetTransportForAudioStream(uint16_t audioStreamID) override;
+    // Reset the transport's sink state for proper preroll buffering before starting transmission
+    void ResetTransportSinkState(Transport * transport) override;
 
 private:
     PreRollBuffer mPreRollBuffer;

--- a/examples/camera-app/linux/include/pushav-prerollbuffer.h
+++ b/examples/camera-app/linux/include/pushav-prerollbuffer.h
@@ -32,6 +32,8 @@ struct BufferSink
     int64_t requestedPreBufferLengthMs; // 0 means live only
     int64_t minKeyframeIntervalMs;
     Transport * transport;
+    int64_t registrationTimeMs;  // Time when sink was registered, used for first frame delivery
+    bool hasDeliveredFirstFrame; // Track if we've successfully delivered at least one frame
 };
 
 struct PreRollFrame

--- a/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
+++ b/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
@@ -37,6 +37,16 @@
 #include <thread>
 #include <vector>
 
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace PushAvStreamTransport {
+class PushAvStreamTransportManager;
+} // namespace PushAvStreamTransport
+} // namespace Clusters
+} // namespace app
+} // namespace chip
+
 static constexpr int kInvalidZoneId             = -1; // Invalid zone id value for trigger detection
 static constexpr int kDefaultSensitivity        = 5;  // Default motion sensitivity level
 static constexpr int kMaxSessionDurationMinutes = 5;  // Maximum session duration in minutes
@@ -128,6 +138,12 @@ public:
 
     void SetFabricIndex(chip::FabricIndex accessingFabricIndex) { mFabricIndex = accessingFabricIndex; }
 
+    // Set the manager reference for coordination
+    void SetTransportManager(chip::app::Clusters::PushAvStreamTransport::PushAvStreamTransportManager * manager)
+    {
+        mManager = manager;
+    }
+
     uint64_t GetSessionNumber() const { return mSessionNumber; }
 
 private:
@@ -156,6 +172,9 @@ private:
     PushAVUploader::CertificatesInfo mCertBuffer;
     AudioStreamStruct mAudioStreamParams;
     VideoStreamStruct mVideoStreamParams;
+
+    // Manager reference for coordination
+    chip::app::Clusters::PushAvStreamTransport::PushAvStreamTransportManager * mManager = nullptr;
 
     // Note, a ZoneID within a Zone List can be Null, meaning the entry applies to all zones.
     std::vector<std::pair<chip::app::DataModel::Nullable<uint16_t>, uint8_t>> mZoneSensitivityList;

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -106,6 +106,7 @@ PushAvStreamTransportManager::AllocatePushTransport(const TransportOptionsStruct
         return Status::Failure;
     }
     mTransportMap[connectionID] = std::move(transport);
+    mTransportMap[connectionID]->SetTransportManager(this);
     mTransportMap[connectionID]->SetPushAvStreamTransportServer(mPushAvStreamTransportServer);
     mTransportMap[connectionID]->SetFabricIndex(accessingFabricIndex);
 
@@ -799,4 +800,12 @@ bool PushAvStreamTransportManager::GetCMAFSessionNumber(const uint16_t connectio
 
     sessionNumber = transportIt->second->GetSessionNumber();
     return true;
+}
+
+void PushAvStreamTransportManager::ResetTransportSinkStateForTransport(PushAVTransport * transport)
+{
+    if (mMediaController != nullptr)
+    {
+        mMediaController->ResetTransportSinkState(transport);
+    }
 }

--- a/examples/camera-app/linux/src/media-controller/default-media-controller.cpp
+++ b/examples/camera-app/linux/src/media-controller/default-media-controller.cpp
@@ -53,6 +53,8 @@ void DefaultMediaController::RegisterTransport(Transport * transport, const std:
     // 1: Deliver with a delay of up to 1 ms (default)
     // Other values: Deliver with the specified delay
     bufferSink->requestedPreBufferLengthMs = 1;
+    bufferSink->registrationTimeMs         = mPreRollBuffer.NowMs();
+    bufferSink->hasDeliveredFirstFrame     = false;
 
     if (mCameraDevice)
     {
@@ -157,4 +159,20 @@ Transport * DefaultMediaController::GetTransportForAudioStream(uint16_t audioStr
         }
     }
     return nullptr;
+}
+
+void DefaultMediaController::ResetTransportSinkState(Transport * transport)
+{
+    auto it = mSinkMap.find(transport);
+    if (it != mSinkMap.end() && it->second != nullptr)
+    {
+        it->second->registrationTimeMs     = mPreRollBuffer.NowMs();
+        it->second->hasDeliveredFirstFrame = false;
+        ChipLogProgress(Camera, "Reset sink state for transport: registrationTimeMs=%lld",
+                        static_cast<long long>(it->second->registrationTimeMs));
+    }
+    else
+    {
+        ChipLogError(Camera, "ResetTransportSinkState: Transport not registered");
+    }
 }

--- a/examples/camera-app/linux/src/pushav-prerollbuffer.cpp
+++ b/examples/camera-app/linux/src/pushav-prerollbuffer.cpp
@@ -43,8 +43,8 @@ void PreRollBuffer::PushFrameToBuffer(const std::string & streamKey, const uint8
         auto & queue = mBuffers[streamKey]; // Get or create the queue for this stream key
         queue.push_back(frame);
         mContentBufferSize += size; // Track total bytes in buffer for all streams
-    } // lock_guard released here
-    PushBufferToTransport(); // Automatically flush after each frame push
+    }                               // lock_guard released here
+    PushBufferToTransport();        // Automatically flush after each frame push
 }
 
 void PreRollBuffer::PushBufferToTransport()

--- a/examples/camera-app/linux/src/pushav-prerollbuffer.cpp
+++ b/examples/camera-app/linux/src/pushav-prerollbuffer.cpp
@@ -32,24 +32,24 @@ void PreRollBuffer::SetMaxTotalBytes(size_t size)
 void PreRollBuffer::PushFrameToBuffer(const std::string & streamKey, const uint8_t * data, size_t size, int64_t timestampMs)
 {
     TrimBuffer();
-    std::lock_guard<std::mutex> lock(mBufferMutex);
-    auto frame       = std::make_shared<PreRollFrame>();
-    frame->streamKey = streamKey;
-    frame->data      = std::make_unique<uint8_t[]>(size);
-    memcpy(frame->data.get(), data, size);
-    frame->size  = size;
-    frame->ptsMs = timestampMs;
-    auto & queue = mBuffers[streamKey]; // Get or create the queue for this stream key
-    queue.push_back(frame);
-    mContentBufferSize += size; // Track total bytes in buffer for all streams
-    mBufferMutex.unlock();
+    {
+        std::lock_guard<std::mutex> lock(mBufferMutex);
+        auto frame       = std::make_shared<PreRollFrame>();
+        frame->streamKey = streamKey;
+        frame->data      = std::make_unique<uint8_t[]>(size);
+        memcpy(frame->data.get(), data, size);
+        frame->size  = size;
+        frame->ptsMs = timestampMs;
+        auto & queue = mBuffers[streamKey]; // Get or create the queue for this stream key
+        queue.push_back(frame);
+        mContentBufferSize += size; // Track total bytes in buffer for all streams
+    } // lock_guard released here
     PushBufferToTransport(); // Automatically flush after each frame push
 }
 
 void PreRollBuffer::PushBufferToTransport()
 {
     std::lock_guard<std::mutex> lock(mBufferMutex);
-    int64_t currentTime = NowMs();
     std::vector<BufferSink *> sinksToRemove;
 
     for (auto & [sink, streamKeys] : mSinkSubscriptions)
@@ -61,11 +61,24 @@ void PreRollBuffer::PushBufferToTransport()
         }
 
         // Determine the cutoff time for frame delivery.
-        // If requestedPreBufferLengthMs is 0, it implies live mode. In this case, we use minKeyframeIntervalMs
-        // to ensure we have at least a keyframe's worth of data, if available.
-        // Otherwise, we use the configured pre-buffer length.
-        int64_t minTimeToDeliver = (sink->requestedPreBufferLengthMs == 0) ? currentTime - sink->minKeyframeIntervalMs
-                                                                           : currentTime - sink->requestedPreBufferLengthMs;
+        // This cutoff only matters for the INITIAL delivery when a sink is first registered,
+        // to decide which buffered frames to send. Once hasDeliveredFirstFrame is true,
+        // we deliver all new frames as they arrive (duplicate detection via deliveredTo handles the rest).
+        int64_t minTimeToDeliver;
+        if (!sink->hasDeliveredFirstFrame)
+        {
+            // For new sinks, deliver frames from registration time minus the pre-buffer length
+            // This ensures frames aren't filtered out if the track takes time to become ready
+            minTimeToDeliver = (sink->requestedPreBufferLengthMs == 0)
+                ? sink->registrationTimeMs - sink->minKeyframeIntervalMs
+                : sink->registrationTimeMs - sink->requestedPreBufferLengthMs;
+        }
+        else
+        {
+            // After first frame delivered, accept all frames (deliveredTo set prevents duplicates)
+            // Setting to 0 effectively disables the timestamp filter
+            minTimeToDeliver = 0;
+        }
 
         for (const std::string & streamKey : streamKeys)
         {
@@ -103,15 +116,17 @@ void PreRollBuffer::PushBufferToTransport()
                     }
                     // Mark as delivered to this sink to avoid duplicate delivery
                     frame->deliveredTo.insert(sink);
+                    // Mark that we've successfully delivered at least one frame to this sink
+                    sink->hasDeliveredFirstFrame = true;
                 }
             }
         }
     }
-    mBufferMutex.unlock();
-    // Remove sinks with no valid senders
+    // Remove sinks with no valid transport (already under lock)
     for (BufferSink * sink : sinksToRemove)
     {
-        DeregisterTransportFromBuffer(sink);
+        ChipLogProgress(Camera, "Removing transport from buffer %p (no valid transport)", sink);
+        mSinkSubscriptions.erase(sink);
     }
 }
 

--- a/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
+++ b/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
@@ -530,13 +530,13 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
             ChipLogDetail(Camera, "Successfully deleted file: %s", data.first.c_str());
         }
     }
-}
 
-cleanup : if (upload.mData)
-{
-    std::free(upload.mData);
-    upload.mData = nullptr;
-}
-curl_easy_cleanup(curl);
-curl_slist_free_all(headers);
+cleanup:
+    if (upload.mData)
+    {
+        std::free(upload.mData);
+        upload.mData = nullptr;
+    }
+    curl_easy_cleanup(curl);
+    curl_slist_free_all(headers);
 }

--- a/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
+++ b/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
@@ -504,9 +504,16 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
 
     if (res != CURLE_OK)
     {
-        ChipLogError(Camera, "CURL upload  failed [%s] %s", data.first.c_str(), curl_easy_strerror(res));
+        ChipLogError(Camera, "CURL upload failed [%s] %s, retrying...", data.first.c_str(), curl_easy_strerror(res));
+        res = curl_easy_perform(curl);
+
+        if (res != CURLE_OK)
+        {
+            ChipLogError(Camera, "CURL upload failed again [%s] %s", data.first.c_str(), curl_easy_strerror(res));
+        }
     }
-    else
+
+    if (res == CURLE_OK)
     {
         ChipLogDetail(Camera, "CURL uploaded file  %s size: %zu", data.first.c_str(), static_cast<size_t>(size));
     }
@@ -515,20 +522,21 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
     {
         if (!std::filesystem::remove(data.first, ec))
         {
-            ChipLogError(Camera, "Failed to delete file: %s, error: %s", data.first.c_str(), ec.message().c_str());
+            ChipLogError(Camera, "Failed to delete file: %s, error code: %d, error: %s, category: %s. May cause file accumulation.",
+                         data.first.c_str(), ec.value(), ec.message().c_str(), ec.category().name());
         }
         else
         {
             ChipLogDetail(Camera, "Successfully deleted file: %s", data.first.c_str());
         }
     }
+}
 
-cleanup:
-    if (upload.mData)
-    {
-        std::free(upload.mData);
-        upload.mData = nullptr;
-    }
-    curl_easy_cleanup(curl);
-    curl_slist_free_all(headers);
+cleanup : if (upload.mData)
+{
+    std::free(upload.mData);
+    upload.mData = nullptr;
+}
+curl_easy_cleanup(curl);
+curl_slist_free_all(headers);
 }

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -145,13 +145,13 @@ void WebrtcTransport::SendAudioVideo(const chip::ByteSpan & data, uint16_t video
 // Implementation of CanSendVideo method
 bool WebrtcTransport::CanSendVideo()
 {
-    return mLocalVideoTrack != nullptr;
+    return mLocalVideoTrack != nullptr && mLocalVideoTrack->IsReady();
 }
 
 // Implementation of CanSendAudio method
 bool WebrtcTransport::CanSendAudio()
 {
-    return mLocalAudioTrack != nullptr;
+    return mLocalAudioTrack != nullptr && mLocalAudioTrack->IsReady();
 }
 
 const char * WebrtcTransport::GetStateStr() const


### PR DESCRIPTION
#### Summary

This PR includes fixes for the following stability issues:

1. Live streaming failure (sometimes) due to PTS validation in Pre-Roll buffer
2. Push AV init file empty issue for audio (sometimes)
3. Outstanding review comments by gemini bot on 1.5.1 Push AV PRs from v1.5_branch

#### Related issues
- Manual Testing

#### Testing
```# Build and run camera application
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debug/chip-camera-app --app-pipe /tmp/pavst_2_12_fifo --camera-test-audiosrc --camera-test-videosrc

# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run Push AV TC
Example:
python3 src/python_testing/TC_PAVST_2_12.py --commissioning-method on-network --discriminator 3840 --passcode 20202021 --storage-path admin_storage.json --endpoint 1   --string-arg host_ip:localhost --app-pipe /tmp/pavst_2_13_fifo
```