### PR TITLE
Create TC_IDM_2_3 test for max read/subscribe paths 

### DIFF
--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -51,6 +51,7 @@ log = logging.getLogger(__name__)
 
 MAX_NUM_PATHS_IN_MTU = 50
 
+
 class TC_IDM_2_3(BasicCompositionTests):
 
     def __init__(self, *args, **kwargs):
@@ -115,9 +116,9 @@ class TC_IDM_2_3(BasicCompositionTests):
 
         if cluster_revision >= 6:
             asserts.assert_is_not_none(capability_minima.readPathsSupported,
-                                        "ReadPathsSupported should be present when ClusterRevision >= 6")
+                                       "ReadPathsSupported should be present when ClusterRevision >= 6")
             asserts.assert_is_not_none(capability_minima.subscribePathsSupported,
-                                        "SubscribePathsSupported should be present when ClusterRevision >= 6")
+                                       "SubscribePathsSupported should be present when ClusterRevision >= 6")
 
             # Extract values, providing defaults if optional fields are missing
             num_read_paths_supported = capability_minima.readPathsSupported
@@ -160,7 +161,7 @@ class TC_IDM_2_3(BasicCompositionTests):
         async def conduct_request_with_potential_path_size_reduction(paths, num_paths, request_function):
             # TODO: The maximum here should be adjusted and be based upon the max size
             # of an AttributePath, as well as the size of the payload for the MTU. See Issue #43083
-            if num_paths>MAX_NUM_PATHS_IN_MTU:
+            if num_paths > MAX_NUM_PATHS_IN_MTU:
                 paths[:] = paths[:MAX_NUM_PATHS_IN_MTU]
             return await request_function(paths)
 

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -21,7 +21,7 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
-#     app: ${ALL_CLUSTERS_APP}
+#     app: ${ALL_DEVICES_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json
@@ -51,6 +51,7 @@ from matter.testing.runner import TestStep, default_matter_test_main
 
 log = logging.getLogger(__name__)
 
+MAX_NUM_PATHS_IN_MTU = 50
 
 class TC_IDM_2_3(BasicCompositionTests):
 
@@ -60,7 +61,7 @@ class TC_IDM_2_3(BasicCompositionTests):
 
     @property
     def default_timeout(self) -> int:
-        return 600
+        return 5 * 60
 
     def steps_TC_IDM_2_3(self) -> list[TestStep]:
         return [
@@ -100,14 +101,24 @@ class TC_IDM_2_3(BasicCompositionTests):
 
         # Step 1: CapabilityMinima
         self.step(1)
-        capability_minima = await self.read_single_attribute_check_success(
-            cluster=Clusters.BasicInformation,
-            attribute=Clusters.BasicInformation.Attributes.CapabilityMinima
+        cluster_revision = await self.read_single_attribute_check_success(
+            cluster=Clusters.BasicInformation, 
+            attribute=Clusters.BasicInformation.Attributes.ClusterRevision
         )
+        
+        # Default values, used for older cluster revisions where these values aren't specified
+        num_read_paths_supported = 9
+        num_subscribe_paths_supported = 3
 
-        # Extract values, providing defaults if optional fields are missing
-        num_read_paths_supported = capability_minima.readPathsSupported if capability_minima.readPathsSupported is not None else 1
-        num_subscribe_paths_supported = capability_minima.subscribePathsSupported if capability_minima.subscribePathsSupported is not None else 1
+        if cluster_revision >= 6:
+            capability_minima = await self.read_single_attribute_check_success(
+                cluster=Clusters.BasicInformation,
+                attribute=Clusters.BasicInformation.Attributes.CapabilityMinima
+            )
+
+            # Extract values, providing defaults if optional fields are missing
+            num_read_paths_supported = capability_minima.readPathsSupported
+            num_subscribe_paths_supported = capability_minima.subscribePathsSupported
 
         log.info(f"CapabilityMinima: readPathsSupported={num_read_paths_supported}, "
                  f"subscribePathsSupported={num_subscribe_paths_supported}")
@@ -138,31 +149,15 @@ class TC_IDM_2_3(BasicCompositionTests):
             log.info("Conducting read request")
             return await self.default_controller.Read(self.dut_node_id, paths)
 
-        # Read requests must fit into 1 MTU, as reads cannot be chained acrross multiple packets. If a device reports
+        # Read requests must fit into 1 MTU, as reads cannot be chained across multiple packets. If a device reports
         # a number of read paths (or subscription paths) larger than what is possible on the controller side, we need to
-        # reduce the number of paths here to be as much as can fit in the request. This requires some trial and error to
-        # see what size works. AttributePath objects can vary slightly in size, so this isn't a fixed number of paths.
+        # reduce the number of paths here to be as much as can fit in the request. 
         async def conduct_request_with_potential_path_size_reduction(paths, num_paths, request_function):
-            num_paths_reduced = num_paths
-            response = None
-            while num_paths_reduced > 0:
-                try:
-                    paths[:] = paths[:num_paths_reduced]
-                    response = await request_function(paths)
-                except ChipStackError as e:  # chipstack-ok: This check is needed to try and build a request until it's a valid size
-                    # Check for CHIP Error 0x0000000B No memory - Thrown when request is too large for 1 MTU
-                    if e.err == 0x0000000B:
-                        num_paths_reduced -= 1
-                    else:
-                        raise e
-                except Exception as e:
-                    raise e
-                else:
-                    break
-            if num_paths_reduced < num_paths:
-                log.info(
-                    f"Reduced number of paths from maximum reported of {num_paths} to {num_paths_reduced} to fit the request in one MTU")
-            return response
+            # TODO: The maximum here should be adjusted and be based upon the max size
+            # of an AttributePath, as well as the size of the payload for the MTU. See Issue #43083
+            if num_paths>MAX_NUM_PATHS_IN_MTU:
+                paths[:] = paths[:MAX_NUM_PATHS_IN_MTU]
+            return await request_function(paths)
 
         read_response = await conduct_request_with_potential_path_size_reduction(read_paths, num_read_paths_supported, read_request)
         asserts.assert_is_not_none(
@@ -178,6 +173,7 @@ class TC_IDM_2_3(BasicCompositionTests):
             attribute=Clusters.BasicInformation.Attributes.NodeLabel
         )
 
+        # TODO: Should have resilience to a missing node label
         sub_paths = self.get_paths(num_subscribe_paths_supported, all_paths)
         sub_paths[0] = AttributePath(EndpointId=0, ClusterId=Clusters.BasicInformation.id,
                                      AttributeId=Clusters.BasicInformation.Attributes.NodeLabel.attribute_id)
@@ -202,14 +198,6 @@ class TC_IDM_2_3(BasicCompositionTests):
         log.info("Successfully completed subscribe request")
         sub_transaction.SetAttributeUpdateCallback(handler)
 
-        # Manually add the priming report value to the handler's queue.
-        # The priming report was received during the Read call, before the callback was set.
-        handler.attribute_queue.put(AttributeValue(
-            endpoint_id=0,
-            attribute=Clusters.BasicInformation.Attributes.NodeLabel,
-            value=initial_node_label
-        ))
-
         # Write new NodeLabel to trigger a subscription report
         new_label = initial_node_label + "_Updated"
         await self.write_single_attribute(
@@ -220,7 +208,7 @@ class TC_IDM_2_3(BasicCompositionTests):
         # Verify the sequence: [Priming Report (initial), Subscription Update (new)]
         handler.await_sequence_of_reports(
             attribute=Clusters.BasicInformation.Attributes.NodeLabel,
-            sequence=[initial_node_label, new_label],
+            sequence=[new_label],
             timeout_sec=10
         )
 

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -36,6 +36,7 @@
 # === END CI TEST ARGUMENTS ===
 
 import logging
+import random
 
 from mobly import asserts
 
@@ -207,7 +208,6 @@ class TC_IDM_2_3(BasicCompositionTests):
 
         # Write new NodeLabel to trigger a subscription report
         # Generate a new label guaranteed different from initial state.
-        import random
         new_label = initial_node_label
         while new_label == initial_node_label:
             new_label = str(random.randint(0, 999999))

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -41,12 +41,10 @@ from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.clusters.Attribute import AttributePath
-from matter.exceptions import ChipStackError
 from matter.testing import global_attribute_ids
 from matter.testing.basic_composition import BasicCompositionTests
 from matter.testing.decorators import async_test_body
 from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
-from matter.testing.matter_testing import AttributeValue
 from matter.testing.runner import TestStep, default_matter_test_main
 
 log = logging.getLogger(__name__)
@@ -102,10 +100,10 @@ class TC_IDM_2_3(BasicCompositionTests):
         # Step 1: CapabilityMinima
         self.step(1)
         cluster_revision = await self.read_single_attribute_check_success(
-            cluster=Clusters.BasicInformation, 
+            cluster=Clusters.BasicInformation,
             attribute=Clusters.BasicInformation.Attributes.ClusterRevision
         )
-        
+
         # Default values for number of read paths and subscribe paths
         num_read_paths_supported = 9
         num_subscribe_paths_supported = 3
@@ -120,7 +118,7 @@ class TC_IDM_2_3(BasicCompositionTests):
                                         "ReadPathsSupported should be present when ClusterRevision >= 6")
             asserts.assert_is_not_none(capability_minima.subscribePathsSupported,
                                         "SubscribePathsSupported should be present when ClusterRevision >= 6")
-            
+
             # Extract values, providing defaults if optional fields are missing
             num_read_paths_supported = capability_minima.readPathsSupported
             num_subscribe_paths_supported = capability_minima.subscribePathsSupported
@@ -158,7 +156,7 @@ class TC_IDM_2_3(BasicCompositionTests):
 
         # Read requests must fit into 1 MTU, as reads cannot be chained across multiple packets. If a device reports
         # a number of read paths (or subscription paths) larger than what is possible on the controller side, we need to
-        # reduce the number of paths here to be as much as can fit in the request. 
+        # reduce the number of paths here to be as much as can fit in the request.
         async def conduct_request_with_potential_path_size_reduction(paths, num_paths, request_function):
             # TODO: The maximum here should be adjusted and be based upon the max size
             # of an AttributePath, as well as the size of the payload for the MTU. See Issue #43083

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 #    Copyright (c) 2026 Project CHIP Authors
 #    All rights reserved.

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -53,6 +53,7 @@ from matter.exceptions import ChipStackError
 
 log = logging.getLogger(__name__)
 
+
 class TC_IDM_2_3(BasicCompositionTests):
 
     def __init__(self, *args, **kwargs):
@@ -128,7 +129,8 @@ class TC_IDM_2_3(BasicCompositionTests):
 
         if not all_paths:
             # Fallback for empty devices (unlikely)
-            all_paths = [AttributePath(EndpointId=0, ClusterId=Clusters.BasicInformation.id, AttributeId=Clusters.BasicInformation.Attributes.NodeLabel.attribute_id)]
+            all_paths = [AttributePath(EndpointId=0, ClusterId=Clusters.BasicInformation.id,
+                                       AttributeId=Clusters.BasicInformation.Attributes.NodeLabel.attribute_id)]
 
         # Step 3: Read max number of paths
         self.step(3)
@@ -160,11 +162,13 @@ class TC_IDM_2_3(BasicCompositionTests):
                 else:
                     break
             if num_paths_reduced < num_paths:
-                log.info(f"Reduced number of paths from maximum reported of {num_paths} to {num_paths_reduced} to fit the request in one MTU")
+                log.info(
+                    f"Reduced number of paths from maximum reported of {num_paths} to {num_paths_reduced} to fit the request in one MTU")
             return response
 
         read_response = await conduct_request_with_potential_path_size_reduction(read_paths, num_read_paths_supported, read_request)
-        asserts.assert_is_not_none(read_response, "No response returned from read request. Ensure the number of paths in request is valid.")
+        asserts.assert_is_not_none(
+            read_response, "No response returned from read request. Ensure the number of paths in request is valid.")
         self.verify_paths_in_response(read_paths, read_response.tlvAttributes)
         log.info("Successfully completed read request")
 
@@ -177,7 +181,8 @@ class TC_IDM_2_3(BasicCompositionTests):
         )
 
         sub_paths = self.get_paths(num_subscribe_paths_supported, all_paths)
-        sub_paths[0] = AttributePath(EndpointId=0, ClusterId=Clusters.BasicInformation.id, AttributeId=Clusters.BasicInformation.Attributes.NodeLabel.attribute_id)
+        sub_paths[0] = AttributePath(EndpointId=0, ClusterId=Clusters.BasicInformation.id,
+                                     AttributeId=Clusters.BasicInformation.Attributes.NodeLabel.attribute_id)
 
         handler = AttributeSubscriptionHandler(
             expected_cluster=Clusters.BasicInformation,
@@ -194,7 +199,8 @@ class TC_IDM_2_3(BasicCompositionTests):
             )
 
         sub_transaction = await conduct_request_with_potential_path_size_reduction(sub_paths, num_subscribe_paths_supported, subscribe_request)
-        asserts.assert_is_not_none(sub_transaction, "No response returned from subscribe request. Ensure the number of paths in request is valid.")
+        asserts.assert_is_not_none(
+            sub_transaction, "No response returned from subscribe request. Ensure the number of paths in request is valid.")
         log.info("Successfully completed subscribe request")
         sub_transaction.SetAttributeUpdateCallback(handler)
 
@@ -221,6 +227,7 @@ class TC_IDM_2_3(BasicCompositionTests):
         )
 
         log.info("Successfully subscribed and verified report sequence.")
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -22,7 +22,7 @@
 # test-runner-runs:
 #   run1:
 #     app: ${ALL_DEVICES_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-args: --device contact-sensor --discriminator 1234 --KVS kvs1
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network
@@ -163,6 +163,7 @@ class TC_IDM_2_3(BasicCompositionTests):
             # of an AttributePath, as well as the size of the payload for the MTU. See Issue #43083
             if num_paths > MAX_NUM_PATHS_IN_MTU:
                 paths[:] = paths[:MAX_NUM_PATHS_IN_MTU]
