### PR TITLE
Fix import

### DIFF
--- a/src/python_testing/TC_SU_2_2.py
+++ b/src/python_testing/TC_SU_2_2.py
@@ -51,8 +51,8 @@ from TC_SUTestBase import SoftwareUpdateBaseTest
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
+from matter.testing.decorators import async_test_body
 from matter.testing.event_attribute_reporting import AttributeMatcher, AttributeSubscriptionHandler, EventSubscriptionHandler
-from matter.testing.matter_testing import async_test_body
 from matter.testing.runner import TestStep, default_matter_test_main
 
 # Create a logger

--- a/src/python_testing/TC_SU_4_1.py
+++ b/src/python_testing/TC_SU_4_1.py
@@ -119,10 +119,11 @@ class TC_SU_4_1(SoftwareUpdateBaseTest):
             ),
         ]
 
+    @async_test_body
     async def teardown_test(self):
         # Clear provider KVS after test to avoid interference with subsequent tests
         self.clear_kvs()
-        await super().teardown_test()
+        super().teardown_test()
 
     @async_test_body
     async def test_TC_SU_4_1(self):


### PR DESCRIPTION
### Summary

Replace from `matter.testing.matter_testing import async_test_body` for `from matter.testing.decorators import async_test_body` in `TC_SU_2_2.py`. Also `teardown_test` is no longer asynchronous in `TC_SU_4_1`.py.

Fixes https://github.com/project-chip/connectedhomeip/issues/43040

### Testing

#### TC_SU_2_2.py

```
# Launch OTA Requestor from Terminal 1:
./out/debug/chip-ota-requestor-app --discriminator 1234 --passcode 20202021 --KVS /tmp/chip_kvs_requestor

# Launch Python test from Terminal 2:
python3 src/python_testing/TC_SU_2_2.py \
  --commissioning-method on-network \
  --discriminator 1234 \
  --passcode 20202021 \
  --string-arg provider_app_path:out/debug/chip-ota-provider-app \
  --string-arg ota_image:firmware_requestor_v2.ota \
  --timeout 600
```

#### TC_SU_4_1

```
# Launch OTA Requestor from Terminal 1:
./out/debug/chip-ota-requestor-app --discriminator 1234 --passcode 20202021 --KVS /tmp/chip_kvs_requestor

# Launch Python test from Terminal 2:
python3 src/python_testing/TC_SU_4_1.py \
  --commissioning-method on-network \
  --discriminator 1234 \
  --passcode 20202021
  ```