### PR TITLE
[Silabs] Optimize Silabs Logging

### DIFF
--- a/examples/light-switch-app/silabs/src/ShellCommands.cpp
+++ b/examples/light-switch-app/silabs/src/ShellCommands.cpp
@@ -477,7 +477,6 @@ CHIP_ERROR LevelControlReadCurrentLevel(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::CurrentLevel::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -488,7 +487,6 @@ CHIP_ERROR LevelControlReadRemainingTime(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::RemainingTime::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -499,7 +497,6 @@ CHIP_ERROR LevelControlReadMinLevel(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::MinLevel::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -510,7 +507,6 @@ CHIP_ERROR LevelControlReadMaxLevel(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::MaxLevel::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -521,7 +517,6 @@ CHIP_ERROR LevelControlReadCurrentFrequency(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::CurrentFrequency::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -532,7 +527,6 @@ CHIP_ERROR LevelControlReadMinFrequency(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::MinFrequency::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -543,7 +537,6 @@ CHIP_ERROR LevelControlReadMaxFrequency(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::MaxFrequency::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -554,7 +547,6 @@ CHIP_ERROR LevelControlReadOptions(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::Options::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -565,7 +557,6 @@ CHIP_ERROR LevelControlReadOnOffTransitionTime(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::OnOffTransitionTime::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -576,7 +567,6 @@ CHIP_ERROR LevelControlReadOnLevel(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::OnLevel::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -587,7 +577,6 @@ CHIP_ERROR LevelControlReadOnTransitionTime(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::OnTransitionTime::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -598,7 +587,6 @@ CHIP_ERROR LevelControlReadOffTransitionTime(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::OffTransitionTime::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -609,7 +597,6 @@ CHIP_ERROR LevelControlReadDefaultMoveRate(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::DefaultMoveRate::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }
@@ -620,7 +607,6 @@ CHIP_ERROR LevelControlReadStartUpCurrentLevel(int argc, char ** argv)
     data->attributeId         = Clusters::LevelControl::Attributes::StartUpCurrentLevel::Id;
     data->clusterId           = Clusters::LevelControl::Id;
     data->isReadAttribute     = true;
-    ChipLogProgress(NotSpecified, "Read cluster=0x%x, attribute=0x%08x", data->clusterId, data->attributeId);
     DeviceLayer::PlatformMgr().ScheduleWork(SwitchWorkerFunction, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
 }

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -330,8 +330,8 @@ CHIP_ERROR BaseApplication::BaseInit()
     ChipLogProgress(AppServer, "Current Software Version String: %s", CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
     ChipLogProgress(AppServer, "Current Software Version: %d", CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION);
 
-    // TODO FIXME : This function fills the UART LOG queue
-    // Write an optimize one to reduces the number of call to ChipLogProgress
+    // TODO FIXME: ConfigurationMgr().LogDeviceConfig() fills the UART log queue.
+    // Write an optimized version to reduce the number of calls to ChipLogProgress.
     // ConfigurationMgr().LogDeviceConfig();
 
     OutputQrCode(true /*refreshLCD at init*/);
@@ -865,7 +865,7 @@ void BaseApplication::DispatchEvent(AppEvent * aEvent)
     }
     else
     {
-        ChipLogError(AppServer, "Event received with no handler. Dropping event.");
+        ChipLogError(AppServer, "Nullptr event received or no handler. Dropping it.");
     }
 }
 

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -266,7 +266,7 @@ CHIP_ERROR BaseApplication::Init()
     CHIP_ERROR err = BaseInit();
     if (err != CHIP_NO_ERROR)
     {
-        SILABS_LOG("BaseInit() failed");
+        ChipLogError(DeviceLayer, "BaseInit() failed");
         appError(err);
         return err;
     }
@@ -274,7 +274,7 @@ CHIP_ERROR BaseApplication::Init()
     err = AppInit();
     if (err != CHIP_NO_ERROR)
     {
-        SILABS_LOG("AppInit() failed");
+        ChipLogError(DeviceLayer, "AppInit() failed");
         appError(err);
         return err;
     }
@@ -295,12 +295,12 @@ CHIP_ERROR BaseApplication::BaseInit()
     /*
      * Wait for the WiFi to be initialized
      */
-    ChipLogProgress(AppServer, "APP: Wait WiFi Init");
+    ChipLogDetail(AppServer, "APP: Wait WiFi Init");
     while (!WifiInterface::GetInstance().IsStationReady())
     {
         osDelay(pdMS_TO_TICKS(10));
     }
-    ChipLogProgress(AppServer, "APP: Done WiFi Init");
+    ChipLogDetail(AppServer, "APP: Done WiFi Init");
 #endif
 
     // Create cmsis os sw timer for Function Selection.
@@ -330,7 +330,9 @@ CHIP_ERROR BaseApplication::BaseInit()
     ChipLogProgress(AppServer, "Current Software Version String: %s", CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
     ChipLogProgress(AppServer, "Current Software Version: %d", CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION);
 
-    ConfigurationMgr().LogDeviceConfig();
+    // TODO FIXME : This function fills the UART LOG queue
+    // Write an optimize one to reduces the number of call to ChipLogProgress
+    // ConfigurationMgr().LogDeviceConfig();
 
     OutputQrCode(true /*refreshLCD at init*/);
 #if (defined(ENABLE_WSTK_LEDS) && (defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT)))
@@ -857,13 +859,13 @@ void BaseApplication::PostEvent(const AppEvent * aEvent)
 
 void BaseApplication::DispatchEvent(AppEvent * aEvent)
 {
-    if (aEvent->Handler)
+    if (aEvent != nullptr && aEvent->Handler)
     {
         aEvent->Handler(aEvent);
     }
     else
     {
-        ChipLogProgress(AppServer, "Event received with no handler. Dropping event.");
+        ChipLogError(AppServer, "Event received with no handler. Dropping event.");
     }
 }
 
@@ -902,7 +904,6 @@ void BaseApplication::DoProvisioningReset()
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
-        ChipLogProgress(DeviceLayer, "Clearing WiFi provision");
         chip::DeviceLayer::ConnectivityMgr().ClearWiFiStationProvision();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
 

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -147,7 +147,6 @@ void UnlockOpenThreadTask(void)
 // ================================================================================
 CHIP_ERROR SilabsMatterConfig::InitOpenThread(void)
 {
-    ChipLogProgress(DeviceLayer, "Initializing OpenThread stack");
     ReturnErrorOnFailure(ThreadStackMgr().InitThreadStack());
 
 #if CHIP_DEVICE_CONFIG_THREAD_FTD
@@ -166,7 +165,6 @@ CHIP_ERROR SilabsMatterConfig::InitOpenThread(void)
 
     TEMPORARY_RETURN_IGNORED sThreadNetworkDriver.Init();
 
-    ChipLogProgress(DeviceLayer, "Starting OpenThread task");
     return ThreadStackMgrImpl().StartThreadTask();
 }
 #endif // CHIP_ENABLE_OPENTHREAD
@@ -191,7 +189,11 @@ void ApplicationStart(void * unused)
     if (err != CHIP_NO_ERROR)
         appError(err);
 
-    ChipLogProgress(DeviceLayer, "Starting App Task");
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    // Initialize device attestation config
+    SetDeviceAttestationCredentialsProvider(&Provision::Manager::GetInstance().GetStorage());
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
     err = AppTask::GetAppTask().StartAppTask();
     if (err != CHIP_NO_ERROR)
         appError(err);
@@ -229,7 +231,7 @@ void SilabsMatterConfig::AppInit()
 CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 {
     using namespace chip::DeviceLayer::Silabs;
-
+    CHIP_ERROR err;
     SILABS_LOG("=====%s starting=====", appName);
 
 #if defined(PW_RPC_ENABLED) && PW_RPC_ENABLED
@@ -245,19 +247,27 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     //==============================================
 
 #ifdef SL_WIFI
-    ReturnErrorOnFailure(WifiInterface::GetInstance().InitWiFiStack());
+    err = WifiInterface::GetInstance().InitWiFiStack();
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err,
+                        ChipLogError(DeviceLayer, "Failed to Init WiFi Stack: %" CHIP_ERROR_FORMAT, err.Format()));
     // Needs to be done post InitWifiStack for 917.
     // TODO move it in InitWiFiStack
     TEMPORARY_RETURN_IGNORED GetPlatform().NvmInit();
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    ReturnErrorOnFailure(WifiSleepManager::GetInstance().Init(&WifiInterface::GetInstance(), &WifiInterface::GetInstance()));
+    err = WifiSleepManager::GetInstance().Init(&WifiInterface::GetInstance(), &WifiInterface::GetInstance());
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err,
+                        ChipLogError(DeviceLayer, "Failed to Init WiFi Sleep Manager: %" CHIP_ERROR_FORMAT, err.Format()));
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #endif // SL_WIFI
 
-    ReturnErrorOnFailure(PlatformMgr().InitChipStack());
+    err = PlatformMgr().InitChipStack();
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err,
+                        ChipLogError(DeviceLayer, "Failed to Init Chip Stack: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    TEMPORARY_RETURN_IGNORED chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(appName);
+    err = chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(appName);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err,
+                        ChipLogError(DeviceLayer, "Failed to Set BLE Device Name: %" CHIP_ERROR_FORMAT, err.Format()));
 
     // Provision Manager
     Provision::Manager & provision = Provision::Manager::GetInstance();
@@ -328,13 +338,13 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Init Matter Server and Start Event Loop
-    CHIP_ERROR err = chip::Server::GetInstance().Init(initParams);
+    err = chip::Server::GetInstance().Init(initParams);
 
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-    ReturnErrorOnFailure(err);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err,
+                        ChipLogError(DeviceLayer, "Failed to Init Matter Server: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    SILABS_LOG("Starting Platform Manager Event Loop");
     ReturnErrorOnFailure(PlatformMgr().StartEventLoopTask());
 
 #ifdef ENABLE_CHIP_SHELL

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -152,7 +152,7 @@ typedef struct
 #if CHIP_DETAIL_LOGGING
 #define UART_MAX_QUEUE_SIZE 60
 #else
-#define UART_MAX_QUEUE_SIZE 20
+#define UART_MAX_QUEUE_SIZE 25
 #endif
 #endif
 

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -242,7 +242,7 @@ uint32_t SlWiFiDriver::GetSupportedWiFiBandsMask() const
 
 bool SlWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)
 {
-    ChipLogProgress(DeviceLayer, "Start Scan WiFi Networks");
+    ChipLogDetail(DeviceLayer, "Start Scan WiFi Networks");
     CHIP_ERROR err = WifiInterface::GetInstance().StartNetworkScan(ssid, OnScanWiFiNetworkDone);
 
     if (err != CHIP_NO_ERROR)

--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -237,7 +237,7 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
     case DeviceEventType::kCHIPoBLESubscribe: {
         ChipDeviceEvent connEstEvent;
 
-        ChipLogProgress(DeviceLayer, "_OnPlatformEvent kCHIPoBLESubscribe");
+        ChipLogDetail(DeviceLayer, "_OnPlatformEvent kCHIPoBLESubscribe");
         HandleSubscribeReceived(event->CHIPoBLESubscribe.ConId, &CHIP_BLE_SVC_ID, &Ble::CHIP_BLE_CHAR_2_UUID);
         connEstEvent.Type = DeviceEventType::kCHIPoBLEConnectionEstablished;
         PlatformMgr().PostEventOrDie(&connEstEvent);
@@ -245,32 +245,32 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
     break;
 
     case DeviceEventType::kCHIPoBLEUnsubscribe: {
-        ChipLogProgress(DeviceLayer, "_OnPlatformEvent kCHIPoBLEUnsubscribe");
+        ChipLogDetail(DeviceLayer, "_OnPlatformEvent kCHIPoBLEUnsubscribe");
         HandleUnsubscribeReceived(event->CHIPoBLEUnsubscribe.ConId, &CHIP_BLE_SVC_ID, &Ble::CHIP_BLE_CHAR_2_UUID);
     }
     break;
 
     case DeviceEventType::kCHIPoBLEWriteReceived: {
-        ChipLogProgress(DeviceLayer, "_OnPlatformEvent kCHIPoBLEWriteReceived");
+        ChipLogDetail(DeviceLayer, "_OnPlatformEvent kCHIPoBLEWriteReceived");
         HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &CHIP_BLE_SVC_ID, &Ble::CHIP_BLE_CHAR_1_UUID,
                             PacketBufferHandle::Adopt(event->CHIPoBLEWriteReceived.Data));
     }
     break;
 
     case DeviceEventType::kCHIPoBLEConnectionError: {
-        ChipLogProgress(DeviceLayer, "_OnPlatformEvent kCHIPoBLEConnectionError");
+        ChipLogDetail(DeviceLayer, "_OnPlatformEvent kCHIPoBLEConnectionError");
         HandleConnectionError(event->CHIPoBLEConnectionError.ConId, event->CHIPoBLEConnectionError.Reason);
     }
     break;
 
     case DeviceEventType::kCHIPoBLEIndicateConfirm: {
-        ChipLogProgress(DeviceLayer, "_OnPlatformEvent kCHIPoBLEIndicateConfirm");
+        ChipLogDetail(DeviceLayer, "_OnPlatformEvent kCHIPoBLEIndicateConfirm");
         HandleIndicationConfirmation(event->CHIPoBLEIndicateConfirm.ConId, &CHIP_BLE_SVC_ID, &Ble::CHIP_BLE_CHAR_2_UUID);
     }
     break;
 
     default:
-        ChipLogProgress(DeviceLayer, "_OnPlatformEvent default:  event->Type = %d", event->Type);
+        ChipLogDetail(DeviceLayer, "_OnPlatformEvent default:  event->Type = %d", event->Type);
         break;
     }
 }
@@ -278,14 +278,14 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 CHIP_ERROR BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId,
                                                    const ChipBleUUID * charId)
 {
-    ChipLogProgress(DeviceLayer, "BLEManagerImpl::SubscribeCharacteristic() not supported");
+    ChipLogDetail(DeviceLayer, "BLEManagerImpl::SubscribeCharacteristic() not supported");
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 CHIP_ERROR BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId,
                                                      const ChipBleUUID * charId)
 {
-    ChipLogProgress(DeviceLayer, "BLEManagerImpl::UnsubscribeCharacteristic() not supported");
+    ChipLogDetail(DeviceLayer, "BLEManagerImpl::UnsubscribeCharacteristic() not supported");
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
@@ -338,7 +338,7 @@ exit:
 CHIP_ERROR BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId,
                                             PacketBufferHandle pBuf)
 {
-    ChipLogProgress(DeviceLayer, "BLEManagerImpl::SendWriteRequest() not supported");
+    ChipLogDetail(DeviceLayer, "BLEManagerImpl::SendWriteRequest() not supported");
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
@@ -701,8 +701,6 @@ void BLEManagerImpl::HandleConnectionCloseEvent(volatile sl_bt_msg_t * evt)
     sl_bt_evt_connection_closed_t * conn_evt = (sl_bt_evt_connection_closed_t *) &(evt->data);
     uint8_t connHandle                       = conn_evt->connection;
 
-    ChipLogProgress(DeviceLayer, "Disconnect Event for handle : %d", connHandle);
-
     if (RemoveConnection(connHandle))
     {
         ChipDeviceEvent event;
@@ -742,7 +740,7 @@ void BLEManagerImpl::HandleWriteEvent(volatile sl_bt_msg_t * evt)
 {
     uint16_t attribute = evt->data.evt_gatt_server_user_write_request.characteristic;
     bool do_provision  = chip::DeviceLayer::Silabs::Provision::Manager::GetInstance().IsProvisionRequired();
-    ChipLogProgress(DeviceLayer, "Char Write Req, char : %d", attribute);
+    ChipLogDetail(DeviceLayer, "Char Write Req, char : %d", attribute);
 
     if (gattdb_CHIPoBLEChar_Rx == attribute)
     {
@@ -771,9 +769,9 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(volatile sl_bt_msg_t * evt)
     // Determine if the client is enabling or disabling notification/indication.
     isIndicationEnabled = (evt->data.evt_gatt_server_characteristic_status.client_config_flags == sl_bt_gatt_indication);
 
-    ChipLogProgress(DeviceLayer, "HandleTXcharCCCDWrite - Config Flags value : %d",
-                    evt->data.evt_gatt_server_characteristic_status.client_config_flags);
-    ChipLogProgress(DeviceLayer, "CHIPoBLE %s received", isIndicationEnabled ? "subscribe" : "unsubscribe");
+    ChipLogDetail(DeviceLayer, "HandleTXcharCCCDWrite - Config Flags value : %d",
+                  evt->data.evt_gatt_server_characteristic_status.client_config_flags);
+    ChipLogDetail(DeviceLayer, "CHIPoBLE %s received", isIndicationEnabled ? "subscribe" : "unsubscribe");
 
     if (isIndicationEnabled)
     {
@@ -840,12 +838,9 @@ void BLEManagerImpl::HandleTxConfirmationEvent(BLE_CONNECTION_OBJECT conId)
     ChipDeviceEvent event;
     uint8_t timerHandle = sInstance.GetTimerHandle(conId, false);
 
-    ChipLogProgress(DeviceLayer, "Tx Confirmation received");
-
     // stop indication confirmation timer
     if (timerHandle < kMaxConnections)
     {
-        ChipLogProgress(DeviceLayer, " stop soft timer");
         sl_bt_system_set_lazy_soft_timer(0, 0, timerHandle, false);
     }
 
@@ -860,7 +855,7 @@ void BLEManagerImpl::HandleSoftTimerEvent(volatile sl_bt_msg_t * evt)
     // If we receive a callback for unknown timer handle ignore this.
     if (evt->data.evt_system_soft_timer.handle < kMaxConnections)
     {
-        ChipLogProgress(DeviceLayer, "BLEManagerImpl::HandleSoftTimerEvent CHIPOBLE_PROTOCOL_ABORT");
+        ChipLogDetail(DeviceLayer, "BLEManagerImpl::HandleSoftTimerEvent CHIPOBLE_PROTOCOL_ABORT");
         ChipDeviceEvent event;
         event.Type                                                   = DeviceEventType::kCHIPoBLEConnectionError;
         event.CHIPoBLEConnectionError.ConId                          = mIndConfId[evt->data.evt_system_soft_timer.handle];
@@ -1068,13 +1063,13 @@ extern "C" void sl_bt_on_event(sl_bt_msg_t * evt)
     switch (SL_BT_MSG_ID(evt->header))
     {
     case sl_bt_evt_system_boot_id: {
-        ChipLogProgress(DeviceLayer, "Bluetooth stack booted: v%d.%d.%d-b%d", evt->data.evt_system_boot.major,
-                        evt->data.evt_system_boot.minor, evt->data.evt_system_boot.patch, evt->data.evt_system_boot.build);
+        ChipLogProgress(DeviceLayer, "BLE stack: v%d.%d.%d-b%d", evt->data.evt_system_boot.major, evt->data.evt_system_boot.minor,
+                        evt->data.evt_system_boot.patch, evt->data.evt_system_boot.build);
         chip::DeviceLayer::Internal::BLEMgrImpl().HandleBootEvent();
 
         RAIL_Version_t railVer;
         RAIL_GetVersion(&railVer, true);
-        ChipLogProgress(DeviceLayer, "RAIL version:, v%d.%d.%d-b%d", railVer.major, railVer.minor, railVer.rev, railVer.build);
+        ChipLogProgress(DeviceLayer, "RAIL: v%d.%d.%d-b%d", railVer.major, railVer.minor, railVer.rev, railVer.build);
         sl_bt_connection_set_default_parameters(BLE_CONFIG_MIN_INTERVAL, BLE_CONFIG_MAX_INTERVAL, BLE_CONFIG_LATENCY,
                                                 BLE_CONFIG_TIMEOUT, BLE_CONFIG_MIN_CE_LENGTH, BLE_CONFIG_MAX_CE_LENGTH);
     }
@@ -1145,8 +1140,8 @@ extern "C" void sl_bt_on_event(sl_bt_msg_t * evt)
     break;
 
     case sl_bt_evt_gatt_server_user_read_request_id: {
-        ChipLogProgress(DeviceLayer, "GATT server user_read_request");
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
+        ChipLogProgress(DeviceLayer, "GATT server user_read_request");
         if (evt->data.evt_gatt_server_user_read_request.characteristic == gattdb_CHIPoBLEChar_C3)
         {
             chip::DeviceLayer::Internal::BLEMgrImpl().HandleC3ReadRequest(evt);
@@ -1156,12 +1151,11 @@ extern "C" void sl_bt_on_event(sl_bt_msg_t * evt)
     break;
 
     case sl_bt_evt_connection_remote_used_features_id: {
-        // ChipLogProgress(DeviceLayer, "link layer features supported by the remote device");
     }
     break;
 
     default:
-        ChipLogProgress(DeviceLayer, "evt_UNKNOWN id = %08" PRIx32, SL_BT_MSG_ID(evt->header));
+        ChipLogDetail(DeviceLayer, "evt_UNKNOWN id = %08" PRIx32, SL_BT_MSG_ID(evt->header));
         break;
     }
 

--- a/src/platform/silabs/efr32/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/efr32/OTAImageProcessorImpl.cpp
@@ -167,7 +167,7 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
     WRAP_BL_DFU_CALL(err = bootloader_init())
     if (err != SL_BOOTLOADER_OK)
     {
-        ChipLogProgress(SoftwareUpdate, "bootloader_init Failed error: %ld", err);
+        ChipLogError(SoftwareUpdate, "bootloader_init Failed error: %ld", err);
     }
 
     mSlotId                                 = 0; // Single slot until we support multiple images

--- a/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
@@ -134,16 +134,16 @@ CHIP_ERROR OTAFactoryDataProcessor::UpdateValue(uint8_t tag, ByteSpan & newValue
     switch (tag)
     {
     case (int) FactoryTags::kDacKey:
-        ChipLogProgress(SoftwareUpdate, "Set Device Attestation Key");
+        ChipLogDetail(SoftwareUpdate, "Set Device Attestation Key");
         return Provision::Manager::GetInstance().GetStorage().SetDeviceAttestationKey(newValue);
     case (int) FactoryTags::kDacCert:
-        ChipLogProgress(SoftwareUpdate, "Set Device Attestation Cert");
+        ChipLogDetail(SoftwareUpdate, "Set Device Attestation Cert");
         return Provision::Manager::GetInstance().GetStorage().SetDeviceAttestationCert(newValue);
     case (int) FactoryTags::kPaiCert:
-        ChipLogProgress(SoftwareUpdate, "Set Product Attestionation Intermediate Cert");
+        ChipLogDetail(SoftwareUpdate, "Set Product Attestation Intermediate Cert");
         return Provision::Manager::GetInstance().GetStorage().SetProductAttestationIntermediateCert(newValue);
     case (int) FactoryTags::kCdCert:
-        ChipLogProgress(SoftwareUpdate, "Set Certification Declaration");
+        ChipLogDetail(SoftwareUpdate, "Set Certification Declaration");
         return Provision::Manager::GetInstance().GetStorage().SetCertificationDeclaration(newValue);
     }
 


### PR DESCRIPTION
#### Summary
It came to our attention that upon reboot we generate way to much logs... Instead of increasing the Uart Log queue which would increase RAM consumption  we've decided to reduced/re-categorized some logs as to alleviate the burden on the uart and not missed any logs.

#### Related issues
None.

#### Testing
Tested with Silicon Labs MG24 using the light-switch app. The number of logs lost are now down to 2 upon a power cycle.

