### PR TITLE
Update ClusterTester and MockCommandHandler to use a test SubjectDescriptor

### DIFF
--- a/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
@@ -38,7 +38,7 @@ using namespace chip::Testing;
 using chip::Testing::IsAcceptedCommandsListEqualTo;
 using chip::Testing::IsGeneratedCommandsListEqualTo;
 
-chip::FabricIndex kTestFabricIndex = Testing::kTestFabrixIndex;
+chip::FabricIndex kTestFabricIndex = Testing::kTestFabricIndex;
 const chip::GroupId kTestGroupId   = 0x1234;
 constexpr uint16_t kTestKeySetId   = 1;
 

--- a/src/app/clusters/tls-client-management-server/tests/TestTLSClientManagementCluster.cpp
+++ b/src/app/clusters/tls-client-management-server/tests/TestTLSClientManagementCluster.cpp
@@ -21,6 +21,7 @@
 
 #include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/SafeAttributePersistenceProvider.h>
+#include <app/data-model-provider/tests/TestConstants.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
 #include <app/server-cluster/testing/ClusterTester.h>
@@ -287,8 +288,8 @@ struct TestTLSClientManagementCluster : public ::testing::Test
         VerifyOrDie(mPersistenceProvider.Init(&mClusterTester.GetServerClusterContext().storage) == CHIP_NO_ERROR);
         app::SetSafeAttributePersistenceProvider(&mPersistenceProvider);
 
-        // Add some test root certificates for the test fabric index (151)
-        constexpr FabricIndex kMockTestFabric = static_cast<FabricIndex>(151);
+        // Add some test root certificates for the test fabric index.
+        constexpr FabricIndex kMockTestFabric = Testing::kTestFabricIndex;
         mMockCertTable.rootCerts.push_back({ kMockTestFabric, 1 });
         mMockCertTable.rootCerts.push_back({ kMockTestFabric, 2 });
 

