### PR TITLE
[Groupcast]Fix TC_GCAST_2.3 .4 .5 .6 test setup by removing all existing KeySetId …

### DIFF
--- a/src/python_testing/TC_GCAST_2_3.py
+++ b/src/python_testing/TC_GCAST_2_3.py
@@ -92,12 +92,12 @@ class TC_GCAST_2_3(MatterBaseTest):
             await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.NotFound,
-                                 f"Send UpdateGroupKey command error should be {Status.NotFound} instead of {e.status}")
+                                 f"Send LeaveGroup command error should be {Status.NotFound} instead of {e.status}")
 
         # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
         resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())
 
-        read_group_key_ids: List[int] = resp.groupKeySetIDs
+        read_group_key_ids: list[int] = resp.groupKeySetIDs
         for key_set_id in read_group_key_ids:
             if key_set_id != 0:
                 await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))

--- a/src/python_testing/TC_GCAST_2_3.py
+++ b/src/python_testing/TC_GCAST_2_3.py
@@ -87,7 +87,20 @@ class TC_GCAST_2_3(MatterBaseTest):
         endpoints_list = [endpoints_list[0]]
 
         self.step("1b")
-        await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
+        # LeaveGroup all groups. If There were no groups, it should fail with Status.NotFound.
+        try:
+            await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.NotFound,
+                                 f"Send UpdateGroupKey command error should be {Status.NotFound} instead of {e.status}")
+
+        # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
+        resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())
+
+        read_group_key_ids: List[int] = resp.groupKeySetIDs
+        for key_set_id in read_group_key_ids:
+            if key_set_id != 0:
+                await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))
 
         self.step("1c")
         sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)

--- a/src/python_testing/TC_GCAST_2_3.py
+++ b/src/python_testing/TC_GCAST_2_3.py
@@ -87,12 +87,11 @@ class TC_GCAST_2_3(MatterBaseTest):
         endpoints_list = [endpoints_list[0]]
 
         self.step("1b")
-        # LeaveGroup all groups. If There were no groups, it should fail with Status.NotFound.
-        try:
+        # Check if there are any groups on the DUT.
+        membership = await self.read_single_attribute_check_success(groupcast_cluster, membership_attribute)
+        if membership:
+            # LeaveGroup with groupID 0 will leave all groups on the fabric.
             await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.NotFound,
-                                 f"Send LeaveGroup command error should be {Status.NotFound} instead of {e.status}")
 
         # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
         resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())

--- a/src/python_testing/TC_GCAST_2_4.py
+++ b/src/python_testing/TC_GCAST_2_4.py
@@ -93,12 +93,11 @@ class TC_GCAST_2_4(MatterBaseTest):
             endpoints_list = endpoints_list[:2]
 
         self.step("1b")
-        # LeaveGroup all groups. If There were no groups, it should fail with Status.NotFound.
-        try:
+        # Check if there are any groups on the DUT.
+        membership = await self.read_single_attribute_check_success(groupcast_cluster, membership_attribute)
+        if membership:
+            # LeaveGroup with groupID 0 will leave all groups on the fabric.
             await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.NotFound,
-                                 f"Send LeaveGroup command error should be {Status.NotFound} instead of {e.status}")
 
         # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
         resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())

--- a/src/python_testing/TC_GCAST_2_4.py
+++ b/src/python_testing/TC_GCAST_2_4.py
@@ -98,12 +98,12 @@ class TC_GCAST_2_4(MatterBaseTest):
             await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.NotFound,
-                                 f"Send UpdateGroupKey command error should be {Status.NotFound} instead of {e.status}")
+                                 f"Send LeaveGroup command error should be {Status.NotFound} instead of {e.status}")
 
         # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
         resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())
 
-        read_group_key_ids: List[int] = resp.groupKeySetIDs
+        read_group_key_ids: list[int] = resp.groupKeySetIDs
         for key_set_id in read_group_key_ids:
             if key_set_id != 0:
                 await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))

