### PR TITLE
Add missing derived-type operator== to ClosureControl generic structs

### DIFF
--- a/src/app/clusters/closure-control-server/closure-control-cluster-objects.h
+++ b/src/app/clusters/closure-control-server/closure-control-cluster-objects.h
@@ -62,6 +62,11 @@ struct GenericOverallCurrentState : public Structs::OverallCurrentStateStruct::T
     {
         return position == rhs.position && latch == rhs.latch && speed == rhs.speed && secureState == rhs.secureState;
     }
+
+    bool operator==(const GenericOverallCurrentState & rhs) const
+    {
+        return operator==(static_cast<const Structs::OverallCurrentStateStruct::Type &>(rhs));
+    }
 };
 
 /**
@@ -96,6 +101,11 @@ struct GenericOverallTargetState : public Structs::OverallTargetStateStruct::Typ
     bool operator==(const Structs::OverallTargetStateStruct::Type & rhs) const
     {
         return position == rhs.position && latch == rhs.latch && speed == rhs.speed;
+    }
+
+    bool operator==(const GenericOverallTargetState & rhs) const
+    {
+        return operator==(static_cast<const Structs::OverallTargetStateStruct::Type &>(rhs));
     }
 };
 


### PR DESCRIPTION
## Summary

`GenericOverallCurrentState` and `GenericOverallTargetState` only define `operator==(const BaseType&)`, but when these types are stored in `Nullable<T>` (which wraps `std::optional<T>`), the compiler requires `operator==(const DerivedType&, const DerivedType&)` for comparisons. This causes compilation failures with GCC 14 / C++23 (e.g. ESP-IDF's default `-std=gnu++2b`).

This PR adds the missing derived-type `operator==` overloads that delegate to the existing base-type comparison.

Fixes #41728

### Testing

- Verified fix resolves the compilation error when building with GCC 14 / `-std=gnu++2b` on ESP32-S3 (ESP-IDF v5.5, esp-matter 1.4.2)