### PR TITLE
IN-DEV: Synchronize access to CastingApp/CastingPlayer to avoid race conditions

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingApp.java
@@ -43,7 +43,8 @@ public final class CastingApp {
 
   private static CastingApp sInstance;
 
-  private CastingAppState mState = CastingAppState.UNINITIALIZED;
+  private volatile CastingAppState mState = CastingAppState.UNINITIALIZED;
+  private final Object mStateLock = new Object();
   private AppParameters appParameters;
   private NsdManagerServiceResolver.NsdManagerResolverAvailState nsdManagerResolverAvailState;
   private ChipAppServer chipAppServer;
@@ -65,42 +66,44 @@ public final class CastingApp {
    */
   public MatterError initialize(AppParameters appParameters) {
     Log.i(TAG, "CastingApp.initialize() called");
-    if (mState != CastingAppState.UNINITIALIZED) {
-      return MatterError.CHIP_ERROR_INCORRECT_STATE;
-    }
+    synchronized (mStateLock) {
+      if (mState != CastingAppState.UNINITIALIZED) {
+        return MatterError.CHIP_ERROR_INCORRECT_STATE;
+      }
 
-    this.appParameters = appParameters;
-    this.nsdManagerResolverAvailState =
-        new NsdManagerServiceResolver.NsdManagerResolverAvailState();
+      this.appParameters = appParameters;
+      this.nsdManagerResolverAvailState =
+          new NsdManagerServiceResolver.NsdManagerResolverAvailState();
 
-    Context applicationContext = appParameters.getApplicationContext();
-    chipPlatform =
-        new AndroidChipPlatform(
-            new AndroidBleManager(),
-            new AndroidNfcCommissioningManager(),
-            new PreferencesKeyValueStoreManager(appParameters.getApplicationContext()),
-            appParameters.getConfigurationManagerProvider().get(),
-            new NsdManagerServiceResolver(
-                applicationContext, nsdManagerResolverAvailState, RESOLVE_SERVICE_TIMEOUT),
-            new NsdManagerServiceBrowser(applicationContext, BROWSE_SERVICE_TIMEOUT),
-            new ChipMdnsCallbackImpl(),
-            new DiagnosticDataProviderImpl(applicationContext));
+      Context applicationContext = appParameters.getApplicationContext();
+      chipPlatform =
+          new AndroidChipPlatform(
+              new AndroidBleManager(),
+              new AndroidNfcCommissioningManager(),
+              new PreferencesKeyValueStoreManager(appParameters.getApplicationContext()),
+              appParameters.getConfigurationManagerProvider().get(),
+              new NsdManagerServiceResolver(
+                  applicationContext, nsdManagerResolverAvailState, RESOLVE_SERVICE_TIMEOUT),
+              new NsdManagerServiceBrowser(applicationContext, BROWSE_SERVICE_TIMEOUT),
+              new ChipMdnsCallbackImpl(),
+              new DiagnosticDataProviderImpl(applicationContext));
 
-    MatterError err = updateAndroidChipPlatformWithCommissionableData();
-    if (err.hasError()) {
-      Log.e(
-          TAG,
-          "CastingApp.initialize() failed to updateCommissionableDataProviderData() on AndroidChipPlatform");
+      MatterError err = updateAndroidChipPlatformWithCommissionableData();
+      if (err.hasError()) {
+        Log.e(
+            TAG,
+            "CastingApp.initialize() failed to updateCommissionableDataProviderData() on AndroidChipPlatform");
+        return err;
+      }
+
+      err = finishInitialization(appParameters);
+
+      if (err.hasNoError()) {
+        chipAppServer = new ChipAppServer(); // get a reference to the Matter server now
+        mState = CastingAppState.NOT_RUNNING; // initialization done, set state to NOT_RUNNING
+      }
       return err;
     }
-
-    err = finishInitialization(appParameters);
-
-    if (err.hasNoError()) {
-      chipAppServer = new ChipAppServer(); // get a reference to the Matter server now
-      mState = CastingAppState.NOT_RUNNING; // initialization done, set state to NOT_RUNNING
-    }
-    return err;
   }
 
   /**
@@ -136,21 +139,23 @@ public final class CastingApp {
    */
   public MatterError start() {
     Log.i(TAG, "CastingApp.start called");
-    if (mState != CastingAppState.NOT_RUNNING) {
-      return MatterError.CHIP_ERROR_INCORRECT_STATE;
-    }
+    synchronized (mStateLock) {
+      if (mState != CastingAppState.NOT_RUNNING) {
+        return MatterError.CHIP_ERROR_INCORRECT_STATE;
+      }
 
-    boolean serverStarted = chipAppServer.startApp();
-    if (!serverStarted) {
-      Log.e(TAG, "CastingApp.start failed to start Matter server");
-      return MatterError.CHIP_ERROR_INCORRECT_STATE;
-    }
+      boolean serverStarted = chipAppServer.startApp();
+      if (!serverStarted) {
+        Log.e(TAG, "CastingApp.start failed to start Matter server");
+        return MatterError.CHIP_ERROR_INCORRECT_STATE;
+      }
 
-    MatterError err = finishStartup();
-    if (err.hasNoError()) {
-      mState = CastingAppState.RUNNING; // CastingApp started successfully, set state to RUNNING
+      MatterError err = finishStartup();
+      if (err.hasNoError()) {
+        mState = CastingAppState.RUNNING; // CastingApp started successfully, set state to RUNNING
+      }
+      return err;
     }
-    return err;
   }
 
   /**
@@ -160,24 +165,49 @@ public final class CastingApp {
    */
   public MatterError stop() {
     Log.i(TAG, "CastingApp.stop called");
-    if (mState != CastingAppState.RUNNING) {
-      return MatterError.CHIP_ERROR_INCORRECT_STATE;
-    }
+    synchronized (mStateLock) {
+      if (mState != CastingAppState.RUNNING) {
+        return MatterError.CHIP_ERROR_INCORRECT_STATE;
+      }
 
-    boolean serverStopped = chipAppServer.stopApp();
-    if (!serverStopped) {
-      Log.e(TAG, "CastingApp.stop failed to stop Matter server");
-      return MatterError.CHIP_ERROR_INCORRECT_STATE;
-    }
-    finishStopping();
-    mState =
-        CastingAppState.NOT_RUNNING; // CastingApp stopped successfully, set state to NOT_RUNNING
+      boolean serverStopped = chipAppServer.stopApp();
+      if (!serverStopped) {
+        Log.e(TAG, "CastingApp.stop failed to stop Matter server");
+        return MatterError.CHIP_ERROR_INCORRECT_STATE;
+      }
+      finishStopping();
+      mState =
+          CastingAppState.NOT_RUNNING; // CastingApp stopped successfully, set state to NOT_RUNNING
 
-    return MatterError.NO_ERROR;
+      return MatterError.NO_ERROR;
+    }
   }
 
   /** @brief Tears down all active subscriptions. */
   public native MatterError shutdownAllSubscriptions();
+
+  /**
+   * Checks if the CastingApp is initialized and ready to accept connection requests.
+   *
+   * @return true if the CastingApp has been initialized (state is NOT_RUNNING or RUNNING), false
+   *     otherwise
+   */
+  public boolean isInitialized() {
+    synchronized (mStateLock) {
+      return mState != CastingAppState.UNINITIALIZED;
+    }
+  }
+
+  /**
+   * Checks if the CastingApp is running and ready to accept connection requests.
+   *
+   * @return true if the CastingApp is in RUNNING state, false otherwise
+   */
+  public boolean isRunning() {
+    synchronized (mStateLock) {
+      return mState == CastingAppState.RUNNING;
+    }
+  }
 
   /**
    * Clears app cache that contains the information about CastingPlayers previously connected to

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -189,7 +189,18 @@ public class MatterCastingPlayer implements CastingPlayer {
    *     MatterError object corresponding to the error.
    */
   @Override
-  public native MatterError sendUDC(
+  public MatterError sendUDC(
+      ConnectionCallbacks connectionCallbacks, IdentificationDeclarationOptions idOptions) {
+    if (!CastingApp.getInstance().isRunning()) {
+      Log.e(
+          TAG,
+          "sendUDC() called before CastingApp is running. Please call CastingApp.initialize() and CastingApp.start() first.");
+      return MatterError.CHIP_ERROR_INCORRECT_STATE;
+    }
+    return sendUDCNative(connectionCallbacks, idOptions);
+  }
+
+  private native MatterError sendUDCNative(
       ConnectionCallbacks connectionCallbacks, IdentificationDeclarationOptions idOptions);
 
   /**
@@ -224,7 +235,21 @@ public class MatterCastingPlayer implements CastingPlayer {
    *     MatterError object corresponding to the error.
    */
   @Override
-  public native MatterError verifyOrEstablishConnection(
+  public MatterError verifyOrEstablishConnection(
+      ConnectionCallbacks connectionCallbacks,
+      short commissioningWindowTimeoutSec,
+      IdentificationDeclarationOptions idOptions) {
+    if (!CastingApp.getInstance().isRunning()) {
+      Log.e(
+          TAG,
+          "verifyOrEstablishConnection() called before CastingApp is running. Please call CastingApp.initialize() and CastingApp.start() first.");
+      return MatterError.CHIP_ERROR_INCORRECT_STATE;
+    }
+    return verifyOrEstablishConnectionNative(
+        connectionCallbacks, commissioningWindowTimeoutSec, idOptions);
+  }
+
+  private native MatterError verifyOrEstablishConnectionNative(
       ConnectionCallbacks connectionCallbacks,
       short commissioningWindowTimeoutSec,
       IdentificationDeclarationOptions idOptions);

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -44,11 +44,11 @@ namespace core {
 
 MatterCastingPlayerJNI MatterCastingPlayerJNI::sInstance;
 
-JNI_METHOD(jobject, sendUDC)
+JNI_METHOD(jobject, sendUDCNative)
 (JNIEnv * env, jobject thiz, jobject jconnectionCallbacks, jobject jIdentificationDeclarationOptions)
 {
     chip::DeviceLayer::StackLock lock;
-    ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::sendUDC() called");
+    ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::sendUDCNative() called");
 
     CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
     VerifyOrReturnValue(castingPlayer != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT));
@@ -56,7 +56,7 @@ JNI_METHOD(jobject, sendUDC)
     // Find the ConnectionCallbacks class, get the field IDs of the connection callbacks and extract the callback objects.
     jclass connectionCallbacksClass = env->GetObjectClass(jconnectionCallbacks);
     VerifyOrReturnValue(connectionCallbacksClass != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
-                        ChipLogError(AppServer, "MatterCastingPlayer-JNI::sendUDC() connectionCallbacksClass == nullptr "));
+                        ChipLogError(AppServer, "MatterCastingPlayer-JNI::sendUDCNative() connectionCallbacksClass == nullptr "));
 
     jfieldID successCallbackFieldID =
         env->GetFieldID(connectionCallbacksClass, "onSuccess", "Lcom/matter/casting/support/MatterCallback;");
@@ -71,28 +71,35 @@ JNI_METHOD(jobject, sendUDC)
 
     VerifyOrReturnValue(
         jSuccessCallback != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
-        ChipLogError(AppServer, "MatterCastingPlayer-JNI::sendUDC() jSuccessCallback == nullptr but is mandatory "));
+        ChipLogError(AppServer, "MatterCastingPlayer-JNI::sendUDCNative() jSuccessCallback == nullptr but is mandatory "));
     VerifyOrReturnValue(
         jFailureCallback != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
-        ChipLogError(AppServer, "MatterCastingPlayer-JNI::sendUDC() jFailureCallback == nullptr but is mandatory "));
+        ChipLogError(AppServer, "MatterCastingPlayer-JNI::sendUDCNative() jFailureCallback == nullptr but is mandatory "));
 
     // jIdentificationDeclarationOptions is optional
-    matter::casting::core::IdentificationDeclarationOptions * idOptions = nullptr;
-    if (jIdentificationDeclarationOptions == nullptr)
+    matter::casting::core::IdentificationDeclarationOptions idOptions;
+    if (jIdentificationDeclarationOptions != nullptr)
     {
-        ChipLogProgress(AppServer,
-                        "MatterCastingPlayer-JNI::sendUDC() Optional jIdentificationDeclarationOptions not "
-                        "provided by the client");
+        ChipLogProgress(
+            AppServer,
+            "MatterCastingPlayer-JNI::sendUDCNative() Optional jIdentificationDeclarationOptions was provided by client");
+        std::unique_ptr<matter::casting::core::IdentificationDeclarationOptions> idOptionsCpp(
+            support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions));
+        if (idOptionsCpp == nullptr)
+        {
+            ChipLogError(AppServer,
+                         "MatterCastingPlayer-JNI::sendUDCNative() "
+                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error");
+            return support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT);
+        }
+        idOptions = *idOptionsCpp;
+        idOptions.LogDetail();
     }
     else
     {
-        ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::sendUDC() jIdentificationDeclarationOptions was provided by client");
-        idOptions = support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions);
-        VerifyOrReturnValue(idOptions != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
-                            ChipLogError(AppServer,
-                                         "MatterCastingPlayer-JNI::sendUDC() "
-                                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error"));
-        idOptions->LogDetail();
+        ChipLogProgress(AppServer,
+                        "MatterCastingPlayer-JNI::sendUDCNative() Optional jIdentificationDeclarationOptions not "
+                        "provided by the client");
     }
 
     TEMPORARY_RETURN_IGNORED MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.SetUp(env, jSuccessCallback);
@@ -102,7 +109,7 @@ JNI_METHOD(jobject, sendUDC)
     if (jCommissionerDeclarationCallback == nullptr)
     {
         ChipLogProgress(AppServer,
-                        "MatterCastingPlayer-JNI::sendUDC() optional jCommissionerDeclarationCallback was not "
+                        "MatterCastingPlayer-JNI::sendUDCNative() optional jCommissionerDeclarationCallback was not "
                         "provided by the client");
     }
     else
@@ -116,17 +123,17 @@ JNI_METHOD(jobject, sendUDC)
     connectionCallbacks.mCommissionerDeclarationCallback =
         MatterCastingPlayerJNI::getInstance().getCommissionerDeclarationCallback();
 
-    castingPlayer->SendUDC(connectionCallbacks, *idOptions);
+    castingPlayer->SendUDC(connectionCallbacks, idOptions);
 
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }
 
-JNI_METHOD(jobject, verifyOrEstablishConnection)
+JNI_METHOD(jobject, verifyOrEstablishConnectionNative)
 (JNIEnv * env, jobject thiz, jobject jconnectionCallbacks, jlong commissioningWindowTimeoutSec,
  jobject jIdentificationDeclarationOptions)
 {
     chip::DeviceLayer::StackLock lock;
-    ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::verifyOrEstablishConnection() called with a timeout of: %d seconds",
+    ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::verifyOrEstablishConnectionNative() called with a timeout of: %d seconds",
                     static_cast<int>(commissioningWindowTimeoutSec));
 
     CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
@@ -136,7 +143,8 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
     jclass connectionCallbacksClass = env->GetObjectClass(jconnectionCallbacks);
     VerifyOrReturnValue(
         connectionCallbacksClass != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
-        ChipLogError(AppServer, "MatterCastingPlayer-JNI::verifyOrEstablishConnection() connectionCallbacksClass == nullptr "));
+        ChipLogError(AppServer,
+                     "MatterCastingPlayer-JNI::verifyOrEstablishConnectionNative() connectionCallbacksClass == nullptr "));
 
     jfieldID successCallbackFieldID =
         env->GetFieldID(connectionCallbacksClass, "onSuccess", "Lcom/matter/casting/support/MatterCallback;");
@@ -152,31 +160,37 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
     VerifyOrReturnValue(
         jSuccessCallback != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
         ChipLogError(AppServer,
-                     "MatterCastingPlayer-JNI::verifyOrEstablishConnection() jSuccessCallback == nullptr but is mandatory "));
+                     "MatterCastingPlayer-JNI::verifyOrEstablishConnectionNative() jSuccessCallback == nullptr but is mandatory "));
     VerifyOrReturnValue(
         jFailureCallback != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
         ChipLogError(AppServer,
-                     "MatterCastingPlayer-JNI::verifyOrEstablishConnection() jFailureCallback == nullptr but is mandatory "));
+                     "MatterCastingPlayer-JNI::verifyOrEstablishConnectionNative() jFailureCallback == nullptr but is mandatory "));
 
     // jIdentificationDeclarationOptions is optional
