### PR TITLE
Move helper functions before parse_matter_test_args

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -826,6 +826,123 @@ def convert_args_to_matter_config(args: argparse.Namespace):
     return config
 
 
+def int_decimal_or_hex(s: str) -> int:
+    val = int(s, 0)
+    if val < 0:
+        raise ValueError("Negative values not supported")
+    return val
+
+
+def byte_string_from_hex(s: str) -> bytes:
+    return unhexlify(s.replace(":", "").replace(" ", "").replace("0x", ""))
+
+
+def str_from_manual_code(s: str) -> str:
+    """Enforces legal format for manual codes and removes spaces/dashes."""
+    s = s.replace("-", "").replace(" ", "")
+    regex = r"^([0-9]{11}|[0-9]{21})$"
+    match = re.match(regex, s)
+    if not match:
+        raise ValueError("Invalid manual code format, does not match %s" % regex)
+
+    return s
+
+
+def int_named_arg(s: str) -> Tuple[str, int]:
+    regex = r"^(?P<name>[a-zA-Z_0-9_.-]+):((?P<hex_value>0x[0-9a-fA-F_]+)|(?P<decimal_value>-?\d+))$"
+    match = re.match(regex, s)
+    if not match:
+        raise ValueError("Invalid int argument format, does not match %s" % regex)
+
+    name = match.group("name")
+    if match.group("hex_value"):
+        value = int(match.group("hex_value"), 0)
+    else:
+        value = int(match.group("decimal_value"), 10)
+    return (name, value)
+
+
+def str_named_arg(s: str) -> Tuple[str, str]:
+    regex = r"^(?P<name>[a-zA-Z_0-9.]+):(?P<value>.*)$"
+    match = re.match(regex, s)
+    if not match:
+        raise ValueError("Invalid string argument format, does not match %s" % regex)
+
+    return (match.group("name"), match.group("value"))
+
+
+def float_named_arg(s: str) -> Tuple[str, float]:
+    regex = r"^(?P<name>[a-zA-Z_0-9.]+):(?P<value>.*)$"
+    match = re.match(regex, s)
+    if not match:
+        raise ValueError("Invalid float argument format, does not match %s" % regex)
+
+    name = match.group("name")
+    value = float(match.group("value"))
+
+    return (name, value)
+
+
+def json_named_arg(s: str) -> Tuple[str, object]:
+    regex = r"^(?P<name>[a-zA-Z_0-9.]+):(?P<value>.*)$"
+    match = re.match(regex, s)
+    if not match:
+        raise ValueError("Invalid JSON argument format, does not match %s" % regex)
+
+    name = match.group("name")
+    value = json.loads(match.group("value"))
+
+    return (name, value)
+
+
+def bool_named_arg(s: str) -> Tuple[str, bool]:
+    regex = r"^(?P<name>[a-zA-Z_0-9.]+):((?P<truth_value>true|false)|(?P<decimal_value>[01]))$"
+    match = re.match(regex, s, re.IGNORECASE)
+    if not match:
+        raise ValueError("Invalid bool argument format, does not match %s" % regex)
+
+    name = match.group("name")
+    if match.group("truth_value"):
+        value = match.group("truth_value").lower() == "true"
+    else:
+        value = int(match.group("decimal_value")) != 0
+
+    return (name, value)
+
+
+def bytes_as_hex_named_arg(s: str) -> Tuple[str, bytes]:
+    regex = r"^(?P<name>[a-zA-Z_0-9.]+):(?P<value>[0-9a-fA-F:]+)$"
+    match = re.match(regex, s)
+    if not match:
+        raise ValueError("Invalid bytes as hex argument format, does not match %s" % regex)
+
+    name = match.group("name")
+    value_str = match.group("value")
+    value_str = value_str.replace(":", "")
+    if len(value_str) % 2 != 0:
+        raise ValueError("Byte string argument value needs to be event number of hex chars")
+    value = unhexlify(value_str)
+
+    return (name, value)
+
+
+def root_index(s: str) -> int:
+    CHIP_TOOL_COMPATIBILITY = {
+        "alpha": 1,
+        "beta": 2,
+        "gamma": 3
+    }
+
+    for name, id in CHIP_TOOL_COMPATIBILITY.items():
+        if s.lower() == name:
+            return id
+    else:
+        root_index = int(s)
+        if root_index == 0:
+            raise ValueError("Only support root index >= 1")
+        return root_index
+
+
 def parse_matter_test_args(argv: Optional[List[str]] = None):
     parser = argparse.ArgumentParser(description='Matter standalone Python test')
 
@@ -956,120 +1073,3 @@ def parse_matter_test_args(argv: Optional[List[str]] = None):
         argv = sys.argv[1:]
 
     return convert_args_to_matter_config(parser.parse_args(argv))
