### PR TITLE
Add Unmounted attribute to SmokeCo cluster - code changes

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/smco-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/smco-stub.cpp
@@ -31,9 +31,9 @@ constexpr const uint16_t kSelfTestingTimeoutSec = 10;
 } // namespace
 
 static std::array<ExpressedStateEnum, SmokeCoAlarmServer::kPriorityOrderLength> sPriorityOrder = {
-    ExpressedStateEnum::kSmokeAlarm,     ExpressedStateEnum::kInterconnectSmoke, ExpressedStateEnum::kCOAlarm,
-    ExpressedStateEnum::kInterconnectCO, ExpressedStateEnum::kHardwareFault,     ExpressedStateEnum::kTesting,
-    ExpressedStateEnum::kEndOfService,   ExpressedStateEnum::kBatteryAlert
+    ExpressedStateEnum::kInoperative, ExpressedStateEnum::kSmokeAlarm,     ExpressedStateEnum::kInterconnectSmoke,
+    ExpressedStateEnum::kCOAlarm,     ExpressedStateEnum::kInterconnectCO, ExpressedStateEnum::kHardwareFault,
+    ExpressedStateEnum::kTesting,     ExpressedStateEnum::kEndOfService,   ExpressedStateEnum::kBatteryAlert
 };
 
 void EndSelfTestingEventHandler(System::Layer * systemLayer, void * appState)
@@ -174,6 +174,16 @@ bool HandleSmokeCOTestEventTrigger(uint64_t eventTrigger)
     case SmokeCOTrigger::kClearSensitivity:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear Smoke Sensitivity");
         SmokeCoAlarmServer::Instance().SetSmokeSensitivityLevel(1, SensitivityEnum::kStandard);
+        break;
+    case SmokeCOTrigger::kForceUnmountedState:
+        ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force Unmounted State");
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(1, true), true);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        break;
+    case SmokeCOTrigger::kClearUnmountedState:
+        ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear Unmounted State");
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(1, false), true);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     default:
 

--- a/examples/all-clusters-app/ameba/main/SmokeCOAlarmManager.cpp
+++ b/examples/all-clusters-app/ameba/main/SmokeCOAlarmManager.cpp
@@ -24,9 +24,9 @@ using namespace chip::app::Clusters::SmokeCoAlarm;
 using namespace chip::DeviceLayer;
 
 static std::array<ExpressedStateEnum, SmokeCoAlarmServer::kPriorityOrderLength> sPriorityOrder = {
-    ExpressedStateEnum::kSmokeAlarm,     ExpressedStateEnum::kInterconnectSmoke, ExpressedStateEnum::kCOAlarm,
-    ExpressedStateEnum::kInterconnectCO, ExpressedStateEnum::kHardwareFault,     ExpressedStateEnum::kTesting,
-    ExpressedStateEnum::kEndOfService,   ExpressedStateEnum::kBatteryAlert
+    ExpressedStateEnum::kInoperative, ExpressedStateEnum::kSmokeAlarm,     ExpressedStateEnum::kInterconnectSmoke,
+    ExpressedStateEnum::kCOAlarm,     ExpressedStateEnum::kInterconnectCO, ExpressedStateEnum::kHardwareFault,
+    ExpressedStateEnum::kTesting,     ExpressedStateEnum::kEndOfService,   ExpressedStateEnum::kBatteryAlert
 };
 
 CHIP_ERROR SmokeCoAlarmManager::Init()
@@ -161,6 +161,16 @@ bool emberAfHandleEventTrigger(uint64_t eventTrigger)
     case SmokeCOTrigger::kClearSensitivity:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear Smoke Sensitivity");
         SmokeCoAlarmServer::Instance().SetSmokeSensitivityLevel(1, SensitivityEnum::kStandard);
+        break;
+    case SmokeCOTrigger::kForceUnmountedState:
+        ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force Unmounted State");
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(1, true), true);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        break;
+    case SmokeCOTrigger::kClearUnmountedState:
+        ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear Unmounted State");
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(1, false), true);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     default:
 

