### PR TITLE
Push AV Motion zone list for clip record

### DIFF
--- a/examples/camera-app/linux/include/CameraAppCommandDelegate.h
+++ b/examples/camera-app/linux/include/CameraAppCommandDelegate.h
@@ -40,7 +40,7 @@ private:
     Json::Value mJsonValue;
     Camera::CameraDevice * mCameraDevice = nullptr;
 
-    void OnZoneTriggeredHandler(uint16_t zoneId);
+    void OnZoneTriggeredHandler(const std::vector<uint16_t> & zoneIds);
     void OnSetHardPrivacyModeOnHandler(bool value);
 };
 

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -313,7 +313,7 @@ public:
 
     void SetVideoDevicePath(const std::string & path) { mVideoDevicePath = path; }
 
-    void HandleSimulatedZoneTriggeredEvent(uint16_t zoneId);
+    void HandleSimulatedZoneTriggeredEvent(const std::vector<uint16_t> & zoneIds);
 
     void HandleSimulatedZoneStoppedEvent(uint16_t zoneId);
 

--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -115,7 +115,7 @@ public:
 
     bool GetCMAFSessionNumber(const uint16_t connectionID, uint64_t & sessionNumber) override;
 
-    void HandleZoneTrigger(uint16_t zoneId);
+    void HandleZoneTrigger(const std::vector<uint16_t> & zoneIds);
 
     void RecordingStreamPrivacyModeChanged(bool privacyModeEnabled);
 

