### PR TITLE
Fix incorrect error message from PushAvStreamTransportManager

### DIFF
--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -645,7 +645,7 @@ void PushAvStreamTransportManager::HandleZoneTrigger(uint16_t zoneId)
     for (auto & pavst : mTransportMap)
     {
         int connectionId = pavst.first;
-        ChipLogError(Camera, "PushAV sending trigger to connection ID %d", connectionId);
+        ChipLogProgress(Camera, "PushAV sending trigger to connection ID %d", connectionId);
 
         if (mTransportOptionsMap[connectionId].triggerOptions.triggerType == TransportTriggerTypeEnum::kMotion)
         {


### PR DESCRIPTION
#### Summary

During Zone Management cert test, I observed error message from PushAvStreamTransportManager, those are actaully good case.

#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
