### PR TITLE
Implement Network Recovery: Linux chip-tool

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -99,6 +99,8 @@ static_library("chip-tool-utils") {
     "commands/discover/DiscoverCommissionersCommand.cpp",
     "commands/icd/ICDCommand.cpp",
     "commands/icd/ICDCommand.h",
+    "commands/network-recovery/NetworkRecoveryCommand.cpp",
+    "commands/network-recovery/NetworkRecoveryCommand.h",
     "commands/pairing/OpenCommissioningWindowCommand.cpp",
     "commands/pairing/OpenCommissioningWindowCommand.h",
     "commands/pairing/PairingCommand.cpp",

--- a/examples/chip-tool/commands/network-recovery/Commands.h
+++ b/examples/chip-tool/commands/network-recovery/Commands.h
@@ -1,0 +1,36 @@
+/*
+ *   Copyright (c) 2026 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "NetworkRecoveryCommand.h"
+#include <commands/common/Commands.h>
+
+void registerCommandsNetworkRecovery(Commands & commands, CredentialIssuerCommands * credsIssuerConfig)
+{
+    const char * clusterName = "networkrecovery";
+
+    commands_list clusterCommands = {
+        make_unique<NetworkRecoveryDiscoverCommand>(credsIssuerConfig),
+        make_unique<NetworkRecoveryRecoverCommand>("recover-wifi", RecoveryNetworkType::WiFi, credsIssuerConfig),
+        make_unique<NetworkRecoveryRecoverCommand>("recover-thread", RecoveryNetworkType::Thread, credsIssuerConfig),
+    };
+
+    commands.RegisterCommandSet(clusterName, clusterCommands,
+                                "Commands for discovering and recovering recoverable devices by chip-tool.");
+}

--- a/examples/chip-tool/commands/network-recovery/NetworkRecoveryCommand.cpp
+++ b/examples/chip-tool/commands/network-recovery/NetworkRecoveryCommand.cpp
@@ -1,0 +1,74 @@
+/*
+ *   Copyright (c) 2026 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "NetworkRecoveryCommand.h"
+#include <commands/common/DeviceScanner.h>
+#include <commands/common/RemoteDataModelLogger.h>
+#include <lib/support/BytesToHex.h>
+
+using namespace ::chip;
+
+void NetworkRecoveryCommandBase::OnNetworkRecoverDiscover(std::list<uint64_t> recoveryIds)
+{
+    ChipLogProgress(chipTool, "Find recoverable devices:");
+    for (const auto & recoveryId : recoveryIds)
+    {
+        ChipLogProgress(chipTool, "0x" ChipLogFormatX64, ChipLogValueX64(recoveryId));
+        (void) recoveryId; // Avoid unused variable warning in case logging is disabled
+    }
+    SetCommandExitStatus(CHIP_NO_ERROR);
+}
+
+void NetworkRecoveryCommandBase::OnNetworkRecoverComplete(NodeId deviceId, CHIP_ERROR error)
+{
+    if (error == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(chipTool, "Recovery complete for devicice " ChipLogFormatX64, ChipLogValueX64(deviceId));
+    }
+    else
+    {
+        ChipLogError(chipTool, "Recovery failed for device " ChipLogFormatX64, ChipLogValueX64(deviceId));
+    }
+    SetCommandExitStatus(error);
+}
+
+CHIP_ERROR NetworkRecoveryDiscoverCommand::RunCommand()
+{
+    uint16_t timeout = mTimeout.ValueOr(30);
+    ChipLogProgress(chipTool, "Start scanning recoverable nodes, timeout:%d", timeout);
+    mCommissioner = &CurrentCommissioner();
+    mCommissioner->RegisterNetworkRecoverDelegate(this);
+    return mCommissioner->DiscoverRecoverableNodes(timeout);
+}
+
+CHIP_ERROR NetworkRecoveryRecoverCommand::RunCommand()
+{
+    CHIP_ERROR err;
+    mCommissioner = &CurrentCommissioner();
+    mCommissioner->RegisterNetworkRecoverDelegate(this);
+    if (mOperationalDataset.empty())
+    {
+        chip::Controller::WiFiCredentials wiFiCreds(mSSID, mPassword);
+        err = mCommissioner->RecoverNode(mNodeId, mRecoveryId, wiFiCreds, mBreadcrumb);
+    }
+    else
+    {
+        err = mCommissioner->RecoverNode(mNodeId, mRecoveryId, mOperationalDataset, mBreadcrumb);
+    }
+    return err;
+}

--- a/examples/chip-tool/commands/network-recovery/NetworkRecoveryCommand.h
+++ b/examples/chip-tool/commands/network-recovery/NetworkRecoveryCommand.h
@@ -1,0 +1,105 @@
+/*
+ *   Copyright (c) 2026 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../common/CHIPCommand.h"
+#include <controller/NetworkRecover.h>
+#include <lib/support/Span.h>
+#include <lib/support/ThreadOperationalDataset.h>
+
+enum class RecoveryNetworkType
+{
+    None,
+    WiFi,
+    Thread,
+};
+
+class NetworkRecoveryCommandBase : public CHIPCommand, public chip::Controller::NetworkRecoverDelegate
+{
+public:
+    NetworkRecoveryCommandBase(const char * name, CredentialIssuerCommands * credsIssuerConfig) :
+        CHIPCommand(name, credsIssuerConfig)
+    {}
+    /////////// NetworkRecoverDelegate Interface /////////
+    void OnNetworkRecoverDiscover(std::list<uint64_t> recoveryIds) override;
+    void OnNetworkRecoverComplete(NodeId deviceId, CHIP_ERROR error) override;
+
+    /////////// CHIPCommand Interface /////////
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }
+
+protected:
+    chip::Controller::DeviceCommissioner * mCommissioner;
+};
+
+class NetworkRecoveryDiscoverCommand : public NetworkRecoveryCommandBase
+{
+public:
+    NetworkRecoveryDiscoverCommand(CredentialIssuerCommands * credsIssuerConfig) :
+        NetworkRecoveryCommandBase("discover", credsIssuerConfig)
+    {
+        AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
+    }
+    CHIP_ERROR RunCommand() override;
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mTimeout.ValueOr(30) + 10);
+    }
+
+private:
+    chip::Optional<uint16_t> mTimeout;
+};
+
+class NetworkRecoveryRecoverCommand : public NetworkRecoveryCommandBase
+{
+public:
+    NetworkRecoveryRecoverCommand(const char * commandName, RecoveryNetworkType networkType,
+                                  CredentialIssuerCommands * credsIssuerConfig) :
+        NetworkRecoveryCommandBase(commandName, credsIssuerConfig), mNetworkType(networkType)
+    {
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
+        AddArgument("recovery-identifier", 0, UINT64_MAX, &mRecoveryId);
+
+        switch (mNetworkType)
+        {
+        case RecoveryNetworkType::WiFi:
+            AddArgument("ssid", &mSSID);
+            AddArgument("password", &mPassword);
+            break;
+        case RecoveryNetworkType::Thread:
+            AddArgument("operational-dataset", &mOperationalDataset);
+            break;
+        default:
+            break;
+        }
+        AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
+    }
+
+    CHIP_ERROR RunCommand() override;
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(70); }
+
+private:
+    chip::NodeId mNodeId;
+    uint64_t mRecoveryId;
+    RecoveryNetworkType mNetworkType;
+    chip::ByteSpan mSSID;
+    chip::ByteSpan mPassword;
+    chip::ByteSpan mOperationalDataset;
+    uint64_t mBreadcrumb;
+    chip::Optional<uint16_t> mTimeout;
+};

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -26,6 +26,7 @@
 #include "commands/group/Commands.h"
 #include "commands/icd/ICDCommand.h"
 #include "commands/interactive/Commands.h"
+#include "commands/network-recovery/Commands.h"
 #include "commands/pairing/Commands.h"
 #include "commands/payload/Commands.h"
 #include "commands/session-management/Commands.h"
@@ -52,6 +53,7 @@ int main(int argc, char * argv[])
     registerCommandsSubscriptions(commands, &credIssuerCommands);
     registerCommandsStorage(commands);
     registerCommandsSessionManagement(commands, &credIssuerCommands);
+    registerCommandsNetworkRecovery(commands, &credIssuerCommands);
 
     return commands.Run(argc, argv);
 }

--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -176,6 +176,7 @@ ALLOW: Dict[str, Set[str]] = {
     # Not really for embedded consumers, because commissioners tend to not be embedded.
     'src/controller/SetUpCodePairer.h': {'deque', 'vector'},
     'src/controller/SetUpCodePairer.cpp': {'vector'},
+    'src/controller/NetworkRecover.h': {'deque', 'list'},
 
     'src/controller/ExamplePersistentStorage.cpp': {'fstream', 'string', 'map'},
     'src/controller/ExamplePersistentStorage.h': {'string'},

--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -50,6 +50,21 @@ void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Cal
 }
 
 void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
+                                                Callback::Callback<OnDeviceConnectionFailure> * onFailure,
+                                                Transport::PeerAddress & addr,
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                                uint8_t attemptCount, Callback::Callback<OnDeviceConnectionRetry> * onRetry,
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                                TransportPayloadCapability transportPayloadCapability)
+{
+    FindOrEstablishSessionHelper(peerId, onConnection, onFailure, nullptr, addr,
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                 attemptCount, onRetry,
+#endif
+                                 transportPayloadCapability);
+}
+
+void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
                                                 Callback::Callback<OperationalSessionSetup::OnSetupFailure> * onSetupFailure,
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
                                                 uint8_t attemptCount, Callback::Callback<OnDeviceConnectionRetry> * onRetry,
@@ -144,6 +159,62 @@ void CASESessionManager::FindOrEstablishSessionHelper(const ScopedNodeId & peerI
     if (onFailure != nullptr)
     {
         session->Connect(onConnection, onFailure, transportPayloadCapability);
+    }
+
+    if (onSetupFailure != nullptr)
+    {
+        session->Connect(onConnection, onSetupFailure, transportPayloadCapability);
+    }
+}
+
+void CASESessionManager::FindOrEstablishSessionHelper(const ScopedNodeId & peerId,
+                                                      Callback::Callback<OnDeviceConnected> * onConnection,
+                                                      Callback::Callback<OnDeviceConnectionFailure> * onFailure,
+                                                      Callback::Callback<OperationalSessionSetup::OnSetupFailure> * onSetupFailure,
+                                                      Transport::PeerAddress & addr,
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                                      uint8_t attemptCount, Callback::Callback<OnDeviceConnectionRetry> * onRetry,
+#endif
+                                                      TransportPayloadCapability transportPayloadCapability)
+{
+    ChipLogDetail(CASESessionManager, "FindOrEstablishSession: PeerId = [%d:" ChipLogFormatX64 "]", peerId.GetFabricIndex(),
+                  ChipLogValueX64(peerId.GetNodeId()));
+
+    bool forAddressUpdate             = false;
+    OperationalSessionSetup * session = FindExistingSessionSetup(peerId, forAddressUpdate);
+    if (session == nullptr)
+    {
+        ChipLogDetail(CASESessionManager, "FindOrEstablishSession: No existing OperationalSessionSetup instance found");
+        session = mConfig.sessionSetupPool->Allocate(mConfig.sessionInitParams, mConfig.clientPool, peerId, this);
+
+        if (session == nullptr)
+        {
+            if (onFailure != nullptr)
+            {
+                onFailure->mCall(onFailure->mContext, peerId, CHIP_ERROR_NO_MEMORY);
+            }
+
+            if (onSetupFailure != nullptr)
+            {
+                OperationalSessionSetup::ConnectionFailureInfo failureInfo(peerId, CHIP_ERROR_NO_MEMORY,
+                                                                           SessionEstablishmentStage::kUnknown);
+                onSetupFailure->mCall(onSetupFailure->mContext, failureInfo);
+            }
+            return;
+        }
+    }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+    session->UpdateAttemptCount(attemptCount);
+    if (onRetry)
+    {
+        session->AddRetryHandler(onRetry);
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+
+    if (onFailure != nullptr)
+    {
+        session->Connect(onConnection, onFailure, addr, transportPayloadCapability);
     }
 
     if (onSetupFailure != nullptr)

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -88,6 +88,16 @@ public:
                                 const Optional<AddressResolve::ResolveResult> & fallbackResolveResult = NullOptional);
 
     /**
+     * TODO:
+     */
+    void FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
+                                Callback::Callback<OnDeviceConnectionFailure> * onFailure, Transport::PeerAddress & addr,
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                uint8_t attemptCount = 1, Callback::Callback<OnDeviceConnectionRetry> * onRetry = nullptr,
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                TransportPayloadCapability transportPayloadCapability = TransportPayloadCapability::kMRPPayload);
+
+    /**
      * Find an existing session for the given node ID or trigger a new session request.
      *
      * The caller can optionally provide `onConnection` and `onSetupFailure`
@@ -206,6 +216,15 @@ private:
 #endif
                                       TransportPayloadCapability transportPayloadCapability,
                                       const Optional<AddressResolve::ResolveResult> & fallbackResolveResult = NullOptional);
+
+    void FindOrEstablishSessionHelper(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
+                                      Callback::Callback<OnDeviceConnectionFailure> * onFailure,
+                                      Callback::Callback<OperationalSessionSetup::OnSetupFailure> * onSetupFailure,
+                                      Transport::PeerAddress & addr,
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                      uint8_t attemptCount, Callback::Callback<OnDeviceConnectionRetry> * onRetry,
+#endif
+                                      TransportPayloadCapability transportPayloadCapability);
 
     CASESessionManagerConfig mConfig;
 };

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -191,6 +191,20 @@ void OperationalSessionSetup::Connect(Callback::Callback<OnDeviceConnected> * on
 }
 
 void OperationalSessionSetup::Connect(Callback::Callback<OnDeviceConnected> * onConnection,
+                                      Callback::Callback<OnDeviceConnectionFailure> * onFailure, Transport::PeerAddress & addr,
+                                      TransportPayloadCapability transportPayloadCapability)
+{
+    mState                      = State::ResolvingAddress;
+    mTransportPayloadCapability = transportPayloadCapability;
+    AddressResolve::ResolveResult result;
+    result.address = addr;
+
+    EnqueueConnectionCallbacks(onConnection, onFailure, nullptr);
+
+    UpdateDeviceData(result);
+}
+
+void OperationalSessionSetup::Connect(Callback::Callback<OnDeviceConnected> * onConnection,
                                       Callback::Callback<OnSetupFailure> * onSetupFailure,
                                       TransportPayloadCapability transportPayloadCapability)
 {
@@ -371,8 +385,8 @@ void OperationalSessionSetup::DequeueConnectionCallbacks(CHIP_ERROR error, Sessi
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
 
     // Gather up state we will need for our notifications.
-    SuccessFailureCallbackList readyCallbacks;
-    readyCallbacks.EnqueueTakeAll(mCallbacks);
+    auto readyCallbacks = std::make_shared<SuccessFailureCallbackList>();
+    readyCallbacks->EnqueueTakeAll(mCallbacks);
     auto * exchangeMgr                            = mInitParams.exchangeMgr;
     Optional<SessionHandle> optionalSessionHandle = mSecureSession.Get();
     ScopedNodeId peerId                           = mPeerId;
@@ -390,7 +404,7 @@ void OperationalSessionSetup::DequeueConnectionCallbacks(CHIP_ERROR error, Sessi
     }
 
     // DO NOT touch any members of this object after this point.  It's dead.
-    NotifyConnectionCallbacks(readyCallbacks, error, stage, peerId, exchangeMgr, optionalSessionHandle, requestedBusyDelay);
+    NotifyConnectionCallbacks(*readyCallbacks, error, stage, peerId, exchangeMgr, optionalSessionHandle, requestedBusyDelay);
 }
 
 void OperationalSessionSetup::NotifyConnectionCallbacks(SuccessFailureCallbackList & ready, CHIP_ERROR error,

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -218,6 +218,13 @@ public:
     void Connect(Callback::Callback<OnDeviceConnected> * onConnection, Callback::Callback<OnDeviceConnectionFailure> * onFailure,
                  TransportPayloadCapability transportPayloadCapability = TransportPayloadCapability::kMRPPayload);
 
+    /**
+     * TODO:
+     */
+    void Connect(Callback::Callback<OnDeviceConnected> * onConnection, Callback::Callback<OnDeviceConnectionFailure> * onFailure,
+                 Transport::PeerAddress & addr,
+                 TransportPayloadCapability transportPayloadCapability = TransportPayloadCapability::kMRPPayload);
+
     /*
      * This function can be called to establish a secure session with the device.
      *

--- a/src/ble/BleConnectionDelegate.h
+++ b/src/ble/BleConnectionDelegate.h
@@ -61,9 +61,15 @@ public:
     typedef void (*OnConnectionErrorFunct)(void * appState, CHIP_ERROR err);
     OnConnectionErrorFunct OnConnectionError;
 
+    typedef void (*OnDiscoverCompleteFunct)(void * appState, uint64_t recoveryIdentifier);
+    OnDiscoverCompleteFunct OnDiscoverComplete;
+
     // Call this function to delegate the connection steps required to get a BLE_CONNECTION_OBJECT
     // out of a peripheral that matches the given discriminator.
     virtual void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) = 0;
+
+    // TODO:
+    virtual void NewConnection(BleLayer * bleLayer, void * appState, uint64_t connRecoveryIdentifier) = 0;
 
     // Call this function to delegate the connection steps required to get a connected BLE_CONNECTION_OBJECT
     // out of a disconnected BLE_CONNECTION_OBJECT.

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -375,6 +375,24 @@ CHIP_ERROR BleLayer::NewBleConnectionByDiscriminator(const SetupDiscriminator & 
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR BleLayer::NewBleConnectionByRecoveryIdentifier(uint64_t connRecoveryIdentifier, void * appState,
+                                                          BleConnectionDelegate::OnConnectionCompleteFunct onSuccess,
+                                                          BleConnectionDelegate::OnConnectionErrorFunct onError,
+                                                          BleConnectionDelegate::OnDiscoverCompleteFunct onDiscover)
+{
+    VerifyOrReturnError(mState == kState_Initialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mConnectionDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mBleTransport != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    mConnectionDelegate->OnConnectionComplete = onSuccess;
+    mConnectionDelegate->OnConnectionError    = onError;
+    mConnectionDelegate->OnDiscoverComplete   = onDiscover;
+
+    mConnectionDelegate->NewConnection(this, appState == nullptr ? this : appState, connRecoveryIdentifier);
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR BleLayer::NewBleConnectionByObject(BLE_CONNECTION_OBJECT connObj, void * appState,
                                               BleConnectionDelegate::OnConnectionCompleteFunct onSuccess,
                                               BleConnectionDelegate::OnConnectionErrorFunct onError)

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -257,6 +257,11 @@ public:
     CHIP_ERROR NewBleConnectionByDiscriminator(const SetupDiscriminator & connDiscriminator, void * appState = nullptr,
                                                BleConnectionDelegate::OnConnectionCompleteFunct onSuccess = OnConnectionComplete,
                                                BleConnectionDelegate::OnConnectionErrorFunct onError      = OnConnectionError);
+    CHIP_ERROR
+    NewBleConnectionByRecoveryIdentifier(uint64_t connRecoveryIdentifier, void * appState = nullptr,
+                                         BleConnectionDelegate::OnConnectionCompleteFunct onSuccess = OnConnectionComplete,
+                                         BleConnectionDelegate::OnConnectionErrorFunct onError      = OnConnectionError,
+                                         BleConnectionDelegate::OnDiscoverCompleteFunct onDiscover  = OnDiscoverComplete);
     CHIP_ERROR NewBleConnectionByObject(BLE_CONNECTION_OBJECT connObj, void * appState,
                                         BleConnectionDelegate::OnConnectionCompleteFunct onSuccess = OnConnectionComplete,
                                         BleConnectionDelegate::OnConnectionErrorFunct onError      = OnConnectionError);
@@ -360,6 +365,7 @@ private:
 
     static void OnConnectionComplete(void * appState, BLE_CONNECTION_OBJECT connObj);
     static void OnConnectionError(void * appState, CHIP_ERROR err);
+    static void OnDiscoverComplete(void * appState, uint64_t recoverIdentifier) {}
 };
 } /* namespace Ble */
 } /* namespace chip */

