### PR TITLE
esp32: Add all-devices-app to esp32 CI.

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -203,6 +203,9 @@ jobs:
             - name: Build example Bridge App
               run: scripts/examples/esp_example.sh bridge-app
 
+            - name: Build example All Devices App
+              run: scripts/examples/esp_example.sh all-devices-app sdkconfig.defaults
+
             - name: Build example Persistent Storage App
               run: scripts/examples/esp_example.sh persistent-storage sdkconfig.defaults
 

--- a/examples/all-devices-app/esp32/main/CMakeLists.txt
+++ b/examples/all-devices-app/esp32/main/CMakeLists.txt
@@ -41,7 +41,6 @@ set(APP_SRCS
     "${ALL_DEVICES_COMMON_DIR}/devices/on-off-light/LoggingOnOffLightDevice.cpp"
     "${ALL_DEVICES_COMMON_DIR}/devices/root-node/RootNodeDevice.cpp"
     "${ALL_DEVICES_COMMON_DIR}/devices/root-node/WifiRootNodeDevice.cpp"
-    "${ALL_DEVICES_COMMON_DIR}/devices/root-node/WifiRootNodeDevice.cpp"
     "${ALL_DEVICES_COMMON_DIR}/devices/speaker/SpeakerDevice.cpp"
     "${ALL_DEVICES_COMMON_DIR}/devices/speaker/impl/LoggingSpeakerDevice.cpp"
     # keep-sorted: end

--- a/examples/all-devices-app/esp32/main/CMakeLists.txt
+++ b/examples/all-devices-app/esp32/main/CMakeLists.txt
@@ -41,6 +41,9 @@ set(APP_SRCS
     "${ALL_DEVICES_COMMON_DIR}/devices/on-off-light/LoggingOnOffLightDevice.cpp"
     "${ALL_DEVICES_COMMON_DIR}/devices/root-node/RootNodeDevice.cpp"
     "${ALL_DEVICES_COMMON_DIR}/devices/root-node/WifiRootNodeDevice.cpp"
+    "${ALL_DEVICES_COMMON_DIR}/devices/root-node/WifiRootNodeDevice.cpp"
+    "${ALL_DEVICES_COMMON_DIR}/devices/speaker/SpeakerDevice.cpp"
+    "${ALL_DEVICES_COMMON_DIR}/devices/speaker/impl/LoggingSpeakerDevice.cpp"
     # keep-sorted: end
 
     # Providers
@@ -107,6 +110,7 @@ set(CLUSTER_SRCS
     "${CHIP_ROOT}/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp"
     "${CHIP_ROOT}/src/app/clusters/groups-server/GroupsCluster.cpp"
     "${CHIP_ROOT}/src/app/clusters/identify-server/IdentifyCluster.cpp"
+    "${CHIP_ROOT}/src/app/clusters/level-control/LevelControlCluster.cpp"
     "${CHIP_ROOT}/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp"
     "${CHIP_ROOT}/src/app/clusters/network-commissioning/WifiScanResponse.cpp"
     "${CHIP_ROOT}/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp"
@@ -117,7 +121,7 @@ set(CLUSTER_SRCS
     "${CHIP_ROOT}/src/app/clusters/scenes-server/SceneHandlerImpl.cpp"
     "${CHIP_ROOT}/src/app/clusters/scenes-server/ScenesManagementCluster.cpp"
     "${CHIP_ROOT}/src/app/clusters/scenes-server/SceneTableImpl.cpp"
-    "${CHIP_ROOT}/src/app/clusters/software-diagnostics-server/SoftwareDiagnosticsLogic.cpp"
+    "${CHIP_ROOT}/src/app/clusters/software-diagnostics-server/SoftwareDiagnosticsCluster.cpp"
     "${CHIP_ROOT}/src/app/clusters/software-diagnostics-server/software-fault-listener.cpp"
     "${CHIP_ROOT}/src/app/clusters/wifi-network-diagnostics-server/WiFiNetworkDiagnosticsCluster.cpp"
     # keep-sorted: end

--- a/examples/all-devices-app/esp32/main/DeviceShellCommands.cpp
+++ b/examples/all-devices-app/esp32/main/DeviceShellCommands.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <DeviceShellCommands.h>
+#include <devices/device-factory/DeviceFactory.h>
 #include <lib/shell/streamer.h>
 
 // Forward declaration of the function defined in main.cpp
@@ -43,8 +44,14 @@ CHIP_ERROR DeviceCommands::SetDeviceTypeHandler(int argc, char ** argv)
 {
     if (argc != 1)
     {
+        const auto supportedDeviceTypes = chip::app::DeviceFactory::GetInstance().SupportedDeviceTypes();
         streamer_printf(streamer_get(), "Usage: devtype set <device-type>\r\n");
         streamer_printf(streamer_get(), "Example: devtype set contact-sensor\r\n");
+        streamer_printf(streamer_get(), "Supported device types:\r\n");
+        for (const auto & deviceType : supportedDeviceTypes)
+        {
+            streamer_printf(streamer_get(), "  - %s\r\n", deviceType.c_str());
+        }
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -389,6 +389,11 @@ extern "C" void app_main()
     CHIP_ERROR nvsErr =
         ESP32Config::ReadConfigValueStr(kConfigKey_DeviceType, storedDeviceType, sizeof(storedDeviceType), storedLen);
 
+#if CONFIG_ENABLE_CHIP_SHELL
+    chip::LaunchShell();
+    chip::Shell::DeviceCommands::GetInstance().Register();
+#endif // CONFIG_ENABLE_CHIP_SHELL
+
     if (nvsErr == CHIP_NO_ERROR && storedLen > 0)
     {
         ESP_LOGI(TAG, "==================================================");
@@ -399,10 +404,6 @@ extern "C" void app_main()
     }
     else
     {
-#if CONFIG_ENABLE_CHIP_SHELL
-        chip::LaunchShell();
-        chip::Shell::DeviceCommands::GetInstance().Register();
-#endif // CONFIG_ENABLE_CHIP_SHELL
         ESP_LOGI(TAG, "==================================================");
         ESP_LOGI(TAG, "No stored device type found.");
         ESP_LOGI(TAG, "Use command: devtype set <device-type>");


### PR DESCRIPTION
#### Summary

- Add all-devices-app to esp32 CI.
- Fixed the example build failures.
- Improved the shell help.

#### Related issues

all-devices-app esp32 keeps breaking whenever new device/cluster added to the example.

#### Testing

CI should pass.
