### PR TITLE
[clang build fix] allow jf-control and jf-admin apps to build with clang

### DIFF
--- a/examples/jf-admin-app/linux/JFADatastoreSync.cpp
+++ b/examples/jf-admin-app/linux/JFADatastoreSync.cpp
@@ -37,12 +37,12 @@ using namespace chip::app::Clusters::JointFabricDatastore;
 
 extern DeviceCommissioner * GetDeviceCommissioner();
 
-constexpr uint8_t kJFAvailableShift = 0;
-constexpr uint8_t kJFAdminShift     = 1;
-constexpr uint8_t kJFAnchorShift    = 2;
-constexpr uint8_t kJFDatastoreShift = 3;
+[[maybe_unused]] constexpr uint8_t kJFAvailableShift = 0;
+[[maybe_unused]] constexpr uint8_t kJFAdminShift     = 1;
+[[maybe_unused]] constexpr uint8_t kJFAnchorShift    = 2;
+[[maybe_unused]] constexpr uint8_t kJFDatastoreShift = 3;
 
-static constexpr EndpointId kJFDatastoreClusterEndpointId = 1;
+[[maybe_unused]] static constexpr EndpointId kJFDatastoreClusterEndpointId = 1;
 
 JFADatastoreSync JFADatastoreSync::sJFDS;
 

--- a/examples/jf-control-app/commands/pairing/PairingCommand.h
+++ b/examples/jf-control-app/commands/pairing/PairingCommand.h
@@ -31,8 +31,10 @@
 
 #include <optional>
 
-using namespace ::chip;
-using namespace ::chip::Credentials;
+using ::chip::ByteSpan;
+using ::chip::NodeId;
+using ::chip::VendorId;
+using ::chip::Credentials::CertificateKeyId;
 
 using JCMDeviceCommissioner            = chip::Controller::JCM::DeviceCommissioner;
 using JCMTrustVerificationStateMachine = chip::Credentials::JCM::TrustVerificationStateMachine;
@@ -265,9 +267,10 @@ public:
 
     /////////// JCMTrustVerificationDelegate /////////
     void OnProgressUpdate(JCMTrustVerificationStateMachine & stateMachine, JCMTrustVerificationStage stage,
-                          JCMTrustVerificationInfo & info, JCMTrustVerificationError error);
-    void OnAskUserForConsent(JCMTrustVerificationStateMachine & stateMachine, JCMTrustVerificationInfo & info);
-    CHIP_ERROR OnLookupOperationalTrustAnchor(VendorId vendorID, CertificateKeyId & subjectKeyId, ByteSpan & globallyTrustedRoot);
+                          JCMTrustVerificationInfo & info, JCMTrustVerificationError error) override;
+    void OnAskUserForConsent(JCMTrustVerificationStateMachine & stateMachine, JCMTrustVerificationInfo & info) override;
+    CHIP_ERROR OnLookupOperationalTrustAnchor(VendorId vendorID, CertificateKeyId & subjectKeyId,
+                                              ByteSpan & globallyTrustedRoot) override;
 
 private:
     CHIP_ERROR RunInternal(NodeId remoteId);


### PR DESCRIPTION
#### Summary

- Allow jf-control and jf-admin apps to build with clang, so that we can run integration and cert tests on AddressSanitized Apps in https://github.com/project-chip/connectedhomeip/pull/43152

#### Testing

```
scripts/build/build_examples.py --target linux-x64-jf-control-app-asan-clang build 
scripts/build/build_examples.py --target linux-x64-jf-admin-app-asan-clang build
```