--- a/src/controller/AutoNetworkRecover.cpp
+++ b/src/controller/AutoNetworkRecover.cpp
@@ -1,0 +1,432 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <controller/AutoNetworkRecover.h>
+
+#include <app-common/zap-generated/cluster-objects.h>
+
+using namespace chip::app::Clusters;
+
+namespace chip {
+namespace Controller {
+
+CHIP_ERROR NetworkRecoverBase::RecoverNetwork(NodeId remoteNodeId, Transport::PeerAddress & addr,
+                                              const Optional<WiFiCredentials> & wiFiCredentials,
+                                              const Optional<ByteSpan> & operationalDataset, uint64_t breadcrumb,
+                                              chip::Callback::Callback<OnNetworkRecover> * callback)
+{
+    if (wiFiCredentials.HasValue())
+    {
+        mNetworkType     = NetworkType::kWiFi;
+        mWiFiCredentials = wiFiCredentials;
+    }
+    else if (operationalDataset.HasValue())
+    {
+        mNetworkType        = NetworkType::kThread;
+        mOperationalDataset = operationalDataset;
+    }
+    else
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    mRemoteNodeId           = remoteNodeId;
+    mBreadcrumb             = breadcrumb;
+    mNetworkRecoverCallback = callback;
+    return mController->GetConnectedDevice(remoteNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback, addr);
+}
+
+CHIP_ERROR NetworkRecoverBase::SendArmFailSafe(uint16_t timeout, Messaging::ExchangeManager & exchangeMgr,
+                                               const SessionHandle & sessionHandle)
+{
+    GeneralCommissioning::Commands::ArmFailSafe::Type request;
+    request.expiryLengthSeconds = timeout;
+    request.breadcrumb          = 0;
+
+    ClusterBase cluster(exchangeMgr, sessionHandle, kRootEndpointId);
+
+    return cluster.InvokeCommand(request, this, OnArmFailSafeResponse, OnCommandFailure);
+}
+
+CHIP_ERROR NetworkRecoverBase::ReadLastNetworkID(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
+{
+    using TypeInfo = NetworkCommissioning::Attributes::LastNetworkID::TypeInfo;
+
+    ClusterBase cluster(exchangeMgr, sessionHandle, kRootEndpointId);
+
+    return cluster.ReadAttribute<TypeInfo>(this, OnSuccessReadLastNetworkID, OnReadAttributeFailure);
+}
+
+CHIP_ERROR NetworkRecoverBase::SendRemoveNetwork(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
+{
+    NetworkCommissioning::Commands::RemoveNetwork::Type request;
+
+    request.networkID = mLastNetworkID;
+
+    ClusterBase cluster(exchangeMgr, sessionHandle, kRootEndpointId);
+
+    return cluster.InvokeCommand(request, this, OnNetworkConfigResponse, OnCommandFailure);
+}
+
+CHIP_ERROR NetworkRecoverBase::SendAddOrUpdateNetwork(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
+{
+    CHIP_ERROR err;
+    ClusterBase cluster(exchangeMgr, sessionHandle, kRootEndpointId);
+    if (mNetworkType == NetworkType::kWiFi)
+    {
+        NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::Type request;
+
+        request.ssid        = mWiFiCredentials.Value().ssid;
+        request.credentials = mWiFiCredentials.Value().credentials;
+        request.breadcrumb.Emplace(mBreadcrumb);
+
+        err = cluster.InvokeCommand(request, this, OnNetworkConfigResponse, OnCommandFailure);
+    }
+    else
+    {
+        NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::Type request;
+        request.operationalDataset = mOperationalDataset.Value();
+        request.breadcrumb.Emplace(mBreadcrumb);
+
+        err = cluster.InvokeCommand(request, this, OnNetworkConfigResponse, OnCommandFailure);
+    }
+    return err;
+}
+
+CHIP_ERROR NetworkRecoverBase::SendConnectNetwork(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
+{
+    ClusterBase cluster(exchangeMgr, sessionHandle, kRootEndpointId);
+
+    NetworkCommissioning::Commands::ConnectNetwork::Type request;
+    if (mNetworkType == NetworkType::kWiFi)
+    {
+        request.networkID = mWiFiCredentials.Value().ssid;
+    }
+    else
+    {
+        request.networkID = mOperationalDataset.Value();
+    }
+    request.breadcrumb.Emplace(mBreadcrumb);
+
+    return cluster.InvokeCommand(request, this, OnConnectNetworkResponse, OnCommandFailure);
+}
+
+CHIP_ERROR NetworkRecoverBase::ReleaseSessions(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
+{
+    CHIP_ERROR err = mController->ExpireAllSessions(mRemoteNodeId);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to release session: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+    else
+    {
+        mNextStep = Step::kSendCommissioningComplete;
+        err = mController->GetConnectedDevice(mRemoteNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+    }
+    return err;
+}
+
+CHIP_ERROR NetworkRecoverBase::SendCommissioningComplete(Messaging::ExchangeManager & exchangeMgr,
+                                                         const SessionHandle & sessionHandle)
+{
+    ClusterBase cluster(exchangeMgr, sessionHandle, kRootEndpointId);
+
+    GeneralCommissioning::Commands::CommissioningComplete::Type request;
+
+    return cluster.InvokeCommand(request, this, OnCommissioningCompleteResponse, OnCommandFailure);
+}
+
+void NetworkRecoverBase::OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr,
+                                             const SessionHandle & sessionHandle)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    auto * self    = static_cast<NetworkRecoverBase *>(context);
+    VerifyOrReturn(self != nullptr, ChipLogProgress(Controller, "Device connected callback with null context. Ignoring"));
+    ChipLogDetail(Controller, "device conncet callback, next step = %d", to_underlying(self->mNextStep));
+    switch (self->mNextStep)
+    {
+    case Step::kSendArmFailSafe: {
+        err = self->SendArmFailSafe(kDefaultFailsafeTimeout, exchangeMgr, sessionHandle);
+        break;
+    }
+    case Step::kReadLastNetworkID: {
+        err = self->ReadLastNetworkID(exchangeMgr, sessionHandle);
+        break;
+    }
+    case Step::kSendRemoveNetwork: {
+        err = self->SendRemoveNetwork(exchangeMgr, sessionHandle);
+        break;
+    }
+    case Step::kSendAddOrUpdateNetwork: {
+        err = self->SendAddOrUpdateNetwork(exchangeMgr, sessionHandle);
+        break;
+    }
+    case Step::kSendConnectNetwork: {
+        err = self->SendConnectNetwork(exchangeMgr, sessionHandle);
+        break;
+    }
+    case Step::kReleaseSessions: {
+        // clean up the case session then re-establish in operational network
+        err = self->ReleaseSessions(exchangeMgr, sessionHandle);
+        break;
+    }
+    case Step::kSendCommissioningComplete: {
+        err = self->SendCommissioningComplete(exchangeMgr, sessionHandle);
+        break;
+    }
+    case Step::kSendDisArmFailSafe: {
+        err = self->SendArmFailSafe(0, exchangeMgr, sessionHandle);
+        break;
+    }
+    default:
+        err = CHIP_ERROR_INCORRECT_STATE;
+        break;
+    }
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Network Recovery failure : %" CHIP_ERROR_FORMAT, err.Format());
+        FinishRecoverNetwork(context, err);
+    }
+}
+
+void NetworkRecoverBase::OnDeviceConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR err)
+{
+    ChipLogProgress(Controller, "OnDeviceConnectionFailureFn: %" CHIP_ERROR_FORMAT, err.Format());
+
+    auto * self = static_cast<NetworkRecoverBase *>(context);
+    VerifyOrReturn(self != nullptr, ChipLogProgress(Controller, "Device connected failure callback with null context. Ignoring"));
+
+    FinishRecoverNetwork(context, err);
+}
+
+void NetworkRecoverBase::OnArmFailSafeResponse(void * context,
+                                               const GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    auto * self = static_cast<NetworkRecoverBase *>(context);
+    VerifyOrReturn(self != nullptr,
+                   ChipLogProgress(Controller, "Success Arm Fail Safe Response callback with null context. Ignoring"));
+
+    ChipLogProgress(Controller, "Received ArmFailSafe response errorCode=%u", to_underlying(data.errorCode));
+    if (data.errorCode != GeneralCommissioning::CommissioningErrorEnum::kOk)
+    {
+        err = CHIP_ERROR_INTERNAL;
+    }
+    else if (self->mNextStep == Step::kSendDisArmFailSafe)
+    {
+        err = CHIP_ERROR_INTERNAL;
+    }
+    else
+    {
+        self->mNextStep = Step::kReadLastNetworkID;
+        err             = self->mController->GetConnectedDevice(self->mRemoteNodeId, &self->mOnDeviceConnectedCallback,
+                                                                &self->mOnDeviceConnectionFailureCallback);
+    }
+    if (err != CHIP_NO_ERROR)
+    {
+        FinishRecoverNetwork(context, err);
+    }
+}
+
+void NetworkRecoverBase::OnSuccessReadLastNetworkID(void * context,
+                                                    const chip::app::DataModel::Nullable<chip::ByteSpan> & networkID)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    auto * self = static_cast<NetworkRecoverBase *>(context);
+    VerifyOrReturn(self != nullptr,
+                   ChipLogProgress(Controller, "Success Read Last Network ID callback with null context. Ignoring"));
+
+    if (networkID.IsNull())
+    {
+        self->mNextStep = Step::kSendAddOrUpdateNetwork;
+    }
+    else
+    {
+        self->mLastNetworkID = networkID.Value();
+        self->mNextStep      = Step::kSendRemoveNetwork;
+    }
+    err = self->mController->GetConnectedDevice(self->mRemoteNodeId, &self->mOnDeviceConnectedCallback,
+                                                &self->mOnDeviceConnectionFailureCallback);
+    if (err != CHIP_NO_ERROR)
+    {
+        FinishRecoverNetwork(context, err);
+    }
+}
+
+void NetworkRecoverBase::OnNetworkConfigResponse(void * context,
+                                                 const NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType & data)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    auto * self = static_cast<NetworkRecoverBase *>(context);
+    VerifyOrReturn(self != nullptr, ChipLogProgress(Controller, "Success Newtork Configure callback with null context. Ignoring"));
+
+    ChipLogProgress(Controller, "Received NetworkConfig response, networkingStatus=%u", to_underlying(data.networkingStatus));
+    if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatusEnum::kSuccess)
+    {
+        err = CHIP_ERROR_INTERNAL;
+    }
+    else
+    {
+        if (self->mNextStep == Step::kSendRemoveNetwork)
+        {
+            self->mNextStep = Step::kSendAddOrUpdateNetwork;
+        }
+        else
+        {
+            self->mNextStep = Step::kSendConnectNetwork;
+        }
+
+        err = self->mController->GetConnectedDevice(self->mRemoteNodeId, &self->mOnDeviceConnectedCallback,
+                                                    &self->mOnDeviceConnectionFailureCallback);
+    }
+    if (err != CHIP_NO_ERROR)
+    {
+        FinishRecoverNetwork(context, err);
+    }
+}
+
+void NetworkRecoverBase::OnConnectNetworkResponse(
+    void * context, const NetworkCommissioning::Commands::ConnectNetworkResponse::DecodableType & data)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    auto * self = static_cast<NetworkRecoverBase *>(context);
+    VerifyOrReturn(self != nullptr, ChipLogProgress(Controller, "Success Connect Network callback with null context. Ignoring"));
+
+    ChipLogProgress(Controller, "Received ConnectNetwork response, networkingStatus=%u", to_underlying(data.networkingStatus));
+    if (data.networkingStatus != NetworkCommissioning::NetworkCommissioningStatusEnum::kSuccess)
+    {
+        err = CHIP_ERROR_INTERNAL;
+    }
+    else
+    {
+        self->mNextStep = Step::kReleaseSessions;
+        err             = self->mController->GetConnectedDevice(self->mRemoteNodeId, &self->mOnDeviceConnectedCallback,
+                                                                &self->mOnDeviceConnectionFailureCallback);
+    }
+    if (err != CHIP_NO_ERROR)
+    {
+        FinishRecoverNetwork(context, err);
+    }
+}
+
+void NetworkRecoverBase::OnCommissioningCompleteResponse(
+    void * context, const GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType & data)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    auto * self = static_cast<NetworkRecoverBase *>(context);
+    VerifyOrReturn(self != nullptr,
+                   ChipLogProgress(Controller, "Success Commissioning Complete Response callback with null context. Ignoring"));
+
+    ChipLogProgress(Controller, "Received CommissioningComplete response, errorCode=%u", to_underlying(data.errorCode));
+    if (data.errorCode != GeneralCommissioning::CommissioningErrorEnum::kOk)
+    {
+        err = CHIP_ERROR_INTERNAL;
+    }
+    FinishRecoverNetwork(context, err);
+}
+
+void NetworkRecoverBase::OnReadAttributeFailure(void * context, CHIP_ERROR err)
+{
+    ChipLogProgress(Controller, "OnReadAttributeFailure %" CHIP_ERROR_FORMAT, err.Format());
+
+    auto * self = static_cast<NetworkRecoverBase *>(context);
+    VerifyOrReturn(self != nullptr, ChipLogProgress(Controller, "Read Attribute failure callback with null context. Ignoring"));
+
+    FinishRecoverNetwork(context, err);
+}
+
+void NetworkRecoverBase::OnCommandFailure(void * context, CHIP_ERROR err)
+{
+    ChipLogProgress(Controller, "OnCommandFailure %" CHIP_ERROR_FORMAT, err.Format());
+
+    auto * self = static_cast<NetworkRecoverBase *>(context);
+    VerifyOrReturn(self != nullptr, ChipLogProgress(Controller, "Send command failure callback with null context. Ignoring"));
+
+    FinishRecoverNetwork(context, err);
+}
+
+void NetworkRecoverBase::FinishRecoverNetwork(void * context, CHIP_ERROR err)
+{
+    auto * self = static_cast<NetworkRecoverBase *>(context);
+    if (err == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(Controller, "Network Recovery succeeded.");
+    }
+    else
+    {
+        ChipLogError(Controller, "Network Recovery failed : %" CHIP_ERROR_FORMAT, err.Format());
+        if (self->mNextStep != Step::kSendDisArmFailSafe && self->mNextStep != Step::kSendCommissioningComplete)
+        {
+            // disarm
+            self->mNextStep = Step::kSendDisArmFailSafe;
+
+            err = self->mController->GetConnectedDevice(self->mRemoteNodeId, &self->mOnDeviceConnectedCallback,
+                                                        &self->mOnDeviceConnectionFailureCallback);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Controller, "Failed to get device connection: %" CHIP_ERROR_FORMAT, err.Format());
+            }
+            return;
+        }
+    }
+    if (self->mNetworkRecoverCallback != nullptr)
+    {
+        self->mNetworkRecoverCallback->mCall(self->mNetworkRecoverCallback->mContext, self->mRemoteNodeId, err);
+    }
+}
+
+AutoNetworkRecover::AutoNetworkRecover(DeviceController * controller) :
+    NetworkRecoverBase(controller), mOnNetworkRecoverCompleteCallback(OnNetworkRecoverComplete, this)
+{}
+
+CHIP_ERROR AutoNetworkRecover::RecoverNetwork(NetworkRecover * recover, NodeId remoteNodeId, Transport::PeerAddress & addr,
+                                              const Optional<WiFiCredentials> & wiFiCredentials,
+                                              const Optional<ByteSpan> & operationalDataset, uint64_t breadcrumb)
+{
+    // Not using Platform::New because we want to keep our constructor private.
+    auto * autoRecover = new (std::nothrow) AutoNetworkRecover(recover->GetCommissioner());
+    if (autoRecover == nullptr)
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    autoRecover->mNetworkRecover = recover;
+
+    CHIP_ERROR err = autoRecover->NetworkRecoverBase::RecoverNetwork(remoteNodeId, addr, wiFiCredentials, operationalDataset,
+                                                                     breadcrumb, &autoRecover->mOnNetworkRecoverCompleteCallback);
+    if (err != CHIP_NO_ERROR)
+    {
+        delete autoRecover;
+    }
+    // Else will clean up when the callback is called.
+    return err;
+}
+
+void AutoNetworkRecover::OnNetworkRecoverComplete(void * context, NodeId remoteNodeId, CHIP_ERROR status)
+{
+    auto * self = static_cast<AutoNetworkRecover *>(context);
+    self->mNetworkRecover->NetworkRecoverComplete(remoteNodeId, status);
+    delete self;
+}
+} // namespace Controller
+} // namespace chip

