### PR TITLE
Switch "dirty generation" value to use 32-bit instead of 64-bit

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -202,6 +202,7 @@ static_library("interaction-model") {
     "WriteClient.h",
     "reporting/Engine.cpp",
     "reporting/Engine.h",
+    "reporting/Generations.h",
     "reporting/ReportScheduler.h",
     "reporting/ReportSchedulerImpl.cpp",
     "reporting/ReportSchedulerImpl.h",

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1206,7 +1206,7 @@ bool InteractionModelEngine::TrimFabricForSubscriptions(FabricIndex aFabricIndex
             candidateEventPathsUsed     = eventPathsUsed;
         }
         // This handler is older than the one we picked before.
-        else if (handler->GetTransactionStartGeneration() < candidate->GetTransactionStartGeneration() &&
+        else if (handler->GetTransactionStartGeneration().After(candidate->GetTransactionStartGeneration()) &&
                  // And the level of resource usage is the same (both exceed or neither exceed)
                  ((attributePathsUsed > perFabricPathCapacity || eventPathsUsed > perFabricPathCapacity) ==
                   (candidateAttributePathsUsed > perFabricPathCapacity || candidateEventPathsUsed > perFabricPathCapacity)))
@@ -1384,7 +1384,7 @@ bool InteractionModelEngine::TrimFabricForRead(FabricIndex aFabricIndex)
             candidate = handler;
         }
         // Read Handlers are "first come first served", so we give eariler read transactions a higher priority.
-        else if (handler->GetTransactionStartGeneration() > candidate->GetTransactionStartGeneration() &&
+        else if (handler->GetTransactionStartGeneration().After(candidate->GetTransactionStartGeneration()) &&
                  // And the level of resource usage is the same (both exceed or neither exceed)
                  ((attributePathsUsed > kMinSupportedPathsPerReadRequest || eventPathsUsed > kMinSupportedPathsPerReadRequest) ==
                   (candidateAttributePathsUsed > kMinSupportedPathsPerReadRequest ||

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1206,7 +1206,7 @@ bool InteractionModelEngine::TrimFabricForSubscriptions(FabricIndex aFabricIndex
             candidateEventPathsUsed     = eventPathsUsed;
         }
         // This handler is older than the one we picked before.
-        else if (handler->GetTransactionStartGeneration().After(candidate->GetTransactionStartGeneration()) &&
+        else if (handler->GetTransactionStartGeneration().Before(candidate->GetTransactionStartGeneration()) &&
                  // And the level of resource usage is the same (both exceed or neither exceed)
                  ((attributePathsUsed > perFabricPathCapacity || eventPathsUsed > perFabricPathCapacity) ==
                   (candidateAttributePathsUsed > perFabricPathCapacity || candidateEventPathsUsed > perFabricPathCapacity)))

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -545,15 +545,15 @@ private:
     // This allows us to reset the iterator to the beginning of the current
     // cluster instead of the beginning of the whole report in AttributePathIsDirty, without
     // permanently missing dirty any paths.
-    uint64_t mDirtyGeneration = 0;
+    uint32_t mDirtyGeneration = 0;
 
     // For subscriptions, we record the timestamp when we started to generate the last report.
     // The mCurrentReportsBeginGeneration records the timestamp for the current report, which won;t be used for checking if this
     // ReadHandler is dirty.
     // mPreviousReportsBeginGeneration will be set to mCurrentReportsBeginGeneration after we sent the last chunk of the current
     // report.
-    uint64_t mPreviousReportsBeginGeneration = 0;
-    uint64_t mCurrentReportsBeginGeneration  = 0;
+    uint32_t mPreviousReportsBeginGeneration = 0;
+    uint32_t mCurrentReportsBeginGeneration  = 0;
     /*
      *           (mDirtyGeneration = b > a, this is a dirty read handler)
      *        +- Start Report -> mCurrentReportsBeginGeneration = c

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -39,6 +39,7 @@
 #include <app/OperationalSessionSetup.h>
 #include <app/SubscriptionResumptionSessionEstablisher.h>
 #include <app/SubscriptionResumptionStorage.h>
+#include <app/reporting/Generations.h>
 #include <lib/core/CHIPCallback.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLVDebug.h>
@@ -427,7 +428,7 @@ private:
     void AttributePathIsDirty(DataModel::Provider * apDataModel, const AttributePathParams & aAttributeChanged);
     bool IsDirty() const
     {
-        return (mDirtyGeneration > mPreviousReportsBeginGeneration) || mFlags.Has(ReadHandlerFlags::ForceDirty);
+        return mDirtyGeneration.After(mPreviousReportsBeginGeneration) || mFlags.Has(ReadHandlerFlags::ForceDirty);
     }
     void ClearForceDirtyFlag() { ClearStateFlag(ReadHandlerFlags::ForceDirty); }
     NodeId GetInitiatorNodeId() const
@@ -545,15 +546,15 @@ private:
     // This allows us to reset the iterator to the beginning of the current
     // cluster instead of the beginning of the whole report in AttributePathIsDirty, without
     // permanently missing dirty any paths.
-    uint32_t mDirtyGeneration = 0;
+    reporting::AttributeGeneration mDirtyGeneration{ 0 };
 
     // For subscriptions, we record the timestamp when we started to generate the last report.
     // The mCurrentReportsBeginGeneration records the timestamp for the current report, which won;t be used for checking if this
     // ReadHandler is dirty.
     // mPreviousReportsBeginGeneration will be set to mCurrentReportsBeginGeneration after we sent the last chunk of the current
     // report.
-    uint32_t mPreviousReportsBeginGeneration = 0;
-    uint32_t mCurrentReportsBeginGeneration  = 0;
+    reporting::AttributeGeneration mPreviousReportsBeginGeneration{ 0 };
+    reporting::AttributeGeneration mCurrentReportsBeginGeneration{ 0 };
     /*
      *           (mDirtyGeneration = b > a, this is a dirty read handler)
      *        +- Start Report -> mCurrentReportsBeginGeneration = c
@@ -572,7 +573,7 @@ private:
 
     // When we don't have enough resources for a new subscription, the oldest subscription might be evicted by interaction model
     // engine, the "oldest" subscription is the subscription with the smallest generation.
-    uint32_t mTransactionStartGeneration = 0;
+    reporting::AttributeGeneration mTransactionStartGeneration{ 0 };
 
     EventNumber mEventMin = 0;
 

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -572,7 +572,7 @@ private:
 
     // When we don't have enough resources for a new subscription, the oldest subscription might be evicted by interaction model
     // engine, the "oldest" subscription is the subscription with the smallest generation.
-    uint64_t mTransactionStartGeneration = 0;
+    uint32_t mTransactionStartGeneration = 0;
 
     EventNumber mEventMin = 0;
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -381,10 +381,9 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeReportIBs(ReportDataMessage::Bu
         ConcreteAttributePath readPath;
 
         ChipLogDetail(DataManagement,
-                      "Building Reports for ReadHandler with LastReportGeneration = 0x" ChipLogFormatX64
-                      " DirtyGeneration = 0x" ChipLogFormatX64,
-                      ChipLogValueX64(apReadHandler->mPreviousReportsBeginGeneration),
-                      ChipLogValueX64(apReadHandler->mDirtyGeneration));
+                      "Building Reports for ReadHandler with LastReportGeneration = 0x%08X"
+                      " DirtyGeneration = 0x%08X",
+                      apReadHandler->mPreviousReportsBeginGeneration, apReadHandler->mDirtyGeneration);
 
         // This ReadHandler is not generating reports, so we reset the iterator for a clean start.
         if (!apReadHandler->IsReporting())

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -381,9 +381,10 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeReportIBs(ReportDataMessage::Bu
         ConcreteAttributePath readPath;
 
         ChipLogDetail(DataManagement,
-                      "Building Reports for ReadHandler with LastReportGeneration = 0x%08X"
-                      " DirtyGeneration = 0x%08X",
-                      apReadHandler->mPreviousReportsBeginGeneration, apReadHandler->mDirtyGeneration);
+                      "Building Reports for ReadHandler with LastReportGeneration = 0x%08lX"
+                      " DirtyGeneration = 0x%08lX",
+                      static_cast<long>(apReadHandler->mPreviousReportsBeginGeneration),
+                      static_cast<long>(apReadHandler->mDirtyGeneration));
 
         // This ReadHandler is not generating reports, so we reset the iterator for a clean start.
         if (!apReadHandler->IsReporting())

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -381,10 +381,9 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeReportIBs(ReportDataMessage::Bu
         ConcreteAttributePath readPath;
 
         ChipLogDetail(DataManagement,
-                      "Building Reports for ReadHandler with LastReportGeneration = 0x%08lX"
-                      " DirtyGeneration = 0x%08lX",
-                      static_cast<long>(apReadHandler->mPreviousReportsBeginGeneration),
-                      static_cast<long>(apReadHandler->mDirtyGeneration));
+                      "Building Reports for ReadHandler with LastReportGeneration = 0x%08lX DirtyGeneration = 0x%08lX",
+                      static_cast<long>(apReadHandler->mPreviousReportsBeginGeneration.Raw()),
+                      static_cast<long>(apReadHandler->mDirtyGeneration.Raw()));
 
         // This ReadHandler is not generating reports, so we reset the iterator for a clean start.
         if (!apReadHandler->IsReporting())
@@ -410,7 +409,7 @@ CHIP_ERROR Engine::BuildSingleReportDataAttributeReportIBs(ReportDataMessage::Bu
                     {
                         // We don't need to worry about paths that were already marked dirty before the last time this read handler
                         // started a report that it completed: those paths already got reported.
-                        if (dirtyPath->mGeneration > apReadHandler->mPreviousReportsBeginGeneration)
+                        if (dirtyPath->mGeneration.After(apReadHandler->mPreviousReportsBeginGeneration))
                         {
                             concretePathDirty = true;
                             return Loop::Break;
@@ -994,7 +993,7 @@ bool Engine::ClearTombPaths()
 {
     bool pathReleased = false;
     mGlobalDirtySet.ForEachActiveObject([&](auto * path) {
-        if (path->mGeneration == 0)
+        if (path->mGeneration.IsZero())
         {
             mGlobalDirtySet.ReleaseObject(path);
             pathReleased = true;
@@ -1007,7 +1006,7 @@ bool Engine::ClearTombPaths()
 bool Engine::MergeDirtyPathsUnderSameCluster()
 {
     mGlobalDirtySet.ForEachActiveObject([&](auto * outerPath) {
-        if (outerPath->HasWildcardClusterId() || outerPath->mGeneration == 0)
+        if (outerPath->HasWildcardClusterId() || outerPath->mGeneration.IsZero())
         {
             return Loop::Continue;
         }
@@ -1022,7 +1021,7 @@ bool Engine::MergeDirtyPathsUnderSameCluster()
             {
                 return Loop::Continue;
             }
-            if (innerPath->mGeneration > outerPath->mGeneration)
+            if (innerPath->mGeneration.After(outerPath->mGeneration))
             {
                 outerPath->mGeneration = innerPath->mGeneration;
             }
@@ -1030,7 +1029,7 @@ bool Engine::MergeDirtyPathsUnderSameCluster()
 
             // The object pool does not allow us to release objects in a nested iteration, mark the path as a tomb by setting its
             // generation to 0 and then clear it later.
-            innerPath->mGeneration = 0;
+            innerPath->mGeneration.Clear();
             return Loop::Continue;
         });
         return Loop::Continue;
@@ -1042,7 +1041,7 @@ bool Engine::MergeDirtyPathsUnderSameCluster()
 bool Engine::MergeDirtyPathsUnderSameEndpoint()
 {
     mGlobalDirtySet.ForEachActiveObject([&](auto * outerPath) {
-        if (outerPath->HasWildcardEndpointId() || outerPath->mGeneration == 0)
+        if (outerPath->HasWildcardEndpointId() || outerPath->mGeneration.IsZero())
         {
             return Loop::Continue;
         }
@@ -1055,7 +1054,7 @@ bool Engine::MergeDirtyPathsUnderSameEndpoint()
             {
                 return Loop::Continue;
             }
-            if (innerPath->mGeneration > outerPath->mGeneration)
+            if (innerPath->mGeneration.After(outerPath->mGeneration))
             {
                 outerPath->mGeneration = innerPath->mGeneration;
             }
@@ -1064,7 +1063,7 @@ bool Engine::MergeDirtyPathsUnderSameEndpoint()
 
             // The object pool does not allow us to release objects in a nested iteration, mark the path as a tomb by setting its
             // generation to 0 and then clear it later.
-            innerPath->mGeneration = 0;
+            innerPath->mGeneration.Clear();
             return Loop::Continue;
         });
         return Loop::Continue;

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -123,7 +123,7 @@ public:
 
     uint32_t GetNumReportsInFlight() const { return mNumReportsInFlight; }
 
-    uint64_t GetDirtySetGeneration() const { return mDirtyGeneration; }
+    uint32_t GetDirtySetGeneration() const { return mDirtyGeneration; }
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     size_t GetGlobalDirtySetSize() { return mGlobalDirtySet.Allocated(); }
@@ -145,9 +145,11 @@ private:
 
     struct AttributePathParamsWithGeneration : public AttributePathParams
     {
-        AttributePathParamsWithGeneration() {}
+        AttributePathParamsWithGeneration() = default;
         AttributePathParamsWithGeneration(const AttributePathParams aPath) : AttributePathParams(aPath) {}
-        uint64_t mGeneration = 0;
+
+        // AttributePathParams is 32-bit aligned, so u32 seems reasonable since we do not use packed structs.
+        uint32_t mGeneration = 0;
     };
 
     /**
@@ -282,7 +284,7 @@ private:
      * Count it from 1, so 0 can be used in ReadHandler to indicate "the read handler has never
      * completed a report".
      */
-    uint64_t mDirtyGeneration = 1;
+    uint32_t mDirtyGeneration = 1;
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     uint32_t mReservedSize          = 0;

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -29,6 +29,7 @@
 #include <app/MessageDef/ReportDataMessage.h>
 #include <app/ReadHandler.h>
 #include <app/data-model-provider/ProviderChangeListener.h>
+#include <app/reporting/Generations.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
@@ -46,6 +47,7 @@ class InteractionModelEngine;
 class TestReadInteraction;
 
 namespace reporting {
+
 /*
  *  @class Engine
  *
@@ -123,7 +125,7 @@ public:
 
     uint32_t GetNumReportsInFlight() const { return mNumReportsInFlight; }
 
-    uint32_t GetDirtySetGeneration() const { return mDirtyGeneration; }
+    AttributeGeneration GetDirtySetGeneration() const { return mDirtyGeneration; }
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     size_t GetGlobalDirtySetSize() { return mGlobalDirtySet.Allocated(); }
@@ -149,7 +151,7 @@ private:
         AttributePathParamsWithGeneration(const AttributePathParams aPath) : AttributePathParams(aPath) {}
 
         // AttributePathParams is 32-bit aligned, so u32 seems reasonable since we do not use packed structs.
-        uint32_t mGeneration = 0;
+        AttributeGeneration mGeneration;
     };
 
     /**
@@ -235,7 +237,7 @@ private:
 
     CHIP_ERROR InsertPathIntoDirtySet(const AttributePathParams & aAttributePath);
 
-    inline void BumpDirtySetGeneration() { mDirtyGeneration++; }
+    inline void BumpDirtySetGeneration() { mDirtyGeneration.Increment(); }
 
     /**
      * Boolean to indicate if ScheduleRun is pending. This flag is used to prevent calling ScheduleRun multiple times
@@ -284,7 +286,7 @@ private:
      * Count it from 1, so 0 can be used in ReadHandler to indicate "the read handler has never
      * completed a report".
      */
-    uint32_t mDirtyGeneration = 1;
+    AttributeGeneration mDirtyGeneration{ 1 };
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     uint32_t mReservedSize          = 0;

--- a/src/app/reporting/Generations.h
+++ b/src/app/reporting/Generations.h
@@ -1,0 +1,89 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace chip::app::reporting {
+
+// u32 generations can generally wrap around. We try to do a best effort figuring out
+// if First < Second considering wrap-around. So we cast their difference to i32 and
+// see if that is positive.
+inline constexpr bool AreGenerationsInOrder(uint32_t generationFirst, uint32_t generationSecond)
+{
+    return static_cast<int32_t>(generationSecond - generationFirst) > 0;
+}
+
+// essentially our unit tests
+static_assert(AreGenerationsInOrder(1, 100));
+static_assert(!AreGenerationsInOrder(100, 1));
+
+static_assert(AreGenerationsInOrder(0xFFFFFFAB, 120));
+static_assert(!AreGenerationsInOrder(120, 0xFFFFFFAb));
+
+static_assert(AreGenerationsInOrder(1, 0x7FFFFFFF));
+static_assert(!AreGenerationsInOrder(0x7FFFFFFF, 1));
+
+// random increases from small numbers
+static_assert(AreGenerationsInOrder(2, 0x80000000));
+static_assert(AreGenerationsInOrder(100, 0x80000000));
+static_assert(AreGenerationsInOrder(1000, 0x800000AB));
+
+// wrap-arounds
+static_assert(AreGenerationsInOrder(0x80000000 + 1000, 900));
+static_assert(AreGenerationsInOrder(0x80000000 + 0x12345, 0x12344));
+
+/// Represents a generation of an attribute. A wrapper of a u32 that does NOT auto-cast back to U32, so that we can
+/// force comparisons to use the wrap-around aware compares
+class AttributeGeneration
+{
+public:
+    explicit AttributeGeneration(uint32_t value) : mValue(value) {}
+
+    AttributeGeneration()                            = default;
+    AttributeGeneration(const AttributeGeneration &) = default;
+    AttributeGeneration(AttributeGeneration &&)      = default;
+
+    AttributeGeneration & operator=(const AttributeGeneration &) = default;
+    AttributeGeneration & operator=(AttributeGeneration &&)      = default;
+
+    constexpr bool Before(const AttributeGeneration & other) const { return AreGenerationsInOrder(mValue, other.mValue); }
+    constexpr bool After(const AttributeGeneration & other) const { return AreGenerationsInOrder(other.mValue, mValue); }
+
+    // zero is a special marker, generally may be used as "not defined"
+    constexpr bool IsZero() const { return mValue == 0; }
+
+    // reset to zero value (since zero is used as a special/uninitialized marker)
+    void Clear() { mValue = 0; }
+
+    uint32_t Raw() const { return mValue; }
+
+    // increment, guarantees 0 is NOT used as a value when incrementing and wrapping around
+    void Increment()
+    {
+        mValue++;
+        if (mValue == 0)
+        {
+            mValue = 1;
+        }
+    }
+
+private:
+    uint32_t mValue{};
+};
+
+} // namespace chip::app::reporting

--- a/src/app/reporting/Generations.h
+++ b/src/app/reporting/Generations.h
@@ -33,7 +33,7 @@ static_assert(AreGenerationsInOrder(1, 100));
 static_assert(!AreGenerationsInOrder(100, 1));
 
 static_assert(AreGenerationsInOrder(0xFFFFFFAB, 120));
-static_assert(!AreGenerationsInOrder(120, 0xFFFFFFAb));
+static_assert(!AreGenerationsInOrder(120, 0xFFFFFFAB));
 
 static_assert(AreGenerationsInOrder(1, 0x7FFFFFFF));
 static_assert(!AreGenerationsInOrder(0x7FFFFFFF, 1));


### PR DESCRIPTION
#### Summary

We have observed products that do frequent updates over some measured values saturate the dirty set here: https://github.com/project-chip/connectedhomeip/blob/master/src/app/reporting/Engine.h#L270

Given that the dirty set is 8 entries by default, the sideffect is that we mark the entire cluster as force dirty, resulting in reports re-sending all the cluster values (including fixed ones which is a waste ... but we do that because we have no metadata of what is fixed or not).

This PR switches mGeneration and releated values to use 32-bit instead of 64, since it seems like 2^32 generations should still be sufficient to reliably detect changes and resent reports. This decreases the size of the `AttributePathParamsWithGeneration` from 24 bytes to 16 bytes (because we also had 4 bytes of padding for alignment) so it makes it much more viable to increase CHIP_IM_SERVER_MAX_NUM_DIRTY_SET without as much of an overhead.

I expect this to also result in some RAM savings for read handlers.

Since we used to assume non-wrapping (u64) I used a separate class for generations, where I try to handle wrapping (we essentially have 31 bits to detect increases and I avoid 0 as a special value during increment).

As long as reports happen within about 31-bits of increments, reporting logic should remain correct (we increment generations on a u32 and we pick "closest assuming wrap-around" to decide if a generation is before or after another generation)

#### Testing

CI should still pass. I tested unit tests locally before creating the PR.

Static-asserts validate that wrapping ordering checks work.