-    matter::casting::core::IdentificationDeclarationOptions * idOptions = nullptr;
-    if (jIdentificationDeclarationOptions == nullptr)
+    matter::casting::core::IdentificationDeclarationOptions idOptions;
+    if (jIdentificationDeclarationOptions != nullptr)
     {
         ChipLogProgress(AppServer,
-                        "MatterCastingPlayer-JNI::verifyOrEstablishConnection() Optional jIdentificationDeclarationOptions not "
-                        "provided by the client");
+                        "MatterCastingPlayer-JNI::verifyOrEstablishConnectionNative() jIdentificationDeclarationOptions was "
+                        "provided by client");
+        std::unique_ptr<matter::casting::core::IdentificationDeclarationOptions> idOptionsCpp(
+            support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions));
+        if (idOptionsCpp == nullptr)
+        {
+            ChipLogError(AppServer,
+                         "MatterCastingPlayer-JNI::verifyOrEstablishConnectionNative() "
+                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error");
+            return support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT);
+        }
+        idOptions = *idOptionsCpp;
+        idOptions.LogDetail();
     }
     else
     {
         ChipLogProgress(
             AppServer,
-            "MatterCastingPlayer-JNI::verifyOrEstablishConnection() jIdentificationDeclarationOptions was provided by client");
-        idOptions = support::convertIdentificationDeclarationOptionsFromJavaToCpp(jIdentificationDeclarationOptions);
-        VerifyOrReturnValue(idOptions != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT),
-                            ChipLogError(AppServer,
-                                         "MatterCastingPlayer-JNI::verifyOrEstablishConnection() "
-                                         "convertIdentificationDeclarationOptionsFromJavaToCpp() error"));
-        idOptions->LogDetail();
+            "MatterCastingPlayer-JNI::verifyOrEstablishConnectionNative() Optional jIdentificationDeclarationOptions not "
+            "provided by the client");
     }
 
     TEMPORARY_RETURN_IGNORED MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.SetUp(env, jSuccessCallback);
