### PR TITLE
[MVE 1.5.1]  [Push AV] Increase blind duration and transport expiry time

### DIFF
--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 
 
 class PAVSTTestBase:
-    DEFAULT_AV_TRANSPORT_EXPIRY_TIME_SEC = 100  # 100 seconds
+    DEFAULT_AV_TRANSPORT_EXPIRY_TIME_SEC = 150  # 150 seconds
 
     async def read_pavst_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.PushAvStreamTransport

--- a/src/python_testing/TC_PAVST_2_13.py
+++ b/src/python_testing/TC_PAVST_2_13.py
@@ -281,14 +281,14 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         initDuration = 5
         augDuration = 2
         maxDuration = 15
-        blindDuration = 3
+        blindDuration = 10
         maxPreRollLen = 4
         try:
             zoneList = [{"zone": zoneID1, "sensitivity": 4}]
             triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
                               "maxPreRollLen": 4000,
                               "motionZones": zoneList,
-                              "motionTimeControl": {"initialDuration": 5, "augmentationDuration": 2, "maxDuration": 15, "blindDuration": 3}}
+                              "motionTimeControl": {"initialDuration": 5, "augmentationDuration": 2, "maxDuration": 15, "blindDuration": 10}}
             status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions,
                                                               tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}/")
             asserts.assert_equal(status, Status.Success,
@@ -323,7 +323,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
                                    self.dut_node_id,
                                    self.get_endpoint())
 
-        timeControl = {"initialDuration": 5, "augmentationDuration": 2, "maxDuration": 15, "blindDuration": 3}
+        timeControl = {"initialDuration": 5, "augmentationDuration": 2, "maxDuration": 15, "blindDuration": 10}
         cmd = pvcluster.Commands.ManuallyTriggerTransport(
             connectionID=aConnectionID,
             activationReason=pvcluster.Enums.TriggerActivationReasonEnum.kEmergency,
@@ -450,7 +450,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
                               "maxPreRollLen": 4000,
                               "motionZones": zoneList,
-                              "motionTimeControl": {"initialDuration": 5, "augmentationDuration": 15, "maxDuration": 10, "blindDuration": 3}}
+                              "motionTimeControl": {"initialDuration": 5, "augmentationDuration": 15, "maxDuration": 10, "blindDuration": 10}}
             status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions,
                                                               tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}/")
             asserts.assert_equal(status, Status.Success,

--- a/src/python_testing/TC_PAVST_2_13.py
+++ b/src/python_testing/TC_PAVST_2_13.py
@@ -34,6 +34,7 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #       --endpoint 1
 #       --app-pipe /tmp/pavst_2_13_fifo
+#       --timeout 300
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -288,7 +289,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
                               "maxPreRollLen": 4000,
                               "motionZones": zoneList,
-                              "motionTimeControl": {"initialDuration": 5, "augmentationDuration": 2, "maxDuration": 15, "blindDuration": 10}}
+                              "motionTimeControl": {"initialDuration": initDuration, "augmentationDuration": augDuration, "maxDuration": maxDuration, "blindDuration": blindDuration}}
             status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions,
                                                               tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}/")
             asserts.assert_equal(status, Status.Success,
@@ -323,7 +324,8 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
                                    self.dut_node_id,
                                    self.get_endpoint())
 
-        timeControl = {"initialDuration": 5, "augmentationDuration": 2, "maxDuration": 15, "blindDuration": 10}
+        timeControl = {"initialDuration": initDuration, "augmentationDuration": augDuration,
+                       "maxDuration": maxDuration, "blindDuration": blindDuration}
         cmd = pvcluster.Commands.ManuallyTriggerTransport(
             connectionID=aConnectionID,
             activationReason=pvcluster.Enums.TriggerActivationReasonEnum.kEmergency,
@@ -450,7 +452,7 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
                               "maxPreRollLen": 4000,
                               "motionZones": zoneList,
-                              "motionTimeControl": {"initialDuration": 5, "augmentationDuration": 15, "maxDuration": 10, "blindDuration": 10}}
+                              "motionTimeControl": {"initialDuration": initDuration, "augmentationDuration": augDuration+13, "maxDuration": maxDuration, "blindDuration": blindDuration}}
             status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions,
                                                               tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}/")
             asserts.assert_equal(status, Status.Success,

--- a/src/python_testing/TC_PAVST_2_13.py
+++ b/src/python_testing/TC_PAVST_2_13.py
@@ -279,9 +279,11 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
             zoneID1 = cmdResponse.zoneID
 
         self.step(6)
+        # Initialze the time control fields
         initDuration = 5
         augDuration = 2
         maxDuration = 15
+        # blindDuration time set as 10 sec to ensure it is sufficient enough to receive the motion event at DUT post the clip recording is completed
         blindDuration = 10
         maxPreRollLen = 4
         try:
@@ -446,13 +448,15 @@ class TC_PAVST_2_13(MatterBaseTest, PAVSTTestBase, PAVSTIUtils):
         )
 
         self.step(17)
+        # update maxDuration and  augDuration fields to ensure initDuration + augDuration > maxDuration
         maxDuration = 10
+        augDuration = 15
         try:
             zoneList = [{"zone": zoneID1, "sensitivity": 4}]
             triggerOptions = {"triggerType": pvcluster.Enums.TransportTriggerTypeEnum.kMotion,
                               "maxPreRollLen": 4000,
                               "motionZones": zoneList,
-                              "motionTimeControl": {"initialDuration": initDuration, "augmentationDuration": augDuration+13, "maxDuration": maxDuration, "blindDuration": blindDuration}}
+                              "motionTimeControl": {"initialDuration": initDuration, "augmentationDuration": augDuration, "maxDuration": maxDuration, "blindDuration": blindDuration}}
             status = await self.allocate_one_pushav_transport(endpoint, trigger_Options=triggerOptions,
                                                               tlsEndPoint=tlsEndpointId, url=f"https://{host_ip}:1234/streams/{uploadStreamId}/")
             asserts.assert_equal(status, Status.Success,


### PR DESCRIPTION
#### Summary
 When the developer / tester verifying the TCs manually, the time taken to trigger motion events is not enough for the blind duration defined in the TCs. Due to this, sometimes, PAVST 2_13 fails as there is no expected response received from DUT.

#### Related issues
Fixes #42926 


#### Testing
```
# Linux PC
#Console 1
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug/
sudo rm -rf /tmp/chip_*; ./out/debug/chip-camera-app --app-pipe /tmp/pavst_2_13_fifo --camera-test-audiosrc --camera-test-videosrc

#Console 2
# Build python controller and active environment
scripts/build_python.sh -m platform -i out/python_env
source out/python_env/bin/activate

# Run Push AV TC
Example:
python3 src/python_testing/TC_PAVST_2_13.py --commissioning-method on-network --discriminator 3840 --passcode 20202021 --storage-path admin_storage.json --endpoint 1   --string-arg host_ip:localhost --app-pipe /tmp/pavst_2_13_fifo

# Press Enter whenever there is a motion command request comes on the terminal and immediately run console #3 command

#Console 3
echo '{"Name": "ZoneTriggered", "ZoneId": 1}' > /tmp/pavst_2_13_fifo
```