--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -610,10 +610,11 @@ void AllClustersAppCommandHandler::HandleCommand(intptr_t context)
     {
         uint8_t unmounted   = static_cast<uint8_t>(self->mJsonValue["Unmounted"].asUInt());
         EndpointId endpoint = static_cast<EndpointId>(self->mJsonValue["EndpointId"].asUInt());
-        TEMPORARY_RETURN_IGNORED SmokeCoAlarmServer::Instance().SetInoperativeWhenUnmounted(true);
+        SmokeCoAlarmServer::Instance().SetInoperativeWhenUnmounted(true);
         if (1 == unmounted || 0 == unmounted)
         {
-            TEMPORARY_RETURN_IGNORED SmokeCoAlarmServer::Instance().SetUnmountedState(endpoint, unmounted);
+            VerifyOrReturn(SmokeCoAlarmServer::Instance().SetUnmountedState(endpoint, static_cast<bool>(unmounted)),
+                           ChipLogError(NotSpecified, "Error setting unmounted state."));
         }
         else
         {

--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -606,6 +606,20 @@ void AllClustersAppCommandHandler::HandleCommand(intptr_t context)
 
         self->OnBooleanStateChangeHandler(endpointId, newState);
     }
+    else if (name == "SetUnmounted")
+    {
+        uint8_t unmounted   = static_cast<uint8_t>(self->mJsonValue["Unmounted"].asUInt());
+        EndpointId endpoint = static_cast<EndpointId>(self->mJsonValue["EndpointId"].asUInt());
+        TEMPORARY_RETURN_IGNORED SmokeCoAlarmServer::Instance().SetInoperativeWhenUnmounted(true);
+        if (1 == unmounted || 0 == unmounted)
+        {
+            TEMPORARY_RETURN_IGNORED SmokeCoAlarmServer::Instance().SetUnmountedState(endpoint, unmounted);
+        }
+        else
+        {
+            ChipLogError(NotSpecified, "Invalid Unmounted state to set.");
+        }
+    }
     else
     {
         ChipLogError(NotSpecified, "Unhandled command '%s': this should never happen", name.c_str());

--- a/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
@@ -30,9 +30,9 @@ using namespace chip::DeviceLayer;
 SmokeCoAlarmManager SmokeCoAlarmManager::sAlarm;
 
 static std::array<ExpressedStateEnum, SmokeCoAlarmServer::kPriorityOrderLength> sPriorityOrder = {
-    ExpressedStateEnum::kSmokeAlarm,     ExpressedStateEnum::kInterconnectSmoke, ExpressedStateEnum::kCOAlarm,
-    ExpressedStateEnum::kInterconnectCO, ExpressedStateEnum::kHardwareFault,     ExpressedStateEnum::kTesting,
-    ExpressedStateEnum::kEndOfService,   ExpressedStateEnum::kBatteryAlert
+    ExpressedStateEnum::kInoperative, ExpressedStateEnum::kSmokeAlarm,     ExpressedStateEnum::kInterconnectSmoke,
+    ExpressedStateEnum::kCOAlarm,     ExpressedStateEnum::kInterconnectCO, ExpressedStateEnum::kHardwareFault,
+    ExpressedStateEnum::kTesting,     ExpressedStateEnum::kEndOfService,   ExpressedStateEnum::kBatteryAlert
 };
 
 CHIP_ERROR SmokeCoAlarmManager::Init()
@@ -240,6 +240,16 @@ CHIP_ERROR SmokeCoAlarmManager::HandleEventTrigger(uint64_t eventTrigger)
     case SmokeCOTrigger::kClearSensitivity:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear Smoke Sensitivity");
         SmokeCoAlarmServer::Instance().SetSmokeSensitivityLevel(1, SensitivityEnum::kStandard);
+        break;
+    case SmokeCOTrigger::kForceUnmountedState:
+        ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force Unmounted State");
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(1, true), true);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        break;
+    case SmokeCOTrigger::kClearUnmountedState:
+        ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear Unmounted State");
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(1, false), true);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     default:
 

--- a/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
@@ -35,6 +35,8 @@ static std::array<ExpressedStateEnum, SmokeCoAlarmServer::kPriorityOrderLength> 
     ExpressedStateEnum::kTesting,     ExpressedStateEnum::kEndOfService,   ExpressedStateEnum::kBatteryAlert
 };
 