@@ -201,7 +215,7 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
         MatterCastingPlayerJNI::getInstance().getCommissionerDeclarationCallback();
 
     castingPlayer->VerifyOrEstablishConnection(connectionCallbacks, static_cast<uint16_t>(commissioningWindowTimeoutSec),
-                                               *idOptions);
+                                               idOptions);
 
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.h
@@ -58,6 +58,11 @@
 - (bool)isRunning;
 
 /**
+ * @brief true, if MCCastingApp has been initialized. false otherwise
+ */
+- (bool)isInitialized;
+
+/**
  * @brief Tears down all active subscriptions.
  */
 - (NSError * _Nullable)ShutdownAllSubscriptions;

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
@@ -46,6 +46,9 @@
 // Client defiend data source used to initialize the MCCommissionableDataProvider and, if needed, update the MCCommissionableDataProvider post initialization. This is necessary for the Commissioner-Generated passcode commissioning feature.
 @property (nonatomic, strong) id<MCDataSource> dataSource;
 
+// Tracks whether the app has been initialized
+@property (atomic) BOOL initialized;
+
 @end
 
 @implementation MCCastingApp
@@ -73,6 +76,13 @@
 - (NSError *)initializeWithDataSource:(id)dataSource
 {
     ChipLogProgress(AppServer, "MCCastingApp.initializeWithDataSource() called");
+
+    // Check if already initialized
+    if (_initialized) {
+        ChipLogError(AppServer, "MCCastingApp.initializeWithDataSource() already initialized");
+        return [MCErrorUtils NSErrorFromChipError:CHIP_ERROR_INCORRECT_STATE];
+    }
+
     // store the data source provided by the client
     _dataSource = dataSource;
 
@@ -107,6 +117,9 @@
 
     // Get and store the CHIP Work queue
     _workQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
+
+    // Mark as initialized
+    _initialized = YES;
 
     return [MCErrorUtils NSErrorFromChipError:CHIP_NO_ERROR];
 }