-
-
-def int_decimal_or_hex(s: str) -> int:
-    val = int(s, 0)
-    if val < 0:
-        raise ValueError("Negative values not supported")
-    return val
-
-
-def byte_string_from_hex(s: str) -> bytes:
-    return unhexlify(s.replace(":", "").replace(" ", "").replace("0x", ""))
-
-
-def str_from_manual_code(s: str) -> str:
-    """Enforces legal format for manual codes and removes spaces/dashes."""
-    s = s.replace("-", "").replace(" ", "")
-    regex = r"^([0-9]{11}|[0-9]{21})$"
-    match = re.match(regex, s)
-    if not match:
-        raise ValueError("Invalid manual code format, does not match %s" % regex)
-
-    return s
-
-
-def int_named_arg(s: str) -> Tuple[str, int]:
-    regex = r"^(?P<name>[a-zA-Z_0-9_.-]+):((?P<hex_value>0x[0-9a-fA-F_]+)|(?P<decimal_value>-?\d+))$"
-    match = re.match(regex, s)
-    if not match:
-        raise ValueError("Invalid int argument format, does not match %s" % regex)
-
-    name = match.group("name")
-    if match.group("hex_value"):
-        value = int(match.group("hex_value"), 0)
-    else:
-        value = int(match.group("decimal_value"), 10)
-    return (name, value)
-
-
-def str_named_arg(s: str) -> Tuple[str, str]:
-    regex = r"^(?P<name>[a-zA-Z_0-9.]+):(?P<value>.*)$"
-    match = re.match(regex, s)
-    if not match:
-        raise ValueError("Invalid string argument format, does not match %s" % regex)
-
-    return (match.group("name"), match.group("value"))
-
-
-def float_named_arg(s: str) -> Tuple[str, float]:
-    regex = r"^(?P<name>[a-zA-Z_0-9.]+):(?P<value>.*)$"
-    match = re.match(regex, s)
-    if not match:
-        raise ValueError("Invalid float argument format, does not match %s" % regex)
-
-    name = match.group("name")
-    value = float(match.group("value"))
-
-    return (name, value)
-
-
-def json_named_arg(s: str) -> Tuple[str, object]:
-    regex = r"^(?P<name>[a-zA-Z_0-9.]+):(?P<value>.*)$"
-    match = re.match(regex, s)
-    if not match:
-        raise ValueError("Invalid JSON argument format, does not match %s" % regex)
-
-    name = match.group("name")
-    value = json.loads(match.group("value"))
-
-    return (name, value)
-
-
-def bool_named_arg(s: str) -> Tuple[str, bool]:
-    regex = r"^(?P<name>[a-zA-Z_0-9.]+):((?P<truth_value>true|false)|(?P<decimal_value>[01]))$"
-    match = re.match(regex, s, re.IGNORECASE)
-    if not match:
-        raise ValueError("Invalid bool argument format, does not match %s" % regex)
-
-    name = match.group("name")
-    if match.group("truth_value"):
-        value = match.group("truth_value").lower() == "true"
-    else:
-        value = int(match.group("decimal_value")) != 0
-
-    return (name, value)
-
-
-def bytes_as_hex_named_arg(s: str) -> Tuple[str, bytes]:
-    regex = r"^(?P<name>[a-zA-Z_0-9.]+):(?P<value>[0-9a-fA-F:]+)$"
-    match = re.match(regex, s)
-    if not match:
-        raise ValueError("Invalid bytes as hex argument format, does not match %s" % regex)
-
-    name = match.group("name")
-    value_str = match.group("value")
-    value_str = value_str.replace(":", "")
-    if len(value_str) % 2 != 0:
-        raise ValueError("Byte string argument value needs to be event number of hex chars")
-    value = unhexlify(value_str)
-
-    return (name, value)
-
-
-def root_index(s: str) -> int:
-    CHIP_TOOL_COMPATIBILITY = {
-        "alpha": 1,
-        "beta": 2,
-        "gamma": 3
-    }
-
-    for name, id in CHIP_TOOL_COMPATIBILITY.items():
-        if s.lower() == name:
-            return id
-    else:
-        root_index = int(s)
-        if root_index == 0:
-            raise ValueError("Only support root index >= 1")
-        return root_index


### PR DESCRIPTION
#### Summary
Follow-up change to keep helper definitions above parse_matter_test_args for readability and consistency.

#### Related issues & PR
Original Issue: https://github.com/project-chip/matter-test-scripts/issues/598
Original PR: https://github.com/project-chip/connectedhomeip/pull/39744
Follow up issue: https://github.com/project-chip/connectedhomeip/issues/40274

#### Testing
These helper functions are indirectly tested through CI. They are used as argument parsers (`type=` parameter in `argparse`) for the test framework's command-line interface in `parse_matter_test_args()`.

The test `TestFrameworkArgParsing.py` runs in CI and validates these parsers with various input formats (including the functions moved in this PR). Any breakage in the refactoring would be caught by the CI test suite.

Related test file: `src/python_testing/TestFrameworkArgParsing.py`