### PR TITLE
Fix -Wtype-limits warnings in attribute-storage when FIXED_ENDPOINT_COUNT is 0

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -195,12 +195,12 @@ void emberAfEndpointConfigure()
 {
     uint16_t ep;
 
-    static_assert(FIXED_ENDPOINT_COUNT <= std::numeric_limits<decltype(ep)>::max(),
-                  "FIXED_ENDPOINT_COUNT must not exceed the size of the endpoint data type");
-
     emberEndpointCount = FIXED_ENDPOINT_COUNT;
 
 #if FIXED_ENDPOINT_COUNT > 0
+
+    static_assert(FIXED_ENDPOINT_COUNT <= std::numeric_limits<decltype(ep)>::max(),
+                  "FIXED_ENDPOINT_COUNT must not exceed the size of the endpoint data type");
 
     constexpr uint16_t fixedEndpoints[]             = FIXED_ENDPOINT_ARRAY;
     constexpr uint16_t fixedDeviceTypeListLengths[] = FIXED_DEVICE_TYPE_LENGTHS;
@@ -936,6 +936,7 @@ uint16_t emberAfGetClusterServerEndpointIndex(EndpointId endpoint, ClusterId clu
         return kEmberInvalidEndpointIndex;
     }
 
+#if FIXED_ENDPOINT_COUNT > 0
     if (epIndex < FIXED_ENDPOINT_COUNT)
     {
         // This endpoint is a fixed one.
@@ -957,6 +958,7 @@ uint16_t emberAfGetClusterServerEndpointIndex(EndpointId endpoint, ClusterId clu
         epIndex = adjustedEndpointIndex;
     }
     else
+#endif // FIXED_ENDPOINT_COUNT > 0
     {
         // This is a dynamic endpoint.
         // Its index is just its index in the dynamic endpoint list, offset by fixedClusterServerEndpointCount.


### PR DESCRIPTION
## Summary

When `FIXED_ENDPOINT_COUNT` is 0 (e.g. in configurations where all endpoints are dynamic), GCC emits two `-Wtype-limits` warnings in `attribute-storage.cpp`:

- **Line 198** (`static_assert`): `0 <= std::numeric_limits<uint16_t>::max()` is trivially true — "comparison is always true due to limited range of data type"
- **Line 932** (`if (epIndex < FIXED_ENDPOINT_COUNT)`): `uint16_t < 0` is trivially false — "comparison is always false due to limited range of data type"

This PR guards both comparisons with `#if FIXED_ENDPOINT_COUNT > 0`, consistent with the existing guards already used throughout the file.

### Testing

- Verified fix resolves both `-Wtype-limits` warnings when building with GCC 14 / `-std=gnu++2b` on ESP32-S3 (ESP-IDF v5.5, esp-matter 1.4.2)