--- a/src/app/data-model-provider/tests/TestConstants.h
+++ b/src/app/data-model-provider/tests/TestConstants.h
@@ -22,23 +22,23 @@
 namespace chip {
 namespace Testing {
 
-constexpr FabricIndex kTestFabrixIndex = kMinValidFabricIndex;
+constexpr FabricIndex kTestFabricIndex = kMinValidFabricIndex;
 constexpr NodeId kTestNodeId           = 0xFFFF'1234'ABCD'4321;
 
 constexpr Access::SubjectDescriptor kAdminSubjectDescriptor{
-    .fabricIndex = kTestFabrixIndex,
+    .fabricIndex = kTestFabricIndex,
     .authMode    = Access::AuthMode::kCase,
     .subject     = kTestNodeId,
 };
 
 constexpr Access::SubjectDescriptor kViewSubjectDescriptor{
-    .fabricIndex = kTestFabrixIndex + 1,
+    .fabricIndex = kTestFabricIndex + 1,
     .authMode    = Access::AuthMode::kCase,
     .subject     = kTestNodeId,
 };
 
 constexpr Access::SubjectDescriptor kDenySubjectDescriptor{
-    .fabricIndex = kTestFabrixIndex + 2,
+    .fabricIndex = kTestFabricIndex + 2,
     .authMode    = Access::AuthMode::kCase,
     .subject     = kTestNodeId,
 };

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -121,7 +121,7 @@ public:
         mReadOperations.push_back(std::move(readOperation));
         chip::Testing::ReadOperation & readOperationRef = *mReadOperations.back().get();
 
-        Access::SubjectDescriptor subjectDescriptor{ .fabricIndex = mHandler.GetAccessingFabricIndex() };
+        const Access::SubjectDescriptor subjectDescriptor = mHandler.GetSubjectDescriptor();
         readOperationRef.SetSubjectDescriptor(subjectDescriptor);
 
         std::unique_ptr<app::AttributeValueEncoder> encoder = readOperationRef.StartEncoding();
@@ -158,7 +158,7 @@ public:
         chip::Testing::WriteOperation writeOp(path);
 
         // Create a stable object on the stack
-        Access::SubjectDescriptor subjectDescriptor{ .fabricIndex = mHandler.GetAccessingFabricIndex() };
+        const Access::SubjectDescriptor subjectDescriptor = mHandler.GetSubjectDescriptor();
         writeOp.SetSubjectDescriptor(subjectDescriptor);
 
         uint8_t buffer[1024];
@@ -231,7 +231,7 @@ public:
             return result;
         }
 
-        const Access::SubjectDescriptor subjectDescriptor{ .fabricIndex = mHandler.GetAccessingFabricIndex() };
+        const Access::SubjectDescriptor subjectDescriptor = mHandler.GetSubjectDescriptor();
         const app::DataModel::InvokeRequest invokeRequest = [&]() {
             app::DataModel::InvokeRequest req;
             req.path              = { paths[0].mEndpointId, paths[0].mClusterId, commandId };
@@ -316,6 +316,10 @@ public:
     std::vector<app::AttributePathParams> & GetDirtyList() { return mTestServerClusterContext.ChangeListener().DirtyList(); }
 
     void SetFabricIndex(FabricIndex fabricIndex) { mHandler.SetFabricIndex(fabricIndex); }
+    void SetSubjectDescriptor(const Access::SubjectDescriptor & subjectDescriptor)
+    {
+        mHandler.SetSubjectDescriptor(subjectDescriptor);
+    }
 
     FabricTestFixture * GetFabricHelper() { return mFabricTestFixture; }
 

--- a/src/app/server-cluster/testing/MockCommandHandler.cpp
+++ b/src/app/server-cluster/testing/MockCommandHandler.cpp
@@ -51,7 +51,7 @@ CHIP_ERROR MockCommandHandler::AddResponseData(const app::ConcreteCommandPath & 
 
     TLV::TLVWriter baseWriter;
     baseWriter.Init(handle->Start(), handle->MaxDataLength());
-    app::DataModel::FabricAwareTLVWriter writer(baseWriter, mFabricIndex);
+    app::DataModel::FabricAwareTLVWriter writer(baseWriter, mSubjectDescriptor.fabricIndex);
     TLV::TLVType ct;
 
     ReturnErrorOnFailure(writer.mTLVWriter.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, ct));

--- a/src/app/server-cluster/testing/MockCommandHandler.h
+++ b/src/app/server-cluster/testing/MockCommandHandler.h
@@ -20,6 +20,7 @@
 #include <app/MessageDef/CommandDataIB.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
 #include <app/data-model-provider/OperationTypes.h>
+#include <app/data-model-provider/tests/TestConstants.h>
 #include <app/data-model/NullObject.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
@@ -33,8 +34,6 @@
 
 namespace chip {
 namespace Testing {
-
-constexpr FabricIndex kTestFabricIndex = static_cast<FabricIndex>(151);
 
 // Mock class that simulates CommandHandler behavior for unit testing, allowing capture and
 // verification of responses and statuses without real network interactions.
@@ -77,7 +76,7 @@ public:
     void AddStatus(const app::ConcreteCommandPath & aRequestCommandPath,
                    const Protocols::InteractionModel::ClusterStatusCode & aStatus, const char * context = nullptr) override;
 
-    FabricIndex GetAccessingFabricIndex() const override { return mFabricIndex; }
+    FabricIndex GetAccessingFabricIndex() const override { return mSubjectDescriptor.fabricIndex; }
 
     // Encodes and stores response data, returning error if encoding fails (fallible version for robust test handling).
     CHIP_ERROR AddResponseData(const app::ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
@@ -89,7 +88,7 @@ public:
 
     bool IsTimedInvoke() const override { return false; }
     void FlushAcksRightAwayOnSlowCommand() override {}
-    Access::SubjectDescriptor GetSubjectDescriptor() const override { return Access::SubjectDescriptor{}; }
+    Access::SubjectDescriptor GetSubjectDescriptor() const override { return mSubjectDescriptor; }
     Messaging::ExchangeContext * GetExchangeContext() const override { return nullptr; }
 
     // Helper methods to extract response data
@@ -136,12 +135,13 @@ public:
     }
 
     // Configuration methods
-    void SetFabricIndex(FabricIndex index) { mFabricIndex = index; }
+    void SetFabricIndex(FabricIndex fabricIndex) { mSubjectDescriptor.fabricIndex = fabricIndex; }
+    void SetSubjectDescriptor(const Access::SubjectDescriptor & subjectDescriptor) { mSubjectDescriptor = subjectDescriptor; }
 
 private:
     std::vector<ResponseRecord> mResponses;
     std::vector<StatusRecord> mStatuses;
-    FabricIndex mFabricIndex = kTestFabricIndex; // Default to a clearly test-only fabric index.
+    Access::SubjectDescriptor mSubjectDescriptor = kAdminSubjectDescriptor; // Default to a clearly test-only subject descriptor.
 };
 
 } // namespace Testing


### PR DESCRIPTION
#### Summary

Test subject descriptor contains valid subject node id. This also allows tests to update the SubjectDescriptor and invoke the test cluster from different nodes.

#### Related issues

`subject` NodeId is supposed to be valid in CASE sessions and in for commissionees in PASE.

#### Testing

Ran unittests

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
