### PR TITLE
[Codedriven conversion] PR#1 - rename for BridgedDeviceBasicInformation

### DIFF
--- a/src/app/clusters/bridged-device-basic-information-server/CodegenIntegration.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/CodegenIntegration.cpp
@@ -48,21 +48,16 @@ void ReachableChanged(EndpointId endpointId)
 
     Events::ReachableChanged::Type event{ reachable };
     EventNumber eventNumber;
-    if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber))
-    {
-        ChipLogError(Zcl, "ReachableChanged: Failed to record ReachableChanged event");
-    }
+    LogErrorOnFailure(LogEvent(event, endpointId, eventNumber));
 }
 
 } // anonymous namespace
 
 void MatterBridgedDeviceBasicInformationClusterServerAttributeChangedCallback(const ConcreteAttributePath & attributePath)
 {
-    if (attributePath.mClusterId != BridgedDeviceBasicInformation::Id)
-    {
-        ChipLogError(Zcl, "MatterBridgedDeviceBasicClusterServerAttributeChangedCallback: Incorrect cluster ID");
-        return;
-    }
+    // just verify without logging - in practice this callback is correctly invoked by the framework since this is based
+    // on generated code.
+    VerifyOrReturn(attributePath.mClusterId == BridgedDeviceBasicInformation::Id);
 
     switch (attributePath.mAttributeId)
     {

--- a/src/app/clusters/bridged-device-basic-information-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/bridged-device-basic-information-server/app_config_dependent_sources.cmake
@@ -16,5 +16,5 @@
 TARGET_SOURCES(
   ${APP_TARGET}
   PRIVATE
-    "${CLUSTER_DIR}/bridged-device-basic-information-server.cpp"
+  "${CLUSTER_DIR}/CodegenIntegration.cpp"
 )

--- a/src/app/clusters/bridged-device-basic-information-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/bridged-device-basic-information-server/app_config_dependent_sources.gni
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-app_config_dependent_sources = [ "bridged-device-basic-information-server.cpp" ]
+app_config_dependent_sources = [ "CodegenIntegration.cpp" ]


### PR DESCRIPTION
#### Summary

Just renames existing integration to CodegenIntegration.cpp

Also some trivial changes regarding logging.

#### Testing

No functional changes. Existing CI should be sufficient.