### PR TITLE
Thread: disable security when Thread not started

### DIFF
--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -262,18 +262,8 @@ CHIP_ERROR UDPEndPointImplOT::SendMsgImpl(const IPPacketInfo * aPktInfo, System:
 
     LockOpenThread();
 
-    switch (otThreadGetDeviceRole(mOTInstance))
-    {
-    case OT_DEVICE_ROLE_DISABLED:
-    case OT_DEVICE_ROLE_DETACHED:
-        settings.mLinkSecurityEnabled = false;
-        break;
-    default:
-        settings.mLinkSecurityEnabled = true;
-        break;
-    }
-
-    settings.mPriority = OT_MESSAGE_PRIORITY_NORMAL;
+    settings.mPriority            = OT_MESSAGE_PRIORITY_NORMAL;
+    settings.mLinkSecurityEnabled = otThreadGetDeviceRole(mOTInstance) != OT_DEVICE_ROLE_DISABLED;
 
     message = otUdpNewMessage(mOTInstance, &settings);
     VerifyOrExit(message != NULL, error = OT_ERROR_NO_BUFS);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
@@ -298,7 +298,7 @@ err_t GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::SendPacket(struc
     // Note that at this point the LwIP core lock is also held.
     ThreadStackMgrImpl().LockThreadStack();
 
-    msgSettings.mLinkSecurityEnabled = otThreadGetDeviceRole(mOTInstance) != OT_DEVICE_ROLE_DISABLED;
+    msgSettings.mLinkSecurityEnabled = otThreadGetDeviceRole(ThreadStackMgrImpl().OTInstance()) != OT_DEVICE_ROLE_DISABLED;
     msgSettings.mPriority            = OT_MESSAGE_PRIORITY_NORMAL;
 
     // Allocate an OpenThread message

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
@@ -290,13 +290,16 @@ err_t GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::SendPacket(struc
 {
     err_t lwipErr = ERR_OK;
     otError otErr;
-    otMessage * pktMsg                  = NULL;
-    const otMessageSettings msgSettings = { true, OT_MESSAGE_PRIORITY_NORMAL };
+    otMessage * pktMsg            = NULL;
+    otMessageSettings msgSettings = {};
     uint16_t remainingLen;
 
     // Lock the OpenThread stack.
     // Note that at this point the LwIP core lock is also held.
     ThreadStackMgrImpl().LockThreadStack();
+
+    msgSettings.mLinkSecurityEnabled = otThreadGetDeviceRole(mOTInstance) != OT_DEVICE_ROLE_DISABLED;
+    msgSettings.mPriority            = OT_MESSAGE_PRIORITY_NORMAL;
 
     // Allocate an OpenThread message
     pktMsg = otIp6NewMessage(ThreadStackMgrImpl().OTInstance(), &msgSettings);


### PR DESCRIPTION
#### Summary

This commit disables sending messages with security enabled when Thread is disabled. This is needed by Matter commissioning over Thread, where the Matter layer needs to send messages when no Thread credentials are provisioned and Thread stack is not fully started yet.

#### Related issues

This is related to the Matter commissioning over Thread effort.

#### Testing

This issue is found when verifying Matter commissioning over Thread on Espressif platform, where lwip stack is used. This is verified on real device.