### PR TITLE
Decouple `Chime` cluster

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
@@ -36,7 +36,8 @@ CHIP_ERROR ChimeDevice::Register(chip::EndpointId endpoint, CodeDrivenDataModelP
     mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
-    mChimeCluster.Create(endpoint, mDelegate, *GetSafeAttributePersistenceProvider());
+    ChimeCluster::Context chimeContext{ .safeAttributePersistenceProvider = *GetSafeAttributePersistenceProvider() };
+    mChimeCluster.Create(endpoint, chimeContext, mDelegate);
     ReturnErrorOnFailure(provider.AddCluster(mChimeCluster.Registration()));
 
     return provider.AddEndpoint(mEndpointRegistration);

--- a/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <app/SafeAttributePersistenceProvider.h>
 #include <devices/Types.h>
 #include <devices/chime/ChimeDevice.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -36,7 +35,7 @@ CHIP_ERROR ChimeDevice::Register(chip::EndpointId endpoint, CodeDrivenDataModelP
     mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
-    mChimeCluster.Create(endpoint, mDelegate, *GetSafeAttributePersistenceProvider());
+    mChimeCluster.Create(endpoint, mDelegate);
     ReturnErrorOnFailure(provider.AddCluster(mChimeCluster.Registration()));
 
     return provider.AddEndpoint(mEndpointRegistration);

--- a/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <app/SafeAttributePersistenceProvider.h>
 #include <devices/Types.h>
 #include <devices/chime/ChimeDevice.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -35,7 +36,7 @@ CHIP_ERROR ChimeDevice::Register(chip::EndpointId endpoint, CodeDrivenDataModelP
     mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
-    mChimeCluster.Create(endpoint, mDelegate);
+    mChimeCluster.Create(endpoint, mDelegate, *GetSafeAttributePersistenceProvider());
     ReturnErrorOnFailure(provider.AddCluster(mChimeCluster.Registration()));
 
     return provider.AddEndpoint(mEndpointRegistration);

--- a/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
@@ -36,8 +36,8 @@ CHIP_ERROR ChimeDevice::Register(chip::EndpointId endpoint, CodeDrivenDataModelP
     mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
-    ChimeCluster::Context chimeContext{ .safeAttributePersistenceProvider = *GetSafeAttributePersistenceProvider() };
-    mChimeCluster.Create(endpoint, chimeContext, mDelegate);
+    ChimeCluster::Context chimeContext{ .delegate = mDelegate, .safeAttributePersistenceProvider = *GetSafeAttributePersistenceProvider() };
+    mChimeCluster.Create(endpoint, chimeContext);
     ReturnErrorOnFailure(provider.AddCluster(mChimeCluster.Registration()));
 
     return provider.AddEndpoint(mEndpointRegistration);

--- a/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
@@ -36,7 +36,8 @@ CHIP_ERROR ChimeDevice::Register(chip::EndpointId endpoint, CodeDrivenDataModelP
     mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
-    ChimeCluster::Context chimeContext{ .delegate = mDelegate, .safeAttributePersistenceProvider = *GetSafeAttributePersistenceProvider() };
+    ChimeCluster::Context chimeContext{ .delegate                         = mDelegate,
+                                        .safeAttributePersistenceProvider = *GetSafeAttributePersistenceProvider() };
     mChimeCluster.Create(endpoint, chimeContext);
     ReturnErrorOnFailure(provider.AddCluster(mChimeCluster.Registration()));
 

--- a/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
@@ -36,8 +36,10 @@ CHIP_ERROR ChimeDevice::Register(chip::EndpointId endpoint, CodeDrivenDataModelP
     mIdentifyCluster.Create(IdentifyCluster::Config(endpoint, mTimerDelegate));
     ReturnErrorOnFailure(provider.AddCluster(mIdentifyCluster.Registration()));
 
+    auto * safeAttributePersistenceProvider = GetSafeAttributePersistenceProvider();
+    VerifyOrReturnError(safeAttributePersistenceProvider != nullptr, CHIP_ERROR_INCORRECT_STATE);
     ChimeCluster::Context chimeContext{ .delegate                         = mDelegate,
-                                        .safeAttributePersistenceProvider = *GetSafeAttributePersistenceProvider() };
+                                        .safeAttributePersistenceProvider = *safeAttributePersistenceProvider };
     mChimeCluster.Create(endpoint, chimeContext);
     ReturnErrorOnFailure(provider.AddCluster(mChimeCluster.Registration()));
 

--- a/examples/all-devices-app/all-devices-common/devices/device-factory/DeviceFactory.h
+++ b/examples/all-devices-app/all-devices-common/devices/device-factory/DeviceFactory.h
@@ -38,11 +38,13 @@ namespace chip::app {
  * Create devices by fetching the instance of this class and passing in the device type argument
  * i.e. DeviceFactory::GetInstance().Create(deviceTypeName)
  */
-class DeviceFactory {
+class DeviceFactory
+{
 public:
     using DeviceCreator = std::function<std::unique_ptr<DeviceInterface>()>;
 
-    struct Context {
+    struct Context
+    {
         Credentials::GroupDataProvider & groupDataProvider;
         FabricTable & fabricTable;
         TimerDelegate & timerDelegate;
@@ -60,7 +62,8 @@ public:
 
     std::unique_ptr<DeviceInterface> Create(const std::string & deviceTypeArg)
     {
-        if (IsValidDevice(deviceTypeArg)) {
+        if (IsValidDevice(deviceTypeArg))
+        {
             return mRegistry.find(deviceTypeArg)->second();
         }
         ChipLogError(
@@ -73,7 +76,8 @@ public:
     std::vector<std::string> SupportedDeviceTypes() const
     {
         std::vector<std::string> result;
-        for (auto & item : mRegistry) {
+        for (auto & item : mRegistry)
+        {
             result.push_back(item.first);
         }
         return result;
@@ -99,19 +103,19 @@ private:
                 &mContext->timerDelegate, Span<const DataModel::DeviceTypeEntry>(&Device::Type::kWaterLeakDetector, 1));
         };
         mRegistry["occupancy-sensor"] = []() { return std::make_unique<TogglingOccupancySensorDevice>(); };
-        mRegistry["chime"] = []() { return std::make_unique<LoggingChimeDevice>(); };
-        mRegistry["on-off-light"] = [this]() {
+        mRegistry["chime"]            = []() { return std::make_unique<LoggingChimeDevice>(); };
+        mRegistry["on-off-light"]     = [this]() {
             VerifyOrDie(mContext.has_value());
-            return std::make_unique<LoggingOnOffLightDevice>(LoggingOnOffLightDevice::Context {
-                .groupDataProvider = mContext->groupDataProvider,
-                .fabricTable = mContext->fabricTable,
-                .timerDelegate = mContext->timerDelegate,
+            return std::make_unique<LoggingOnOffLightDevice>(LoggingOnOffLightDevice::Context{
+                    .groupDataProvider = mContext->groupDataProvider,
+                    .fabricTable       = mContext->fabricTable,
+                    .timerDelegate     = mContext->timerDelegate,
             });
         };
         mRegistry["speaker"] = [this]() {
             VerifyOrDie(mContext.has_value());
             return std::make_unique<LoggingSpeakerDevice>(
-                LoggingSpeakerDevice::Context { .timerDelegate = mContext->timerDelegate });
+                LoggingSpeakerDevice::Context{ .timerDelegate = mContext->timerDelegate });
         };
     }
 };

--- a/examples/all-devices-app/all-devices-common/devices/device-factory/DeviceFactory.h
+++ b/examples/all-devices-app/all-devices-common/devices/device-factory/DeviceFactory.h
@@ -38,13 +38,11 @@ namespace chip::app {
  * Create devices by fetching the instance of this class and passing in the device type argument
  * i.e. DeviceFactory::GetInstance().Create(deviceTypeName)
  */
-class DeviceFactory
-{
+class DeviceFactory {
 public:
     using DeviceCreator = std::function<std::unique_ptr<DeviceInterface>()>;
 
-    struct Context
-    {
+    struct Context {
         Credentials::GroupDataProvider & groupDataProvider;
         FabricTable & fabricTable;
         TimerDelegate & timerDelegate;
@@ -62,8 +60,7 @@ public:
 
     std::unique_ptr<DeviceInterface> Create(const std::string & deviceTypeArg)
     {
-        if (IsValidDevice(deviceTypeArg))
-        {
+        if (IsValidDevice(deviceTypeArg)) {
             return mRegistry.find(deviceTypeArg)->second();
         }
         ChipLogError(
@@ -76,8 +73,7 @@ public:
     std::vector<std::string> SupportedDeviceTypes() const
     {
         std::vector<std::string> result;
-        for (auto & item : mRegistry)
-        {
+        for (auto & item : mRegistry) {
             result.push_back(item.first);
         }
         return result;
@@ -103,19 +99,19 @@ private:
                 &mContext->timerDelegate, Span<const DataModel::DeviceTypeEntry>(&Device::Type::kWaterLeakDetector, 1));
         };
         mRegistry["occupancy-sensor"] = []() { return std::make_unique<TogglingOccupancySensorDevice>(); };
-        mRegistry["chime"]            = []() { return std::make_unique<LoggingChimeDevice>(); };
-        mRegistry["on-off-light"]     = [this]() {
+        mRegistry["chime"] = []() { return std::make_unique<LoggingChimeDevice>(); };
+        mRegistry["on-off-light"] = [this]() {
             VerifyOrDie(mContext.has_value());
-            return std::make_unique<LoggingOnOffLightDevice>(LoggingOnOffLightDevice::Context{
-                    .groupDataProvider = mContext->groupDataProvider,
-                    .fabricTable       = mContext->fabricTable,
-                    .timerDelegate     = mContext->timerDelegate,
+            return std::make_unique<LoggingOnOffLightDevice>(LoggingOnOffLightDevice::Context {
+                .groupDataProvider = mContext->groupDataProvider,
+                .fabricTable = mContext->fabricTable,
+                .timerDelegate = mContext->timerDelegate,
             });
         };
         mRegistry["speaker"] = [this]() {
             VerifyOrDie(mContext.has_value());
             return std::make_unique<LoggingSpeakerDevice>(
-                LoggingSpeakerDevice::Context{ .timerDelegate = mContext->timerDelegate });
+                LoggingSpeakerDevice::Context { .timerDelegate = mContext->timerDelegate });
         };
     }
 };

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
@@ -56,6 +56,7 @@ public:
         DeviceLoadStatusProvider & deviceLoadStatusProvider;
         DeviceLayer::DiagnosticDataProvider & diagnosticDataProvider;
         TestEventTriggerDelegate * testEventTriggerDelegate;
+        SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         TermsAndConditionsProvider & termsAndConditionsProvider;

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
@@ -37,57 +37,57 @@
 namespace chip {
 namespace app {
 
-    class RootNodeDevice : public SingleEndpointDevice {
-    public:
-        struct Context {
-            CommissioningWindowManager & commissioningWindowManager;
-            DeviceLayer::ConfigurationManager & configurationManager;
-            DeviceLayer::DeviceControlServer & deviceControlServer;
-            FabricTable & fabricTable;
-            Access::AccessControl & accessControl;
-            PersistentStorageDelegate & persistentStorage;
-            FailSafeContext & failSafeContext;
-            DeviceLayer::DeviceInstanceInfoProvider & deviceInstanceInfoProvider;
-            DeviceLayer::PlatformManager & platformManager;
-            Credentials::GroupDataProvider & groupDataProvider;
-            SessionManager & sessionManager;
-            DnssdServer & dnssdServer;
-            DeviceLoadStatusProvider & deviceLoadStatusProvider;
-            DeviceLayer::DiagnosticDataProvider & diagnosticDataProvider;
-            TestEventTriggerDelegate * testEventTriggerDelegate;
-            SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
+class RootNodeDevice : public SingleEndpointDevice
+{
+public:
+    struct Context
+    {
+        CommissioningWindowManager & commissioningWindowManager;
+        DeviceLayer::ConfigurationManager & configurationManager;
+        DeviceLayer::DeviceControlServer & deviceControlServer;
+        FabricTable & fabricTable;
+        Access::AccessControl & accessControl;
+        PersistentStorageDelegate & persistentStorage;
+        FailSafeContext & failSafeContext;
+        DeviceLayer::DeviceInstanceInfoProvider & deviceInstanceInfoProvider;
+        DeviceLayer::PlatformManager & platformManager;
+        Credentials::GroupDataProvider & groupDataProvider;
+        SessionManager & sessionManager;
+        DnssdServer & dnssdServer;
+        DeviceLoadStatusProvider & deviceLoadStatusProvider;
+        DeviceLayer::DiagnosticDataProvider & diagnosticDataProvider;
+        TestEventTriggerDelegate * testEventTriggerDelegate;
+        SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-            TermsAndConditionsProvider & termsAndConditionsProvider;
+        TermsAndConditionsProvider & termsAndConditionsProvider;
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-        };
-
-        RootNodeDevice(const Context & context)
-            : SingleEndpointDevice(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kRootNode, 1))
-            , mContext(context)
-        {
-        }
-        ~RootNodeDevice() override = default;
-
-        CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider,
-            EndpointId parentId = kInvalidEndpointId) override;
-        void UnRegister(CodeDrivenDataModelProvider & provider) override;
-
-    protected:
-        Context mContext;
-
-        LazyRegisteredServerCluster<Clusters::GeneralCommissioningCluster> mGeneralCommissioningCluster;
-
-    private:
-        LazyRegisteredServerCluster<Clusters::BasicInformationCluster> mBasicInformationCluster;
-        LazyRegisteredServerCluster<Clusters::AdministratorCommissioningWithBasicCommissioningWindowCluster>
-            mAdministratorCommissioningCluster;
-        LazyRegisteredServerCluster<Clusters::GeneralDiagnosticsCluster> mGeneralDiagnosticsCluster;
-        LazyRegisteredServerCluster<Clusters::GroupKeyManagementCluster> mGroupKeyManagementCluster;
-        LazyRegisteredServerCluster<Clusters::SoftwareDiagnosticsServerCluster> mSoftwareDiagnosticsServerCluster;
-        LazyRegisteredServerCluster<Clusters::AccessControlCluster> mAccessControlCluster;
-        LazyRegisteredServerCluster<Clusters::OperationalCredentialsCluster> mOperationalCredentialsCluster;
     };
+
+    RootNodeDevice(const Context & context) :
+        SingleEndpointDevice(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kRootNode, 1)), mContext(context)
+    {}
+    ~RootNodeDevice() override = default;
+
+    CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider,
+                        EndpointId parentId = kInvalidEndpointId) override;
+    void UnRegister(CodeDrivenDataModelProvider & provider) override;
+
+protected:
+    Context mContext;
+
+    LazyRegisteredServerCluster<Clusters::GeneralCommissioningCluster> mGeneralCommissioningCluster;
+
+private:
+    LazyRegisteredServerCluster<Clusters::BasicInformationCluster> mBasicInformationCluster;
+    LazyRegisteredServerCluster<Clusters::AdministratorCommissioningWithBasicCommissioningWindowCluster>
+        mAdministratorCommissioningCluster;
+    LazyRegisteredServerCluster<Clusters::GeneralDiagnosticsCluster> mGeneralDiagnosticsCluster;
+    LazyRegisteredServerCluster<Clusters::GroupKeyManagementCluster> mGroupKeyManagementCluster;
+    LazyRegisteredServerCluster<Clusters::SoftwareDiagnosticsServerCluster> mSoftwareDiagnosticsServerCluster;
+    LazyRegisteredServerCluster<Clusters::AccessControlCluster> mAccessControlCluster;
+    LazyRegisteredServerCluster<Clusters::OperationalCredentialsCluster> mOperationalCredentialsCluster;
+};
 
 } // namespace app
 } // namespace chip

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
@@ -56,7 +56,6 @@ public:
         DeviceLoadStatusProvider & deviceLoadStatusProvider;
         DeviceLayer::DiagnosticDataProvider & diagnosticDataProvider;
         TestEventTriggerDelegate * testEventTriggerDelegate;
-        SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         TermsAndConditionsProvider & termsAndConditionsProvider;

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <app/DeviceLoadStatusProvider.h>
+#include <app/SafeAttributePersistenceProvider.h>
 #include <app/TestEventTriggerDelegate.h>
 #include <app/clusters/access-control-server/access-control-cluster.h>
 #include <app/clusters/administrator-commissioning-server/AdministratorCommissioningCluster.h>
@@ -36,57 +37,57 @@
 namespace chip {
 namespace app {
 
-class RootNodeDevice : public SingleEndpointDevice
-{
-public:
-    struct Context
-    {
-        CommissioningWindowManager & commissioningWindowManager;
-        DeviceLayer::ConfigurationManager & configurationManager;
-        DeviceLayer::DeviceControlServer & deviceControlServer;
-        FabricTable & fabricTable;
-        Access::AccessControl & accessControl;
-        PersistentStorageDelegate & persistentStorage;
-        FailSafeContext & failSafeContext;
-        DeviceLayer::DeviceInstanceInfoProvider & deviceInstanceInfoProvider;
-        DeviceLayer::PlatformManager & platformManager;
-        Credentials::GroupDataProvider & groupDataProvider;
-        SessionManager & sessionManager;
-        DnssdServer & dnssdServer;
-        DeviceLoadStatusProvider & deviceLoadStatusProvider;
-        DeviceLayer::DiagnosticDataProvider & diagnosticDataProvider;
-        TestEventTriggerDelegate * testEventTriggerDelegate;
-        SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
+    class RootNodeDevice : public SingleEndpointDevice {
+    public:
+        struct Context {
+            CommissioningWindowManager & commissioningWindowManager;
+            DeviceLayer::ConfigurationManager & configurationManager;
+            DeviceLayer::DeviceControlServer & deviceControlServer;
+            FabricTable & fabricTable;
+            Access::AccessControl & accessControl;
+            PersistentStorageDelegate & persistentStorage;
+            FailSafeContext & failSafeContext;
+            DeviceLayer::DeviceInstanceInfoProvider & deviceInstanceInfoProvider;
+            DeviceLayer::PlatformManager & platformManager;
+            Credentials::GroupDataProvider & groupDataProvider;
+            SessionManager & sessionManager;
+            DnssdServer & dnssdServer;
+            DeviceLoadStatusProvider & deviceLoadStatusProvider;
+            DeviceLayer::DiagnosticDataProvider & diagnosticDataProvider;
+            TestEventTriggerDelegate * testEventTriggerDelegate;
+            SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-        TermsAndConditionsProvider & termsAndConditionsProvider;
+            TermsAndConditionsProvider & termsAndConditionsProvider;
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
+        };
+
+        RootNodeDevice(const Context & context)
+            : SingleEndpointDevice(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kRootNode, 1))
+            , mContext(context)
+        {
+        }
+        ~RootNodeDevice() override = default;
+
+        CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider,
+            EndpointId parentId = kInvalidEndpointId) override;
+        void UnRegister(CodeDrivenDataModelProvider & provider) override;
+
+    protected:
+        Context mContext;
+
+        LazyRegisteredServerCluster<Clusters::GeneralCommissioningCluster> mGeneralCommissioningCluster;
+
+    private:
+        LazyRegisteredServerCluster<Clusters::BasicInformationCluster> mBasicInformationCluster;
+        LazyRegisteredServerCluster<Clusters::AdministratorCommissioningWithBasicCommissioningWindowCluster>
+            mAdministratorCommissioningCluster;
+        LazyRegisteredServerCluster<Clusters::GeneralDiagnosticsCluster> mGeneralDiagnosticsCluster;
+        LazyRegisteredServerCluster<Clusters::GroupKeyManagementCluster> mGroupKeyManagementCluster;
+        LazyRegisteredServerCluster<Clusters::SoftwareDiagnosticsServerCluster> mSoftwareDiagnosticsServerCluster;
+        LazyRegisteredServerCluster<Clusters::AccessControlCluster> mAccessControlCluster;
+        LazyRegisteredServerCluster<Clusters::OperationalCredentialsCluster> mOperationalCredentialsCluster;
     };
-
-    RootNodeDevice(const Context & context) :
-        SingleEndpointDevice(Span<const DataModel::DeviceTypeEntry>(&Device::Type::kRootNode, 1)), mContext(context)
-    {}
-    ~RootNodeDevice() override = default;
-
-    CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider,
-                        EndpointId parentId = kInvalidEndpointId) override;
-    void UnRegister(CodeDrivenDataModelProvider & provider) override;
-
-protected:
-    Context mContext;
-
-    LazyRegisteredServerCluster<Clusters::GeneralCommissioningCluster> mGeneralCommissioningCluster;
-
-private:
-    LazyRegisteredServerCluster<Clusters::BasicInformationCluster> mBasicInformationCluster;
-    LazyRegisteredServerCluster<Clusters::AdministratorCommissioningWithBasicCommissioningWindowCluster>
-        mAdministratorCommissioningCluster;
-    LazyRegisteredServerCluster<Clusters::GeneralDiagnosticsCluster> mGeneralDiagnosticsCluster;
-    LazyRegisteredServerCluster<Clusters::GroupKeyManagementCluster> mGroupKeyManagementCluster;
-    LazyRegisteredServerCluster<Clusters::SoftwareDiagnosticsServerCluster> mSoftwareDiagnosticsServerCluster;
-    LazyRegisteredServerCluster<Clusters::AccessControlCluster> mAccessControlCluster;
-    LazyRegisteredServerCluster<Clusters::OperationalCredentialsCluster> mOperationalCredentialsCluster;
-};
 
 } // namespace app
 } // namespace chip

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/InteractionModelEngine.h>
 #include <app/persistence/DefaultAttributePersistenceProvider.h>
 #include <app/server/Dnssd.h>
@@ -95,6 +96,7 @@ DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 #endif // CONFIG_ENABLE_ESP32_DEVICE_INFO_PROVIDER
 
 chip::app::DefaultAttributePersistenceProvider gAttributePersistenceProvider;
+chip::app::DefaultSafeAttributePersistenceProvider gSafeAttributePersistenceProvider;
 Credentials::GroupDataProviderImpl gGroupDataProvider;
 chip::app::CodeDrivenDataModelProvider * gDataModelProvider = nullptr;
 std::unique_ptr<WifiRootNodeDevice> gRootNodeDevice;
@@ -194,6 +196,14 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
         return nullptr;
     }
 
+    // Initialize the safe attribute persistence provider with the storage delegate
+    err = gSafeAttributePersistenceProvider.Init(delegate);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "Failed to init safe attribute persistence provider: %" CHIP_ERROR_FORMAT, err.Format());
+        return nullptr;
+    }
+
     static chip::app::CodeDrivenDataModelProvider dataModelProvider =
         chip::app::CodeDrivenDataModelProvider(*delegate, gAttributePersistenceProvider);
 
@@ -207,25 +217,26 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
     }
 
     gRootNodeDevice = std::make_unique<WifiRootNodeDevice>(
-        RootNodeDevice::Context {
-            .commissioningWindowManager     = Server::GetInstance().GetCommissioningWindowManager(), //
-                .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
-                .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-                .fabricTable                = Server::GetInstance().GetFabricTable(),                //
-                .accessControl              = Server::GetInstance().GetAccessControl(),              //
-                .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
-                .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
-                .deviceInstanceInfoProvider = *provider,                                             //
-                .platformManager            = DeviceLayer::PlatformMgr(),                            //
-                .groupDataProvider          = gGroupDataProvider,                                    //
-                .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //
-                .dnssdServer                = DnssdServer::Instance(),                               //
-                .deviceLoadStatusProvider   = *InteractionModelEngine::GetInstance(),                //
-                .diagnosticDataProvider     = DeviceLayer::GetDiagnosticDataProvider(),              //
-                .testEventTriggerDelegate   = testEventTriggerDelegate,                              //
+        RootNodeDevice::Context{
+            .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
+            .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
+            .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+            .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
+            .accessControl                    = Server::GetInstance().GetAccessControl(),              //
+            .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
+            .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
+            .deviceInstanceInfoProvider       = *provider,                                             //
+            .platformManager                  = DeviceLayer::PlatformMgr(),                            //
+            .groupDataProvider                = gGroupDataProvider,                                    //
+            .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
+            .dnssdServer                      = DnssdServer::Instance(),                               //
+            .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
+            .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
+            .testEventTriggerDelegate         = testEventTriggerDelegate,                              //
+            .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         WifiRootNodeDevice::WifiContext{

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -219,26 +219,26 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
     }
 
     gRootNodeDevice = std::make_unique<WifiRootNodeDevice>(
-        RootNodeDevice::Context{
-            .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
-            .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
-            .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-            .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
-            .accessControl                    = Server::GetInstance().GetAccessControl(),              //
-            .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
-            .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
-            .deviceInstanceInfoProvider       = *provider,                                             //
-            .platformManager                  = DeviceLayer::PlatformMgr(),                            //
-            .groupDataProvider                = gGroupDataProvider,                                    //
-            .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
-            .dnssdServer                      = DnssdServer::Instance(),                               //
-            .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
-            .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
-            .testEventTriggerDelegate         = testEventTriggerDelegate,                              //
-            .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
+        RootNodeDevice::Context {
+            .commissioningWindowManager           = Server::GetInstance().GetCommissioningWindowManager(), //
+                .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
+                .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
+                .accessControl                    = Server::GetInstance().GetAccessControl(),              //
+                .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
+                .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
+                .deviceInstanceInfoProvider       = *provider,                                             //
+                .platformManager                  = DeviceLayer::PlatformMgr(),                            //
+                .groupDataProvider                = gGroupDataProvider,                                    //
+                .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
+                .dnssdServer                      = DnssdServer::Instance(),                               //
+                .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
+                .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
+                .testEventTriggerDelegate         = testEventTriggerDelegate,                              //
+                .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         WifiRootNodeDevice::WifiContext{

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/InteractionModelEngine.h>
 #include <app/persistence/DefaultAttributePersistenceProvider.h>
 #include <app/server/Dnssd.h>
@@ -95,6 +96,7 @@ DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 #endif // CONFIG_ENABLE_ESP32_DEVICE_INFO_PROVIDER
 
 chip::app::DefaultAttributePersistenceProvider gAttributePersistenceProvider;
+chip::app::DefaultSafeAttributePersistenceProvider gSafeAttributePersistenceProvider;
 Credentials::GroupDataProviderImpl gGroupDataProvider;
 chip::app::CodeDrivenDataModelProvider * gDataModelProvider = nullptr;
 std::unique_ptr<WifiRootNodeDevice> gRootNodeDevice;
@@ -194,6 +196,14 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
         return nullptr;
     }
 
+    // Initialize the safe attribute persistence provider with the storage delegate
+    err = gSafeAttributePersistenceProvider.Init(delegate);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "Failed to init safe attribute persistence provider: %" CHIP_ERROR_FORMAT, err.Format());
+        return nullptr;
+    }
+
     static chip::app::CodeDrivenDataModelProvider dataModelProvider =
         chip::app::CodeDrivenDataModelProvider(*delegate, gAttributePersistenceProvider);
 
@@ -208,21 +218,22 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
 
     gRootNodeDevice = std::make_unique<WifiRootNodeDevice>(
         RootNodeDevice::Context {
-            .commissioningWindowManager     = Server::GetInstance().GetCommissioningWindowManager(), //
-                .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
-                .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-                .fabricTable                = Server::GetInstance().GetFabricTable(),                //
-                .accessControl              = Server::GetInstance().GetAccessControl(),              //
-                .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
-                .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
-                .deviceInstanceInfoProvider = *provider,                                             //
-                .platformManager            = DeviceLayer::PlatformMgr(),                            //
-                .groupDataProvider          = gGroupDataProvider,                                    //
-                .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //
-                .dnssdServer                = DnssdServer::Instance(),                               //
-                .deviceLoadStatusProvider   = *InteractionModelEngine::GetInstance(),                //
-                .diagnosticDataProvider     = DeviceLayer::GetDiagnosticDataProvider(),              //
-                .testEventTriggerDelegate   = testEventTriggerDelegate,                              //
+            .commissioningWindowManager           = Server::GetInstance().GetCommissioningWindowManager(), //
+                .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
+                .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
+                .accessControl                    = Server::GetInstance().GetAccessControl(),              //
+                .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
+                .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
+                .deviceInstanceInfoProvider       = *provider,                                             //
+                .platformManager                  = DeviceLayer::PlatformMgr(),                            //
+                .groupDataProvider                = gGroupDataProvider,                                    //
+                .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
+                .dnssdServer                      = DnssdServer::Instance(),                               //
+                .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
+                .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
+                .testEventTriggerDelegate         = testEventTriggerDelegate,                              //
+                .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
                 .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -18,6 +18,7 @@
 
 #include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/InteractionModelEngine.h>
+#include <app/SafeAttributePersistenceProvider.h>
 #include <app/persistence/DefaultAttributePersistenceProvider.h>
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
@@ -203,6 +204,7 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
         ESP_LOGE(TAG, "Failed to init safe attribute persistence provider: %" CHIP_ERROR_FORMAT, err.Format());
         return nullptr;
     }
+    SetSafeAttributePersistenceProvider(&gSafeAttributePersistenceProvider);
 
     static chip::app::CodeDrivenDataModelProvider dataModelProvider =
         chip::app::CodeDrivenDataModelProvider(*delegate, gAttributePersistenceProvider);
@@ -217,26 +219,26 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
     }
 
     gRootNodeDevice = std::make_unique<WifiRootNodeDevice>(
-        RootNodeDevice::Context {
-            .commissioningWindowManager           = Server::GetInstance().GetCommissioningWindowManager(), //
-                .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
-                .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-                .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
-                .accessControl                    = Server::GetInstance().GetAccessControl(),              //
-                .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
-                .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
-                .deviceInstanceInfoProvider       = *provider,                                             //
-                .platformManager                  = DeviceLayer::PlatformMgr(),                            //
-                .groupDataProvider                = gGroupDataProvider,                                    //
-                .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
-                .dnssdServer                      = DnssdServer::Instance(),                               //
-                .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
-                .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
-                .testEventTriggerDelegate         = testEventTriggerDelegate,                              //
-                .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
+        RootNodeDevice::Context{
+            .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
+            .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
+            .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+            .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
+            .accessControl                    = Server::GetInstance().GetAccessControl(),              //
+            .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
+            .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
+            .deviceInstanceInfoProvider       = *provider,                                             //
+            .platformManager                  = DeviceLayer::PlatformMgr(),                            //
+            .groupDataProvider                = gGroupDataProvider,                                    //
+            .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
+            .dnssdServer                      = DnssdServer::Instance(),                               //
+            .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
+            .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
+            .testEventTriggerDelegate         = testEventTriggerDelegate,                              //
+            .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         WifiRootNodeDevice::WifiContext{

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -217,26 +217,26 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
     }
 
     gRootNodeDevice = std::make_unique<WifiRootNodeDevice>(
-        RootNodeDevice::Context{
-            .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
-            .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
-            .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-            .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
-            .accessControl                    = Server::GetInstance().GetAccessControl(),              //
-            .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
-            .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
-            .deviceInstanceInfoProvider       = *provider,                                             //
-            .platformManager                  = DeviceLayer::PlatformMgr(),                            //
-            .groupDataProvider                = gGroupDataProvider,                                    //
-            .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
-            .dnssdServer                      = DnssdServer::Instance(),                               //
-            .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
-            .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
-            .testEventTriggerDelegate         = testEventTriggerDelegate,                              //
-            .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
+        RootNodeDevice::Context {
+            .commissioningWindowManager           = Server::GetInstance().GetCommissioningWindowManager(), //
+                .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
+                .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
+                .accessControl                    = Server::GetInstance().GetAccessControl(),              //
+                .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
+                .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
+                .deviceInstanceInfoProvider       = *provider,                                             //
+                .platformManager                  = DeviceLayer::PlatformMgr(),                            //
+                .groupDataProvider                = gGroupDataProvider,                                    //
+                .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
+                .dnssdServer                      = DnssdServer::Instance(),                               //
+                .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
+                .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
+                .testEventTriggerDelegate         = testEventTriggerDelegate,                              //
+                .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+                .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         },
         WifiRootNodeDevice::WifiContext{

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -16,7 +16,6 @@
  *    limitations under the License.
  */
 
-#include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/InteractionModelEngine.h>
 #include <app/persistence/DefaultAttributePersistenceProvider.h>
 #include <app/server/Dnssd.h>
@@ -96,7 +95,6 @@ DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 #endif // CONFIG_ENABLE_ESP32_DEVICE_INFO_PROVIDER
 
 chip::app::DefaultAttributePersistenceProvider gAttributePersistenceProvider;
-chip::app::DefaultSafeAttributePersistenceProvider gSafeAttributePersistenceProvider;
 Credentials::GroupDataProviderImpl gGroupDataProvider;
 chip::app::CodeDrivenDataModelProvider * gDataModelProvider = nullptr;
 std::unique_ptr<WifiRootNodeDevice> gRootNodeDevice;
@@ -196,14 +194,6 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
         return nullptr;
     }
 
-    // Initialize the safe attribute persistence provider with the storage delegate
-    err = gSafeAttributePersistenceProvider.Init(delegate);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "Failed to init safe attribute persistence provider: %" CHIP_ERROR_FORMAT, err.Format());
-        return nullptr;
-    }
-
     static chip::app::CodeDrivenDataModelProvider dataModelProvider =
         chip::app::CodeDrivenDataModelProvider(*delegate, gAttributePersistenceProvider);
 
@@ -218,22 +208,21 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
 
     gRootNodeDevice = std::make_unique<WifiRootNodeDevice>(
         RootNodeDevice::Context {
-            .commissioningWindowManager           = Server::GetInstance().GetCommissioningWindowManager(), //
-                .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
-                .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-                .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
-                .accessControl                    = Server::GetInstance().GetAccessControl(),              //
-                .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
-                .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
-                .deviceInstanceInfoProvider       = *provider,                                             //
-                .platformManager                  = DeviceLayer::PlatformMgr(),                            //
-                .groupDataProvider                = gGroupDataProvider,                                    //
-                .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
-                .dnssdServer                      = DnssdServer::Instance(),                               //
-                .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
-                .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
-                .testEventTriggerDelegate         = testEventTriggerDelegate,                              //
-                .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
+            .commissioningWindowManager     = Server::GetInstance().GetCommissioningWindowManager(), //
+                .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
+                .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+                .fabricTable                = Server::GetInstance().GetFabricTable(),                //
+                .accessControl              = Server::GetInstance().GetAccessControl(),              //
+                .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
+                .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
+                .deviceInstanceInfoProvider = *provider,                                             //
+                .platformManager            = DeviceLayer::PlatformMgr(),                            //
+                .groupDataProvider          = gGroupDataProvider,                                    //
+                .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //
+                .dnssdServer                = DnssdServer::Instance(),                               //
+                .deviceLoadStatusProvider   = *InteractionModelEngine::GetInstance(),                //
+                .diagnosticDataProvider     = DeviceLayer::GetDiagnosticDataProvider(),              //
+                .testEventTriggerDelegate   = testEventTriggerDelegate,                              //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
                 .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -107,25 +107,25 @@ public:
         mContext(context), mDataModelProvider(mContext.storageDelegate, mAttributePersistence),
         mRootNode(
             {
-                .commissioningWindowManager       = mContext.commissioningWindowManager,       //
-                .configurationManager             = mContext.configurationManager,             //
-                .deviceControlServer              = mContext.deviceControlServer,              //
-                .fabricTable                      = mContext.fabricTable,                      //
-                .accessControl                    = mContext.accessControl,                    //
-                .persistentStorage                = mContext.persistentStorage,                //
-                .failSafeContext                  = mContext.failSafeContext,                  //
-                .deviceInstanceInfoProvider       = mContext.deviceInstanceInfoProvider,       //
-                .platformManager                  = mContext.platformManager,                  //
-                .groupDataProvider                = mContext.groupDataProvider,                //
-                .sessionManager                   = mContext.sessionManager,                   //
-                .dnssdServer                      = mContext.dnssdServer,                      //
-                .deviceLoadStatusProvider         = mContext.deviceLoadStatusProvider,         //
-                .diagnosticDataProvider           = mContext.diagnosticDataProvider,           //
-                .testEventTriggerDelegate         = mContext.testEventTriggerDelegate,         //
-                .safeAttributePersistenceProvider = mContext.safeAttributePersistenceProvider, //
+                .commissioningWindowManager           = mContext.commissioningWindowManager,       //
+                    .configurationManager             = mContext.configurationManager,             //
+                    .deviceControlServer              = mContext.deviceControlServer,              //
+                    .fabricTable                      = mContext.fabricTable,                      //
+                    .accessControl                    = mContext.accessControl,                    //
+                    .persistentStorage                = mContext.persistentStorage,                //
+                    .failSafeContext                  = mContext.failSafeContext,                  //
+                    .deviceInstanceInfoProvider       = mContext.deviceInstanceInfoProvider,       //
+                    .platformManager                  = mContext.platformManager,                  //
+                    .groupDataProvider                = mContext.groupDataProvider,                //
+                    .sessionManager                   = mContext.sessionManager,                   //
+                    .dnssdServer                      = mContext.dnssdServer,                      //
+                    .deviceLoadStatusProvider         = mContext.deviceLoadStatusProvider,         //
+                    .diagnosticDataProvider           = mContext.diagnosticDataProvider,           //
+                    .testEventTriggerDelegate         = mContext.testEventTriggerDelegate,         //
+                    .safeAttributePersistenceProvider = mContext.safeAttributePersistenceProvider, //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+                    .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
             },
             []() {
@@ -202,26 +202,26 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
     SetSafeAttributePersistenceProvider(&gSafeAttributePersistenceProvider);
 
     static CodeDrivenDataModelDevices devices({
-        .storageDelegate                  = *initParams.persistentStorageDelegate,                 //
-        .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
-        .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
-        .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-        .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
-        .accessControl                    = Server::GetInstance().GetAccessControl(),              //
-        .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
-        .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
-        .deviceInstanceInfoProvider       = *provider,                                             //
-        .platformManager                  = DeviceLayer::PlatformMgr(),                            //
-        .groupDataProvider                = gGroupDataProvider,                                    //
-        .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
-        .dnssdServer                      = DnssdServer::Instance(),                               //
-        .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
-        .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
-        .testEventTriggerDelegate         = initParams.testEventTriggerDelegate,                   //
-        .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
+        .storageDelegate                      = *initParams.persistentStorageDelegate,                 //
+            .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
+            .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
+            .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+            .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
+            .accessControl                    = Server::GetInstance().GetAccessControl(),              //
+            .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
+            .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
+            .deviceInstanceInfoProvider       = *provider,                                             //
+            .platformManager                  = DeviceLayer::PlatformMgr(),                            //
+            .groupDataProvider                = gGroupDataProvider,                                    //
+            .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
+            .dnssdServer                      = DnssdServer::Instance(),                               //
+            .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
+            .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
+            .testEventTriggerDelegate         = initParams.testEventTriggerDelegate,                   //
+            .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-        .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
     });
 

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -24,6 +24,7 @@
 #include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/DeviceLoadStatusProvider.h>
 #include <app/InteractionModelEngine.h>
+#include <app/SafeAttributePersistenceProvider.h>
 #include <app/TestEventTriggerDelegate.h>
 #include <app/persistence/DefaultAttributePersistenceProvider.h>
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
@@ -106,25 +107,25 @@ public:
         mContext(context), mDataModelProvider(mContext.storageDelegate, mAttributePersistence),
         mRootNode(
             {
-                .commissioningWindowManager           = mContext.commissioningWindowManager,       //
-                    .configurationManager             = mContext.configurationManager,             //
-                    .deviceControlServer              = mContext.deviceControlServer,              //
-                    .fabricTable                      = mContext.fabricTable,                      //
-                    .accessControl                    = mContext.accessControl,                    //
-                    .persistentStorage                = mContext.persistentStorage,                //
-                    .failSafeContext                  = mContext.failSafeContext,                  //
-                    .deviceInstanceInfoProvider       = mContext.deviceInstanceInfoProvider,       //
-                    .platformManager                  = mContext.platformManager,                  //
-                    .groupDataProvider                = mContext.groupDataProvider,                //
-                    .sessionManager                   = mContext.sessionManager,                   //
-                    .dnssdServer                      = mContext.dnssdServer,                      //
-                    .deviceLoadStatusProvider         = mContext.deviceLoadStatusProvider,         //
-                    .diagnosticDataProvider           = mContext.diagnosticDataProvider,           //
-                    .testEventTriggerDelegate         = mContext.testEventTriggerDelegate,         //
-                    .safeAttributePersistenceProvider = mContext.safeAttributePersistenceProvider, //
+                .commissioningWindowManager       = mContext.commissioningWindowManager,       //
+                .configurationManager             = mContext.configurationManager,             //
+                .deviceControlServer              = mContext.deviceControlServer,              //
+                .fabricTable                      = mContext.fabricTable,                      //
+                .accessControl                    = mContext.accessControl,                    //
+                .persistentStorage                = mContext.persistentStorage,                //
+                .failSafeContext                  = mContext.failSafeContext,                  //
+                .deviceInstanceInfoProvider       = mContext.deviceInstanceInfoProvider,       //
+                .platformManager                  = mContext.platformManager,                  //
+                .groupDataProvider                = mContext.groupDataProvider,                //
+                .sessionManager                   = mContext.sessionManager,                   //
+                .dnssdServer                      = mContext.dnssdServer,                      //
+                .deviceLoadStatusProvider         = mContext.deviceLoadStatusProvider,         //
+                .diagnosticDataProvider           = mContext.diagnosticDataProvider,           //
+                .testEventTriggerDelegate         = mContext.testEventTriggerDelegate,         //
+                .safeAttributePersistenceProvider = mContext.safeAttributePersistenceProvider, //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                    .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
             },
             []() {
@@ -198,28 +199,29 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
 
     // Initialize the safe attribute persistence provider
     SuccessOrDie(gSafeAttributePersistenceProvider.Init(initParams.persistentStorageDelegate));
+    SetSafeAttributePersistenceProvider(&gSafeAttributePersistenceProvider);
 
     static CodeDrivenDataModelDevices devices({
-        .storageDelegate                      = *initParams.persistentStorageDelegate,                 //
-            .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
-            .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
-            .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-            .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
-            .accessControl                    = Server::GetInstance().GetAccessControl(),              //
-            .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
-            .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
-            .deviceInstanceInfoProvider       = *provider,                                             //
-            .platformManager                  = DeviceLayer::PlatformMgr(),                            //
-            .groupDataProvider                = gGroupDataProvider,                                    //
-            .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
-            .dnssdServer                      = DnssdServer::Instance(),                               //
-            .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
-            .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
-            .testEventTriggerDelegate         = initParams.testEventTriggerDelegate,                   //
-            .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
+        .storageDelegate                  = *initParams.persistentStorageDelegate,                 //
+        .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
+        .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
+        .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+        .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
+        .accessControl                    = Server::GetInstance().GetAccessControl(),              //
+        .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
+        .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
+        .deviceInstanceInfoProvider       = *provider,                                             //
+        .platformManager                  = DeviceLayer::PlatformMgr(),                            //
+        .groupDataProvider                = gGroupDataProvider,                                    //
+        .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
+        .dnssdServer                      = DnssdServer::Instance(),                               //
+        .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
+        .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
+        .testEventTriggerDelegate         = initParams.testEventTriggerDelegate,                   //
+        .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+        .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
     });
 

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -21,7 +21,6 @@
 #include <AppRootNode.h>
 #include <LinuxCommissionableDataProvider.h>
 #include <TracingCommandLineArgument.h>
-#include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/DeviceLoadStatusProvider.h>
 #include <app/InteractionModelEngine.h>
 #include <app/TestEventTriggerDelegate.h>
@@ -53,7 +52,6 @@ AppMainLoopImplementation * gMainLoopImplementation = nullptr;
 
 AllDevicesExampleDeviceInfoProviderImpl gExampleDeviceInfoProvider;
 Credentials::GroupDataProviderImpl gGroupDataProvider;
-chip::app::DefaultSafeAttributePersistenceProvider gSafeAttributePersistenceProvider;
 
 // To hold SPAKE2+ verifier, discriminator, passcode
 LinuxCommissionableDataProvider gCommissionableDataProvider;
@@ -95,7 +93,6 @@ public:
         DeviceLoadStatusProvider & deviceLoadStatusProvider;
         DeviceLayer::DiagnosticDataProvider & diagnosticDataProvider;
         TestEventTriggerDelegate * testEventTriggerDelegate;
-        SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         TermsAndConditionsProvider & termsAndConditionsProvider;
@@ -106,22 +103,21 @@ public:
         mContext(context), mDataModelProvider(mContext.storageDelegate, mAttributePersistence),
         mRootNode(
             {
-                .commissioningWindowManager           = mContext.commissioningWindowManager,       //
-                    .configurationManager             = mContext.configurationManager,             //
-                    .deviceControlServer              = mContext.deviceControlServer,              //
-                    .fabricTable                      = mContext.fabricTable,                      //
-                    .accessControl                    = mContext.accessControl,                    //
-                    .persistentStorage                = mContext.persistentStorage,                //
-                    .failSafeContext                  = mContext.failSafeContext,                  //
-                    .deviceInstanceInfoProvider       = mContext.deviceInstanceInfoProvider,       //
-                    .platformManager                  = mContext.platformManager,                  //
-                    .groupDataProvider                = mContext.groupDataProvider,                //
-                    .sessionManager                   = mContext.sessionManager,                   //
-                    .dnssdServer                      = mContext.dnssdServer,                      //
-                    .deviceLoadStatusProvider         = mContext.deviceLoadStatusProvider,         //
-                    .diagnosticDataProvider           = mContext.diagnosticDataProvider,           //
-                    .testEventTriggerDelegate         = mContext.testEventTriggerDelegate,         //
-                    .safeAttributePersistenceProvider = mContext.safeAttributePersistenceProvider, //
+                .commissioningWindowManager     = mContext.commissioningWindowManager, //
+                    .configurationManager       = mContext.configurationManager,       //
+                    .deviceControlServer        = mContext.deviceControlServer,        //
+                    .fabricTable                = mContext.fabricTable,                //
+                    .accessControl              = mContext.accessControl,              //
+                    .persistentStorage          = mContext.persistentStorage,          //
+                    .failSafeContext            = mContext.failSafeContext,            //
+                    .deviceInstanceInfoProvider = mContext.deviceInstanceInfoProvider, //
+                    .platformManager            = mContext.platformManager,            //
+                    .groupDataProvider          = mContext.groupDataProvider,          //
+                    .sessionManager             = mContext.sessionManager,             //
+                    .dnssdServer                = mContext.dnssdServer,                //
+                    .deviceLoadStatusProvider   = mContext.deviceLoadStatusProvider,   //
+                    .diagnosticDataProvider     = mContext.diagnosticDataProvider,     //
+                    .testEventTriggerDelegate   = mContext.testEventTriggerDelegate,   //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
                     .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
@@ -196,27 +192,23 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
         chipDie();
     }
 
-    // Initialize the safe attribute persistence provider
-    SuccessOrDie(gSafeAttributePersistenceProvider.Init(initParams.persistentStorageDelegate));
-
     static CodeDrivenDataModelDevices devices({
-        .storageDelegate                      = *initParams.persistentStorageDelegate,                 //
-            .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
-            .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
-            .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-            .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
-            .accessControl                    = Server::GetInstance().GetAccessControl(),              //
-            .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
-            .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
-            .deviceInstanceInfoProvider       = *provider,                                             //
-            .platformManager                  = DeviceLayer::PlatformMgr(),                            //
-            .groupDataProvider                = gGroupDataProvider,                                    //
-            .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
-            .dnssdServer                      = DnssdServer::Instance(),                               //
-            .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
-            .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
-            .testEventTriggerDelegate         = initParams.testEventTriggerDelegate,                   //
-            .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
+        .storageDelegate                = *initParams.persistentStorageDelegate,                 //
+            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
+            .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
+            .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+            .fabricTable                = Server::GetInstance().GetFabricTable(),                //
+            .accessControl              = Server::GetInstance().GetAccessControl(),              //
+            .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
+            .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
+            .deviceInstanceInfoProvider = *provider,                                             //
+            .platformManager            = DeviceLayer::PlatformMgr(),                            //
+            .groupDataProvider          = gGroupDataProvider,                                    //
+            .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //
+            .dnssdServer                = DnssdServer::Instance(),                               //
+            .deviceLoadStatusProvider   = *InteractionModelEngine::GetInstance(),                //
+            .diagnosticDataProvider     = DeviceLayer::GetDiagnosticDataProvider(),              //
+            .testEventTriggerDelegate   = initParams.testEventTriggerDelegate,                   //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
             .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -21,6 +21,7 @@
 #include <AppRootNode.h>
 #include <LinuxCommissionableDataProvider.h>
 #include <TracingCommandLineArgument.h>
+#include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/DeviceLoadStatusProvider.h>
 #include <app/InteractionModelEngine.h>
 #include <app/TestEventTriggerDelegate.h>
@@ -52,6 +53,7 @@ AppMainLoopImplementation * gMainLoopImplementation = nullptr;
 
 AllDevicesExampleDeviceInfoProviderImpl gExampleDeviceInfoProvider;
 Credentials::GroupDataProviderImpl gGroupDataProvider;
+chip::app::DefaultSafeAttributePersistenceProvider gSafeAttributePersistenceProvider;
 
 // To hold SPAKE2+ verifier, discriminator, passcode
 LinuxCommissionableDataProvider gCommissionableDataProvider;
@@ -93,6 +95,7 @@ public:
         DeviceLoadStatusProvider & deviceLoadStatusProvider;
         DeviceLayer::DiagnosticDataProvider & diagnosticDataProvider;
         TestEventTriggerDelegate * testEventTriggerDelegate;
+        SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         TermsAndConditionsProvider & termsAndConditionsProvider;
@@ -103,21 +106,22 @@ public:
         mContext(context), mDataModelProvider(mContext.storageDelegate, mAttributePersistence),
         mRootNode(
             {
-                .commissioningWindowManager     = mContext.commissioningWindowManager, //
-                    .configurationManager       = mContext.configurationManager,       //
-                    .deviceControlServer        = mContext.deviceControlServer,        //
-                    .fabricTable                = mContext.fabricTable,                //
-                    .accessControl              = mContext.accessControl,              //
-                    .persistentStorage          = mContext.persistentStorage,          //
-                    .failSafeContext            = mContext.failSafeContext,            //
-                    .deviceInstanceInfoProvider = mContext.deviceInstanceInfoProvider, //
-                    .platformManager            = mContext.platformManager,            //
-                    .groupDataProvider          = mContext.groupDataProvider,          //
-                    .sessionManager             = mContext.sessionManager,             //
-                    .dnssdServer                = mContext.dnssdServer,                //
-                    .deviceLoadStatusProvider   = mContext.deviceLoadStatusProvider,   //
-                    .diagnosticDataProvider     = mContext.diagnosticDataProvider,     //
-                    .testEventTriggerDelegate   = mContext.testEventTriggerDelegate,   //
+                .commissioningWindowManager           = mContext.commissioningWindowManager,       //
+                    .configurationManager             = mContext.configurationManager,             //
+                    .deviceControlServer              = mContext.deviceControlServer,              //
+                    .fabricTable                      = mContext.fabricTable,                      //
+                    .accessControl                    = mContext.accessControl,                    //
+                    .persistentStorage                = mContext.persistentStorage,                //
+                    .failSafeContext                  = mContext.failSafeContext,                  //
+                    .deviceInstanceInfoProvider       = mContext.deviceInstanceInfoProvider,       //
+                    .platformManager                  = mContext.platformManager,                  //
+                    .groupDataProvider                = mContext.groupDataProvider,                //
+                    .sessionManager                   = mContext.sessionManager,                   //
+                    .dnssdServer                      = mContext.dnssdServer,                      //
+                    .deviceLoadStatusProvider         = mContext.deviceLoadStatusProvider,         //
+                    .diagnosticDataProvider           = mContext.diagnosticDataProvider,           //
+                    .testEventTriggerDelegate         = mContext.testEventTriggerDelegate,         //
+                    .safeAttributePersistenceProvider = mContext.safeAttributePersistenceProvider, //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
                     .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
@@ -192,23 +196,27 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
         chipDie();
     }
 
+    // Initialize the safe attribute persistence provider
+    SuccessOrDie(gSafeAttributePersistenceProvider.Init(initParams.persistentStorageDelegate));
+
     static CodeDrivenDataModelDevices devices({
-        .storageDelegate                = *initParams.persistentStorageDelegate,                 //
-            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
-            .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
-            .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-            .fabricTable                = Server::GetInstance().GetFabricTable(),                //
-            .accessControl              = Server::GetInstance().GetAccessControl(),              //
-            .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
-            .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
-            .deviceInstanceInfoProvider = *provider,                                             //
-            .platformManager            = DeviceLayer::PlatformMgr(),                            //
-            .groupDataProvider          = gGroupDataProvider,                                    //
-            .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //
-            .dnssdServer                = DnssdServer::Instance(),                               //
-            .deviceLoadStatusProvider   = *InteractionModelEngine::GetInstance(),                //
-            .diagnosticDataProvider     = DeviceLayer::GetDiagnosticDataProvider(),              //
-            .testEventTriggerDelegate   = initParams.testEventTriggerDelegate,                   //
+        .storageDelegate                      = *initParams.persistentStorageDelegate,                 //
+            .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
+            .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
+            .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+            .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
+            .accessControl                    = Server::GetInstance().GetAccessControl(),              //
+            .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
+            .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
+            .deviceInstanceInfoProvider       = *provider,                                             //
+            .platformManager                  = DeviceLayer::PlatformMgr(),                            //
+            .groupDataProvider                = gGroupDataProvider,                                    //
+            .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
+            .dnssdServer                      = DnssdServer::Instance(),                               //
+            .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
+            .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
+            .testEventTriggerDelegate         = initParams.testEventTriggerDelegate,                   //
+            .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
             .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -106,25 +106,25 @@ public:
         mContext(context), mDataModelProvider(mContext.storageDelegate, mAttributePersistence),
         mRootNode(
             {
-                .commissioningWindowManager       = mContext.commissioningWindowManager,       //
-                .configurationManager             = mContext.configurationManager,             //
-                .deviceControlServer              = mContext.deviceControlServer,              //
-                .fabricTable                      = mContext.fabricTable,                      //
-                .accessControl                    = mContext.accessControl,                    //
-                .persistentStorage                = mContext.persistentStorage,                //
-                .failSafeContext                  = mContext.failSafeContext,                  //
-                .deviceInstanceInfoProvider       = mContext.deviceInstanceInfoProvider,       //
-                .platformManager                  = mContext.platformManager,                  //
-                .groupDataProvider                = mContext.groupDataProvider,                //
-                .sessionManager                   = mContext.sessionManager,                   //
-                .dnssdServer                      = mContext.dnssdServer,                      //
-                .deviceLoadStatusProvider         = mContext.deviceLoadStatusProvider,         //
-                .diagnosticDataProvider           = mContext.diagnosticDataProvider,           //
-                .testEventTriggerDelegate         = mContext.testEventTriggerDelegate,         //
-                .safeAttributePersistenceProvider = mContext.safeAttributePersistenceProvider, //
+                .commissioningWindowManager           = mContext.commissioningWindowManager,       //
+                    .configurationManager             = mContext.configurationManager,             //
+                    .deviceControlServer              = mContext.deviceControlServer,              //
+                    .fabricTable                      = mContext.fabricTable,                      //
+                    .accessControl                    = mContext.accessControl,                    //
+                    .persistentStorage                = mContext.persistentStorage,                //
+                    .failSafeContext                  = mContext.failSafeContext,                  //
+                    .deviceInstanceInfoProvider       = mContext.deviceInstanceInfoProvider,       //
+                    .platformManager                  = mContext.platformManager,                  //
+                    .groupDataProvider                = mContext.groupDataProvider,                //
+                    .sessionManager                   = mContext.sessionManager,                   //
+                    .dnssdServer                      = mContext.dnssdServer,                      //
+                    .deviceLoadStatusProvider         = mContext.deviceLoadStatusProvider,         //
+                    .diagnosticDataProvider           = mContext.diagnosticDataProvider,           //
+                    .testEventTriggerDelegate         = mContext.testEventTriggerDelegate,         //
+                    .safeAttributePersistenceProvider = mContext.safeAttributePersistenceProvider, //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+                    .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
             },
             []() {
@@ -200,26 +200,26 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
     SuccessOrDie(gSafeAttributePersistenceProvider.Init(initParams.persistentStorageDelegate));
 
     static CodeDrivenDataModelDevices devices({
-        .storageDelegate                  = *initParams.persistentStorageDelegate,                 //
-        .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
-        .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
-        .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-        .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
-        .accessControl                    = Server::GetInstance().GetAccessControl(),              //
-        .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
-        .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
-        .deviceInstanceInfoProvider       = *provider,                                             //
-        .platformManager                  = DeviceLayer::PlatformMgr(),                            //
-        .groupDataProvider                = gGroupDataProvider,                                    //
-        .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
-        .dnssdServer                      = DnssdServer::Instance(),                               //
-        .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
-        .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
-        .testEventTriggerDelegate         = initParams.testEventTriggerDelegate,                   //
-        .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
+        .storageDelegate                      = *initParams.persistentStorageDelegate,                 //
+            .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
+            .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
+            .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+            .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
+            .accessControl                    = Server::GetInstance().GetAccessControl(),              //
+            .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
+            .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
+            .deviceInstanceInfoProvider       = *provider,                                             //
+            .platformManager                  = DeviceLayer::PlatformMgr(),                            //
+            .groupDataProvider                = gGroupDataProvider,                                    //
+            .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
+            .dnssdServer                      = DnssdServer::Instance(),                               //
+            .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
+            .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
+            .testEventTriggerDelegate         = initParams.testEventTriggerDelegate,                   //
+            .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-        .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
     });
 

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -21,6 +21,7 @@
 #include <AppRootNode.h>
 #include <LinuxCommissionableDataProvider.h>
 #include <TracingCommandLineArgument.h>
+#include <app/DefaultSafeAttributePersistenceProvider.h>
 #include <app/DeviceLoadStatusProvider.h>
 #include <app/InteractionModelEngine.h>
 #include <app/TestEventTriggerDelegate.h>
@@ -52,6 +53,7 @@ AppMainLoopImplementation * gMainLoopImplementation = nullptr;
 
 AllDevicesExampleDeviceInfoProviderImpl gExampleDeviceInfoProvider;
 Credentials::GroupDataProviderImpl gGroupDataProvider;
+chip::app::DefaultSafeAttributePersistenceProvider gSafeAttributePersistenceProvider;
 
 // To hold SPAKE2+ verifier, discriminator, passcode
 LinuxCommissionableDataProvider gCommissionableDataProvider;
@@ -93,6 +95,7 @@ public:
         DeviceLoadStatusProvider & deviceLoadStatusProvider;
         DeviceLayer::DiagnosticDataProvider & diagnosticDataProvider;
         TestEventTriggerDelegate * testEventTriggerDelegate;
+        SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         TermsAndConditionsProvider & termsAndConditionsProvider;
@@ -103,24 +106,25 @@ public:
         mContext(context), mDataModelProvider(mContext.storageDelegate, mAttributePersistence),
         mRootNode(
             {
-                .commissioningWindowManager     = mContext.commissioningWindowManager, //
-                    .configurationManager       = mContext.configurationManager,       //
-                    .deviceControlServer        = mContext.deviceControlServer,        //
-                    .fabricTable                = mContext.fabricTable,                //
-                    .accessControl              = mContext.accessControl,              //
-                    .persistentStorage          = mContext.persistentStorage,          //
-                    .failSafeContext            = mContext.failSafeContext,            //
-                    .deviceInstanceInfoProvider = mContext.deviceInstanceInfoProvider, //
-                    .platformManager            = mContext.platformManager,            //
-                    .groupDataProvider          = mContext.groupDataProvider,          //
-                    .sessionManager             = mContext.sessionManager,             //
-                    .dnssdServer                = mContext.dnssdServer,                //
-                    .deviceLoadStatusProvider   = mContext.deviceLoadStatusProvider,   //
-                    .diagnosticDataProvider     = mContext.diagnosticDataProvider,     //
-                    .testEventTriggerDelegate   = mContext.testEventTriggerDelegate,   //
+                .commissioningWindowManager       = mContext.commissioningWindowManager,       //
+                .configurationManager             = mContext.configurationManager,             //
+                .deviceControlServer              = mContext.deviceControlServer,              //
+                .fabricTable                      = mContext.fabricTable,                      //
+                .accessControl                    = mContext.accessControl,                    //
+                .persistentStorage                = mContext.persistentStorage,                //
+                .failSafeContext                  = mContext.failSafeContext,                  //
+                .deviceInstanceInfoProvider       = mContext.deviceInstanceInfoProvider,       //
+                .platformManager                  = mContext.platformManager,                  //
+                .groupDataProvider                = mContext.groupDataProvider,                //
+                .sessionManager                   = mContext.sessionManager,                   //
+                .dnssdServer                      = mContext.dnssdServer,                      //
+                .deviceLoadStatusProvider         = mContext.deviceLoadStatusProvider,         //
+                .diagnosticDataProvider           = mContext.diagnosticDataProvider,           //
+                .testEventTriggerDelegate         = mContext.testEventTriggerDelegate,         //
+                .safeAttributePersistenceProvider = mContext.safeAttributePersistenceProvider, //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-                    .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
+                .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
             },
             []() {
@@ -192,26 +196,30 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
         chipDie();
     }
 
+    // Initialize the safe attribute persistence provider
+    SuccessOrDie(gSafeAttributePersistenceProvider.Init(initParams.persistentStorageDelegate));
+
     static CodeDrivenDataModelDevices devices({
-        .storageDelegate                = *initParams.persistentStorageDelegate,                 //
-            .commissioningWindowManager = Server::GetInstance().GetCommissioningWindowManager(), //
-            .configurationManager       = DeviceLayer::ConfigurationMgr(),                       //
-            .deviceControlServer        = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
-            .fabricTable                = Server::GetInstance().GetFabricTable(),                //
-            .accessControl              = Server::GetInstance().GetAccessControl(),              //
-            .persistentStorage          = Server::GetInstance().GetPersistentStorage(),          //
-            .failSafeContext            = Server::GetInstance().GetFailSafeContext(),            //
-            .deviceInstanceInfoProvider = *provider,                                             //
-            .platformManager            = DeviceLayer::PlatformMgr(),                            //
-            .groupDataProvider          = gGroupDataProvider,                                    //
-            .sessionManager             = Server::GetInstance().GetSecureSessionManager(),       //
-            .dnssdServer                = DnssdServer::Instance(),                               //
-            .deviceLoadStatusProvider   = *InteractionModelEngine::GetInstance(),                //
-            .diagnosticDataProvider     = DeviceLayer::GetDiagnosticDataProvider(),              //
-            .testEventTriggerDelegate   = initParams.testEventTriggerDelegate,                   //
+        .storageDelegate                  = *initParams.persistentStorageDelegate,                 //
+        .commissioningWindowManager       = Server::GetInstance().GetCommissioningWindowManager(), //
+        .configurationManager             = DeviceLayer::ConfigurationMgr(),                       //
+        .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),  //
+        .fabricTable                      = Server::GetInstance().GetFabricTable(),                //
+        .accessControl                    = Server::GetInstance().GetAccessControl(),              //
+        .persistentStorage                = Server::GetInstance().GetPersistentStorage(),          //
+        .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),            //
+        .deviceInstanceInfoProvider       = *provider,                                             //
+        .platformManager                  = DeviceLayer::PlatformMgr(),                            //
+        .groupDataProvider                = gGroupDataProvider,                                    //
+        .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),       //
+        .dnssdServer                      = DnssdServer::Instance(),                               //
+        .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                //
+        .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),              //
+        .testEventTriggerDelegate         = initParams.testEventTriggerDelegate,                   //
+        .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                     //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
-            .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
+        .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
     });
 

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -59,7 +59,13 @@ CHIP_ERROR ChimeCluster::Startup(ServerClusterContext & context)
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
 
-    LoadPersistentAttributes(context);
+    AttributePersistence persistence(context.attributeStorage);
+    // Load Active Chime ID
+    persistence.LoadNativeEndianValue<uint8_t>(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id),
+                                               mSelectedChime, 0);
+    // Load Enabled
+    (void) persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, true);
+
     return CHIP_NO_ERROR;
 }
 
@@ -78,18 +84,6 @@ CHIP_ERROR ChimeCluster::Attributes(const ConcreteClusterPath & path, ReadOnlyBu
     // Chime does not have optional attributes implemented yet (or exposed via options),
     // so we just return mandatory ones.
     return listBuilder.Append(Span(Chime::Attributes::kMandatoryMetadata), {});
-}
-
-void ChimeCluster::LoadPersistentAttributes(ServerClusterContext & context)
-{
-    AttributePersistence persistence(context.attributeStorage);
-
-    // Load Active Chime ID
-    persistence.LoadNativeEndianValue<uint8_t>(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id),
-                                               mSelectedChime, 0);
-
-    // Load Enabled
-    (void) persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, true);
 }
 
 DataModel::ActionReturnStatus ChimeCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -212,7 +212,7 @@ Status ChimeCluster::SetSelectedChime(uint8_t chimeID)
     }
     if (SetAttributeValue(mSelectedChime, chimeID, Attributes::SelectedChime::Id))
     {
-        VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Success);
+        VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Failure);
         LogErrorOnFailure(
             mContext->attributeStorage.WriteValue({ mPath.mEndpointId, Chime::Id, Attributes::SelectedChime::Id },
                                                   { reinterpret_cast<const uint8_t *>(&mSelectedChime), sizeof(mSelectedChime) }));
@@ -224,7 +224,7 @@ Status ChimeCluster::SetEnabled(bool enabled)
 {
     if (SetAttributeValue(mEnabled, enabled, Attributes::Enabled::Id))
     {
-        VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Success);
+        VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Failure);
         LogErrorOnFailure(
             mContext->attributeStorage.WriteValue({ mPath.mEndpointId, Chime::Id, Attributes::Enabled::Id },
                                                   { reinterpret_cast<const uint8_t *>(&mEnabled), sizeof(mEnabled) }));

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -46,8 +46,8 @@ namespace Clusters {
 
 ChimeCluster::ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate,
                            SafeAttributePersistenceProvider & safeAttributePersistenceProvider) :
-    DefaultServerCluster({ endpointId, Chime::Id }), mDelegate(delegate),
-    mSafeAttributePersistenceProvider(safeAttributePersistenceProvider)
+    DefaultServerCluster({ endpointId, Chime::Id }),
+    mDelegate(delegate), mSafeAttributePersistenceProvider(safeAttributePersistenceProvider)
 {
     mDelegate.SetChimeCluster(this);
 }

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -44,10 +44,8 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
-ChimeCluster::ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate,
-                           SafeAttributePersistenceProvider & safeAttributePersistenceProvider) :
-    DefaultServerCluster({ endpointId, Chime::Id }),
-    mDelegate(delegate), mSafeAttributePersistenceProvider(safeAttributePersistenceProvider)
+ChimeCluster::ChimeCluster(EndpointId endpointId, const Context & context, ChimeDelegate & delegate) :
+    DefaultServerCluster({ endpointId, Chime::Id }), mContext(context), mDelegate(delegate)
 {
     mDelegate.SetChimeCluster(this);
 }
@@ -87,7 +85,7 @@ void ChimeCluster::LoadPersistentAttributes()
 {
     // Load Active Chime ID
     uint8_t storedSelectedChime = 0;
-    CHIP_ERROR err              = mSafeAttributePersistenceProvider.ReadScalarValue(
+    CHIP_ERROR err = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id), storedSelectedChime);
     if (err == CHIP_NO_ERROR)
     {
@@ -101,8 +99,8 @@ void ChimeCluster::LoadPersistentAttributes()
 
     // Load Enabled
     bool storedEnabled = false;
-    err = mSafeAttributePersistenceProvider.ReadScalarValue(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, Enabled::Id),
-                                                            storedEnabled);
+    err = mContext.safeAttributePersistenceProvider.ReadScalarValue(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, Enabled::Id),
+                                                                    storedEnabled);
     if (err == CHIP_NO_ERROR)
     {
         mEnabled = storedEnabled;
@@ -232,7 +230,7 @@ Status ChimeCluster::SetSelectedChime(uint8_t chimeID)
     if (SetAttributeValue(mSelectedChime, chimeID, Attributes::SelectedChime::Id))
     {
         // TODO: Migrate to use context.attributeStorage
-        TEMPORARY_RETURN_IGNORED mSafeAttributePersistenceProvider.WriteScalarValue(
+        TEMPORARY_RETURN_IGNORED mContext.safeAttributePersistenceProvider.WriteScalarValue(
             { mPath.mEndpointId, Chime::Id, Attributes::SelectedChime::Id }, mSelectedChime);
     }
     return Protocols::InteractionModel::Status::Success;
@@ -243,7 +241,7 @@ Status ChimeCluster::SetEnabled(bool enabled)
     if (SetAttributeValue(mEnabled, enabled, Attributes::Enabled::Id))
     {
         // TODO: Migrate to use context.attributeStorage
-        TEMPORARY_RETURN_IGNORED mSafeAttributePersistenceProvider.WriteScalarValue(
+        TEMPORARY_RETURN_IGNORED mContext.safeAttributePersistenceProvider.WriteScalarValue(
             { mPath.mEndpointId, Chime::Id, Attributes::Enabled::Id }, mEnabled);
     }
     return Protocols::InteractionModel::Status::Success;

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -209,9 +209,9 @@ Status ChimeCluster::SetSelectedChime(uint8_t chimeID)
     if (SetAttributeValue(mSelectedChime, chimeID, Attributes::SelectedChime::Id))
     {
         VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Success);
-        TEMPORARY_RETURN_IGNORED mContext->attributeStorage.WriteValue(
-            { mPath.mEndpointId, Chime::Id, Attributes::SelectedChime::Id },
-            { reinterpret_cast<const uint8_t *>(&mSelectedChime), sizeof(mSelectedChime) });
+        LogErrorOnFailure(
+            mContext->attributeStorage.WriteValue({ mPath.mEndpointId, Chime::Id, Attributes::SelectedChime::Id },
+                                                  { reinterpret_cast<const uint8_t *>(&mSelectedChime), sizeof(mSelectedChime) }));
     }
     return Protocols::InteractionModel::Status::Success;
 }
@@ -221,9 +221,9 @@ Status ChimeCluster::SetEnabled(bool enabled)
     if (SetAttributeValue(mEnabled, enabled, Attributes::Enabled::Id))
     {
         VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Success);
-        TEMPORARY_RETURN_IGNORED mContext->attributeStorage.WriteValue(
-            { mPath.mEndpointId, Chime::Id, Attributes::Enabled::Id },
-            { reinterpret_cast<const uint8_t *>(&mEnabled), sizeof(mEnabled) });
+        LogErrorOnFailure(
+            mContext->attributeStorage.WriteValue({ mPath.mEndpointId, Chime::Id, Attributes::Enabled::Id },
+                                                  { reinterpret_cast<const uint8_t *>(&mEnabled), sizeof(mEnabled) }));
     }
     return Protocols::InteractionModel::Status::Success;
 }

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -64,7 +64,7 @@ CHIP_ERROR ChimeCluster::Startup(ServerClusterContext & context)
     if (!persistence.LoadNativeEndianValue<uint8_t>(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id),
                                                     mSelectedChime, 0))
     {
-        ChipLogDetail(Zcl, "Chime: Failed to load SelectedChime from persistence, using default value");
+        ChipLogError(Zcl, "Chime: Failed to load SelectedChime from persistence, using default value");
     }
     // Load Enabled
     // Specialization because some platforms `#define` true/false as 1/0 and we get;
@@ -72,7 +72,7 @@ CHIP_ERROR ChimeCluster::Startup(ServerClusterContext & context)
     //   'chip::app::AttributePersistence::LoadNativeEndianValue(<brace-enclosed initializer list>, bool&, int)'
     if (!persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, true))
     {
-        ChipLogDetail(Zcl, "Chime: Failed to load Enabled from persistence, using default value");
+        ChipLogError(Zcl, "Chime: Failed to load Enabled from persistence, using default value");
     }
 
     return CHIP_NO_ERROR;

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -85,7 +85,7 @@ void ChimeCluster::LoadPersistentAttributes()
 {
     // Load Active Chime ID
     uint8_t storedSelectedChime = 0;
-    CHIP_ERROR err = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+    CHIP_ERROR err              = mContext.safeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id), storedSelectedChime);
     if (err == CHIP_NO_ERROR)
     {
@@ -99,8 +99,8 @@ void ChimeCluster::LoadPersistentAttributes()
 
     // Load Enabled
     bool storedEnabled = false;
-    err = mContext.safeAttributePersistenceProvider.ReadScalarValue(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, Enabled::Id),
-                                                                    storedEnabled);
+    err                = mContext.safeAttributePersistenceProvider.ReadScalarValue(
+        ConcreteAttributePath(mPath.mEndpointId, Chime::Id, Enabled::Id), storedEnabled);
     if (err == CHIP_NO_ERROR)
     {
         mEnabled = storedEnabled;

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -44,15 +44,15 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
-ChimeCluster::ChimeCluster(EndpointId endpointId, const Context & context, ChimeDelegate & delegate) :
-    DefaultServerCluster({ endpointId, Chime::Id }), mContext(context), mDelegate(delegate)
+ChimeCluster::ChimeCluster(EndpointId endpointId, const Context & context) :
+    DefaultServerCluster({ endpointId, Chime::Id }), mContext(context)
 {
-    mDelegate.SetChimeCluster(this);
+    mContext.delegate.SetChimeCluster(this);
 }
 
 ChimeCluster::~ChimeCluster()
 {
-    mDelegate.SetChimeCluster(nullptr);
+    mContext.delegate.SetChimeCluster(nullptr);
 }
 
 CHIP_ERROR ChimeCluster::Startup(ServerClusterContext & context)
@@ -156,7 +156,7 @@ CHIP_ERROR ChimeCluster::EncodeSupportedChimeSounds(const AttributeValueEncoder:
         // CopyCharSpanToMutableCharSpan to copy data in
         char buffer[kMaxChimeSoundNameSize];
         MutableCharSpan name(buffer);
-        auto err = mDelegate.GetChimeSoundByIndex(i, chimeSound.chimeID, name);
+        auto err = mContext.delegate.GetChimeSoundByIndex(i, chimeSound.chimeID, name);
 
         // return if we've run off the end of the Chime Sound List on the delegate
         if (err == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED)
@@ -185,7 +185,7 @@ CHIP_ERROR ChimeCluster::EncodeSupportedChimeSounds(const AttributeValueEncoder:
 bool ChimeCluster::IsSupportedChimeID(uint8_t chimeID)
 {
     uint8_t supportedChimeID;
-    for (uint8_t i = 0; mDelegate.GetChimeIDByIndex(i, supportedChimeID) != CHIP_ERROR_PROVIDER_LIST_EXHAUSTED; i++)
+    for (uint8_t i = 0; mContext.delegate.GetChimeIDByIndex(i, supportedChimeID) != CHIP_ERROR_PROVIDER_LIST_EXHAUSTED; i++)
     {
         if (supportedChimeID == chimeID)
         {
@@ -289,7 +289,7 @@ DataModel::ActionReturnStatus ChimeCluster::HandlePlayChimeSound(CommandHandler 
         chimeIDToUse = commandData.chimeID.Value();
     }
 
-    Status status = mDelegate.PlayChimeSound(chimeIDToUse);
+    Status status = mContext.delegate.PlayChimeSound(chimeIDToUse);
     if (status == Status::Success)
     {
         // Generate the event

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -44,10 +44,8 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
-ChimeCluster::ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate,
-                           SafeAttributePersistenceProvider & safeAttributePersistenceProvider) :
-    DefaultServerCluster({ endpointId, Chime::Id }),
-    mDelegate(delegate), mSafeAttributePersistenceProvider(safeAttributePersistenceProvider)
+ChimeCluster::ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate) :
+    DefaultServerCluster({ endpointId, Chime::Id }), mDelegate(delegate)
 {
     mDelegate.SetChimeCluster(this);
 }
@@ -87,7 +85,7 @@ void ChimeCluster::LoadPersistentAttributes()
 {
     // Load Active Chime ID
     uint8_t storedSelectedChime = 0;
-    CHIP_ERROR err              = mSafeAttributePersistenceProvider.ReadScalarValue(
+    CHIP_ERROR err              = GetSafeAttributePersistenceProvider()->ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id), storedSelectedChime);
     if (err == CHIP_NO_ERROR)
     {
@@ -101,8 +99,8 @@ void ChimeCluster::LoadPersistentAttributes()
 
     // Load Enabled
     bool storedEnabled = false;
-    err = mSafeAttributePersistenceProvider.ReadScalarValue(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, Enabled::Id),
-                                                            storedEnabled);
+    err = GetSafeAttributePersistenceProvider()->ReadScalarValue(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, Enabled::Id),
+                                                                 storedEnabled);
     if (err == CHIP_NO_ERROR)
     {
         mEnabled = storedEnabled;
@@ -232,7 +230,7 @@ Status ChimeCluster::SetSelectedChime(uint8_t chimeID)
     if (SetAttributeValue(mSelectedChime, chimeID, Attributes::SelectedChime::Id))
     {
         // TODO: Migrate to use context.attributeStorage
-        TEMPORARY_RETURN_IGNORED mSafeAttributePersistenceProvider.WriteScalarValue(
+        TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(
             { mPath.mEndpointId, Chime::Id, Attributes::SelectedChime::Id }, mSelectedChime);
     }
     return Protocols::InteractionModel::Status::Success;
@@ -243,7 +241,7 @@ Status ChimeCluster::SetEnabled(bool enabled)
     if (SetAttributeValue(mEnabled, enabled, Attributes::Enabled::Id))
     {
         // TODO: Migrate to use context.attributeStorage
-        TEMPORARY_RETURN_IGNORED mSafeAttributePersistenceProvider.WriteScalarValue(
+        TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(
             { mPath.mEndpointId, Chime::Id, Attributes::Enabled::Id }, mEnabled);
     }
     return Protocols::InteractionModel::Status::Success;

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -23,7 +23,7 @@
 #include "ChimeCluster.h"
 
 #include <app/EventLogging.h>
-#include <app/SafeAttributePersistenceProvider.h>
+#include <app/persistence/AttributePersistence.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <clusters/Chime/Attributes.h>
 #include <clusters/Chime/Commands.h>
@@ -59,7 +59,7 @@ CHIP_ERROR ChimeCluster::Startup(ServerClusterContext & context)
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
 
-    LoadPersistentAttributes();
+    LoadPersistentAttributes(context);
     return CHIP_NO_ERROR;
 }
 
@@ -80,36 +80,16 @@ CHIP_ERROR ChimeCluster::Attributes(const ConcreteClusterPath & path, ReadOnlyBu
     return listBuilder.Append(Span(Chime::Attributes::kMandatoryMetadata), {});
 }
 
-// TODO: Migrate to use context.attributeStorage instead of SafeAttributePersistenceProvider
-void ChimeCluster::LoadPersistentAttributes()
+void ChimeCluster::LoadPersistentAttributes(ServerClusterContext & context)
 {
+    AttributePersistence persistence(context.attributeStorage);
+
     // Load Active Chime ID
-    uint8_t storedSelectedChime = 0;
-    CHIP_ERROR err              = GetSafeAttributePersistenceProvider()->ReadScalarValue(
-        ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id), storedSelectedChime);
-    if (err == CHIP_NO_ERROR)
-    {
-        mSelectedChime = storedSelectedChime;
-    }
-    else
-    {
-        // otherwise defaults
-        ChipLogDetail(Zcl, "Chime: Unable to load the SelectedChime attribute from the KVS. Defaulting to %u", mSelectedChime);
-    }
+    (void) persistence.LoadNativeEndianValue<uint8_t>(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id),
+                                                      mSelectedChime, 0);
 
     // Load Enabled
-    bool storedEnabled = false;
-    err = GetSafeAttributePersistenceProvider()->ReadScalarValue(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, Enabled::Id),
-                                                                 storedEnabled);
-    if (err == CHIP_NO_ERROR)
-    {
-        mEnabled = storedEnabled;
-    }
-    else
-    {
-        // otherwise take the default
-        ChipLogDetail(Zcl, "Chime: Unable to load the Enabled attribute from the KVS. Defaulting to %u", mEnabled);
-    }
+    (void) persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, false);
 }
 
 DataModel::ActionReturnStatus ChimeCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
@@ -229,9 +209,10 @@ Status ChimeCluster::SetSelectedChime(uint8_t chimeID)
     }
     if (SetAttributeValue(mSelectedChime, chimeID, Attributes::SelectedChime::Id))
     {
-        // TODO: Migrate to use context.attributeStorage
-        TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(
-            { mPath.mEndpointId, Chime::Id, Attributes::SelectedChime::Id }, mSelectedChime);
+        VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Success);
+        TEMPORARY_RETURN_IGNORED mContext->attributeStorage.WriteValue(
+            { mPath.mEndpointId, Chime::Id, Attributes::SelectedChime::Id },
+            { reinterpret_cast<const uint8_t *>(&mSelectedChime), sizeof(mSelectedChime) });
     }
     return Protocols::InteractionModel::Status::Success;
 }
@@ -240,9 +221,10 @@ Status ChimeCluster::SetEnabled(bool enabled)
 {
     if (SetAttributeValue(mEnabled, enabled, Attributes::Enabled::Id))
     {
-        // TODO: Migrate to use context.attributeStorage
-        TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(
-            { mPath.mEndpointId, Chime::Id, Attributes::Enabled::Id }, mEnabled);
+        VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Success);
+        TEMPORARY_RETURN_IGNORED mContext->attributeStorage.WriteValue(
+            { mPath.mEndpointId, Chime::Id, Attributes::Enabled::Id },
+            { reinterpret_cast<const uint8_t *>(&mEnabled), sizeof(mEnabled) });
     }
     return Protocols::InteractionModel::Status::Success;
 }

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -210,9 +210,9 @@ Status ChimeCluster::SetSelectedChime(uint8_t chimeID)
     {
         return Protocols::InteractionModel::Status::NotFound;
     }
+    VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Failure);
     if (SetAttributeValue(mSelectedChime, chimeID, Attributes::SelectedChime::Id))
     {
-        VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Failure);
         LogErrorOnFailure(
             mContext->attributeStorage.WriteValue({ mPath.mEndpointId, Chime::Id, Attributes::SelectedChime::Id },
                                                   { reinterpret_cast<const uint8_t *>(&mSelectedChime), sizeof(mSelectedChime) }));
@@ -222,9 +222,9 @@ Status ChimeCluster::SetSelectedChime(uint8_t chimeID)
 
 Status ChimeCluster::SetEnabled(bool enabled)
 {
+    VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Failure);
     if (SetAttributeValue(mEnabled, enabled, Attributes::Enabled::Id))
     {
-        VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Failure);
         LogErrorOnFailure(
             mContext->attributeStorage.WriteValue({ mPath.mEndpointId, Chime::Id, Attributes::Enabled::Id },
                                                   { reinterpret_cast<const uint8_t *>(&mEnabled), sizeof(mEnabled) }));

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -64,6 +64,9 @@ CHIP_ERROR ChimeCluster::Startup(ServerClusterContext & context)
     persistence.LoadNativeEndianValue<uint8_t>(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id),
                                                mSelectedChime, 0);
     // Load Enabled
+    // Specialization because some platforms `#define` true/false as 1/0 and we get;
+    // error: no matching function for call to
+    //   'chip::app::AttributePersistence::LoadNativeEndianValue(<brace-enclosed initializer list>, bool&, int)'
     (void) persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, true);
 
     return CHIP_NO_ERROR;

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -64,7 +64,7 @@ CHIP_ERROR ChimeCluster::Startup(ServerClusterContext & context)
     if (!persistence.LoadNativeEndianValue<uint8_t>(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id),
                                                     mSelectedChime, 0))
     {
-        ChipLogError(Zcl, "Chime: Failed to load SelectedChime from persistence, using default value");
+        ChipLogDetail(Zcl, "Chime: Failed to load SelectedChime from persistence, using default value");
     }
     // Load Enabled
     // Specialization because some platforms `#define` true/false as 1/0 and we get;
@@ -72,7 +72,7 @@ CHIP_ERROR ChimeCluster::Startup(ServerClusterContext & context)
     //   'chip::app::AttributePersistence::LoadNativeEndianValue(<brace-enclosed initializer list>, bool&, int)'
     if (!persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, true))
     {
-        ChipLogError(Zcl, "Chime: Failed to load Enabled from persistence, using default value");
+        ChipLogDetail(Zcl, "Chime: Failed to load Enabled from persistence, using default value");
     }
 
     return CHIP_NO_ERROR;

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -85,11 +85,11 @@ void ChimeCluster::LoadPersistentAttributes(ServerClusterContext & context)
     AttributePersistence persistence(context.attributeStorage);
 
     // Load Active Chime ID
-    (void) persistence.LoadNativeEndianValue<uint8_t>(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id),
-                                                      mSelectedChime, 0);
+    persistence.LoadNativeEndianValue<uint8_t>(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id),
+                                               mSelectedChime, 0);
 
     // Load Enabled
-    (void) persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, false);
+    (void) persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, true);
 }
 
 DataModel::ActionReturnStatus ChimeCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -44,8 +44,10 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
-ChimeCluster::ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate) :
-    DefaultServerCluster({ endpointId, Chime::Id }), mDelegate(delegate)
+ChimeCluster::ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate,
+                           SafeAttributePersistenceProvider & safeAttributePersistenceProvider) :
+    DefaultServerCluster({ endpointId, Chime::Id }), mDelegate(delegate),
+    mSafeAttributePersistenceProvider(safeAttributePersistenceProvider)
 {
     mDelegate.SetChimeCluster(this);
 }
@@ -85,7 +87,7 @@ void ChimeCluster::LoadPersistentAttributes()
 {
     // Load Active Chime ID
     uint8_t storedSelectedChime = 0;
-    CHIP_ERROR err              = GetSafeAttributePersistenceProvider()->ReadScalarValue(
+    CHIP_ERROR err              = mSafeAttributePersistenceProvider.ReadScalarValue(
         ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id), storedSelectedChime);
     if (err == CHIP_NO_ERROR)
     {
@@ -99,8 +101,8 @@ void ChimeCluster::LoadPersistentAttributes()
 
     // Load Enabled
     bool storedEnabled = false;
-    err = GetSafeAttributePersistenceProvider()->ReadScalarValue(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, Enabled::Id),
-                                                                 storedEnabled);
+    err = mSafeAttributePersistenceProvider.ReadScalarValue(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, Enabled::Id),
+                                                            storedEnabled);
     if (err == CHIP_NO_ERROR)
     {
         mEnabled = storedEnabled;
@@ -230,7 +232,7 @@ Status ChimeCluster::SetSelectedChime(uint8_t chimeID)
     if (SetAttributeValue(mSelectedChime, chimeID, Attributes::SelectedChime::Id))
     {
         // TODO: Migrate to use context.attributeStorage
-        TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(
+        TEMPORARY_RETURN_IGNORED mSafeAttributePersistenceProvider.WriteScalarValue(
             { mPath.mEndpointId, Chime::Id, Attributes::SelectedChime::Id }, mSelectedChime);
     }
     return Protocols::InteractionModel::Status::Success;
@@ -241,7 +243,7 @@ Status ChimeCluster::SetEnabled(bool enabled)
     if (SetAttributeValue(mEnabled, enabled, Attributes::Enabled::Id))
     {
         // TODO: Migrate to use context.attributeStorage
-        TEMPORARY_RETURN_IGNORED GetSafeAttributePersistenceProvider()->WriteScalarValue(
+        TEMPORARY_RETURN_IGNORED mSafeAttributePersistenceProvider.WriteScalarValue(
             { mPath.mEndpointId, Chime::Id, Attributes::Enabled::Id }, mEnabled);
     }
     return Protocols::InteractionModel::Status::Success;

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -61,15 +61,19 @@ CHIP_ERROR ChimeCluster::Startup(ServerClusterContext & context)
 
     AttributePersistence persistence(context.attributeStorage);
     // Load Active Chime ID
-    VerifyOrReturnValue(persistence.LoadNativeEndianValue<uint8_t>(
-                            ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id), mSelectedChime, 0),
-                        CHIP_NO_ERROR);
+    if (!persistence.LoadNativeEndianValue<uint8_t>(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id),
+                                                    mSelectedChime, 0))
+    {
+        ChipLogError(Zcl, "Chime: Failed to load SelectedChime from persistence, using default value");
+    }
     // Load Enabled
     // Specialization because some platforms `#define` true/false as 1/0 and we get;
     // error: no matching function for call to
     //   'chip::app::AttributePersistence::LoadNativeEndianValue(<brace-enclosed initializer list>, bool&, int)'
-    VerifyOrReturnValue(persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, true),
-                        CHIP_NO_ERROR);
+    if (!persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, true))
+    {
+        ChipLogError(Zcl, "Chime: Failed to load Enabled from persistence, using default value");
+    }
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -23,7 +23,7 @@
 #include "ChimeCluster.h"
 
 #include <app/EventLogging.h>
