### PR TITLE
Matter Casting Android - fix memory leak & null pointer dereference

### DIFF
--- a/examples/tv-casting-app/APIs.md
+++ b/examples/tv-casting-app/APIs.md
@@ -1185,7 +1185,8 @@ std::string instanceName = GenerateRandomInstanceName(); // Implement your rando
 // Step 2: Set up IdentificationDeclarationOptions with NoPasscode and targetAppInfo
 matter::casting::core::IdentificationDeclarationOptions idOptions;
 idOptions.mNoPasscode = true;
-idOptions.mInstanceName = instanceName.c_str();
+strncpy(idOptions.mCommissioneeInstanceName, instanceName.c_str(), sizeof(idOptions.mCommissioneeInstanceName) - 1);
+idOptions.mCommissioneeInstanceName[sizeof(idOptions.mCommissioneeInstanceName) - 1] = '\0';
 
 chip::Protocols::UserDirectedCommissioning::TargetAppInfo targetAppInfo;
 targetAppInfo.vendorId = kDesiredAppVendorId;  // Your target app's vendor ID
@@ -1211,7 +1212,8 @@ connectionCallbacks.mCommissionerDeclarationCallback = [&instanceName, &targetCa
     // Step 4: Cancel the UDC session by sending CancelPasscode
     matter::casting::core::IdentificationDeclarationOptions cancelOptions;
     cancelOptions.mCancelPasscode = true;
-    cancelOptions.mInstanceName = instanceName.c_str();
+    strncpy(cancelOptions.mCommissioneeInstanceName, instanceName.c_str(), sizeof(cancelOptions.mCommissioneeInstanceName) - 1);
+    cancelOptions.mCommissioneeInstanceName[sizeof(cancelOptions.mCommissioneeInstanceName) - 1] = '\0';
 
     matter::casting::core::ConnectionCallbacks cancelCallbacks;
     // Send the cancel message using SendUDC

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -164,24 +164,27 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
                      "MatterCastingPlayer-JNI::verifyOrEstablishConnection() jFailureCallback == nullptr but is mandatory "));
 
     // jIdentificationDeclarationOptions is optional
-    matter::casting::core::IdentificationDeclarationOptions * idOptions = nullptr;
-    if (jIdentificationDeclarationOptions == nullptr)
+    matter::casting::core::IdentificationDeclarationOptions idOptions;
+    if (jIdentificationDeclarationOptions != nullptr)
     {
-        ChipLogProgress(AppServer,
-                        "MatterCastingPlayer-JNI::verifyOrEstablishConnection() Optional jIdentificationDeclarationOptions not "
-                        "provided by the client");
+        ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::sendUDC() jIdentificationDeclarationOptions was provided by client");
+        std::unique_ptr<matter::casting::core::IdentificationDeclarationOptions> idOptionsCpp(
+            support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions));
+        if (idOptionsCpp == nullptr)
+        {
+            ChipLogError(AppServer,
+                         "MatterCastingPlayer-JNI::sendUDC() "
+                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error");
+            return support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT);
+        }
+        idOptions = *idOptionsCpp;
+        idOptions.LogDetail();
     }
     else
     {
-        ChipLogProgress(
-            AppServer,
-            "MatterCastingPlayer-JNI::verifyOrEstablishConnection() jIdentificationDeclarationOptions was provided by client");
-        idOptions = support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions);
-        VerifyOrReturnValue(idOptions != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
-                            ChipLogError(AppServer,
-                                         "MatterCastingPlayer-JNI::verifyOrEstablishConnection() "
-                                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error"));
-        idOptions->LogDetail();
+        ChipLogProgress(AppServer,
+                        "MatterCastingPlayer-JNI::sendUDC() Optional jIdentificationDeclarationOptions not "
+                        "provided by the client");
     }
 
     TEMPORARY_RETURN_IGNORED MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.SetUp(env, jSuccessCallback);
@@ -206,7 +209,7 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
         MatterCastingPlayerJNI::getInstance().getCommissionerDeclarationCallback();
 
     castingPlayer->VerifyOrEstablishConnection(connectionCallbacks, static_cast<uint16_t>(commissioningWindowTimeoutSec),
-                                               *idOptions);
+                                               idOptions);
 
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -167,13 +167,13 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
     matter::casting::core::IdentificationDeclarationOptions idOptions;
     if (jIdentificationDeclarationOptions != nullptr)
     {
-        ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::sendUDC() jIdentificationDeclarationOptions was provided by client");
+        ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::verifyOrEstablishConnection() jIdentificationDeclarationOptions was provided by client");
         std::unique_ptr<matter::casting::core::IdentificationDeclarationOptions> idOptionsCpp(
             support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions));
         if (idOptionsCpp == nullptr)
         {
             ChipLogError(AppServer,
-                         "MatterCastingPlayer-JNI::sendUDC() "
+                         "MatterCastingPlayer-JNI::verifyOrEstablishConnection() "
                          "convertIdentificationDeclarationOptionsFromJavaToCpp() error");
             return support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT);
         }
@@ -183,7 +183,7 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
     else
     {
         ChipLogProgress(AppServer,
-                        "MatterCastingPlayer-JNI::sendUDC() Optional jIdentificationDeclarationOptions not "
+                        "MatterCastingPlayer-JNI::verifyOrEstablishConnection() Optional jIdentificationDeclarationOptions not "
                         "provided by the client");
     }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -167,7 +167,9 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
     matter::casting::core::IdentificationDeclarationOptions idOptions;
     if (jIdentificationDeclarationOptions != nullptr)
     {
-        ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::verifyOrEstablishConnection() jIdentificationDeclarationOptions was provided by client");
+        ChipLogProgress(
+            AppServer,
+            "MatterCastingPlayer-JNI::verifyOrEstablishConnection() jIdentificationDeclarationOptions was provided by client");
         std::unique_ptr<matter::casting::core::IdentificationDeclarationOptions> idOptionsCpp(
             support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions));
         if (idOptionsCpp == nullptr)

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -77,22 +77,27 @@ JNI_METHOD(jobject, sendUDC)
         ChipLogError(AppServer, "MatterCastingPlayer-JNI::sendUDC() jFailureCallback == nullptr but is mandatory "));
 
     // jIdentificationDeclarationOptions is optional
-    matter::casting::core::IdentificationDeclarationOptions * idOptions = nullptr;
-    if (jIdentificationDeclarationOptions == nullptr)
+    matter::casting::core::IdentificationDeclarationOptions idOptions;
+    if (jIdentificationDeclarationOptions != nullptr)
+    {
+        ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::sendUDC() jIdentificationDeclarationOptions was provided by client");
+        std::unique_ptr<matter::casting::core::IdentificationDeclarationOptions> idOptionsCpp(
+            support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions));
+        if (idOptionsCpp == nullptr)
+        {
+            ChipLogError(AppServer,
+                         "MatterCastingPlayer-JNI::sendUDC() "
+                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error");
+            return support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT);
+        }
+        idOptions = *idOptionsCpp;
+        idOptions.LogDetail();
+    }
+    else
     {
         ChipLogProgress(AppServer,
                         "MatterCastingPlayer-JNI::sendUDC() Optional jIdentificationDeclarationOptions not "
                         "provided by the client");
-    }
-    else
-    {
-        ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::sendUDC() jIdentificationDeclarationOptions was provided by client");
-        idOptions = support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions);
-        VerifyOrReturnValue(idOptions != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
-                            ChipLogError(AppServer,
-                                         "MatterCastingPlayer-JNI::sendUDC() "
-                                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error"));
-        idOptions->LogDetail();
     }
 
     TEMPORARY_RETURN_IGNORED MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.SetUp(env, jSuccessCallback);
@@ -116,7 +121,7 @@ JNI_METHOD(jobject, sendUDC)
     connectionCallbacks.mCommissionerDeclarationCallback =
         MatterCastingPlayerJNI::getInstance().getCommissionerDeclarationCallback();
 
-    castingPlayer->SendUDC(connectionCallbacks, *idOptions);
+    castingPlayer->SendUDC(connectionCallbacks, idOptions);
 
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -217,7 +217,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                             //
                             // persist the TargetCastingPlayer information into the CastingStore and call mOnCompleted()
                             support::EndpointListLoader::GetInstance()->Initialize(&exchangeMgr, &sessionHandle);
-                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance() -> Load();
+                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance()->Load();
                         },
                         [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
                             ChipLogError(AppServer,

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -35,10 +35,8 @@ void CastingPlayer::SendUDC(ConnectionCallbacks connectionCallbacks, Identificat
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(
-        connectionCallbacks.mOnConnectionComplete != nullptr,
-        ChipLogError(AppServer,
-                     "CastingPlayer::VerifyOrEstablishConnection() ConnectionCallbacks.mOnConnectionComplete was not provided"));
+    VerifyOrExit(connectionCallbacks.mOnConnectionComplete != nullptr,
+                 ChipLogError(AppServer, "CastingPlayer::SendUDC() ConnectionCallbacks.mOnConnectionComplete was not provided"));
 
     mOnCompleted         = connectionCallbacks.mOnConnectionComplete;
     mTargetCastingPlayer = weak_from_this();
@@ -219,7 +217,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                             //
                             // persist the TargetCastingPlayer information into the CastingStore and call mOnCompleted()
                             support::EndpointListLoader::GetInstance()->Initialize(&exchangeMgr, &sessionHandle);
-                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance()->Load();
+                            TEMPORARY_RETURN_IGNORED support::EndpointListLoader::GetInstance() -> Load();
                         },
                         [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
                             ChipLogError(AppServer,


### PR DESCRIPTION
#### Summary

Late feedback from previous PRs (https://github.com/project-chip/connectedhomeip/commit/6e399f15eb741b5e218e28f4f1e8a76308ea3ad0)

- **Memory Leak**: The idOptions pointer allocated by support::convertIdentificationDeclarationOptionsFromJavaToCpp is never freed.
- **Null Pointer Dereference**: If jIdentificationDeclarationOptions is nullptr, idOptions remains nullptr, leading to a crash when it's dereferenced in the call to castingPlayer->VerifyOrEstablishConnection(..., *idOptions).

This memory leak was found by the AI reviewer.

#### Testing

build, unit tests and android running for smoke/regression testing