--- a/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
+++ b/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
@@ -88,7 +88,7 @@ public:
     void SetTransportStatus(chip::app::Clusters::PushAvStreamTransport::TransportStatusEnum status);
 
     void TriggerTransport(chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum activationReason,
-                          int zoneId = kInvalidZoneId, int sensitivity = kDefaultSensitivity);
+                          const std::vector<int> & zoneIds, int sensitivity = kDefaultSensitivity);
     // Get Transport status
     bool GetTransportStatus()
     {

--- a/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
+++ b/examples/camera-app/linux/include/pushav-transport/pushav-transport.h
@@ -88,7 +88,7 @@ public:
     void SetTransportStatus(chip::app::Clusters::PushAvStreamTransport::TransportStatusEnum status);
 
     void TriggerTransport(chip::app::Clusters::PushAvStreamTransport::TriggerActivationReasonEnum activationReason,
-                          const std::vector<int> & zoneIds, int sensitivity = kDefaultSensitivity);
+                          const std::vector<int> & zoneIds = { kInvalidZoneId }, int sensitivity = kDefaultSensitivity);
     // Get Transport status
     bool GetTransportStatus()
     {

--- a/examples/camera-app/linux/src/CameraAppCommandDelegate.cpp
+++ b/examples/camera-app/linux/src/CameraAppCommandDelegate.cpp
@@ -54,8 +54,25 @@ void CameraAppCommandHandler::HandleCommand(intptr_t context)
 
     if (name == "ZoneTriggered")
     {
-        uint16_t zoneId = static_cast<uint16_t>(self->mJsonValue["ZoneId"].asUInt());
-        self->OnZoneTriggeredHandler(zoneId);
+        std::vector<uint16_t> zoneIds;
+        const Json::Value & zoneIdValue = self->mJsonValue["ZoneId"];
+
+        // Check if ZoneId is an array or a single value
+        if (zoneIdValue.isArray())
+        {
+            // Handle array of zone IDs
+            for (const auto & zoneId : zoneIdValue)
+            {
+                zoneIds.push_back(static_cast<uint16_t>(zoneId.asUInt()));
+            }
+        }
+        else
+        {
+            // Handle single zone ID
+            zoneIds.push_back(static_cast<uint16_t>(zoneIdValue.asUInt()));
+        }
+
+        self->OnZoneTriggeredHandler(zoneIds);
     }
     else if (name == "SetHardPrivacyModeOn")
     {
@@ -76,9 +93,9 @@ void CameraAppCommandHandler::SetCameraDevice(Camera::CameraDevice * aCameraDevi
     mCameraDevice = aCameraDevice;
 }
 
-void CameraAppCommandHandler::OnZoneTriggeredHandler(uint16_t zoneId)
+void CameraAppCommandHandler::OnZoneTriggeredHandler(const std::vector<uint16_t> & zoneIds)
 {
-    mCameraDevice->HandleSimulatedZoneTriggeredEvent(zoneId);
+    mCameraDevice->HandleSimulatedZoneTriggeredEvent(zoneIds);
 }
 
 void CameraAppCommandHandler::OnSetHardPrivacyModeOnHandler(bool value)

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -1638,10 +1638,14 @@ CameraError CameraDevice::RemoveZoneTrigger(const uint16_t zoneId)
 
 void CameraDevice::HandleSimulatedZoneTriggeredEvent(const std::vector<uint16_t> & zoneIds)
 {
+    // Zone events are per-zone - each zone needs its own event notification
     for (const auto & zoneId : zoneIds)
     {
         mZoneManager.OnZoneTriggeredEvent(zoneId, ZoneEventTriggeredReasonEnum::kMotion);
     }
+    // Transport trigger is per-motion-event - all zones are passed together
+    // This deliberate asymmetry reflects that zone events track individual zone activity
+    // while transport triggers coordinate recording across all zones in a single motion event
     mPushAVTransportManager.HandleZoneTrigger(zoneIds);
 }
 

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -1636,10 +1636,13 @@ CameraError CameraDevice::RemoveZoneTrigger(const uint16_t zoneId)
     return CameraError::SUCCESS;
 }
 
-void CameraDevice::HandleSimulatedZoneTriggeredEvent(uint16_t zoneId)
+void CameraDevice::HandleSimulatedZoneTriggeredEvent(const std::vector<uint16_t> & zoneIds)
 {
-    mZoneManager.OnZoneTriggeredEvent(zoneId, ZoneEventTriggeredReasonEnum::kMotion);
-    mPushAVTransportManager.HandleZoneTrigger(zoneId);
+    for (const auto & zoneId : zoneIds)
+    {
+        mZoneManager.OnZoneTriggeredEvent(zoneId, ZoneEventTriggeredReasonEnum::kMotion);
+    }
+    mPushAVTransportManager.HandleZoneTrigger(zoneIds);
 }
 
 void CameraDevice::HandleSimulatedZoneStoppedEvent(uint16_t zoneId)

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -308,8 +308,8 @@ Protocols::InteractionModel::Status PushAvStreamTransportManager::ManuallyTrigge
     }
 
     // Pass zoneIDs with at least 1 invalidZoneId to match the earlier implementation
-    std::vector<int> zoneIds = { kInvalidZoneId };
-    mTransportMap[connectionID]->TriggerTransport(activationReason, zoneIds);
+    // Using the default parameter value { kInvalidZoneId } from the TriggerTransport function
+    mTransportMap[connectionID]->TriggerTransport(activationReason);
 
     return Status::Success;
 }
