### PR TITLE
Clean some follow-up issues

### DIFF
--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -58,6 +58,18 @@ source_set("joint_fabric") {
   ]
 }
 
+static_library("thread_rendezvous_announcement") {
+  sources = [
+    "ThreadRendezvousAnnouncement.cpp",
+    "ThreadRendezvousAnnouncement.h",
+  ]
+  deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/dnssd",
+    "${chip_root}/src/lib/dnssd/minimal_mdns",
+  ]
+}
+
 static_library("server") {
   output_name = "libCHIPAppServer"
 
@@ -76,8 +88,6 @@ static_library("server") {
     "EchoHandler.h",
     "Server.cpp",
     "Server.h",
-    "ThreadRendezvousAnnouncement.cpp",
-    "ThreadRendezvousAnnouncement.h",
   ]
 
   public_configs = [ ":server_config" ]
@@ -102,10 +112,7 @@ static_library("server") {
   ]
 
   if (chip_device_config_enable_thread_meshcop) {
-    public_deps += [
-      "${chip_root}/src/lib/dnssd/minimal_mdns",
-      "${chip_root}/src/lib/dnssd/minimal_mdns/records",
-    ]
+    deps = [ ":thread_rendezvous_announcement" ]
   }
 
   if (chip_terms_and_conditions_required) {

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -41,12 +41,8 @@
 #include <algorithm>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
-#include <app/server/ThreadRendezvousAnnouncement.h>
-#include <inttypes.h>
-#include <stdarg.h>
-#include <stdio.h>
-
 #include <app/server/Server.h>
+#include <app/server/ThreadRendezvousAnnouncement.h> // nogncheck
 #endif
 
 using namespace chip;

--- a/src/app/server/ThreadRendezvousAnnouncement.cpp
+++ b/src/app/server/ThreadRendezvousAnnouncement.cpp
@@ -23,11 +23,9 @@
 
 #include <lib/support/CodeUtils.h>
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
-#include <lib/dnssd/minimal_mdns/ResponseBuilder.h> // nogncheck
-#include <lib/dnssd/minimal_mdns/records/Srv.h>     // nogncheck
-#include <lib/dnssd/minimal_mdns/records/Txt.h>     // nogncheck
-#endif
+#include <lib/dnssd/minimal_mdns/ResponseBuilder.h>
+#include <lib/dnssd/minimal_mdns/records/Srv.h>
+#include <lib/dnssd/minimal_mdns/records/Txt.h>
 
 namespace chip {
 namespace app {
@@ -113,7 +111,6 @@ CHIP_ERROR TxtStringsBuilder::FormatAndAdd(const char * format, ...)
     return CHIP_NO_ERROR;
 }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
 CHIP_ERROR BuildThreadRendezvousAnnouncement(const Dnssd::CommissionAdvertisingParameters & params,
                                              System::PacketBufferHandle & outBuffer)
 {
@@ -143,7 +140,6 @@ CHIP_ERROR BuildThreadRendezvousAnnouncement(const Dnssd::CommissionAdvertisingP
 
     return CHIP_NO_ERROR;
 }
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
 
 } // namespace app
 } // namespace chip

--- a/src/app/server/ThreadRendezvousAnnouncement.h
+++ b/src/app/server/ThreadRendezvousAnnouncement.h
@@ -58,8 +58,6 @@ private:
     const char * mTxtStrings[Dnssd::CommissionAdvertisingParameters::kTxtMaxNumber];
 };
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
-
 /**
  * @brief Builds the Thread Rendezvous Announcement packet buffer.
  *
@@ -69,8 +67,6 @@ private:
  */
 CHIP_ERROR BuildThreadRendezvousAnnouncement(const Dnssd::CommissionAdvertisingParameters & params,
                                              System::PacketBufferHandle & outBuffer);
-
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP
 
 } // namespace app
 } // namespace chip

--- a/src/app/server/tests/BUILD.gn
+++ b/src/app/server/tests/BUILD.gn
@@ -30,6 +30,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/app/server",
     "${chip_root}/src/app/server:joint_fabric",
+    "${chip_root}/src/app/server:thread_rendezvous_announcement",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support:testing",
   ]

--- a/src/app/server/tests/TestThreadRendezvousAnnouncement.cpp
+++ b/src/app/server/tests/TestThreadRendezvousAnnouncement.cpp
@@ -45,17 +45,6 @@ TEST_F(TestThreadRendezvousAnnouncement, TxtStringsBuilder)
 
     TxtStringsBuilder builder;
     EXPECT_EQ(builder.Fill(params), CHIP_NO_ERROR);
-
-    // Expected entries:
-    // VP=123+456
-    // D=789
-    // CM=1
-    // DT=1
-    // DN=TestDevice
-    // RI=1234567890
-    // PH=2
-    // PI=Press button
-
     EXPECT_EQ(builder.GetCount(), 8u);
     const char * const * entries = builder.GetEntries();
 

--- a/src/lib/dnssd/minimal_mdns/core/QNameString.h
+++ b/src/lib/dnssd/minimal_mdns/core/QNameString.h
@@ -45,12 +45,18 @@ public:
 private:
     bool EndsWith(const char * aSuffix, size_t aLength) const
     {
+        if (!Fit())
+        {
+            return false;
+        }
+
         const char * buffer = mBuffer.c_str();
         size_t bufferLength = strlen(buffer);
         if (bufferLength < aLength)
         {
             return false;
         }
+
         return memcmp(buffer + bufferLength - aLength, aSuffix, aLength) == 0;
     }
 

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestQNameString.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestQNameString.cpp
@@ -64,4 +64,17 @@ TEST_F(TestQNameString, EndsWith)
     EXPECT_FALSE(qName.EndsWith("test"));
     EXPECT_FALSE(qName.EndsWith("abc.test"));
 }
+
+TEST_F(TestQNameString, LongQName)
+{
+    const testing::TestQName<10> kLong({ "label1234567890", "label1234567890", "label1234567890", "label1234567890",
+                                         "label1234567890", "label1234567890", "label1234567890", "label1234567890",
+                                         "label1234567890", "label1234567890" });
+    QNameString qName(kLong.Serialized());
+
+    // QNameString buffer is 128 bytes. 10 * 15 + 9 = 159 bytes.
+    EXPECT_FALSE(qName.Fit());
+    // EndsWith should return false if Fit() is false, even if the suffix matches what's in the buffer
+    EXPECT_FALSE(qName.EndsWith("label1234567890"));
+}
 } // namespace


### PR DESCRIPTION
#### Summary

This commit is a follow-up of #42992 fixing remaining issues:

1. Removed unnecessary guards.
2. Removed unnecessary comments in `src/app/server/tests/TestThreadRendezvousAnnouncement.cpp`
3. Verify QNameString fits before comparing.

#### Related issues

#42992 

#### Testing

No new test added. This commit fixes style issues and strengthen the check of `QNameString::EndsWith()`
