### PR TITLE
Disable flaky tests in CI.

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -25,6 +25,10 @@ not_automated:
       reason:
           AVSM flaky test in CI.
           https://github.com/project-chip/connectedhomeip/issues/42871
+    - name: TC_AVSM_2_21.py
+      reason:
+          AVSM flaky test in CI.
+          https://github.com/project-chip/connectedhomeip/issues/42871
     - name: TC_BRBINFO_3_1.py
       reason:
           Attribute is not implemented in the bridge app. Same code as

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -13,6 +13,18 @@ not_automated:
       reason: Code/Test not being used or not shared code for any other tests
     - name: TC_AVSMTestBase.py
       reason: Shared code for TC_AVSM, not a standalone test
+    - name: TC_AVSM_2_18.py
+      reason:
+          AVSM flaky test in CI.
+          https://github.com/project-chip/connectedhomeip/issues/42871
+    - name: TC_AVSM_2_19.py
+      reason:
+          AVSM flaky test in CI.
+          https://github.com/project-chip/connectedhomeip/issues/42871
+    - name: TC_AVSM_2_20.py
+      reason:
+          AVSM flaky test in CI.
+          https://github.com/project-chip/connectedhomeip/issues/42871
     - name: TC_BRBINFO_3_1.py
       reason:
           Attribute is not implemented in the bridge app. Same code as


### PR DESCRIPTION
#### Summary
Some of the new AVSM tests are showing some flakiness in CI builds. Disabling as a first step while they get investigated.

#### Testing
Ci sanity checks

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