-#include <app/persistence/AttributePersistence.h>
+#include <app/SafeAttributePersistenceProvider.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <clusters/Chime/Attributes.h>
 #include <clusters/Chime/Commands.h>
@@ -44,8 +44,10 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
-ChimeCluster::ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate) :
-    DefaultServerCluster({ endpointId, Chime::Id }), mDelegate(delegate)
+ChimeCluster::ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate,
+                           SafeAttributePersistenceProvider & safeAttributePersistenceProvider) :
+    DefaultServerCluster({ endpointId, Chime::Id }),
+    mDelegate(delegate), mSafeAttributePersistenceProvider(safeAttributePersistenceProvider)
 {
     mDelegate.SetChimeCluster(this);
 }
@@ -59,22 +61,7 @@ CHIP_ERROR ChimeCluster::Startup(ServerClusterContext & context)
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
 
-    AttributePersistence persistence(context.attributeStorage);
-    // Load Active Chime ID
-    if (!persistence.LoadNativeEndianValue<uint8_t>(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id),
-                                                    mSelectedChime, 0))
-    {
-        ChipLogError(Zcl, "Chime: Failed to load SelectedChime from persistence, using default value");
-    }
-    // Load Enabled
-    // Specialization because some platforms `#define` true/false as 1/0 and we get;
-    // error: no matching function for call to
-    //   'chip::app::AttributePersistence::LoadNativeEndianValue(<brace-enclosed initializer list>, bool&, int)'
-    if (!persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, true))
-    {
-        ChipLogError(Zcl, "Chime: Failed to load Enabled from persistence, using default value");
-    }
-
+    LoadPersistentAttributes();
     return CHIP_NO_ERROR;
 }
 
