### PR TITLE
[Bugfix] stack-use-after-return in EVSE and Water heater apps

### DIFF
--- a/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
@@ -51,6 +51,22 @@ using namespace chip::app::Clusters::PowerTopology;
 
 namespace {
 
+const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type kMeasurementAccuracyRanges[] = {
+    { .rangeMin   = 0,
+      .rangeMax   = 1'000'000'000'000'000, // 1 million Mwh
+      .percentMax = MakeOptional(static_cast<chip::Percent100ths>(500)),
+      .percentMin = MakeOptional(static_cast<chip::Percent100ths>(50)) }
+};
+
+const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyStruct::Type kMeasurementAccuracy = {
+    .measurementType  = MeasurementTypeEnum::kElectricalEnergy,
+    .measured         = true,
+    .minMeasuredValue = 0,
+    .maxMeasuredValue = 1'000'000'000'000'000, // 1 million Mwh
+    .accuracyRanges   = DataModel::List<const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type>(
+        kMeasurementAccuracyRanges)
+};
+
 // Common cluster instances
 std::unique_ptr<DeviceEnergyManagementDelegate> gDEMDelegate;
 std::unique_ptr<DeviceEnergyManagementManager> gDEMInstance;
@@ -256,22 +272,6 @@ void emberAfElectricalEnergyMeasurementClusterInitCallback(chip::EndpointId endp
         BitMask<ElectricalEnergyMeasurement::OptionalAttributes, uint32_t>(
             ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset));
 
-    ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type energyAccuracyRanges[] = {
-        { .rangeMin   = 0,
-          .rangeMax   = 1'000'000'000'000'000, // 1 million Mwh
-          .percentMax = MakeOptional(static_cast<chip::Percent100ths>(500)),
-          .percentMin = MakeOptional(static_cast<chip::Percent100ths>(50)) }
-    };
-
-    ElectricalEnergyMeasurement::Structs::MeasurementAccuracyStruct::Type accuracy = {
-        .measurementType  = MeasurementTypeEnum::kElectricalEnergy,
-        .measured         = true,
-        .minMeasuredValue = 0,
-        .maxMeasuredValue = 1'000'000'000'000'000,
-        .accuracyRanges =
-            DataModel::List<const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type>(energyAccuracyRanges)
-    };
-
     ElectricalEnergyMeasurement::Structs::CumulativeEnergyResetStruct::Type resetStruct = {
         .importedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
         .exportedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
@@ -282,7 +282,7 @@ void emberAfElectricalEnergyMeasurementClusterInitCallback(chip::EndpointId endp
     if (gEEMAttrAccess)
     {
         TEMPORARY_RETURN_IGNORED gEEMAttrAccess->Init();
-        TEMPORARY_RETURN_IGNORED SetMeasurementAccuracy(endpointId, accuracy);
+        TEMPORARY_RETURN_IGNORED SetMeasurementAccuracy(endpointId, kMeasurementAccuracy);
         TEMPORARY_RETURN_IGNORED SetCumulativeReset(endpointId, MakeOptional(resetStruct));
     }
 }

--- a/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
+++ b/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
@@ -51,6 +51,22 @@ using namespace chip::app::Clusters::WaterHeaterManagement;
 
 namespace {
 
+const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type kMeasurementAccuracyRanges[] = {
+    { .rangeMin   = 0,
+      .rangeMax   = 1'000'000'000'000'000, // 1 million Mwh
+      .percentMax = MakeOptional(static_cast<chip::Percent100ths>(500)),
+      .percentMin = MakeOptional(static_cast<chip::Percent100ths>(50)) }
+};
+
+const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyStruct::Type kMeasurementAccuracy = {
+    .measurementType  = MeasurementTypeEnum::kElectricalEnergy,
+    .measured         = true,
+    .minMeasuredValue = 0,
+    .maxMeasuredValue = 1'000'000'000'000'000, // 1 million Mwh
+    .accuracyRanges   = DataModel::List<const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type>(
+        kMeasurementAccuracyRanges)
+};
+
 // Common cluster instances
 std::unique_ptr<DeviceEnergyManagementDelegate> gDEMDelegate;
 std::unique_ptr<DeviceEnergyManagementManager> gDEMInstance;
@@ -250,22 +266,6 @@ void emberAfElectricalEnergyMeasurementClusterInitCallback(chip::EndpointId endp
         BitMask<ElectricalEnergyMeasurement::OptionalAttributes, uint32_t>(
             ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset));
 
-    ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type energyAccuracyRanges[] = {
-        { .rangeMin   = 0,
-          .rangeMax   = 1'000'000'000'000'000, // 1 million Mwh
-          .percentMax = MakeOptional(static_cast<chip::Percent100ths>(500)),
-          .percentMin = MakeOptional(static_cast<chip::Percent100ths>(50)) }
-    };
-
-    ElectricalEnergyMeasurement::Structs::MeasurementAccuracyStruct::Type accuracy = {
-        .measurementType  = MeasurementTypeEnum::kElectricalEnergy,
-        .measured         = true,
-        .minMeasuredValue = 0,
-        .maxMeasuredValue = 1'000'000'000'000'000, // 1 million Mwh
-        .accuracyRanges =
-            DataModel::List<const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type>(energyAccuracyRanges)
-    };
-
     ElectricalEnergyMeasurement::Structs::CumulativeEnergyResetStruct::Type resetStruct = {
         .importedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
         .exportedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
@@ -276,7 +276,7 @@ void emberAfElectricalEnergyMeasurementClusterInitCallback(chip::EndpointId endp
     if (gEEMAttrAccess)
     {
         TEMPORARY_RETURN_IGNORED gEEMAttrAccess->Init();
-        TEMPORARY_RETURN_IGNORED SetMeasurementAccuracy(endpointId, accuracy);
+        TEMPORARY_RETURN_IGNORED SetMeasurementAccuracy(endpointId, kMeasurementAccuracy);
         TEMPORARY_RETURN_IGNORED SetCumulativeReset(endpointId, MakeOptional(resetStruct));
     }
 }


### PR DESCRIPTION
#### Summary

- both apps store a stack array in DataModel::List (which is effectively a Span), causing stack-use-after-return when the list is read later.
- This was detected as part of https://github.com/project-chip/connectedhomeip/pull/43152

- Fix: move the stack variables to constants in anonymous namespace

#### Testing

```scripts/build/build_examples.py --target linux-x64-evse-asan-clang build```

```cpp
 ./scripts/run_in_python_env.sh out/matter-repl 'scripts/tests/run_python_test.py --factory-reset --script src/python_testing/TC_EEM_2_1.py --script-args "--commissioning-method on-network -p 20202021 -d 3840 --PICS src/app/tests/suites/certification/ci-pics-values --endpoint 1 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f " --app out/linux-x64-evse-ipv6only-no-ble-no-wifi-asan-clang/chip-evse-app --app-args "--enable-key 000102030405060708090a0b0c0d0e0f"'

```