--- a/src/controller/AutoNetworkRecover.h
+++ b/src/controller/AutoNetworkRecover.h
@@ -1,0 +1,138 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/OperationalSessionSetup.h>
+#include <controller/CHIPDeviceController.h>
+#include <lib/core/CHIPCallback.h>
+
+namespace chip {
+namespace Controller {
+
+typedef void (*OnNetworkRecover)(void * context, NodeId remoteNodeId, CHIP_ERROR status);
+
+/**
+ * A helper class to recover network given some parameters.
+ */
+class NetworkRecoverBase
+{
+public:
+    NetworkRecoverBase(DeviceController * controller) :
+        mController(controller), mOnDeviceConnectedCallback(&OnDeviceConnectedFn, this),
+        mOnDeviceConnectionFailureCallback(&OnDeviceConnectionFailureFn, this)
+    {}
+    ~NetworkRecoverBase() {}
+
+    enum class NetworkType : uint8_t
+    {
+        kWiFi,
+        kThread,
+    };
+
+    enum class Step : uint8_t
+    {
+        // Ready to start recovering the network.
+        kSendArmFailSafe = 0,
+        // Need to get Last Newtork ID
+        kReadLastNetworkID,
+        // Need to send Remove Network Command.
+        kSendRemoveNetwork,
+        // Need to send Add or Update WiFi/Thread Network Command.
+        kSendAddOrUpdateNetwork,
+        // Need to send Connect Network Command.
+        kSendConnectNetwork,
+        // Need to release CASE Sessions.
+        kReleaseSessions,
+        // Need to send Commissioning Complete Command.
+        kSendCommissioningComplete,
+        // Need to send DisArmFailSafe Command.
+        kSendDisArmFailSafe,
+    };
+
+    CHIP_ERROR RecoverNetwork(NodeId remoteNodeId, Transport::PeerAddress & addr, const Optional<WiFiCredentials> & wiFiCredentials,
+                              const Optional<ByteSpan> & operationalDataset, uint64_t breadcrumb,
+                              chip::Callback::Callback<OnNetworkRecover> * callback);
+
+private:
+    DeviceController * mController;
+
+    chip::Callback::Callback<OnDeviceConnected> mOnDeviceConnectedCallback;
+    chip::Callback::Callback<OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
+    chip::Callback::Callback<OnNetworkRecover> * mNetworkRecoverCallback;
+
+    NodeId mRemoteNodeId;
+    NetworkType mNetworkType;
+    Optional<WiFiCredentials> mWiFiCredentials;
+    Optional<chip::ByteSpan> mOperationalDataset;
+    uint64_t mBreadcrumb;
+    chip::ByteSpan mLastNetworkID;
+
+    Step mNextStep = Step::kSendArmFailSafe;
+
+    CHIP_ERROR SendArmFailSafe(uint16_t timeout, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
+    CHIP_ERROR ReadLastNetworkID(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
+    CHIP_ERROR SendRemoveNetwork(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
+    CHIP_ERROR SendAddOrUpdateNetwork(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
+    CHIP_ERROR SendConnectNetwork(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
+    CHIP_ERROR ReleaseSessions(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
+    CHIP_ERROR SendCommissioningComplete(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
+
+    static void OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
+    static void OnDeviceConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
+
+    static void
+    OnArmFailSafeResponse(void * context,
+                          const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data);
+    static void OnSuccessReadLastNetworkID(void * context, const chip::app::DataModel::Nullable<chip::ByteSpan> & networkID);
+    static void
+    OnNetworkConfigResponse(void * context,
+                            const chip::app::Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType & data);
+    static void OnConnectNetworkResponse(
+        void * context, const chip::app::Clusters::NetworkCommissioning::Commands::ConnectNetworkResponse::DecodableType & data);
+    static void OnCommissioningCompleteResponse(
+        void * context,
+        const chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType & data);
+
+    static void OnReadAttributeFailure(void * context, CHIP_ERROR error);
+    static void OnCommandFailure(void * context, CHIP_ERROR error);
+
+    static void FinishRecoverNetwork(void * context, CHIP_ERROR err);
+};
+
+/**
+ * A helper class that can be used by consumers that don't care about the callback from the
+ * network recovery process and just want automatic cleanup of the AutoNetworkRecover when done
+ * with it.
+ */
+class AutoNetworkRecover : private NetworkRecoverBase
+{
+public:
+    static CHIP_ERROR RecoverNetwork(NetworkRecover * recover, NodeId remoteNodeId, Transport::PeerAddress & addr,
+                                     const Optional<WiFiCredentials> & wiFiCredentials,
+                                     const Optional<ByteSpan> & operationalDataset, uint64_t breadcrumb = 0);
+
+private:
+    NetworkRecover * mNetworkRecover = nullptr;
+    AutoNetworkRecover(DeviceController * controller);
+    static void OnNetworkRecoverComplete(void * context, NodeId remoteNodeId, CHIP_ERROR status);
+    chip::Callback::Callback<OnNetworkRecover> mOnNetworkRecoverCompleteCallback;
+};
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -58,6 +58,7 @@ static_library("controller") {
     # dependencies
     "AbstractDnssdDiscoveryController.h",
     "AutoCommissioner.h",
+    "AutoNetworkRecover.h",
     "CHIPCommissionableNodeController.h",
     "CHIPDeviceController.h",
     "CHIPDeviceControllerSystemState.h",
@@ -69,6 +70,7 @@ static_library("controller") {
     "DeviceDiscoveryDelegate.h",
     "DevicePairingDelegate.h",
     "ExampleOperationalCredentialsIssuer.h",
+    "NetworkRecover.h",
     "SetUpCodePairer.h",
   ]
 
@@ -86,6 +88,7 @@ static_library("controller") {
       "CommissionerDiscoveryController.h",
       "CommissioningDelegate.cpp",
       "ExampleOperationalCredentialsIssuer.cpp",
+      "NetworkRecover.cpp",
       "SetUpCodePairer.cpp",
     ]
 
@@ -94,6 +97,7 @@ static_library("controller") {
 
     if (chip_enable_read_client) {
       sources += [
+        "AutoNetworkRecover.cpp",
         "CHIPDeviceController.cpp",
         "CommissioningWindowOpener.cpp",
         "CurrentFabricRemover.cpp",

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -34,6 +34,7 @@
 #include <app/InteractionModelEngine.h>
 #include <app/OperationalSessionSetup.h>
 #include <app/server/Dnssd.h>
+#include <controller/AutoNetworkRecover.h>
 #include <controller/CurrentFabricRemover.h>
 #include <controller/InvokeInteraction.h>
 #include <controller/WriteInteraction.h>
@@ -480,7 +481,7 @@ DeviceCommissioner::DeviceCommissioner() :
     mOnDeviceConnectionRetryCallback(OnDeviceConnectionRetryFn, this),
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
     mDeviceAttestationInformationVerificationCallback(OnDeviceAttestationInformationVerification, this),
-    mDeviceNOCChainCallback(OnDeviceNOCChainGeneration, this), mSetUpCodePairer(this)
+    mDeviceNOCChainCallback(OnDeviceNOCChainGeneration, this), mSetUpCodePairer(this), mNetworkRecover(this)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     (void) mPeerAdminJFAdminClusterEndpointId;
@@ -541,8 +542,10 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
     mSetUpCodePairer.SetSystemLayer(mSystemState->SystemLayer());
+    mNetworkRecover.SetSystemLayer(mSystemState->SystemLayer());
 #if CONFIG_NETWORK_LAYER_BLE
     mSetUpCodePairer.SetBleLayer(mSystemState->BleLayer());
+    mNetworkRecover.SetBleLayer(mSystemState->BleLayer());
 #endif // CONFIG_NETWORK_LAYER_BLE
 
     return CHIP_NO_ERROR;
@@ -3962,6 +3965,21 @@ bool DeviceCommissioner::HasValidCommissioningMode(const Dnssd::CommissionNodeDa
         return false;
     }
     return true;
+}
+
+CHIP_ERROR DeviceCommissioner::DiscoverRecoverableNodes(uint16_t timeout)
+{
+    return mNetworkRecover.Discover(timeout);
+}
+
+CHIP_ERROR DeviceCommissioner::RecoverNode(NodeId remoteId, uint64_t recoveryId, WiFiCredentials wiFiCreds, uint64_t breadcrumb)
+{
+    return mNetworkRecover.Recover(remoteId, recoveryId, wiFiCreds, breadcrumb);
+}
+
+CHIP_ERROR DeviceCommissioner::RecoverNode(NodeId remoteId, uint64_t recoveryId, ByteSpan operationalDataset, uint64_t breadcrumb)
+{
+    return mNetworkRecover.Recover(remoteId, recoveryId, operationalDataset, breadcrumb);
 }
 
 } // namespace Controller

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -41,6 +41,7 @@
 #include <controller/CommissioneeDeviceProxy.h>
 #include <controller/CommissioningDelegate.h>
 #include <controller/DevicePairingDelegate.h>
+#include <controller/NetworkRecover.h>
 #include <controller/OperationalCredentialsDelegate.h>
 #include <controller/SetUpCodePairer.h>
 #include <credentials/FabricTable.h>
@@ -264,6 +265,34 @@ public:
                                                                1, nullptr,
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
                                                                transportPayloadCapability);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR
+    GetConnectedDevice(NodeId peerNodeId, Callback::Callback<OnDeviceConnected> * onConnection,
+                       chip::Callback::Callback<OnDeviceConnectionFailure> * onFailure, Transport::PeerAddress & addr,
+                       TransportPayloadCapability transportPayloadCapability = TransportPayloadCapability::kMRPPayload)
+    {
+        VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
+        mSystemState->CASESessionMgr()->FindOrEstablishSession(ScopedNodeId(peerNodeId, GetFabricIndex()), onConnection, onFailure,
+                                                               addr,
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                                               1, nullptr,
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                                               transportPayloadCapability);
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR ReleaseSession(NodeId peerNodeId)
+    {
+        VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
+        mSystemState->CASESessionMgr()->ReleaseSession(ScopedNodeId(peerNodeId, GetFabricIndex()));
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR ExpireAllSessions(NodeId peerNodeId)
+    {
+        mSystemState->SessionMgr()->ExpireAllSessions(ScopedNodeId(peerNodeId, GetFabricIndex()));
         return CHIP_NO_ERROR;
     }
 
@@ -848,6 +877,13 @@ public:
                                          /* fireAndForget = */ true);
     }
 
+    void RegisterNetworkRecoverDelegate(NetworkRecoverDelegate * delegate) { mNetworkRecover.SetNetworkRecoverDelegate(delegate); }
+
+    CHIP_ERROR DiscoverRecoverableNodes(uint16_t timeout);
+
+    CHIP_ERROR RecoverNode(NodeId remoteId, uint64_t recoveryId, WiFiCredentials wiFiCreds, uint64_t breadcrumb = 0);
+    CHIP_ERROR RecoverNode(NodeId remoteId, uint64_t recoveryId, ByteSpan operationaDataset, uint64_t breadcrumb = 0);
+
     // Check if the commissioning mode is valid for the current commissioning parameters.
     virtual bool HasValidCommissioningMode(const Dnssd::CommissionNodeData & nodeData);
 
@@ -1149,6 +1185,7 @@ private:
     chip::Callback::Callback<OnNOCChainGeneration> mDeviceNOCChainCallback;
     SetUpCodePairer mSetUpCodePairer;
     AutoCommissioner mAutoCommissioner;
+    NetworkRecover mNetworkRecover;
     CommissioningDelegate * mDefaultCommissioner =
         &mAutoCommissioner; // Commissioning delegate to call when PairDevice / Commission functions are used
     CommissioningDelegate * mCommissioningDelegate =

--- a/src/controller/NetworkRecover.cpp
+++ b/src/controller/NetworkRecover.cpp
@@ -1,0 +1,287 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Implementation of SetUp Code Pairer, a class that parses a given
+ *      setup code and uses the extracted informations to discover and
+ *      filter commissionables nodes, before initiating the pairing process.
+ *
+ */
+
+#include <controller/NetworkRecover.h>
+
+#include <controller/AutoNetworkRecover.h>
+#include <controller/CHIPDeviceController.h>
+#include <lib/support/CodeUtils.h>
+#include <memory>
+#include <system/SystemClock.h>
+#include <tracing/metric_event.h>
+
+using namespace chip::Tracing;
+
+namespace chip {
+namespace Controller {
+
+#if CONFIG_NETWORK_LAYER_BLE
+NetworkRecoverParameters::NetworkRecoverParameters(BLE_CONNECTION_OBJECT connObj)
+{
+    Transport::PeerAddress peerAddress = Transport::PeerAddress::BLE();
+    SetPeerAddress(peerAddress);
+    SetConnectionObject(connObj);
+}
+#endif // CONFIG_NETWORK_LAYER_BLE
+
+NetworkRecoverParameters::NetworkRecoverParameters(const uint64_t recoveryId) : mRecoveryId(recoveryId)
+{
+    Transport::PeerAddress peerAddress = Transport::PeerAddress::BLE();
+    SetPeerAddress(peerAddress);
+}
+
+CHIP_ERROR NetworkRecover::Discover(uint16_t timeout)
+{
+    VerifyOrReturnErrorWithMetric(kMetricNetworkRecover, mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    mDiscoverTimeout         = false;
+    mNetworkRecoverBehaviour = NetworkRecoverBehaviour::kDiscover;
+    ReturnErrorOnFailureWithMetric(kMetricNetworkRecover, StartDiscoverOverBle(0));
+    auto errorCode = mSystemLayer->StartTimer(System::Clock::Milliseconds32(timeout * chip::kMillisecondsPerSecond),
+                                              OnRecoverableDiscoveredTimeoutCallback, this);
+    if (CHIP_NO_ERROR == errorCode)
+    {
+        MATTER_LOG_METRIC_BEGIN(kMetricNetworkRecover);
+    }
+    return errorCode;
+}
+
+CHIP_ERROR NetworkRecover::Recover(NodeId remoteId, uint64_t recoveryId, WiFiCredentials wiFiCreds, uint64_t breadcrumb)
+{
+    mRemoteId = remoteId;
+    mWiFiCreds.SetValue(wiFiCreds);
+    mBreadcrumb              = breadcrumb;
+    mNetworkRecoverBehaviour = NetworkRecoverBehaviour::kRecover;
+    ReturnErrorOnFailureWithMetric(kMetricNetworkRecover, StartDiscoverOverBle(recoveryId));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR NetworkRecover::Recover(NodeId remoteId, uint64_t recoveryId, ByteSpan operationalDataset, uint64_t breadcrumb)
+{
+    mRemoteId = remoteId;
+    mOperationalDataset.SetValue(operationalDataset);
+    mBreadcrumb              = breadcrumb;
+    mNetworkRecoverBehaviour = NetworkRecoverBehaviour::kRecover;
+    ReturnErrorOnFailureWithMetric(kMetricNetworkRecover, StartDiscoverOverBle(recoveryId));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR NetworkRecover::StartDiscoverOverBle(uint64_t recoveryId)
+{
+    if (mNetworkRecoverBehaviour == NetworkRecoverBehaviour::kDiscover && mDiscoverTimeout)
+    {
+        // stop recoverable scanning
+        return CHIP_NO_ERROR;
+    }
+#if CONFIG_NETWORK_LAYER_BLE
+#if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+    VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    mCommissioner->ConnectBleTransportToSelf();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+    VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+
+    ChipLogProgress(Controller, "Starting recoverable discovery over BLE");
+
+    // Handle possibly-sync callbacks.
+    CHIP_ERROR err = mBleLayer->NewBleConnectionByRecoveryIdentifier(recoveryId, this, OnDiscoveredDeviceOverBleConnected,
+                                                                     OnDiscoveredDeviceOverBleError, OnDiscoveredDeviceOverBle);
+    return err;
+#else
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif // CONFIG_NETWORK_LAYER_BLE
+}
+
+CHIP_ERROR NetworkRecover::StopConnectOverBle()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+#if CONFIG_NETWORK_LAYER_BLE
+    VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+    err = mBleLayer->CancelBleIncompleteConnection();
+#endif // CONFIG_NETWORK_LAYER_BLE
+    return err;
+}
+
+bool NetworkRecover::NotifyOrConnectToDiscoveredDevice()
+{
+    while (!mNetworkRecoverParameters.empty())
+    {
+        // Grab the first element from the queue and try connecting to it.
+        // Remove it from the queue before we try to connect, in case the
+        // connection attempt fails and calls right back into us to try the next
+        // thing.
+        NetworkRecoverParameters params(mNetworkRecoverParameters.front());
+        mNetworkRecoverParameters.pop_front();
+
+#if CHIP_PROGRESS_LOGGING
+        char buf[Transport::PeerAddress::kMaxToStringSize];
+        params.GetPeerAddress().ToString(buf);
+        ChipLogProgress(Controller, "Found recoverable device %s", buf);
+#endif // CHIP_PROGRESS_LOGGING
+
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        if (mNetworkRecoverBehaviour == NetworkRecoverBehaviour::kDiscover)
+        {
+            // notify to application
+            ChipLogProgress(Controller, "Notify recoverable devices " ChipLogFormatX64, ChipLogValueX64(params.GetRecoveryId()));
+            auto iter = std::find(mDiscoveredRecoveryIds.begin(), mDiscoveredRecoveryIds.end(), params.GetRecoveryId());
+            if (iter == mDiscoveredRecoveryIds.end())
+            {
+                mDiscoveredRecoveryIds.push_back(params.GetRecoveryId());
+            }
+
+            // TODO:
+            err = StartDiscoverOverBle(0);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Controller, "Failed to discover recoverable device: %" CHIP_ERROR_FORMAT, err.Format());
+            }
+        }
+        else
+        {
+            ChipLogProgress(Controller, "Starting network recovery");
+#if CONFIG_NETWORK_LAYER_BLE
+            err = mBleLayer->NewBleConnectionByObject(params.GetConnectionObject());
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Controller, "Failed to connect to device: %" CHIP_ERROR_FORMAT, err.Format());
+                NetworkRecoverComplete(mRemoteId, err);
+                break;
+            }
+#endif // CONFIG_NETWORK_LAYER_BLE
+            auto addr = params.GetPeerAddress();
+            if (mWiFiCreds.HasValue())
+            {
+                err = AutoNetworkRecover::RecoverNetwork(this, mRemoteId, addr, mWiFiCreds, chip::NullOptional, mBreadcrumb);
+            }
+            else
+            {
+                err =
+                    AutoNetworkRecover::RecoverNetwork(this, mRemoteId, addr, chip::NullOptional, mOperationalDataset, mBreadcrumb);
+            }
+
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Controller, "Failed to recover device: %" CHIP_ERROR_FORMAT, err.Format());
+                NetworkRecoverComplete(mRemoteId, err);
+            }
+        }
+    }
+
+    return true;
+}
+
+void NetworkRecover::NetworkRecoverDiscoverFinish()
+{
+    if (mNetworkRecoverDelegate != nullptr)
+    {
+        mNetworkRecoverDelegate->OnNetworkRecoverDiscover(mDiscoveredRecoveryIds);
+    }
+    mSystemLayer->CancelTimer(OnRecoverableDiscoveredTimeoutCallback, this);
+    mDiscoveredRecoveryIds.clear();
+}
+
+void NetworkRecover::NetworkRecoverComplete(NodeId deviceId, CHIP_ERROR error)
+{
+    LogErrorOnFailure(StopConnectOverBle());
+    if (mNetworkRecoverDelegate != nullptr)
+    {
+        mNetworkRecoverDelegate->OnNetworkRecoverComplete(deviceId, error);
+    }
+}
+
+void NetworkRecover::OnRecoverableDiscoveredTimeoutCallback(System::Layer * layer, void * context)
+{
+    ChipLogProgress(Controller, "Discovery timed out");
+    auto * recover = static_cast<NetworkRecover *>(context);
+    recover->NetworkRecoverDiscoverFinish();
+    recover->mDiscoverTimeout = true;
+    MATTER_LOG_METRIC_END(kMetricNetworkRecover, CHIP_NO_ERROR);
+}
+
+#if CONFIG_NETWORK_LAYER_BLE
+void NetworkRecover::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj)
+{
+    ChipLogProgress(Controller, "Connected recoverable device over BLE");
+    // In order to not wait for all the possible addresses discovered over mdns to
+    // be tried before trying to connect over BLE, the discovered connection object is
+    // inserted at the beginning of the list.
+    //
+    // It makes it the 'next' thing to try to connect to if there are already some
+    // discovered parameters in the list.
+    mNetworkRecoverParameters.emplace_front(connObj);
+    NotifyOrConnectToDiscoveredDevice();
+}
+void NetworkRecover::OnDiscoveredDeviceOverBle(uint64_t recoveryId)
+{
+    ChipLogProgress(Controller, "Discovered recoverable device over BLE");
+    // In order to not wait for all the possible addresses discovered over mdns to
+    // be tried before trying to connect over BLE, the discovered connection object is
+    // inserted at the beginning of the list.
+    //
+    // It makes it the 'next' thing to try to connect to if there are already some
+    // discovered parameters in the list.
+    mNetworkRecoverParameters.emplace_front(recoveryId);
+    NotifyOrConnectToDiscoveredDevice();
+}
+
+void NetworkRecover::OnBLEDiscoveryError(CHIP_ERROR err)
+{
+    ChipLogError(Controller, "discovery over BLE failed: %" CHIP_ERROR_FORMAT, err.Format());
+    LogErrorOnFailure(err);
+    if (mNetworkRecoverBehaviour == NetworkRecoverBehaviour::kRecover)
+    {
+        // finish recover connection
+        NetworkRecoverComplete(mRemoteId, err);
+    }
+    else
+    {
+        // BLE scan timeout, no recoverable found, scan again
+        CHIP_ERROR err = StartDiscoverOverBle(0);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Controller, "Failed to start recoverable node discovery over BLE: %" CHIP_ERROR_FORMAT, err.Format());
+        }
+    }
+}
+
+void NetworkRecover::OnDiscoveredDeviceOverBle(void * appState, uint64_t recoveryId)
+{
+    (static_cast<NetworkRecover *>(appState))->OnDiscoveredDeviceOverBle(recoveryId);
+}
+
+void NetworkRecover::OnDiscoveredDeviceOverBleConnected(void * appState, BLE_CONNECTION_OBJECT connObj)
+{
+    (static_cast<NetworkRecover *>(appState))->OnDiscoveredDeviceOverBle(connObj);
+}
+
+void NetworkRecover::OnDiscoveredDeviceOverBleError(void * appState, CHIP_ERROR err)
+{
+    static_cast<NetworkRecover *>(appState)->OnBLEDiscoveryError(err);
+}
+#endif // CONFIG_NETWORK_LAYER_BLE
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/NetworkRecover.h
+++ b/src/controller/NetworkRecover.h
@@ -1,0 +1,124 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <list>
+
+#include <controller/CommissioningDelegate.h>
+#include <lib/support/DLLUtil.h>
+#include <platform/CHIPDeviceConfig.h>
+#include <protocols/secure_channel/RendezvousParameters.h>
+
+#if CONFIG_NETWORK_LAYER_BLE
+#include <ble/Ble.h>
+#endif // CONFIG_NETWORK_BLE
+
+#include <deque>
+
+namespace chip {
+namespace Controller {
+
+class DeviceCommissioner;
+
+class NetworkRecoverParameters : public RendezvousParameters
+{
+public:
+    NetworkRecoverParameters() = default;
+#if CONFIG_NETWORK_LAYER_BLE
+    NetworkRecoverParameters(BLE_CONNECTION_OBJECT connObj);
+#endif // CONFIG_NETWORK_LAYER_BLE
+    NetworkRecoverParameters(uint64_t recoveryId);
+
+    bool HasRecoveryId() { return mRecoveryId != 0; }
+    uint64_t GetRecoveryId() { return mRecoveryId; }
+
+private:
+    uint64_t mRecoveryId;
+};
+
+/// Callbacks for CHIP network recovery
+class DLL_EXPORT NetworkRecoverDelegate
+{
+public:
+    virtual ~NetworkRecoverDelegate() {}
+    virtual void OnNetworkRecoverDiscover(std::list<uint64_t> recoveryIds)   = 0;
+    virtual void OnNetworkRecoverComplete(NodeId deviceId, CHIP_ERROR error) = 0;
+};
+
+enum class NetworkRecoverBehaviour : uint8_t
+{
+    kDiscover,
+    kRecover,
+};
+
+class DLL_EXPORT NetworkRecover
+{
+public:
+    NetworkRecover(DeviceCommissioner * commissioner) : mCommissioner(commissioner) {}
+    virtual ~NetworkRecover() {}
+
+    CHIP_ERROR Discover(uint16_t timeout);
+    CHIP_ERROR Recover(NodeId remoteId, uint64_t recoveryId, WiFiCredentials wiFiCreds, uint64_t breadcrumb = 0);
+    CHIP_ERROR Recover(NodeId remoteId, uint64_t recoveryId, ByteSpan operationalDataset, uint64_t breadcrumb = 0);
+
+    DeviceCommissioner * GetCommissioner() { return mCommissioner; }
+
+    void SetSystemLayer(System::Layer * systemLayer) { mSystemLayer = systemLayer; }
+#if CONFIG_NETWORK_LAYER_BLE
+    void SetBleLayer(Ble::BleLayer * bleLayer) { mBleLayer = bleLayer; }
+#endif
+    void SetNetworkRecoverDelegate(NetworkRecoverDelegate * delegate) { mNetworkRecoverDelegate = delegate; }
+    NetworkRecoverDelegate * GetNetworkRecoverDelegate() const { return mNetworkRecoverDelegate; }
+
+    void NetworkRecoverComplete(NodeId deviceId, CHIP_ERROR error);
+
+private:
+    CHIP_ERROR StartDiscoverOverBle(uint64_t recoveryId);
+    CHIP_ERROR StopConnectOverBle();
+    bool NotifyOrConnectToDiscoveredDevice();
+    void NetworkRecoverDiscoverFinish();
+    static void OnRecoverableDiscoveredTimeoutCallback(System::Layer * layer, void * context);
+
+#if CONFIG_NETWORK_LAYER_BLE
+    Ble::BleLayer * mBleLayer = nullptr;
+    void OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj);
+    void OnDiscoveredDeviceOverBle(uint64_t recoveryId);
+    void OnBLEDiscoveryError(CHIP_ERROR err);
+    /////////// BLEConnectionDelegate Callbacks /////////
+    static void OnDiscoveredDeviceOverBle(void * appState, uint64_t recoveryId);
+    static void OnDiscoveredDeviceOverBleConnected(void * appState, BLE_CONNECTION_OBJECT connObj);
+    static void OnDiscoveredDeviceOverBleError(void * appState, CHIP_ERROR err);
+#endif // CONFIG_NETWORK_LAYER_BLE
+
+    NodeId mRemoteId;
+    Optional<WiFiCredentials> mWiFiCreds;
+    Optional<ByteSpan> mOperationalDataset;
+    uint64_t mBreadcrumb;
+
+    NetworkRecoverBehaviour mNetworkRecoverBehaviour = NetworkRecoverBehaviour::kDiscover;
+    NetworkRecoverDelegate * mNetworkRecoverDelegate = nullptr;
+    DeviceCommissioner * mCommissioner               = nullptr;
+    std::deque<NetworkRecoverParameters> mNetworkRecoverParameters;
+    System::Layer * mSystemLayer = nullptr;
+    std::list<uint64_t> mDiscoveredRecoveryIds;
+    bool mDiscoverTimeout;
+};
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/python/matter/ble/LinuxImpl.cpp
+++ b/src/controller/python/matter/ble/LinuxImpl.cpp
@@ -100,8 +100,7 @@ public:
 
     ScannerDelegateImpl(PyObject * context, DeviceScannedCallback scanCallback, ScanCompleteCallback completeCallback,
                         ScanErrorCallback errorCallback) :
-        mContext(context),
-        mScanCallback(scanCallback), mCompleteCallback(completeCallback), mErrorCallback(errorCallback)
+        mContext(context), mScanCallback(scanCallback), mCompleteCallback(completeCallback), mErrorCallback(errorCallback)
     {}
 
     CHIP_ERROR ScannerInit(BluezAdapter1 * adapter)
@@ -145,6 +144,8 @@ public:
                           info.GetVendorId());
         }
     }
+
+    void OnDeviceScanned(BluezDevice1 & device, const chip::Ble::ChipBLENetworkRecoveryInfo & info) override {}
 
     void OnScanComplete() override
     {

--- a/src/platform/Darwin/BleConnectionDelegateImpl.h
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.h
@@ -36,6 +36,7 @@ public:
     CHIP_ERROR NewConnection(Ble::BleLayer * bleLayer, void * appState, const Span<const SetupDiscriminator> & discriminators,
                              OnConnectionByDiscriminatorsCompleteFunct onConnectionComplete,
                              OnConnectionErrorFunct onConnectionError) override;
+    void NewConnection(Ble::BleLayer * bleLayer, void * appState, uint64_t recoveryIdentifier) override {};
     CHIP_ERROR CancelConnection() override;
 
 private:

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -192,7 +192,8 @@ private:
 #ifdef CONFIG_ENABLE_ESP32_BLE_CONTROLLER
 
     void NewConnection(chip::Ble::BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(chip::Ble::BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
+    void NewConnection(chip::Ble::BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
+    void NewConnection(chip::Ble::BleLayer * bleLayer, void * appState, uint64_t recoveryIdentifier) override {};
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -741,6 +741,17 @@ void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const S
         [this] { InitiateScan(BleScanState::kScanForDiscriminator); });
 }
 
+void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, uint64_t connRecoveryIdentifier)
+{
+    mBLEScanConfig.mAppState           = appState;
+    mBLEScanConfig.mRecoveryIdentifier = connRecoveryIdentifier;
+    auto scanState =
+        connRecoveryIdentifier == 0 ? BleScanState::kScanForNetworkRecoveryDiscover : BleScanState::kScanForNetworkRecoveryRecover;
+
+    // Scan initiation performed async, to ensure that the BLE subsystem is initialized.
+    DeviceLayer::SystemLayer().ScheduleLambda([this, scanState] { InitiateScan(scanState); });
+}
+
 CHIP_ERROR BLEManagerImpl::CancelConnection()
 {
     if (mBLEScanConfig.mBleScanState == BleScanState::kConnecting)
@@ -862,6 +873,47 @@ void BLEManagerImpl::OnDeviceScanned(BluezDevice1 & device, const chip::Ble::Chi
     ChipLogProgress(Ble, "New device connected: %s", address);
 }
 
+void BLEManagerImpl::OnDeviceScanned(BluezDevice1 & device, const chip::Ble::ChipBLENetworkRecoveryInfo & info)
+{
+    if (mBLEScanConfig.mBleScanState == BleScanState::kScanForNetworkRecoveryRecover)
+    {
+        auto isMatch = (mBLEScanConfig.mRecoveryIdentifier == (info.GetRecoveryIdentifier()));
+        VerifyOrReturn(isMatch,
+                       ChipLogError(Ble, "Skip connection: recovery identifier does not match: %lu != %lu",
+                                    info.GetRecoveryIdentifier(), mBLEScanConfig.mRecoveryIdentifier));
+        ChipLogProgress(Ble, "Recovery identifier match. Attempting to connect.");
+    }
+    else
+    {
+        chip::DeviceLayer::PlatformMgr().LockChipStack();
+        // We StartScan in the ChipStack thread.
+        // StopScan should also be performed in the ChipStack thread.
+        // At the same time, the scan timer also needs to be canceled in the ChipStack thread.
+        DeviceLayer::SystemLayer().CancelTimer(HandleScanTimer, this);
+        TEMPORARY_RETURN_IGNORED mDeviceScanner.StopScan();
+        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+        BleConnectionDelegate::OnDiscoverComplete(mBLEScanConfig.mAppState, info.GetRecoveryIdentifier());
+        return;
+    }
+
+    mBLEScanConfig.mBleScanState = BleScanState::kConnecting;
+
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    // We StartScan in the ChipStack thread.
+    // StopScan should also be performed in the ChipStack thread.
+    // At the same time, the scan timer also needs to be canceled in the ChipStack thread.
+    DeviceLayer::SystemLayer().CancelTimer(HandleScanTimer, this);
+    TEMPORARY_RETURN_IGNORED mDeviceScanner.StopScan();
+    // Stop scanning and then start connecting timer
+    DeviceLayer::SystemLayer().StartTimer(kConnectTimeout, HandleConnectTimer, this);
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
+    CHIP_ERROR err = mEndpoint.ConnectDevice(device);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Ble, "Device connection failed: %" CHIP_ERROR_FORMAT, err.Format()));
+
+    ChipLogProgress(Ble, "New device connected: %s", bluez_device1_get_address(&device));
+}
+
 void BLEManagerImpl::HandleConnectTimer(chip::System::Layer *, void * appState)
 {
     auto * manager = static_cast<BLEManagerImpl *>(appState);
@@ -878,6 +930,8 @@ void BLEManagerImpl::OnScanComplete()
         break;
     case BleScanState::kScanForAddress:
     case BleScanState::kScanForDiscriminator:
+    case BleScanState::kScanForNetworkRecoveryDiscover:
+    case BleScanState::kScanForNetworkRecoveryRecover:
         mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
         ChipLogProgress(Ble, "Scan complete. No matching device found.");
         break;

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -45,6 +45,8 @@ enum class BleScanState : uint8_t
     kScanForDiscriminator,
     kScanForAddress,
     kConnecting,
+    kScanForNetworkRecoveryDiscover,
+    kScanForNetworkRecoveryRecover,
 };
 
 struct BLEScanConfig
@@ -57,6 +59,9 @@ struct BLEScanConfig
 
     // If scanning by address, what address are we searching for
     std::string mAddress;
+
+    // If scanning by network recovery, what are we scanning for
+    uint64_t mRecoveryIdentifier;
 
     // Optional argument to be passed to callback functions provided by the BLE scan/connect requestor
     void * mAppState = nullptr;
@@ -137,12 +142,14 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
+    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
+    void NewConnection(BleLayer * bleLayer, void * appState, uint64_t connRecoveryIdentifier) override;
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate
 
     void OnDeviceScanned(BluezDevice1 & device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) override;
+    void OnDeviceScanned(BluezDevice1 & device, const chip::Ble::ChipBLENetworkRecoveryInfo & info) override;
     void OnScanComplete() override;
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -50,6 +50,31 @@ bool BluezGetChipDeviceInfo(BluezDevice1 & aDevice, chip::Ble::ChipBLEDeviceIden
     VerifyOrReturnError(dataBytes != nullptr && dataLen >= sizeof(aDeviceInfo), false);
 
     memcpy(&aDeviceInfo, dataBytes, sizeof(aDeviceInfo));
+    if (aDeviceInfo.OpCode != 0)
+    {
+        return false;
+    }
+    return true;
+}
+
+/// Retrieve CHIP network recovery info from the device advertising data
+bool BluezGetChipRecoveryInfo(BluezDevice1 & aDevice, chip::Ble::ChipBLENetworkRecoveryInfo & aRecoveryInfo)
+{
+    GVariant * serviceData = bluez_device1_get_service_data(&aDevice);
+    VerifyOrReturnError(serviceData != nullptr, false);
+
+    GAutoPtr<GVariant> dataValue(g_variant_lookup_value(serviceData, Ble::CHIP_BLE_SERVICE_LONG_UUID_STR, nullptr));
+    VerifyOrReturnError(dataValue != nullptr, false);
+
+    size_t dataLen         = 0;
+    const void * dataBytes = g_variant_get_fixed_array(dataValue.get(), &dataLen, sizeof(uint8_t));
+    VerifyOrReturnError(dataBytes != nullptr && dataLen >= sizeof(aRecoveryInfo), false);
+
+    memcpy(&aRecoveryInfo, dataBytes, sizeof(aRecoveryInfo));
+    if (aRecoveryInfo.OpCode != 1)
+    {
+        return false;
+    }
     return true;
 }
 
@@ -95,8 +120,8 @@ CHIP_ERROR ChipDeviceScanner::StartScan()
     VerifyOrReturnError(mScannerState != ChipDeviceScannerState::SCANNING, CHIP_ERROR_INCORRECT_STATE);
 
     mCancellable.reset(g_cancellable_new());
-    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
+    CHIP_ERROR err =
+        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed to initiate BLE scan start: %" CHIP_ERROR_FORMAT, err.Format());
@@ -115,8 +140,8 @@ CHIP_ERROR ChipDeviceScanner::StopScan()
     assertChipStackLockedByCurrentThread();
     VerifyOrReturnError(mScannerState == ChipDeviceScannerState::SCANNING, CHIP_NO_ERROR);
 
-    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](ChipDeviceScanner * self) { return self->StopScanImpl(); }, this);
+    CHIP_ERROR err =
+        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](ChipDeviceScanner * self) { return self->StopScanImpl(); }, this);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed to initiate BLE scan stop: %" CHIP_ERROR_FORMAT, err.Format());
@@ -180,13 +205,28 @@ void ChipDeviceScanner::ReportDevice(BluezDevice1 & device)
 
     chip::Ble::ChipBLEDeviceIdentificationInfo deviceInfo;
 
