### PR TITLE
[Camera] Decouples TLSCertificateManagementCluster from global dependencies through dependency injection

### DIFF
--- a/src/app/clusters/tls-certificate-management-server/BUILD.gn
+++ b/src/app/clusters/tls-certificate-management-server/BUILD.gn
@@ -35,9 +35,9 @@ source_set("tls-certificate-management-server") {
 
   deps = [
     ":certificate-table",
-    "${chip_root}/src/app:attribute-persistence",
-    "${chip_root}/src/app/server",
+    "${chip_root}/src/app:interaction-model",
     "${chip_root}/src/app/server-cluster:server-cluster",
+    "${chip_root}/src/credentials",
     "${chip_root}/zzz_generated/app-common/clusters:all-headers",
     "${chip_root}/zzz_generated/app-common/clusters:all-metadata",
   ]

--- a/src/app/clusters/tls-certificate-management-server/CodegenIntegration.cpp
+++ b/src/app/clusters/tls-certificate-management-server/CodegenIntegration.cpp
@@ -19,6 +19,7 @@
 #include "CodegenIntegration.h"
 
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
+#include <app/server/Server.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
@@ -109,7 +110,10 @@ void MatterTlsCertificateManagementClusterInitCallback(EndpointId endpointId)
 
     LogErrorOnFailure(gCertificateTable->SetEndpoint(endpointId));
 
-    gClusterInstance.Create(endpointId, *gDelegate, *gDependencyChecker, *gCertificateTable,
+    TLSCertificateManagementCluster::Context context = {
+        Server::GetInstance().GetFabricTable(),
+    };
+    gClusterInstance.Create(context, endpointId, *gDelegate, *gDependencyChecker, *gCertificateTable,
                             static_cast<uint8_t>(kMaxRootCertificatesPerFabric),
                             static_cast<uint8_t>(kMaxClientCertificatesPerFabric));
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Register(gClusterInstance.Registration());

--- a/src/app/clusters/tls-certificate-management-server/TLSCertificateManagementCluster.h
+++ b/src/app/clusters/tls-certificate-management-server/TLSCertificateManagementCluster.h
@@ -25,6 +25,7 @@
 #include <clusters/TlsCertificateManagement/Commands.h>
 #include <clusters/TlsCertificateManagement/Metadata.h>
 #include <clusters/TlsCertificateManagement/Structs.h>
+#include <credentials/FabricTable.h>
 #include <lib/core/CHIPError.h>
 #include <protocols/interaction_model/StatusCode.h>
 
@@ -37,8 +38,16 @@ class TLSCertificateManagementDelegate;
 class TLSCertificateManagementCluster : public DefaultServerCluster, private FabricTable::Delegate
 {
 public:
+    struct Context
+    {
+        FabricTable & fabricTable;
+    };
+
     /**
      * Creates a TlsCertificateManagement server instance.
+     * @param context The context containing injected dependencies.
+     *                           Note: the caller must ensure that the provided dependencies
+     *                           outlive this instance.
      * @param endpointId The endpoint on which this cluster exists. This must match the zap configuration.
      * @param delegate A reference to the delegate to be used by this server.
      * @param dependencyChecker A reference to a CertificateDependencyChecker which checks for transitive dependencies
@@ -47,7 +56,7 @@ public:
      * @param maxClientCertificates The maximum number of client certificates which can be provisioned
      * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
      */
-    TLSCertificateManagementCluster(EndpointId endpointId, TLSCertificateManagementDelegate & delegate,
+    TLSCertificateManagementCluster(const Context & context, EndpointId endpointId, TLSCertificateManagementDelegate & delegate,
                                     Tls::CertificateDependencyChecker & dependencyChecker, Tls::CertificateTable & certificateTable,
                                     uint8_t maxRootCertificates, uint8_t maxClientCertificates);
     ~TLSCertificateManagementCluster();
@@ -89,6 +98,7 @@ public:
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
 private:
+    Context mContext;
     TLSCertificateManagementDelegate & mDelegate;
     Tls::CertificateDependencyChecker & mDependencyChecker;
     Tls::CertificateTable & mCertificateTable;

--- a/src/app/clusters/tls-certificate-management-server/tests/BUILD.gn
+++ b/src/app/clusters/tls-certificate-management-server/tests/BUILD.gn
@@ -28,6 +28,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/app:attribute-persistence",
     "${chip_root}/src/app/clusters/tls-certificate-management-server",
     "${chip_root}/src/app/data-model-provider/tests:encode-decode",
+    "${chip_root}/src/app/server",
     "${chip_root}/src/app/server-cluster/testing:testing",
     "${chip_root}/src/lib/support",
   ]

--- a/src/app/clusters/tls-certificate-management-server/tests/TestTLSCertificateManagementCluster.cpp
+++ b/src/app/clusters/tls-certificate-management-server/tests/TestTLSCertificateManagementCluster.cpp
@@ -26,6 +26,7 @@
 #include <app/server-cluster/testing/ClusterTester.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <credentials/CHIPCert.h>
+#include <credentials/FabricTable.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/support/ReadOnlyBuffer.h>
 #include <lib/support/TimeUtils.h>
@@ -479,9 +480,10 @@ struct TestTLSCertificateManagementCluster : public ::testing::Test
     MockTLSCertificateManagementDelegate mMockDelegate;
     MockCertificateTable mMockCertTable;
     MockCertificateDependencyChecker mMockDependencyChecker;
+    FabricTable mFabricTable;
 
-    TLSCertificateManagementCluster mCluster{ kTestEndpointId, mMockDelegate,        mMockDependencyChecker,
-                                              mMockCertTable,  kMaxRootCertificates, kMaxClientCertificates };
+    TLSCertificateManagementCluster mCluster{ { mFabricTable }, kTestEndpointId,      mMockDelegate,         mMockDependencyChecker,
+                                              mMockCertTable,   kMaxRootCertificates, kMaxClientCertificates };
 
     ClusterTester mClusterTester{ mCluster };
 


### PR DESCRIPTION

#### Summary

This PR decouples TLSCertificateManagementCluster from global dependencies through dependency injection with a Context struct. The global dependencies are:

GetFabricTable()


#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
