### PR TITLE
[CI Linux Builds] Disable gcc_debug and some WithoutLogging builds for PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,23 +77,27 @@ jobs:
                   languages: "cpp"
                   queries: security-extended, security-and-quality
             - name: Setup Build
+              if: github.event.pull_request.number == null
               run: scripts/build/gn_gen.sh --args="chip_config_memory_debug_checks=true chip_config_memory_debug_dmalloc=false"
             - name: Run Build
+              if: github.event.pull_request.number == null
               run: scripts/run_in_build_env.sh "ninja -C ./out"
             - name: Run Tests
+              if: github.event.pull_request.number == null
               run: scripts/tests/gn_tests.sh
             - name: Clean out build output
+              if: github.event.pull_request.number == null
               run: rm -rf ./out
 
             # Do not run below steps with CodeQL since we are getting "Out of runner space issues" with CodeQL and their added coverage is limited
             - name: Set up Build Without Detail Logging
-              if: inputs.run-codeql != true
+              if: inputs.run-codeql != true && github.event.pull_request.number == null
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false"
             - name: Run Build Without Detail Logging
-              if: inputs.run-codeql != true
+              if: inputs.run-codeql != true && github.event.pull_request.number == null
               run: scripts/run_in_build_env.sh "ninja -C ./out"
             - name: Cleanout build output
-              if: inputs.run-codeql != true
+              if: inputs.run-codeql != true && github.event.pull_request.number == null
               run: rm -rf ./out
             - name: Set up Build Without Progress Logging
               if: inputs.run-codeql != true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,22 +100,22 @@ jobs:
               if: inputs.run-codeql != true && github.event.pull_request.number == null
               run: rm -rf ./out
             - name: Set up Build Without Progress Logging
-              if: inputs.run-codeql != true
+              if: inputs.run-codeql != true && github.event.pull_request.number == null
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false chip_progress_logging=false"
             - name: Run Build Without Progress Logging
-              if: inputs.run-codeql != true
+              if: inputs.run-codeql != true && github.event.pull_request.number == null
               run: scripts/run_in_build_env.sh "ninja -C ./out"
             - name: Clean out build output
-              if: inputs.run-codeql != true
+              if: inputs.run-codeql != true && github.event.pull_request.number == null
               run: rm -rf ./out
             - name: Set up Build Without Error Logging
-              if: inputs.run-codeql != true
+              if: inputs.run-codeql != true && github.event.pull_request.number == null
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false chip_progress_logging=false chip_error_logging=false"
             - name: Run Build Without Error Logging
-              if: inputs.run-codeql != true
+              if: inputs.run-codeql != true && github.event.pull_request.number == null
               run: scripts/run_in_build_env.sh "ninja -C ./out"
             - name: Clean out build output
-              if: inputs.run-codeql != true
+              if: inputs.run-codeql != true && github.event.pull_request.number == null
               run: rm -rf ./out
             - name: Set up Build Without Logging
               if: inputs.run-codeql != true
@@ -522,10 +522,7 @@ jobs:
 
         env:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
-        # No need to run this job for pull requests since Codecov is disabled and the generated 
-        # coverage reports are not used anywhere. Running coverage build post-merge is sufficient for the moment.
-        # Original issue tracking Codecov integration: #36556
-        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true && github.event.pull_request.number == null
+        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
         # Use namespace to get more disk space and slightly better performance (Compile and unit tests
         # are CPU bound)
         runs-on: namespace-profile-4x8

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -522,8 +522,10 @@ jobs:
 
         env:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
-
-        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
+        # No need to run this job for pull requests since Codecov is disabled and the generated 
+        # coverage reports are not used anywhere. Running coverage build post-merge is sufficient for the moment.
+        # Original issue tracking Codecov integration: #36556
+        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true && github.event.pull_request.number == null
         # Use namespace to get more disk space and slightly better performance (Compile and unit tests
         # are CPU bound)
         runs-on: namespace-profile-4x8

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -522,6 +522,7 @@ jobs:
 
         env:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
+            
         if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
         # Use namespace to get more disk space and slightly better performance (Compile and unit tests
         # are CPU bound)


### PR DESCRIPTION
#### Summary

- for Each Pull Request, we have too many redundunt builds that are unlikely to add much value and take up runner time.

- This PR makes the following changes (Save ≈ 1 hour per push to a PR ) :
- four builds from the `build_linux_gcc_debug` job will longer be run on pull requests **(Saves ≈ 35 mins)**:
   1. regular GCC build
   2. Build Without Detail Logging
   3. Build Without Progress Logging
   4. Build Without Error Logging

- I kept the `Build Without Logging` since it deactivates all types of logging and might catch some errors
#### Testing

- Checking CI