### PR TITLE
[TestCommissioningWindowManager]: Fix bug where timer callbacks not being called

### DIFF
--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -334,8 +334,7 @@ chip_test_suite("tests") {
 
   # TestCommissioningWindowManager uses MockClock to advance time and force timer expiration which
   # does not behave as expected on darwin
-  if (chip_config_network_layer_ble &&
-      (chip_device_platform == "linux" || chip_device_platform == "darwin")) {
+  if (chip_config_network_layer_ble && chip_device_platform == "linux") {
     test_sources += [ "TestCommissioningWindowManager.cpp" ]
     public_deps += [
       "${chip_root}/src/app/clusters/administrator-commissioning-server:administrator-commissioning-server",

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -334,7 +334,8 @@ chip_test_suite("tests") {
 
   # TestCommissioningWindowManager uses MockClock to advance time and force timer expiration which
   # does not behave as expected on darwin
-  if (chip_config_network_layer_ble && chip_device_platform == "linux") {
+  if (chip_config_network_layer_ble &&
+      (chip_device_platform == "linux" || chip_device_platform == "darwin")) {
     test_sources += [ "TestCommissioningWindowManager.cpp" ]
     public_deps += [
       "${chip_root}/src/app/clusters/administrator-commissioning-server:administrator-commissioning-server",

--- a/src/app/tests/TestCommissioningWindowManager.cpp
+++ b/src/app/tests/TestCommissioningWindowManager.cpp
@@ -249,8 +249,10 @@ void TestCommissioningWindowManager::ServiceEvents()
 {
     DrainAndServiceIO();
 
-    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(
-        [](intptr_t) -> void { EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().StopEventLoopTask()); }, (intptr_t) nullptr));
+    EXPECT_SUCCESS(chip::DeviceLayer::SystemLayer().StartTimer(
+        chip::System::Clock::Milliseconds32(0),
+        [](chip::System::Layer *, void *) { EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().StopEventLoopTask()); }, nullptr));
+
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 }
 

--- a/src/app/tests/TestCommissioningWindowManager.cpp
+++ b/src/app/tests/TestCommissioningWindowManager.cpp
@@ -77,6 +77,9 @@ bool sAdminFabricIndexDirty = false;
 bool sAdminVendorIdDirty    = false;
 bool sWindowStatusDirty     = false;
 
+bool sSimulateFailedSessionEstablishmentTaskCalled          = false;
+bool sCheckCommissioningWindowManagerWindowClosedTaskCalled = false;
+
 void ResetDirtyFlags()
 {
     sAdminFabricIndexDirty = false;
@@ -152,6 +155,25 @@ public:
     uint32_t mNumPairingComplete = 0;
 };
 
+class MockAppDelegate : public AppDelegate
+{
+public:
+    void OnCommissioningWindowOpened() override { mOnCommissioningWindowOpenedCount++; }
+    void OnCommissioningWindowClosed() override { mOnCommissioningWindowClosedCount++; }
+
+    void OnCommissioningSessionEstablishmentError(CHIP_ERROR error) override
+    {
+        mOnCommissioningSessionEstablishmentErrorCount++;
+        mError = error;
+    }
+
+    uint8_t mOnCommissioningWindowOpenedCount              = 0;
+    uint8_t mOnCommissioningWindowClosedCount              = 0;
+    uint8_t mOnCommissioningSessionEstablishmentErrorCount = 0;
+
+    CHIP_ERROR mError;
+};
+
 class TestCommissioningWindowManager : public chip::Testing::LoopbackMessagingContext
 {
 public:
@@ -213,6 +235,8 @@ public:
     {
         ConfigInitializeNodes(false);
         chip::Testing::LoopbackMessagingContext::SetUp();
+        sSimulateFailedSessionEstablishmentTaskCalled          = false;
+        sCheckCommissioningWindowManagerWindowClosedTaskCalled = false;
     }
 
     void EstablishPASEHandshake(SessionManager & sessionManager, PASESession & pairingCommissioner,
@@ -225,9 +249,8 @@ void TestCommissioningWindowManager::ServiceEvents()
 {
     DrainAndServiceIO();
 
-    TEMPORARY_RETURN_IGNORED chip::DeviceLayer::PlatformMgr().ScheduleWork(
-        [](intptr_t) -> void { TEMPORARY_RETURN_IGNORED chip::DeviceLayer::PlatformMgr().StopEventLoopTask(); },
-        (intptr_t) nullptr);
+    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(
+        [](intptr_t) -> void { EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().StopEventLoopTask()); }, (intptr_t) nullptr));
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 }
 
@@ -297,7 +320,7 @@ private:
     SessionManager mSessionManager;
 };
 
-void CheckCommissioningWindowManagerBasicWindowOpenCloseTask(intptr_t context)
+TEST_F(TestCommissioningWindowManager, TestCheckCommissioningWindowManagerBasicWindowOpenClose)
 {
     EXPECT_FALSE(sWindowStatusDirty);
     EXPECT_FALSE(sAdminFabricIndexDirty);
@@ -325,15 +348,7 @@ void CheckCommissioningWindowManagerBasicWindowOpenCloseTask(intptr_t context)
     EXPECT_FALSE(sAdminVendorIdDirty);
 }
 
-TEST_F(TestCommissioningWindowManager, TestCheckCommissioningWindowManagerBasicWindowOpenClose)
-{
-
-    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(CheckCommissioningWindowManagerBasicWindowOpenCloseTask));
-    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(StopEventLoop));
-    chip::DeviceLayer::PlatformMgr().RunEventLoop();
-}
-
-void CheckCommissioningWindowManagerBasicWindowOpenCloseFromClusterTask(intptr_t context)
+TEST_F(TestCommissioningWindowManager, TestCheckCommissioningWindowManagerBasicWindowOpenCloseFromCluster)
 {
     EXPECT_FALSE(sWindowStatusDirty);
     EXPECT_FALSE(sAdminFabricIndexDirty);
@@ -373,14 +388,6 @@ void CheckCommissioningWindowManagerBasicWindowOpenCloseFromClusterTask(intptr_t
     ResetDirtyFlags();
 }
 
-TEST_F(TestCommissioningWindowManager, TestCheckCommissioningWindowManagerBasicWindowOpenCloseFromCluster)
-{
-    EXPECT_SUCCESS(
-        chip::DeviceLayer::PlatformMgr().ScheduleWork(CheckCommissioningWindowManagerBasicWindowOpenCloseFromClusterTask));
-    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(StopEventLoop));
-    chip::DeviceLayer::PlatformMgr().RunEventLoop();
-}
-
 void CheckCommissioningWindowManagerWindowClosedTask(chip::System::Layer *, void *)
 {
     CommissioningWindowManager & commissionMgr = Server::GetInstance().GetCommissioningWindowManager();
@@ -390,25 +397,34 @@ void CheckCommissioningWindowManagerWindowClosedTask(chip::System::Layer *, void
     EXPECT_FALSE(sWindowStatusDirty);
     EXPECT_FALSE(sAdminFabricIndexDirty);
     EXPECT_FALSE(sAdminVendorIdDirty);
+
+    sCheckCommissioningWindowManagerWindowClosedTaskCalled = true;
 }
 
-void CheckCommissioningWindowManagerWindowTimeoutTask(intptr_t context)
+TEST_F(TestCommissioningWindowManager, TestCheckCommissioningWindowManagerWindowTimeout)
 {
+    System::Clock::Internal::RAIIMockClock clock;
 
     EXPECT_FALSE(sWindowStatusDirty);
     EXPECT_FALSE(sAdminFabricIndexDirty);
     EXPECT_FALSE(sAdminVendorIdDirty);
 
     CommissioningWindowManager & commissionMgr = Server::GetInstance().GetCommissioningWindowManager();
-    constexpr auto kTimeoutSeconds             = chip::System::Clock::Seconds32(1);
-    constexpr uint16_t kTimeoutMs              = 1000;
-    constexpr unsigned kSleepPadding           = 100;
+    MockAppDelegate delegateApp;
+    commissionMgr.SetAppDelegate(&delegateApp);
+
+    constexpr auto kTimeoutSeconds   = chip::System::Clock::Seconds32(1);
+    constexpr uint16_t kTimeoutMs    = 1000;
+    constexpr unsigned kSleepPadding = 100;
     commissionMgr.OverrideMinCommissioningTimeout(kTimeoutSeconds);
-    EXPECT_EQ(commissionMgr.OpenBasicCommissioningWindow(kTimeoutSeconds, CommissioningWindowAdvertisement::kDnssdOnly),
-              CHIP_NO_ERROR);
+    EXPECT_SUCCESS(commissionMgr.OpenBasicCommissioningWindow(kTimeoutSeconds, CommissioningWindowAdvertisement::kDnssdOnly));
+
     EXPECT_TRUE(commissionMgr.IsCommissioningWindowOpen());
     EXPECT_EQ(commissionMgr.CommissioningWindowStatusForCluster(),
               chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
+    EXPECT_EQ(delegateApp.mOnCommissioningWindowOpenedCount, 1u);
+    EXPECT_EQ(delegateApp.mOnCommissioningWindowClosedCount, 0u);
+
     EXPECT_FALSE(chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled());
     EXPECT_FALSE(sWindowStatusDirty);
     EXPECT_FALSE(sAdminFabricIndexDirty);
@@ -416,17 +432,19 @@ void CheckCommissioningWindowManagerWindowTimeoutTask(intptr_t context)
 
     EXPECT_SUCCESS(chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(kTimeoutMs + kSleepPadding),
                                                                CheckCommissioningWindowManagerWindowClosedTask, nullptr));
-}
 
-TEST_F(TestCommissioningWindowManager, TestCheckCommissioningWindowManagerWindowTimeout)
-{
-    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(CheckCommissioningWindowManagerWindowTimeoutTask));
-    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(StopEventLoop));
-    chip::DeviceLayer::PlatformMgr().RunEventLoop();
+    clock.AdvanceMonotonic(chip::System::Clock::Milliseconds64(kTimeoutMs + kSleepPadding));
+    ServiceEvents();
+
+    EXPECT_TRUE(sCheckCommissioningWindowManagerWindowClosedTaskCalled);
+    EXPECT_EQ(delegateApp.mOnCommissioningWindowClosedCount, 1u);
+
+    commissionMgr.SetAppDelegate(nullptr);
 }
 
 void SimulateFailedSessionEstablishmentTask(chip::System::Layer *, void *)
 {
+
     CommissioningWindowManager & commissionMgr = Server::GetInstance().GetCommissioningWindowManager();
     EXPECT_TRUE(commissionMgr.IsCommissioningWindowOpen());
     EXPECT_EQ(commissionMgr.CommissioningWindowStatusForCluster(),
@@ -443,19 +461,28 @@ void SimulateFailedSessionEstablishmentTask(chip::System::Layer *, void *)
     EXPECT_FALSE(sWindowStatusDirty);
     EXPECT_FALSE(sAdminFabricIndexDirty);
     EXPECT_FALSE(sAdminVendorIdDirty);
+
+    sSimulateFailedSessionEstablishmentTaskCalled = true;
 }
 
-void CheckCommissioningWindowManagerWindowTimeoutWithSessionEstablishmentErrorsTask(intptr_t context)
+TEST_F(TestCommissioningWindowManager, CheckCommissioningWindowManagerWindowTimeoutWithSessionEstablishmentErrors)
 {
+    System::Clock::Internal::RAIIMockClock clock;
+
     EXPECT_FALSE(sWindowStatusDirty);
     EXPECT_FALSE(sAdminFabricIndexDirty);
     EXPECT_FALSE(sAdminVendorIdDirty);
 
     CommissioningWindowManager & commissionMgr = Server::GetInstance().GetCommissioningWindowManager();
-    constexpr auto kTimeoutSeconds             = chip::System::Clock::Seconds16(1);
-    constexpr uint16_t kTimeoutMs              = 1000;
-    constexpr unsigned kSleepPadding           = 100;
+    MockAppDelegate delegateApp;
+    commissionMgr.SetAppDelegate(&delegateApp);
 
+    constexpr auto kTimeoutSeconds                          = chip::System::Clock::Seconds16(1);
+    constexpr uint16_t kTimeoutMs                           = 1000;
+    constexpr unsigned kSleepPadding                        = 100;
+    constexpr uint16_t kFailedSessionEstablishmentTimeoutMs = kTimeoutMs / 4 * 3;
+
+    commissionMgr.OverrideMinCommissioningTimeout(kTimeoutSeconds);
     EXPECT_EQ(commissionMgr.OpenBasicCommissioningWindow(kTimeoutSeconds, CommissioningWindowAdvertisement::kDnssdOnly),
               CHIP_NO_ERROR);
 
@@ -468,23 +495,35 @@ void CheckCommissioningWindowManagerWindowTimeoutWithSessionEstablishmentErrorsT
     EXPECT_FALSE(sAdminFabricIndexDirty);
     EXPECT_FALSE(sAdminVendorIdDirty);
 
+    EXPECT_EQ(delegateApp.mOnCommissioningWindowOpenedCount, 1u);
+    EXPECT_EQ(delegateApp.mOnCommissioningWindowClosedCount, 0u);
+    EXPECT_EQ(delegateApp.mOnCommissioningSessionEstablishmentErrorCount, 0u);
+
     EXPECT_SUCCESS(chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(kTimeoutMs + kSleepPadding),
                                                                CheckCommissioningWindowManagerWindowClosedTask, nullptr));
     // Simulate a session establishment error during that window, such that the
     // delay for the error plus the window size exceeds our "timeout + padding" above.
-    EXPECT_SUCCESS(chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(kTimeoutMs / 4 * 3),
-                                                               SimulateFailedSessionEstablishmentTask, nullptr));
+    EXPECT_SUCCESS(DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kFailedSessionEstablishmentTimeoutMs),
+                                                         SimulateFailedSessionEstablishmentTask, nullptr));
+
+    // Advance time so that SimulateFailedSessionEstablishmentTask is fired
+    clock.AdvanceMonotonic(chip::System::Clock::Milliseconds64(kFailedSessionEstablishmentTimeoutMs));
+    ServiceEvents();
+
+    EXPECT_TRUE(sSimulateFailedSessionEstablishmentTaskCalled);
+    EXPECT_EQ(delegateApp.mOnCommissioningSessionEstablishmentErrorCount, 1u);
+
+    // Advance time so that the CheckCommissioningWindowManagerWindowClosedTask is fired
+    clock.AdvanceMonotonic(chip::System::Clock::Milliseconds64(kTimeoutMs + kSleepPadding - kFailedSessionEstablishmentTimeoutMs));
+    ServiceEvents();
+
+    EXPECT_TRUE(sCheckCommissioningWindowManagerWindowClosedTaskCalled);
+    EXPECT_EQ(delegateApp.mOnCommissioningWindowClosedCount, 1u);
+
+    commissionMgr.SetAppDelegate(nullptr);
 }
 
