### PR TITLE
[Camera] Decouples TLSClientManagementCluster from global dependencies through dependency injection

### DIFF
--- a/src/app/clusters/tls-client-management-server/BUILD.gn
+++ b/src/app/clusters/tls-client-management-server/BUILD.gn
@@ -21,8 +21,8 @@ source_set("tls-client-management-server") {
 
   public_deps = [
     "${chip_root}/src/app/",
-    "${chip_root}/src/app/server",
     "${chip_root}/src/app/server-cluster",
+    "${chip_root}/src/credentials",
     "${chip_root}/src/lib/core:types",
     "${chip_root}/zzz_generated/app-common/clusters/TlsClientManagement",
   ]

--- a/src/app/clusters/tls-client-management-server/CodegenIntegration.cpp
+++ b/src/app/clusters/tls-client-management-server/CodegenIntegration.cpp
@@ -19,6 +19,7 @@
 #include "CodegenIntegration.h"
 
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
+#include <app/server/Server.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
@@ -96,7 +97,10 @@ void MatterTlsClientManagementClusterInitCallback(EndpointId endpointId)
 
     LogErrorOnFailure(gCertificateTable->SetEndpoint(endpointId));
 
-    gClusterInstance.Create(endpointId, *gDelegate, *gCertificateTable, kDefaultMaxProvisionedEndpoints);
+    TLSClientManagementCluster::Context context = {
+        .fabricTable = Server::GetInstance().GetFabricTable(),
+    };
+    gClusterInstance.Create(context, endpointId, *gDelegate, *gCertificateTable, kDefaultMaxProvisionedEndpoints);
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Register(gClusterInstance.Registration());
     if (err != CHIP_NO_ERROR)
     {

--- a/src/app/clusters/tls-client-management-server/CodegenIntegration.cpp
+++ b/src/app/clusters/tls-client-management-server/CodegenIntegration.cpp
@@ -97,9 +97,7 @@ void MatterTlsClientManagementClusterInitCallback(EndpointId endpointId)
 
     LogErrorOnFailure(gCertificateTable->SetEndpoint(endpointId));
 
-    TLSClientManagementCluster::Context context = {
-        .fabricTable = Server::GetInstance().GetFabricTable(),
-    };
+    TLSClientManagementCluster::Context context{ Server::GetInstance().GetFabricTable() };
     gClusterInstance.Create(context, endpointId, *gDelegate, *gCertificateTable, kDefaultMaxProvisionedEndpoints);
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Register(gClusterInstance.Registration());
     if (err != CHIP_NO_ERROR)

--- a/src/app/clusters/tls-client-management-server/TLSClientManagementCluster.h
+++ b/src/app/clusters/tls-client-management-server/TLSClientManagementCluster.h
@@ -25,6 +25,7 @@
 #include <clusters/TlsClientManagement/Commands.h>
 #include <clusters/TlsClientManagement/Metadata.h>
 #include <clusters/TlsClientManagement/Structs.h>
+#include <credentials/FabricTable.h>
 #include <lib/core/CHIPError.h>
 #include <protocols/interaction_model/StatusCode.h>
 
@@ -38,15 +39,23 @@ class TLSClientManagementDelegate;
 class TLSClientManagementCluster : public DefaultServerCluster, private chip::FabricTable::Delegate
 {
 public:
+    struct Context
+    {
+        FabricTable & fabricTable;
+    };
+
     /**
      * Creates a TLSClientManagement server instance.
+     * @param context The context containing injected dependencies.
+     *                           Note: the caller must ensure that the provided dependencies
+     *                           outlives this instance.
      * @param endpointId The endpoint on which this cluster exists. This must match the zap configuration.
      * @param delegate A reference to the delegate to be used by this server.
      * @param certificateTable A reference to the certificate table for looking up certificates
      * @param maxProvisioned The maximum number of endpoints which can be provisioned
      * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
      */
-    TLSClientManagementCluster(EndpointId endpointId, TLSClientManagementDelegate & delegate,
+    TLSClientManagementCluster(const Context & context, EndpointId endpointId, TLSClientManagementDelegate & delegate,
                                Tls::CertificateTable & certificateTable, uint8_t maxProvisioned);
     ~TLSClientManagementCluster();
 
@@ -75,6 +84,7 @@ public:
                                                                CommandHandler * handler) override;
 
 private:
+    Context mContext;
     TLSClientManagementDelegate & mDelegate;
     Tls::CertificateTable & mCertificateTable;
 

--- a/src/app/clusters/tls-client-management-server/TLSClientManagementCluster.h
+++ b/src/app/clusters/tls-client-management-server/TLSClientManagementCluster.h
@@ -48,7 +48,7 @@ public:
      * Creates a TLSClientManagement server instance.
      * @param context The context containing injected dependencies.
      *                           Note: the caller must ensure that the provided dependencies
-     *                           outlives this instance.
+     *                           outlive this instance.
      * @param endpointId The endpoint on which this cluster exists. This must match the zap configuration.
      * @param delegate A reference to the delegate to be used by this server.
      * @param certificateTable A reference to the certificate table for looking up certificates

--- a/src/app/clusters/tls-client-management-server/tests/BUILD.gn
+++ b/src/app/clusters/tls-client-management-server/tests/BUILD.gn
@@ -25,6 +25,7 @@ chip_test_suite("tests") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    "${chip_root}/src/app:attribute-persistence",
     "${chip_root}/src/app/clusters/tls-certificate-management-server",
     "${chip_root}/src/app/clusters/tls-client-management-server",
     "${chip_root}/src/app/data-model-provider/tests:encode-decode",

--- a/src/app/clusters/tls-client-management-server/tests/TestTLSClientManagementCluster.cpp
+++ b/src/app/clusters/tls-client-management-server/tests/TestTLSClientManagementCluster.cpp
@@ -26,6 +26,7 @@
 #include <app/server-cluster/testing/AttributeTesting.h>
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
+#include <credentials/FabricTable.h>
 #include <lib/support/ReadOnlyBuffer.h>
 
 using namespace chip;
@@ -304,8 +305,9 @@ struct TestTLSClientManagementCluster : public ::testing::Test
 
     MockTLSClientManagementDelegate mMockDelegate;
     MockCertificateTable mMockCertTable;
+    FabricTable mFabricTable;
 
-    TLSClientManagementCluster mCluster{ kTestEndpointId, mMockDelegate, mMockCertTable, kMaxProvisioned };
+    TLSClientManagementCluster mCluster{ { mFabricTable }, kTestEndpointId, mMockDelegate, mMockCertTable, kMaxProvisioned };
 
     ClusterTester mClusterTester{ mCluster };
 


### PR DESCRIPTION
#### Summary

This PR decouples TLSClientManagementCluster from global dependencies through dependency injection with a Context struct. The global dependencies are:

GetFabricTable()

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