+constexpr chip::EndpointId kSmokeCoAlarmEndpointId = 1;
+
 CHIP_ERROR SmokeCoAlarmManager::Init()
 {
     // Create cmsisos sw timer for alarm timer.
@@ -52,7 +54,7 @@ CHIP_ERROR SmokeCoAlarmManager::Init()
 
     // read current State on endpoint one
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-    SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+    SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     mEndSelfTesting = false;
@@ -110,8 +112,8 @@ void SmokeCoAlarmManager::EndSelfTestingEventHandler(AppEvent * aEvent)
     AlarmMgr().mEndSelfTesting = false;
 
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-    SmokeCoAlarmServer::Instance().SetTestInProgress(1, false);
-    SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+    SmokeCoAlarmServer::Instance().SetTestInProgress(kSmokeCoAlarmEndpointId, false);
+    SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     SILABS_LOG("End self-testing!");
@@ -126,130 +128,149 @@ CHIP_ERROR SmokeCoAlarmManager::HandleEventTrigger(uint64_t eventTrigger)
     {
     case SmokeCOTrigger::kForceSmokeCritical:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force smoke (critical)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(1, AlarmStateEnum::kCritical), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(kSmokeCoAlarmEndpointId, AlarmStateEnum::kCritical),
+                            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceSmokeWarning:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force smoke (warning)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(1, AlarmStateEnum::kWarning), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(kSmokeCoAlarmEndpointId, AlarmStateEnum::kWarning),
+                            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceSmokeInterconnect:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force smoke interconnect (warning)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectSmokeAlarm(1, AlarmStateEnum::kWarning), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(
+            SmokeCoAlarmServer::Instance().SetInterconnectSmokeAlarm(kSmokeCoAlarmEndpointId, AlarmStateEnum::kWarning),
+            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceCOCritical:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force CO (critical)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(1, AlarmStateEnum::kCritical), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(kSmokeCoAlarmEndpointId, AlarmStateEnum::kCritical),
+                            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceCOWarning:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force CO (warning)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(1, AlarmStateEnum::kWarning), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(kSmokeCoAlarmEndpointId, AlarmStateEnum::kWarning),
+                            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceCOInterconnect:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force CO (warning)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectCOAlarm(1, AlarmStateEnum::kWarning), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(
+            SmokeCoAlarmServer::Instance().SetInterconnectCOAlarm(kSmokeCoAlarmEndpointId, AlarmStateEnum::kWarning),
+            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceSmokeContaminationHigh:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force smoke contamination (critical)");
-        SmokeCoAlarmServer::Instance().SetContaminationState(1, ContaminationStateEnum::kCritical);
+        SmokeCoAlarmServer::Instance().SetContaminationState(kSmokeCoAlarmEndpointId, ContaminationStateEnum::kCritical);
         break;
     case SmokeCOTrigger::kForceSmokeContaminationLow:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force smoke contamination (warning)");
-        SmokeCoAlarmServer::Instance().SetContaminationState(1, ContaminationStateEnum::kLow);
+        SmokeCoAlarmServer::Instance().SetContaminationState(kSmokeCoAlarmEndpointId, ContaminationStateEnum::kLow);
         break;
     case SmokeCOTrigger::kForceSmokeSensitivityHigh:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force smoke sensistivity (high)");
-        SmokeCoAlarmServer::Instance().SetSmokeSensitivityLevel(1, SensitivityEnum::kHigh);
+        SmokeCoAlarmServer::Instance().SetSmokeSensitivityLevel(kSmokeCoAlarmEndpointId, SensitivityEnum::kHigh);
         break;
     case SmokeCOTrigger::kForceSmokeSensitivityLow:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force smoke sensitivity (low)");
-        SmokeCoAlarmServer::Instance().SetSmokeSensitivityLevel(1, SensitivityEnum::kLow);
+        SmokeCoAlarmServer::Instance().SetSmokeSensitivityLevel(kSmokeCoAlarmEndpointId, SensitivityEnum::kLow);
         break;
     case SmokeCOTrigger::kForceMalfunction:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force malfunction");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetHardwareFaultAlert(1, true), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetHardwareFaultAlert(kSmokeCoAlarmEndpointId, true), CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceLowBatteryWarning:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force low battery (warning)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(1, AlarmStateEnum::kWarning), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(kSmokeCoAlarmEndpointId, AlarmStateEnum::kWarning),
+                            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceLowBatteryCritical:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force low battery (critical)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(1, AlarmStateEnum::kCritical), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(kSmokeCoAlarmEndpointId, AlarmStateEnum::kCritical),
+                            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceEndOfLife:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force end-of-life");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetEndOfServiceAlert(1, EndOfServiceEnum::kExpired), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(
+            SmokeCoAlarmServer::Instance().SetEndOfServiceAlert(kSmokeCoAlarmEndpointId, EndOfServiceEnum::kExpired),
+            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceSilence:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force silence");
-        SmokeCoAlarmServer::Instance().SetDeviceMuted(1, MuteStateEnum::kMuted);
+        SmokeCoAlarmServer::Instance().SetDeviceMuted(kSmokeCoAlarmEndpointId, MuteStateEnum::kMuted);
         break;
     case SmokeCOTrigger::kClearSmoke:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear smoke");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(1, AlarmStateEnum::kNormal), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(kSmokeCoAlarmEndpointId, AlarmStateEnum::kNormal),
+                            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearCO:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear CO");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(1, AlarmStateEnum::kNormal), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(kSmokeCoAlarmEndpointId, AlarmStateEnum::kNormal),
+                            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearSmokeInterconnect:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear smoke interconnect");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectSmokeAlarm(1, AlarmStateEnum::kNormal), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(
+            SmokeCoAlarmServer::Instance().SetInterconnectSmokeAlarm(kSmokeCoAlarmEndpointId, AlarmStateEnum::kNormal),
+            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearCOInterconnect:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear CO interconnect");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectCOAlarm(1, AlarmStateEnum::kNormal), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectCOAlarm(kSmokeCoAlarmEndpointId, AlarmStateEnum::kNormal),
+                            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearMalfunction:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear malfunction");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetHardwareFaultAlert(1, false), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetHardwareFaultAlert(kSmokeCoAlarmEndpointId, false), CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearEndOfLife:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear end-of-life");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetEndOfServiceAlert(1, EndOfServiceEnum::kNormal), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetEndOfServiceAlert(kSmokeCoAlarmEndpointId, EndOfServiceEnum::kNormal),
+                            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearSilence:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear silence");
-        SmokeCoAlarmServer::Instance().SetDeviceMuted(1, MuteStateEnum::kNotMuted);
+        SmokeCoAlarmServer::Instance().SetDeviceMuted(kSmokeCoAlarmEndpointId, MuteStateEnum::kNotMuted);
         break;
     case SmokeCOTrigger::kClearBatteryLevelLow:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear low battery");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(1, AlarmStateEnum::kNormal), CHIP_NO_ERROR);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(kSmokeCoAlarmEndpointId, AlarmStateEnum::kNormal),
+                            CHIP_NO_ERROR);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearContamination:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force SmokeContamination (warning)");
-        SmokeCoAlarmServer::Instance().SetContaminationState(1, ContaminationStateEnum::kNormal);
+        SmokeCoAlarmServer::Instance().SetContaminationState(kSmokeCoAlarmEndpointId, ContaminationStateEnum::kNormal);
         break;
     case SmokeCOTrigger::kClearSensitivity:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear Smoke Sensitivity");
-        SmokeCoAlarmServer::Instance().SetSmokeSensitivityLevel(1, SensitivityEnum::kStandard);
+        SmokeCoAlarmServer::Instance().SetSmokeSensitivityLevel(kSmokeCoAlarmEndpointId, SensitivityEnum::kStandard);
         break;
     case SmokeCOTrigger::kForceUnmountedState:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force Unmounted State");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(1, true), true);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(kSmokeCoAlarmEndpointId, true), true);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearUnmountedState:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear Unmounted State");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(1, false), true);
