### PR TITLE
Update BooleanStateConfiguration test scripts to check event generation on FAULTEV

### DIFF
--- a/src/python_testing/TC_BOOLCFG_4_2.py
+++ b/src/python_testing/TC_BOOLCFG_4_2.py
@@ -210,8 +210,8 @@ class TC_BOOLCFG_4_2(MatterBaseTest):
         if alarms_state_changed_event_supported and (is_vis_feature_supported or is_aud_feature_supported):
             event = event_listener.wait_for_event_report(
                 cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
-            asserts.assert_not_equal(event.alarmsActive, 0,
-                                     "AlarmsStateChanged event did not report non-zero alarmsActive after sensor trigger")
+            asserts.assert_equal(event.alarmsActive, activeAlarms,
+                                 "AlarmsStateChanged event alarmsActive does not match expected value after sensor trigger")
             log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
         else:
             log.info("AlarmsStateChanged event not supported or no alarms enabled. Skipping step 7c.")

--- a/src/python_testing/TC_BOOLCFG_4_2.py
+++ b/src/python_testing/TC_BOOLCFG_4_2.py
@@ -43,6 +43,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import async_test_body
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 
@@ -69,14 +70,17 @@ class TC_BOOLCFG_4_2(MatterBaseTest):
             TestStep("3b", "If VIS is supported, set bit 0 to 1"),
             TestStep("3c", "If AUD is supported, set bit 1 to 1"),
             TestStep("3d", "Set AlarmsEnabled attribute to value of enabledAlarms using EnableDisableAlarm command"),
+            TestStep("3e", "Set up event subscription for BooleanStateConfiguration cluster"),
             TestStep(4, "Send TestEventTrigger with SensorTrigger event"),
             TestStep(5, "Read AlarmsActive attribute"),
             TestStep("6a", "Verify VIS alarm is active, if supported"),
             TestStep("6b", "Verify VIS alarm is not active, if not supported"),
             TestStep("7a", "Verify AUD alarm is active, if supported"),
             TestStep("7b", "Verify AUD alarm is not active, if not supported"),
+            TestStep("7c", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated with expected alarmsActive"),
             TestStep(8, "Send TestEventTrigger with SensorUntrigger event"),
             TestStep(9, "Read AlarmsActive attribute"),
+            TestStep("9a", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated with alarmsActive == 0"),
         ]
 
     def pics_TC_BOOLCFG_4_2(self) -> list[str]:
@@ -97,32 +101,39 @@ class TC_BOOLCFG_4_2(MatterBaseTest):
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
         endpoint = self.get_endpoint()
+        node_id = self.dut_node_id
+        dev_ctrl = self.default_controller
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)
-        attributes = Clusters.BooleanStateConfiguration.Attributes
+        cluster = Clusters.BooleanStateConfiguration
+        attributes = cluster.Attributes
 
         self.step("2a")
         feature_map = await self.read_boolcfg_attribute_expect_success(endpoint=endpoint, attribute=attributes.FeatureMap)
 
-        is_vis_feature_supported = feature_map & Clusters.BooleanStateConfiguration.Bitmaps.Feature.kVisual
-        is_aud_feature_supported = feature_map & Clusters.BooleanStateConfiguration.Bitmaps.Feature.kAudible
+        is_vis_feature_supported = feature_map & cluster.Bitmaps.Feature.kVisual
+        is_aud_feature_supported = feature_map & cluster.Bitmaps.Feature.kAudible
 
         self.step("2b")
         attribute_list = await self.read_boolcfg_attribute_expect_success(endpoint=endpoint, attribute=attributes.AttributeList)
+
+        # Check if AlarmsStateChanged event (BOOLCFG.S.E00) is supported
+        alarms_state_changed_event_supported = self.check_pics("BOOLCFG.S.E00")
+        log.info(f"AlarmsStateChanged event supported (BOOLCFG.S.E00): {alarms_state_changed_event_supported}")
 
         self.step("3a")
         enabledAlarms = 0
 
         self.step("3b")
         if attributes.AlarmsEnabled.attribute_id in attribute_list and is_vis_feature_supported:
-            enabledAlarms |= Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kVisual
+            enabledAlarms |= cluster.Bitmaps.AlarmModeBitmap.kVisual
         else:
             log.info("Test step skipped")
 
         self.step("3c")
         if attributes.AlarmsEnabled.attribute_id in attribute_list and is_aud_feature_supported:
-            enabledAlarms |= Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible
+            enabledAlarms |= cluster.Bitmaps.AlarmModeBitmap.kAudible
         else:
             log.info("Test step skipped")
 
@@ -135,6 +146,17 @@ class TC_BOOLCFG_4_2(MatterBaseTest):
                 pass
         else:
             log.info("Test step skipped")
+
+        # Set up event subscription
+        self.step("3e")
+        event_listener = None
+        if alarms_state_changed_event_supported:
+            event_listener = EventSubscriptionHandler(expected_cluster=cluster)
+            await event_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30)
+            log.info("Event subscription established for BooleanStateConfiguration cluster.")
+        else:
+            log.info("AlarmsStateChanged event not supported. Skipping event subscription setup.")
+            self.mark_current_step_skipped()
 
         self.step(4)
         if is_vis_feature_supported or is_aud_feature_supported:
@@ -158,13 +180,13 @@ class TC_BOOLCFG_4_2(MatterBaseTest):
         self.step("6a")
         if is_vis_feature_supported:
             asserts.assert_not_equal(
-                (activeAlarms & Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kVisual), 0, "Bit 0 in AlarmsActive is not 1")
+                (activeAlarms & cluster.Bitmaps.AlarmModeBitmap.kVisual), 0, "Bit 0 in AlarmsActive is not 1")
         else:
             log.info("Test step skipped")
 
         self.step("6b")
         if not is_vis_feature_supported:
-            asserts.assert_equal((activeAlarms & Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kVisual),
+            asserts.assert_equal((activeAlarms & cluster.Bitmaps.AlarmModeBitmap.kVisual),
                                  0, "Bit 0 in AlarmsActive is not 0")
         else:
             log.info("Test step skipped")
@@ -172,16 +194,32 @@ class TC_BOOLCFG_4_2(MatterBaseTest):
         self.step("7a")
         if is_aud_feature_supported:
             asserts.assert_not_equal(
-                (activeAlarms & Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible), 0, "Bit 1 in AlarmsActive is not 1")
+                (activeAlarms & cluster.Bitmaps.AlarmModeBitmap.kAudible), 0, "Bit 1 in AlarmsActive is not 1")
         else:
             log.info("Test step skipped")
 
         self.step("7b")
         if not is_aud_feature_supported:
-            asserts.assert_equal((activeAlarms & Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible),
+            asserts.assert_equal((activeAlarms & cluster.Bitmaps.AlarmModeBitmap.kAudible),
                                  0, "Bit 1 in AlarmsActive is not 0")
         else:
             log.info("Test step skipped")
+
+        # Verify AlarmsStateChanged event after sensor trigger
+        self.step("7c")
+        if alarms_state_changed_event_supported and (is_vis_feature_supported or is_aud_feature_supported):
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_not_equal(event.alarmsActive, 0,
+                                     "AlarmsStateChanged event did not report non-zero alarmsActive after sensor trigger")
+            log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
+        else:
+            log.info("AlarmsStateChanged event not supported or no alarms enabled. Skipping step 7c.")
+            self.mark_current_step_skipped()
+
+        # Reset event listener for next cycle
+        if event_listener is not None:
+            event_listener.reset()
 
         self.step(8)
         if is_vis_feature_supported or is_aud_feature_supported:
@@ -199,6 +237,18 @@ class TC_BOOLCFG_4_2(MatterBaseTest):
             asserts.assert_equal(activeAlarms, 0, "AlarmsActive is not 0")
         else:
             log.info("Test step skipped")
+
+        # Verify AlarmsStateChanged event after sensor untrigger
+        self.step("9a")
+        if alarms_state_changed_event_supported and (is_vis_feature_supported or is_aud_feature_supported):
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_equal(event.alarmsActive, 0,
+                                 "AlarmsStateChanged event did not report alarmsActive == 0 after sensor untrigger")
+            log.info("Received AlarmsStateChanged event with alarmsActive = 0")
+        else:
+            log.info("AlarmsStateChanged event not supported or no alarms enabled. Skipping step 9a.")
+            self.mark_current_step_skipped()
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_BOOLCFG_4_3.py
+++ b/src/python_testing/TC_BOOLCFG_4_3.py
@@ -197,8 +197,8 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
         if alarms_state_changed_event_supported and is_vis_feature_supported:
             event = event_listener.wait_for_event_report(
                 cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
-            asserts.assert_not_equal(event.alarmsActive, 0,
-                                     "AlarmsStateChanged event did not report non-zero alarmsActive after sensor trigger")
+            asserts.assert_equal(event.alarmsActive, cluster.Bitmaps.AlarmModeBitmap.kVisual,
+                                 "AlarmsStateChanged event alarmsActive does not match expected value after sensor trigger")
             log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
         else:
             log.info("Test step skipped")
@@ -315,8 +315,8 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
         if alarms_state_changed_event_supported and is_aud_feature_supported:
             event = event_listener.wait_for_event_report(
                 cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
-            asserts.assert_not_equal(event.alarmsActive, 0,
-                                     "AlarmsStateChanged event did not report non-zero alarmsActive after sensor trigger")
+            asserts.assert_equal(event.alarmsActive, cluster.Bitmaps.AlarmModeBitmap.kAudible,
+                                 "AlarmsStateChanged event alarmsActive does not match expected kAudible after sensor trigger")
             log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
         else:
             log.info("Test step skipped")

--- a/src/python_testing/TC_BOOLCFG_4_3.py
+++ b/src/python_testing/TC_BOOLCFG_4_3.py
@@ -43,6 +43,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import async_test_body
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 
@@ -66,13 +67,16 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
             TestStep("2a", "Read FeatureMap attribute"),
             TestStep("2b", "Read AttributeList attribute"),
             TestStep(3, "Verify AlarmsEnabled is supported"),
+            TestStep("3a", "Set up event subscription for BooleanStateConfiguration cluster"),
             TestStep(4, "Create enabledAlarms and set to 0"),
             TestStep("5a", "Enable VIS alarm in enabledAlarms"),
             TestStep("5b", "Set AlarmsEnabled attribute to value of enabledAlarms using AlarmsToEnableDisable command"),
             TestStep(6, "Send TestEventTrigger with SensorTrigger event"),
             TestStep(7, "Read AlarmsActive attribute"),
+            TestStep("7a", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated"),
             TestStep(8, "Send TestEventTrigger with SensorUntrigger event"),
             TestStep(9, "Read AlarmsActive attribute"),
+            TestStep("9a", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated with alarmsActive == 0"),
             TestStep(10, "Set enabledAlarms to 0"),
             TestStep(11, "Set AlarmsEnabled attribute to value of enabledAlarms using AlarmsToEnableDisable command"),
             TestStep(12, "Send TestEventTrigger with SensorTrigger event"),
@@ -82,8 +86,10 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
             TestStep("15b", "Set AlarmsEnabled attribute to value of enabledAlarms using AlarmsToEnableDisable command"),
             TestStep(16, "Send TestEventTrigger with SensorTrigger event"),
             TestStep(17, "Read AlarmsActive attribute"),
+            TestStep("17a", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated"),
             TestStep(18, "Send TestEventTrigger with SensorUntrigger event"),
             TestStep(19, "Read AlarmsActive attribute"),
+            TestStep("19a", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated with alarmsActive == 0"),
             TestStep(20, "Set enabledAlarms to 0"),
             TestStep(21, "Set AlarmsEnabled attribute to value of enabledAlarms using AlarmsToEnableDisable command"),
             TestStep(22, "Send TestEventTrigger with SensorTrigger event"),
@@ -109,19 +115,25 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
         endpoint = self.get_endpoint()
+        node_id = self.dut_node_id
+        dev_ctrl = self.default_controller
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)
-        attributes = Clusters.BooleanStateConfiguration.Attributes
+        cluster = Clusters.BooleanStateConfiguration
+        attributes = cluster.Attributes
 
         self.step("2a")
         feature_map = await self.read_boolcfg_attribute_expect_success(endpoint=endpoint, attribute=attributes.FeatureMap)
 
-        is_vis_feature_supported = feature_map & Clusters.BooleanStateConfiguration.Bitmaps.Feature.kVisual
-        is_aud_feature_supported = feature_map & Clusters.BooleanStateConfiguration.Bitmaps.Feature.kAudible
+        is_vis_feature_supported = feature_map & cluster.Bitmaps.Feature.kVisual
+        is_aud_feature_supported = feature_map & cluster.Bitmaps.Feature.kAudible
 
         self.step("2b")
         attribute_list = await self.read_boolcfg_attribute_expect_success(endpoint=endpoint, attribute=attributes.AttributeList)
+
+        # Check if AlarmsStateChanged event (BOOLCFG.S.E00) is supported
+        alarms_state_changed_event_supported = self.check_pics("BOOLCFG.S.E00")
 
         self.step(3)
         if attributes.AlarmsEnabled.attribute_id not in attribute_list:
@@ -135,12 +147,23 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
             return
         log.info("Test step skipped")
 
+        # Set up event subscription
+        self.step("3a")
+        event_listener = None
+        if alarms_state_changed_event_supported:
+            event_listener = EventSubscriptionHandler(expected_cluster=cluster)
+            await event_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30)
+            log.info("Event subscription established for BooleanStateConfiguration cluster.")
+        else:
+            log.info("AlarmsStateChanged event not supported. Skipping event subscription setup.")
+            self.mark_current_step_skipped()
+
         self.step(4)
         enabledAlarms = 0
 
         self.step("5a")
         if is_vis_feature_supported:
-            enabledAlarms |= Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kVisual
+            enabledAlarms |= cluster.Bitmaps.AlarmModeBitmap.kVisual
         else:
             log.info("Test step skipped")
 
@@ -164,10 +187,25 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
         self.step(7)
         if is_vis_feature_supported:
             activeAlarms = await self.read_boolcfg_attribute_expect_success(endpoint=endpoint, attribute=attributes.AlarmsActive)
-            asserts.assert_equal(activeAlarms, Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kVisual,
+            asserts.assert_equal(activeAlarms, cluster.Bitmaps.AlarmModeBitmap.kVisual,
                                  "AlarmsActive does not match expected value")
         else:
             log.info("Test step skipped")
+
+        # Verify AlarmsStateChanged event after VIS trigger
+        self.step("7a")
+        if alarms_state_changed_event_supported and is_vis_feature_supported:
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_not_equal(event.alarmsActive, 0,
+                                     "AlarmsStateChanged event did not report non-zero alarmsActive after sensor trigger")
+            log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
+        else:
+            log.info("Test step skipped")
+            self.mark_current_step_skipped()
+
+        if event_listener is not None:
+            event_listener.reset()
 
         self.step(8)
         if is_vis_feature_supported:
@@ -185,6 +223,21 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
             asserts.assert_equal(activeAlarms, 0, "AlarmsActive does not match expected value")
         else:
             log.info("Test step skipped")
+
+        # Verify AlarmsStateChanged event after VIS untrigger
+        self.step("9a")
+        if alarms_state_changed_event_supported and is_vis_feature_supported:
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_equal(event.alarmsActive, 0,
+                                 "AlarmsStateChanged event did not report alarmsActive == 0 after sensor untrigger")
+            log.info("Received AlarmsStateChanged event with alarmsActive = 0")
+        else:
+            log.info("Test step skipped")
+            self.mark_current_step_skipped()
+
+        if event_listener is not None:
+            event_listener.reset()
 
         self.step(10)
         enabledAlarms = 0
@@ -225,7 +278,7 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
 
         self.step("15a")
         if is_aud_feature_supported:
-            enabledAlarms |= Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible
+            enabledAlarms |= cluster.Bitmaps.AlarmModeBitmap.kAudible
         else:
             log.info("Test step skipped")
 
@@ -235,6 +288,9 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
+
+        if event_listener is not None:
+            event_listener.reset()
 
         self.step(16)
         if is_aud_feature_supported:
@@ -249,10 +305,25 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
         self.step(17)
         if is_aud_feature_supported:
             activeAlarms = await self.read_boolcfg_attribute_expect_success(endpoint=endpoint, attribute=attributes.AlarmsActive)
-            asserts.assert_equal(activeAlarms, Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible,
+            asserts.assert_equal(activeAlarms, cluster.Bitmaps.AlarmModeBitmap.kAudible,
                                  "AlarmsActive does not match expected value")
         else:
             log.info("Test step skipped")
+
+        # Verify AlarmsStateChanged event after AUD trigger
+        self.step("17a")
+        if alarms_state_changed_event_supported and is_aud_feature_supported:
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_not_equal(event.alarmsActive, 0,
+                                     "AlarmsStateChanged event did not report non-zero alarmsActive after sensor trigger")
+            log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
+        else:
+            log.info("Test step skipped")
+            self.mark_current_step_skipped()
+
+        if event_listener is not None:
+            event_listener.reset()
 
         self.step(18)
         if is_aud_feature_supported:
@@ -270,6 +341,21 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
             asserts.assert_equal(activeAlarms, 0, "AlarmsActive does not match expected value")
         else:
             log.info("Test step skipped")
+
+        # Verify AlarmsStateChanged event after AUD untrigger
+        self.step("19a")
+        if alarms_state_changed_event_supported and is_aud_feature_supported:
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_equal(event.alarmsActive, 0,
+                                 "AlarmsStateChanged event did not report alarmsActive == 0 after sensor untrigger")
+            log.info("Received AlarmsStateChanged event with alarmsActive = 0")
+        else:
+            log.info("Test step skipped")
+            self.mark_current_step_skipped()
+
+        if event_listener is not None:
+            event_listener.reset()
 
         self.step(20)
         enabledAlarms = 0

--- a/src/python_testing/TC_BOOLCFG_4_4.py
+++ b/src/python_testing/TC_BOOLCFG_4_4.py
@@ -195,8 +195,8 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
         if alarms_state_changed_event_supported and (is_vis_feature_supported or is_aud_feature_supported):
             event = event_listener.wait_for_event_report(
                 cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
-            asserts.assert_not_equal(event.alarmsActive, 0,
-                                     "AlarmsStateChanged event did not report non-zero alarmsActive after sensor trigger")
+            asserts.assert_equal(event.alarmsActive, activeAlarms,
+                                 "AlarmsStateChanged event alarmsActive does not match expected mask after sensor trigger")
             log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
         else:
             log.info("Test step skipped")

--- a/src/python_testing/TC_BOOLCFG_4_4.py
+++ b/src/python_testing/TC_BOOLCFG_4_4.py
@@ -43,6 +43,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import async_test_body
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 
@@ -66,20 +67,24 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
             TestStep("2a", "Read FeatureMap attribute"),
             TestStep("2b", "Read AttributeList attribute"),
             TestStep(3, "Verify AlarmsEnabled is supported"),
+            TestStep("3a", "Set up event subscription for BooleanStateConfiguration cluster"),
             TestStep(4, "Create enabledAlarms and set to 0"),
             TestStep("5a", "Enable VIS alarm in enabledAlarms"),
             TestStep("5b", "Enable AUD alarm in enabledAlarms"),
             TestStep("5c", "Set AlarmsEnabled attribute to value of enabledAlarms using AlarmsToEnableDisable command"),
             TestStep(6, "Send TestEventTrigger with SensorTrigger event"),
             TestStep(7, "Read AlarmsActive attribute"),
+            TestStep("7a", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated"),
             TestStep(8, "Verify VIS alarm is active"),
             TestStep("9a", "Disable VIS alarm in enabledAlarms"),
             TestStep("9b", "Set AlarmsEnabled attribute to value of enabledAlarms using AlarmsToEnableDisable command"),
             TestStep(10, "Read AlarmsActive attribute"),
+            TestStep("10a", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated after disabling VIS"),
             TestStep(11, "Verify AUD alarm is active"),
-            TestStep("12a", "Disable VIS alarm in enabledAlarms"),
+            TestStep("12a", "Disable AUD alarm in enabledAlarms"),
             TestStep("12b", "Set AlarmsEnabled attribute to value of enabledAlarms using AlarmsToEnableDisable command"),
             TestStep(13, "Read AlarmsActive attribute"),
+            TestStep("13a", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated after disabling AUD"),
             TestStep(14, "Send TestEventTrigger with SensorUntrigger event"),
         ]
 
@@ -101,19 +106,25 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
         endpoint = self.get_endpoint()
+        node_id = self.dut_node_id
+        dev_ctrl = self.default_controller
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)
-        attributes = Clusters.BooleanStateConfiguration.Attributes
+        cluster = Clusters.BooleanStateConfiguration
+        attributes = cluster.Attributes
 
         self.step("2a")
         feature_map = await self.read_boolcfg_attribute_expect_success(endpoint=endpoint, attribute=attributes.FeatureMap)
 
-        is_vis_feature_supported = feature_map & Clusters.BooleanStateConfiguration.Bitmaps.Feature.kVisual
-        is_aud_feature_supported = feature_map & Clusters.BooleanStateConfiguration.Bitmaps.Feature.kAudible
+        is_vis_feature_supported = feature_map & cluster.Bitmaps.Feature.kVisual
+        is_aud_feature_supported = feature_map & cluster.Bitmaps.Feature.kAudible
 
         self.step("2b")
         attribute_list = await self.read_boolcfg_attribute_expect_success(endpoint=endpoint, attribute=attributes.AttributeList)
+
+        # Check if AlarmsStateChanged event (BOOLCFG.S.E00) is supported
+        alarms_state_changed_event_supported = self.check_pics("BOOLCFG.S.E00")
 
         self.step(3)
         if attributes.AlarmsEnabled.attribute_id not in attribute_list:
@@ -127,18 +138,29 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
             return
         log.info("Test step skipped")
 
+        # Set up event subscription
+        self.step("3a")
+        event_listener = None
+        if alarms_state_changed_event_supported:
+            event_listener = EventSubscriptionHandler(expected_cluster=cluster)
+            await event_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30)
+            log.info("Event subscription established for BooleanStateConfiguration cluster.")
+        else:
+            log.info("AlarmsStateChanged event not supported. Skipping event subscription setup.")
+            self.mark_current_step_skipped()
+
         self.step(4)
         enabledAlarms = 0
 
         self.step("5a")
         if is_vis_feature_supported:
-            enabledAlarms |= Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kVisual
+            enabledAlarms |= cluster.Bitmaps.AlarmModeBitmap.kVisual
         else:
             log.info("Test step skipped")
 
         self.step("5b")
         if is_aud_feature_supported:
-            enabledAlarms |= Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible
+            enabledAlarms |= cluster.Bitmaps.AlarmModeBitmap.kAudible
         else:
             log.info("Test step skipped")
 
@@ -168,6 +190,21 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
         else:
             log.info("Test step skipped")
 
+        # Verify AlarmsStateChanged event after trigger
+        self.step("7a")
+        if alarms_state_changed_event_supported and (is_vis_feature_supported or is_aud_feature_supported):
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_not_equal(event.alarmsActive, 0,
+                                     "AlarmsStateChanged event did not report non-zero alarmsActive after sensor trigger")
+            log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
+        else:
+            log.info("Test step skipped")
+            self.mark_current_step_skipped()
+
+        if event_listener is not None:
+            event_listener.reset()
+
         self.step(8)
         if is_vis_feature_supported:
             asserts.assert_not_equal((activeAlarms & 0b01), 0, "Bit 0 in AlarmsActive is not 1")
@@ -176,7 +213,7 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
 
         self.step("9a")
         if is_vis_feature_supported:
-            enabledAlarms &= ~(Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kVisual)
+            enabledAlarms &= ~(cluster.Bitmaps.AlarmModeBitmap.kVisual)
         else:
             log.info("Test step skipped")
 
@@ -194,6 +231,21 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
         else:
             log.info("Test step skipped")
 
+        # Verify AlarmsStateChanged event after disabling VIS
+        self.step("10a")
+        if alarms_state_changed_event_supported and is_vis_feature_supported:
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_equal((event.alarmsActive & 0b01), 0,
+                                 "AlarmsStateChanged event still reports VIS alarm active after disabling")
+            log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
+        else:
+            log.info("Test step skipped")
+            self.mark_current_step_skipped()
+
+        if event_listener is not None:
+            event_listener.reset()
+
         self.step(11)
         if is_aud_feature_supported:
             asserts.assert_not_equal((activeAlarms & 0b10), 0, "Bit 1 in AlarmsActive is not 1")
@@ -202,7 +254,7 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
 
         self.step("12a")
         if is_aud_feature_supported:
-            enabledAlarms &= ~(Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible)
+            enabledAlarms &= ~(cluster.Bitmaps.AlarmModeBitmap.kAudible)
         else:
             log.info("Test step skipped")
 
@@ -219,6 +271,18 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
             asserts.assert_equal((activeAlarms & 0b10), 0, "Bit 1 in AlarmsActive is not 0")
         else:
             log.info("Test step skipped")
+
+        # Verify AlarmsStateChanged event after disabling AUD
+        self.step("13a")
+        if alarms_state_changed_event_supported and is_aud_feature_supported:
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_equal(event.alarmsActive, 0,
+                                 "AlarmsStateChanged event did not report alarmsActive == 0 after disabling all alarms")
+            log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
+        else:
+            log.info("Test step skipped")
+            self.mark_current_step_skipped()
 
         self.step(14)
         if is_vis_feature_supported or is_aud_feature_supported:

--- a/src/python_testing/TC_BOOLCFG_5_2.py
+++ b/src/python_testing/TC_BOOLCFG_5_2.py
@@ -178,8 +178,8 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
         if alarms_state_changed_event_supported and (is_vis_feature_supported or is_aud_feature_supported):
             event = event_listener.wait_for_event_report(
                 cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
-            asserts.assert_not_equal(event.alarmsActive, 0,
-                                     "AlarmsStateChanged event did not report non-zero alarmsActive after sensor trigger")
+            asserts.assert_equal(event.alarmsActive, enabledAlarms,
+                                 "AlarmsStateChanged event alarmsActive does not match expected enabledAlarms after sensor trigger")
             log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
         else:
             log.info("AlarmsStateChanged event not supported or no alarms enabled. Skipping step 6a.")
@@ -210,8 +210,8 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
         if alarms_state_changed_event_supported and is_vis_feature_supported:
             event = event_listener.wait_for_event_report(
                 cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
-            asserts.assert_is_not_none(event.alarmsSuppressed,
-                                       "AlarmsStateChanged event missing alarmsSuppressed field after VIS suppress")
+            asserts.assert_equal(event.alarmsSuppressed, alarms_suppressed_dut,
+                                 "AlarmsStateChanged event alarmsSuppressed does not match expected value after VIS suppress")
             log.info(f"Received AlarmsStateChanged event with alarmsSuppressed = {event.alarmsSuppressed}")
         else:
             log.info("Test step skipped")
@@ -242,8 +242,8 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
         if alarms_state_changed_event_supported and is_aud_feature_supported:
             event = event_listener.wait_for_event_report(
                 cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
-            asserts.assert_is_not_none(event.alarmsSuppressed,
-                                       "AlarmsStateChanged event missing alarmsSuppressed field after AUD suppress")
+            asserts.assert_equal(event.alarmsSuppressed, alarms_suppressed_dut,
+                                 "AlarmsStateChanged event alarmsSuppressed does not match expected value after AUD suppress")
             log.info(f"Received AlarmsStateChanged event with alarmsSuppressed = {event.alarmsSuppressed}")
         else:
             log.info("Test step skipped")

--- a/src/python_testing/TC_BOOLCFG_5_2.py
+++ b/src/python_testing/TC_BOOLCFG_5_2.py
@@ -43,6 +43,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import async_test_body
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
 
@@ -65,15 +66,19 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep(2, "Read FeatureMap attribute"),
             TestStep(3, "Verify SPRS feature is supported"),
+            TestStep("3a", "Set up event subscription for BooleanStateConfiguration cluster"),
             TestStep(4, "Create enabledAlarms and set to 0"),
             TestStep("5a", "Enable VIS alarm in enabledAlarms"),
             TestStep("5b", "Enable AUD alarm in enabledAlarms"),
             TestStep("5c", "Set AlarmsEnabled attribute to value of enabledAlarms using AlarmsToEnableDisable command"),
             TestStep(6, "Send TestEventTrigger with SensorTrigger event"),
+            TestStep("6a", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated after trigger"),
             TestStep(7, "Suppress VIS alarm using SuppressAlarm command"),
             TestStep(8, "Read AlarmsSuppressed attribute"),
+            TestStep("8a", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated after VIS suppress"),
             TestStep(9, "Suppress AUD alarm using SuppressAlarm command"),
             TestStep(10, "Read AlarmsActive attribute"),
+            TestStep("10a", "If BOOLCFG.S.E00, verify AlarmsStateChanged event was generated after AUD suppress"),
             TestStep(11, "Send TestEventTrigger with SensorUntrigger event")
         ]
 
@@ -95,17 +100,23 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
         endpoint = self.get_endpoint()
+        node_id = self.dut_node_id
+        dev_ctrl = self.default_controller
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)
-        attributes = Clusters.BooleanStateConfiguration.Attributes
+        cluster = Clusters.BooleanStateConfiguration
+        attributes = cluster.Attributes
 
         self.step(2)
         feature_map = await self.read_boolcfg_attribute_expect_success(endpoint=endpoint, attribute=attributes.FeatureMap)
 
-        is_sprs_feature_supported = feature_map & Clusters.BooleanStateConfiguration.Bitmaps.Feature.kAlarmSuppress
-        is_vis_feature_supported = feature_map & Clusters.BooleanStateConfiguration.Bitmaps.Feature.kVisual
-        is_aud_feature_supported = feature_map & Clusters.BooleanStateConfiguration.Bitmaps.Feature.kAudible
+        is_sprs_feature_supported = feature_map & cluster.Bitmaps.Feature.kAlarmSuppress
+        is_vis_feature_supported = feature_map & cluster.Bitmaps.Feature.kVisual
+        is_aud_feature_supported = feature_map & cluster.Bitmaps.Feature.kAudible
+
+        # Check if AlarmsStateChanged event (BOOLCFG.S.E00) is supported
+        alarms_state_changed_event_supported = self.check_pics("BOOLCFG.S.E00")
 
         self.step(3)
         if not is_sprs_feature_supported:
@@ -119,18 +130,29 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
             return
         log.info("Test step skipped")
 
+        # Set up event subscription
+        self.step("3a")
+        event_listener = None
+        if alarms_state_changed_event_supported:
+            event_listener = EventSubscriptionHandler(expected_cluster=cluster)
+            await event_listener.start(dev_ctrl, node_id, endpoint=endpoint, min_interval_sec=0, max_interval_sec=30)
+            log.info("Event subscription established for BooleanStateConfiguration cluster.")
+        else:
+            log.info("AlarmsStateChanged event not supported. Skipping event subscription setup.")
+            self.mark_current_step_skipped()
+
         self.step(4)
         enabledAlarms = 0
 
         self.step("5a")
         if is_vis_feature_supported:
-            enabledAlarms |= Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kVisual
+            enabledAlarms |= cluster.Bitmaps.AlarmModeBitmap.kVisual
         else:
             log.info("Test step skipped")
 
         self.step("5b")
         if is_aud_feature_supported:
-            enabledAlarms |= Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible
+            enabledAlarms |= cluster.Bitmaps.AlarmModeBitmap.kAudible
         else:
             log.info("Test step skipped")
 
@@ -151,10 +173,25 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
         else:
             log.info("Test step skipped")
 
+        # Verify AlarmsStateChanged event after trigger
+        self.step("6a")
+        if alarms_state_changed_event_supported and (is_vis_feature_supported or is_aud_feature_supported):
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_not_equal(event.alarmsActive, 0,
+                                     "AlarmsStateChanged event did not report non-zero alarmsActive after sensor trigger")
+            log.info(f"Received AlarmsStateChanged event with alarmsActive = {event.alarmsActive}")
+        else:
+            log.info("AlarmsStateChanged event not supported or no alarms enabled. Skipping step 6a.")
+            self.mark_current_step_skipped()
+
+        if event_listener is not None:
+            event_listener.reset()
+
         self.step(7)
         if is_vis_feature_supported:
             try:
-                await self.send_single_cmd(cmd=Clusters.Objects.BooleanStateConfiguration.Commands.SuppressAlarm(alarmsToSuppress=Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kVisual), endpoint=endpoint)
+                await self.send_single_cmd(cmd=Clusters.Objects.BooleanStateConfiguration.Commands.SuppressAlarm(alarmsToSuppress=cluster.Bitmaps.AlarmModeBitmap.kVisual), endpoint=endpoint)
             except InteractionModelError as e:
                 asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
                 pass
@@ -168,10 +205,25 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
         else:
             log.info("Test step skipped")
 
+        # Verify AlarmsStateChanged event after VIS suppress
+        self.step("8a")
+        if alarms_state_changed_event_supported and is_vis_feature_supported:
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_is_not_none(event.alarmsSuppressed,
+                                       "AlarmsStateChanged event missing alarmsSuppressed field after VIS suppress")
+            log.info(f"Received AlarmsStateChanged event with alarmsSuppressed = {event.alarmsSuppressed}")
+        else:
+            log.info("Test step skipped")
+            self.mark_current_step_skipped()
+
+        if event_listener is not None:
+            event_listener.reset()
+
         self.step(9)
         if is_aud_feature_supported:
             try:
-                await self.send_single_cmd(cmd=Clusters.Objects.BooleanStateConfiguration.Commands.SuppressAlarm(alarmsToSuppress=Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible), endpoint=endpoint)
+                await self.send_single_cmd(cmd=Clusters.Objects.BooleanStateConfiguration.Commands.SuppressAlarm(alarmsToSuppress=cluster.Bitmaps.AlarmModeBitmap.kAudible), endpoint=endpoint)
             except InteractionModelError as e:
                 asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
                 pass
@@ -184,6 +236,18 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
             asserts.assert_not_equal((alarms_suppressed_dut & 0b10), 0, "Bit 1 in AlarmsSuppressed is not 1")
         else:
             log.info("Test step skipped")
+
+        # Verify AlarmsStateChanged event after AUD suppress
+        self.step("10a")
+        if alarms_state_changed_event_supported and is_aud_feature_supported:
+            event = event_listener.wait_for_event_report(
+                cluster.Events.AlarmsStateChanged, timeout_sec=30.0)
+            asserts.assert_is_not_none(event.alarmsSuppressed,
+                                       "AlarmsStateChanged event missing alarmsSuppressed field after AUD suppress")
+            log.info(f"Received AlarmsStateChanged event with alarmsSuppressed = {event.alarmsSuppressed}")
+        else:
+            log.info("Test step skipped")
+            self.mark_current_step_skipped()
 
         self.step(11)
         if is_vis_feature_supported or is_aud_feature_supported:


### PR DESCRIPTION
#### Summary
Update `BooleanStateConfiguration` test scripts (`TC_BOOLCFG_4_2`, `TC_BOOLCFG_4_3`,`TC_BOOLCFG_4_4`,`TC_BOOLCFG_5_2`) to verify the generation of the AlarmsStateChanged event as required by the specifications and recent test plan updates [#12589](https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/12589), [#5757](https://github.com/CHIP-Specifications/chip-test-plans/issues/5757)

Key changes:

Added `EventSubscriptionHandler` to subscribe to `AlarmsStateChanged` events.
Implemented verification steps to check alarmsActive and alarmsSuppressed fields in the event payload upon state changes (triggering, untriggering, suppressing).
Updated:

- `TC_BOOLCFG_4_2.py`
- `TC_BOOLCFG_4_3.py`
-  `TC_BOOLCFG_4_4.py`
-  `TC_BOOLCFG_5_2.py`
- Conditioned event verification steps on BOOLCFG.S.E00 (AlarmsStateChanged event) support.

#### Related issues

Addresses [#42426](https://github.com/project-chip/connectedhomeip/issues/42426)

#### Testing

Verified all modified tests pass locally against `chip-all-clusters-app` with PICS enabled. Confirmed `AlarmsStateChanged` events are correctly received and decoded.

To reproduce test (Repeat for each of the test scripts):

In terminal 1:
```
source scripts/activate.sh
./out/linux-x64-all-clusters/chip-all-clusters-app \
  --discriminator 1234 \
  --KVS /tmp/kvs_boolcfg_test \
  --enable-key 000102030405060708090a0b0c0d0e0f
```

In terminal 2:
```
source out/python_env/bin/activate
python3 src/python_testing/TC_BOOLCFG_4_2.py \
  --storage-path /tmp/admin_storage_boolcfg.json \
  --commissioning-method on-network \
  --discriminator 1234 \
  --passcode 20202021 \
  --endpoint 1 \
  --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f \
  --PICS src/app/tests/suites/certification/ci-pics-values
```