### PR TITLE
Groupcast integration

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -23,6 +23,7 @@
 
 #include "AccessControl.h"
 
+#include <credentials/GroupDataProvider.h> // nogncheck
 #include <lib/core/Global.h>
 
 namespace chip {
@@ -349,6 +350,22 @@ CHIP_ERROR AccessControl::Check(const SubjectDescriptor & subjectDescriptor, con
     }
 #endif
 
+    if ((result != CHIP_NO_ERROR) && (Access::AuthMode::kGroup == subjectDescriptor.authMode) &&
+        (Access::RequestType::kCommandInvokeRequest == requestPath.requestType) &&
+        (Access::Privilege::kOperate == requestPrivilege))
+    {
+        // Groupcast
+        Credentials::GroupDataProvider * groups = Credentials::GetGroupDataProvider();
+        VerifyOrReturnError(nullptr != groups, result);
+
+        GroupId gid = GroupIdFromNodeId(subjectDescriptor.subject);
+        Credentials::GroupDataProvider::GroupInfo info;
+        ReturnErrorOnFailure(groups->GetGroupInfo(subjectDescriptor.fabricIndex, gid, info));
+        if (!(info.flags & static_cast<uint8_t>(Credentials::GroupDataProvider::GroupInfo::Flags::kMcastAddrPolicy)))
+        {
+            return CHIP_NO_ERROR;
+        }
+    }
     return result;
 }
 

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -23,8 +23,9 @@
 
 #include "AccessControl.h"
 
-#include <credentials/GroupDataProvider.h> // nogncheck
 #include <lib/core/Global.h>
