### PR TITLE
Get rid of InteractionModelEngine::GetInstance() in BasicInformation

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -50,9 +50,12 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
 
     mBasicInformationCluster.Create(
         optionalAttributeSet,
-        BasicInformationCluster::Context{ .deviceInstanceInfoProvider = mContext.deviceInstanceInfoProvider,
-                                          .configurationManager       = mContext.configurationManager,
-                                          .platformManager            = mContext.platformManager });
+        BasicInformationCluster::Context{
+            .deviceInstanceInfoProvider = mContext.deviceInstanceInfoProvider,
+            .configurationManager       = mContext.configurationManager,
+            .platformManager            = mContext.platformManager,
+            .subscriptionsPerFabric     = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric(),
+        });
 
     ReturnErrorOnFailure(provider.AddCluster(mBasicInformationCluster.Registration()));
     mGeneralCommissioningCluster.Create(

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -16,7 +16,7 @@
  */
 #include <app/clusters/basic-information/BasicInformationCluster.h>
 
-#include <app/InteractionModelEngine.h>
+#include <app/SpecificationDefinedRevisions.h>
 #include <app/persistence/AttributePersistence.h>
 #include <app/persistence/AttributePersistenceProvider.h>
 #include <app/persistence/PascalString.h>
@@ -213,7 +213,8 @@ inline CHIP_ERROR ReadUniqueID(DeviceLayer::ConfigurationManager & configManager
     return EncodeStringOnSuccess(status, aEncoder, uniqueId, kMaxLen);
 }
 
-inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, DeviceInstanceInfoProvider & deviceInfoProvider)
+inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, DeviceInstanceInfoProvider & deviceInfoProvider,
+                                       uint16_t & subscriptionsPerFabric)
 {
     BasicInformation::Structs::CapabilityMinimaStruct::Type capabilityMinima;
 
@@ -223,7 +224,7 @@ inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, DeviceI
     auto capabilityMinimasFromDeviceInfo = deviceInfoProvider.GetSupportedCapabilityMinimaValues();
 
     capabilityMinima.caseSessionsPerFabric  = kMinCaseSessionsPerFabricMandatedBySpec;
-    capabilityMinima.subscriptionsPerFabric = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric();
+    capabilityMinima.subscriptionsPerFabric = subscriptionsPerFabric;
     capabilityMinima.simultaneousInvocationsSupported =
         chip::MakeOptional<uint16_t>(capabilityMinimasFromDeviceInfo.simultaneousInvocationsSupported);
     capabilityMinima.simultaneousWritesSupported =
@@ -355,7 +356,7 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
     case UniqueID::Id:
         return ReadUniqueID(configManager, encoder);
     case CapabilityMinima::Id:
-        return ReadCapabilityMinima(encoder, deviceInfoProvider);
+        return ReadCapabilityMinima(encoder, deviceInfoProvider, mClusterContext.subscriptionsPerFabric);
     case ProductAppearance::Id:
         return ReadProductAppearance(deviceInfoProvider, encoder);
     case SpecificationVersion::Id:

--- a/src/app/clusters/basic-information/BasicInformationCluster.h
+++ b/src/app/clusters/basic-information/BasicInformationCluster.h
@@ -41,13 +41,10 @@ public:
     // Define the Context struct with References
     struct Context
     {
-        // https://github.com/project-chip/connectedhomeip/blob/master/src/app/InteractionModelEngine.cpp#L61
-        static constexpr uint16_t kMaxNumSubscriptionsPerFabric = 10000;
-
         DeviceLayer::DeviceInstanceInfoProvider & deviceInstanceInfoProvider;
         DeviceLayer::ConfigurationManager & configurationManager;
         DeviceLayer::PlatformManager & platformManager;
-        uint16_t subscriptionsPerFabric = kMaxNumSubscriptionsPerFabric;
+        uint16_t subscriptionsPerFabric;
     };
 
     using OptionalAttributesSet = chip::app::OptionalAttributeSet< //

--- a/src/app/clusters/basic-information/BasicInformationCluster.h
+++ b/src/app/clusters/basic-information/BasicInformationCluster.h
@@ -41,9 +41,13 @@ public:
     // Define the Context struct with References
     struct Context
     {
+        // https://github.com/project-chip/connectedhomeip/blob/master/src/app/InteractionModelEngine.cpp#L61
+        static constexpr uint16_t kMaxNumSubscriptionsPerFabric = 10000;
+
         DeviceLayer::DeviceInstanceInfoProvider & deviceInstanceInfoProvider;
         DeviceLayer::ConfigurationManager & configurationManager;
         DeviceLayer::PlatformManager & platformManager;
+        uint16_t subscriptionsPerFabric = kMaxNumSubscriptionsPerFabric;
     };
 
     using OptionalAttributesSet = chip::app::OptionalAttributeSet< //

--- a/src/app/clusters/basic-information/CodegenIntegration.cpp
+++ b/src/app/clusters/basic-information/CodegenIntegration.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/InteractionModelEngine.h>
 #include <app/clusters/basic-information/BasicInformationCluster.h>
 #include <app/static-cluster-config/BasicInformation.h>
 #include <app/util/attribute-storage.h>
@@ -62,9 +63,12 @@ public:
         DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();
         VerifyOrDie(provider != nullptr);
 
-        BasicInformationCluster::Context context = { .deviceInstanceInfoProvider = *provider,
-                                                     .configurationManager       = DeviceLayer::ConfigurationMgr(),
-                                                     .platformManager            = DeviceLayer::PlatformMgr() };
+        BasicInformationCluster::Context context = {
+            .deviceInstanceInfoProvider = *provider,
+            .configurationManager       = DeviceLayer::ConfigurationMgr(),
+            .platformManager            = DeviceLayer::PlatformMgr(),
+            .subscriptionsPerFabric     = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric()
+        };
         gServer.Create(optionalAttributeSet, context);
 
         // This disabling of the unique id attribute is here only for test purposes. The uniqe id attribute

--- a/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
@@ -15,6 +15,7 @@
  */
 #include <pw_unit_test/framework.h>
 
+#include <app/InteractionModelEngine.h>
 #include <app/clusters/basic-information/BasicInformationCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/server-cluster/DefaultServerCluster.h>
@@ -132,9 +133,12 @@ public:
 struct TestBasicInformationCluster : public ::testing::Test
 {
     MockDeviceInstanceInfoProvider mDeviceInfoProvider;
-    BasicInformationCluster::Context mContext = { .deviceInstanceInfoProvider = mDeviceInfoProvider,
-                                                  .configurationManager       = chip::DeviceLayer::ConfigurationMgr(),
-                                                  .platformManager            = chip::DeviceLayer::PlatformMgr() };
+    BasicInformationCluster::Context mContext = {
+        .deviceInstanceInfoProvider = mDeviceInfoProvider,
+        .configurationManager       = chip::DeviceLayer::ConfigurationMgr(),
+        .platformManager            = chip::DeviceLayer::PlatformMgr(),
+        .subscriptionsPerFabric     = app::InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric(),
+    };
 
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }

--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <app/InteractionModelEngine.h>
 #include <app/clusters/basic-information/BasicInformationCluster.h>
 #include <app/persistence/AttributePersistence.h>
 #include <app/server-cluster/testing/AttributeTesting.h>
@@ -304,6 +305,7 @@ struct TestBasicInformationReadWrite : public ::testing::Test
         .deviceInstanceInfoProvider = mDeviceInfoProvider,
         .configurationManager       = mMockConfigurationManager,
         .platformManager            = chip::DeviceLayer::PlatformMgr(),
+        .subscriptionsPerFabric     = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric(),
     };
 };
 


### PR DESCRIPTION
#### Summary

Refactors `BasicInformationCluster`

* **Interaction Model:** Removes hidden dependency on `InteractionModelEngine` by injecting `subscriptionsPerFabric` through the context.

#### Related issues

Fixes #42602

#### Testing

* Verified that `RootNodeDevice` and code generation integrations compile with the new constructor signature.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

* [x] PR title is
[[descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
* [x] Apply the
*[[“When in Rome…”](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)*
rule (coding style)
* [x] PR size is short
* [ ] Try to avoid "squashing" and "force-update" in commit history
* [x] CI time didn't increase