@@ -171,6 +184,11 @@
         running = matter::casting::core::CastingApp::GetInstance()->isRunning();
     });
     return running;
+}
+
+- (bool)isInitialized
+{
+    return _initialized;
 }
 
 - (NSError *)ShutdownAllSubscriptions

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
@@ -54,7 +54,7 @@ static const NSInteger kMinCommissioningWindowTimeoutSec = matter::casting::core
     ChipLogProgress(AppServer, "MCCastingPlayer.sendUDCWithCallbacks() called");
     VerifyOrReturnValue([[MCCastingApp getSharedInstance] isRunning],
         [MCErrorUtils NSErrorFromChipError:CHIP_ERROR_INCORRECT_STATE],
-        ChipLogError(AppServer, "MCCastingPlayer.sendUDCWithCallbacks() MCCastingApp NOT running"));
+        ChipLogError(AppServer, "MCCastingPlayer.sendUDCWithCallbacks() called before MCCastingApp is running. Please call MCCastingApp.initializeWithDataSource() and MCCastingApp.startWithCompletionBlock() first."));
 
     dispatch_queue_t workQueue = [[MCCastingApp getSharedInstance] getWorkQueue];
     dispatch_sync(workQueue, ^{
@@ -133,7 +133,7 @@ static const NSInteger kMinCommissioningWindowTimeoutSec = matter::casting::core
     ChipLogProgress(AppServer, "MCCastingPlayer.verifyOrEstablishConnectionWithCallbacks() called, MCConnectionCallbacks, timeout and MCIdentificationDeclarationOptions parameters");
     VerifyOrReturnValue([[MCCastingApp getSharedInstance] isRunning],
         [MCErrorUtils NSErrorFromChipError:CHIP_ERROR_INCORRECT_STATE],
-        ChipLogError(AppServer, "MCCastingPlayer.verifyOrEstablishConnectionWithCallbacks() MCCastingApp NOT running"));
+        ChipLogError(AppServer, "MCCastingPlayer.verifyOrEstablishConnectionWithCallbacks() called before MCCastingApp is running. Please call MCCastingApp.initializeWithDataSource() and MCCastingApp.startWithCompletionBlock() first."));
 
     dispatch_queue_t workQueue = [[MCCastingApp getSharedInstance] getWorkQueue];
     dispatch_sync(workQueue, ^{
@@ -316,8 +316,8 @@ static const NSInteger kMinCommissioningWindowTimeoutSec = matter::casting::core
 - (NSString * _Nonnull)description
 {
     return [NSString stringWithFormat:@"%@ with Product ID: %hu and Vendor ID: %hu. Resolved IPAddr?: %@. Supports Commissioner-Generated Passcode?: %@.",
-                     self.deviceName, self.productId, self.vendorId, self.ipAddresses != nil && self.ipAddresses.count > 0 ? @"YES" : @"NO",
-                     self.supportsCommissionerGeneratedPasscode ? @"YES" : @"NO"];
+        self.deviceName, self.productId, self.vendorId, self.ipAddresses != nil && self.ipAddresses.count > 0 ? @"YES" : @"NO",
+        self.supportsCommissionerGeneratedPasscode ? @"YES" : @"NO"];
 }
 
 - (NSString * _Nonnull)identifier

--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -99,6 +99,24 @@ void CASESessionManager::FindOrEstablishSessionHelper(const ScopedNodeId & peerI
     ChipLogDetail(CASESessionManager, "FindOrEstablishSession: PeerId = [%d:" ChipLogFormatX64 "]", peerId.GetFabricIndex(),
                   ChipLogValueX64(peerId.GetNodeId()));
 
+    // Check if CASESessionManager is properly initialized
+    if (mConfig.sessionSetupPool == nullptr)
+    {
+        ChipLogError(CASESessionManager, "FindOrEstablishSession called before CASESessionManager is initialized");
+        if (onFailure != nullptr)
+        {
+            onFailure->mCall(onFailure->mContext, peerId, CHIP_ERROR_INCORRECT_STATE);
+        }
+
+        if (onSetupFailure != nullptr)
+        {
+            OperationalSessionSetup::ConnectionFailureInfo failureInfo(peerId, CHIP_ERROR_INCORRECT_STATE,
+                                                                       SessionEstablishmentStage::kUnknown);
+            onSetupFailure->mCall(onSetupFailure->mContext, failureInfo);
+        }
+        return;
+    }
+
     bool forAddressUpdate             = false;
     OperationalSessionSetup * session = FindExistingSessionSetup(peerId, forAddressUpdate);
     if (session == nullptr)
@@ -144,17 +162,28 @@ void CASESessionManager::FindOrEstablishSessionHelper(const ScopedNodeId & peerI
 
 void CASESessionManager::ReleaseSessionsForFabric(FabricIndex fabricIndex)
 {
+    if (mConfig.sessionSetupPool == nullptr)
+    {
+        ChipLogError(CASESessionManager, "ReleaseSessionsForFabric called before CASESessionManager is initialized");
+        return;
+    }
     mConfig.sessionSetupPool->ReleaseAllSessionSetupsForFabric(fabricIndex);
 }
 
 void CASESessionManager::ReleaseAllSessions()
 {
+    if (mConfig.sessionSetupPool == nullptr)
+    {
+        ChipLogError(CASESessionManager, "ReleaseAllSessions called before CASESessionManager is initialized");
+        return;
+    }
     mConfig.sessionSetupPool->ReleaseAllSessionSetup();
 }
 
 CHIP_ERROR CASESessionManager::GetPeerAddress(const ScopedNodeId & peerId, Transport::PeerAddress & addr,
                                               TransportPayloadCapability transportPayloadCapability)
 {
+    VerifyOrReturnError(mConfig.sessionInitParams.sessionManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mConfig.sessionInitParams.Validate());
     auto optionalSessionHandle = FindExistingSession(peerId, transportPayloadCapability);
     VerifyOrReturnError(optionalSessionHandle.HasValue(), CHIP_ERROR_NOT_CONNECTED);
@@ -164,6 +193,12 @@ CHIP_ERROR CASESessionManager::GetPeerAddress(const ScopedNodeId & peerId, Trans
 
 void CASESessionManager::UpdatePeerAddress(ScopedNodeId peerId)
 {
+    if (mConfig.sessionSetupPool == nullptr)
+    {
+        ChipLogError(CASESessionManager, "UpdatePeerAddress called before CASESessionManager is initialized");
+        return;
+    }
+
     bool forAddressUpdate             = true;
     OperationalSessionSetup * session = FindExistingSessionSetup(peerId, forAddressUpdate);
     if (session == nullptr)
@@ -189,18 +224,33 @@ void CASESessionManager::UpdatePeerAddress(ScopedNodeId peerId)
 
 OperationalSessionSetup * CASESessionManager::FindExistingSessionSetup(const ScopedNodeId & peerId, bool forAddressUpdate) const
 {
+    if (mConfig.sessionSetupPool == nullptr)
+    {
+        ChipLogError(CASESessionManager, "FindExistingSessionSetup called before CASESessionManager is initialized");
+        return nullptr;
+    }
     return mConfig.sessionSetupPool->FindSessionSetup(peerId, forAddressUpdate);
 }
 
 Optional<SessionHandle> CASESessionManager::FindExistingSession(const ScopedNodeId & peerId,
                                                                 const TransportPayloadCapability transportPayloadCapability) const
 {
+    if (mConfig.sessionInitParams.sessionManager == nullptr)
+    {
+        ChipLogError(CASESessionManager, "FindExistingSession called before CASESessionManager is initialized");
+        return Optional<SessionHandle>::Missing();
+    }
     return mConfig.sessionInitParams.sessionManager->FindSecureSessionForNode(
         peerId, MakeOptional(Transport::SecureSession::Type::kCASE), transportPayloadCapability);
 }
 
 void CASESessionManager::ReleaseSession(const ScopedNodeId & peerId)
 {
+    if (mConfig.sessionSetupPool == nullptr)
+    {
+        ChipLogError(CASESessionManager, "ReleaseSession called before CASESessionManager is initialized");
+        return;
+    }
     auto * session = mConfig.sessionSetupPool->FindSessionSetup(peerId, false);
     ReleaseSession(session);
 }
@@ -209,6 +259,11 @@ void CASESessionManager::ReleaseSession(OperationalSessionSetup * session)
 {
     if (session != nullptr)
     {
+        if (mConfig.sessionSetupPool == nullptr)
+        {
+            ChipLogError(CASESessionManager, "ReleaseSession called before CASESessionManager is initialized");
+            return;
+        }
         mConfig.sessionSetupPool->Release(session);
     }
 }


### PR DESCRIPTION
#### Summary

Avoid synchronization issues when Server.init is slow.

When running multiple instances of the CastingApp on the phone (in different apps), synchronization issues have been observed

#### Testing

iOS and Android phone. More TBD