@@ -674,6 +674,15 @@ PushAvStreamTransportManager::PersistentAttributesLoadedCallback()
 
 void PushAvStreamTransportManager::HandleZoneTrigger(const std::vector<uint16_t> & zoneIds)
 {
+    // Convert uint16_t zone IDs to int zone IDs for the transport API
+    // This conversion is done once outside the loop for efficiency
+    std::vector<int> intZoneIds;
+    intZoneIds.reserve(zoneIds.size());
+    for (const auto & zoneId : zoneIds)
+    {
+        intZoneIds.push_back(static_cast<int>(zoneId));
+    }
+
     for (auto & pavst : mTransportMap)
     {
         int connectionId = pavst.first;
@@ -681,15 +690,7 @@ void PushAvStreamTransportManager::HandleZoneTrigger(const std::vector<uint16_t>
 
         if (mTransportOptionsMap[connectionId].triggerOptions.triggerType == TransportTriggerTypeEnum::kMotion)
         {
-            // Convert uint16_t zone IDs to int zone IDs for the transport API
-            std::vector<int> intZoneIds;
-            intZoneIds.reserve(zoneIds.size());
-            for (const auto & zoneId : zoneIds)
-            {
-                intZoneIds.push_back(static_cast<int>(zoneId));
-            }
-
-            pavst.second->TriggerTransport(TriggerActivationReasonEnum::kAutomation, intZoneIds, 10);
+            pavst.second->TriggerTransport(TriggerActivationReasonEnum::kAutomation, intZoneIds, kDefaultSensitivity);
         }
     }
 }

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -306,7 +306,10 @@ Protocols::InteractionModel::Status PushAvStreamTransportManager::ManuallyTrigge
     {
         mTransportMap[connectionID]->ConfigureRecorderTimeSetting(timeControl.Value());
     }
-    mTransportMap[connectionID]->TriggerTransport(activationReason);
+
+    // Pass zoneIDs with at least 1 invalidZoneId to match the earlier implementation
+    std::vector<int> zoneIds = { kInvalidZoneId };
+    mTransportMap[connectionID]->TriggerTransport(activationReason, zoneIds);
 
     return Status::Success;
 }
@@ -669,7 +672,7 @@ PushAvStreamTransportManager::PersistentAttributesLoadedCallback()
     return CHIP_NO_ERROR;
 }
 
-void PushAvStreamTransportManager::HandleZoneTrigger(uint16_t zoneId)
+void PushAvStreamTransportManager::HandleZoneTrigger(const std::vector<uint16_t> & zoneIds)
 {
     for (auto & pavst : mTransportMap)
     {
@@ -678,7 +681,15 @@ void PushAvStreamTransportManager::HandleZoneTrigger(uint16_t zoneId)
 
         if (mTransportOptionsMap[connectionId].triggerOptions.triggerType == TransportTriggerTypeEnum::kMotion)
         {
-            pavst.second->TriggerTransport(TriggerActivationReasonEnum::kAutomation, zoneId, 10);
+            // Convert uint16_t zone IDs to int zone IDs for the transport API
+            std::vector<int> intZoneIds;
+            intZoneIds.reserve(zoneIds.size());
+            for (const auto & zoneId : zoneIds)
+            {
+                intZoneIds.push_back(static_cast<int>(zoneId));
+            }
+
+            pavst.second->TriggerTransport(TriggerActivationReasonEnum::kAutomation, intZoneIds, 10);
         }
     }
 }

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -307,8 +307,6 @@ Protocols::InteractionModel::Status PushAvStreamTransportManager::ManuallyTrigge
         mTransportMap[connectionID]->ConfigureRecorderTimeSetting(timeControl.Value());
     }
 
-    // Pass zoneIDs with at least 1 invalidZoneId to match the earlier implementation
-    // Using the default parameter value { kInvalidZoneId } from the TriggerTransport function
     mTransportMap[connectionID]->TriggerTransport(activationReason);
 
     return Status::Success;

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -483,7 +483,8 @@ void PushAVTransport::TriggerTransport(TriggerActivationReasonEnum activationRea
                     (uint16_t) activationReason, zoneIds.size(), sensitivity);
 
     // Handle edge case where zoneIds is empty