-        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(kSmokeCoAlarmEndpointId, false), true);
+        SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     default:
 

--- a/examples/smoke-co-alarm-app/telink/src/SmokeCoAlarmManager.cpp
+++ b/examples/smoke-co-alarm-app/telink/src/SmokeCoAlarmManager.cpp
@@ -28,9 +28,9 @@ LOG_MODULE_DECLARE(COsensor, CONFIG_CHIP_APP_LOG_LEVEL);
 SmokeCoAlarmManager SmokeCoAlarmManager::sAlarm;
 
 static std::array<ExpressedStateEnum, SmokeCoAlarmServer::kPriorityOrderLength> sPriorityOrder = {
-    ExpressedStateEnum::kSmokeAlarm,     ExpressedStateEnum::kInterconnectSmoke, ExpressedStateEnum::kCOAlarm,
-    ExpressedStateEnum::kInterconnectCO, ExpressedStateEnum::kHardwareFault,     ExpressedStateEnum::kTesting,
-    ExpressedStateEnum::kEndOfService,   ExpressedStateEnum::kBatteryAlert
+    ExpressedStateEnum::kInoperative, ExpressedStateEnum::kSmokeAlarm,     ExpressedStateEnum::kInterconnectSmoke,
+    ExpressedStateEnum::kCOAlarm,     ExpressedStateEnum::kInterconnectCO, ExpressedStateEnum::kHardwareFault,
+    ExpressedStateEnum::kTesting,     ExpressedStateEnum::kEndOfService,   ExpressedStateEnum::kBatteryAlert
 };
 
 CHIP_ERROR SmokeCoAlarmManager::Init()

