### PR TITLE
[Python] Update import of `Traversable` to work with python 3.14+

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/credentials.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/credentials.py
@@ -19,7 +19,7 @@ import importlib.resources as pkg_resources
 import os
 import zipfile
 from enum import Enum, auto
-from importlib.abc import Traversable
+from importlib.resources.abc import Traversable
 from typing import Union
 
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/spec_parsing.py
@@ -27,7 +27,7 @@ import zipfile
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum, StrEnum, auto
-from importlib.abc import Traversable
+from importlib.resources.abc import Traversable
 from typing import Optional, Union
 
 import matter.clusters as Clusters

--- a/src/python_testing/test_testing/TestSpecParsingNamespace.py
+++ b/src/python_testing/test_testing/TestSpecParsingNamespace.py
@@ -17,7 +17,7 @@
 
 import xml.etree.ElementTree as ElementTree
 import zipfile
-from importlib.abc import Traversable
+from importlib.resources.abc import Traversable
 
 from jinja2 import Template
 from mobly import asserts


### PR DESCRIPTION
#### Summary

The new class was added in 3.9 and old version was deprecated in 3.12 slated for removal in 3.14.
Chip supports python 3.11 + according to our docs.

This fixes python 3.14 running tests.

https://docs.python.org/3.11/library/importlib.resources.abc.html#importlib.resources.abc.Traversable
https://docs.python.org/3.12/library/importlib.resources.abc.html#importlib.abc.Traversable (for deprecation notice)


#### Testing

This works on python 3.14 for me. CI will validate that things are not broken.
I checked docs that this class exists in python 3.11