### PR TITLE
[Ameba] Cherry-pick fix for WiFi connection and server initialization

### DIFF
--- a/examples/air-purifier-app/ameba/main/chipinterface.cpp
+++ b/examples/air-purifier-app/ameba/main/chipinterface.cpp
@@ -144,9 +144,9 @@ static void InitServer(intptr_t context)
 
     static AmebaObserver sAmebaObserver;
     initParams.appDelegate = &sAmebaObserver;
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
     chip::Server::GetInstance().Init(initParams);
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     NetWorkCommissioningInstInit();
 

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -132,17 +132,13 @@ static void InitServer(intptr_t context)
 {
     // Init ZCL Data Model and CHIP App Server
     static chip::CommonCaseDeviceServerInitParams initParams;
+    initParams.InitializeStaticResourcesBeforeServerInit();
+    initParams.dataModelProvider = CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
 
 #if CONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER
     static AmebaTestEventTriggerDelegate sTestEventTriggerDelegate{ ByteSpan(sTestEventTriggerEnableKey) };
     initParams.testEventTriggerDelegate = &sTestEventTriggerDelegate;
 #endif
-
-    static AmebaObserver sAmebaObserver;
-    initParams.appDelegate = &sAmebaObserver;
-
-    initParams.InitializeStaticResourcesBeforeServerInit();
-    initParams.dataModelProvider = CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
 
 #if CONFIG_ENABLE_AMEBA_CRYPTO
     ChipLogProgress(DeviceLayer, "platform crypto enabled!");
@@ -151,10 +147,11 @@ static void InitServer(intptr_t context)
     initParams.operationalKeystore = &sAmebaPersistentStorageOpKeystore;
 #endif
 
+    static AmebaObserver sAmebaObserver;
+    initParams.appDelegate = &sAmebaObserver;
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
     chip::Server::GetInstance().Init(initParams);
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
-    // TODO: Use our own DeviceInfoProvider
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
 #if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
     const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(

--- a/examples/chef/ameba/main/chipinterface.cpp
+++ b/examples/chef/ameba/main/chipinterface.cpp
@@ -100,11 +100,9 @@ static void InitServer(intptr_t context)
 
     static AmebaObserver sAmebaObserver;
     initParams.appDelegate = &sAmebaObserver;
-
-    chip::Server::GetInstance().Init(initParams);
-
-    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
+    chip::Server::GetInstance().Init(initParams);
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
 
     NetWorkCommissioningInstInit();
 

--- a/examples/light-switch-app/ameba/main/chipinterface.cpp
+++ b/examples/light-switch-app/ameba/main/chipinterface.cpp
@@ -109,9 +109,9 @@ static void InitServer(intptr_t context)
 
     static AmebaObserver sAmebaObserver;
     initParams.appDelegate = &sAmebaObserver;
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
     chip::Server::GetInstance().Init(initParams);
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     NetWorkCommissioningInstInit();
 

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -136,9 +136,9 @@ static void InitServer(intptr_t context)
 
     static AmebaObserver sAmebaObserver;
     initParams.appDelegate = &sAmebaObserver;
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
     chip::Server::GetInstance().Init(initParams);
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
 #if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
     const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -78,12 +78,13 @@ static void InitServer(intptr_t context)
     // Init ZCL Data Model and CHIP App Server
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+
     static AmebaObserver sAmebaObserver;
     initParams.dataModelProvider = CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
     initParams.appDelegate       = &sAmebaObserver;
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
     chip::Server::GetInstance().Init(initParams);
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     NetWorkCommissioningInstInit();
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -630,11 +630,6 @@ void ConnectivityManagerImpl::OnStationDisconnected()
             chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::ConnectionStatusEnum::kNotConnected));
     }
 
-    if (reason != RTW_NO_ERROR)
-    {
-        NetworkCommissioning::AmebaWiFiDriver::GetInstance().OnConnectWiFiNetworkFailed(reason);
-    }
-
     UpdateInternetConnectivityState();
 }
 

--- a/src/platform/Ameba/NetworkCommissioningDriver.h
+++ b/src/platform/Ameba/NetworkCommissioningDriver.h
@@ -26,7 +26,7 @@ namespace NetworkCommissioning {
 namespace {
 inline constexpr uint8_t kMaxWiFiNetworks                  = 1;
 inline constexpr uint8_t kWiFiScanNetworksTimeOutSeconds   = 10;
-inline constexpr uint8_t kWiFiConnectNetworkTimeoutSeconds = 20;
+inline constexpr uint8_t kWiFiConnectNetworkTimeoutSeconds = 35;
 } // namespace
 
 class AmebaScanResponseIterator : public Iterator<WiFiScanResponse>
@@ -111,6 +111,7 @@ public:
     CHIP_ERROR ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen);
     void OnConnectWiFiNetwork();
     void OnConnectWiFiNetworkFailed(uint16_t reason);
+    static void OnConnectWiFiNetworkFailedTimer(chip::System::Layer * aLayer, void * aAppState);
     void OnScanWiFiNetworkDone();
     void OnNetworkStatusChange();
 


### PR DESCRIPTION
#### Summary

* Prevent commissioning failure when the first Wi-Fi connection attempt is temporarily rejected. Start a connection timeout timer and report ConnectWiFiNetworkFailed to the controller only if the timeout expires.

* Ensure SetDeviceInfoProvider completes before server initialization when supporting FixedLabel, UserLabel, Localization, or TimeFormatLocalization. Reorder initialization sequence accordingly.

#### Related issues

Cherry-pick from master branch 
[Ameba] Fix Wi-Fi connection handling and server initialization order (#42912)

#### Testing

1. Entered an incorrect Wi-Fi password:
   - DUT waits for the connection timeout and restores the initial state for the next commissioning flow.
   - The subsequent commissioning attempt succeeds.

2. Simulated a failure on the first Wi-Fi connection attempt:
   - DUT retries the connection and successfully connects to Wi-Fi.
   - Commissioning completes successfully.

3. Verified server initialization order:
   - DUT previously hung when DeviceInfoProvider was not set before server initialization.
   - After correcting the initialization order, the DUT no longer hangs.