@@ -93,6 +80,38 @@ CHIP_ERROR ChimeCluster::Attributes(const ConcreteClusterPath & path, ReadOnlyBu
     // Chime does not have optional attributes implemented yet (or exposed via options),
     // so we just return mandatory ones.
     return listBuilder.Append(Span(Chime::Attributes::kMandatoryMetadata), {});
+}
+
+// TODO: Migrate to use context.attributeStorage instead of SafeAttributePersistenceProvider
+void ChimeCluster::LoadPersistentAttributes()
+{
+    // Load Active Chime ID
+    uint8_t storedSelectedChime = 0;
+    CHIP_ERROR err              = mSafeAttributePersistenceProvider.ReadScalarValue(
+        ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id), storedSelectedChime);
+    if (err == CHIP_NO_ERROR)
+    {
+        mSelectedChime = storedSelectedChime;
+    }
+    else
+    {
+        // otherwise defaults
+        ChipLogDetail(Zcl, "Chime: Unable to load the SelectedChime attribute from the KVS. Defaulting to %u", mSelectedChime);
+    }
+
+    // Load Enabled
+    bool storedEnabled = false;
+    err = mSafeAttributePersistenceProvider.ReadScalarValue(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, Enabled::Id),
+                                                            storedEnabled);
+    if (err == CHIP_NO_ERROR)
+    {
+        mEnabled = storedEnabled;
+    }
+    else
+    {
+        // otherwise take the default
+        ChipLogDetail(Zcl, "Chime: Unable to load the Enabled attribute from the KVS. Defaulting to %u", mEnabled);
+    }
 }
 
 DataModel::ActionReturnStatus ChimeCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
