### PR TITLE
Thread: unify border agent arguments

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
@@ -87,8 +87,8 @@ class CommissioningInfo:
     wifi_ssid: Optional[str] = None
     tc_version_to_simulate: Optional[int] = None
     tc_user_response_to_simulate: Optional[int] = None
-    border_agent_ip_addr: Optional[str] = None
-    border_agent_port: Optional[int] = None
+    thread_ba_host: Optional[str] = None
+    thread_ba_port: Optional[int] = None
 
 
 @dataclass
@@ -238,21 +238,21 @@ async def commission_device(
                                        "Thread dataset must be provided for thread-meshcop commissioning")
             # Type assertion to help mypy understand this is not None after the assert
             assert commissioning_info.thread_operational_dataset is not None
-            asserts.assert_is_not_none(commissioning_info.border_agent_ip_addr,
-                                       "border_agent_ip_addr must be provided for thread-meshcop commissioning")
+            asserts.assert_is_not_none(commissioning_info.thread_ba_host,
+                                       "thread_ba_host must be provided for thread-meshcop commissioning")
             # Type assertion to help mypy understand this is not None after the assert
-            assert commissioning_info.border_agent_ip_addr is not None
-            asserts.assert_is_not_none(commissioning_info.border_agent_port,
-                                       "border_agent_port must be provided for thread-meshcop commissioning")
+            assert commissioning_info.thread_ba_host is not None
+            asserts.assert_is_not_none(commissioning_info.thread_ba_port,
+                                       "thread_ba_port must be provided for thread-meshcop commissioning")
             # Type assertion to help mypy understand this is not None after the assert
-            assert commissioning_info.border_agent_port is not None
+            assert commissioning_info.thread_ba_port is not None
 
             await dev_ctrl.CommissionThreadMeshcop(
                 node_id,
                 info.passcode,
                 info.filter_value,
-                commissioning_info.border_agent_ip_addr,
-                commissioning_info.border_agent_port,
+                commissioning_info.thread_ba_host,
+                commissioning_info.thread_ba_port,
                 commissioning_info.thread_operational_dataset,
             )
             return PairingStatus()
@@ -368,8 +368,8 @@ class CommissionDeviceTest(base_test.BaseTestClass):
             wifi_ssid=meta_config['wifi_ssid'],
             tc_version_to_simulate=meta_config['tc_version_to_simulate'],
             tc_user_response_to_simulate=meta_config['tc_user_response_to_simulate'],
-            border_agent_ip_addr=meta_config['border_agent_ip_addr'],
-            border_agent_port=meta_config['border_agent_port'],
+            thread_ba_host=meta_config['thread_ba_host'],
+            thread_ba_port=meta_config['thread_ba_port'],
         )
         self.setup_payloads: List[SetupPayloadInfo] = get_setup_payload_info_config(
             global_stash.unstash_globally(test_config.user_params['matter_test_config']))

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_test_config.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_test_config.py
@@ -53,8 +53,8 @@ class MatterTestConfig:
     maximize_cert_chains: bool = True
 
     # Border Agent information for Thread MeshCoP Commissioning
-    border_agent_ip_addr: Optional[str] = None
-    border_agent_port: Optional[int] = None
+    thread_ba_host: Optional[str] = None
+    thread_ba_port: Optional[int] = None
 
     # By default, let's set validity to 10 years
     certificate_validity_period = int(timedelta(days=10*365).total_seconds())

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -879,8 +879,8 @@ class MatterBaseTest(base_test.BaseTestClass):
             wifi_ssid=self.matter_test_config.wifi_ssid,
             tc_version_to_simulate=self.matter_test_config.tc_version_to_simulate,
             tc_user_response_to_simulate=self.matter_test_config.tc_user_response_to_simulate,
-            border_agent_ip_addr=self.matter_test_config.border_agent_ip_addr,
-            border_agent_port=self.matter_test_config.border_agent_port,
+            thread_ba_host=self.matter_test_config.thread_ba_host,
+            thread_ba_port=self.matter_test_config.thread_ba_port,
         )
 
         return await commission_devices(dev_ctrl, dut_node_ids, setup_payloads, commissioning_info)

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -728,11 +728,11 @@ def populate_commissioning_args(args: argparse.Namespace, config) -> bool:
             return False
         config.thread_operational_dataset = args.thread_dataset_hex
         if commissioning_method == 'thread-meshcop':
-            if args.border_agent_ip_addr is None or args.border_agent_port is None:
-                print("error: missing --border-agent-ip-addr or --border-agent-port for --commissioning-method thread-meshcop!")
+            if args.thread_ba_host is None or args.thread_ba_port is None:
+                print("error: missing --thread-ba-host or --thread-ba-port for --commissioning-method thread-meshcop!")
                 return False
-            config.border_agent_ip_addr = args.border_agent_ip_addr
-            config.border_agent_port = args.border_agent_port
+            config.thread_ba_host = args.thread_ba_host
+            config.thread_ba_port = args.thread_ba_port
     elif config.commissioning_method == "on-network-ip":
         if args.ip_addr is None:
             print("error: missing --ip-addr <IP_ADDRESS> for --commissioning-method on-network-ip")
@@ -914,9 +914,9 @@ def parse_matter_test_args(argv: Optional[List[str]] = None):
     commission_group.add_argument('--case-admin-subject', action="store", type=int_decimal_or_hex,
                                   metavar="CASE_ADMIN_SUBJECT",
                                   help="Set the CASE admin subject to an explicit value (default to commissioner Node ID)")
-    commission_group.add_argument('--border-agent-ip-addr', action="store", type=str,
+    commission_group.add_argument('--thread-ba-host', action="store", type=str,
                                   help="Border Agent IP address")
-    commission_group.add_argument('--border-agent-port', action="store", type=int,
+    commission_group.add_argument('--thread-ba-port', action="store", type=int,
                                   help="Border Agent port")
 
     commission_group.add_argument('--commission-only', action="store_true", default=False,

--- a/src/python_testing/provisional/TC_SC_TC_4_1.py
+++ b/src/python_testing/provisional/TC_SC_TC_4_1.py
@@ -25,8 +25,8 @@
 #       --commissioning-method thread-meshcop
 #       --discriminator 1234
 #       --passcode 20202021
-#       --border-agent-ip-addr 127.0.0.1
-#       --border-agent-port 49152
+#       --thread-ba-host 127.0.0.1
+#       --thread-ba-port 49152
 #       --thread-dataset-hex 0e08000000000001000000030000104a0300001635060004001fffe0020884fa18779329ac770708fd269658e44aa21a030f4f70656e5468726561642d32386335010228c50c0402a0f7f8051000112233445566778899aabbccddeeff041000112233445566778899aabbccddeeff
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto


### PR DESCRIPTION
#### Summary

This commit unifies the border agent arguments of the python controller to chip-tool.

#### Related issues

This is a follow-up of #43029.

#### Testing

This commit unifies the arguments and replaces all usage of the arguments. No new tests are added.