### PR TITLE
Fix compiler warning on auto-release in NetworkComissioning cluster for `-Wctad-maybe-unsupported`.

### DIFF
--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -1165,8 +1165,7 @@ CHIP_ERROR NetworkCommissioningCluster::AcceptedCommands(const ConcreteClusterPa
     }
     else
 #endif // (CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP)
-    {
-    }
+    {}
 
     if (Features().Has(Feature::kPerDeviceCredentials))
     {
@@ -1244,8 +1243,7 @@ CHIP_ERROR NetworkCommissioningCluster::Attributes(const ConcreteClusterPath & p
     }
     else
 #endif // (CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP)
-    {
-    }
+    {}
 
     return attributeListBuilder.Append(Span(kMandatoryMetadata), Span(kOptionalAttributes), optionalAttributes);
 }

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -38,6 +38,7 @@
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
+#include <lib/support/AutoRelease.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/SortUtils.h>
@@ -107,30 +108,6 @@ BitFlags<Feature> WiFiFeatures(WiFiDriver * driver)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
     return features;
 }
-
-/// Performs an auto-release of the given item, generally an `Iterator` type
-/// like Wifi or Thread scan results.
-template <typename T>
-class AutoRelease
-{
-public:
-    AutoRelease(const AutoRelease &)             = delete;
-    AutoRelease & operator=(const AutoRelease &) = delete;
-    AutoRelease & operator=(AutoRelease &&)      = delete;
-
-    AutoRelease(AutoRelease && other) : mValue(other.mValue) { other.mValue = nullptr; }
-    AutoRelease(T * iterator) : mValue(iterator) {}
-    ~AutoRelease()
-    {
-        if (mValue != nullptr)
-        {
-            mValue->Release();
-        }
-    }
-
-private:
-    T * mValue;
-};
 
 // avoid `-Wctad-maybe-unsupported` error
 template <typename T>

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -116,9 +116,9 @@ class AutoRelease
 public:
     AutoRelease(const AutoRelease &)             = delete;
     AutoRelease & operator=(const AutoRelease &) = delete;
+    AutoRelease & operator=(AutoRelease &&)      = delete;
 
-    AutoRelease(AutoRelease &&)             = default;
-    AutoRelease & operator=(AutoRelease &&) = default;
+    AutoRelease(AutoRelease && other) : mValue(other.mValue) { other.mValue = nullptr; }
     AutoRelease(T * iterator) : mValue(iterator) {}
     ~AutoRelease()
     {
@@ -1188,7 +1188,8 @@ CHIP_ERROR NetworkCommissioningCluster::AcceptedCommands(const ConcreteClusterPa
     }
     else
 #endif // (CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP)
-    {}
+    {
+    }
 
     if (Features().Has(Feature::kPerDeviceCredentials))
     {
@@ -1266,7 +1267,8 @@ CHIP_ERROR NetworkCommissioningCluster::Attributes(const ConcreteClusterPath & p
     }
     else
 #endif // (CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP)
-    {}
+    {
+    }
 
     return attributeListBuilder.Append(Span(kMandatoryMetadata), Span(kOptionalAttributes), optionalAttributes);
 }

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -130,7 +130,7 @@ private:
 // avoid `-Wctad-maybe-unsupported` error
 struct AllowCTAD;
 
-// A dummy deduction guide, which is never slected because the struct is incomplete
+// A dummy deduction guide, which is never selected because the struct is incomplete
 [[maybe_unused]] AutoRelease(AllowCTAD) -> AutoRelease<void>;
 
 /// Convenience macro to auto-create a variable for you to release the given name at

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -109,16 +109,9 @@ BitFlags<Feature> WiFiFeatures(WiFiDriver * driver)
     return features;
 }
 
-// avoid `-Wctad-maybe-unsupported` error
-template <typename T>
-AutoRelease<T> MakeAutoRelease(T * iterator)
-{
-    return AutoRelease<T>(iterator);
-}
-
 /// Convenience macro to auto-create a variable for you to release the given name at
 /// the exit of the current scope.