@@ -210,24 +229,22 @@ Status ChimeCluster::SetSelectedChime(uint8_t chimeID)
     {
         return Protocols::InteractionModel::Status::NotFound;
     }
-    VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Failure);
     if (SetAttributeValue(mSelectedChime, chimeID, Attributes::SelectedChime::Id))
     {
-        LogErrorOnFailure(
-            mContext->attributeStorage.WriteValue({ mPath.mEndpointId, Chime::Id, Attributes::SelectedChime::Id },
-                                                  { reinterpret_cast<const uint8_t *>(&mSelectedChime), sizeof(mSelectedChime) }));
+        // TODO: Migrate to use context.attributeStorage
+        TEMPORARY_RETURN_IGNORED mSafeAttributePersistenceProvider.WriteScalarValue(
+            { mPath.mEndpointId, Chime::Id, Attributes::SelectedChime::Id }, mSelectedChime);
     }
     return Protocols::InteractionModel::Status::Success;
 }
 
 Status ChimeCluster::SetEnabled(bool enabled)
 {
-    VerifyOrReturnValue(mContext != nullptr, Protocols::InteractionModel::Status::Failure);
     if (SetAttributeValue(mEnabled, enabled, Attributes::Enabled::Id))
     {
-        LogErrorOnFailure(
-            mContext->attributeStorage.WriteValue({ mPath.mEndpointId, Chime::Id, Attributes::Enabled::Id },
-                                                  { reinterpret_cast<const uint8_t *>(&mEnabled), sizeof(mEnabled) }));
+        // TODO: Migrate to use context.attributeStorage
+        TEMPORARY_RETURN_IGNORED mSafeAttributePersistenceProvider.WriteScalarValue(
+            { mPath.mEndpointId, Chime::Id, Attributes::Enabled::Id }, mEnabled);
     }
     return Protocols::InteractionModel::Status::Success;
 }