--- a/src/app/clusters/smoke-co-alarm-server/SmokeCOTestEventTriggerHandler.h
+++ b/src/app/clusters/smoke-co-alarm-server/SmokeCOTestEventTriggerHandler.h
@@ -52,6 +52,7 @@ enum class SmokeCOTrigger : uint64_t
     kForceSmokeCritical          = 0x005c'0000'0000009c,
     kForceCOCritical             = 0x005c'0000'0000009d,
     kForceLowBatteryCritical     = 0x005c'0000'0000009e,
+    kForceUnmountedState         = 0x005c'0000'0000009f,
     // Clear alarm commands
     kClearSmoke             = 0x005c'0000'000000a0,
     kClearCO                = 0x005c'0000'000000a1,
@@ -62,7 +63,8 @@ enum class SmokeCOTrigger : uint64_t
     kClearContamination     = 0x005c'0000'000000a6,
     kClearSensitivity       = 0x005c'0000'000000a8,
     kClearEndOfLife         = 0x005c'0000'000000aa,
-    kClearSilence           = 0x005c'0000'000000ab
+    kClearSilence           = 0x005c'0000'000000ab,
+    kClearUnmountedState    = 0x005c'0000'000000ac
 };
 
 class SmokeCOTestEventTriggerHandler : public TestEventTriggerHandler

--- a/src/app/clusters/smoke-co-alarm-server/smoke-co-alarm-server.h
+++ b/src/app/clusters/smoke-co-alarm-server/smoke-co-alarm-server.h
@@ -36,7 +36,7 @@ public:
     static SmokeCoAlarmServer & Instance();
 
     /* Expected byte size of the PriorityOrder */
-    static constexpr size_t kPriorityOrderLength = 8;
+    static constexpr size_t kPriorityOrderLength = 9;
 
     using AlarmStateEnum         = chip::app::Clusters::SmokeCoAlarm::AlarmStateEnum;
     using ContaminationStateEnum = chip::app::Clusters::SmokeCoAlarm::ContaminationStateEnum;
@@ -76,6 +76,8 @@ public:
     bool SetInterconnectCOAlarm(chip::EndpointId endpointId, AlarmStateEnum newInterconnectCOAlarm);
     bool SetContaminationState(chip::EndpointId endpointId, ContaminationStateEnum newContaminationState);
     bool SetSmokeSensitivityLevel(chip::EndpointId endpointId, SensitivityEnum newSmokeSensitivityLevel);
+    bool SetUnmountedState(chip::EndpointId endpointId, bool isUnmounted);
+    void SetInoperativeWhenUnmounted(bool inoperative) { mInoperativeWhenUnmounted = inoperative; }
 
     bool GetExpressedState(chip::EndpointId endpointId, ExpressedStateEnum & expressedState);
     bool GetSmokeState(chip::EndpointId endpointId, AlarmStateEnum & smokeState);
@@ -90,6 +92,8 @@ public:
     bool GetContaminationState(chip::EndpointId endpointId, ContaminationStateEnum & contaminationState);
     bool GetSmokeSensitivityLevel(chip::EndpointId endpointId, SensitivityEnum & smokeSensitivityLevel);
     bool GetExpiryDate(chip::EndpointId endpointId, uint32_t & expiryDate);