-#define DEFER_AUTO_RELEASE(name) auto autoRelease##__COUNTER__ = MakeAutoRelease(name)
+#define DEFER_AUTO_RELEASE(name) AutoRelease autoRelease##__COUNTER__(name)
 
 } // namespace
 

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -114,11 +114,11 @@ template <typename T>
 class AutoRelease
 {
 public:
-    AutoRelease(const AutoRelease &) = delete;
-    AutoRelease& operator=(const AutoRelease &) = delete;
+    AutoRelease(const AutoRelease &)             = delete;
+    AutoRelease & operator=(const AutoRelease &) = delete;
 
-    AutoRelease(AutoRelease &&) = default;
-    AutoRelease& operator=(AutoRelease &&) = default;
+    AutoRelease(AutoRelease &&)             = default;
+    AutoRelease & operator=(AutoRelease &&) = default;
     AutoRelease(T * iterator) : mValue(iterator) {}
     ~AutoRelease()
     {
@@ -133,8 +133,9 @@ private:
 };
 
 // avoid `-Wctad-maybe-unsupported` error
-template<typename T>
-AutoRelease<T> MakeAutoRelease(T *iterator) {
+template <typename T>
+AutoRelease<T> MakeAutoRelease(T * iterator)
+{
     return AutoRelease<T>(iterator);
 }
 

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -127,6 +127,12 @@ private:
     T * mValue;
 };
 
+// avoid `-Wctad-maybe-unsupported` error
+struct AllowCTAD;
+
+// A dummy deduction guide, which is never slected because the struct is incomplete
+[[maybe_unused]] AutoRelease(AllowCTAD) -> AutoRelease<void>;
+
 /// Convenience macro to auto-create a variable for you to release the given name at
 /// the exit of the current scope.
 #define DEFER_AUTO_RELEASE(name) AutoRelease autoRelease##__COUNTER__(name)

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -114,6 +114,11 @@ template <typename T>
 class AutoRelease
 {
 public:
+    AutoRelease(const AutoRelease &) = delete;
+    AutoRelease& operator=(const AutoRelease &) = delete;
+
+    AutoRelease(AutoRelease &&) = default;
+    AutoRelease& operator=(AutoRelease &&) = default;
     AutoRelease(T * iterator) : mValue(iterator) {}
     ~AutoRelease()
     {
@@ -128,14 +133,14 @@ private:
 };
 
 // avoid `-Wctad-maybe-unsupported` error
-struct AllowCTAD;
-
-// A dummy deduction guide, which is never selected because the struct is incomplete
-[[maybe_unused]] AutoRelease(AllowCTAD) -> AutoRelease<void>;
+template<typename T>
+AutoRelease<T> MakeAutoRelease(T *iterator) {
+    return AutoRelease<T>(iterator);
+}
 
 /// Convenience macro to auto-create a variable for you to release the given name at
 /// the exit of the current scope.
-#define DEFER_AUTO_RELEASE(name) AutoRelease autoRelease##__COUNTER__(name)
+#define DEFER_AUTO_RELEASE(name) auto autoRelease##__COUNTER__ = MakeAutoRelease(name)
 
 } // namespace
 

--- a/src/lib/support/AutoRelease.h
+++ b/src/lib/support/AutoRelease.h
@@ -45,8 +45,13 @@ public:
     AutoRelease(AutoRelease && other) : mReleasable(other.mReleasable) { other.mReleasable = nullptr; }
     AutoRelease & operator=(AutoRelease && other)
     {
-        Set(other.mReleasable);
-        other.mReleasable = nullptr;
+        if (this != &other)
+        {
+            Release();
+            mReleasable       = other.mReleasable;
+            other.mReleasable = nullptr;
+        }
+        return *this;
     }
 
     inline Releasable * operator->() { return mReleasable; }

--- a/src/lib/support/AutoRelease.h
+++ b/src/lib/support/AutoRelease.h
@@ -38,12 +38,16 @@ public:
     AutoRelease(Releasable * releasable) : mReleasable(releasable) {}
     ~AutoRelease() { Release(); }
 
-    // Not copyable or movable
+    // Not copyable
     AutoRelease(const AutoRelease &)             = delete;
     AutoRelease & operator=(const AutoRelease &) = delete;
-    AutoRelease & operator=(AutoRelease &&)      = delete;
 
     AutoRelease(AutoRelease && other) : mReleasable(other.mReleasable) { other.mReleasable = nullptr; }
+    AutoRelease & operator=(AutoRelease && other)
+    {
+        Set(other.mReleasable);
+        other.mReleasable = nullptr;
+    }
 
     inline Releasable * operator->() { return mReleasable; }
     inline const Releasable * operator->() const { return mReleasable; }

--- a/src/lib/support/AutoRelease.h
+++ b/src/lib/support/AutoRelease.h
@@ -77,4 +77,8 @@ protected:
     Releasable * mReleasable = nullptr;
 };
 
+// Template deduction guides to allow auto-release creation from pointers
+template <class T>
+AutoRelease(T * releasable) -> AutoRelease<T>;
+
 } // namespace chip

--- a/src/lib/support/AutoRelease.h
+++ b/src/lib/support/AutoRelease.h
@@ -40,8 +40,10 @@ public:
 
     // Not copyable or movable
     AutoRelease(const AutoRelease &)             = delete;
-    AutoRelease(const AutoRelease &&)            = delete;
     AutoRelease & operator=(const AutoRelease &) = delete;