+    // TODO:
     if (!BluezGetChipDeviceInfo(device, deviceInfo))
     {
-        ChipLogDetail(Ble, "Device %s does not look like a CHIP device.", bluez_device1_get_address(&device));
-        return;
+        // ChipLogDetail(Ble, "Device %s does not look like a CHIP device.", bluez_device1_get_address(&device));
+        // return;
+    }
+    else
+    {
+        return mDelegate->OnDeviceScanned(device, deviceInfo);
     }
 
-    mDelegate->OnDeviceScanned(device, deviceInfo);
+    chip::Ble::ChipBLENetworkRecoveryInfo recoveryInfo;
+
+    if (!BluezGetChipRecoveryInfo(device, recoveryInfo))
+    {
+        // ChipLogDetail(Ble, "Device %s does not look like a recoverable device.", bluez_device1_get_address(&device));
+        // return;
+    }
+    else
+    {
+        return mDelegate->OnDeviceScanned(device, recoveryInfo);
+    }
 }
 
 void ChipDeviceScanner::RemoveDevice(BluezDevice1 & device)
@@ -195,8 +235,9 @@ void ChipDeviceScanner::RemoveDevice(BluezDevice1 & device)
                           g_dbus_proxy_get_object_path(reinterpret_cast<GDBusProxy *>(mAdapter.get()))) == 0);
 
     chip::Ble::ChipBLEDeviceIdentificationInfo deviceInfo;
