### PR TITLE
[NXP][platform][common] Fix DeviceInfoProvider initialization order regression in Matter server startup

### DIFF
--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -207,7 +207,7 @@ void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
 #endif
 
     VerifyOrDie((chip::Server::GetInstance().Init(initParams)) == CHIP_NO_ERROR);
-    
+
 #if CONFIG_CHIP_APP_OPERATIONAL_KEYSTORE
     auto * persistentStorage = &Server::GetInstance().GetPersistentStorage();
     TEMPORARY_RETURN_IGNORED chip::NXP::App::OperationalKeystore::Init(persistentStorage);

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -191,6 +191,7 @@ void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
 
 #if CONFIG_DEVICE_INFO_PROVIDER_IMPL
+    gExampleDeviceInfoProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 #endif
 
@@ -206,13 +207,10 @@ void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
 #endif
 
     VerifyOrDie((chip::Server::GetInstance().Init(initParams)) == CHIP_NO_ERROR);
-    auto * persistentStorage = &Server::GetInstance().GetPersistentStorage();
+    
 #if CONFIG_CHIP_APP_OPERATIONAL_KEYSTORE
+    auto * persistentStorage = &Server::GetInstance().GetPersistentStorage();
     TEMPORARY_RETURN_IGNORED chip::NXP::App::OperationalKeystore::Init(persistentStorage);
-#endif
-
-#if CONFIG_DEVICE_INFO_PROVIDER_IMPL
-    gExampleDeviceInfoProvider.SetStorageDelegate(persistentStorage);
 #endif
 
     GetAppTask().PostInitMatterServerInstance();

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -189,6 +189,11 @@ void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
     initParams.operationalKeystore = chip::NXP::App::OperationalKeystore::GetInstance();
 #endif
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+
+#if CONFIG_DEVICE_INFO_PROVIDER_IMPL
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
+#endif
+
     initParams.dataModelProvider = app::CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
 
 #if CONFIG_NET_L2_OPENTHREAD
@@ -208,7 +213,6 @@ void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
 
 #if CONFIG_DEVICE_INFO_PROVIDER_IMPL
     gExampleDeviceInfoProvider.SetStorageDelegate(persistentStorage);
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 #endif
 
     GetAppTask().PostInitMatterServerInstance();


### PR DESCRIPTION
#### Summary

This PR fixes a crash occurring during Matter server startup caused by the `DeviceInfoProvider` being registered too late. Recent changes in Matter modified the initialization flow so that cluster registration now accesses the DeviceInfoProvider earlier than before. Our NXP platform registered the provider only after server initialization, resulting in a nullptr being used during cluster initialization.

The fix implemented is to register the DeviceInfoProvider before initializing the DataModelProvider, by reversing the order in `AppTaskBase::InitServer()`.

#### Testing

Tested by building NXP Zephyr application and running it on FRDM-RW612 board.
- Build command: "west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr"