### PR TITLE
[Camera] Decouples CameraAVStreamManagementCluster from global dependencies through dependency injection

### DIFF
--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -19,6 +19,7 @@
 #include "data-model-providers/codegen/CodegenDataModelProvider.h"
 #include "tls-certificate-management-instance.h"
 #include "tls-client-management-instance.h"
+#include <app/SafeAttributePersistenceProvider.h>
 #include <app/clusters/push-av-stream-transport-server/CodegenIntegration.h>
 
 using namespace chip;
@@ -277,7 +278,8 @@ void CameraApp::CreateAndInitializeCameraAVStreamMgmt()
     std::vector<StreamUsageEnum> streamUsagePriorities = mCameraDevice->GetCameraHALInterface().GetStreamUsagePriorities();
 
     // Instantiate the CameraAVStreamMgmt Server
-    mAVStreamMgmtServer.Create(mCameraDevice->GetCameraAVStreamMgmtDelegate(), mEndpoint, avsmFeatures, avsmOptionalAttrs,
+    mAVStreamMgmtServer.Create(CameraAVStreamManagementCluster::Context{ *app::GetSafeAttributePersistenceProvider() },
+                               mCameraDevice->GetCameraAVStreamMgmtDelegate(), mEndpoint, avsmFeatures, avsmOptionalAttrs,
                                maxConcurrentVideoEncoders, maxEncodedPixelRate, sensorParams, nightVisionUsesInfrared, minViewport,
                                rateDistortionTradeOffPoints, maxContentBufferSize, micCapabilities, spkrCapabilities,
                                twowayTalkSupport, snapshotCapabilities, maxNetworkBandwidth, supportedStreamUsages,

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
@@ -397,6 +397,8 @@ public:
      * to be registered and called by the interaction model at the appropriate times.
      *
      * @param aContext                          Context providing injected dependencies (e.g., SafeAttributePersistenceProvider).
+     *                                          Note: the caller must ensure that the provided SafeAttributePersistenceProvider
+     *                                          outlives this instance.
      *
      * @param aDelegate                         A pointer to the delegate to be used by this server.
      *                                          Note: the caller must ensure that the delegate lives throughout the instance's

--- a/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
+++ b/src/app/clusters/camera-av-stream-management-server/CameraAVStreamManagementCluster.h
@@ -387,9 +387,16 @@ enum class OptionalAttribute : uint32_t
 class CameraAVStreamManagementCluster : public DefaultServerCluster
 {
 public:
+    struct Context
+    {
+        SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
+    };
+
     /**
      * @brief Creates a Camera AV Stream Management cluster instance. The Init() function needs to be called for this instance
      * to be registered and called by the interaction model at the appropriate times.
+     *
+     * @param aContext                          Context providing injected dependencies (e.g., SafeAttributePersistenceProvider).
      *
      * @param aDelegate                         A pointer to the delegate to be used by this server.
      *                                          Note: the caller must ensure that the delegate lives throughout the instance's
@@ -422,7 +429,7 @@ public:
      * for the transmission of its media streams.
      *
      */
-    CameraAVStreamManagementCluster(CameraAVStreamManagementDelegate & aDelegate, EndpointId aEndpointId,
+    CameraAVStreamManagementCluster(const Context & aContext, CameraAVStreamManagementDelegate & aDelegate, EndpointId aEndpointId,
                                     const BitFlags<Feature> aFeatures, const BitFlags<OptionalAttribute> aOptionalAttrs,
                                     uint8_t aMaxConcurrentEncoders, uint32_t aMaxEncodedPixelRate,
                                     const VideoSensorParamsStruct & aVideoSensorParams, bool aNightVisionUsesInfrared,
@@ -693,6 +700,7 @@ private:
     template <AttributeId TAttributeId>
     friend struct StreamTraits;
 
+    Context mContext;
     CameraAVStreamManagementDelegate & mDelegate;
     const BitFlags<Feature> mEnabledFeatures;
     const BitFlags<OptionalAttribute> mOptionalAttrs;
@@ -755,7 +763,7 @@ private:
             auto path    = ConcreteAttributePath(mPath.mEndpointId, CameraAvStreamManagement::Id, attributeId);
             if (shouldPersist)
             {
-                ReturnErrorOnFailure(GetSafeAttributePersistenceProvider()->WriteScalarValue(path, currentValue));
+                ReturnErrorOnFailure(mContext.safeAttributePersistenceProvider.WriteScalarValue(path, currentValue));
             }
             mDelegate.OnAttributeChanged(attributeId);
             NotifyAttributeChanged(attributeId);

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -278,7 +278,8 @@ struct TestCameraAVStreamManagementCluster : public ::testing::Test
 
     TestCameraAVStreamManagementCluster() :
         mMockDelegate(&mVideoStreams, &mAudioStreams, &mSnapshotStreams),
-        mServer(mMockDelegate, kTestEndpointId,
+        mServer(CameraAvStreamManagement::CameraAVStreamManagementCluster::Context{ mPersistenceProvider }, mMockDelegate,
+                kTestEndpointId,
                 chip::BitFlags<CameraAvStreamManagement::Feature>(
                     CameraAvStreamManagement::Feature::kVideo, CameraAvStreamManagement::Feature::kAudio,
                     CameraAvStreamManagement::Feature::kSnapshot, CameraAvStreamManagement::Feature::kSpeaker,
@@ -302,21 +303,20 @@ struct TestCameraAVStreamManagementCluster : public ::testing::Test
     void SetUp() override
     {
         VerifyOrDie(mPersistenceProvider.Init(&mClusterTester.GetServerClusterContext().storage) == CHIP_NO_ERROR);
-        app::SetSafeAttributePersistenceProvider(&mPersistenceProvider);
         EXPECT_EQ(mServer.Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
         EXPECT_EQ(InitializeCameraAVSMDefaults(mServer), CHIP_NO_ERROR);
         EXPECT_EQ(mServer.Init(), CHIP_NO_ERROR);
     }
 
-    void TearDown() override { app::SetSafeAttributePersistenceProvider(nullptr); }
+    void TearDown() override {}
 
     std::vector<VideoStreamStruct> mVideoStreams;
     std::vector<AudioStreamStruct> mAudioStreams;
     std::vector<SnapshotStreamStruct> mSnapshotStreams;
     MockCameraAVStreamManagementDelegate mMockDelegate;
+    app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
     CameraAvStreamManagement::CameraAVStreamManagementCluster mServer;
     ClusterTester mClusterTester;
-    app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
 };
 
 TEST_F(TestCameraAVStreamManagementCluster, TestAttributes)

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -308,8 +308,6 @@ struct TestCameraAVStreamManagementCluster : public ::testing::Test
         EXPECT_EQ(mServer.Init(), CHIP_NO_ERROR);
     }
 
-    void TearDown() override {}
-
     std::vector<VideoStreamStruct> mVideoStreams;
     std::vector<AudioStreamStruct> mAudioStreams;
     std::vector<SnapshotStreamStruct> mSnapshotStreams;


### PR DESCRIPTION
#### Summary

This PR decouples CameraAVStreamManagementCluster from global dependencies through dependency injection with a Context struct. The global dependencies are:

GetSafeAttributePersistenceProvider()

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
