### PR TITLE
[OccupancySensingCluster] Remove incorrect feature map config from CodegenIntegration and add Documentation

### DIFF
--- a/src/app/clusters/occupancy-sensor-server/CodegenIntegration.cpp
+++ b/src/app/clusters/occupancy-sensor-server/CodegenIntegration.cpp
@@ -50,7 +50,10 @@ public:
                                                    uint32_t optionalAttributeBits, uint32_t featureMap) override
     {
         OccupancySensingCluster::Config config(endpointId);
-        config.WithFeatures(BitFlags<Feature>(featureMap));
+
+        // No features enabled (defaults to PIR). If the app needs other features, it MUST instantiate and configure the cluster
+        // directly instead of relying on CodegenIntegration.
+        config.WithFeatures(BitFlags<Feature>(0u));
 
         // If the optional HoldTime attribute is enabled, enable the HoldTime logic.
         // The delay attributes are required if the corresponding sensor feature is present.
@@ -96,7 +99,7 @@ void MatterOccupancySensingClusterInitCallback(EndpointId endpointId)
             .clusterId                 = OccupancySensing::Id,
             .fixedClusterInstanceCount = kOccupancySensingFixedClusterCount,
             .maxClusterInstanceCount   = kOccupancySensingMaxClusterCount,
-            .fetchFeatureMap           = true,
+            .fetchFeatureMap           = false,
             .fetchOptionalAttributes   = true,
         },
         integrationDelegate);

--- a/src/app/clusters/occupancy-sensor-server/README.md
+++ b/src/app/clusters/occupancy-sensor-server/README.md
@@ -173,5 +173,5 @@ Post attribute change callback are now exclusively handled by implementing an
 The Feature map is hardcoded to 0 (defaults to PIR) when relying on
 `CodegenIntegration.cpp` (ZAP) for legacy usade. If your application needs to
 enable other features, it MUST instantiate and configure the cluster directly
-using `config.WithFeatures(featureMap)`as shown in section [Instantiate Delegates and Cluster](#2-instantiate-delegates-and-cluster)
-.
+using `config.WithFeatures(featureMap)`as shown in section
+[Instantiate Delegates and Cluster](#2-instantiate-delegates-and-cluster) .

--- a/src/app/clusters/occupancy-sensor-server/README.md
+++ b/src/app/clusters/occupancy-sensor-server/README.md
@@ -157,6 +157,8 @@ void MySensorHardwareCallback(bool isOccupied)
 }
 ```
 
+### Notes and Limitations for Legacy Usage
+
 Unlike the legacy implementation, the current implementation handles all timer
 related functionality related to the `holdTime` attribute. So the application
 should no longer maintain any `holdTime` timer.
@@ -167,3 +169,9 @@ class.
 
 Post attribute change callback are now exclusively handled by implementing an
 `OccupancySensingDelegate`.
+
+The Feature map is hardcoded to 0 (defaults to PIR) when relying on
+`CodegenIntegration.cpp` (ZAP) for legacy usade. If your application needs to
+enable other features, it MUST instantiate and configure the cluster directly
+using `config.WithFeatures(featureMap)`as shown in section [Instantiate Delegates and Cluster](#2-instantiate-delegates-and-cluster)
+.

--- a/src/app/clusters/occupancy-sensor-server/README.md
+++ b/src/app/clusters/occupancy-sensor-server/README.md
@@ -161,8 +161,9 @@ void MySensorHardwareCallback(bool isOccupied)
 
 ### Timer Handling
 
-The cluster implementation now handles all timer related functionality related to
-the `holdTime` attribute. Applications must not maintain any `holdTime` timer.
+The cluster implementation now handles all timer related functionality related
+to the `holdTime` attribute. Applications must not maintain any `holdTime`
+timer.
 
 ### Attribute Access
 
@@ -181,15 +182,13 @@ The Feature map is hardcoded to 0 (defaults to PIR) when relying on
 `CodegenIntegration.cpp` (ZAP) for backward compatibility. If your application
 needs to enable other features, it MUST instantiate and configure the cluster
 directly. The deprecated API assumed there was only a single instance of
-Occupancy Sensor and allowed the application to configure the feature map
-with:
+Occupancy Sensor and allowed the application to configure the feature map with:
 
 ```
 OccupancySensing::Instance(Feature::kPassiveInfrared);
 ```
 
-This must be done using `config.WithFeatures(featureMap)` as shown in
-section
+This must be done using `config.WithFeatures(featureMap)` as shown in section
 [Instantiate Delegates and Cluster](#2-instantiate-delegates-and-cluster)
 through the constructor for each instance of the cluster:
 

--- a/src/app/clusters/occupancy-sensor-server/README.md
+++ b/src/app/clusters/occupancy-sensor-server/README.md
@@ -171,7 +171,7 @@ Post attribute change callback are now exclusively handled by implementing an
 `OccupancySensingDelegate`.
 
 The Feature map is hardcoded to 0 (defaults to PIR) when relying on
-`CodegenIntegration.cpp` (ZAP) for legacy usade. If your application needs to
+`CodegenIntegration.cpp` (ZAP) for legacy usage. If your application needs to
 enable other features, it MUST instantiate and configure the cluster directly
 using `config.WithFeatures(featureMap)`as shown in section
 [Instantiate Delegates and Cluster](#2-instantiate-delegates-and-cluster) .

--- a/src/app/clusters/occupancy-sensor-server/README.md
+++ b/src/app/clusters/occupancy-sensor-server/README.md
@@ -121,9 +121,9 @@ void MySensorHardwareCallback(bool isOccupied)
 }
 ```
 
-## Legacy Usage (Not Recommended)
+## Compatibility with ZAP/Codegen
 
-For backwards compatibility with applications that rely on older ZAP-generated
+For backwards compatibility with applications that rely on ZAP-generated
 patterns (like the `all-clusters-app`), a compatibility layer is provided in
 `CodegenIntegration.h` and `CodegenIntegration.cpp`.
 
@@ -157,29 +157,41 @@ void MySensorHardwareCallback(bool isOccupied)
 }
 ```
 
-### Notes and Limitations for Legacy Usage
+## Migration from SDK versions < 1.6
 
-* Unlike the legacy implementation, the current implementation handles all timer
-related functionality related to the `holdTime` attribute. So the application
-should no longer maintain any `holdTime` timer.
+### Timer Handling
 
-* The global attribute setter/getters are no longer available. This is now
+The cluster implementation now handles all timer related functionality related to
+the `holdTime` attribute. Applications must not maintain any `holdTime` timer.
+
+### Attribute Access
+
+The global attribute setter/getters are no longer available. Attribute access is
 exclusively done using the public methods from the `OccupancySensingCluster`
 class.
 
-* Post attribute change callback are now exclusively handled by implementing an
+### Callbacks
+
+Post attribute change callbacks are exclusively handled by implementing an
 `OccupancySensingDelegate`.
 
-* The Feature map is hardcoded to 0 (defaults to PIR) when relying on
-`CodegenIntegration.cpp` (ZAP) for legacy usage. If your application needs to
-enable other features, it MUST instantiate and configure the cluster directly.
-The legacy API assumed there was only a single instance of Occupancy Sensor 
-and allowed the application to configure the feature map with:
+### Feature Map Configuration
+
+The Feature map is hardcoded to 0 (defaults to PIR) when relying on
+`CodegenIntegration.cpp` (ZAP) for backward compatibility. If your application
+needs to enable other features, it MUST instantiate and configure the cluster
+directly. The deprecated API assumed there was only a single instance of
+Occupancy Sensor and allowed the application to configure the feature map
+with:
+
 ```
 OccupancySensing::Instance(Feature::kPassiveInfrared);
 ```
-Now, this must be done using `config.WithFeatures(featureMap)`as shown in section
-[Instantiate Delegates and Cluster](#2-instantiate-delegates-and-cluster) through the constructor for each instance of the cluster:
+
+This must be done using `config.WithFeatures(featureMap)` as shown in
+section
+[Instantiate Delegates and Cluster](#2-instantiate-delegates-and-cluster)
+through the constructor for each instance of the cluster:
 
 ```
 auto config = Clusters::OccupancySensingCluster::Config(kYourEndpointId)

