### PR TITLE
Added test TC-DD-3.22 checking NFC-based commissioning for DUT as Commissioner

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 3.3.22 [TC-DD-3.22] NFC-based commissioning [DUT as Commissioner]
+
+PICS:
+  - MCORE.ROLE.COMMISSIONER
+  - MCORE.DD.NFC
+  - MCORE.DD.NTL
+
+config:
+  nodeId: 0x12344321
+  cluster: "Basic Information"
+  endpoint: 0
+
+tests:
+  - label:
+      "Step 1: Power up the TH Device and put the TH Device in commissioning
+      mode"
+    verification: |
+      1. Power up the TH device.
+      2. Put the TH device into commissioning mode as per the device-specific procedure.
+      3. Verify that the TH device indicates it is in commissioning mode
+         (e.g., via LED pattern, display, or log output).
+    disabled: true
+
+  - label: "Step 2: Bring the DUT close to the NFC tag for the TH Device"
+    verification: |
+      1. Bring and hold the DUT close to the NFC tag on the TH Device.
+      2. Verify on the DUT that onboarding information is read via NFC and a
+         commissioning flow is initiated.
+      3. Complete any on-screen/on-UI prompts on the DUT to finish commissioning.
+      4. Check on the TH Device that commissioning is completed successfully
+    disabled: true

--- a/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 3.3.22 [TC-DD-3.22] NFC-based commissioning [DUT as Commissioner]
+name: 3.3.22. [TC-DD-3.22] NFC-based commissioning [DUT as Commissioner]
 
 PICS:
     - MCORE.ROLE.COMMISSIONER

--- a/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
@@ -16,7 +16,7 @@ name: 3.3.22. [TC-DD-3.22] NFC-based commissioning [DUT as Commissioner]
 
 PICS:
     - MCORE.ROLE.COMMISSIONER
-    - MCORE.DD.NFC
+    - MCORE.DD.SCAN_NFC
     - MCORE.DD.NTL
 
 config:

--- a/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_22.yaml
@@ -15,31 +15,31 @@
 name: 3.3.22 [TC-DD-3.22] NFC-based commissioning [DUT as Commissioner]
 
 PICS:
-  - MCORE.ROLE.COMMISSIONER
-  - MCORE.DD.NFC
-  - MCORE.DD.NTL
+    - MCORE.ROLE.COMMISSIONER
+    - MCORE.DD.NFC
+    - MCORE.DD.NTL
 
 config:
-  nodeId: 0x12344321
-  cluster: "Basic Information"
-  endpoint: 0
+    nodeId: 0x12344321
+    cluster: "Basic Information"
+    endpoint: 0
 
 tests:
-  - label:
-      "Step 1: Power up the TH Device and put the TH Device in commissioning
-      mode"
-    verification: |
-      1. Power up the TH device.
-      2. Put the TH device into commissioning mode as per the device-specific procedure.
-      3. Verify that the TH device indicates it is in commissioning mode
-         (e.g., via LED pattern, display, or log output).
-    disabled: true
+    - label:
+          "Step 1: Power up the TH Device and put the TH Device in commissioning
+          mode"
+      verification: |
+          1. Power up the TH device.
+          2. Put the TH device into commissioning mode as per the device-specific procedure.
+          3. Verify that the TH device indicates it is in commissioning mode
+             (e.g., via LED pattern, display, or log output).
+      disabled: true
 
-  - label: "Step 2: Bring the DUT close to the NFC tag for the TH Device"
-    verification: |
-      1. Bring and hold the DUT close to the NFC tag on the TH Device.
-      2. Verify on the DUT that onboarding information is read via NFC and a
-         commissioning flow is initiated.
-      3. Complete any on-screen/on-UI prompts on the DUT to finish commissioning.
-      4. Check on the TH Device that commissioning is completed successfully
-    disabled: true
+    - label: "Step 2: Bring the DUT close to the NFC tag for the TH Device"
+      verification: |
+          1. Bring and hold the DUT close to the NFC tag on the TH Device.
+          2. Verify on the DUT that onboarding information is read via NFC and a
+             commissioning flow is initiated.
+          3. Complete any on-screen/on-UI prompts on the DUT to finish commissioning.
+          4. Check on the TH Device that commissioning is completed successfully
+      disabled: true


### PR DESCRIPTION
Add test TC_DD_3_22 checking NFC-based commissioning for DUT as Commissioner

#### Testing
Tested that the test is working as expected. 