### PR TITLE
Replace all usages of ChipLogFailure with ChipLogError

### DIFF
--- a/examples/closure-app/silabs/src/ClosureManager.cpp
+++ b/examples/closure-app/silabs/src/ClosureManager.cpp
@@ -123,7 +123,10 @@ void ClosureManager::Init()
     if (pTestEventDelegate != nullptr)
     {
         CHIP_ERROR err = pTestEventDelegate->AddHandler(&mClosureEndpoint1.GetDelegate());
-        ChipLogError(AppServer, "Failed to add handler for delegate: %" CHIP_ERROR_FORMAT, err.Format());
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(AppServer, "Failed to add handler for delegate: %" CHIP_ERROR_FORMAT, err.Format());
+        }
     }
     else
     {

--- a/examples/closure-app/silabs/src/ClosureManager.cpp
+++ b/examples/closure-app/silabs/src/ClosureManager.cpp
@@ -123,7 +123,7 @@ void ClosureManager::Init()
     if (pTestEventDelegate != nullptr)
     {
         CHIP_ERROR err = pTestEventDelegate->AddHandler(&mClosureEndpoint1.GetDelegate());
-        ChipLogFailure(err, AppServer, "Failed to add handler for delegate");
+        ChipLogError(AppServer, "Failed to add handler for delegate: %" CHIP_ERROR_FORMAT, err.Format());
     }
     else
     {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1274,7 +1274,7 @@ void DeviceCommissioner::OnSessionEstablished(const SessionHandle & session)
     CHIP_ERROR err = device->SetConnected(session);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogFailure(err, Controller, "Failed in setting up secure channel");
+        ChipLogError(Controller, "Failed in setting up secure channel: %" CHIP_ERROR_FORMAT, err.Format());
         OnSessionEstablishmentError(err);
         return;
     }

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -464,7 +464,7 @@ void DiscoveryImplPlatform::HandleDnssdInit(void * context, CHIP_ERROR initError
     }
     else
     {
-        ChipLogFailure(initError, Discovery, "DNS-SD initialization failed with");
+        ChipLogError(Discovery, "DNS-SD initialization failed with: %" CHIP_ERROR_FORMAT, initError.Format());
         publisher->mState = State::kUninitialized;
     }
 }

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -1286,11 +1286,11 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
     /* Send StartScan Request to Scanner Class */
     strcpy(data.service_uuid, Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR);
     err = mDeviceScanner.StartScan(ScanFilterType::kServiceData, data);
-    SuccessOrExitAction(err, ChipLogFailure(err, Ble, "Failed to start BLE scan"));
+    SuccessOrExitAction(err, ChipLogError(Ble, "Failed to start BLE scan: %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = DeviceLayer::SystemLayer().StartTimer(kNewConnectionScanTimeout, HandleScanTimeout, this);
     SuccessOrExitAction(err, TEMPORARY_RETURN_IGNORED mDeviceScanner.StopScan();
-                        ChipLogFailure(err, Ble, "Failed to start BLE scan timeout"));
+                        ChipLogError(Ble, "Failed to start BLE scan timeout: %" CHIP_ERROR_FORMAT, err.Format()));
 
     mBLEScanConfig.mBleScanState = scanType;
     return;


### PR DESCRIPTION
#### Summary

The `ChipLogFailure()` suggests that there is another logging level. However, `ChipLogFailure` simply calls `ChipLogError` internally. Since the `ChipLogFailure` is used only in few places, replace it with `ChipLogError` to make the codebase consistent.

#### Testing

Simple change, CI should verify it.
