### PR TITLE
Replace deprecated std::aligned_storage with alignas

### DIFF
--- a/src/lib/support/LambdaBridge.h
+++ b/src/lib/support/LambdaBridge.h
@@ -43,7 +43,10 @@ public:
     void operator()() const { mLambdaProxy(mLambdaBody); }
 
 private:
-    using LambdaStorage = std::aligned_storage_t<CHIP_CONFIG_LAMBDA_EVENT_SIZE, CHIP_CONFIG_LAMBDA_EVENT_ALIGN>;
+    struct LambdaStorage
+    {
+        alignas(CHIP_CONFIG_LAMBDA_EVENT_ALIGN) unsigned char data[CHIP_CONFIG_LAMBDA_EVENT_SIZE];
+    };
     void (*mLambdaProxy)(const LambdaStorage & body);
     LambdaStorage mLambdaBody;
 };

--- a/src/lib/support/Variant.h
+++ b/src/lib/support/Variant.h
@@ -139,7 +139,10 @@ private:
     static constexpr std::size_t kDataAlign   = std::max({ alignof(Ts)... });
     static constexpr std::size_t kInvalidType = SIZE_MAX;
 
-    using Data  = typename std::aligned_storage<kDataSize, kDataAlign>::type;
+    struct Data
+    {
+        alignas(kDataAlign) unsigned char data[kDataSize];
+    };
     using Curry = VariantInternal::VariantCurry<0, Ts...>;
 
     std::size_t mTypeId;


### PR DESCRIPTION
## Summary

Replace deprecated `std::aligned_storage` / `std::aligned_storage_t` in `LambdaBridge.h` and `Variant.h` with the C++ standard committee's recommended replacement: a struct containing an `alignas`-qualified `unsigned char` array.

`std::aligned_storage` was deprecated in C++23 ([P1413R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1413r3.pdf)), causing `-Wdeprecated-declarations` warnings with GCC 14+ and Clang 16+. The replacement is backward compatible to C++11 and produces identical memory layout (same size, alignment, and triviality).

### Testing

Trivial change — the replacement is a mechanical substitution that produces the same memory layout. The existing `static_assert(std::is_trivial<LambdaBridge>)` validates that `LambdaBridge` remains trivial after the change. Existing `TestVariant` and `TestStateMachine` tests cover `Variant` usage.