### PR TITLE
[1.5-branch] Cherry-pick Parse and set ICE servers to PeerConnection (#42955)

### DIFF
--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -138,6 +138,8 @@ private:
     void OnLocalDescription(const std::string & sdp, SDPType type, const uint16_t sessionId);
     void OnConnectionStateChanged(bool connected, const uint16_t sessionId);
 
+    void CleanupSession(uint16_t sessionId);
+
     WebrtcTransport * GetTransport(uint16_t sessionId);
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnConnectedCallback;

--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -24,6 +24,7 @@
 #include <app/CASESessionManager.h>
 #include <app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.h>
 #include <media-controller.h>
+#include <system/SystemLayer.h>
 #include <webrtc-transport.h>
 
 #include <map>
@@ -140,6 +141,14 @@ private:
 
     void CleanupSession(uint16_t sessionId);
 
+    void StartConnectionTimer(uint16_t sessionId);
+
+    void CancelConnectionTimer(uint16_t sessionId);
+
+    void HandleConnectionTimeout(uint16_t sessionId);
+
+    static void OnConnectionTimeoutCallback(chip::System::Layer * systemLayer, void * context);
+
     WebrtcTransport * GetTransport(uint16_t sessionId);
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnConnectedCallback;
@@ -158,6 +167,15 @@ private:
     CameraDeviceInterface * mCameraDevice = nullptr;
 
     bool mSoftLiveStreamPrivacyEnabled = false;
+
+    struct ConnectionTimeoutContext
+    {
+        WebRTCProviderManager * manager;
+        uint16_t sessionId;
+    };
+
+    // Map to track active connection timeout timers for cancellation
+    std::unordered_map<uint16_t, ConnectionTimeoutContext *> mConnectionTimerContexts;
 };
 
 } // namespace WebRTCTransportProvider

--- a/examples/camera-app/linux/include/webrtc-abstract.h
+++ b/examples/camera-app/linux/include/webrtc-abstract.h
@@ -49,6 +49,13 @@ struct ICECandidateInfo
     int mlineIndex;
 };
 
+struct ICEServerInfo
+{
+    std::vector<std::string> urls;
+    std::string username;
+    std::string credential;
+};
+
 using OnLocalDescriptionCallback = std::function<void(const std::string & sdp, SDPType type)>;
 using OnICECandidateCallback     = std::function<void(const ICECandidateInfo & candidateInfo)>;
 using OnConnectionStateCallback  = std::function<void(bool connected)>;
@@ -83,4 +90,4 @@ public:
     virtual int GetPayloadType(const std::string & sdp, SDPType type, const std::string & codec) { return -1; };
 };
 
-std::shared_ptr<WebRTCPeerConnection> CreateWebRTCPeerConnection();
+std::shared_ptr<WebRTCPeerConnection> CreateWebRTCPeerConnection(const std::vector<ICEServerInfo> & iceServers = {});

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -101,6 +101,9 @@ public:
     // Adds audio track to the peerconnection with opus codec with default payload type as 111
     void AddAudioTrack(const std::string & audioMid = "audio", int payloadType = 111);
 
+    // Set ICE servers to use when creating the underlying PeerConnection. Call this before Start().
+    void SetICEServers(const std::vector<ICEServerInfo> & servers);
+
     std::shared_ptr<WebRTCPeerConnection> GetPeerConnection() { return mPeerConnection; }
 
     std::string GetLocalDescription() { return mLocalSdp; }
@@ -145,6 +148,7 @@ private:
     RequestArgs mRequestArgs;
     OnTransportLocalDescriptionCallback mOnLocalDescription = nullptr;
     OnTransportConnectionStateCallback mOnConnectionState   = nullptr;
+    std::vector<ICEServerInfo> mICEServers;
 
     std::mutex mTrackStatusLock;
 };

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -281,10 +281,19 @@ private:
 class LibDataChannelPeerConnection : public WebRTCPeerConnection
 {
 public:
-    LibDataChannelPeerConnection()
+    LibDataChannelPeerConnection(const std::vector<ICEServerInfo> & servers = {})
     {
         rtc::Configuration config;
-        // config.iceServers.emplace_back("stun.l.google.com:19302");
+        for (const auto & server : servers)
+        {
+            for (const auto & url : server.urls)
+            {
+                rtc::IceServer iceServer(url);
+                iceServer.username = server.username;
+                iceServer.password = server.credential;
+                config.iceServers.push_back(iceServer);
+            }
+        }
         mPeerConnection = std::make_shared<rtc::PeerConnection>(config);
     }
 
@@ -455,7 +464,7 @@ private:
 
 } // namespace
 