+                log.info(f"Reduced number of paths used from {num_paths} to {MAX_NUM_PATHS_IN_MTU}")
             return await request_function(paths)
 
         read_response = await conduct_request_with_potential_path_size_reduction(read_paths, num_read_paths_supported, read_request)

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -212,7 +212,7 @@ class TC_IDM_2_3(BasicCompositionTests):
             endpoint_id=0
         )
 
-        # Verify the sequence: [Priming Report (initial), Subscription Update (new)]
+        # Verify change of NodeLabel received.
         handler.await_sequence_of_reports(
             attribute=Clusters.BasicInformation.Attributes.NodeLabel,
             sequence=[new_label],

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -37,21 +37,17 @@
 # === END CI TEST ARGUMENTS ===
 
 import logging
-import queue
 
 from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.clusters.Attribute import AttributePath
-from matter.interaction_model import InteractionModelError
 from matter.testing import global_attribute_ids
 from matter.testing.basic_composition import BasicCompositionTests
 from matter.testing.decorators import async_test_body
 from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
 from matter.testing.matter_testing import AttributeValue
 from matter.testing.runner import TestStep, default_matter_test_main
-from matter.ChipDeviceCtrl import TransportPayloadCapability
-from TC_SC_3_6 import AttributeChangeAccumulator
 from matter.exceptions import ChipStackError
 
 
@@ -66,7 +62,7 @@ class TC_IDM_2_3(BasicCompositionTests):
     @property
     def default_timeout(self) -> int:
         return 600
-    
+
     def steps_TC_IDM_2_3(self) -> list[TestStep]:
         return [
             TestStep(1, "TH reads from the DUT the CapabilityMinima attribute from the Basic Information Cluster."),
@@ -81,12 +77,12 @@ class TC_IDM_2_3(BasicCompositionTests):
             endpoint_id = path.EndpointId
             cluster_id = path.ClusterId
             attribute_id = path.AttributeId
-            
-            asserts.assert_in(endpoint_id, response_tlv, 
+
+            asserts.assert_in(endpoint_id, response_tlv,
                               f"Endpoint {endpoint_id} missing in response")
-            asserts.assert_in(cluster_id, response_tlv[endpoint_id], 
+            asserts.assert_in(cluster_id, response_tlv[endpoint_id],
                               f"Cluster {cluster_id} missing in response for endpoint {endpoint_id}")
-            asserts.assert_in(attribute_id, response_tlv[endpoint_id][cluster_id], 
+            asserts.assert_in(attribute_id, response_tlv[endpoint_id][cluster_id],
                               f"Attribute {attribute_id} missing in response for endpoint {endpoint_id}, cluster {cluster_id}")
 
     def get_paths(self, count, all_paths):
@@ -97,7 +93,7 @@ class TC_IDM_2_3(BasicCompositionTests):
             path_index = i % num_available_paths
             path_list.append(all_paths[path_index])
         return path_list
-    
+
     @async_test_body
     async def test_TC_IDM_2_3(self):
         # Setup class helper performs wildcard read and populates self.endpoints_tlv
@@ -106,14 +102,14 @@ class TC_IDM_2_3(BasicCompositionTests):
         # Step 1: CapabilityMinima
         self.step(1)
         capability_minima = await self.read_single_attribute_check_success(
-            cluster=Clusters.BasicInformation, 
+            cluster=Clusters.BasicInformation,
             attribute=Clusters.BasicInformation.Attributes.CapabilityMinima
         )
-        
+
         # Extract values, providing defaults if optional fields are missing
         num_read_paths_supported = capability_minima.readPathsSupported if capability_minima.readPathsSupported is not None else 1
         num_subscribe_paths_supported = capability_minima.subscribePathsSupported if capability_minima.subscribePathsSupported is not None else 1
-        
+
         log.info(f"CapabilityMinima: readPathsSupported={num_read_paths_supported}, "
                  f"subscribePathsSupported={num_subscribe_paths_supported}")
 
@@ -129,7 +125,7 @@ class TC_IDM_2_3(BasicCompositionTests):
                 if attr_list:
                     for attr_id in attr_list:
                         all_paths.append(AttributePath(EndpointId=endpoint_id, ClusterId=cluster_id, AttributeId=attr_id))
-        
+
         if not all_paths:
             # Fallback for empty devices (unlikely)
             all_paths = [AttributePath(EndpointId=0, ClusterId=Clusters.BasicInformation.id, AttributeId=Clusters.BasicInformation.Attributes.NodeLabel.attribute_id)]
@@ -143,8 +139,8 @@ class TC_IDM_2_3(BasicCompositionTests):
             return await self.default_controller.Read(self.dut_node_id, paths)
 
         # Read requests must fit into 1 MTU, as reads cannot be chained acrross multiple packets. If a device reports
-        # a number of read paths (or subscription paths) larger than what is possible on the controller side, we need to 
-        # reduce the number of paths here to be as much as can fit in the request. This requires some trial and error to 
+        # a number of read paths (or subscription paths) larger than what is possible on the controller side, we need to
+        # reduce the number of paths here to be as much as can fit in the request. This requires some trial and error to
         # see what size works. AttributePath objects can vary slightly in size, so this isn't a fixed number of paths.
         async def conduct_request_with_potential_path_size_reduction(paths, num_paths, request_function):
             num_paths_reduced = num_paths
@@ -154,7 +150,7 @@ class TC_IDM_2_3(BasicCompositionTests):
                     paths[:] = paths[:num_paths_reduced]
                     response = await request_function(paths)
                 except ChipStackError as e:
-                    # Check for CHIP Error 0x0000000B No memory - Thrown when request is too large for 1 MTU 
+                    # Check for CHIP Error 0x0000000B No memory - Thrown when request is too large for 1 MTU
                     if e.err == 11:
                         num_paths_reduced -= 1
                     else:
@@ -170,7 +166,7 @@ class TC_IDM_2_3(BasicCompositionTests):
         read_response = await conduct_request_with_potential_path_size_reduction(read_paths, num_read_paths_supported, read_request)
         asserts.assert_is_not_none(read_response, "No response returned from read request. Ensure the number of paths in request is valid.")
         self.verify_paths_in_response(read_paths, read_response.tlvAttributes)
-        log.info(f"Successfully completed read request")
+        log.info("Successfully completed read request")
 
         # Step 4: Subscribe with max paths in a single request
         self.step(4)
@@ -224,7 +220,7 @@ class TC_IDM_2_3(BasicCompositionTests):
             timeout_sec=10
         )
 
-        log.info(f"Successfully subscribed and verified report sequence.")
-        
+        log.info("Successfully subscribed and verified report sequence.")
+
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -106,19 +106,26 @@ class TC_IDM_2_3(BasicCompositionTests):
             attribute=Clusters.BasicInformation.Attributes.ClusterRevision
         )
         
-        # Default values, used for older cluster revisions where these values aren't specified
+        # Default values for number of read paths and subscribe paths
         num_read_paths_supported = 9
         num_subscribe_paths_supported = 3
 
-        if cluster_revision >= 6:
-            capability_minima = await self.read_single_attribute_check_success(
-                cluster=Clusters.BasicInformation,
-                attribute=Clusters.BasicInformation.Attributes.CapabilityMinima
-            )
+        capability_minima = await self.read_single_attribute_check_success(
+            cluster=Clusters.BasicInformation,
+            attribute=Clusters.BasicInformation.Attributes.CapabilityMinima
+        )
 
+        if cluster_revision >= 6:
+            asserts.assert_is_not_none(capability_minima.readPathsSupported,
+                                        "ReadPathsSupported should be present when ClusterRevision >= 6")
+            asserts.assert_is_not_none(capability_minima.subscribePathsSupported,
+                                        "SubscribePathsSupported should be present when ClusterRevision >= 6")
+            
             # Extract values, providing defaults if optional fields are missing
             num_read_paths_supported = capability_minima.readPathsSupported
             num_subscribe_paths_supported = capability_minima.subscribePathsSupported
+        else:
+            log.info("Basic Information Cluster revision is less than 6, read paths and subscribe paths are not part of CapabilityMinima struct.")
 
         log.info(f"CapabilityMinima: readPathsSupported={num_read_paths_supported}, "
                  f"subscribePathsSupported={num_subscribe_paths_supported}")

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -206,7 +206,11 @@ class TC_IDM_2_3(BasicCompositionTests):
         sub_transaction.SetAttributeUpdateCallback(handler)
 
         # Write new NodeLabel to trigger a subscription report
-        new_label = initial_node_label + "_Updated"
+        # Generate a new label guaranteed different from initial state.
+        import random
+        new_label = initial_node_label
+        while new_label == initial_node_label:
+            new_label = str(random.randint(0, 999999))
         await self.write_single_attribute(
             Clusters.BasicInformation.Attributes.NodeLabel(value=new_label),
             endpoint_id=0

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -42,14 +42,13 @@ from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.clusters.Attribute import AttributePath
+from matter.exceptions import ChipStackError
 from matter.testing import global_attribute_ids
 from matter.testing.basic_composition import BasicCompositionTests
 from matter.testing.decorators import async_test_body
 from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
 from matter.testing.matter_testing import AttributeValue
 from matter.testing.runner import TestStep, default_matter_test_main
-from matter.exceptions import ChipStackError
-
 
 log = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -150,9 +150,9 @@ class TC_IDM_2_3(BasicCompositionTests):
                 try:
                     paths[:] = paths[:num_paths_reduced]
                     response = await request_function(paths)
-                except ChipStackError as e:
+                except ChipStackError as e: # chipstack-ok: This check is needed to try and build a request until it's a valid size
                     # Check for CHIP Error 0x0000000B No memory - Thrown when request is too large for 1 MTU
-                    if e.err == 11:
+                    if e.err == 0x0000000B:
                         num_paths_reduced -= 1
                     else:
                         raise e

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -150,7 +150,7 @@ class TC_IDM_2_3(BasicCompositionTests):
                 try:
                     paths[:] = paths[:num_paths_reduced]
                     response = await request_function(paths)
-                except ChipStackError as e: # chipstack-ok: This check is needed to try and build a request until it's a valid size
+                except ChipStackError as e:  # chipstack-ok: This check is needed to try and build a request until it's a valid size
                     # Check for CHIP Error 0x0000000B No memory - Thrown when request is too large for 1 MTU
                     if e.err == 0x0000000B:
                         num_paths_reduced -= 1

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -34,7 +34,7 @@
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
-
+#
 import logging
 
 from mobly import asserts

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -34,7 +34,7 @@
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
-#
+
 import logging
 
 from mobly import asserts

--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import logging
+import queue
+
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters.Attribute import AttributePath
+from matter.interaction_model import InteractionModelError
+from matter.testing import global_attribute_ids
+from matter.testing.basic_composition import BasicCompositionTests
+from matter.testing.decorators import async_test_body
+from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
+from matter.testing.matter_testing import AttributeValue
+from matter.testing.runner import TestStep, default_matter_test_main
+from matter.ChipDeviceCtrl import TransportPayloadCapability
+from TC_SC_3_6 import AttributeChangeAccumulator
+from matter.exceptions import ChipStackError
+
+
+log = logging.getLogger(__name__)
+
+class TC_IDM_2_3(BasicCompositionTests):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.endpoint = 0
+
+    @property
+    def default_timeout(self) -> int:
+        return 600
+    
+    def steps_TC_IDM_2_3(self) -> list[TestStep]:
+        return [
+            TestStep(1, "TH reads from the DUT the CapabilityMinima attribute from the Basic Information Cluster."),
+            TestStep(2, "TH reads from the DUT all attributes from all clusters on all endpoints, to collect valid AttributePaths."),
+            TestStep(3, "TH sends a Read Request Message to the DUT with a number of paths up to the ReadPathsSupported value."),
+            TestStep(4, "TH sends a Subscribe Request Message to the DUT with a number of paths up to the SubscribePathsSupported value. TH then modifies one of the subscribed attributes and waits for a Report Data Action."),
+        ]
+
+    def verify_paths_in_response(self, requested_paths, response_tlv):
+        """Helper to verify that all requested paths are present in the response TLV data."""
+        for path in requested_paths:
+            endpoint_id = path.EndpointId
+            cluster_id = path.ClusterId
+            attribute_id = path.AttributeId
+            
+            asserts.assert_in(endpoint_id, response_tlv, 
+                              f"Endpoint {endpoint_id} missing in response")
+            asserts.assert_in(cluster_id, response_tlv[endpoint_id], 
+                              f"Cluster {cluster_id} missing in response for endpoint {endpoint_id}")
+            asserts.assert_in(attribute_id, response_tlv[endpoint_id][cluster_id], 
+                              f"Attribute {attribute_id} missing in response for endpoint {endpoint_id}, cluster {cluster_id}")
+
+    def get_paths(self, count, all_paths):
+        path_list = []
+        num_available_paths = len(all_paths)
+        for i in range(count):
+            # Use modulo to wrap around if count > num_available_paths
+            path_index = i % num_available_paths
+            path_list.append(all_paths[path_index])
+        return path_list
+    
+    @async_test_body
+    async def test_TC_IDM_2_3(self):
+        # Setup class helper performs wildcard read and populates self.endpoints_tlv
+        await self.setup_class_helper(allow_pase=False)
+
+        # Step 1: CapabilityMinima
+        self.step(1)
+        capability_minima = await self.read_single_attribute_check_success(
+            cluster=Clusters.BasicInformation, 
+            attribute=Clusters.BasicInformation.Attributes.CapabilityMinima
+        )
+        
+        # Extract values, providing defaults if optional fields are missing
+        num_read_paths_supported = capability_minima.readPathsSupported if capability_minima.readPathsSupported is not None else 1
+        num_subscribe_paths_supported = capability_minima.subscribePathsSupported if capability_minima.subscribePathsSupported is not None else 1
+        
+        log.info(f"CapabilityMinima: readPathsSupported={num_read_paths_supported}, "
+                 f"subscribePathsSupported={num_subscribe_paths_supported}")
+
+        # Step 2: Collect available paths
+        self.step(2)
+        all_paths = []
+        for endpoint_id, clusters in self.endpoints_tlv.items():
+            for cluster_id, cluster_data in clusters.items():
+                if global_attribute_ids.cluster_id_type(cluster_id) != global_attribute_ids.ClusterIdType.kStandard:
+                    continue
+                # Use Global Attribute List to find valid attributes
+                attr_list = cluster_data.get(global_attribute_ids.GlobalAttributeIds.ATTRIBUTE_LIST_ID)
+                if attr_list:
+                    for attr_id in attr_list:
+                        all_paths.append(AttributePath(EndpointId=endpoint_id, ClusterId=cluster_id, AttributeId=attr_id))
+        
+        if not all_paths:
+            # Fallback for empty devices (unlikely)
+            all_paths = [AttributePath(EndpointId=0, ClusterId=Clusters.BasicInformation.id, AttributeId=Clusters.BasicInformation.Attributes.NodeLabel.attribute_id)]
+
+        # Step 3: Read max number of paths
+        self.step(3)
+        read_paths = self.get_paths(num_read_paths_supported, all_paths)
+
+        async def read_request(paths):
+            log.info("Conducting read request")
+            return await self.default_controller.Read(self.dut_node_id, paths)
+
+        # Read requests must fit into 1 MTU, as reads cannot be chained acrross multiple packets. If a device reports
+        # a number of read paths (or subscription paths) larger than what is possible on the controller side, we need to 
+        # reduce the number of paths here to be as much as can fit in the request. This requires some trial and error to 
+        # see what size works. AttributePath objects can vary slightly in size, so this isn't a fixed number of paths.
+        async def conduct_request_with_potential_path_size_reduction(paths, num_paths, request_function):
+            num_paths_reduced = num_paths
+            response = None
+            while num_paths_reduced > 0:
+                try:
+                    paths[:] = paths[:num_paths_reduced]
+                    response = await request_function(paths)
+                except ChipStackError as e:
+                    # Check for CHIP Error 0x0000000B No memory - Thrown when request is too large for 1 MTU 
+                    if e.err == 11:
+                        num_paths_reduced -= 1
+                    else:
+                        raise e
+                except Exception as e:
+                    raise e
+                else:
+                    break
+            if num_paths_reduced < num_paths:
+                log.info(f"Reduced number of paths from maximum reported of {num_paths} to {num_paths_reduced} to fit the request in one MTU")
+            return response
+
+        read_response = await conduct_request_with_potential_path_size_reduction(read_paths, num_read_paths_supported, read_request)
+        asserts.assert_is_not_none(read_response, "No response returned from read request. Ensure the number of paths in request is valid.")
+        self.verify_paths_in_response(read_paths, read_response.tlvAttributes)
+        log.info(f"Successfully completed read request")
+
+        # Step 4: Subscribe with max paths in a single request
+        self.step(4)
+
+        initial_node_label = await self.read_single_attribute_check_success(
+            cluster=Clusters.BasicInformation,
+            attribute=Clusters.BasicInformation.Attributes.NodeLabel
+        )
+
+        sub_paths = self.get_paths(num_subscribe_paths_supported, all_paths)
+        sub_paths[0] = AttributePath(EndpointId=0, ClusterId=Clusters.BasicInformation.id, AttributeId=Clusters.BasicInformation.Attributes.NodeLabel.attribute_id)
+
+        handler = AttributeSubscriptionHandler(
+            expected_cluster=Clusters.BasicInformation,
+            expected_attribute=Clusters.BasicInformation.Attributes.NodeLabel
+        )
+
+        async def subscribe_request(paths):
+            log.info("Conducting subscribe request")
+            return await self.default_controller.Read(
+                self.dut_node_id,
+                paths,
+                reportInterval=(1, 1000),
+                keepSubscriptions=False
+            )
+
+        sub_transaction = await conduct_request_with_potential_path_size_reduction(sub_paths, num_subscribe_paths_supported, subscribe_request)
+        asserts.assert_is_not_none(sub_transaction, "No response returned from subscribe request. Ensure the number of paths in request is valid.")
+        log.info("Successfully completed subscribe request")
+        sub_transaction.SetAttributeUpdateCallback(handler)
+
+        # Manually add the priming report value to the handler's queue.
+        # The priming report was received during the Read call, before the callback was set.
+        handler.attribute_queue.put(AttributeValue(
+            endpoint_id=0,
+            attribute=Clusters.BasicInformation.Attributes.NodeLabel,
+            value=initial_node_label
+        ))
+
+        # Write new NodeLabel to trigger a subscription report
+        new_label = initial_node_label + "_Updated"
+        await self.write_single_attribute(
+            Clusters.BasicInformation.Attributes.NodeLabel(value=new_label),
+            endpoint_id=0
+        )
+
+        # Verify the sequence: [Priming Report (initial), Subscription Update (new)]
+        handler.await_sequence_of_reports(
+            attribute=Clusters.BasicInformation.Attributes.NodeLabel,
+            sequence=[initial_node_label, new_label],
+            timeout_sec=10
+        )
+
+        log.info(f"Successfully subscribed and verified report sequence.")
+        
+if __name__ == "__main__":
+    default_matter_test_main()


### PR DESCRIPTION
#### Summary

This PR adds a new test `TC_IDM_2_3`. The test ensures that the maximum number of read and subscribe paths a device reports from the capability minima struct of the basic information cluster can actually be supported by the device under test. The test will create a read request and subscribe request with the number of paths the device reports.

#### Related issues
#41824 

#### Testing

- Ran this test with the arguments listed at the top of the file
- All other tests should pass and be unaffected by this PR