### PR TITLE
[Tizen] Use MATTER_PLATFORM_ERROR for scanner error handling

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -420,26 +420,16 @@ void BLEManagerImpl::HandleConnectionTimeout(System::Layer *, void * appState)
 
 CHIP_ERROR BLEManagerImpl::ConnectChipThing(const char * address)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    int ret;
-
     ChipLogProgress(DeviceLayer, "ConnectRequest: Addr [%s]", StringOrNullMarker(address));
 
-    ret = bt_gatt_client_create(address, &mGattClient);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Failed to create GATT client: %s", get_error_message(ret));
-                 err = MATTER_PLATFORM_ERROR(ret));
+    int ret = bt_gatt_client_create(address, &mGattClient);
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret), NotifyHandleConnectFailed(MATTER_PLATFORM_ERROR(ret)));
 
     ret = bt_gatt_connect(address, false);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "Failed to issue GATT connect request: %s", get_error_message(ret));
-                 err = MATTER_PLATFORM_ERROR(ret));
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret), NotifyHandleConnectFailed(MATTER_PLATFORM_ERROR(ret)));
 
     ChipLogProgress(DeviceLayer, "GATT Connect Issued");
-
-exit:
-    if (err != CHIP_NO_ERROR)
-        NotifyHandleConnectFailed(err);
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 void BLEManagerImpl::OnDeviceScanned(const bt_adapter_le_device_scan_result_info_s & scanInfo,

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -697,16 +697,11 @@ CHIP_ERROR BLEManagerImpl::StopBLEAdvertising()
     ChipLogProgress(DeviceLayer, "Stop Advertising");
 
     int ret = bt_adapter_le_stop_advertising(mAdvertiser);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_adapter_le_stop_advertising() failed: %s", get_error_message(ret)));
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
+                        NotifyBLEPeripheralAdvStopComplete(MATTER_PLATFORM_ERROR(ret)));
 
     mAdvReqInProgress = true;
     return CHIP_NO_ERROR;
-
-exit:
-    auto err = MATTER_PLATFORM_ERROR(ret);
-    NotifyBLEPeripheralAdvStopComplete(err);
-    return err;
 }
 
 static bool __GattClientForeachCharCb(int total, int index, bt_gatt_h charHandle, void * data)
@@ -938,26 +933,18 @@ exit:
 
 CHIP_ERROR BLEManagerImpl::_Init()
 {
-    CHIP_ERROR err;
-
-    err = BleLayer::Init(this, this, this, &DeviceLayer::SystemLayer());
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(BleLayer::Init(this, this, this, &DeviceLayer::SystemLayer()));
 
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
 
     ChipLogProgress(DeviceLayer, "Initialize Tizen BLE Layer");
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BLEManagerImpl * self) { return self->_InitImpl(); }, this);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(
+        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BLEManagerImpl * self) { return self->_InitImpl(); }, this));
 
     mFlags.Set(Flags::kTizenBLELayerInitialized);
