### PR TITLE
Fix MakeInstanceName to use PRIX32 so it is portable to embed devices…

### DIFF
--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -36,8 +36,12 @@ CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, const PeerId & peer
     NodeId nodeId               = peerId.GetNodeId();
     CompressedFabricId fabricId = peerId.GetCompressedFabricId();
 
+    uint32_t fabricIdHi = static_cast<uint32_t>(fabricId >> 32);
+    uint32_t fabricIdLo = static_cast<uint32_t>(fabricId);
+    uint32_t nodeIdHi   = static_cast<uint32_t>(nodeId >> 32);
+    uint32_t nodeIdLo   = static_cast<uint32_t>(nodeId);
     StringBuilderBase builder(buffer, bufferLen);
-    builder.AddFormat("%016" PRIX64 "-%016" PRIX64, fabricId, nodeId);
+    builder.AddFormat("%08" PRIX32 "%08" PRIX32 "-%08" PRIX32 "%08" PRIX32, fabricIdHi, fabricIdLo, nodeIdHi, nodeIdLo);
 
     VerifyOrReturnError(builder.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
     return CHIP_NO_ERROR;


### PR DESCRIPTION
… that do not natively support u64 formating

#### Summary
The PR https://github.com/project-chip/connectedhomeip/pull/42938/ cleanup up the string formating instructions in  MakeInstanceName but changed to use PRIX64. This cause issue for platform that don't natively support u64 formating.

This PR converts the fabricID and NodeID uint64 to uint32 MSBs and LSBs so PRIX32 can be use which is more portable to embedded devices.

#### Related issues
n/a

#### Testing
Successfully commission silabs's EFR32 lighting-app with the change.