--- a/src/python_testing/TC_GCAST_2_4.py
+++ b/src/python_testing/TC_GCAST_2_4.py
@@ -93,7 +93,20 @@ class TC_GCAST_2_4(MatterBaseTest):
             endpoints_list = endpoints_list[:2]
 
         self.step("1b")
-        await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
+        # LeaveGroup all groups. If There were no groups, it should fail with Status.NotFound.
+        try:
+            await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.NotFound,
+                                 f"Send UpdateGroupKey command error should be {Status.NotFound} instead of {e.status}")
+
+        # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
+        resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())
+
+        read_group_key_ids: List[int] = resp.groupKeySetIDs
+        for key_set_id in read_group_key_ids:
+            if key_set_id != 0:
+                await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))
 
         self.step("1c")
         sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)

--- a/src/python_testing/TC_GCAST_2_5.py
+++ b/src/python_testing/TC_GCAST_2_5.py
@@ -87,12 +87,11 @@ class TC_GCAST_2_5(MatterBaseTest):
         endpoints_list = [endpoints_list[0]]
 
         self.step("1b")
-        # LeaveGroup all groups. If There were no groups, it should fail with Status.NotFound.
-        try:
+        # Check if there are any groups on the DUT.
+        membership = await self.read_single_attribute_check_success(groupcast_cluster, membership_attribute)
+        if membership:
+            # LeaveGroup with groupID 0 will leave all groups on the fabric.
             await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.NotFound,
-                                 f"Send LeaveGroup command error should be {Status.NotFound} instead of {e.status}")
 
         # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
         resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())

--- a/src/python_testing/TC_GCAST_2_5.py
+++ b/src/python_testing/TC_GCAST_2_5.py
@@ -92,12 +92,12 @@ class TC_GCAST_2_5(MatterBaseTest):
             await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.NotFound,
-                                 f"Send UpdateGroupKey command error should be {Status.NotFound} instead of {e.status}")
+                                 f"Send LeaveGroup command error should be {Status.NotFound} instead of {e.status}")
 
         # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
         resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())
 
-        read_group_key_ids: List[int] = resp.groupKeySetIDs
+        read_group_key_ids: list[int] = resp.groupKeySetIDs
         for key_set_id in read_group_key_ids:
             if key_set_id != 0:
                 await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))

--- a/src/python_testing/TC_GCAST_2_5.py
+++ b/src/python_testing/TC_GCAST_2_5.py
@@ -87,7 +87,20 @@ class TC_GCAST_2_5(MatterBaseTest):
         endpoints_list = [endpoints_list[0]]
 
         self.step("1b")
-        await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
+        # LeaveGroup all groups. If There were no groups, it should fail with Status.NotFound.
+        try:
+            await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.NotFound,
+                                 f"Send UpdateGroupKey command error should be {Status.NotFound} instead of {e.status}")
+
+        # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
+        resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())
+
+        read_group_key_ids: List[int] = resp.groupKeySetIDs
+        for key_set_id in read_group_key_ids:
+            if key_set_id != 0:
+                await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))
 
         self.step("1c")
         sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)

--- a/src/python_testing/TC_GCAST_2_6.py
+++ b/src/python_testing/TC_GCAST_2_6.py
@@ -119,12 +119,12 @@ class TC_GCAST_2_6(MatterBaseTest):
             await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.NotFound,
-                                 f"Send UpdateGroupKey command error should be {Status.NotFound} instead of {e.status}")
+                                 f"Send LeaveGroup command error should be {Status.NotFound} instead of {e.status}")
 
         # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
         resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())
 
-        read_group_key_ids: List[int] = resp.groupKeySetIDs
+        read_group_key_ids: list[int] = resp.groupKeySetIDs
         for key_set_id in read_group_key_ids:
             if key_set_id != 0:
                 await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))

--- a/src/python_testing/TC_GCAST_2_6.py
+++ b/src/python_testing/TC_GCAST_2_6.py
@@ -115,7 +115,7 @@ class TC_GCAST_2_6(MatterBaseTest):
 
         self.step("1c")
         # Check if there are any groups on the DUT.