+
+#include <credentials/GroupDataProvider.h>
 
 namespace chip {
 namespace Access {
@@ -350,18 +351,16 @@ CHIP_ERROR AccessControl::Check(const SubjectDescriptor & subjectDescriptor, con
     }
 #endif
 
-    if ((result != CHIP_NO_ERROR) && (Access::AuthMode::kGroup == subjectDescriptor.authMode) &&
+    if ((CHIP_NO_ERROR != result) && (Access::AuthMode::kGroup == subjectDescriptor.authMode) &&
         (Access::RequestType::kCommandInvokeRequest == requestPath.requestType) &&
         (Access::Privilege::kOperate == requestPrivilege))
     {
-        // Groupcast
         Credentials::GroupDataProvider * groups = Credentials::GetGroupDataProvider();
         VerifyOrReturnError(nullptr != groups, result);
-
-        GroupId gid = GroupIdFromNodeId(subjectDescriptor.subject);
         Credentials::GroupDataProvider::GroupInfo info;
+        GroupId gid = GroupIdFromNodeId(subjectDescriptor.subject);
         ReturnErrorOnFailure(groups->GetGroupInfo(subjectDescriptor.fabricIndex, gid, info));
-        if (!(info.flags & static_cast<uint8_t>(Credentials::GroupDataProvider::GroupInfo::Flags::kMcastAddrPolicy)))
+        if (info.HasAuxiliaryACL())
         {
             return CHIP_NO_ERROR;
         }

--- a/src/access/BUILD.gn
+++ b/src/access/BUILD.gn
@@ -66,6 +66,7 @@ static_library("access") {
   public_deps = [
     ":access_config",
     ":types",
+    "${chip_root}/src/credentials",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/core:types",
     "${chip_root}/src/lib/support",

--- a/src/app/clusters/groupcast/CodegenIntegration.cpp
+++ b/src/app/clusters/groupcast/CodegenIntegration.cpp
@@ -52,10 +52,12 @@ public:
         Credentials::GroupDataProvider * groupDataProvider = Credentials::GetGroupDataProvider();
         VerifyOrDie(groupDataProvider != nullptr); // we require app main to set this before cluster startup
 
-        gServer.Create(GroupcastContext{
-            .fabrics  = Server::GetInstance().GetFabricTable(),
-            .provider = *groupDataProvider,
-        });
+        gServer.Create(
+            GroupcastContext{
+                .fabrics  = Server::GetInstance().GetFabricTable(),
+                .provider = *groupDataProvider,
+            },
+            BitFlags<Groupcast::Feature>(featureMap));
         return gServer.Registration();
     }
 
@@ -84,7 +86,7 @@ void MatterGroupcastClusterInitCallback(chip::EndpointId endpointId)
             .clusterId                 = Groupcast::Id,
             .fixedClusterInstanceCount = Groupcast::StaticApplicationConfig::kFixedClusterConfig.size(),
             .maxClusterInstanceCount   = 1, // Cluster is a singleton on the root node and this is the only thing supported
-            .fetchFeatureMap           = false,
+            .fetchFeatureMap           = true,
             .fetchOptionalAttributes   = false,
         },
         integrationDelegate);

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -32,6 +32,12 @@ DataModel::ActionReturnStatus GroupcastCluster::ReadAttribute(const DataModel::R
         return mLogic.ReadMembership(request.subjectDescriptor, request.path.mEndpointId, encoder);
     case Groupcast::Attributes::MaxMembershipCount::Id:
         return mLogic.ReadMaxMembershipCount(request.path.mEndpointId, encoder);
+    case Groupcast::Attributes::MaxMcastAddrCount::Id:
+        return mLogic.ReadMaxMcastAddrCount(request.path.mEndpointId, encoder);
+    case Groupcast::Attributes::UsedMcastAddrCount::Id:
+        return mLogic.ReadUsedMcastAddrCount(request.path.mEndpointId, encoder);
+    case Groupcast::Attributes::FabricUnderTest::Id:
+        return mLogic.ReadFabricUnderTest(request.path.mEndpointId, encoder);
     }
     return Protocols::InteractionModel::Status::UnsupportedAttribute;
 }

--- a/src/app/clusters/groupcast/GroupcastLogic.cpp
+++ b/src/app/clusters/groupcast/GroupcastLogic.cpp
@@ -81,6 +81,26 @@ CHIP_ERROR GroupcastLogic::ReadMaxMembershipCount(EndpointId endpoint, Attribute
     return aEncoder.Encode(groups.getMaxMembershipCount());
 }
 
+CHIP_ERROR GroupcastLogic::ReadMaxMcastAddrCount(EndpointId endpoint, AttributeValueEncoder & aEncoder)
+{
+    GroupDataProvider & groups = Provider();
+    return aEncoder.Encode(groups.getMaxMcastAddrCount());
+}
+
+CHIP_ERROR GroupcastLogic::ReadUsedMcastAddrCount(EndpointId endpoint, AttributeValueEncoder & aEncoder)
+{
+    GroupDataProvider & groups = Provider();
+    uint16_t count             = 0;
+    ReturnErrorOnFailure(groups.getUsedMcastAddrCount(count));
+    return aEncoder.Encode(count);
+}
+
+CHIP_ERROR GroupcastLogic::ReadFabricUnderTest(EndpointId endpoint, AttributeValueEncoder & aEncoder)
+{
+    FabricIndex fabric_index = kUndefinedFabricIndex;
+    return aEncoder.Encode(fabric_index);
+}
+
 Status GroupcastLogic::JoinGroup(FabricIndex fabric_index, const Groupcast::Commands::JoinGroup::DecodableType & data)
 {
     GroupDataProvider & groups = Provider();
@@ -197,6 +217,7 @@ Status GroupcastLogic::LeaveGroup(FabricIndex fabric_index, const Groupcast::Com
         // Apply changes to all groups
         GroupInfoIterator * iter = groups.IterateGroupInfo(fabric_index);
         VerifyOrReturnError(nullptr != iter, Status::ResourceExhausted);
+        VerifyOrReturnError(iter->Count() > 0, Status::NotFound);
 
         GroupInfo info;
         while (iter->Next(info) && (Status::Success == err))
@@ -235,6 +256,9 @@ Status GroupcastLogic::ConfigureAuxiliaryACL(FabricIndex fabric_index,
 {
     GroupDataProvider & groups = Provider();
     CHIP_ERROR err             = CHIP_NO_ERROR;
+
+    // AuxiliaryACL can only be present if LN feature is supported
+    VerifyOrReturnError(mFeatures.Has(Groupcast::Feature::kListener), Status::ConstraintError);
 
     // Get group info
     GroupDataProvider::GroupInfo info;
@@ -318,16 +342,8 @@ Status GroupcastLogic::RemoveGroup(FabricIndex fabric_index, GroupId group_id,
     else
     {
         // Remove whole group (with all endpoints)
-        EndpointIterator * iter = groups.IterateEndpoints(fabric_index, data.groupID);
-        VerifyOrReturnError(nullptr != iter, Status::ResourceExhausted);
-        GroupEndpoint mapping;
-        while (iter->Next(mapping) && (endpoints.count < kMaxMembershipEndpoints))
-        {
-            stat = RemoveGroupEndpoint(fabric_index, group_id, mapping.endpoint_id, endpoints);
-            VerifyOrReturnError(Status::Success == stat, stat);
-        }
-        iter->Release();
-        CHIP_ERROR err = groups.RemoveGroupInfo(fabric_index, data.groupID);
+        CHIP_ERROR err = groups.RemoveGroupInfo(fabric_index, group_id);
+        VerifyOrReturnError(CHIP_ERROR_NOT_FOUND != err, Status::NotFound);
         VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
     }
 

--- a/src/app/clusters/groupcast/GroupcastLogic.cpp
+++ b/src/app/clusters/groupcast/GroupcastLogic.cpp
@@ -1,4 +1,5 @@
 #include "GroupcastLogic.h"
+#include <access/AccessControl.h>
 #include <app/util/endpoint-config-api.h>
 #include <credentials/GroupDataProvider.h>
 
@@ -56,10 +57,9 @@ CHIP_ERROR GroupcastLogic::ReadMembership(const chip::Access::SubjectDescriptor 
                     group.fabricIndex     = fabric_index;
                     group.groupID         = info.group_id;
                     group.keySetID        = keyset_id;
-                    group.hasAuxiliaryACL = MakeOptional(info.flags & chip::to_underlying(GroupInfo::Flags::kHasAuxiliaryACL));
-                    group.mcastAddrPolicy = (info.flags & chip::to_underlying(GroupInfo::Flags::kMcastAddrPolicy)
-                                                 ? Groupcast::MulticastAddrPolicyEnum::kPerGroup
-                                                 : Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
+                    group.hasAuxiliaryACL = MakeOptional(info.HasAuxiliaryACL());
+                    group.mcastAddrPolicy = info.UsePerGroupAddress() ? Groupcast::MulticastAddrPolicyEnum::kPerGroup
+                                                                      : Groupcast::MulticastAddrPolicyEnum::kIanaAddr;
                     group.endpoints       = MakeOptional(DataModel::List<const chip::EndpointId>(endpoints.entries, split_count));
                     status                = encoder.Encode(group);
                     split_count           = 0;
@@ -89,9 +89,23 @@ CHIP_ERROR GroupcastLogic::ReadMaxMcastAddrCount(EndpointId endpoint, AttributeV
 
 CHIP_ERROR GroupcastLogic::ReadUsedMcastAddrCount(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
-    GroupDataProvider & groups = Provider();
-    uint16_t count             = 0;
-    ReturnErrorOnFailure(groups.getUsedMcastAddrCount(count));
+    uint16_t count = 0;
+    // Iterate all fabrics
+    for (const FabricInfo & fabric : Fabrics())
+    {
+        // Count all the groups with Per-group addresses
+        GroupInfoIterator * iter = Provider().IterateGroupInfo(fabric.GetFabricIndex());
+        VerifyOrReturnError(nullptr != iter, CHIP_ERROR_NO_MEMORY);
+        GroupInfo group;
+        while (iter->Next(group))
+        {
+            if (group.UsePerGroupAddress())
+            {
+                count++;
+            }
+        }
+        iter->Release();
+    }
     return aEncoder.Encode(count);
 }
 
@@ -308,6 +322,7 @@ Status GroupcastLogic::SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, c
             VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
             // Set keys
             err = groups.SetKeySet(fabric_index, compressed_fabric_id, ks);
+            VerifyOrReturnError(CHIP_ERROR_INVALID_LIST_LENGTH != err, Status::ResourceExhausted);
             VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
         }
     }
@@ -316,6 +331,7 @@ Status GroupcastLogic::SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, c
         // Cannot set an existing key
         return Status::AlreadyExists;
     }
+
     return Status::Success;
 }
 
@@ -367,6 +383,7 @@ Status GroupcastLogic::RemoveGroupEndpoint(FabricIndex fabric_index, GroupId gro
     {
         endpoints.entries[endpoints.count++] = endpoint_id;
     }
+
     return Status::Success;
 }
 

--- a/src/app/clusters/groupcast/GroupcastLogic.h
+++ b/src/app/clusters/groupcast/GroupcastLogic.h
@@ -59,6 +59,9 @@ public:
     CHIP_ERROR ReadMembership(const chip::Access::SubjectDescriptor * subject, EndpointId endpoint,
                               AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadMaxMembershipCount(EndpointId endpoint, AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadMaxMcastAddrCount(EndpointId endpoint, AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadUsedMcastAddrCount(EndpointId endpoint, AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadFabricUnderTest(EndpointId endpoint, AttributeValueEncoder & aEncoder);
 
     Status JoinGroup(FabricIndex fabric_index, const Groupcast::Commands::JoinGroup::DecodableType & data);
     Status LeaveGroup(FabricIndex fabric_index, const Groupcast::Commands::LeaveGroup::DecodableType & data,

--- a/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
@@ -199,6 +199,8 @@ public:
     GroupSessionIterator * IterateGroupSessions(uint16_t) override { return nullptr; }
     Crypto::SymmetricKeyContext * GetKeyContext(FabricIndex, GroupId) override { return nullptr; }
     uint16_t getMaxMembershipCount() override { return 0; }
+    uint16_t getMaxMcastAddrCount() override { return 0; }
+    CHIP_ERROR getUsedMcastAddrCount(uint16_t & count) override { return CHIP_NO_ERROR; }
 
     bool mHasEndpoint = true;
 };

--- a/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
@@ -200,7 +200,6 @@ public:
     Crypto::SymmetricKeyContext * GetKeyContext(FabricIndex, GroupId) override { return nullptr; }
     uint16_t getMaxMembershipCount() override { return 0; }
     uint16_t getMaxMcastAddrCount() override { return 0; }
-    CHIP_ERROR getUsedMcastAddrCount(uint16_t & count) override { return CHIP_NO_ERROR; }
 
     bool mHasEndpoint = true;
 };

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -674,6 +674,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
             return mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
                                                            .SetAddressType(Inet::IPAddressType::kIPv6)
                                                            .SetListenPort(port)
+                                                           .SetNativeParams(initParams.endpointNativeParams)
 #if INET_CONFIG_ENABLE_IPV4
                                               ,
                                           Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
@@ -689,6 +690,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     err              = mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
                                                   .SetAddressType(Inet::IPAddressType::kIPv6)
                                                   .SetListenPort(mCdcListenPort)
+                                                  .SetNativeParams(initParams.endpointNativeParams)
 #if INET_CONFIG_ENABLE_IPV4
                                                   ,
                                               Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
@@ -800,9 +802,8 @@ void Server::RejoinExistingMulticastGroups()
             // GroupDataProvider was able to allocate rescources for an iterator
             while (iterator->Next(groupInfo))
             {
-                bool use_iana_addr =
-                    !(groupInfo.flags & static_cast<uint8_t>(Credentials::GroupDataProvider::GroupInfo::Flags::kMcastAddrPolicy));
-                if (use_iana_addr and groupcast_joined)
+                bool use_iana_addr = !groupInfo.UsePerGroupAddress();
+                if (use_iana_addr && groupcast_joined)
                 {
                     // Already joined groupcast address
                     continue;

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -674,7 +674,6 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
             return mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
                                                            .SetAddressType(Inet::IPAddressType::kIPv6)
                                                            .SetListenPort(port)
-                                                           .SetNativeParams(initParams.endpointNativeParams)
 #if INET_CONFIG_ENABLE_IPV4
                                               ,
                                           Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
@@ -690,7 +689,6 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     err              = mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
                                                   .SetAddressType(Inet::IPAddressType::kIPv6)
                                                   .SetListenPort(mCdcListenPort)
-                                                  .SetNativeParams(initParams.endpointNativeParams)
 #if INET_CONFIG_ENABLE_IPV4
                                                   ,
                                               Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())
@@ -790,6 +788,8 @@ void Server::RejoinExistingMulticastGroups()
 {
     ChipLogProgress(AppServer, "Joining Multicast groups");
     CHIP_ERROR err = CHIP_NO_ERROR;
+
+    bool groupcast_joined = false;
     for (const FabricInfo & fabric : mFabrics)
     {
         Credentials::GroupDataProvider::GroupInfo groupInfo;
@@ -800,8 +800,19 @@ void Server::RejoinExistingMulticastGroups()
             // GroupDataProvider was able to allocate rescources for an iterator
             while (iterator->Next(groupInfo))
             {
-                err = mTransports.MulticastGroupJoinLeave(
-                    Transport::PeerAddress::Multicast(fabric.GetFabricId(), groupInfo.group_id), true);
+                bool use_iana_addr =
+                    !(groupInfo.flags & static_cast<uint8_t>(Credentials::GroupDataProvider::GroupInfo::Flags::kMcastAddrPolicy));
+                if (use_iana_addr and groupcast_joined)
+                {
+                    // Already joined groupcast address
+                    continue;
+                }
+
+                const Transport::PeerAddress & address = use_iana_addr
+                    ? Transport::PeerAddress::Groupcast()
+                    : Transport::PeerAddress::Multicast(fabric.GetFabricId(), groupInfo.group_id);
+
+                err = mTransports.MulticastGroupJoinLeave(address, true);
                 if (err != CHIP_NO_ERROR)
                 {
                     ChipLogError(AppServer, "Error when trying to join Group %u of fabric index %u : %" CHIP_ERROR_FORMAT,
@@ -812,6 +823,8 @@ void Server::RejoinExistingMulticastGroups()
                     iterator->Release();
                     return;
                 }
+                if (use_iana_addr)
+                    groupcast_joined = true;
             }
 
             iterator->Release();

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -95,6 +95,9 @@ public:
                 SetName(other.name);
             }
         }
+        bool HasAuxiliaryACL() const { return (flags & static_cast<uint8_t>(Flags::kHasAuxiliaryACL)); }
+        bool UsePerGroupAddress() const { return (flags & static_cast<uint8_t>(Flags::kMcastAddrPolicy)); }
+
         bool operator==(const GroupInfo & other) const
         {
             return (this->group_id == other.group_id) && !strncmp(this->name, other.name, kGroupNameMax);
@@ -348,9 +351,8 @@ public:
     void RemoveListener() { mListener = nullptr; };
 
     // Groupcast
-    virtual uint16_t getMaxMembershipCount()                   = 0;
-    virtual uint16_t getMaxMcastAddrCount()                    = 0;
-    virtual CHIP_ERROR getUsedMcastAddrCount(uint16_t & count) = 0;
+    virtual uint16_t getMaxMembershipCount() = 0;
+    virtual uint16_t getMaxMcastAddrCount()  = 0;
 
 protected:
     void GroupAdded(FabricIndex fabric_index, const GroupInfo & new_group)

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -347,8 +347,10 @@ public:
     void SetListener(GroupListener * listener) { mListener = listener; };
     void RemoveListener() { mListener = nullptr; };
 
-    // Groupcast MaxMembershipCount
-    virtual uint16_t getMaxMembershipCount() = 0;
+    // Groupcast
+    virtual uint16_t getMaxMembershipCount()                   = 0;
+    virtual uint16_t getMaxMcastAddrCount()                    = 0;
+    virtual CHIP_ERROR getUsedMcastAddrCount(uint16_t & count) = 0;
 
 protected:
     void GroupAdded(FabricIndex fabric_index, const GroupInfo & new_group)

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -2013,6 +2013,39 @@ void GroupDataProviderImpl::GroupSessionIteratorImpl::Release()
     mProvider.mGroupSessionsIterator.ReleaseObject(this);
 }
 
+//
+// Groupcast
+//
+
+CHIP_ERROR GroupDataProviderImpl::getUsedMcastAddrCount(uint16_t & count)
+{
+    count = 0;
+    FabricList fabric_list;
+    CHIP_ERROR err = fabric_list.Load(mStorage);
+    VerifyOrReturnError(CHIP_ERROR_NOT_FOUND != err, CHIP_NO_ERROR);
+    ReturnErrorOnFailure(err);
+
+    // Iterate all fabrics with groups
+    FabricData fabric(fabric_list.first_entry);
+    for (size_t i = 0; i < fabric_list.entry_count; i++)
+    {
+        // Count all the groups with Pergroup addresses
+        GroupInfoIterator * iter = IterateGroupInfo(fabric.fabric_index);
+        VerifyOrReturnError(nullptr != iter, CHIP_ERROR_NO_MEMORY);
+        GroupInfo info;
+        while (iter->Next(info))
+        {
+            if (info.flags & chip::to_underlying(GroupInfo::Flags::kMcastAddrPolicy))
+            {
+                count++;
+            }
+        }
+        iter->Release();
+        fabric.fabric_index = fabric.next;
+    }
+    return CHIP_NO_ERROR;
+}
+
 namespace {
 
 GroupDataProvider * gGroupsProvider = nullptr;

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -2013,39 +2013,6 @@ void GroupDataProviderImpl::GroupSessionIteratorImpl::Release()
     mProvider.mGroupSessionsIterator.ReleaseObject(this);
 }
 
-//
-// Groupcast
-//
-
-CHIP_ERROR GroupDataProviderImpl::getUsedMcastAddrCount(uint16_t & count)
-{
-    count = 0;
-    FabricList fabric_list;
-    CHIP_ERROR err = fabric_list.Load(mStorage);
-    VerifyOrReturnError(CHIP_ERROR_NOT_FOUND != err, CHIP_NO_ERROR);
-    ReturnErrorOnFailure(err);
-
-    // Iterate all fabrics with groups
-    FabricData fabric(fabric_list.first_entry);
-    for (size_t i = 0; i < fabric_list.entry_count; i++)
-    {
-        // Count all the groups with Pergroup addresses
-        GroupInfoIterator * iter = IterateGroupInfo(fabric.fabric_index);
-        VerifyOrReturnError(nullptr != iter, CHIP_ERROR_NO_MEMORY);
-        GroupInfo info;
-        while (iter->Next(info))
-        {
-            if (info.flags & chip::to_underlying(GroupInfo::Flags::kMcastAddrPolicy))
-            {
-                count++;
-            }
-        }
-        iter->Release();
-        fabric.fabric_index = fabric.next;
-    }
-    return CHIP_NO_ERROR;
-}
-
 namespace {
 
 GroupDataProvider * gGroupsProvider = nullptr;

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -106,7 +106,6 @@ public:
     // Groupcast
     uint16_t getMaxMembershipCount() override { return kMaxMembershipCount; }
     uint16_t getMaxMcastAddrCount() override { return kMaxMcastAddrCount; }
-    CHIP_ERROR getUsedMcastAddrCount(uint16_t & count) override;
 
 protected:
     class GroupInfoIteratorImpl : public GroupInfoIterator

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -29,6 +29,7 @@ class GroupDataProviderImpl : public GroupDataProvider
 public:
     static constexpr size_t kIteratorsMax         = CHIP_CONFIG_MAX_GROUP_CONCURRENT_ITERATORS;
     static constexpr uint16_t kMaxMembershipCount = 10;
+    static constexpr uint16_t kMaxMcastAddrCount  = 4;
 
     GroupDataProviderImpl() = default;
     GroupDataProviderImpl(uint16_t maxGroupsPerFabric, uint16_t maxGroupKeysPerFabric) :
@@ -102,8 +103,10 @@ public:
     Crypto::SymmetricKeyContext * GetKeyContext(FabricIndex fabric_index, GroupId group_id) override;
     GroupSessionIterator * IterateGroupSessions(uint16_t session_id) override;
 
-    // Groupcast MaxMembershipCount
+    // Groupcast
     uint16_t getMaxMembershipCount() override { return kMaxMembershipCount; }
+    uint16_t getMaxMcastAddrCount() override { return kMaxMcastAddrCount; }
+    CHIP_ERROR getUsedMcastAddrCount(uint16_t & count) override;
 
 protected:
     class GroupInfoIteratorImpl : public GroupInfoIterator

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -226,9 +226,9 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
 
         Credentials::GroupDataProvider::GroupInfo info;
         ReturnErrorOnFailure(groups->GetGroupInfo(groupSession->GetFabricIndex(), groupSession->GetGroupId(), info));
-        destination_address = (info.flags & chip::to_underlying(Credentials::GroupDataProvider::GroupInfo::Flags::kMcastAddrPolicy)) ?
-            Transport::PeerAddress::Multicast(fabric->GetFabricId(), groupSession->GetGroupId()) :
-            Transport::PeerAddress::Groupcast();
+        destination_address = (info.UsePerGroupAddress())
+            ? Transport::PeerAddress::Multicast(fabric->GetFabricId(), groupSession->GetGroupId())
+            : Transport::PeerAddress::Groupcast();
 
         Crypto::SymmetricKeyContext * keyContext =
             groups->GetKeyContext(groupSession->GetFabricIndex(), groupSession->GetGroupId());
@@ -424,14 +424,14 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
 
         const FabricInfo * fabric = mFabricTable->FindFabricWithIndex(groupSession->GetFabricIndex());
         VerifyOrReturnError(fabric != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-        auto * groups     = Credentials::GetGroupDataProvider();
+        auto * groups = Credentials::GetGroupDataProvider();
         VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INTERNAL);
 
         Credentials::GroupDataProvider::GroupInfo info;
         ReturnErrorOnFailure(groups->GetGroupInfo(groupSession->GetFabricIndex(), groupSession->GetGroupId(), info));
-        multicastAddress = (info.flags & chip::to_underlying(Credentials::GroupDataProvider::GroupInfo::Flags::kMcastAddrPolicy)) ?
-            Transport::PeerAddress::Multicast(fabric->GetFabricId(), groupSession->GetGroupId()) :
-            Transport::PeerAddress::Groupcast();
+        multicastAddress = (info.UsePerGroupAddress())
+            ? Transport::PeerAddress::Multicast(fabric->GetFabricId(), groupSession->GetGroupId())
+            : Transport::PeerAddress::Groupcast();
         destination      = &multicastAddress;
     }
     break;

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -224,7 +224,11 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
             return CHIP_ERROR_INTERNAL;
         }
 
-        destination_address = Transport::PeerAddress::Multicast(fabric->GetFabricId(), groupSession->GetGroupId());
+        Credentials::GroupDataProvider::GroupInfo info;
+        ReturnErrorOnFailure(groups->GetGroupInfo(groupSession->GetFabricIndex(), groupSession->GetGroupId(), info));
+        destination_address = (info.flags & chip::to_underlying(Credentials::GroupDataProvider::GroupInfo::Flags::kMcastAddrPolicy)) ?
+            Transport::PeerAddress::Multicast(fabric->GetFabricId(), groupSession->GetGroupId()) :
+            Transport::PeerAddress::Groupcast();
 
         Crypto::SymmetricKeyContext * keyContext =
             groups->GetKeyContext(groupSession->GetFabricIndex(), groupSession->GetGroupId());
@@ -420,8 +424,14 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
 
         const FabricInfo * fabric = mFabricTable->FindFabricWithIndex(groupSession->GetFabricIndex());
         VerifyOrReturnError(fabric != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        auto * groups     = Credentials::GetGroupDataProvider();
+        VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INTERNAL);
 
-        multicastAddress = Transport::PeerAddress::Multicast(fabric->GetFabricId(), groupSession->GetGroupId());
+        Credentials::GroupDataProvider::GroupInfo info;
+        ReturnErrorOnFailure(groups->GetGroupInfo(groupSession->GetFabricIndex(), groupSession->GetGroupId(), info));
+        multicastAddress = (info.flags & chip::to_underlying(Credentials::GroupDataProvider::GroupInfo::Flags::kMcastAddrPolicy)) ?
+            Transport::PeerAddress::Multicast(fabric->GetFabricId(), groupSession->GetGroupId()) :
+            Transport::PeerAddress::Groupcast();
         destination      = &multicastAddress;
     }
     break;


### PR DESCRIPTION
#### Summary

Enables groupcast messaging in the Matter stack:
* Registers the IANA address, when needed
* Adds an ACL exception for groupcast messages
* Added missing attributes:
  - MaxMcastAddrCount
  - UsedMcastAddrCount
  - FabricUnderTest
* Bugfixes:
  - Feature map read from ZAP
  - Missing check to ConfigureAuxiliaryACL
  - Register/unregister group address according to type (IANA/Per-group)

Note: FabricUnderTest not fully implemented. To be done in a follow-up.

#### Related issues

N/A

#### Testing

Unit tests ran successfully:
* TestGeneralCommissioningCluster
* TestGeneralDiagnosticsCluster
* TestGroupcastCluster
* TestGroupDataProvider
* TestGroupedCallbackList
* TestGroupKeyManagementCluster
* TestGroupMessageCounter
* TestGroupOperationalCredentials

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