-std::shared_ptr<WebRTCPeerConnection> CreateWebRTCPeerConnection()
+std::shared_ptr<WebRTCPeerConnection> CreateWebRTCPeerConnection(const std::vector<ICEServerInfo> & iceServers)
 {
-    return std::make_shared<LibDataChannelPeerConnection>();
+    return std::make_shared<LibDataChannelPeerConnection>(iceServers);
 }

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -62,6 +62,11 @@ void WebrtcTransport::SetRequestArgs(const RequestArgs & args)
     mRequestArgs = args;
 }
 
+void WebrtcTransport::SetICEServers(const std::vector<ICEServerInfo> & servers)
+{
+    mICEServers = servers;
+}
+
 WebrtcTransport::RequestArgs & WebrtcTransport::GetRequestArgs()
 {
     return mRequestArgs;
@@ -195,7 +200,7 @@ void WebrtcTransport::Start()
         return;
     }
 
-    mPeerConnection = CreateWebRTCPeerConnection();
+    mPeerConnection = CreateWebRTCPeerConnection(mICEServers);
 
     mPeerConnection->SetCallbacks([this](const std::string & sdp, SDPType type) { this->OnLocalDescription(sdp, type); },
                                   [this](const ICECandidateInfo & candidateInfo) { this->OnICECandidate(candidateInfo); },

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.cpp
@@ -553,6 +553,11 @@ DataModel::ActionReturnStatus CameraAVStreamManagementCluster::ReadAttribute(con
     case FeatureMap::Id:
         ReturnErrorOnFailure(aEncoder.Encode(mEnabledFeatures));
         break;
+
+    case ClusterRevision::Id:
+        ReturnErrorOnFailure(aEncoder.Encode(CameraAvStreamManagement::kRevision));
+        break;
+
     case MaxConcurrentEncoders::Id:
         VerifyOrReturnError(HasFeature(Feature::kVideo), CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute),
                             ChipLogError(Zcl,

--- a/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.cpp
+++ b/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.cpp
@@ -46,6 +46,11 @@ constexpr DataModel::AcceptedCommandEntry kAcceptedCommands[] = {
     Commands::ProvideICECandidates::kMetadataEntry, Commands::EndSession::kMetadataEntry,
 };
 
+constexpr CommandId kGeneratedCommands[] = {
+    Commands::SolicitOfferResponse::Id,
+    Commands::ProvideOfferResponse::Id,
+};
+
 NodeId GetNodeIdFromCtx(const CommandHandler & commandHandler)
 {
     auto descriptor = commandHandler.GetSubjectDescriptor();
@@ -271,6 +276,12 @@ CHIP_ERROR WebRTCTransportProviderCluster::AcceptedCommands(const ConcreteCluste
                                                             ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder)
 {
     return builder.ReferenceExisting(kAcceptedCommands);
+}
+
+CHIP_ERROR WebRTCTransportProviderCluster::GeneratedCommands(const ConcreteClusterPath & path,
+                                                             ReadOnlyBufferBuilder<CommandId> & builder)
+{
+    return builder.ReferenceExisting(kGeneratedCommands);
 }
 
 CHIP_ERROR WebRTCTransportProviderCluster::Attributes(const ConcreteClusterPath & path,

--- a/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.h
+++ b/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.h
@@ -398,6 +398,8 @@ public:
     CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path,
                                 ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder) override;
 
+    CHIP_ERROR GeneratedCommands(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<CommandId> & builder) override;
+
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
     /**


### PR DESCRIPTION
#### Summary

Cherry pick

1. [WebRTC] Parse and set ICE servers to PeerConnection (#42955)
2. Fixes WEBRTCP and AVSM for TC-IDM tests (#42971)
3. Add a connection timeout timer to clean up the stale session. (#42952)
4. Consolidate cleanup sites to use the shared CleanupSession (#42954)


#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