-TEST_F(TestCommissioningWindowManager, CheckCommissioningWindowManagerWindowTimeoutWithSessionEstablishmentErrors)
-{
-    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(
-        CheckCommissioningWindowManagerWindowTimeoutWithSessionEstablishmentErrorsTask));
-    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(StopEventLoop));
-    chip::DeviceLayer::PlatformMgr().RunEventLoop();
-}
-
-void CheckCommissioningWindowManagerEnhancedWindowTask(intptr_t context)
+TEST_F(TestCommissioningWindowManager, TestCheckCommissioningWindowManagerEnhancedWindow)
 {
     CommissioningWindowManager & commissionMgr = Server::GetInstance().GetCommissioningWindowManager();
     uint16_t originDiscriminator;
@@ -532,13 +571,6 @@ void CheckCommissioningWindowManagerEnhancedWindowTask(intptr_t context)
     EXPECT_TRUE(sAdminVendorIdDirty);
 
     ResetDirtyFlags();
-}
-
-TEST_F(TestCommissioningWindowManager, TestCheckCommissioningWindowManagerEnhancedWindow)
-{
-    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(CheckCommissioningWindowManagerEnhancedWindowTask));
-    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(StopEventLoop));
-    chip::DeviceLayer::PlatformMgr().RunEventLoop();
 }
 
 TEST_F(TestCommissioningWindowManager, RevokeCommissioningClearsPASESession)

