### PR TITLE
Remove some duplicate CI runs (only `--debug` added)

### DIFF
--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -20,7 +20,7 @@
 #
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
-#   run1: # Runs through all tests
+#   run1: # Runs through all tests with debug mode enabled (dumps attribute data on failure)
 #     app: ${ALL_CLUSTERS_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 #     script-args: >
@@ -29,6 +29,7 @@
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --debug
 #     factory-reset: true
 #     quiet: true
 #   run2: # tests PASE connection using manual code (12.1 only)
@@ -158,19 +159,17 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
 #     quiet: true
-#   run16: # Tests against all-devices-app - default (contactsensor) with debug mode enabled (dumps attribute data on failure)
+#   run16: # Tests against all-devices-app - default (contactsensor)
 #     app: ${ALL_DEVICES_APP}
 #     app-args: >
 #       --discriminator 1234
 #       --KVS kvs1
-#       --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --manual-code 10054912339
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#       --debug
 #     factory-reset: true
 #     quiet: true
 #   run17: # Tests against all-devices-app - on/off light

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -158,17 +158,19 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
 #     quiet: true
-#   run16: # Tests against all-devices-app - default (contactsensor)
+#   run16: # Tests against all-devices-app - default (contactsensor) with debug mode enabled (dumps attribute data on failure)
 #     app: ${ALL_DEVICES_APP}
 #     app-args: >
 #       --discriminator 1234
 #       --KVS kvs1
+#       --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --manual-code 10054912339
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --debug
 #     factory-reset: true
 #     quiet: true
 #   run17: # Tests against all-devices-app - on/off light
@@ -183,18 +185,6 @@
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#     factory-reset: true
-#     quiet: true
-#   run18: # Runs through all tests with debug mode enabled (dumps attribute data on failure)
-#     app: ${ALL_CLUSTERS_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
-#     script-args: >
-#       --storage-path admin_storage.json
-#       --manual-code 10054912339
-#       --PICS src/app/tests/suites/certification/ci-pics-values
-#       --trace-to json:${TRACE_TEST_JSON}.json
-#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#       --debug
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_DeviceConformance.py
+++ b/src/python_testing/TC_DeviceConformance.py
@@ -31,23 +31,10 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #       --tests test_TC_IDM_10_2 test_TC_IDM_10_6 test_TC_DESC_2_3 test_TC_IDM_14_1
-#     factory-reset: true
-#     quiet: true
-#   run2:
-#     app: ${CHIP_LOCK_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
-#     script-args: >
-#       --storage-path admin_storage.json
-#       --manual-code 10054912339
-#       --bool-arg ignore_in_progress:True allow_provisional:True
-#       --PICS src/app/tests/suites/certification/ci-pics-values
-#       --trace-to json:${TRACE_TEST_JSON}.json
-#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#       --tests test_TC_IDM_10_2 test_TC_IDM_10_6 test_TC_DESC_2_3 test_TC_IDM_14_1
 #       --debug
 #     factory-reset: true
 #     quiet: true
-#   run3:
+#   run2:
 #     app: ${ALL_DEVICES_APP}
 #     app-args: >
 #       --discriminator 1234


### PR DESCRIPTION
#### Summary

We seem to be running identical tests, the only difference since #41020 being the addition of `--debug`.

This removes the duplicate and only keeps one run with `--debug` enabled.

#### Testing

CI should validate 