+    bool GetUnmountedState(chip::EndpointId endpointId, bool & unmountedState);
+    void GetInoperativeWhenUnmounted(bool & inoperative) { inoperative = mInoperativeWhenUnmounted; }
 
     chip::BitFlags<Feature> GetFeatures(chip::EndpointId endpointId);
 
@@ -161,6 +165,7 @@ private:
         const chip::app::Clusters::SmokeCoAlarm::Commands::SelfTestRequest::DecodableType & commandData);
 
     static SmokeCoAlarmServer sInstance;
+    bool mInoperativeWhenUnmounted = false;
 };
 
 // =============================================================================

--- a/src/app/clusters/smoke-co-alarm-server/smoke-co-alarm-server.h
+++ b/src/app/clusters/smoke-co-alarm-server/smoke-co-alarm-server.h
@@ -76,7 +76,16 @@ public:
     bool SetInterconnectCOAlarm(chip::EndpointId endpointId, AlarmStateEnum newInterconnectCOAlarm);
     bool SetContaminationState(chip::EndpointId endpointId, ContaminationStateEnum newContaminationState);
     bool SetSmokeSensitivityLevel(chip::EndpointId endpointId, SensitivityEnum newSmokeSensitivityLevel);
+    /**
+     * @brief Sets unmounted attribute and updates expressed state respectively.
+     * @param endpointId ID of the endpoint
+     * @param isUnmounted unmounted state
+     * @return true on success, false on failure
+     */
     bool SetUnmountedState(chip::EndpointId endpointId, bool isUnmounted);
+    /**
+     * @brief If set to true, unmounting the device leads to inoperative state.
+     */
     void SetInoperativeWhenUnmounted(bool inoperative) { mInoperativeWhenUnmounted = inoperative; }
 
     bool GetExpressedState(chip::EndpointId endpointId, ExpressedStateEnum & expressedState);

--- a/src/app/tests/suites/certification/PICS.yaml
+++ b/src/app/tests/suites/certification/PICS.yaml
@@ -6086,6 +6086,9 @@ PICS:
     - label: "Does the device implement the ExpiryDate attribute?"
       id: SMOKECO.S.A000c
 
+    - label: "Does the device implement the Unmounted attribute?"
+      id: SMOKECO.S.A000d
+
     #
     # server / Events
     #
@@ -6134,6 +6137,9 @@ PICS:
           "Can the DeviceMuted attribute be changed by physical control at the
           device?"
       id: SMOKECO.M.ManuallyControlledMute
+
+    - label: "Is the device inoperative when it is unmounted?"
+      id: SMOKECO.M.InoperativeWhenUnmounted
 
     #
     # server / commandsReceived

--- a/src/app/tests/suites/certification/ci-pics-values
+++ b/src/app/tests/suites/certification/ci-pics-values
@@ -2749,6 +2749,7 @@ SMOKECO.S.A0009=1
 SMOKECO.S.A000a=1
 SMOKECO.S.A000b=1
 SMOKECO.S.A000c=1
+SMOKECO.S.A000d=1
 SMOKECO.S.E00=1
 SMOKECO.S.E01=1
 SMOKECO.S.E02=1
@@ -2762,6 +2763,7 @@ SMOKECO.S.E09=1
 SMOKECO.S.E0a=1
 SMOKECO.M.ManuallyControlledTest=1
 SMOKECO.M.ManuallyControlledMute=1
+SMOKECO.M.InoperativeWhenUnmounted=1
 SMOKECO.S.C00.Rsp=1
 
 #Temperature Controlled Cabinet Mode Cluster


### PR DESCRIPTION
#### Summary

Follow up to #43043 

- added implementation for unmounted attribute in smokeco cluster
- added new PICS and default values for CI
- added support for test even trigger and CI file pipe testing

It is related to this approved TCR: https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/12537
The Spec changed got already merged: https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/12544
The test plan PR: https://github.com/CHIP-Specifications/chip-test-plans/pull/5821

#### Related issues

XML changes already merged - #43043 

#### Testing

Tested with  https://github.com/project-chip/connectedhomeip/pull/42828, which needs to land as well.

