### PR TITLE
Thread: specify vendor name and product name

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:183
+            image: ghcr.io/project-chip/chip-build:184
             options: >-
                 --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
@@ -316,6 +316,8 @@ jobs:
                    -DCMAKE_BUILD_TYPE=Debug \
                    -DOTBR_BORDER_ROUTING=ON \
                    -DOTBR_MDNS=openthread \
+                   -DOTBR_VENDOR_NAME=MatterTest \
+                   -DOTBR_PRODUCT_NAME=MatterTest \
                    -DOT_POSIX_SETTINGS_PATH='\"tmp\"' \
                    -DOT_FIREWALL=OFF \
                    -DOT_LOG_LEVEL=INFO \


### PR DESCRIPTION
#### Summary

This commit specifies vendor name and product/model name for OpenThread Border Router, which is not required either by specifying it at run time or build time. Specifying it at compile time is simpler.

This commit also uprev the docker image used for `Test Suites - Linux` for missing `tcpdump`.

#### Related issues

This blocks #43027.

#### Testing

This should be covered by existing `BLE-Thread` and `Thread-MeshCoP` tests.