### PR TITLE
Add 'linux' As a Platform Choice for GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/001-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/001-bug-report.yaml
@@ -51,6 +51,7 @@ body:
               - freeRTOS
               - IMX8
               - k32w
+              - linux
               - nrf
               - python
               - raspi

--- a/.github/ISSUE_TEMPLATE/002-1.0-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/002-1.0-issue.yaml
@@ -51,6 +51,7 @@ body:
               - freeRTOS
               - IMX8
               - k32w
+              - linux
               - nrf connect
               - nrf
               - python

--- a/.github/ISSUE_TEMPLATE/003-1.1-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/003-1.1-issue.yaml
@@ -51,6 +51,7 @@ body:
         - freeRTOS
         - IMX8
         - k32w
+        - linux
         - nrf connect
         - nrf
         - python

--- a/.github/ISSUE_TEMPLATE/004-1.2-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/004-1.2-issue.yaml
@@ -51,6 +51,7 @@ body:
         - freeRTOS
         - IMX8
         - k32w
+        - linux
         - nrf connect
         - nrf
         - python

--- a/.github/ISSUE_TEMPLATE/005-1.3-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/005-1.3-issue.yaml
@@ -51,6 +51,7 @@ body:
         - freeRTOS
         - IMX8
         - k32w
+        - linux
         - nrf connect
         - nrf
         - python

--- a/.github/ISSUE_TEMPLATE/049-trivial-fix.yaml
+++ b/.github/ISSUE_TEMPLATE/049-trivial-fix.yaml
@@ -42,6 +42,7 @@ body:
               - freeRTOS
               - IMX8
               - k32w
+              - linux
               - nrf connect
               - nrf
               - python

--- a/.github/ISSUE_TEMPLATE/050-tooling-fix.yaml
+++ b/.github/ISSUE_TEMPLATE/050-tooling-fix.yaml
@@ -37,6 +37,7 @@ body:
               - freeRTOS
               - IMX8
               - k32w
+              - linux
               - nrf connect
               - nrf
               - python

--- a/.github/ISSUE_TEMPLATE/060-platform-fix.yaml
+++ b/.github/ISSUE_TEMPLATE/060-platform-fix.yaml
@@ -37,6 +37,7 @@ body:
               - freeRTOS
               - IMX8
               - k32w
+              - linux
               - nrf connect
               - nrf
               - python

--- a/.github/ISSUE_TEMPLATE/080-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/080-feature-request.yaml
@@ -32,6 +32,7 @@ body:
               - freeRTOS
               - IMX8
               - k32w
+              - linux
               - nrf connect
               - nrf
               - python

--- a/.github/ISSUE_TEMPLATE/090-sve-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/090-sve-issue.yaml
@@ -51,6 +51,7 @@ body:
               - freeRTOS
               - IMX8
               - k32w
+              - linux
               - nrf connect
               - nrf
               - python

--- a/.github/ISSUE_TEMPLATE/091-cert-blocker.yaml
+++ b/.github/ISSUE_TEMPLATE/091-cert-blocker.yaml
@@ -85,6 +85,7 @@ body:
         - freeRTOS
         - IMX8
         - k32w
+        - linux
         - nrf
         - python
         - raspi

--- a/.github/ISSUE_TEMPLATE/097-ci-test-failure.yaml
+++ b/.github/ISSUE_TEMPLATE/097-ci-test-failure.yaml
@@ -34,6 +34,7 @@ body:
         - freeRTOS
         - IMX8
         - k32w
+        - linux
         - nrf connect
         - nrf
         - python

--- a/.github/ISSUE_TEMPLATE/098-build-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/098-build-issue.yaml
@@ -34,6 +34,7 @@ body:
         - freeRTOS
         - IMX8
         - k32w
+        - linux
         - nrf connect
         - nrf
         - python

--- a/.github/ISSUE_TEMPLATE/099-github-workflow-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/099-github-workflow-issue.yaml
@@ -34,6 +34,7 @@ body:
               - freeRTOS
               - IMX8
               - k32w
+              - linux
               - nrf connect
               - nrf
               - python

--- a/.github/ISSUE_TEMPLATE/100-documentation-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/100-documentation-issue.yaml
@@ -34,6 +34,7 @@ body:
               - freeRTOS
               - IMX8
               - k32w
+              - linux
               - nrf connect
               - nrf
               - python


### PR DESCRIPTION
#### Summary

Linux is missing as a possible platform dropdown choice in the following GitHub issue templates:

* _.github/ISSUE_TEMPLATE/001-bug-report.yaml_
* _.github/ISSUE_TEMPLATE/002-1.0-issue.yaml_
* _.github/ISSUE_TEMPLATE/003-1.1-issue.yaml_
* _.github/ISSUE_TEMPLATE/004-1.2-issue.yaml_
* _.github/ISSUE_TEMPLATE/005-1.3-issue.yaml_
* _.github/ISSUE_TEMPLATE/049-trivial-fix.yaml_
* _.github/ISSUE_TEMPLATE/050-tooling-fix.yaml_
* _.github/ISSUE_TEMPLATE/060-platform-fix.yaml_
* _.github/ISSUE_TEMPLATE/080-feature-request.yaml_
* _.github/ISSUE_TEMPLATE/090-sve-issue.yaml_
* _.github/ISSUE_TEMPLATE/091-cert-blocker.yaml_
* _.github/ISSUE_TEMPLATE/097-ci-test-failure.yaml_
* _.github/ISSUE_TEMPLATE/098-build-issue.yaml_
* _.github/ISSUE_TEMPLATE/099-github-workflow-issue.yaml_
* _.github/ISSUE_TEMPLATE/100-documentation-issue.yaml_

This fixes and closes #43089 by adding `linux` as a potential platform choice.

#### Related issues

#43089 

#### Testing

Ran / running the proposed fix through CI.