### PR TITLE
[Silabs] Update device type as Extended Color Device for wifi lighting app

### DIFF
--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
@@ -2944,7 +2944,7 @@ endpoint 0 {
 }
 endpoint 1 {
   device type ma_powersource = 17, version 1;
-  device type ma_dimmablelight = 257, version 3;
+  device type ma_extendedcolorlight = 269, version 4;
 
 
   server cluster Identify {

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
@@ -2963,18 +2963,18 @@
       "id": 2,
       "name": "MA-dimmablelight",
       "deviceTypeRef": {
-        "code": 257,
+        "code": 269,
         "profileId": 259,
-        "label": "MA-dimmablelight",
-        "name": "MA-dimmablelight",
+        "label": "MA-extendedcolorlight",
+        "name": "MA-extendedcolorlight",
         "deviceTypeOrder": 0
       },
       "deviceTypes": [
         {
-          "code": 257,
+          "code": 269,
           "profileId": 259,
-          "label": "MA-dimmablelight",
-          "name": "MA-dimmablelight",
+          "label": "MA-extendedcolorlight",
+          "name": "MA-extendedcolorlight",
           "deviceTypeOrder": 0
         },
         {
@@ -2986,15 +2986,15 @@
         }
       ],
       "deviceVersions": [
-        3,
+        4,
         1
       ],
       "deviceIdentifiers": [
-        257,
+        269,
         17
       ],
-      "deviceTypeName": "MA-dimmablelight",
-      "deviceTypeCode": 257,
+      "deviceTypeName": "MA-extendedcolorlight",
+      "deviceTypeCode": 269,
       "deviceTypeProfileId": 259,
       "clusters": [
         {


### PR DESCRIPTION
#### Summary

For lighting wifi app, IDM conformance test (TC_IDM_10_5) fails with an “extra cluster found” error. The lighting-wifi-app declares Dimmable Light (0x0101) on endpoint 1 but also exposes the Color Control server cluster. The Dimmable Light device type does not allow Color Control in the spec, so the test reports Color Control as an extra cluster and fails.

This PR fixes the issue by updating the lighting-app zap file : The lighting endpoint type (id 2, used by endpoint 1) was updated from Dimmable Light to Extended Color Light

#### Related issues

N/A

#### Testing

Built lighting app, ran IDM_10_5 testcase and confirmed that the testcase passes

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
