### PR TITLE
CI: Disabling TC_ACL_2_10.py due to flakiness

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -194,6 +194,10 @@ not_automated:
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.
+    - name: TC_ACL_2_10.py
+      reason:
+          Flaky, see
+          https://github.com/project-chip/connectedhomeip/issues/43056
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially


### PR DESCRIPTION
#### Summary

- Test has been very flaky lately, it was the case a while ago, disabling as advised by team
- Ticket with logs: https://github.com/project-chip/connectedhomeip/issues/43056

#### Testing

- CI Testing 