+    chip::Ble::ChipBLENetworkRecoveryInfo recoveryInfo;
 
-    if (!BluezGetChipDeviceInfo(device, deviceInfo))
+    if (!BluezGetChipDeviceInfo(device, deviceInfo) && !BluezGetChipRecoveryInfo(device, recoveryInfo))
     {
         return;
     }

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -42,6 +42,7 @@ public:
 
     // Called when a CHIP device was found
     virtual void OnDeviceScanned(BluezDevice1 & device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) = 0;
+    virtual void OnDeviceScanned(BluezDevice1 & device, const chip::Ble::ChipBLENetworkRecoveryInfo & info)      = 0;
 
     // Called when a scan was completed (stopped or timed out)
     virtual void OnScanComplete() = 0;

--- a/src/platform/NuttX/BLEManagerImpl.h
+++ b/src/platform/NuttX/BLEManagerImpl.h
@@ -135,7 +135,8 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
+    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
+    void NewConnection(BleLayer * bleLayer, void * appState, uint64_t connRecoveryIdentifier) override {};
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -146,7 +146,8 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
+    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
+    void NewConnection(BleLayer * bleLayer, void * appState, uint64_t connRecoveryIdentifier) override {};
     CHIP_ERROR CancelConnection() override;
 
     //  ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/platform/android/BLEManagerImpl.h