-
-    err = DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveBLEState(); });
-
-exit:
-    return err;
+    return DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveBLEState(); });
 }
 
 void BLEManagerImpl::_Shutdown()

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -379,7 +379,7 @@ void BLEManagerImpl::NotifyBLEDisconnection(BLE_CONNECTION_OBJECT conId)
 
 void BLEManagerImpl::NotifyHandleConnectFailed(CHIP_ERROR error)
 {
-    ChipLogProgress(DeviceLayer, "Connection failed: %" CHIP_ERROR_FORMAT, error.Format());
+    ChipLogError(DeviceLayer, "Connection failed: %" CHIP_ERROR_FORMAT, error.Format());
     if (mIsCentral)
     {
         ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformTizenBLECentralConnectFailed,
@@ -499,8 +499,8 @@ void BLEManagerImpl::OnScanComplete()
 
 void BLEManagerImpl::OnScanError(CHIP_ERROR err)
 {
+    ChipLogError(Ble, "BLE scan error: %" CHIP_ERROR_FORMAT, err.Format());
     BleConnectionDelegate::OnConnectionError(mBLEScanConfig.mAppState, err);
-    ChipLogDetail(Ble, "BLE scan error: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 CHIP_ERROR BLEManagerImpl::RegisterGATTServer()

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -940,8 +940,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
 
     ChipLogProgress(DeviceLayer, "Initialize Tizen BLE Layer");
 
-    ReturnErrorOnFailure(
-        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BLEManagerImpl * self) { return self->_InitImpl(); }, this));
+    ReturnErrorOnFailure(PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BLEManagerImpl * self) { return self->_InitImpl(); }, this));
 
     mFlags.Set(Flags::kTizenBLELayerInitialized);
     return DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveBLEState(); });

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -141,7 +141,8 @@ CHIP_ERROR ChipDeviceScanner::StartScan(ScanFilterType filterType, const ScanFil
         ChipLogProgress(DeviceLayer, "Proceeding with filterless scan");
     }
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err, TEMPORARY_RETURN_IGNORED StopScan());
 
     return CHIP_NO_ERROR;

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -104,8 +104,7 @@ CHIP_ERROR ChipDeviceScanner::StartScanImpl()
             return reinterpret_cast<ChipDeviceScanner *>(self)->LeScanResultCb(result, scanInfo);
         },
         this);
-    VerifyOrReturnValue(ret == BT_ERROR_NONE, CHIP_ERROR_INTERNAL,
-                        ChipLogError(DeviceLayer, "bt_adapter_le_start_scan() failed: %s", get_error_message(ret)));
+    VerifyOrReturnValue(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret));
     mIsScanning = true;
     return CHIP_NO_ERROR;
 }
@@ -119,23 +118,19 @@ static bool __IsScanFilterSupported()
     return is_supported;
 }
 
-int ChipDeviceScanner::SetupScanFilter(ScanFilterType filterType, const ScanFilterData & filterData)
+CHIP_ERROR ChipDeviceScanner::SetupScanFilter(ScanFilterType filterType, const ScanFilterData & filterData)
 {
-    VerifyOrReturnValue(__IsScanFilterSupported(), BT_ERROR_NONE, ChipLogError(DeviceLayer, "BLE scan filter not supported"));
+    if (!__IsScanFilterSupported())
+    {
+        ChipLogProgress(DeviceLayer, "BLE scan filter is not supported. Proceeding with filterless scan.");
+        return CHIP_NO_ERROR;
+    }
 
-    int ret = CreateLEScanFilter(filterType);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "BLE scan filter creation failed: %s. Do Normal Scan", get_error_message(ret)));
+    int ret = bt_adapter_le_scan_filter_create(&mScanFilter);
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret));
 
-    ret = RegisterScanFilter(filterType, filterData);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "BLE scan filter registration failed: %s. Do Normal Scan", get_error_message(ret)));
-
-    return ret;
-
-exit:
-    UnRegisterScanFilter();
-    return ret;
+    ReturnErrorOnFailure(RegisterScanFilter(filterType, filterData), UnRegisterScanFilter());
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ChipDeviceScanner::StartScan(ScanFilterType filterType, const ScanFilterData & filterData)
@@ -143,8 +138,8 @@ CHIP_ERROR ChipDeviceScanner::StartScan(ScanFilterType filterType, const ScanFil
     CHIP_ERROR err = CHIP_NO_ERROR;
     VerifyOrReturnError(!mIsScanning, CHIP_ERROR_INCORRECT_STATE);
 
-    // Scan Filter Setup if supported: silently bypass error & do filterless scan in case of error
-    SetupScanFilter(filterType, filterData);
+    // Setup scan filter if supported. Otherwise, do filterless scan.
+    RETURN_SAFELY_IGNORED SetupScanFilter(filterType, filterData);
 
     // All set to trigger LE Scan
     err = PlatformMgrImpl().GLibMatterContextInvokeSync(
@@ -192,56 +187,44 @@ void ChipDeviceScanner::UnRegisterScanFilter()
     }
 }
 