--- a/src/app/clusters/chime-server/ChimeCluster.cpp
+++ b/src/app/clusters/chime-server/ChimeCluster.cpp
@@ -61,13 +61,15 @@ CHIP_ERROR ChimeCluster::Startup(ServerClusterContext & context)
 
     AttributePersistence persistence(context.attributeStorage);
     // Load Active Chime ID
-    persistence.LoadNativeEndianValue<uint8_t>(ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id),
-                                               mSelectedChime, 0);
+    VerifyOrReturnValue(persistence.LoadNativeEndianValue<uint8_t>(
+                            ConcreteAttributePath(mPath.mEndpointId, Chime::Id, SelectedChime::Id), mSelectedChime, 0),
+                        CHIP_NO_ERROR);
     // Load Enabled
     // Specialization because some platforms `#define` true/false as 1/0 and we get;
     // error: no matching function for call to
     //   'chip::app::AttributePersistence::LoadNativeEndianValue(<brace-enclosed initializer list>, bool&, int)'
-    (void) persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, true);
+    VerifyOrReturnValue(persistence.LoadNativeEndianValue<bool>({ mPath.mEndpointId, Chime::Id, Enabled::Id }, mEnabled, true),
+                        CHIP_NO_ERROR);
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/clusters/chime-server/ChimeCluster.h
+++ b/src/app/clusters/chime-server/ChimeCluster.h
@@ -40,7 +40,8 @@ public:
      * @param aSafeAttributePersistenceProvider A reference to the SafeAttributePersistenceProvider to be used for persistence.
      * Note: the caller must ensure that the delegate and SafeAttributePersistenceProvider live throughout the instance's lifetime.
      */