+    AutoRelease & operator=(AutoRelease &&)      = delete;
+
+    AutoRelease(AutoRelease && other) : mReleasable(other.mReleasable) { other.mReleasable = nullptr; }
 
     inline Releasable * operator->() { return mReleasable; }
     inline const Releasable * operator->() const { return mReleasable; }

--- a/src/lib/support/tests/TestAutoRelease.cpp
+++ b/src/lib/support/tests/TestAutoRelease.cpp
@@ -100,7 +100,7 @@ TEST_F(TestAutoRelease, TestMove)
         EXPECT_EQ(releasable.Counter(), 1);
 
         // move
-        AutoRelease<TestCounterRelease> r2{std::move(r1)};
+        AutoRelease<TestCounterRelease> r2{ std::move(r1) };
         EXPECT_EQ(releasable.Counter(), 1);
 
         AutoRelease<TestCounterRelease> r3(&releasable2);

--- a/src/lib/support/tests/TestAutoRelease.cpp
+++ b/src/lib/support/tests/TestAutoRelease.cpp
@@ -100,7 +100,7 @@ TEST_F(TestAutoRelease, TestMove)
         EXPECT_EQ(releasable.Counter(), 1);
 
         // move
-        AutoRelease<TestCounterRelease> r2 = std::move(r1);
+        AutoRelease<TestCounterRelease> r2{std::move(r1)};
         EXPECT_EQ(releasable.Counter(), 1);
 
         AutoRelease<TestCounterRelease> r3(&releasable2);

--- a/src/lib/support/tests/TestAutoRelease.cpp
+++ b/src/lib/support/tests/TestAutoRelease.cpp
@@ -88,4 +88,35 @@ TEST_F(TestAutoRelease, TestOperators)
     EXPECT_TRUE(other.IsNull());
 }
 
+TEST_F(TestAutoRelease, TestMove)
+{
+    TestCounterRelease releasable;
+    TestCounterRelease releasable2;
+
+    EXPECT_EQ(releasable.Counter(), 1);
+    EXPECT_EQ(releasable2.Counter(), 1);
+    {
+        AutoRelease r1(&releasable); // template type should be auto-detected for pointers
+        EXPECT_EQ(releasable.Counter(), 1);
+
+        // move
+        AutoRelease<TestCounterRelease> r2 = std::move(r1);
+        EXPECT_EQ(releasable.Counter(), 1);
+
+        AutoRelease<TestCounterRelease> r3(&releasable2);
+        EXPECT_EQ(releasable.Counter(), 1);
+        EXPECT_EQ(releasable2.Counter(), 1);
+
+        r3 = std::move(r2);
+
+        // all still in scope and we only moved (so only one reference)
+        EXPECT_EQ(releasable.Counter(), 1);
+        EXPECT_EQ(releasable2.Counter(), 1);
+    }
+
+    // cleanup done
+    EXPECT_EQ(releasable.Counter(), 0);
+    EXPECT_EQ(releasable2.Counter(), 0);
+}
+
 } // namespace

--- a/src/lib/support/tests/TestAutoRelease.cpp
+++ b/src/lib/support/tests/TestAutoRelease.cpp
@@ -109,9 +109,9 @@ TEST_F(TestAutoRelease, TestMove)
 
         r3 = std::move(r2);
 
-        // all still in scope and we only moved (so only one reference)
+        // relesable2 was released, since r3 took over releasable
         EXPECT_EQ(releasable.Counter(), 1);
-        EXPECT_EQ(releasable2.Counter(), 1);
+        EXPECT_EQ(releasable2.Counter(), 0);
     }
 
     // cleanup done

--- a/src/lib/support/tests/TestAutoRelease.cpp
+++ b/src/lib/support/tests/TestAutoRelease.cpp
@@ -109,7 +109,7 @@ TEST_F(TestAutoRelease, TestMove)
 
         r3 = std::move(r2);
 
-        // relesable2 was released, since r3 took over releasable
+        // r3 now owns releasable, and releasable2 should have been released by the move-assignment.
         EXPECT_EQ(releasable.Counter(), 1);
         EXPECT_EQ(releasable2.Counter(), 0);
     }


### PR DESCRIPTION
#### Summary

Without this, we can get:

```
error: 'AutoRelease' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]
  887 |     DEFER_AUTO_RELEASE(networks);
note: expanded from macro 'DEFER_AUTO_RELEASE'
  132 | #define DEFER_AUTO_RELEASE(name) AutoRelease autoRelease##__COUNTER__(name)
      |                                  ^
note: add a deduction guide to suppress this warning
  114 | class AutoRelease
      |       ^
```

#### Testing

I enabled `-Wctad-maybe-unsupported` locally and this fixed compilation.
CI will validate that this does not break other things (I do not expect it to).