-int ChipDeviceScanner::RegisterScanFilter(ScanFilterType filterType, const ScanFilterData & filterData)
+CHIP_ERROR ChipDeviceScanner::RegisterScanFilter(ScanFilterType filterType, const ScanFilterData & filterData)
 {
-    int ret = BT_ERROR_NONE;
+    int ret;
 
     switch (filterType)
     {
-    case ScanFilterType::kAddress: {
+    case ScanFilterType::kAddress:
         ChipLogProgress(DeviceLayer, "Register BLE scan filter: Address");
         ret = bt_adapter_le_scan_filter_set_device_address(mScanFilter, filterData.address);
-        VerifyOrExit(
-            ret == BT_ERROR_NONE,
+        VerifyOrReturnError(
+            ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
             ChipLogError(DeviceLayer, "bt_adapter_le_scan_filter_set_device_address() failed: %s", get_error_message(ret)));
         break;
-    }
-    case ScanFilterType::kServiceUUID: {
+    case ScanFilterType::kServiceUUID:
         ChipLogProgress(DeviceLayer, "Register BLE scan filter: Service UUID");
         ret = bt_adapter_le_scan_filter_set_service_uuid(mScanFilter, filterData.service_uuid);
-        VerifyOrExit(ret == BT_ERROR_NONE,
-                     ChipLogError(DeviceLayer, "bt_adapter_le_scan_filter_set_service_uuid() failed: %s", get_error_message(ret)));
+        VerifyOrReturnError(
+            ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
+            ChipLogError(DeviceLayer, "bt_adapter_le_scan_filter_set_service_uuid() failed: %s", get_error_message(ret)));
         break;
-    }
-    case ScanFilterType::kServiceData: {
+    case ScanFilterType::kServiceData:
         ChipLogProgress(DeviceLayer, "Register BLE scan filter: Service Data");
         ret = bt_adapter_le_scan_filter_set_service_data(mScanFilter, filterData.service_uuid, filterData.service_data,
                                                          filterData.service_data_len);
-        VerifyOrExit(ret == BT_ERROR_NONE,
-                     ChipLogError(DeviceLayer, "bt_adapter_le_scan_filter_set_service_data() failed: %s", get_error_message(ret)));
+        VerifyOrReturnError(
+            ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
+            ChipLogError(DeviceLayer, "bt_adapter_le_scan_filter_set_service_data() failed: %s", get_error_message(ret)));
         break;
-    }
     case ScanFilterType::kNoFilter:
     default:
-        goto exit;
+        return CHIP_NO_ERROR;
     }
 
     ret = bt_adapter_le_scan_filter_register(mScanFilter);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_adapter_le_scan_filter_register() failed: %s", get_error_message(ret)));
+    VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret),
+                        ChipLogError(DeviceLayer, "bt_adapter_le_scan_filter_register() failed: %s", get_error_message(ret)));
 