-    ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate, SafeAttributePersistenceProvider & aSafeAttributePersistenceProvider);
+    ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate,
+                 SafeAttributePersistenceProvider & aSafeAttributePersistenceProvider);
     ~ChimeCluster();
 
     // Attribute Setters

--- a/src/app/clusters/chime-server/ChimeCluster.h
+++ b/src/app/clusters/chime-server/ChimeCluster.h
@@ -35,6 +35,7 @@ class ChimeCluster : public DefaultServerCluster
 public:
     struct Context
     {
+        ChimeDelegate & delegate;
         SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
     };
 
@@ -42,10 +43,9 @@ public:
      * Creates a Chime Cluster instance.
      * @param aEndpointId The endpoint on which this cluster exists.
      * @param context The context containing injected dependencies.
-     * @param delegate A reference to the delegate to be used by this server.
-     * Note: the caller must ensure that the provided dependencies and delegate live throughout the instance's lifetime.
+     * Note: the caller must ensure that the provided dependencies live throughout the instance's lifetime.
      */
-    ChimeCluster(EndpointId endpointId, const Context & context, ChimeDelegate & delegate);
+    ChimeCluster(EndpointId endpointId, const Context & context);
     ~ChimeCluster();
 
     // Attribute Setters
@@ -97,7 +97,6 @@ public:
 
 private:
     Context mContext;
-    ChimeDelegate & mDelegate;
 
     // Attribute local storage
     uint8_t mSelectedChime = 0;

--- a/src/app/clusters/chime-server/ChimeCluster.h
+++ b/src/app/clusters/chime-server/ChimeCluster.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include <app/SafeAttributePersistenceProvider.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/Chime/Attributes.h>
 #include <clusters/Chime/Commands.h>
@@ -37,11 +36,9 @@ public:
      * Creates a Chime Cluster instance.
      * @param aEndpointId The endpoint on which this cluster exists.
      * @param aDelegate A reference to the delegate to be used by this server.
-     * @param aSafeAttributePersistenceProvider A reference to the SafeAttributePersistenceProvider to be used for persistence.
-     * Note: the caller must ensure that the delegate and SafeAttributePersistenceProvider live throughout the instance's lifetime.
+     * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
      */
-    ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate,
-                 SafeAttributePersistenceProvider & aSafeAttributePersistenceProvider);
+    ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate);
     ~ChimeCluster();
 
     // Attribute Setters
@@ -93,7 +90,6 @@ public:
 
 private:
     ChimeDelegate & mDelegate;
-    SafeAttributePersistenceProvider & mSafeAttributePersistenceProvider;
 
     // Attribute local storage
     uint8_t mSelectedChime = 0;