+++ b/src/platform/android/BLEManagerImpl.h
@@ -90,7 +90,8 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
+    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
+    void NewConnection(BleLayer * bleLayer, void * appState, uint64_t connRecoveryIdentifier) override {};
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/webos/BLEManagerImpl.h
+++ b/src/platform/webos/BLEManagerImpl.h
@@ -131,7 +131,8 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
+    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
+    void NewConnection(BleLayer * bleLayer, void * appState, uint64_t connRecoveryIdentifier) override {};
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/tracing/metric_keys.h
+++ b/src/tracing/metric_keys.h
@@ -78,5 +78,8 @@ constexpr MetricKey kMetricDeviceRMPRetryCount = "core_dev_rmp_retry_count";
 // Subscription setup
 constexpr MetricKey kMetricDeviceSubscriptionSetup = "core_dev_subscription_setup";
 
+// Network Recovery
+constexpr MetricKey kMetricNetworkRecover = "core_dev_network_recover";
+
 } // namespace Tracing
 } // namespace chip


### PR DESCRIPTION
This change brings up the Network Recovery feature implementation PR https://github.com/project-chip/connectedhomeip/pull/38421 to the latest master branch of open source.

### Usage:
For discovering nodes who advertising network recovery message in BLE
```
chip-tool networkrecovery discover --timeout 10
```
If don't specific the timeout value, it will take 30 seconds as default for Network Recovery scan.
Once scan completed, the RecoveryIdentifier value from each recoverable device will be listed in the chip-tool log, for example:
```
[1744899521.197] [1746:1751] [CTL] Discovery timed out
[1744899521.198] [1746:1751] [TOO] Find recoverable devices:
[1744899521.198] [1746:1751] [TOO] 0x8877665544332211
[1744899521.199] [1746:1747] [BLE] BLE removing known devices
[1744899521.202] [1746:1747] [BLE] BLE initiating scan
[1744899521.217] [1746:1751] [BLE] ChipDeviceScanner has started scanning!
[1744899521.218] [1746:1746] [CTL] Shutting down the commissioner
```
For recovering a node's Wi-Fi network in BLE
chip-tool networkrecovery recover-wifi node-id recovery-identifier ssid password breadcrumb, for example:
```
chip-tool networkrecovery recover-wifi 1 9833440827789222417 my-ssid my-password 0
```
### Testing
manually validated with WiFi Linux All Clusters App