-exit:
-    return ret;
-}
-
-int ChipDeviceScanner::CreateLEScanFilter(ScanFilterType filterType)
-{
-    int ret = bt_adapter_le_scan_filter_create(&mScanFilter);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_adapter_le_scan_filter_create() failed: %s", get_error_message(ret)));
-    ChipLogProgress(DeviceLayer, "BLE scan filter created successfully");
-exit:
-    return ret;
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Internal

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -120,11 +120,7 @@ static bool __IsScanFilterSupported()
 
 CHIP_ERROR ChipDeviceScanner::SetupScanFilter(ScanFilterType filterType, const ScanFilterData & filterData)
 {
-    if (!__IsScanFilterSupported())
-    {
-        ChipLogProgress(DeviceLayer, "BLE scan filter is not supported. Proceeding with filterless scan.");
-        return CHIP_NO_ERROR;
-    }
+    VerifyOrReturnError(__IsScanFilterSupported(), MATTER_PLATFORM_ERROR(BT_ERROR_NOT_SUPPORTED));
 
     int ret = bt_adapter_le_scan_filter_create(&mScanFilter);
     VerifyOrReturnError(ret == BT_ERROR_NONE, MATTER_PLATFORM_ERROR(ret));
@@ -135,23 +131,20 @@ CHIP_ERROR ChipDeviceScanner::SetupScanFilter(ScanFilterType filterType, const S
 
 CHIP_ERROR ChipDeviceScanner::StartScan(ScanFilterType filterType, const ScanFilterData & filterData)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     VerifyOrReturnError(!mIsScanning, CHIP_ERROR_INCORRECT_STATE);
 
     // Setup scan filter if supported. Otherwise, do filterless scan.
-    RETURN_SAFELY_IGNORED SetupScanFilter(filterType, filterData);
+    CHIP_ERROR err = SetupScanFilter(filterType, filterData);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to set up scan filter: %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogProgress(DeviceLayer, "Proceeding with filterless scan");
+    }
 
-    // All set to trigger LE Scan
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
-    SuccessOrExit(err);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err, TEMPORARY_RETURN_IGNORED StopScan());
 
     return CHIP_NO_ERROR;
-
-exit:
-    ChipLogError(DeviceLayer, "Start CHIP Scan could not succeed fully! Stop Scan...");
-    TEMPORARY_RETURN_IGNORED StopScan();
-    return err;
 }
 
 CHIP_ERROR ChipDeviceScanner::StopScan()

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -151,7 +151,6 @@ CHIP_ERROR ChipDeviceScanner::StartScan(ScanFilterType filterType, const ScanFil
 exit:
     ChipLogError(DeviceLayer, "Start CHIP Scan could not succeed fully! Stop Scan...");
     TEMPORARY_RETURN_IGNORED StopScan();
-    UnRegisterScanFilter();
     return err;
 }
 
@@ -183,6 +182,7 @@ void ChipDeviceScanner::UnRegisterScanFilter()
     if (mScanFilter)
     {
         bt_adapter_le_scan_filter_unregister(mScanFilter);
+        bt_adapter_le_scan_filter_destroy(mScanFilter);
         mScanFilter = nullptr;
     }
 }

--- a/src/platform/Tizen/ChipDeviceScanner.h
+++ b/src/platform/Tizen/ChipDeviceScanner.h
@@ -92,9 +92,8 @@ private:
     void LeScanResultCb(int result, bt_adapter_le_device_scan_result_info_s * scanInfo);
     CHIP_ERROR StartScanImpl();
 
-    int CreateLEScanFilter(ScanFilterType filterType);
-    int RegisterScanFilter(ScanFilterType filterType, const ScanFilterData & filterData);
-    int SetupScanFilter(ScanFilterType filterType, const ScanFilterData & filterData);
+    CHIP_ERROR RegisterScanFilter(ScanFilterType filterType, const ScanFilterData & filterData);
+    CHIP_ERROR SetupScanFilter(ScanFilterType filterType, const ScanFilterData & filterData);
     void UnRegisterScanFilter();
 
     ChipDeviceScannerDelegate * mDelegate;


### PR DESCRIPTION
#### Summary

- Use MATTER_PLATFORM_ERROR for scanner error handling
- Properly destroy scan filter after unregistration (fix memory leak)
- Fix log verbose level for BLE error reports
- Report scan filter setup failure

#### Testing

Tested chip-tool on Tizen. Scanner works as before, but with better error handling:

```
...
[1771318675.878] [28231:28236] [BLE] Start CHIP BLE scan: timeout=20000ms
[1771318675.890] [28231:28236] [DL] Failed to set up scan filter: src/platform/Tizen/ChipDeviceScanner.cpp:187: Platform Error 0xC0000002: Not supported
[1771318675.890] [28231:28236] [DL] Proceeding with filterless scan
[1771318676.005] [28231:28232] [DL] LE device reported: 04:E4:B6:C7:52:1B
[1771318676.005] [28231:28232] [BLE] Device 04:E4:B6:C7:52:1B does not look like a CHIP device
...
```