-        membership = await self.read_single_attribute_check_success(groupcast_cluster, membership_attribute)
+        membership = await self.read_single_attribute_check_success(groupcast_cluster, Clusters.Groupcast.Attributes.Membership)
         if membership:
             # LeaveGroup with groupID 0 will leave all groups on the fabric.
             await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))

--- a/src/python_testing/TC_GCAST_2_6.py
+++ b/src/python_testing/TC_GCAST_2_6.py
@@ -114,12 +114,11 @@ class TC_GCAST_2_6(MatterBaseTest):
         )
 
         self.step("1c")
-        # LeaveGroup all groups. If There were no groups, it should fail with Status.NotFound.
-        try:
+        # Check if there are any groups on the DUT.
+        membership = await self.read_single_attribute_check_success(groupcast_cluster, membership_attribute)
+        if membership:
+            # LeaveGroup with groupID 0 will leave all groups on the fabric.
             await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.NotFound,
-                                 f"Send LeaveGroup command error should be {Status.NotFound} instead of {e.status}")
 
         # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
         resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())

--- a/src/python_testing/TC_GCAST_2_6.py
+++ b/src/python_testing/TC_GCAST_2_6.py
@@ -114,8 +114,20 @@ class TC_GCAST_2_6(MatterBaseTest):
         )
 
         self.step("1c")
-        groupID0 = 0
-        await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=groupID0))
+        # LeaveGroup all groups. If There were no groups, it should fail with Status.NotFound.
+        try:
+            await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.NotFound,
+                                 f"Send UpdateGroupKey command error should be {Status.NotFound} instead of {e.status}")
+
+        # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
+        resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())
+
+        read_group_key_ids: List[int] = resp.groupKeySetIDs
+        for key_set_id in read_group_key_ids:
+            if key_set_id != 0:
+                await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))
 
         self.step(2)
         groupID1 = 1

--- a/src/python_testing/TC_GCAST_2_7.py
+++ b/src/python_testing/TC_GCAST_2_7.py
@@ -102,8 +102,19 @@ class TC_GCAST_2_7(MatterBaseTest):
             endpoints_list = [endpoints_list[0]]
 
         self.step("1b")
-        groupID0 = 0
-        await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=groupID0))
+        # Check if there are any groups on the DUT.
+        membership = await self.read_single_attribute_check_success(groupcast_cluster, membership_attribute)
+        if membership:
+            # LeaveGroup with groupID 0 will leave all groups on the fabric.
+            await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(groupID=0))
+
+        # remove any existing KeySetID on the DUT, except KeySetId 0 (IPK).
+        resp: Clusters.GroupKeyManagement.Commands.KeySetReadAllIndicesResponse = await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetReadAllIndices())
+
+        read_group_key_ids: list[int] = resp.groupKeySetIDs
+        for key_set_id in read_group_key_ids:
+            if key_set_id != 0:
+                await self.send_single_cmd(Clusters.GroupKeyManagement.Commands.KeySetRemove(key_set_id))
 
         self.step("1c")
         sub = AttributeSubscriptionHandler(groupcast_cluster, membership_attribute)


### PR DESCRIPTION
#### Summary

the step 1b (for most case) leads to test fails for two reasons

> | 1b | | | TH removes any existing group and KeySetID on the DUT. |

1. we leave all groups with LeaveGroup(GroupId=0) and expect a success. However, If no group exist for the fabric, NOT_FOUND is returns. Test script must handle Success or NOT_FOUND as expected results.
2. Pre-existing KeySetId are not deleted. The GroupKeyManagement cluster can have KeySetId created from previous test causing future test steps failures when KeySetId are reused to create new KeySets. Step 1 b must be extended to remove all KeySetId from the GroupKeyManagement cluster for the fabric under test

Fix TC_GCAST_2.3 .4 .5 .6 test setup by removing all existing KeySetId with the groupKeyManagement cluster and allowing LeaveGroup All return NotFound if the fabric had no groups

#### Related issues
fixes #43086

#### Testing
Run TC_GCAST 2.3 and 2.4 on a lighting app with groupcast cluster as listener.
Validated that the setup steps completes and KeySetId can be reused between test runs.