-    if (zoneIds.empty()) {
+    if (zoneIds.empty())
+    {
         ChipLogProgress(Camera, "PushAVTransport trigger transport ignored - empty zoneIds list provided");
         return;
     }

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -482,6 +482,12 @@ void PushAVTransport::TriggerTransport(TriggerActivationReasonEnum activationRea
     ChipLogProgress(Camera, "PushAVTransport trigger transport, activation reason: [%u], ZoneIds count: [%zu], Sensitivity: [%d]",
                     (uint16_t) activationReason, zoneIds.size(), sensitivity);
 
+    // Handle edge case where zoneIds is empty
+    if (zoneIds.empty()) {
+        ChipLogProgress(Camera, "PushAVTransport trigger transport ignored - empty zoneIds list provided");
+        return;
+    }
+
     // For a single motion event with multiple zones, we need to check if any zone should trigger
     bool shouldProcessTrigger = false;
     bool hasManualTrigger     = false;

--- a/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
+++ b/examples/camera-app/linux/src/pushav-transport/pushav-transport.cpp
@@ -476,31 +476,60 @@ bool PushAVTransport::ValidateZoneAndSensitivity(
     return false;
 }
 
-void PushAVTransport::TriggerTransport(TriggerActivationReasonEnum activationReason, int zoneId, int sensitivity)
+void PushAVTransport::TriggerTransport(TriggerActivationReasonEnum activationReason, const std::vector<int> & zoneIds,
+                                       int sensitivity)
 {
-    ChipLogProgress(Camera, "PushAVTransport trigger transport, activation reason: [%u], ZoneId: [%d], Sensitivity: [%d]",
-                    (uint16_t) activationReason, zoneId, sensitivity);
+    ChipLogProgress(Camera, "PushAVTransport trigger transport, activation reason: [%u], ZoneIds count: [%zu], Sensitivity: [%d]",
+                    (uint16_t) activationReason, zoneIds.size(), sensitivity);
 
-    mCurrentActivationByManualTrigger = (zoneId == kInvalidZoneId) ? true : false;
+    // For a single motion event with multiple zones, we need to check if any zone should trigger
+    bool shouldProcessTrigger = false;
+    bool hasManualTrigger     = false;
+
+    // Check if this is a manual trigger (invalid zone ID)
+    for (int zoneId : zoneIds)
+    {
+        if (zoneId == kInvalidZoneId)
+        {
+            hasManualTrigger = true;
+            break;
+        }
+    }
+
+    mCurrentActivationByManualTrigger = hasManualTrigger;
     mActivationReason                 = chip::MakeOptional(activationReason);
 
     // Check if trigger should be processed based on transport type
-    bool shouldProcessTrigger = false;
-
     if (mTransportTriggerType == TransportTriggerTypeEnum::kCommand)
     {
         shouldProcessTrigger = true;
     }
     else if (mTransportTriggerType == TransportTriggerTypeEnum::kMotion)
     {
-        shouldProcessTrigger =
-            mCurrentActivationByManualTrigger || ValidateZoneAndSensitivity(mZoneSensitivityList, zoneId, sensitivity);
+        // For motion triggers, check if any zone in the list should trigger
+        if (hasManualTrigger)
+        {
+            shouldProcessTrigger = true;
+        }
+        else
+        {
+            // Check if any zone in the list passes validation
+            for (int zoneId : zoneIds)
+            {
+                if (ValidateZoneAndSensitivity(mZoneSensitivityList, zoneId, sensitivity))
+                {
+                    shouldProcessTrigger = true;
+                    break;
+                }
+            }
+        }
     }
     else if (mTransportTriggerType == TransportTriggerTypeEnum::kContinuous)
     {
         ChipLogProgress(Camera, "PushAVTransport continuous transport trigger received. No action needed");
         return;
     }
+
     // Process the trigger if conditions are met
     if (shouldProcessTrigger)
     {


### PR DESCRIPTION
#### Summary

This PR handle the motion zones list validation for clip record which avoids wrong augmentation

- Earlier, each zone id is considered as different motion event for clip record
- Now, All zone ids in under one trigger is considered as single motion event for clip record

#### Related issues
Fixes #42639 

#### Testing
```
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debug/chip-camera-app --app-pipe /tmp/pavst_2_12_fifo --camera-test-audiosrc --camera-test-videosrc

# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run Push AV TC
Example:
python3 src/python_testing/TC_PAVST_2_12.py --commissioning-method on-network --discriminator 3840 --passcode 20202021 --storage-path admin_storage.json --endpoint 1   --string-arg host_ip:localhost --app-pipe /tmp/pavst_2_13_fifo
```