### PR TITLE
[DNSSD] Prevent failure when Dnssd::ServiceAdvertiser is not initialized

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -487,7 +487,7 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
 {
     TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, 0);
 
-    if(Dnssd::ServiceAdvertiser::Instance().Init(chip::DeviceLayer::UDPEndPointManager()) != CHIP_NO_ERROR)
+    if (Dnssd::ServiceAdvertiser::Instance().Init(chip::DeviceLayer::UDPEndPointManager()) != CHIP_NO_ERROR)
     {
         // No need to do anything if init failed device is probably not commissionned/not on network
         ChipLogError(Discovery, "Failed to initialize advertiser");
@@ -532,7 +532,6 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
     SuccessOrLog(Dnssd::ServiceAdvertiser::Instance().FinalizeServiceUpdate(), Discovery, "Failed to finalize service update");
-
 }
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID)

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -393,15 +393,15 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
 
     auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
 
-    ChipLogProgress(Discovery, "Advertise commission parameter vendorID=%u productID=%u discriminator=%04u/%02u cm=%u cp=%u jf=%u",
-                    advertiseParameters.GetVendorId().value_or(0), advertiseParameters.GetProductId().value_or(0),
-                    advertiseParameters.GetLongDiscriminator(), advertiseParameters.GetShortDiscriminator(),
-                    to_underlying(advertiseParameters.GetCommissioningMode()),
-                    advertiseParameters.GetCommissionerPasscodeSupported().value_or(false) ? 1 : 0,
+    ChipLogDetail(Discovery, "Advertise commission parameter vendorID=%u productID=%u discriminator=%04u/%02u cm=%u cp=%u jf=%u",
+                  advertiseParameters.GetVendorId().value_or(0), advertiseParameters.GetProductId().value_or(0),
+                  advertiseParameters.GetLongDiscriminator(), advertiseParameters.GetShortDiscriminator(),
+                  to_underlying(advertiseParameters.GetCommissioningMode()),
+                  advertiseParameters.GetCommissionerPasscodeSupported().value_or(false) ? 1 : 0,
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-                    advertiseParameters.GetJointFabricMode().Raw()
+                  advertiseParameters.GetJointFabricMode().Raw()
 #else
-                    0 // Dummy value when Joint Fabric is disabled
+                  0 // Dummy value when Joint Fabric is disabled
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     );
 
@@ -485,12 +485,16 @@ void DnssdServer::StopServer()
 
 void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
 {
-    ChipLogProgress(Discovery, "Updating services using commissioning mode %d", static_cast<int>(mode));
-
     TEMPORARY_RETURN_IGNORED DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, 0);
 
-    SuccessOrLog(Dnssd::ServiceAdvertiser::Instance().Init(chip::DeviceLayer::UDPEndPointManager()), Discovery,
-                 "Failed to initialize advertiser");
+    if(Dnssd::ServiceAdvertiser::Instance().Init(chip::DeviceLayer::UDPEndPointManager()) != CHIP_NO_ERROR)
+    {
+        // No need to do anything if init failed
+        ChipLogError(Discovery, "Failed to initialize advertiser");
+        return;
+    }
+
+    ChipLogProgress(Discovery, "Updating services using commissioning mode %d", static_cast<int>(mode));
 
     SuccessOrLog(Dnssd::ServiceAdvertiser::Instance().RemoveServices(), Discovery, "Failed to remove advertised services");
 
@@ -528,6 +532,7 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
     SuccessOrLog(Dnssd::ServiceAdvertiser::Instance().FinalizeServiceUpdate(), Discovery, "Failed to finalize service update");
+
 }
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID)

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -489,7 +489,7 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
 
     if(Dnssd::ServiceAdvertiser::Instance().Init(chip::DeviceLayer::UDPEndPointManager()) != CHIP_NO_ERROR)
     {
-        // No need to do anything if init failed
+        // No need to do anything if init failed device is probably not commissionned/not on network
         ChipLogError(Discovery, "Failed to initialize advertiser");
         return;
     }

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -497,6 +497,7 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
     if (!Dnssd::ServiceAdvertiser::Instance().IsInitialized())
     {
         // Somehow Init can succeed without being initialized...
+        // Issue #13844
         ChipLogError(Discovery, "Advertiser not initialized");
         return;
     }

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -494,7 +494,7 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
         return;
     }
 
-    if ( !Dnssd::ServiceAdvertiser::Instance().IsInitialized())
+    if (!Dnssd::ServiceAdvertiser::Instance().IsInitialized())
     {
         // Somehow Init can succeed without being initialized...
         ChipLogError(Discovery, "Advertiser not initialized");

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -494,6 +494,13 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
         return;
     }
 
+    if ( !Dnssd::ServiceAdvertiser::Instance().IsInitialized())
+    {
+        // Somehow Init can succeed without being initialized...
+        ChipLogError(Discovery, "Advertiser not initialized");
+        return;
+    }
+
     ChipLogProgress(Discovery, "Updating services using commissioning mode %d", static_cast<int>(mode));
 
     SuccessOrLog(Dnssd::ServiceAdvertiser::Instance().RemoveServices(), Discovery, "Failed to remove advertised services");


### PR DESCRIPTION
#### Summary
Upon booting a non-commissionned device `DNSSD::StartServer` is called twice triggering 6 logs of errors. 

These errors comes from the fact that calling the `Dnssd::ServiceAdvertiser::Instance().Init()` functions does not put the ServiceAdvertiser in the `Initialized` state but in the `Initializing` state cause subsequent function to fail automatically when they check if the state is `Initialized`. This PR prevent this failure by doing the check before calling said functions.

#### Related issues

Relates to #13844 as this is is more of a workaround to alleviate the symptoms of a confusing Init sequence for the DNSSD.

#### Testing

Tested with a Silicon Labs EFR32MG24 light-switch app. Errors logs do not show up with this fix and the device is able to advertise and commission as expected. 

Upon Power-cycle, the device is still able to advertise as expected