--- a/src/app/clusters/chime-server/ChimeCluster.h
+++ b/src/app/clusters/chime-server/ChimeCluster.h
@@ -33,15 +33,19 @@ class ChimeDelegate;
 class ChimeCluster : public DefaultServerCluster
 {
 public:
+    struct Context
+    {
+        SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
+    };
+
     /**
      * Creates a Chime Cluster instance.
      * @param aEndpointId The endpoint on which this cluster exists.
-     * @param aDelegate A reference to the delegate to be used by this server.
-     * @param aSafeAttributePersistenceProvider A reference to the SafeAttributePersistenceProvider to be used for persistence.
-     * Note: the caller must ensure that the delegate and SafeAttributePersistenceProvider live throughout the instance's lifetime.
+     * @param context The context containing injected dependencies.
+     * @param delegate A reference to the delegate to be used by this server.
+     * Note: the caller must ensure that the provided dependencies and delegate live throughout the instance's lifetime.
      */
-    ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate,
-                 SafeAttributePersistenceProvider & aSafeAttributePersistenceProvider);
+    ChimeCluster(EndpointId endpointId, const Context & context, ChimeDelegate & delegate);
     ~ChimeCluster();
 
     // Attribute Setters
@@ -92,8 +96,8 @@ public:
                                                                CommandHandler * handler) override;
 
 private:
+    Context mContext;
     ChimeDelegate & mDelegate;
-    SafeAttributePersistenceProvider & mSafeAttributePersistenceProvider;
 
     // Attribute local storage
     uint8_t mSelectedChime = 0;

--- a/src/app/clusters/chime-server/ChimeCluster.h
+++ b/src/app/clusters/chime-server/ChimeCluster.h
@@ -96,7 +96,7 @@ private:
     bool mEnabled          = true;
     // Helpers
     // Loads all the persistent attributes from the KVS.
-    void LoadPersistentAttributes();
+    void LoadPersistentAttributes(ServerClusterContext & context);
 
     // Checks if the chimeID is supported by the delegate
     bool IsSupportedChimeID(uint8_t chimeID);

--- a/src/app/clusters/chime-server/ChimeCluster.h
+++ b/src/app/clusters/chime-server/ChimeCluster.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <app/SafeAttributePersistenceProvider.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/Chime/Attributes.h>
 #include <clusters/Chime/Commands.h>
@@ -36,9 +37,11 @@ public:
      * Creates a Chime Cluster instance.
      * @param aEndpointId The endpoint on which this cluster exists.
      * @param aDelegate A reference to the delegate to be used by this server.
-     * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
+     * @param aSafeAttributePersistenceProvider A reference to the SafeAttributePersistenceProvider to be used for persistence.
+     * Note: the caller must ensure that the delegate and SafeAttributePersistenceProvider live throughout the instance's lifetime.
      */
-    ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate);
+    ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate,
+                 SafeAttributePersistenceProvider & aSafeAttributePersistenceProvider);
     ~ChimeCluster();
 
     // Attribute Setters
@@ -90,11 +93,15 @@ public:
 
 private:
     ChimeDelegate & mDelegate;
+    SafeAttributePersistenceProvider & mSafeAttributePersistenceProvider;
 
     // Attribute local storage
     uint8_t mSelectedChime = 0;
     bool mEnabled          = true;
     // Helpers
+    // Loads all the persistent attributes from the KVS.
+    void LoadPersistentAttributes();
+
     // Checks if the chimeID is supported by the delegate
     bool IsSupportedChimeID(uint8_t chimeID);
 

--- a/src/app/clusters/chime-server/ChimeCluster.h
+++ b/src/app/clusters/chime-server/ChimeCluster.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <app/SafeAttributePersistenceProvider.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/Chime/Attributes.h>
 #include <clusters/Chime/Commands.h>
@@ -36,9 +37,10 @@ public:
      * Creates a Chime Cluster instance.
      * @param aEndpointId The endpoint on which this cluster exists.
      * @param aDelegate A reference to the delegate to be used by this server.
-     * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
+     * @param aSafeAttributePersistenceProvider A reference to the SafeAttributePersistenceProvider to be used for persistence.
+     * Note: the caller must ensure that the delegate and SafeAttributePersistenceProvider live throughout the instance's lifetime.
      */
-    ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate);
+    ChimeCluster(EndpointId endpointId, ChimeDelegate & delegate, SafeAttributePersistenceProvider & aSafeAttributePersistenceProvider);
     ~ChimeCluster();
 
     // Attribute Setters
@@ -90,6 +92,7 @@ public:
 
 private:
     ChimeDelegate & mDelegate;
+    SafeAttributePersistenceProvider & mSafeAttributePersistenceProvider;
 
     // Attribute local storage
     uint8_t mSelectedChime = 0;

--- a/src/app/clusters/chime-server/ChimeCluster.h
+++ b/src/app/clusters/chime-server/ChimeCluster.h
@@ -95,9 +95,6 @@ private:
     uint8_t mSelectedChime = 0;
     bool mEnabled          = true;
     // Helpers
-    // Loads all the persistent attributes from the KVS.
-    void LoadPersistentAttributes(ServerClusterContext & context);
-
     // Checks if the chimeID is supported by the delegate
     bool IsSupportedChimeID(uint8_t chimeID);
 

--- a/src/app/clusters/chime-server/CodegenIntegration.cpp
+++ b/src/app/clusters/chime-server/CodegenIntegration.cpp
@@ -40,7 +40,8 @@ CHIP_ERROR ChimeServer::Init()
     SafeAttributePersistenceProvider * provider = GetSafeAttributePersistenceProvider();
     VerifyOrReturnError(provider != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    mCluster.Create(mEndpointId, *mDelegate, *provider);
+    ChimeCluster::Context context{ .safeAttributePersistenceProvider = *provider };
+    mCluster.Create(mEndpointId, context, *mDelegate);
     return CodegenDataModelProvider::Instance().Registry().Register(mCluster.Registration());
 }
 

--- a/src/app/clusters/chime-server/CodegenIntegration.cpp
+++ b/src/app/clusters/chime-server/CodegenIntegration.cpp
@@ -25,37 +25,46 @@ using namespace chip;
 using namespace chip::app;
 using chip::app::Clusters::ChimeServer;
 
