### PR TITLE
Linux Platform: Ensure that 'CHIP_DEFAULT_{CONFIG,DATA,FACTORY}_PATH' Can Be Overridden

### DIFF
--- a/src/platform/Linux/CHIPLinuxStorage.h
+++ b/src/platform/Linux/CHIPLinuxStorage.h
@@ -49,15 +49,23 @@
 #define LOCALSTATEDIR "/tmp"
 #endif
 
+#ifndef CHIP_DEFAULT_FACTORY_PATH
 #define CHIP_DEFAULT_FACTORY_PATH                                                                                                  \
     FATCONFDIR "/"                                                                                                                 \
                "chip_factory.ini"
+#endif // CHIP_DEFAULT_FACTORY_PATH
+
+#ifndef CHIP_DEFAULT_CONFIG_PATH
 #define CHIP_DEFAULT_CONFIG_PATH                                                                                                   \
     SYSCONFDIR "/"                                                                                                                 \
                "chip_config.ini"
+#endif // CHIP_DEFAULT_CONFIG_PATH
+
+#ifndef CHIP_DEFAULT_DATA_PATH
 #define CHIP_DEFAULT_DATA_PATH                                                                                                     \
     LOCALSTATEDIR "/"                                                                                                              \
                   "chip_counters.ini"
+#endif // CHIP_DEFAULT_DATA_PATH
 
 namespace chip {
 namespace DeviceLayer {


### PR DESCRIPTION
#### Summary

Per #43087, there are a number of inconsistencies and incongruences with Linux platform non-volatile storage configuration. For this issue, in particular:

1. Why are three of these not `#ifndef .. #define .. #endif` and one of them is?

This makes `CHIP_DEFAULT_{CONFIG,DATA,FACTORY}_PATH` consistent with `CHIP_CONFIG_KVS_PATH` in _src/platform/Linux/CHIPPlatformConfig.h_ in that they now follow a similar `#ifndef .. #define .. #endif` pattern such that they can be overridden by the preprocessor.

#### Related issues

#43087 

#### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.2 Apple "Home" app with a Connectivity Manager implementation using this infrastructure with the values set as follows:

1. `CHIP_CONFIG_KVS_PATH`=_/var/lib/matter/matter-key-value-store.ini_
2. `CHIP_DEFAULT_CONFIG_PATH`=_/var/lib/matter/matter-config.ini_
3. `CHIP_DEFAULT_DATA_PATH`=_/var/lib/matter/matter-counters.ini_
4. `CHIP_DEFAULT_FACTORY_PATH`=_/var/lib/matter/matter-provisioning.ini_

In addition:

1. Rebooted the paired / commissioned system and verified that it was **still** paired / commissioned.
2. Factory reset the paired / commissioned system and verified that it was **no longer** paired / commissioned.