### PR TITLE
Matter Casting - Fix NoPasscode (tv app check) handling (#42605)

### DIFF
--- a/examples/tv-casting-app/APIs.md
+++ b/examples/tv-casting-app/APIs.md
@@ -1149,6 +1149,252 @@ func connect(selectedCastingPlayer: MCCastingPlayer?) {
 }
 ```
 
+### Detecting App Presence on Casting Player (Optional)
+
+Before establishing a full commissioning session, a Casting Client can use the
+UDC protocol to check if a specific app is installed on the target
+`CastingPlayer`. This is useful when the user experience requires a specific app
+to be present, or when you need to verify that the correct account is active in
+the app. This feature is described in the Matter specification section 5.3.7.4 -
+"UDC with no Passcode prompt (targeted app selection)".
+
+The app detection workflow consists of four steps:
+
+1. **Generate a unique session identifier**: Create a random `instanceName`
+   string for this UDC session.
+2. **Send initial IdentificationDeclaration**: Send an IdentificationDeclaration
+   message to the `CastingPlayer` with the `instanceName`, `NoPasscode` set to
+   `true`, and `targetAppInfo` containing the app you want to check for.
+3. **Check the CommissionerDeclaration response**: The `CastingPlayer` will
+   respond with a CommissionerDeclaration message with `NeedsPasscode` set to
+   `true` and `PasscodeDialogDisplayed` set to `false`. If the `NoAppsFound`
+   field is `true`, the target app was not found on the `CastingPlayer`.
+4. **Cancel the UDC session**: Send another IdentificationDeclaration message
+   with the same `instanceName` and `CancelPasscode` set to `true` to
+   immediately end the UDC session. This is important because the default Matter
+   SDK behavior on the TV supports one UDC session at a time, and without
+   canceling, the TV will block new UDC sessions until the current one times out
+   (which could take up to 30 seconds).
+
+On Linux, you can detect app presence as follows:
+
+```c
+// Step 1: Generate a unique instanceName for this UDC session
+std::string instanceName = GenerateRandomInstanceName(); // Implement your random string generator
+
+// Step 2: Set up IdentificationDeclarationOptions with NoPasscode and targetAppInfo
+matter::casting::core::IdentificationDeclarationOptions idOptions;
+idOptions.mNoPasscode = true;
+idOptions.mInstanceName = instanceName.c_str();
+
+chip::Protocols::UserDirectedCommissioning::TargetAppInfo targetAppInfo;
+targetAppInfo.vendorId = kDesiredAppVendorId;  // Your target app's vendor ID
+// Optionally set productId if you want to be more specific
+// targetAppInfo.productId = kDesiredAppProductId;
+CHIP_ERROR result = idOptions.addTargetAppInfo(targetAppInfo);
+
+// Step 3: Set up callbacks to handle the CommissionerDeclaration response
+matter::casting::core::ConnectionCallbacks connectionCallbacks;
+connectionCallbacks.mCommissionerDeclarationCallback = [&instanceName, &targetCastingPlayer](
+    const chip::Transport::PeerAddress & source,
+    chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd) {
+
+    if (cd.GetNoAppsFound()) {
+        ChipLogProgress(AppServer, "Target app not found on CastingPlayer");
+        // Handle the case where the app is not installed
+        // You may choose not to proceed with commissioning
+    } else {
+        ChipLogProgress(AppServer, "Target app found on CastingPlayer");
+        // App is present, you can proceed with commissioning if desired
+    }
+
+    // Step 4: Cancel the UDC session by sending CancelPasscode
+    matter::casting::core::IdentificationDeclarationOptions cancelOptions;
+    cancelOptions.mCancelPasscode = true;
+    cancelOptions.mInstanceName = instanceName.c_str();
+
+    matter::casting::core::ConnectionCallbacks cancelCallbacks;
+    // Send the cancel message using SendUDC
+    targetCastingPlayer->SendUDC(cancelCallbacks, cancelOptions);
+};
+
+// Send the initial IdentificationDeclaration using SendUDC
+targetCastingPlayer->SendUDC(connectionCallbacks, idOptions);
+```
+
+On Android, you can detect app presence as follows:
+
+```java
+// Step 1: Generate a unique instanceName for this UDC session
+String instanceName = UUID.randomUUID().toString();
+
+// Step 2: Set up IdentificationDeclarationOptions with NoPasscode and targetAppInfo
+IdentificationDeclarationOptions idOptions = new IdentificationDeclarationOptions(
+    /* noPasscode= */ true,
+    /* cdUponPasscodeDialog= */ false,
+    /* commissionerPasscode= */ false,
+    /* commissionerPasscodeReady= */ false,
+    /* cancelPasscode= */ false,
+    /* passcodeLength= */ 0
+);
+idOptions.setInstanceName(instanceName);
+
+TargetAppInfo targetAppInfo = new TargetAppInfo(DESIRED_APP_VENDOR_ID);
+// Optionally set productId if you want to be more specific
+// targetAppInfo.setProductId(DESIRED_APP_PRODUCT_ID);
+idOptions.addTargetAppInfo(targetAppInfo);
+
+// Step 3: Set up callbacks to handle the CommissionerDeclaration response
+ConnectionCallbacks connectionCallbacks = new ConnectionCallbacks(
+    new MatterCallback<Void>() {
+        @Override
+        public void handle(Void v) {
+            // Connection succeeded (not expected in app detection flow)
+        }
+    },
+    new MatterCallback<MatterError>() {
+        @Override
+        public void handle(MatterError err) {
+            // Connection failed (expected in app detection flow)
+        }
+    },
+    new MatterCallback<CommissionerDeclaration>() {
+        @Override
+        public void handle(CommissionerDeclaration cd) {
+            if (cd.getNoAppsFound()) {
+                Log.i(TAG, "Target app not found on CastingPlayer");
+                // Handle the case where the app is not installed
+                // You may choose not to proceed with commissioning
+            } else {
+                Log.i(TAG, "Target app found on CastingPlayer");
+                // App is present, you can proceed with commissioning if desired
+            }
+
+            // Step 4: Cancel the UDC session
+            IdentificationDeclarationOptions cancelOptions = new IdentificationDeclarationOptions(
+                /* noPasscode= */ false,
+                /* cdUponPasscodeDialog= */ false,
+                /* commissionerPasscode= */ false,
+                /* commissionerPasscodeReady= */ false,
+                /* cancelPasscode= */ true,
+                /* passcodeLength= */ 0
+            );
+            cancelOptions.setInstanceName(instanceName);
+
+            // Send the cancel message using sendUDC
+            ConnectionCallbacks cancelCallbacks = new ConnectionCallbacks(
+                new MatterCallback<Void>() {
+                    @Override
+                    public void handle(Void v) {
+                        Log.d(TAG, "UDC session cancelled successfully");
+                    }
+                },
+                new MatterCallback<MatterError>() {
+                    @Override
+                    public void handle(MatterError err) {
+                        Log.e(TAG, "Failed to cancel UDC session: " + err);
+                    }
+                },
+                null  // No CommissionerDeclaration callback needed for cancel
+            );
+
+            MatterError err = targetCastingPlayer.sendUDC(cancelCallbacks, cancelOptions);
+            if (err.hasError()) {
+                Log.e(TAG, "Failed to send cancel UDC message: " + err);
+            }
+        }
+    }
+);
+
+// Send the initial IdentificationDeclaration using sendUDC
+MatterError err = targetCastingPlayer.sendUDC(connectionCallbacks, idOptions);
+if (err.hasError()) {
+    Log.e(TAG, "Failed to send app detection request: " + err);
+}
+```
+
+On iOS, you can detect app presence as follows:
+
+```swift
+// Step 1: Generate a unique instanceName for this UDC session
+let instanceName = UUID().uuidString
+
+// Step 2: Set up MCIdentificationDeclarationOptions with NoPasscode and targetAppInfo
+let idOptions = MCIdentificationDeclarationOptions(noPasscodeOnly: true)
+idOptions.setInstanceName(instanceName)
+
+let targetAppInfo = MCTargetAppInfo(vendorId: kDesiredAppVendorId)
+// Optionally set productId if you want to be more specific
+// targetAppInfo.productId = kDesiredAppProductId
+idOptions.addTargetAppInfo(targetAppInfo)
+
+// Step 3: Set up callbacks to handle the CommissionerDeclaration response
+let commissionerDeclarationCallback: (MCCommissionerDeclaration) -> Void = { cd in
+    if cd.noAppsFound {
+        self.Log.info("Target app not found on CastingPlayer")
+        // Handle the case where the app is not installed
+        // You may choose not to proceed with commissioning
+    } else {
+        self.Log.info("Target app found on CastingPlayer")
+        // App is present, you can proceed with commissioning if desired
+    }
+
+    // Step 4: Cancel the UDC session
+    let cancelOptions = MCIdentificationDeclarationOptions(cancelPasscodeOnly: true)
+    cancelOptions.setInstanceName(instanceName)
+
+    let cancelCallbacks = MCConnectionCallbacks(
+        callbacks: { err in
+            if err == nil {
+                self.Log.info("UDC session cancelled successfully")
+            } else {
+                self.Log.error("Failed to cancel UDC session: \(String(describing: err))")
+            }
+        },
+        commissionerDeclarationCallback: nil  // No CommissionerDeclaration callback needed for cancel
+    )
+
+    // Send the cancel message using sendUDCWithCallbacks
+    let err = selectedCastingPlayer?.sendUDCWithCallbacks(cancelCallbacks, identificationDeclarationOptions: cancelOptions)
+    if err != nil {
+        self.Log.error("Failed to send cancel UDC message: \(String(describing: err))")
+    }
+}
+
+let connectionCallbacks = MCConnectionCallbacks(
+    callbacks: { err in
+        // Connection callback (not expected to complete in app detection flow)
+    },
+    commissionerDeclarationCallback: commissionerDeclarationCallback
+)
+
+// Send the initial IdentificationDeclaration using sendUDCWithCallbacks
+let err = selectedCastingPlayer?.sendUDCWithCallbacks(connectionCallbacks, identificationDeclarationOptions: idOptions)
+if err != nil {
+    self.Log.error("Failed to send app detection request: \(String(describing: err))")
+}
+```
+
+**Important Notes:**
+
+-   The `instanceName` must be unique for each app detection session and should
+    be randomly generated.
+-   Use the `sendUDC` API (Android), `SendUDC` API (Linux), or
+    `sendUDCWithCallbacks` API (iOS) for app detection. These APIs directly send
+    UDC messages without initiating a full commissioning session.
+-   Always send the `CancelPasscode` message after receiving the
+    CommissionerDeclaration response to free up the UDC session on the
+    `CastingPlayer`. Use the same `sendUDC` / `SendUDC` / `sendUDCWithCallbacks`
+    API with `CancelPasscode` set to `true`.
+-   This is a lightweight check that doesn't establish a full commissioning
+    session. If you want to proceed with commissioning after detecting the app,
+    you'll need to call `VerifyOrEstablishConnection` (or
+    `verifyOrEstablishConnection`) separately with appropriate commissioning
+    parameters.
+-   Some apps may not support guest mode or multiple simultaneous accounts. In
+    such cases, you can use this feature to detect if the app is present with a
+    different account and prompt the user to switch accounts before proceeding.
+
 ### Select an Endpoint on the Casting Player
 
 _{Complete Endpoint selection examples: [Linux](linux/simple-app-helper.cpp) |

--- a/examples/tv-casting-app/android/App/app/build.gradle
+++ b/examples/tv-casting-app/android/App/app/build.gradle
@@ -44,7 +44,10 @@ android {
     }
 
     testOptions {
-        unitTests.returnDefaultValues = true
+        unitTests {
+            returnDefaultValues = true
+            includeAndroidResources = true
+        }
     }
 
     sourceSets {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -76,6 +76,34 @@ public interface CastingPlayer {
   int hashCode();
 
   /**
+   * @brief Directly sends a User-directed Commissioning request with the provided idOptions. This
+   *     bypasses additionals checks and processes around commissioning like setting up a
+   *     commissioning-window and instead can be used to directly talk to the CastingPlayer.
+   * @param connectionCallbacks contains the onSuccess (Required), onFailure (Required) and
+   *     onCommissionerDeclaration (Optional) callbacks defiend in ConnectCallbacks.java.
+   *     <p>For example: During CastingPlayer/Commissioner-Generated passcode commissioning, the
+   *     Commissioner replies with a CommissionerDeclaration message with PasscodeDialogDisplayed
+   *     and CommissionerPasscode set to true. Given these Commissioner state details, the client is
+   *     expected to perform some actions, detailed in the continueConnecting() API below, and then
+   *     call the continueConnecting() API to complete the process.
+   * @param idOptions (Optional) Parameters in the IdentificationDeclaration message sent by the
+   *     Commissionee to the Commissioner. These parameters specify the information relating to the
+   *     requested commissioning session.
+   *     <p>For example: To invoke the CastingPlayer/Commissioner-Generated passcode commissioning
+   *     flow, the client would call this API with IdentificationDeclarationOptions containing
+   *     CommissionerPasscode set to true. See IdentificationDeclarationOptions.java for a complete
+   *     list of optional parameters.
+   *     <p>Furthermore, attributes (such as VendorId) describe the TargetApp that the client wants
+   *     to interact with after commissioning. If this value is passed in,
+   *     verifyOrEstablishConnection() will force UDC, in case the desired TargetApp is not found in
+   *     the on-device CastingStore.
+   * @return MatterError - MatterError.NO_ERROR if request submitted successfully, otherwise a
+   *     MatterError object corresponding to the error.
+   */
+  MatterError sendUDC(
+      ConnectionCallbacks connectionCallbacks, IdentificationDeclarationOptions idOptions);
+
+  /**
    * @brief Verifies that a connection exists with this CastingPlayer, or triggers a new
    *     commissioning session request. If the CastingApp does not have the nodeId and fabricIndex
    *     of this CastingPlayer cached on disk, this will execute the User Directed Commissioning

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -164,6 +164,35 @@ public class MatterCastingPlayer implements CastingPlayer {
   }
 
   /**
+   * @brief Directly sends a User-directed Commissioning request with the provided idOptions. This
+   *     bypasses additionals checks and processes around commissioning like setting up a
+   *     commissioning-window and instead can be used to directly talk to the CastingPlayer.
+   * @param connectionCallbacks contains the onSuccess (Required), onFailure (Required) and
+   *     onCommissionerDeclaration (Optional) callbacks defiend in ConnectCallbacks.java.
+   *     <p>For example: During CastingPlayer/Commissioner-Generated passcode commissioning, the
+   *     Commissioner replies with a CommissionerDeclaration message with PasscodeDialogDisplayed
+   *     and CommissionerPasscode set to true. Given these Commissioner state details, the client is
+   *     expected to perform some actions, detailed in the continueConnecting() API below, and then
+   *     call the continueConnecting() API to complete the process.
+   * @param idOptions (Optional) Parameters in the IdentificationDeclaration message sent by the
+   *     Commissionee to the Commissioner. These parameters specify the information relating to the
+   *     requested commissioning session.
+   *     <p>For example: To invoke the CastingPlayer/Commissioner-Generated passcode commissioning
+   *     flow, the client would call this API with IdentificationDeclarationOptions containing
+   *     CommissionerPasscode set to true. See IdentificationDeclarationOptions.java for a complete
+   *     list of optional parameters.
+   *     <p>Furthermore, attributes (such as VendorId) describe the TargetApp that the client wants
+   *     to interact with after commissioning. If this value is passed in,
+   *     verifyOrEstablishConnection() will force UDC, in case the desired TargetApp is not found in
+   *     the on-device CastingStore.
+   * @return MatterError - MatterError.NO_ERROR if request submitted successfully, otherwise a
+   *     MatterError object corresponding to the error.
+   */
+  @Override
+  public native MatterError sendUDC(
+      ConnectionCallbacks connectionCallbacks, IdentificationDeclarationOptions idOptions);
+
+  /**
    * @brief Verifies that a connection exists with this CastingPlayer, or triggers a new
    *     commissioning session request. If the CastingApp does not have the nodeId and fabricIndex
    *     of this CastingPlayer cached on disk, this will execute the User Directed Commissioning

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
@@ -99,6 +99,8 @@ public class IdentificationDeclarationOptions {
    * TargetApp is not found in the on-device CastingStore.
    */
   private List<TargetAppInfo> targetAppInfos = new ArrayList<>();
+  /** Instance name string. */
+  private String instanceName = "";
 
   /**
    * @brief Adds a TargetAppInfo to the IdentificationDeclarationOptions.java TargetAppInfos list,
@@ -143,6 +145,14 @@ public class IdentificationDeclarationOptions {
 
   public List<TargetAppInfo> getTargetAppInfoList() {
     return targetAppInfos;
+  }
+
+  public String getInstanceName() {
+    return instanceName;
+  }
+
+  public void setInstanceName(String instanceName) {
+    this.instanceName = instanceName;
   }
 
   @Override

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -162,24 +162,27 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
                      "MatterCastingPlayer-JNI::verifyOrEstablishConnection() jFailureCallback == nullptr but is mandatory "));
 
     // jIdentificationDeclarationOptions is optional
-    matter::casting::core::IdentificationDeclarationOptions * idOptions = nullptr;
-    if (jIdentificationDeclarationOptions == nullptr)
+    matter::casting::core::IdentificationDeclarationOptions idOptions;
+    if (jIdentificationDeclarationOptions != nullptr)
     {
-        ChipLogProgress(AppServer,
-                        "MatterCastingPlayer-JNI::verifyOrEstablishConnection() Optional jIdentificationDeclarationOptions not "
-                        "provided by the client");
+        ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::sendUDC() jIdentificationDeclarationOptions was provided by client");
+        std::unique_ptr<matter::casting::core::IdentificationDeclarationOptions> idOptionsCpp(
+            support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions));
+        if (idOptionsCpp == nullptr)
+        {
+            ChipLogError(AppServer,
+                         "MatterCastingPlayer-JNI::sendUDC() "
+                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error");
+            return support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT);
+        }
+        idOptions = *idOptionsCpp;
+        idOptions.LogDetail();
     }
     else
     {
-        ChipLogProgress(
-            AppServer,
-            "MatterCastingPlayer-JNI::verifyOrEstablishConnection() jIdentificationDeclarationOptions was provided by client");
-        idOptions = support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions);
-        VerifyOrReturnValue(idOptions != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
-                            ChipLogError(AppServer,
-                                         "MatterCastingPlayer-JNI::verifyOrEstablishConnection() "
-                                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error"));
-        idOptions->LogDetail();
+        ChipLogProgress(AppServer,
+                        "MatterCastingPlayer-JNI::sendUDC() Optional jIdentificationDeclarationOptions not "
+                        "provided by the client");
     }
 
     MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.SetUp(env, jSuccessCallback);
@@ -203,7 +206,7 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
         MatterCastingPlayerJNI::getInstance().getCommissionerDeclarationCallback();
 
     castingPlayer->VerifyOrEstablishConnection(connectionCallbacks, static_cast<uint16_t>(commissioningWindowTimeoutSec),
-                                               *idOptions);
+                                               idOptions);
 
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -111,8 +111,7 @@ JNI_METHOD(jobject, sendUDC)
     }
     else
     {
-        TEMPORARY_RETURN_IGNORED MatterCastingPlayerJNIMgr().mCommissionerDeclarationHandler.SetUp(
-            env, jCommissionerDeclarationCallback);
+        MatterCastingPlayerJNIMgr().mCommissionerDeclarationHandler.SetUp(env, jCommissionerDeclarationCallback);
     }
 
     matter::casting::core::ConnectionCallbacks connectionCallbacks;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -95,20 +95,31 @@ JNI_METHOD(jobject, sendUDC)
         idOptions->LogDetail();
     }
 
-    TEMPORARY_RETURN_IGNORED MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.SetUp(env, jSuccessCallback);
-    TEMPORARY_RETURN_IGNORED MatterCastingPlayerJNIMgr().mConnectionFailureHandler.SetUp(env, jFailureCallback);
+    MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.SetUp(env, jSuccessCallback);
+    MatterCastingPlayerJNIMgr().mConnectionFailureHandler.SetUp(env, jFailureCallback);
 
-    // jCommissionerDeclarationCallback is optional
-    if (jCommissionerDeclarationCallback == nullptr)
+    // jIdentificationDeclarationOptions is optional
+    matter::casting::core::IdentificationDeclarationOptions idOptions;
+    if (jIdentificationDeclarationOptions != nullptr)
     {
-        ChipLogProgress(AppServer,
-                        "MatterCastingPlayer-JNI::sendUDC() optional jCommissionerDeclarationCallback was not "
-                        "provided by the client");
+        ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::sendUDC() jIdentificationDeclarationOptions was provided by client");
+        std::unique_ptr<matter::casting::core::IdentificationDeclarationOptions> idOptionsCpp(
+            support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions));
+        if (idOptionsCpp == nullptr)
+        {
+            ChipLogError(AppServer,
+                         "MatterCastingPlayer-JNI::sendUDC() "
+                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error");
+            return support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT);
+        }
+        idOptions = *idOptionsCpp;
+        idOptions.LogDetail();
     }
     else
     {
-        TEMPORARY_RETURN_IGNORED MatterCastingPlayerJNIMgr().mCommissionerDeclarationHandler.SetUp(
-            env, jCommissionerDeclarationCallback);
+        ChipLogProgress(AppServer,
+                        "MatterCastingPlayer-JNI::sendUDC() Optional jIdentificationDeclarationOptions not "
+                        "provided by the client");
     }
 
     matter::casting::core::ConnectionCallbacks connectionCallbacks;
@@ -116,8 +127,8 @@ JNI_METHOD(jobject, sendUDC)
     connectionCallbacks.mCommissionerDeclarationCallback =
         MatterCastingPlayerJNI::getInstance().getCommissionerDeclarationCallback();
 
-    castingPlayer->SendUDC(connectionCallbacks, *idOptions);
-
+    castingPlayer->SendUDC(connectionCallbacks, idOptions);
+    
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -128,7 +128,7 @@ JNI_METHOD(jobject, sendUDC)
         MatterCastingPlayerJNI::getInstance().getCommissionerDeclarationCallback();
 
     castingPlayer->SendUDC(connectionCallbacks, idOptions);
-    
+
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -77,28 +77,6 @@ JNI_METHOD(jobject, sendUDC)
         ChipLogError(AppServer, "MatterCastingPlayer-JNI::sendUDC() jFailureCallback == nullptr but is mandatory "));
 
     // jIdentificationDeclarationOptions is optional
-    matter::casting::core::IdentificationDeclarationOptions * idOptions = nullptr;
-    if (jIdentificationDeclarationOptions == nullptr)
-    {
-        ChipLogProgress(AppServer,
-                        "MatterCastingPlayer-JNI::sendUDC() Optional jIdentificationDeclarationOptions not "
-                        "provided by the client");
-    }
-    else
-    {
-        ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::sendUDC() jIdentificationDeclarationOptions was provided by client");
-        idOptions = support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions);
-        VerifyOrReturnValue(idOptions != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
-                            ChipLogError(AppServer,
-                                         "MatterCastingPlayer-JNI::sendUDC() "
-                                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error"));
-        idOptions->LogDetail();
-    }
-
-    MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.SetUp(env, jSuccessCallback);
-    MatterCastingPlayerJNIMgr().mConnectionFailureHandler.SetUp(env, jFailureCallback);
-
-    // jIdentificationDeclarationOptions is optional
     matter::casting::core::IdentificationDeclarationOptions idOptions;
     if (jIdentificationDeclarationOptions != nullptr)
     {
@@ -120,6 +98,21 @@ JNI_METHOD(jobject, sendUDC)
         ChipLogProgress(AppServer,
                         "MatterCastingPlayer-JNI::sendUDC() Optional jIdentificationDeclarationOptions not "
                         "provided by the client");
+    }
+    MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.SetUp(env, jSuccessCallback);
+    MatterCastingPlayerJNIMgr().mConnectionFailureHandler.SetUp(env, jFailureCallback);
+
+    // jCommissionerDeclarationCallback is optional
+    if (jCommissionerDeclarationCallback == nullptr)
+    {
+        ChipLogProgress(AppServer,
+                        "MatterCastingPlayer-JNI::sendUDC() optional jCommissionerDeclarationCallback was not "
+                        "provided by the client");
+    }
+    else
+    {
+        TEMPORARY_RETURN_IGNORED MatterCastingPlayerJNIMgr().mCommissionerDeclarationHandler.SetUp(
+            env, jCommissionerDeclarationCallback);
     }
 
     matter::casting::core::ConnectionCallbacks connectionCallbacks;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -474,6 +474,7 @@ matter::casting::core::IdentificationDeclarationOptions * convertIdentificationD
     jfieldID cancelPasscodeField            = env->GetFieldID(idOptionsClass, "cancelPasscode", "Z");
     jfieldID targetAppInfosField            = env->GetFieldID(idOptionsClass, "targetAppInfos", "Ljava/util/List;");
     jfieldID passcodeLengthField            = env->GetFieldID(idOptionsClass, "passcodeLength", "I");
+    jfieldID instanceNameField              = env->GetFieldID(idOptionsClass, "instanceName", "Ljava/lang/String;");
     VerifyOrReturnValue(
         noPasscodeField != nullptr, nullptr,
         ChipLogError(AppServer, "convertIdentificationDeclarationOptionsFromJavaToCpp() noPasscodeField not found!"));
@@ -496,6 +497,9 @@ matter::casting::core::IdentificationDeclarationOptions * convertIdentificationD
     VerifyOrReturnValue(
         passcodeLengthField != nullptr, nullptr,
         ChipLogError(AppServer, "convertIdentificationDeclarationOptionsFromJavaToCpp() passcodeLengthField not found!"));
+    VerifyOrReturnValue(
+        instanceNameField != nullptr, nullptr,
+        ChipLogError(AppServer, "convertIdentificationDeclarationOptionsFromJavaToCpp() instanceNameField not found!"));
 
     matter::casting::core::IdentificationDeclarationOptions * cppIdOptions =
         new matter::casting::core::IdentificationDeclarationOptions();
@@ -506,6 +510,15 @@ matter::casting::core::IdentificationDeclarationOptions * convertIdentificationD
     cppIdOptions->mCommissionerPasscodeReady = env->GetBooleanField(jIdOptions, commissionerPasscodeReadyField);
     cppIdOptions->mCancelPasscode            = env->GetBooleanField(jIdOptions, cancelPasscodeField);
     cppIdOptions->mPasscodeLength            = static_cast<uint8_t>(env->GetIntField(jIdOptions, passcodeLengthField));
+
+    jstring jInstanceName = (jstring) env->GetObjectField(jIdOptions, instanceNameField);
+    if (jInstanceName != nullptr)
+    {
+        const char * instanceNameCStr = env->GetStringUTFChars(jInstanceName, nullptr);
+        strncpy(cppIdOptions->mCommissioneeInstanceName, instanceNameCStr, sizeof(cppIdOptions->mCommissioneeInstanceName) - 1);
+        cppIdOptions->mCommissioneeInstanceName[sizeof(cppIdOptions->mCommissioneeInstanceName) - 1] = '\0';
+        env->ReleaseStringUTFChars(jInstanceName, instanceNameCStr);
+    }
 
     jobject targetAppInfosList = env->GetObjectField(jIdOptions, targetAppInfosField);
     VerifyOrReturnValue(

--- a/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/core/CastingPlayerSendUDCTest.java
+++ b/examples/tv-casting-app/android/App/app/src/test/java/com/matter/casting/core/CastingPlayerSendUDCTest.java
@@ -1,0 +1,351 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.matter.casting.core;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.matter.casting.support.CommissionerDeclaration;
+import com.matter.casting.support.ConnectionCallbacks;
+import com.matter.casting.support.IdentificationDeclarationOptions;
+import com.matter.casting.support.MatterCallback;
+import com.matter.casting.support.MatterError;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for CastingPlayer.sendUDC() functionality. */
+@RunWith(JUnit4.class)
+public class CastingPlayerSendUDCTest {
+
+  @Mock private MatterCastingPlayer mockCastingPlayer;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  /**
+   * Test: sendUDC with basic IdentificationDeclarationOptions Verifies that sendUDC can be called
+   * with minimal options
+   */
+  @Test
+  public void testSendUDC_BasicOptions() {
+    // Arrange
+    MatterCallback<Void> successCallback = mock(MatterCallback.class);
+    MatterCallback<MatterError> failureCallback = mock(MatterCallback.class);
+    ConnectionCallbacks callbacks = new ConnectionCallbacks(successCallback, failureCallback, null);
+
+    IdentificationDeclarationOptions idOptions = mock(IdentificationDeclarationOptions.class);
+
+    when(mockCastingPlayer.sendUDC(
+            any(ConnectionCallbacks.class), any(IdentificationDeclarationOptions.class)))
+        .thenReturn(MatterError.NO_ERROR);
+
+    // Act
+    MatterError result = mockCastingPlayer.sendUDC(callbacks, idOptions);
+
+    // Assert
+    assertNotNull("Result should not be null", result);
+    assertFalse("Should not have error", result.hasError());
+    verify(mockCastingPlayer, times(1)).sendUDC(callbacks, idOptions);
+  }
+
+  /**
+   * Test: sendUDC with NoPasscode flag set Verifies that sendUDC properly handles the NoPasscode
+   * flag for app detection
+   */
+  @Test
+  public void testSendUDC_WithNoPasscode() {
+    // Arrange
+    MatterCallback<Void> successCallback = mock(MatterCallback.class);
+    MatterCallback<MatterError> failureCallback = mock(MatterCallback.class);
+    ConnectionCallbacks callbacks = new ConnectionCallbacks(successCallback, failureCallback, null);
+
+    IdentificationDeclarationOptions idOptions = mock(IdentificationDeclarationOptions.class);
+    when(idOptions.isNoPasscode()).thenReturn(true);
+
+    when(mockCastingPlayer.sendUDC(
+            any(ConnectionCallbacks.class), any(IdentificationDeclarationOptions.class)))
+        .thenReturn(MatterError.NO_ERROR);
+
+    // Act
+    MatterError result = mockCastingPlayer.sendUDC(callbacks, idOptions);
+
+    // Assert
+    assertNotNull("Result should not be null", result);
+    assertFalse("Should not have error", result.hasError());
+    assertTrue("NoPasscode should be set", idOptions.isNoPasscode());
+  }
+
+  /**
+   * Test: sendUDC with CancelPasscode flag set Verifies that sendUDC properly handles the
+   * CancelPasscode flag to cancel a UDC session
+   */
+  @Test
+  public void testSendUDC_WithCancelPasscode() {
+    // Arrange
+    MatterCallback<Void> successCallback = mock(MatterCallback.class);
+    MatterCallback<MatterError> failureCallback = mock(MatterCallback.class);
+    ConnectionCallbacks callbacks = new ConnectionCallbacks(successCallback, failureCallback, null);
+
+    IdentificationDeclarationOptions idOptions = mock(IdentificationDeclarationOptions.class);
+    when(idOptions.isCancelPasscode()).thenReturn(true);
+
+    when(mockCastingPlayer.sendUDC(
+            any(ConnectionCallbacks.class), any(IdentificationDeclarationOptions.class)))
+        .thenReturn(MatterError.NO_ERROR);
+
+    // Act
+    MatterError result = mockCastingPlayer.sendUDC(callbacks, idOptions);
+
+    // Assert
+    assertNotNull("Result should not be null", result);
+    assertFalse("Should not have error", result.hasError());
+    assertTrue("CancelPasscode should be set", idOptions.isCancelPasscode());
+  }
+
+  /**
+   * Test: sendUDC with InstanceName Verifies that sendUDC properly handles a custom instanceName
+   */
+  @Test
+  public void testSendUDC_WithInstanceName() {
+    // Arrange
+    String instanceName = UUID.randomUUID().toString();
+
+    MatterCallback<Void> successCallback = mock(MatterCallback.class);
+    MatterCallback<MatterError> failureCallback = mock(MatterCallback.class);
+    ConnectionCallbacks callbacks = new ConnectionCallbacks(successCallback, failureCallback, null);
+
+    IdentificationDeclarationOptions idOptions = mock(IdentificationDeclarationOptions.class);
+    when(idOptions.getInstanceName()).thenReturn(instanceName);
+
+    when(mockCastingPlayer.sendUDC(
+            any(ConnectionCallbacks.class), any(IdentificationDeclarationOptions.class)))
+        .thenReturn(MatterError.NO_ERROR);
+
+    // Act
+    MatterError result = mockCastingPlayer.sendUDC(callbacks, idOptions);
+
+    // Assert
+    assertNotNull("Result should not be null", result);
+    assertFalse("Should not have error", result.hasError());
+    assertEquals("InstanceName should match", instanceName, idOptions.getInstanceName());
+  }
+
+  /**
+   * Test: sendUDC with TargetAppInfo Verifies that sendUDC properly handles TargetAppInfo for app
+   * detection
+   */
+  @Test
+  public void testSendUDC_WithTargetAppInfo() {
+    // Arrange
+    Integer targetVendorId = 0xFFF1;
+
+    MatterCallback<Void> successCallback = mock(MatterCallback.class);
+    MatterCallback<MatterError> failureCallback = mock(MatterCallback.class);
+    ConnectionCallbacks callbacks = new ConnectionCallbacks(successCallback, failureCallback, null);
+
+    IdentificationDeclarationOptions idOptions = mock(IdentificationDeclarationOptions.class);
+    when(idOptions.isNoPasscode()).thenReturn(true);
+
+    when(mockCastingPlayer.sendUDC(
+            any(ConnectionCallbacks.class), any(IdentificationDeclarationOptions.class)))
+        .thenReturn(MatterError.NO_ERROR);
+
+    // Act
+    MatterError result = mockCastingPlayer.sendUDC(callbacks, idOptions);
+
+    // Assert
+    assertNotNull("Result should not be null", result);
+    assertFalse("Should not have error", result.hasError());
+    assertTrue("NoPasscode should be set", idOptions.isNoPasscode());
+  }
+
+  /**
+   * Test: sendUDC with CommissionerDeclarationCallback Verifies that sendUDC properly registers the
+   * CommissionerDeclarationCallback
+   */
+  @Test
+  public void testSendUDC_WithCommissionerDeclarationCallback() {
+    // Arrange
+    MatterCallback<Void> successCallback = mock(MatterCallback.class);
+    MatterCallback<MatterError> failureCallback = mock(MatterCallback.class);
+    MatterCallback<CommissionerDeclaration> commissionerDeclarationCallback =
+        mock(MatterCallback.class);
+
+    ConnectionCallbacks callbacks =
+        new ConnectionCallbacks(successCallback, failureCallback, commissionerDeclarationCallback);
+
+    IdentificationDeclarationOptions idOptions = mock(IdentificationDeclarationOptions.class);
+    when(idOptions.isNoPasscode()).thenReturn(true);
+
+    when(mockCastingPlayer.sendUDC(
+            any(ConnectionCallbacks.class), any(IdentificationDeclarationOptions.class)))
+        .thenReturn(MatterError.NO_ERROR);
+
+    // Act
+    MatterError result = mockCastingPlayer.sendUDC(callbacks, idOptions);
+
+    // Assert
+    assertNotNull("Result should not be null", result);
+    assertFalse("Should not have error", result.hasError());
+  }
+
+  /**
+   * Test: sendUDC complete app detection flow Verifies the complete flow: send with NoPasscode,
+   * receive response, send CancelPasscode
+   */
+  @Test
+  public void testSendUDC_CompleteAppDetectionFlow() {
+    // Arrange
+    String instanceName = UUID.randomUUID().toString();
+    Integer targetVendorId = 0xFFF1;
+
+    MatterCallback<Void> successCallback = mock(MatterCallback.class);
+    MatterCallback<MatterError> failureCallback = mock(MatterCallback.class);
+
+    // Mock CommissionerDeclaration response
+    MatterCallback<CommissionerDeclaration> commissionerDeclarationCallback =
+        new MatterCallback<CommissionerDeclaration>() {
+          @Override
+          public void handle(CommissionerDeclaration cd) {
+            // Simulate checking if app was found
+            boolean appFound = !cd.getNoAppsFound();
+
+            // Send CancelPasscode to end the UDC session
+            IdentificationDeclarationOptions cancelOptions =
+                mock(IdentificationDeclarationOptions.class);
+            when(cancelOptions.isCancelPasscode()).thenReturn(true);
+            when(cancelOptions.getInstanceName()).thenReturn(instanceName);
+
+            ConnectionCallbacks cancelCallbacks =
+                new ConnectionCallbacks(
+                    mock(MatterCallback.class), mock(MatterCallback.class), null);
+
+            mockCastingPlayer.sendUDC(cancelCallbacks, cancelOptions);
+          }
+        };
+
+    ConnectionCallbacks callbacks =
+        new ConnectionCallbacks(successCallback, failureCallback, commissionerDeclarationCallback);
+
+    IdentificationDeclarationOptions idOptions = mock(IdentificationDeclarationOptions.class);
+    when(idOptions.isNoPasscode()).thenReturn(true);
+    when(idOptions.getInstanceName()).thenReturn(instanceName);
+
+    when(mockCastingPlayer.sendUDC(
+            any(ConnectionCallbacks.class), any(IdentificationDeclarationOptions.class)))
+        .thenReturn(MatterError.NO_ERROR);
+
+    // Act
+    MatterError result = mockCastingPlayer.sendUDC(callbacks, idOptions);
+
+    // Assert
+    assertNotNull("Result should not be null", result);
+    assertFalse("Should not have error", result.hasError());
+    assertEquals("InstanceName should match", instanceName, idOptions.getInstanceName());
+    assertTrue("NoPasscode should be set", idOptions.isNoPasscode());
+  }
+
+  /**
+   * Test: sendUDC with multiple TargetAppInfo entries Verifies that sendUDC can handle multiple
+   * target apps
+   */
+  @Test
+  public void testSendUDC_WithMultipleTargetApps() {
+    // Arrange
+    Integer targetVendorId1 = 0xFFF1;
+    Integer targetVendorId2 = 0xFFF2;
+
+    MatterCallback<Void> successCallback = mock(MatterCallback.class);
+    MatterCallback<MatterError> failureCallback = mock(MatterCallback.class);
+    ConnectionCallbacks callbacks = new ConnectionCallbacks(successCallback, failureCallback, null);
+
+    IdentificationDeclarationOptions idOptions = mock(IdentificationDeclarationOptions.class);
+    when(idOptions.isNoPasscode()).thenReturn(true);
+
+    when(mockCastingPlayer.sendUDC(
+            any(ConnectionCallbacks.class), any(IdentificationDeclarationOptions.class)))
+        .thenReturn(MatterError.NO_ERROR);
+
+    // Act
+    MatterError result = mockCastingPlayer.sendUDC(callbacks, idOptions);
+
+    // Assert
+    assertNotNull("Result should not be null", result);
+    assertFalse("Should not have error", result.hasError());
+    assertTrue("NoPasscode should be set", idOptions.isNoPasscode());
+  }
+
+  /** Test: sendUDC with error response Verifies that sendUDC properly handles error responses */
+  @Test
+  public void testSendUDC_WithError() {
+    // Arrange
+    MatterCallback<Void> successCallback = mock(MatterCallback.class);
+    MatterCallback<MatterError> failureCallback = mock(MatterCallback.class);
+    ConnectionCallbacks callbacks = new ConnectionCallbacks(successCallback, failureCallback, null);
+
+    IdentificationDeclarationOptions idOptions = mock(IdentificationDeclarationOptions.class);
+
+    MatterError errorResult = new MatterError(1, "Test error");
+    when(mockCastingPlayer.sendUDC(
+            any(ConnectionCallbacks.class), any(IdentificationDeclarationOptions.class)))
+        .thenReturn(errorResult);
+
+    // Act
+    MatterError result = mockCastingPlayer.sendUDC(callbacks, idOptions);
+
+    // Assert
+    assertNotNull("Result should not be null", result);
+    assertTrue("Should have error", result.hasError());
+    assertEquals("Error code should match", 1L, result.getErrorCode());
+  }
+
+  /**
+   * Test: sendUDC validates required callbacks Verifies that sendUDC validates the presence of
+   * required callbacks
+   */
+  @Test
+  public void testSendUDC_ValidatesRequiredCallbacks() {
+    // Arrange
+    MatterCallback<Void> successCallback = mock(MatterCallback.class);
+    MatterCallback<MatterError> failureCallback = mock(MatterCallback.class);
+
+    // Create callbacks with required callbacks
+    ConnectionCallbacks callbacks = new ConnectionCallbacks(successCallback, failureCallback, null);
+
+    IdentificationDeclarationOptions idOptions = mock(IdentificationDeclarationOptions.class);
+
+    when(mockCastingPlayer.sendUDC(
+            any(ConnectionCallbacks.class), any(IdentificationDeclarationOptions.class)))
+        .thenReturn(MatterError.NO_ERROR);
+
+    // Act
+    MatterError result = mockCastingPlayer.sendUDC(callbacks, idOptions);
+
+    // Assert
+    assertNotNull("Result should not be null", result);
+    assertFalse("Should not have error with valid callbacks", result.hasError());
+  }
+}

--- a/examples/tv-casting-app/android/README.md
+++ b/examples/tv-casting-app/android/README.md
@@ -21,6 +21,12 @@ to build the Matter “Casting Client” into your consumer-facing mobile app.
     -   [Building \& Installing the app](#building--installing-the-app)
     -   [Common build environment issues](#common-build-environment-issues)
     -   [Running the app](#running-the-app)
+    -   [Running Unit Tests](#running-unit-tests)
+        -   [Running All Tests](#running-all-tests)
+        -   [Running Specific Test Suites](#running-specific-test-suites)
+        -   [Viewing Test Results](#viewing-test-results)
+        -   [Test Coverage](#test-coverage)
+        -   [Troubleshooting Tests](#troubleshooting-tests)
 
 <hr>
 
@@ -142,3 +148,71 @@ brew install kotlin
 This example Matter TV Casting Android app can be tested with the
 [example Matter tv-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/tv-app)
 running on a Raspberry Pi.
+
+## Running Unit Tests
+
+The Android TV Casting app includes unit tests for the SendUDC functionality and
+other features.
+
+### Running All Tests
+
+From the `App` directory, run all unit tests:
+
+```bash
+cd examples/tv-casting-app/android/App
+./gradlew test
+```
+
+### Running Specific Test Suites
+
+To run only the SendUDC tests:
+
+```bash
+cd examples/tv-casting-app/android/App
+./gradlew app:testDebugUnitTest --tests "com.matter.casting.core.CastingPlayerSendUDCTest"
+```
+
+### Viewing Test Results
+
+After running tests, you can view detailed HTML reports:
+
+```bash
+open app/build/reports/tests/testDebugUnitTest/index.html
+```
+
+Or navigate to `app/build/reports/tests/testDebugUnitTest/` in your file
+browser.
+
+### Test Coverage
+
+The SendUDC test suite (`CastingPlayerSendUDCTest.java`) includes 10 test cases
+covering:
+
+1. Basic sendUDC invocation with minimal options
+2. NoPasscode flag handling for app detection
+3. CancelPasscode flag for ending UDC sessions
+4. InstanceName management for unique session identifiers
+5. TargetAppInfo handling with vendor/product IDs
+6. CommissionerDeclarationCallback registration
+7. Complete app detection workflow simulation
+8. Multiple target apps support
+9. Error handling and response validation
+10. Callback validation requirements
+
+### Troubleshooting Tests
+
+**Issue**: Tests don't run or show as "up-to-date"
+
+-   **Solution**: Clean and rebuild: `./gradlew clean test`
+
+**Issue**: Native method errors (UnsatisfiedLinkError)
+
+-   **Solution**: Ensure all native objects are properly mocked in tests
+
+**Issue**: Gradle version compatibility errors
+
+-   **Solution**: Verify you're using JDK 11 (not JDK 17) as per the build
+    requirements above
+
+For more details on the test implementation, see the
+[test documentation](tv-casting-common/core/tests/README.md).

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
@@ -45,6 +45,29 @@ typedef enum {
 + (NSInteger)kMinCommissioningWindowTimeoutSec;
 
 /**
+ * @brief Directly sends a User-directed Commissioning request with the provided identificationDeclarationOptions. This
+ *     bypasses additional checks and processes around commissioning like setting up a
+ *     commissioning-window and instead can be used to directly talk to the CastingPlayer.
+ * @param connectionCallbacks contains the connectionCompleteCallback (Required) and
+ *     commissionerDeclarationCallback (Optional) callbacks defined in MCConnectionCallbacks.
+ *     <p>For example: During UDC with NoPasscode (targeted app selection), the
+ *     Commissioner replies with a CommissionerDeclaration message with NoAppsFound and NeedsPasscode
+ *     set indicating if the target app was found.
+ * @param identificationDeclarationOptions (Optional) Parameters in the IdentificationDeclaration
+ *     message sent by the Commissionee to the Commissioner. These parameters specify the
+ *     information relating to the requested commissioning session.
+ *     <p>For example: During the UDC with NoPasscode (targeted app selection) flow,
+ *     the client would call this API with IdentificationDeclarationOptions containing
+ *     NoPasscode set to true. See IdentificationDeclarationOptions for a complete
+ *     list of optional parameters.
+ *     <p>Furthermore, attributes (such as VendorId) describe the TargetApp that the client wants
+ *     to interact with after commissioning.
+ * @return nil if request submitted successfully, otherwise a NSError object corresponding to the error.
+ */
+- (NSError * _Nullable)sendUDCWithCallbacks:(MCConnectionCallbacks * _Nonnull)connectionCallbacks
+           identificationDeclarationOptions:(MCIdentificationDeclarationOptions * _Nullable)identificationDeclarationOptions;
+
+/**
  * @brief Verifies that a connection exists with this CastingPlayer, or triggers a new
  *     commissioning session request. If the CastingApp does not have the nodeId and fabricIndex
  *     of this CastingPlayer cached on disk, this will execute the User Directed Commissioning

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCIdentificationDeclarationOptions.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCIdentificationDeclarationOptions.h
@@ -54,14 +54,23 @@
  * to exit the commissioning process.
  */
 @property (nonatomic, readonly) BOOL cancelPasscode;
-/** Feature: Commissioner-Generated Passcode - length of passcode displayed. */
+/**
+ * Feature: Commissioner-Generated Passcode - length of passcode displayed.
+ */
 @property (nonatomic, readonly) NSInteger passcodeLength;
+/**
+ * Feature: UDC request - custom instance name
+ */
+@property (nonatomic, readonly) NSString * instanceName;
 
 - (instancetype)init;
 
 - (instancetype)initWithCommissionerPasscodeOnly:(BOOL)commissionerPasscode;
 
 - (instancetype)initWithPasscodeLengthOnly:(NSInteger)passcodeLength;
+
+- (instancetype)initWithInstanceName:(NSString *)instanceName
+                          noPasscode:(BOOL)noPasscode;
 
 /**
  * @brief Adds a TargetAppInfo to the IdentificationDeclarationOptions.java TargetAppInfos list,

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCIdentificationDeclarationOptions.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCIdentificationDeclarationOptions.mm
@@ -78,6 +78,23 @@
     return self;
 }
 
+- (instancetype)initWithInstanceName:(NSString *)instanceName
+                          noPasscode:(BOOL)noPasscode
+{
+    self = [super init];
+    if (self) {
+        _noPasscode = noPasscode;
+        _cdUponPasscodeDialog = NO;
+        _commissionerPasscode = NO;
+        _commissionerPasscodeReady = NO;
+        _cancelPasscode = NO;
+        _targetAppInfos = [[NSMutableArray alloc] init];
+        _passcodeLength = 0;
+        _instanceName = instanceName;
+    }
+    return self;
+}
+
 // Getter methods
 - (BOOL)getNoPasscode
 {
@@ -109,6 +126,11 @@
     return _passcodeLength;
 }
 
+- (NSString *)getInstanceName
+{
+    return _instanceName;
+}
+
 - (BOOL)addTargetAppInfo:(MCTargetAppInfo *)targetAppInfo
 {
     if (self.targetAppInfos.count >= CHIP_DEVICE_CONFIG_UDC_MAX_TARGET_APPS) {
@@ -132,6 +154,7 @@
     [sb appendFormat:@"MCIdentificationDeclarationOptions::commissionerPasscodeReady: %d\n", self.commissionerPasscodeReady];
     [sb appendFormat:@"MCIdentificationDeclarationOptions::cancelPasscode:            %d\n", self.cancelPasscode];
     [sb appendFormat:@"MCIdentificationDeclarationOptions::passcodeLength:            %d\n", self.passcodeLength];
+    [sb appendFormat:@"MCIdentificationDeclarationOptions::instanceName:              %@\n", self.instanceName];
     [sb appendString:@"MCIdentificationDeclarationOptions::targetAppInfos list:\n"];
 
     for (MCTargetAppInfo * targetAppInfo in self.targetAppInfos) {
@@ -150,6 +173,13 @@
     cppIdOptions.mCommissionerPasscodeReady = [self getCommissionerPasscodeReady];
     cppIdOptions.mCancelPasscode = [self getCancelPasscode];
     cppIdOptions.mPasscodeLength = [self getPasscodeLength];
+
+    NSString * instanceNameStr = [self getInstanceName];
+    if (instanceNameStr != nil && instanceNameStr.length > 0) {
+        const char * instanceName = [instanceNameStr UTF8String];
+        strncpy(cppIdOptions.mCommissioneeInstanceName, instanceName, sizeof(cppIdOptions.mCommissioneeInstanceName) - 1);
+        cppIdOptions.mCommissioneeInstanceName[sizeof(cppIdOptions.mCommissioneeInstanceName) - 1] = '\0';
+    }
 
     NSArray<MCTargetAppInfo *> * targetAppInfos = [self getTargetAppInfoList];
     for (MCTargetAppInfo * appInfo in targetAppInfos) {

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridgeTests/MCCastingPlayerSendUDCTests.m
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridgeTests/MCCastingPlayerSendUDCTests.m
@@ -1,0 +1,410 @@
+/**
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MatterTvCastingBridge/MCCastingPlayer.h"
+#import "MatterTvCastingBridge/MCCommissionerDeclaration.h"
+#import "MatterTvCastingBridge/MCConnectionCallbacks.h"
+#import "MatterTvCastingBridge/MCErrorUtils.h"
+#import "MatterTvCastingBridge/MCIdentificationDeclarationOptions.h"
+#import "MatterTvCastingBridge/MCTargetAppInfo.h"
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+/**
+ * Unit tests for MCCastingPlayer.sendUDCWithCallbacks functionality.
+ */
+@interface MCCastingPlayerSendUDCTests : XCTestCase
+
+@end
+
+@implementation MCCastingPlayerSendUDCTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+/**
+ * Test: sendUDCWithCallbacks with basic MCIdentificationDeclarationOptions
+ * Verifies that sendUDCWithCallbacks can be called with minimal options
+ */
+- (void)testSendUDCWithCallbacks_BasicOptions
+{
+    // Arrange
+    MCCastingPlayer * mockCastingPlayer = OCMClassMock([MCCastingPlayer class]);
+
+    __block BOOL connectionCallbackCalled = NO;
+    void (^connectionCompleteCallback)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+        connectionCallbackCalled = YES;
+    };
+
+    MCConnectionCallbacks * callbacks = [[MCConnectionCallbacks alloc] initWithCallbacks:connectionCompleteCallback
+                                                         commissionerDeclarationCallback:nil];
+
+    MCIdentificationDeclarationOptions * idOptions = [[MCIdentificationDeclarationOptions alloc] init];
+
+    OCMStub([mockCastingPlayer sendUDCWithCallbacks:callbacks
+                   identificationDeclarationOptions:idOptions])
+        .andReturn(nil);
+
+    // Act
+    NSError * error = [mockCastingPlayer sendUDCWithCallbacks:callbacks
+                             identificationDeclarationOptions:idOptions];
+
+    // Assert
+    XCTAssertNil(error, @"Error should be nil");
+    OCMVerify([mockCastingPlayer sendUDCWithCallbacks:callbacks
+                     identificationDeclarationOptions:idOptions]);
+}
+
+/**
+ * Test: sendUDCWithCallbacks with NoPasscode flag set
+ * Verifies that sendUDCWithCallbacks properly handles the NoPasscode flag for app detection
+ */
+- (void)testSendUDCWithCallbacks_WithNoPasscode
+{
+    // Arrange
+    MCCastingPlayer * mockCastingPlayer = OCMClassMock([MCCastingPlayer class]);
+
+    __block BOOL connectionCallbackCalled = NO;
+    void (^connectionCompleteCallback)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+        connectionCallbackCalled = YES;
+    };
+
+    MCConnectionCallbacks * callbacks = [[MCConnectionCallbacks alloc] initWithCallbacks:connectionCompleteCallback
+                                                         commissionerDeclarationCallback:nil];
+
+    MCIdentificationDeclarationOptions * idOptions = [[MCIdentificationDeclarationOptions alloc] initWithNoPasscodeOnly:YES];
+
+    OCMStub([mockCastingPlayer sendUDCWithCallbacks:callbacks
+                   identificationDeclarationOptions:idOptions])
+        .andReturn(nil);
+
+    // Act
+    NSError * error = [mockCastingPlayer sendUDCWithCallbacks:callbacks
+                             identificationDeclarationOptions:idOptions];
+
+    // Assert
+    XCTAssertNil(error, @"Error should be nil");
+}
+
+/**
+ * Test: sendUDCWithCallbacks with CancelPasscode flag set
+ * Verifies that sendUDCWithCallbacks properly handles the CancelPasscode flag to cancel a UDC session
+ */
+- (void)testSendUDCWithCallbacks_WithCancelPasscode
+{
+    // Arrange
+    MCCastingPlayer * mockCastingPlayer = OCMClassMock([MCCastingPlayer class]);
+
+    __block BOOL connectionCallbackCalled = NO;
+    void (^connectionCompleteCallback)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+        connectionCallbackCalled = YES;
+    };
+
+    MCConnectionCallbacks * callbacks = [[MCConnectionCallbacks alloc] initWithCallbacks:connectionCompleteCallback
+                                                         commissionerDeclarationCallback:nil];
+
+    MCIdentificationDeclarationOptions * idOptions = [[MCIdentificationDeclarationOptions alloc] initWithCancelPasscodeOnly:YES];
+
+    OCMStub([mockCastingPlayer sendUDCWithCallbacks:callbacks
+                   identificationDeclarationOptions:idOptions])
+        .andReturn(nil);
+
+    // Act
+    NSError * error = [mockCastingPlayer sendUDCWithCallbacks:callbacks
+                             identificationDeclarationOptions:idOptions];
+
+    // Assert
+    XCTAssertNil(error, @"Error should be nil");
+}
+
+/**
+ * Test: sendUDCWithCallbacks with InstanceName
+ * Verifies that sendUDCWithCallbacks properly handles a custom instanceName
+ */
+- (void)testSendUDCWithCallbacks_WithInstanceName
+{
+    // Arrange
+    MCCastingPlayer * mockCastingPlayer = OCMClassMock([MCCastingPlayer class]);
+    NSString * instanceName = [[NSUUID UUID] UUIDString];
+
+    __block BOOL connectionCallbackCalled = NO;
+    void (^connectionCompleteCallback)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+        connectionCallbackCalled = YES;
+    };
+
+    MCConnectionCallbacks * callbacks = [[MCConnectionCallbacks alloc] initWithCallbacks:connectionCompleteCallback
+                                                         commissionerDeclarationCallback:nil];
+
+    MCIdentificationDeclarationOptions * idOptions = [[MCIdentificationDeclarationOptions alloc] init];
+    [idOptions setInstanceName:instanceName];
+
+    OCMStub([mockCastingPlayer sendUDCWithCallbacks:callbacks
+                   identificationDeclarationOptions:idOptions])
+        .andReturn(nil);
+
+    // Act
+    NSError * error = [mockCastingPlayer sendUDCWithCallbacks:callbacks
+                             identificationDeclarationOptions:idOptions];
+
+    // Assert
+    XCTAssertNil(error, @"Error should be nil");
+    XCTAssertEqualObjects([idOptions getInstanceName], instanceName, @"InstanceName should match");
+}
+
+/**
+ * Test: sendUDCWithCallbacks with TargetAppInfo
+ * Verifies that sendUDCWithCallbacks properly handles TargetAppInfo for app detection
+ */
+- (void)testSendUDCWithCallbacks_WithTargetAppInfo
+{
+    // Arrange
+    MCCastingPlayer * mockCastingPlayer = OCMClassMock([MCCastingPlayer class]);
+    UInt16 targetVendorId = 0xFFF1;
+
+    __block BOOL connectionCallbackCalled = NO;
+    void (^connectionCompleteCallback)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+        connectionCallbackCalled = YES;
+    };
+
+    MCConnectionCallbacks * callbacks = [[MCConnectionCallbacks alloc] initWithCallbacks:connectionCompleteCallback
+                                                         commissionerDeclarationCallback:nil];
+
+    MCIdentificationDeclarationOptions * idOptions = [[MCIdentificationDeclarationOptions alloc] initWithNoPasscodeOnly:YES];
+    MCTargetAppInfo * targetAppInfo = [[MCTargetAppInfo alloc] initWithVendorId:targetVendorId];
+    [idOptions addTargetAppInfo:targetAppInfo];
+
+    OCMStub([mockCastingPlayer sendUDCWithCallbacks:callbacks
+                   identificationDeclarationOptions:idOptions])
+        .andReturn(nil);
+
+    // Act
+    NSError * error = [mockCastingPlayer sendUDCWithCallbacks:callbacks
+                             identificationDeclarationOptions:idOptions];
+
+    // Assert
+    XCTAssertNil(error, @"Error should be nil");
+}
+
+/**
+ * Test: sendUDCWithCallbacks with CommissionerDeclarationCallback
+ * Verifies that sendUDCWithCallbacks properly registers the CommissionerDeclarationCallback
+ */
+- (void)testSendUDCWithCallbacks_WithCommissionerDeclarationCallback
+{
+    // Arrange
+    MCCastingPlayer * mockCastingPlayer = OCMClassMock([MCCastingPlayer class]);
+
+    __block BOOL connectionCallbackCalled = NO;
+    __block BOOL commissionerDeclarationCallbackCalled = NO;
+
+    void (^connectionCompleteCallback)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+        connectionCallbackCalled = YES;
+    };
+
+    void (^commissionerDeclarationCallback)(MCCommissionerDeclaration * _Nonnull) = ^(MCCommissionerDeclaration * _Nonnull cd) {
+        commissionerDeclarationCallbackCalled = YES;
+    };
+
+    MCConnectionCallbacks * callbacks = [[MCConnectionCallbacks alloc] initWithCallbacks:connectionCompleteCallback
+                                                         commissionerDeclarationCallback:commissionerDeclarationCallback];
+
+    MCIdentificationDeclarationOptions * idOptions = [[MCIdentificationDeclarationOptions alloc] initWithNoPasscodeOnly:YES];
+
+    OCMStub([mockCastingPlayer sendUDCWithCallbacks:callbacks
+                   identificationDeclarationOptions:idOptions])
+        .andReturn(nil);
+
+    // Act
+    NSError * error = [mockCastingPlayer sendUDCWithCallbacks:callbacks
+                             identificationDeclarationOptions:idOptions];
+
+    // Assert
+    XCTAssertNil(error, @"Error should be nil");
+}
+
+/**
+ * Test: sendUDCWithCallbacks complete app detection flow
+ * Verifies the complete flow: send with NoPasscode, receive response, send CancelPasscode
+ */
+- (void)testSendUDCWithCallbacks_CompleteAppDetectionFlow
+{
+    // Arrange
+    MCCastingPlayer * mockCastingPlayer = OCMClassMock([MCCastingPlayer class]);
+    NSString * instanceName = [[NSUUID UUID] UUIDString];
+    UInt16 targetVendorId = 0xFFF1;
+
+    __block BOOL connectionCallbackCalled = NO;
+    __block BOOL commissionerDeclarationCallbackCalled = NO;
+    __block BOOL appFound = NO;
+
+    void (^connectionCompleteCallback)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+        connectionCallbackCalled = YES;
+    };
+
+    void (^commissionerDeclarationCallback)(MCCommissionerDeclaration * _Nonnull) = ^(MCCommissionerDeclaration * _Nonnull cd) {
+        commissionerDeclarationCallbackCalled = YES;
+
+        // Check if app was found
+        appFound = !cd.noAppsFound;
+
+        // Send CancelPasscode to end the UDC session
+        MCIdentificationDeclarationOptions * cancelOptions = [[MCIdentificationDeclarationOptions alloc] initWithCancelPasscodeOnly:YES];
+        [cancelOptions setInstanceName:instanceName];
+
+        void (^cancelCallback)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+            // Cancel complete
+        };
+
+        MCConnectionCallbacks * cancelCallbacks = [[MCConnectionCallbacks alloc] initWithCallbacks:cancelCallback
+                                                                   commissionerDeclarationCallback:nil];
+
+        [mockCastingPlayer sendUDCWithCallbacks:cancelCallbacks
+               identificationDeclarationOptions:cancelOptions];
+    };
+
+    MCConnectionCallbacks * callbacks = [[MCConnectionCallbacks alloc] initWithCallbacks:connectionCompleteCallback
+                                                         commissionerDeclarationCallback:commissionerDeclarationCallback];
+
+    MCIdentificationDeclarationOptions * idOptions = [[MCIdentificationDeclarationOptions alloc] initWithNoPasscodeOnly:YES];
+    [idOptions setInstanceName:instanceName];
+
+    MCTargetAppInfo * targetAppInfo = [[MCTargetAppInfo alloc] initWithVendorId:targetVendorId];
+    [idOptions addTargetAppInfo:targetAppInfo];
+
+    OCMStub([mockCastingPlayer sendUDCWithCallbacks:[OCMArg any]
+                   identificationDeclarationOptions:[OCMArg any]])
+        .andReturn(nil);
+
+    // Act
+    NSError * error = [mockCastingPlayer sendUDCWithCallbacks:callbacks
+                             identificationDeclarationOptions:idOptions];
+
+    // Assert
+    XCTAssertNil(error, @"Error should be nil");
+    XCTAssertEqualObjects([idOptions getInstanceName], instanceName, @"InstanceName should match");
+}
+
+/**
+ * Test: sendUDCWithCallbacks with multiple TargetAppInfo entries
+ * Verifies that sendUDCWithCallbacks can handle multiple target apps
+ */
+- (void)testSendUDCWithCallbacks_WithMultipleTargetApps
+{
+    // Arrange
+    MCCastingPlayer * mockCastingPlayer = OCMClassMock([MCCastingPlayer class]);
+    UInt16 targetVendorId1 = 0xFFF1;
+    UInt16 targetVendorId2 = 0xFFF2;
+
+    __block BOOL connectionCallbackCalled = NO;
+    void (^connectionCompleteCallback)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+        connectionCallbackCalled = YES;
+    };
+
+    MCConnectionCallbacks * callbacks = [[MCConnectionCallbacks alloc] initWithCallbacks:connectionCompleteCallback
+                                                         commissionerDeclarationCallback:nil];
+
+    MCIdentificationDeclarationOptions * idOptions = [[MCIdentificationDeclarationOptions alloc] initWithNoPasscodeOnly:YES];
+
+    MCTargetAppInfo * targetAppInfo1 = [[MCTargetAppInfo alloc] initWithVendorId:targetVendorId1];
+    MCTargetAppInfo * targetAppInfo2 = [[MCTargetAppInfo alloc] initWithVendorId:targetVendorId2];
+    [idOptions addTargetAppInfo:targetAppInfo1];
+    [idOptions addTargetAppInfo:targetAppInfo2];
+
+    OCMStub([mockCastingPlayer sendUDCWithCallbacks:callbacks
+                   identificationDeclarationOptions:idOptions])
+        .andReturn(nil);
+
+    // Act
+    NSError * error = [mockCastingPlayer sendUDCWithCallbacks:callbacks
+                             identificationDeclarationOptions:idOptions];
+
+    // Assert
+    XCTAssertNil(error, @"Error should be nil");
+}
+
+/**
+ * Test: sendUDCWithCallbacks with error response
+ * Verifies that sendUDCWithCallbacks properly handles error responses
+ */
+- (void)testSendUDCWithCallbacks_WithError
+{
+    // Arrange
+    MCCastingPlayer * mockCastingPlayer = OCMClassMock([MCCastingPlayer class]);
+
+    __block BOOL connectionCallbackCalled = NO;
+    void (^connectionCompleteCallback)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+        connectionCallbackCalled = YES;
+    };
+
+    MCConnectionCallbacks * callbacks = [[MCConnectionCallbacks alloc] initWithCallbacks:connectionCompleteCallback
+                                                         commissionerDeclarationCallback:nil];
+
+    MCIdentificationDeclarationOptions * idOptions = [[MCIdentificationDeclarationOptions alloc] init];
+
+    NSError * testError = [NSError errorWithDomain:@"TestDomain" code:1 userInfo:@{ NSLocalizedDescriptionKey : @"Test error" }];
+    OCMStub([mockCastingPlayer sendUDCWithCallbacks:callbacks
+                   identificationDeclarationOptions:idOptions])
+        .andReturn(testError);
+
+    // Act
+    NSError * error = [mockCastingPlayer sendUDCWithCallbacks:callbacks
+                             identificationDeclarationOptions:idOptions];
+
+    // Assert
+    XCTAssertNotNil(error, @"Error should not be nil");
+    XCTAssertEqual(error.code, 1, @"Error code should match");
+}
+
+/**
+ * Test: sendUDCWithCallbacks validates required callbacks
+ * Verifies that sendUDCWithCallbacks validates the presence of required callbacks
+ */
+- (void)testSendUDCWithCallbacks_ValidatesRequiredCallbacks
+{
+    // Arrange
+    MCCastingPlayer * mockCastingPlayer = OCMClassMock([MCCastingPlayer class]);
+
+    __block BOOL connectionCallbackCalled = NO;
+    void (^connectionCompleteCallback)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+        connectionCallbackCalled = YES;
+    };
+
+    MCConnectionCallbacks * callbacks = [[MCConnectionCallbacks alloc] initWithCallbacks:connectionCompleteCallback
+                                                         commissionerDeclarationCallback:nil];
+
+    MCIdentificationDeclarationOptions * idOptions = [[MCIdentificationDeclarationOptions alloc] init];
+
+    OCMStub([mockCastingPlayer sendUDCWithCallbacks:callbacks
+                   identificationDeclarationOptions:idOptions])
+        .andReturn(nil);
+
+    // Act
+    NSError * error = [mockCastingPlayer sendUDCWithCallbacks:callbacks
+                             identificationDeclarationOptions:idOptions];
+
+    // Assert
+    XCTAssertNil(error, @"Error should be nil with valid callbacks");
+}
+
+@end

--- a/examples/tv-casting-app/darwin/README.md
+++ b/examples/tv-casting-app/darwin/README.md
@@ -1,0 +1,168 @@
+# Matter TV Casting Darwin (iOS/macOS) App Example
+
+This is a Matter TV Casting app for iOS and macOS that can be used to cast
+content to a TV. This app discovers TVs on the local network that act as
+commissioners, lets the user select one, sends the TV a User Directed
+Commissioning request, enters commissioning mode, advertises itself as a
+Commissionable Node and gets commissioned. Then it allows the user to send
+Matter commands to the TV.
+
+Refer to the
+[Matter Casting APIs documentation](https://project-chip.github.io/connectedhomeip-doc/examples/tv-casting-app/APIs.html)
+to build the Matter "Casting Client" into your consumer-facing mobile app.
+
+## Requirements
+
+-   Xcode 15.0 or later
+-   macOS with Apple Silicon or Intel processor
+-   iOS Simulator or physical iOS device for testing
+
+## Building the App
+
+### Using Xcode
+
+1. Open the workspace:
+
+    ```bash
+    cd examples/tv-casting-app/darwin
+    open TvCastingDarwin.xcworkspace
+    ```
+
+2. Select the appropriate scheme:
+
+    - `TvCasting` - Main iOS app
+    - `MatterTvCastingBridge` - Framework/library
+
+3. Select your target device (simulator or physical device)
+
+4. Build and run: `Cmd+R`
+
+### Using Command Line
+
+Build the framework:
+
+```bash
+cd examples/tv-casting-app/darwin
+xcodebuild -workspace TvCastingDarwin.xcworkspace \
+  -scheme MatterTvCastingBridge \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  build
+```
+
+## Running Unit Tests
+
+The Darwin TV Casting app includes unit tests for the SendUDC functionality and
+other features.
+
+### Prerequisites
+
+The test files have been created but require one-time setup in Xcode to add them
+to the project:
+
+1. **Open the project in Xcode**:
+
+    ```bash
+    cd examples/tv-casting-app/darwin
+    open MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj
+    ```
+
+2. **Add a test target** (if not already present):
+
+    - File → New → Target
+    - Choose "Unit Testing Bundle" under iOS
+    - Name it `MatterTvCastingBridgeTests`
+    - Set the target to be tested to `MatterTvCastingBridge`
+    - Click Finish
+
+3. **Add the test file to the test target**:
+
+    - In the Project Navigator, right-click on `MatterTvCastingBridgeTests`
+      folder
+    - Choose "Add Files to MatterTvCastingBridge..."
+    - Navigate to `MatterTvCastingBridgeTests/MCCastingPlayerSendUDCTests.m`
+    - Ensure it's added to the `MatterTvCastingBridgeTests` target
+    - Click Add
+
+4. **Add OCMock dependency**:
+
+    - Select the project in Project Navigator
+    - Select the `MatterTvCastingBridgeTests` target
+    - Go to "Build Phases" → "Link Binary With Libraries"
+    - Add OCMock framework (install via CocoaPods or Swift Package Manager if
+      needed)
+
+### Running Tests in Xcode
+
+Once the test target is configured:
+
+1. Open the project in Xcode
+2. Press `Cmd+U` to run all tests
+3. Or click the diamond icon next to individual test methods to run specific
+   tests
+4. Or use the Test Navigator (`Cmd+6`) to browse and run tests
+
+### Running Tests from Command Line
+
+After the test target is properly configured in Xcode:
+
+```bash
+cd examples/tv-casting-app/darwin
+xcodebuild test \
+  -project MatterTvCastingBridge/MatterTvCastingBridge.xcodeproj \
+  -scheme MatterTvCastingBridge \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+### Test Coverage
+
+The SendUDC test suite (`MCCastingPlayerSendUDCTests.m`) includes 10 test cases
+covering:
+
+1. Basic sendUDCWithCallbacks invocation
+2. NoPasscode flag handling for app detection
+3. CancelPasscode flag for ending UDC sessions
+4. InstanceName management with UUID-based identifiers
+5. MCTargetAppInfo handling with vendor/product IDs
+6. CommissionerDeclarationCallback registration
+7. Complete app detection workflow simulation
+8. Multiple target apps support
+9. Error handling with NSError responses
+10. Callback validation requirements
+
+### Reviewing Test Code Without Running
+
+If you prefer to review the test structure without setting up the test target:
+
+```bash
+cd examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridgeTests
+cat MCCastingPlayerSendUDCTests.m
+```
+
+The test file is complete and demonstrates proper usage of the SendUDC API with
+OCMock for mocking dependencies.
+
+### Troubleshooting Tests
+
+**Issue**: "Scheme is not currently configured for the test action"
+
+-   **Solution**: The test target needs to be added to the Xcode project (see
+    Prerequisites above)
+
+**Issue**: Build errors when running tests
+
+-   **Solution**: Ensure all dependencies are properly linked and the project
+    builds successfully before running tests
+
+**Issue**: OCMock not found
+
+-   **Solution**: Install OCMock via CocoaPods or Swift Package Manager and link
+    it to the test target
+
+For more details on the test implementation, see the
+[test documentation](../tv-casting-common/core/tests/README.md).
+
+## Running the App
+
+This example Matter TV Casting Darwin app can be tested with the
+[example Matter tv-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/tv-app)
+running on a Raspberry Pi or other supported platform.

--- a/examples/tv-casting-app/linux/BUILD.gn
+++ b/examples/tv-casting-app/linux/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/build/chip/tools.gni")
 import("${chip_root}/src/lib/lib.gni")
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -29,6 +29,48 @@ namespace core {
 
 memory::Weak<CastingPlayer> CastingPlayer::mTargetCastingPlayer;
 
+void CastingPlayer::SendUDC(ConnectionCallbacks connectionCallbacks, IdentificationDeclarationOptions idOptions)
+{
+    ChipLogProgress(AppServer, "CastingPlayer::SendUDC() called");
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(
+        connectionCallbacks.mOnConnectionComplete != nullptr,
+        ChipLogError(AppServer,
+                     "CastingPlayer::VerifyOrEstablishConnection() ConnectionCallbacks.mOnConnectionComplete was not provided"));
+
+    mOnCompleted         = connectionCallbacks.mOnConnectionComplete;
+    mTargetCastingPlayer = weak_from_this();
+    mIdOptions           = idOptions;
+
+    mIdOptions.LogDetail();
+
+    if (connectionCallbacks.mCommissionerDeclarationCallback != nullptr)
+    {
+        ChipLogProgress(AppServer,
+                        "CastingPlayer::SendUDC() Setting CommissionerDeclarationCallback in "
+                        "CommissionerDeclarationHandler");
+        // Set the callback for handling CommissionerDeclaration messages.
+        matter::casting::core::CommissionerDeclarationHandler::GetInstance()->SetCommissionerDeclarationCallback(
+            connectionCallbacks.mCommissionerDeclarationCallback);
+        mClientProvidedCommissionerDeclarationCallback = true;
+    }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
+    SuccessOrExit(err = SendUserDirectedCommissioningRequest());
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
+    // clear the UdcStatus to allow other UDC messages to be sent
+    TEMPORARY_RETURN_IGNORED support::ChipDeviceEventHandler::SetUdcStatus(false);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "CastingPlayer::SendUDC() failed with %" CHIP_ERROR_FORMAT, err.Format());
+        resetState(err);
+    }
+}
+
 void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCallbacks, uint16_t commissioningWindowTimeoutSec,
                                                 IdentificationDeclarationOptions idOptions)
 {

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -35,10 +35,8 @@ void CastingPlayer::SendUDC(ConnectionCallbacks connectionCallbacks, Identificat
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(
-        connectionCallbacks.mOnConnectionComplete != nullptr,
-        ChipLogError(AppServer,
-                     "CastingPlayer::VerifyOrEstablishConnection() ConnectionCallbacks.mOnConnectionComplete was not provided"));
+    VerifyOrExit(connectionCallbacks.mOnConnectionComplete != nullptr,
+                 ChipLogError(AppServer, "CastingPlayer::SendUDC() ConnectionCallbacks.mOnConnectionComplete was not provided"));
 
     mOnCompleted         = connectionCallbacks.mOnConnectionComplete;
     mTargetCastingPlayer = weak_from_this();
@@ -61,7 +59,7 @@ void CastingPlayer::SendUDC(ConnectionCallbacks connectionCallbacks, Identificat
     SuccessOrExit(err = SendUserDirectedCommissioningRequest());
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // clear the UdcStatus to allow other UDC messages to be sent
-    TEMPORARY_RETURN_IGNORED support::ChipDeviceEventHandler::SetUdcStatus(false);
+    support::ChipDeviceEventHandler::SetUdcStatus(false);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -144,6 +144,33 @@ public:
     bool IsConnected() const { return mConnectionState == CASTING_PLAYER_CONNECTED; }
 
     /**
+     * @brief Directly sends a User-directed Commissioning request with the provided idOptions.
+     * This bypasses additionals checks and processes around commissioning like setting up a
+     * commissioning-window and instead can be used to directly talk to the CastingPlayer.
+     *
+     * @param connectionCallbacks contains the ConnectCallback (Required) and CommissionerDeclarationCallback (Optional) defined in
+     * ConnectCallbacks.h.
+     *
+     * For example: During CastingPlayer/Commissioner-Generated passcode commissioning, the Commissioner replies with a
+     * CommissionerDeclaration message with PasscodeDialogDisplayed and CommissionerPasscode set to true. Given these Commissioner
+     * state details, the client is expected to perform some actions, detailed in the ContinueConnecting() API below, and then call
+     * the ContinueConnecting() API to complete the process.
+     *
+     * @param idOptions (Optional) Parameters in the IdentificationDeclaration message sent by the Commissionee to the Commissioner.
+     * These parameters specify the information relating to the requested commissioning session.
+     *
+     * For example: To invoke the CastingPlayer/Commissioner-Generated passcode commissioning flow, the client would call this API
+     * with IdentificationDeclarationOptions containing CommissionerPasscode set to true. See IdentificationDeclarationOptions.h for
+     * a complete list of optional parameters.
+     *
+     * Furthermore, attributes (such as VendorId) describe the TargetApp that the client wants to interact with after commissioning.
+     * If this value is passed in, VerifyOrEstablishConnection() will force UDC, in case the desired
+     * TargetApp is not found in the on-device CastingStore.
+     */
+    void SendUDC(ConnectionCallbacks connectionCallbacks,
+                 IdentificationDeclarationOptions idOptions = IdentificationDeclarationOptions());
+
+    /**
      * @brief Verifies that a connection exists with this CastingPlayer, or triggers a new commissioning session request. If the
      * CastingApp does not have the nodeId and fabricIndex of this CastingPlayer cached on disk, this will execute the User Directed
      * Commissioning (UDC) process by sending an IdentificationDeclaration message to the CastingPlayer/Commissioner. For certain

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
@@ -65,7 +65,7 @@ void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(
         ChipLogProgress(AppServer,
                         "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() "
                         "needs passcode - This is likely an App Check response");
-        TEMPORARY_RETURN_IGNORED support::ChipDeviceEventHandler::SetUdcStatus(false);
+        support::ChipDeviceEventHandler::SetUdcStatus(false);
     }
 
     // Flag to indicate when the CastingPlayer/Commissioner user has decided to exit the commissioning process.

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
@@ -57,6 +57,17 @@ void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(
         support::ChipDeviceEventHandler::SetUdcStatus(false);
     }
 
+    // During the workflow for Detecting App Presence on Casting Player, we send UDC with NoPasscode=True.
+    // The CD we get back will indicate NeedsPasscode=true and PasscodeDialogDisplayed=false.
+    // In this scenario, we want to clear the UDC status to allow other UDC messages to be sent.
+    if (cd.GetNeedsPasscode() && !cd.GetPasscodeDialogDisplayed())
+    {
+        ChipLogProgress(AppServer,
+                        "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() "
+                        "needs passcode - This is likely an App Check response");
+        TEMPORARY_RETURN_IGNORED support::ChipDeviceEventHandler::SetUdcStatus(false);
+    }
+
     // Flag to indicate when the CastingPlayer/Commissioner user has decided to exit the commissioning process.
     if (cd.GetCancelPasscode())
     {

--- a/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
+++ b/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
@@ -129,6 +129,11 @@ public:
             id.SetCommissionerPasscodeReady(true);
             id.SetInstanceName(mCommissioneeInstanceName);
         }
+        // mCommissioneeInstanceName cannot be null
+        else if ((mCancelPasscode || mNoPasscode) && strlen(mCommissioneeInstanceName) != 0)
+        {
+            id.SetInstanceName(mCommissioneeInstanceName);
+        }
         else
         {
             ChipLogProgress(AppServer,

--- a/src/controller/CommissionerDiscoveryController.cpp
+++ b/src/controller/CommissionerDiscoveryController.cpp
@@ -87,6 +87,7 @@ void CommissionerDiscoveryController::OnCancel(UDCClientState state)
     {
         mUserPrompter->HidePromptsOnCancel(state.GetVendorId(), state.GetProductId(), state.GetDeviceName());
     }
+    ResetState();
     return;
 }
 
@@ -384,6 +385,7 @@ void CommissionerDiscoveryController::HandleTargetContentAppCheck(TargetAppInfo 
         CommissionerDeclaration cd;
         cd.SetNoAppsFound(true);
         mUdcServer->SendCDCMessage(cd, Transport::PeerAddress::UDP(client->GetPeerAddress().GetIPAddress(), client->GetCdPort()));
+        ResetState();
     }
     ChipLogDetail(AppServer, "UX Ok - HandleContentAppCheck: advancing");
     // otherwise, advance to the next step for trying to obtain a passcode.
@@ -512,6 +514,7 @@ void CommissionerDiscoveryController::InternalHandleContentAppPasscodeResponse()
         CommissionerDeclaration cd;
         cd.SetNeedsPasscode(true);
         mUdcServer->SendCDCMessage(cd, Transport::PeerAddress::UDP(client->GetPeerAddress().GetIPAddress(), client->GetCdPort()));
+        ResetState();
         return;
     }
 

--- a/src/protocols/user_directed_commissioning/UDCClients.h
+++ b/src/protocols/user_directed_commissioning/UDCClients.h
@@ -26,7 +26,7 @@ namespace Protocols {
 namespace UserDirectedCommissioning {
 
 // UDC client state times out after 1 hour. This may need to be tweaked.
-inline constexpr const System::Clock::Timestamp kUDCClientTimeout = System::Clock::Milliseconds64(60 * 60 * 1000);
+inline constexpr const System::Clock::Timestamp kUDCClientTimeout = System::Clock::Milliseconds64(30 * 1000);
 
 /**
  * Handles a set of UDC Client Processing States.


### PR DESCRIPTION
#### Summary

* Fix NoPasscode handling

* Add android sample app code for testing

* clang

* clang

* clang

* Reset state in more scenarios

* Allow custom instance name

* Reset UDC state upon needsPasscode

* reset status after sending

* Reduce UDC cache timeout to match TVs

* Add API to darwin

* missing darwin

* CI fixes

* remove instance name from CD

* clang

* CI

* Add documentation for this feature

* update documentation for this feature

* clang

* ci

* add unit tests

* clang

* clang

* clang

* clang

* address comments

* CI

* CI

* CI

(cherry picked from commit 6e399f15eb741b5e218e28f4f1e8a76308ea3ad0)

#### Testing

build, unit tests