### PR TITLE
Groupcast: Address policy defaults to PerAddress when using Group clu…

### DIFF
--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -44,23 +44,24 @@ public:
             kHasAuxiliaryACL = 0b00000001,
             kMcastAddrPolicy = 0b00000010,
         };
+        static constexpr uint8_t kFlagsDefault = to_underlying(GroupInfo::Flags::kMcastAddrPolicy);
 
         // Identifies group within the scope of the given Fabric
         GroupId group_id = kUndefinedGroupId;
         // Lastest group name written for a given GroupId on any Endpoint via the Groups cluster
         char name[kGroupNameMax + 1] = { 0 };
-        uint8_t flags                = 0;
+        uint8_t flags                = kFlagsDefault;
         uint16_t count               = 0;
 
         GroupInfo() { SetName(nullptr); }
         GroupInfo(const GroupInfo & other) { Copy(other); }
         GroupInfo(const char * groupName) { SetName(groupName); }
         GroupInfo(const CharSpan & groupName) { SetName(groupName); }
-        GroupInfo(GroupId id, const char * groupName, uint8_t groupFlags = 0) : group_id(id), flags(groupFlags)
+        GroupInfo(GroupId id, const char * groupName, uint8_t groupFlags = kFlagsDefault) : group_id(id), flags(groupFlags)
         {
             SetName(groupName);
         }
-        GroupInfo(GroupId id, const CharSpan & groupName, uint8_t groupFlags = 0) : group_id(id), flags(groupFlags)
+        GroupInfo(GroupId id, const CharSpan & groupName, uint8_t groupFlags = kFlagsDefault) : group_id(id), flags(groupFlags)
         {
             SetName(groupName);
         }


### PR DESCRIPTION
#### Summary

Corrects the default group address policy for backward compatibility with the legacy Group cluster. When creating a group though Groupcast cluster, the cluster implementation sets the flags accordingly, but currently, when creating a group through the Group cluster, the flags defaults to zero, with stands for IANA address, instead of PerGroup address as expected.

An optional argument has been added to `chip-tool`'s `groupsettings` command, so the policy may be set to 0 (IANA address) when configuring Groupcast groups.

#### Related issues

N/A

#### Testing

Testing
Unit tests ran successfully:

* TestGeneralCommissioningCluster
* TestGeneralDiagnosticsCluster
* TestGroupcastCluster
* TestGroupDataProvider
* TestGroupedCallbackList
* TestGroupKeyManagementCluster
* TestGroupMessageCounter
* TestGroupOperationalCredentials

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
