### PR TITLE
[all-devices-app] Log Volume Percentage in LoggingSpeakerDevice

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/speaker/impl/LoggingSpeakerDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/speaker/impl/LoggingSpeakerDevice.cpp
@@ -30,8 +30,8 @@ LoggingSpeakerDevice::~LoggingSpeakerDevice() {}
 
 void LoggingSpeakerDevice::OnLevelChanged(uint8_t value)
 {
-    uint8_t min = LevelControlCluster().GetMinLevel();
-    uint8_t max = LevelControlCluster().GetMaxLevel();
+    uint8_t min  = LevelControlCluster().GetMinLevel();
+    uint8_t max  = LevelControlCluster().GetMaxLevel();
     uint32_t pct = (max > min) ? (static_cast<uint32_t>(value - min) * 100) / (max - min) : 0;
     ChipLogProgress(AppServer, "LoggingSpeakerDevice: Volume set to %u (%u%%)", value, pct);
 }

--- a/examples/all-devices-app/all-devices-common/devices/speaker/impl/LoggingSpeakerDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/speaker/impl/LoggingSpeakerDevice.cpp
@@ -30,7 +30,10 @@ LoggingSpeakerDevice::~LoggingSpeakerDevice() {}
 
 void LoggingSpeakerDevice::OnLevelChanged(uint8_t value)
 {
-    ChipLogProgress(AppServer, "LoggingSpeakerDevice: Volume set to %u", value);
+    uint8_t min = LevelControlCluster().GetMinLevel();
+    uint8_t max = LevelControlCluster().GetMaxLevel();
+    uint32_t pct = (max > min) ? (static_cast<uint32_t>(value - min) * 100) / (max - min) : 0;
+    ChipLogProgress(AppServer, "LoggingSpeakerDevice: Volume set to %u (%u%%)", value, pct);
 }
 
 void LoggingSpeakerDevice::OnOptionsChanged(BitMask<Clusters::LevelControl::OptionsBitmap> value)


### PR DESCRIPTION
#### Summary

This PR updates `LoggingSpeakerDevice` to log volume changes as a percentage (0-100%) alongside the raw `uint8_t` value. This improves readability and debugging by providing a clear indication of the relative volume level based on the configured minimum and maximum levels.

#### Testing

Verified the log now shows percentage. Example:
```
[1771018472.233] [1325468:1325468] [SVR] LoggingSpeakerDevice: Volume set to 124 (48%)
```