-ChimeServer::ChimeServer(EndpointId endpointId, ChimeDelegate & delegate) :
-    mCluster(endpointId, delegate, *GetSafeAttributePersistenceProvider())
-{}
+ChimeServer::ChimeServer(EndpointId endpointId, ChimeDelegate & delegate) : mEndpointId(endpointId), mDelegate(&delegate) {}
 
 ChimeServer::~ChimeServer()
 {
-    RETURN_SAFELY_IGNORED CodegenDataModelProvider::Instance().Registry().Unregister(&(mCluster.Cluster()));
+    if (mCluster.IsConstructed())
+    {
+        RETURN_SAFELY_IGNORED CodegenDataModelProvider::Instance().Registry().Unregister(&(mCluster.Cluster()));
+    }
 }
 
 CHIP_ERROR ChimeServer::Init()
 {
+    SafeAttributePersistenceProvider * provider = GetSafeAttributePersistenceProvider();
+    VerifyOrReturnError(provider != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    mCluster.Create(mEndpointId, *mDelegate, *provider);
     return CodegenDataModelProvider::Instance().Registry().Register(mCluster.Registration());
 }
 
 Protocols::InteractionModel::Status ChimeServer::SetSelectedChime(uint8_t chimeSoundID)
 {
+    VerifyOrDie(mCluster.IsConstructed());
     return mCluster.Cluster().SetSelectedChime(chimeSoundID);
 }
 
 Protocols::InteractionModel::Status ChimeServer::SetEnabled(bool Enabled)
 {
+    VerifyOrDie(mCluster.IsConstructed());
     return mCluster.Cluster().SetEnabled(Enabled);
 }
 
 uint8_t ChimeServer::GetSelectedChime() const
 {
+    VerifyOrDie(mCluster.IsConstructed());
     return mCluster.Cluster().GetSelectedChime();
 }
 
 bool ChimeServer::GetEnabled() const
 {
+    VerifyOrDie(mCluster.IsConstructed());
     return mCluster.Cluster().GetEnabled();
 }
 

--- a/src/app/clusters/chime-server/CodegenIntegration.cpp
+++ b/src/app/clusters/chime-server/CodegenIntegration.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "CodegenIntegration.h"
+#include <app/SafeAttributePersistenceProvider.h>
 #include <app/clusters/chime-server/ChimeCluster.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <lib/support/CodeUtils.h>
@@ -24,7 +25,9 @@ using namespace chip;
 using namespace chip::app;
 using chip::app::Clusters::ChimeServer;
 
-ChimeServer::ChimeServer(EndpointId endpointId, ChimeDelegate & delegate) : mCluster(endpointId, delegate) {}
+ChimeServer::ChimeServer(EndpointId endpointId, ChimeDelegate & delegate) :
+    mCluster(endpointId, delegate, *GetSafeAttributePersistenceProvider())
+{}
 
 ChimeServer::~ChimeServer()
 {

--- a/src/app/clusters/chime-server/CodegenIntegration.cpp
+++ b/src/app/clusters/chime-server/CodegenIntegration.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "CodegenIntegration.h"
-#include <app/SafeAttributePersistenceProvider.h>
 #include <app/clusters/chime-server/ChimeCluster.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <lib/support/CodeUtils.h>
@@ -25,9 +24,7 @@ using namespace chip;
 using namespace chip::app;
 using chip::app::Clusters::ChimeServer;
 
-ChimeServer::ChimeServer(EndpointId endpointId, ChimeDelegate & delegate) :
-    mCluster(endpointId, delegate, *GetSafeAttributePersistenceProvider())
-{}
+ChimeServer::ChimeServer(EndpointId endpointId, ChimeDelegate & delegate) : mCluster(endpointId, delegate) {}
 
 ChimeServer::~ChimeServer()
 {

--- a/src/app/clusters/chime-server/CodegenIntegration.cpp
+++ b/src/app/clusters/chime-server/CodegenIntegration.cpp
@@ -40,8 +40,8 @@ CHIP_ERROR ChimeServer::Init()
     SafeAttributePersistenceProvider * provider = GetSafeAttributePersistenceProvider();
     VerifyOrReturnError(provider != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    ChimeCluster::Context context{ .safeAttributePersistenceProvider = *provider };
-    mCluster.Create(mEndpointId, context, *mDelegate);
+    ChimeCluster::Context context{ .delegate = *mDelegate, .safeAttributePersistenceProvider = *provider };
+    mCluster.Create(mEndpointId, context);
     return CodegenDataModelProvider::Instance().Registry().Register(mCluster.Registration());
 }
 

--- a/src/app/clusters/chime-server/CodegenIntegration.h
+++ b/src/app/clusters/chime-server/CodegenIntegration.h
@@ -71,11 +71,7 @@ public:
     /**
      * @return The endpoint ID.
      */
-    EndpointId GetEndpointId()
-    {
-        VerifyOrDie(mCluster.IsConstructed());
-        return mCluster.Cluster().GetPaths()[0].mEndpointId;
-    }
+    EndpointId GetEndpointId() { return mEndpointId; }
 
     // Cluster constants from the spec
     static constexpr uint8_t kMaxChimeSoundNameSize = ChimeCluster::kMaxChimeSoundNameSize;

--- a/src/app/clusters/chime-server/CodegenIntegration.h
+++ b/src/app/clusters/chime-server/CodegenIntegration.h
@@ -19,66 +19,74 @@
 
 #include <app/clusters/chime-server/ChimeCluster.h>
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
+#include <lib/support/CodeUtils.h>
 
 namespace chip {
 namespace app {
-namespace Clusters {
+    namespace Clusters {
 
-class ChimeServer
-{
-public:
-    /**
-     * Creates a chime server instance. This is just a backwards compatibility wrapper around the ChimeCluster.
-     * @param aEndpointId The endpoint on which this cluster exists. This must match the zap configuration.
-     * @param aDelegate A reference to the delegate to be used by this server.
-     * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
-     */
-    ChimeServer(EndpointId endpointId, ChimeDelegate & delegate);
-    ~ChimeServer();
+        class ChimeServer {
+        public:
+            /**
+             * Creates a chime server instance. This is just a backwards compatibility wrapper around the ChimeCluster.
+             * @param aEndpointId The endpoint on which this cluster exists. This must match the zap configuration.
+             * @param aDelegate A reference to the delegate to be used by this server.
+             * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
+             */
+            ChimeServer(EndpointId endpointId, ChimeDelegate & delegate);
+            ~ChimeServer();
 
-    /**
-     * Register the chime cluster instance with the codegen data model provider.
-     * @return Returns an error if registration fails.
-     */
-    CHIP_ERROR Init();
+            /**
+             * Register the chime cluster instance with the codegen data model provider.
+             * @return Returns an error if registration fails.
+             */
+            CHIP_ERROR Init();
 
-    // Attribute Setters
-    /**
-     * Sets the SelectedChime attribute. Note, this also handles writing the new value into non-volatile storage.
-     * @param chimeSoundID The value to which the SelectedChime  is to be set.
-     * @return Returns a ConstraintError if the chimeSoundID value is not valid. Returns Success otherwise.
-     */
-    Protocols::InteractionModel::Status SetSelectedChime(uint8_t chimeSoundID);
+            // Attribute Setters
+            /**
+             * Sets the SelectedChime attribute. Note, this also handles writing the new value into non-volatile storage.
+             * @param chimeSoundID The value to which the SelectedChime  is to be set.
+             * @return Returns a ConstraintError if the chimeSoundID value is not valid. Returns Success otherwise.
+             */
+            Protocols::InteractionModel::Status SetSelectedChime(uint8_t chimeSoundID);
 
-    /**
-     * Sets the Enabled attribute. Note, this also handles writing the new value into non-volatile storage.
-     * @param Enabled The value to which the Enabled  is to be set.
-     */
-    Protocols::InteractionModel::Status SetEnabled(bool Enabled);
+            /**
+             * Sets the Enabled attribute. Note, this also handles writing the new value into non-volatile storage.
+             * @param Enabled The value to which the Enabled  is to be set.
+             */
+            Protocols::InteractionModel::Status SetEnabled(bool Enabled);
 
-    // Attribute Getters
-    /**
-     * @return The Current SelectedChime.
-     */
-    uint8_t GetSelectedChime() const;
+            // Attribute Getters
+            /**
+             * @return The Current SelectedChime.
+             */
+            uint8_t GetSelectedChime() const;
 
-    /**
-     * @return The Enabled attribute..
-     */
-    bool GetEnabled() const;
+            /**
+             * @return The Enabled attribute..
+             */
+            bool GetEnabled() const;
 
-    /**
-     * @return The endpoint ID.
-     */
-    EndpointId GetEndpointId() { return mCluster.Cluster().GetPaths()[0].mEndpointId; }
+            /**
+             * @return The endpoint ID.
+             */
+            EndpointId GetEndpointId()
+            {
+                VerifyOrDie(mCluster.IsConstructed());
+                return mCluster.Cluster().GetPaths()[0].mEndpointId;
+            }
 
-    // Cluster constants from the spec
-    static constexpr uint8_t kMaxChimeSoundNameSize = ChimeCluster::kMaxChimeSoundNameSize;
+            // Cluster constants from the spec
+            static constexpr uint8_t kMaxChimeSoundNameSize = ChimeCluster::kMaxChimeSoundNameSize;
 
-    // The Code Driven ChimeCluster instance
-    chip::app::RegisteredServerCluster<ChimeCluster> mCluster;
-};
+            // The Code Driven ChimeCluster instance (lazy-initialized)
+            chip::app::LazyRegisteredServerCluster<ChimeCluster> mCluster;
 
-} // namespace Clusters
+        private:
+            EndpointId mEndpointId;
+            ChimeDelegate * mDelegate;
+        };
+
+    } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/chime-server/CodegenIntegration.h
+++ b/src/app/clusters/chime-server/CodegenIntegration.h
@@ -23,70 +23,71 @@
 
 namespace chip {
 namespace app {
-    namespace Clusters {
+namespace Clusters {
 
-        class ChimeServer {
-        public:
-            /**
-             * Creates a chime server instance. This is just a backwards compatibility wrapper around the ChimeCluster.
-             * @param aEndpointId The endpoint on which this cluster exists. This must match the zap configuration.
-             * @param aDelegate A reference to the delegate to be used by this server.
-             * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
-             */
-            ChimeServer(EndpointId endpointId, ChimeDelegate & delegate);
-            ~ChimeServer();
+class ChimeServer
+{
+public:
+    /**
+     * Creates a chime server instance. This is just a backwards compatibility wrapper around the ChimeCluster.
+     * @param aEndpointId The endpoint on which this cluster exists. This must match the zap configuration.
+     * @param aDelegate A reference to the delegate to be used by this server.
+     * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
+     */
+    ChimeServer(EndpointId endpointId, ChimeDelegate & delegate);
+    ~ChimeServer();
 
-            /**
-             * Register the chime cluster instance with the codegen data model provider.
-             * @return Returns an error if registration fails.
-             */
-            CHIP_ERROR Init();
+    /**
+     * Register the chime cluster instance with the codegen data model provider.
+     * @return Returns an error if registration fails.
+     */
+    CHIP_ERROR Init();
 
-            // Attribute Setters
-            /**
-             * Sets the SelectedChime attribute. Note, this also handles writing the new value into non-volatile storage.
-             * @param chimeSoundID The value to which the SelectedChime  is to be set.
-             * @return Returns a ConstraintError if the chimeSoundID value is not valid. Returns Success otherwise.
-             */
-            Protocols::InteractionModel::Status SetSelectedChime(uint8_t chimeSoundID);
+    // Attribute Setters
+    /**
+     * Sets the SelectedChime attribute. Note, this also handles writing the new value into non-volatile storage.
+     * @param chimeSoundID The value to which the SelectedChime  is to be set.
+     * @return Returns a ConstraintError if the chimeSoundID value is not valid. Returns Success otherwise.
+     */
+    Protocols::InteractionModel::Status SetSelectedChime(uint8_t chimeSoundID);
 
-            /**
-             * Sets the Enabled attribute. Note, this also handles writing the new value into non-volatile storage.
-             * @param Enabled The value to which the Enabled  is to be set.
-             */
-            Protocols::InteractionModel::Status SetEnabled(bool Enabled);
+    /**
+     * Sets the Enabled attribute. Note, this also handles writing the new value into non-volatile storage.
+     * @param Enabled The value to which the Enabled  is to be set.
+     */
+    Protocols::InteractionModel::Status SetEnabled(bool Enabled);
 
-            // Attribute Getters
-            /**
-             * @return The Current SelectedChime.
-             */
-            uint8_t GetSelectedChime() const;
+    // Attribute Getters
+    /**
+     * @return The Current SelectedChime.
+     */
+    uint8_t GetSelectedChime() const;
 
-            /**
-             * @return The Enabled attribute..
-             */
-            bool GetEnabled() const;
+    /**
+     * @return The Enabled attribute..
+     */
+    bool GetEnabled() const;
 
-            /**
-             * @return The endpoint ID.
-             */
-            EndpointId GetEndpointId()
-            {
-                VerifyOrDie(mCluster.IsConstructed());
-                return mCluster.Cluster().GetPaths()[0].mEndpointId;
-            }
+    /**
+     * @return The endpoint ID.
+     */
+    EndpointId GetEndpointId()
+    {
+        VerifyOrDie(mCluster.IsConstructed());
+        return mCluster.Cluster().GetPaths()[0].mEndpointId;
+    }
 
-            // Cluster constants from the spec
-            static constexpr uint8_t kMaxChimeSoundNameSize = ChimeCluster::kMaxChimeSoundNameSize;
+    // Cluster constants from the spec
+    static constexpr uint8_t kMaxChimeSoundNameSize = ChimeCluster::kMaxChimeSoundNameSize;
 
-            // The Code Driven ChimeCluster instance (lazy-initialized)
-            chip::app::LazyRegisteredServerCluster<ChimeCluster> mCluster;
+    // The Code Driven ChimeCluster instance (lazy-initialized)
+    chip::app::LazyRegisteredServerCluster<ChimeCluster> mCluster;
 
-        private:
-            EndpointId mEndpointId;
-            ChimeDelegate * mDelegate;
-        };
+private:
+    EndpointId mEndpointId;
+    ChimeDelegate * mDelegate;
+};
 
-    } // namespace Clusters
+} // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/chime-server/CodegenIntegration.h
+++ b/src/app/clusters/chime-server/CodegenIntegration.h
@@ -19,7 +19,6 @@
 
 #include <app/clusters/chime-server/ChimeCluster.h>
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
-#include <lib/support/CodeUtils.h>
 
 namespace chip {
 namespace app {

--- a/src/app/clusters/chime-server/README.md
+++ b/src/app/clusters/chime-server/README.md
@@ -65,12 +65,18 @@ requires it. Using `RegisteredServerCluster` simplifies registration.
 
 ```cpp
 #include "app/server-cluster/ServerClusterInterfaceRegistry.h"
+#include "app/SafeAttributePersistenceProvider.h"
 
 // In a .cpp file
 MyChimeDelegate gMyChimeDelegate;
+chip::app::SafeAttributePersistenceProvider & persistenceProvider = /* ... */;
+
+chip::app::Clusters::ChimeCluster::Context chimeContext{
+    .safeAttributePersistenceProvider = persistenceProvider
+};
 
 chip::app::RegisteredServerCluster<chip::app::Clusters::ChimeCluster> gChimeCluster(
-    chip::EndpointId{ 1 }, gMyChimeDelegate);
+    chip::EndpointId{ 1 }, chimeContext, gMyChimeDelegate);
 ```
 
 ### 3. Register the Cluster

--- a/src/app/clusters/chime-server/README.md
+++ b/src/app/clusters/chime-server/README.md
@@ -72,11 +72,12 @@ MyChimeDelegate gMyChimeDelegate;
 chip::app::SafeAttributePersistenceProvider & persistenceProvider = /* ... */;
 
 chip::app::Clusters::ChimeCluster::Context chimeContext{
+    .delegate = gMyChimeDelegate,
     .safeAttributePersistenceProvider = persistenceProvider
 };
 
 chip::app::RegisteredServerCluster<chip::app::Clusters::ChimeCluster> gChimeCluster(
-    chip::EndpointId{ 1 }, chimeContext, gMyChimeDelegate);
+    chip::EndpointId{ 1 }, chimeContext);
 ```
 
 ### 3. Register the Cluster

--- a/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
+++ b/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
@@ -98,7 +98,9 @@ struct TestChimeCluster : public ::testing::Test
     MockChimeDelegate mMockDelegate;
     app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
 
-    ChimeCluster mCluster{ kTestEndpointId, ChimeCluster::Context{ .delegate = mMockDelegate, .safeAttributePersistenceProvider = mPersistenceProvider } };
+    ChimeCluster mCluster{ kTestEndpointId,
+                           ChimeCluster::Context{ .delegate                         = mMockDelegate,
+                                                  .safeAttributePersistenceProvider = mPersistenceProvider } };
 
     ClusterTester mClusterTester{ mCluster };
 };
@@ -259,7 +261,9 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 1. Initial startup, verify default values
     {
-        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .delegate = mockDelegate, .safeAttributePersistenceProvider = persistenceProvider });
+        ChimeCluster cluster(
+            kTestEndpointId,
+            ChimeCluster::Context{ .delegate = mockDelegate, .safeAttributePersistenceProvider = persistenceProvider });
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         ClusterTester tester(cluster);
 
@@ -278,7 +282,9 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 2. Restart (create new cluster instance), verify modified values are loaded
     {
-        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .delegate = mockDelegate, .safeAttributePersistenceProvider = persistenceProvider });
+        ChimeCluster cluster(
+            kTestEndpointId,
+            ChimeCluster::Context{ .delegate = mockDelegate, .safeAttributePersistenceProvider = persistenceProvider });
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         chip::Testing::ClusterTester tester(cluster);
 

--- a/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
+++ b/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
@@ -89,7 +89,7 @@ struct TestChimeCluster : public ::testing::Test
 
     void SetUp() override
     {
-        VerifyOrDie(mPersistenceProvider.Init(&mClusterTester.GetServerClusterContext().storage) == CHIP_NO_ERROR);
+        VerifyOrDie(mPersistenceProvider.Init(&mTestContext.StorageDelegate()) == CHIP_NO_ERROR);
         app::SetSafeAttributePersistenceProvider(&mPersistenceProvider);
         EXPECT_EQ(mCluster.Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
     }
@@ -97,12 +97,12 @@ struct TestChimeCluster : public ::testing::Test
     void TearDown() override { app::SetSafeAttributePersistenceProvider(nullptr); }
 
     MockChimeDelegate mMockDelegate;
+    TestServerClusterContext mTestContext;
+    app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
 
-    ChimeCluster mCluster{ kTestEndpointId, mMockDelegate };
+    ChimeCluster mCluster{ kTestEndpointId, mMockDelegate, mPersistenceProvider };
 
     ClusterTester mClusterTester{ mCluster };
-
-    app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
 };
 
 TEST_F(TestChimeCluster, TestAttributesList)
@@ -262,7 +262,7 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 1. Initial startup, verify default values
     {
-        ChimeCluster cluster(kTestEndpointId, mockDelegate);
+        ChimeCluster cluster(kTestEndpointId, mockDelegate, persistenceProvider);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         ClusterTester tester(cluster);
 
@@ -281,7 +281,7 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 2. Restart (create new cluster instance), verify modified values are loaded
     {
-        ChimeCluster cluster(kTestEndpointId, mockDelegate);
+        ChimeCluster cluster(kTestEndpointId, mockDelegate, persistenceProvider);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         chip::Testing::ClusterTester tester(cluster);
 

--- a/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
+++ b/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
@@ -90,11 +90,10 @@ struct TestChimeCluster : public ::testing::Test
     void SetUp() override
     {
         VerifyOrDie(mPersistenceProvider.Init(&mTestContext.StorageDelegate()) == CHIP_NO_ERROR);
-        app::SetSafeAttributePersistenceProvider(&mPersistenceProvider);
         EXPECT_EQ(mCluster.Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
     }
 
-    void TearDown() override { app::SetSafeAttributePersistenceProvider(nullptr); }
+    void TearDown() override {}
 
     MockChimeDelegate mMockDelegate;
     TestServerClusterContext mTestContext;
@@ -257,7 +256,6 @@ TEST_F(TestChimeCluster, TestPersistence)
     TestServerClusterContext context;
     app::DefaultSafeAttributePersistenceProvider persistenceProvider;
     EXPECT_EQ(persistenceProvider.Init(&context.Get().storage), CHIP_NO_ERROR);
-    app::SetSafeAttributePersistenceProvider(&persistenceProvider);
     MockChimeDelegate mockDelegate;
 
     // 1. Initial startup, verify default values

--- a/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
+++ b/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
@@ -89,14 +89,13 @@ struct TestChimeCluster : public ::testing::Test
 
     void SetUp() override
     {
-        VerifyOrDie(mPersistenceProvider.Init(&mTestContext.StorageDelegate()) == CHIP_NO_ERROR);
+        VerifyOrDie(mPersistenceProvider.Init(&mClusterTester.GetServerClusterContext().storage) == CHIP_NO_ERROR);
         EXPECT_EQ(mCluster.Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
     }
 
     void TearDown() override {}
 
     MockChimeDelegate mMockDelegate;
-    TestServerClusterContext mTestContext;
     app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
 
     ChimeCluster mCluster{ kTestEndpointId, mMockDelegate, mPersistenceProvider };

--- a/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
+++ b/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
@@ -98,7 +98,8 @@ struct TestChimeCluster : public ::testing::Test
     MockChimeDelegate mMockDelegate;
     app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
 
-    ChimeCluster mCluster{ kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = mPersistenceProvider }, mMockDelegate };
+    ChimeCluster mCluster{ kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = mPersistenceProvider },
+                           mMockDelegate };
 
     ClusterTester mClusterTester{ mCluster };
 };
@@ -259,7 +260,8 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 1. Initial startup, verify default values
     {
-        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = persistenceProvider }, mockDelegate);
+        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = persistenceProvider },
+                             mockDelegate);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         ClusterTester tester(cluster);
 
@@ -278,7 +280,8 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 2. Restart (create new cluster instance), verify modified values are loaded
     {
-        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = persistenceProvider }, mockDelegate);
+        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = persistenceProvider },
+                             mockDelegate);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         chip::Testing::ClusterTester tester(cluster);
 

--- a/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
+++ b/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
@@ -98,7 +98,7 @@ struct TestChimeCluster : public ::testing::Test
     MockChimeDelegate mMockDelegate;
     app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
 
-    ChimeCluster mCluster{ kTestEndpointId, mMockDelegate, mPersistenceProvider };
+    ChimeCluster mCluster{ kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = mPersistenceProvider }, mMockDelegate };
 
     ClusterTester mClusterTester{ mCluster };
 };
@@ -259,7 +259,7 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 1. Initial startup, verify default values
     {
-        ChimeCluster cluster(kTestEndpointId, mockDelegate, persistenceProvider);
+        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = persistenceProvider }, mockDelegate);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         ClusterTester tester(cluster);
 
@@ -278,7 +278,7 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 2. Restart (create new cluster instance), verify modified values are loaded
     {
-        ChimeCluster cluster(kTestEndpointId, mockDelegate, persistenceProvider);
+        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = persistenceProvider }, mockDelegate);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         chip::Testing::ClusterTester tester(cluster);
 

--- a/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
+++ b/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
@@ -98,8 +98,7 @@ struct TestChimeCluster : public ::testing::Test
     MockChimeDelegate mMockDelegate;
     app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
 
-    ChimeCluster mCluster{ kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = mPersistenceProvider },
-                           mMockDelegate };
+    ChimeCluster mCluster{ kTestEndpointId, ChimeCluster::Context{ .delegate = mMockDelegate, .safeAttributePersistenceProvider = mPersistenceProvider } };
 
     ClusterTester mClusterTester{ mCluster };
 };
@@ -260,8 +259,7 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 1. Initial startup, verify default values
     {
-        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = persistenceProvider },
-                             mockDelegate);
+        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .delegate = mockDelegate, .safeAttributePersistenceProvider = persistenceProvider });
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         ClusterTester tester(cluster);
 
@@ -280,8 +278,7 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 2. Restart (create new cluster instance), verify modified values are loaded
     {
-        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .safeAttributePersistenceProvider = persistenceProvider },
-                             mockDelegate);
+        ChimeCluster cluster(kTestEndpointId, ChimeCluster::Context{ .delegate = mockDelegate, .safeAttributePersistenceProvider = persistenceProvider });
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         chip::Testing::ClusterTester tester(cluster);
 

--- a/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
+++ b/src/app/clusters/chime-server/tests/TestChimeCluster.cpp
@@ -89,7 +89,7 @@ struct TestChimeCluster : public ::testing::Test
 
     void SetUp() override
     {
-        VerifyOrDie(mPersistenceProvider.Init(&mTestContext.StorageDelegate()) == CHIP_NO_ERROR);
+        VerifyOrDie(mPersistenceProvider.Init(&mClusterTester.GetServerClusterContext().storage) == CHIP_NO_ERROR);
         app::SetSafeAttributePersistenceProvider(&mPersistenceProvider);
         EXPECT_EQ(mCluster.Startup(mClusterTester.GetServerClusterContext()), CHIP_NO_ERROR);
     }
@@ -97,12 +97,12 @@ struct TestChimeCluster : public ::testing::Test
     void TearDown() override { app::SetSafeAttributePersistenceProvider(nullptr); }
 
     MockChimeDelegate mMockDelegate;
-    TestServerClusterContext mTestContext;
-    app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
 
-    ChimeCluster mCluster{ kTestEndpointId, mMockDelegate, mPersistenceProvider };
+    ChimeCluster mCluster{ kTestEndpointId, mMockDelegate };
 
     ClusterTester mClusterTester{ mCluster };
+
+    app::DefaultSafeAttributePersistenceProvider mPersistenceProvider;
 };
 
 TEST_F(TestChimeCluster, TestAttributesList)
@@ -262,7 +262,7 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 1. Initial startup, verify default values
     {
-        ChimeCluster cluster(kTestEndpointId, mockDelegate, persistenceProvider);
+        ChimeCluster cluster(kTestEndpointId, mockDelegate);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         ClusterTester tester(cluster);
 
@@ -281,7 +281,7 @@ TEST_F(TestChimeCluster, TestPersistence)
 
     // 2. Restart (create new cluster instance), verify modified values are loaded
     {
-        ChimeCluster cluster(kTestEndpointId, mockDelegate, persistenceProvider);
+        ChimeCluster cluster(kTestEndpointId, mockDelegate);
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
         chip::Testing::ClusterTester tester(cluster);
 


### PR DESCRIPTION
#### Summary

This PR decouples `ChimeCluster` from singleton dependencies by migrating from direct global singleton usage (`GetSafeAttributePersistenceProvider()`) to constructor-based dependency injection:

**Constructor-based dependency injection**: `ChimeCluster` now accepts `SafeAttributePersistenceProvider` as a constructor parameter instead of calling `GetSafeAttributePersistenceProvider()` directly within its methods.

#### Related issues

#42949

#### Testing

- All existing tests pass with the new dependency injection approach