### PR TITLE
[Telink] Fix TC-OPCREDS-3.6 test

### DIFF
--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -242,6 +242,7 @@ if CHIP_PERSISTENT_SUBSCRIPTIONS
 
 config CHIP_MAX_FABRICS
 	int "Maximum number of Matter fabrics"
+	default 3 if BOARD_TL3218X_RETENTION
 	default 5
 	help
 	  The maximum number of Matter fabrics that device can be joined to.

--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -238,14 +238,14 @@ config CHIP_PERSISTENT_SUBSCRIPTIONS
 	# selecting experimental for this feature since there is an issue with multiple controllers.
 	select EXPERIMENTAL
 
-if CHIP_PERSISTENT_SUBSCRIPTIONS
-
 config CHIP_MAX_FABRICS
 	int "Maximum number of Matter fabrics"
 	default 3 if BOARD_TL3218X_RETENTION
 	default 5
 	help
 	  The maximum number of Matter fabrics that device can be joined to.
+
+if CHIP_PERSISTENT_SUBSCRIPTIONS
 
 config CHIP_MAX_ACTIVE_CASE_CLIENTS
 	int "Maximum number of outgoing CASE sessions"

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -291,6 +291,10 @@ config NVS_LOOKUP_CACHE_SIZE
 config SETTINGS_NVS_SECTOR_SIZE_MULT
     default 1
 
+# Enable extended discovery
+config CHIP_EXTENDED_DISCOVERY
+    default y
+
 # Enable OpenThread
 config NET_L2_OPENTHREAD
     default y if !WIFI

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -132,11 +132,7 @@ public:
 AppCallbacks sCallbacks;
 } // namespace
 
-class AppFabricTableDelegate : public FabricTable::Delegate
-{
-    void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex)
-    {
-        if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0)
+static void DoDelayedFactoryReset(struct k_work * work)
         {
             ChipLogProgress(DeviceLayer, "Erasing settings partition");
 
@@ -167,6 +163,17 @@ class AppFabricTableDelegate : public FabricTable::Delegate
                 ChipLogProgress(DeviceLayer, "Rebooting board");
                 sys_reboot(SYS_REBOOT_WARM);
             }
+}
+
+static k_work_delayable sDelayedFactoryResetWork = Z_WORK_DELAYABLE_INITIALIZER(DoDelayedFactoryReset);
+
+class AppFabricTableDelegate : public FabricTable::Delegate
+{
+    void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex)
+    {
+        if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0)
+        {
+            k_work_schedule(&sDelayedFactoryResetWork, K_SECONDS(2));
         }
     }
 };

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -133,36 +133,36 @@ AppCallbacks sCallbacks;
 } // namespace
 
 static void DoDelayedFactoryReset(struct k_work * work)
-        {
-            ChipLogProgress(DeviceLayer, "Erasing settings partition");
+{
+    ChipLogProgress(DeviceLayer, "Erasing settings partition");
 
-            // TC-OPCREDS-3.6 (device doesn't need to reboot automatically after the last fabric is removed) can't use FactoryReset
-            void * storage = nullptr;
-            int status     = settings_storage_get(&storage);
+    // TC-OPCREDS-3.6 (device doesn't need to reboot automatically after the last fabric is removed) can't use FactoryReset
+    void * storage = nullptr;
+    int status     = settings_storage_get(&storage);
 
-            if (!status)
-            {
-                status = nvs_clear(static_cast<nvs_fs *>(storage));
-            }
+    if (!status)
+    {
+        status = nvs_clear(static_cast<nvs_fs *>(storage));
+    }
 
-            if (!status)
-            {
-                status = nvs_mount(static_cast<nvs_fs *>(storage));
-            }
+    if (!status)
+    {
+        status = nvs_mount(static_cast<nvs_fs *>(storage));
+    }
 
-            if (status)
-            {
-                ChipLogError(DeviceLayer, "Storage clear failed: %d", status);
-            }
+    if (status)
+    {
+        ChipLogError(DeviceLayer, "Storage clear failed: %d", status);
+    }
 #ifdef CONFIG_TFLM_FEATURE
-            AppTask::MicroSpeechProcessStop();
+    AppTask::MicroSpeechProcessStop();
 #endif
-            // Reboot in case of failed commissioning to allow new pairing via BLE
-            if (sIsCommissioningFailed)
-            {
-                ChipLogProgress(DeviceLayer, "Rebooting board");
-                sys_reboot(SYS_REBOOT_WARM);
-            }
+    // Reboot in case of failed commissioning to allow new pairing via BLE
+    if (sIsCommissioningFailed)
+    {
+        ChipLogProgress(DeviceLayer, "Rebooting board");
+        sys_reboot(SYS_REBOOT_WARM);
+    }
 }
 
 static k_work_delayable sDelayedFactoryResetWork = Z_WORK_DELAYABLE_INITIALIZER(DoDelayedFactoryReset);


### PR DESCRIPTION
#### Summary

- Enable extended discovery.
- Add delay of Erasing settings partition to allow SRP update succeeded.
- Decrease CHIP_MAX_FABRICS for BOARD_TL3218X_RETENTION.

#### Testing

- Tested manually by using TC-OPCREDS-3.6