--- a/src/app/clusters/occupancy-sensor-server/README.md
+++ b/src/app/clusters/occupancy-sensor-server/README.md
@@ -159,19 +159,30 @@ void MySensorHardwareCallback(bool isOccupied)
 
 ### Notes and Limitations for Legacy Usage
 
-Unlike the legacy implementation, the current implementation handles all timer
+* Unlike the legacy implementation, the current implementation handles all timer
 related functionality related to the `holdTime` attribute. So the application
 should no longer maintain any `holdTime` timer.
 
-The global attribute setter/getters are no longer available. This is now
+* The global attribute setter/getters are no longer available. This is now
 exclusively done using the public methods from the `OccupancySensingCluster`
 class.
 
-Post attribute change callback are now exclusively handled by implementing an
+* Post attribute change callback are now exclusively handled by implementing an
 `OccupancySensingDelegate`.
 
-The Feature map is hardcoded to 0 (defaults to PIR) when relying on
+* The Feature map is hardcoded to 0 (defaults to PIR) when relying on
 `CodegenIntegration.cpp` (ZAP) for legacy usage. If your application needs to
-enable other features, it MUST instantiate and configure the cluster directly
-using `config.WithFeatures(featureMap)`as shown in section
-[Instantiate Delegates and Cluster](#2-instantiate-delegates-and-cluster) .
+enable other features, it MUST instantiate and configure the cluster directly.
+The legacy API assumed there was only a single instance of Occupancy Sensor 
+and allowed the application to configure the feature map with:
+```
+OccupancySensing::Instance(Feature::kPassiveInfrared);
+```
+Now, this must be done using `config.WithFeatures(featureMap)`as shown in section
+[Instantiate Delegates and Cluster](#2-instantiate-delegates-and-cluster) through the constructor for each instance of the cluster:
+
+```
+auto config = Clusters::OccupancySensingCluster::Config(kYourEndpointId)
+
+RegisteredServerCluster<Clusters::OccupancySensingCluster> myOccupancyCluster(config.WithFeatures(Feature::kPassiveInfrared));
+```


### PR DESCRIPTION
#### Summary

Fix `failed to load featuremap` errors related to OCcupancySensing for legacy apps.

Context:
 in https://github.com/project-chip/connectedhomeip/pull/34658 the featureMap attribute was marked as callback so ember does not store it and after converting it to CodeDriven in https://github.com/project-chip/connectedhomeip/pull/41954, we lost the ability to configure the featureMap in codegen mode. So this PR documents it.

#### Testing

Trivial change. CI will validate.