--- a/src/app/tests/TestCommissioningWindowManager.cpp
+++ b/src/app/tests/TestCommissioningWindowManager.cpp
@@ -249,10 +249,8 @@ void TestCommissioningWindowManager::ServiceEvents()
 {
     DrainAndServiceIO();
 
-    EXPECT_SUCCESS(chip::DeviceLayer::SystemLayer().StartTimer(
-        chip::System::Clock::Milliseconds32(0),
-        [](chip::System::Layer *, void *) { EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().StopEventLoopTask()); }, nullptr));
-
+    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(
+        [](intptr_t) -> void { EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().StopEventLoopTask()); }, (intptr_t) nullptr));
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 }
 

--- a/src/app/tests/TestCommissioningWindowManager.cpp
+++ b/src/app/tests/TestCommissioningWindowManager.cpp
@@ -248,7 +248,7 @@ void TestCommissioningWindowManager::ServiceEvents()
 {
     DrainAndServiceIO();
 
-    EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(
+    ASSERT_SUCCESS(chip::DeviceLayer::PlatformMgr().ScheduleWork(
         [](intptr_t) -> void { EXPECT_SUCCESS(chip::DeviceLayer::PlatformMgr().StopEventLoopTask()); }, (intptr_t) nullptr));
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 }
@@ -427,7 +427,7 @@ TEST_F(TestCommissioningWindowManager, TestCheckCommissioningWindowManagerWindow
     EXPECT_FALSE(sAdminFabricIndexDirty);
     EXPECT_FALSE(sAdminVendorIdDirty);
 
-    // Advance time to so that the commissioning window times out
+    // Advance time so that the commissioning window times out
     clock.AdvanceMonotonic(chip::System::Clock::Milliseconds64(kTimeoutMs + kSleepPadding));
     ServiceEvents();
 

--- a/src/app/tests/TestCommissioningWindowManager.cpp
+++ b/src/app/tests/TestCommissioningWindowManager.cpp
@@ -73,11 +73,11 @@ Spake2pVerifier sTestSpake2p01_PASEVerifier = { .mW0 = {
     0xCF
 } };
 
+bool sSimulateFailedSessionEstablishmentTaskCalled = false;
+
 bool sAdminFabricIndexDirty = false;
 bool sAdminVendorIdDirty    = false;
 bool sWindowStatusDirty     = false;
-
-bool sSimulateFailedSessionEstablishmentTaskCalled = false;
 
 void ResetDirtyFlags()
 {
@@ -170,7 +170,7 @@ public:
     uint8_t mOnCommissioningWindowClosedCount              = 0;
     uint8_t mOnCommissioningSessionEstablishmentErrorCount = 0;
 
-    CHIP_ERROR mError;
+    CHIP_ERROR mError = CHIP_NO_ERROR;
 };
 
 class TestCommissioningWindowManager : public chip::Testing::LoopbackMessagingContext
@@ -234,6 +234,8 @@ public:
     {
         ConfigInitializeNodes(false);
         chip::Testing::LoopbackMessagingContext::SetUp();
+
+        sSimulateFailedSessionEstablishmentTaskCalled = false;
     }
 
     void EstablishPASEHandshake(SessionManager & sessionManager, PASESession & pairingCommissioner,


### PR DESCRIPTION
#### Summary

- Fixed timer-based unit tests that were silently passing without verifying assertions; since the timer callbacks that evaluate test assertions were never being executed.
- Timer callbacks were never fired because `StopEventLoop()` was called before timers elapsed.


- Fix:
  - Refactored tests from async task pattern to direct execution. 
  - Used MockClock and `AdvanceMonotonic` to control time deterministically
  - added `MockAppDelegate` to ensure `CommissioningWindowManager` callbacks are invoked correctly (this also increases coverage).


#### Testing

- Run TestCommissioningWindowManager.cpp locally and in CI
