### PR TITLE
Bugfix: Groups without keysets prevent reading Groupcast Membership.

### DIFF
--- a/src/app/clusters/groupcast/GroupcastLogic.cpp
+++ b/src/app/clusters/groupcast/GroupcastLogic.cpp
@@ -31,41 +31,44 @@ CHIP_ERROR GroupcastLogic::ReadMembership(const chip::Access::SubjectDescriptor 
         while (group_iter->Next(info) && (CHIP_NO_ERROR == status))
         {
             // Group Key
-            KeysetId keyset_id = 0;
-            ReturnErrorOnFailure(groups->GetGroupKey(fabric_index, info.group_id, keyset_id));
-
-            // Endpoints
-            EndpointIterator * end_iter = groups->IterateEndpoints(fabric_index, info.group_id);
-            if (nullptr == end_iter)
+            KeysetId keyset_id = kInvalidKeysetId;
+            status             = groups->GetGroupKey(fabric_index, info.group_id, keyset_id);
+            // Since keys are managed by the GroupKeyManagement cluster, groups may not have an associated keyset
+            VerifyOrDo(CHIP_ERROR_NOT_FOUND != status, status = CHIP_NO_ERROR);
+            if (CHIP_NO_ERROR == status)
             {
-                status = CHIP_ERROR_NO_MEMORY;
-                break;
-            }
-
-            // Return endpoints in kMaxMembershipEndpoints chunks or less
-            size_t group_total = end_iter->Count();
-            size_t group_count = 0;
-            size_t split_count = 0;
-            GroupEndpoint mapping;
-            while (end_iter->Next(mapping) && (CHIP_NO_ERROR == status))
-            {
-                group_count++;
-                endpoints.entries[split_count++] = mapping.endpoint_id;
-                if ((group_count == group_total) || (split_count == kMaxMembershipEndpoints))
+                // Endpoints
+                EndpointIterator * end_iter = groups->IterateEndpoints(fabric_index, info.group_id);
+                if (nullptr == end_iter)
                 {
-                    Groupcast::Structs::MembershipStruct::Type group;
-                    group.fabricIndex     = fabric_index;
-                    group.groupID         = info.group_id;
-                    group.keySetID        = keyset_id;
-                    group.hasAuxiliaryACL = MakeOptional(info.HasAuxiliaryACL());
-                    group.mcastAddrPolicy = info.UsePerGroupAddress() ? Groupcast::MulticastAddrPolicyEnum::kPerGroup
-                                                                      : Groupcast::MulticastAddrPolicyEnum::kIanaAddr;
-                    group.endpoints       = MakeOptional(DataModel::List<const chip::EndpointId>(endpoints.entries, split_count));
-                    status                = encoder.Encode(group);
-                    split_count           = 0;
+                    status = CHIP_ERROR_NO_MEMORY;
+                    break;
                 }
+                // Return endpoints in kMaxMembershipEndpoints chunks or less
+                size_t group_total = end_iter->Count();
+                size_t group_count = 0;
+                size_t split_count = 0;
+                GroupEndpoint mapping;
+                while (end_iter->Next(mapping) && (CHIP_NO_ERROR == status))
+                {
+                    group_count++;
+                    endpoints.entries[split_count++] = mapping.endpoint_id;
+                    if ((group_count == group_total) || (split_count == kMaxMembershipEndpoints))
+                    {
+                        Groupcast::Structs::MembershipStruct::Type group;
+                        group.fabricIndex     = fabric_index;
+                        group.groupID         = info.group_id;
+                        group.keySetID        = keyset_id;
+                        group.hasAuxiliaryACL = MakeOptional(info.HasAuxiliaryACL());
+                        group.mcastAddrPolicy = info.UsePerGroupAddress() ? Groupcast::MulticastAddrPolicyEnum::kPerGroup
+                                                                          : Groupcast::MulticastAddrPolicyEnum::kIanaAddr;
+                        group.endpoints = MakeOptional(DataModel::List<const chip::EndpointId>(endpoints.entries, split_count));
+                        status          = encoder.Encode(group);
+                        split_count     = 0;
+                    }
+                }
+                end_iter->Release();
             }
-            end_iter->Release();
         }
         group_iter->Release();
 

--- a/src/app/clusters/groupcast/GroupcastLogic.cpp
+++ b/src/app/clusters/groupcast/GroupcastLogic.cpp
@@ -32,43 +32,45 @@ CHIP_ERROR GroupcastLogic::ReadMembership(const chip::Access::SubjectDescriptor 
         {
             // Group Key
             KeysetId keyset_id = kInvalidKeysetId;
-            status             = groups->GetGroupKey(fabric_index, info.group_id, keyset_id);
             // Since keys are managed by the GroupKeyManagement cluster, groups may not have an associated keyset
-            VerifyOrDo(CHIP_ERROR_NOT_FOUND != status, status = CHIP_NO_ERROR);
-            if (CHIP_NO_ERROR == status)
+            status = groups->GetGroupKey(fabric_index, info.group_id, keyset_id).NoErrorIf(CHIP_ERROR_NOT_FOUND);
+            if (CHIP_NO_ERROR != status)
             {
-                // Endpoints
-                EndpointIterator * end_iter = groups->IterateEndpoints(fabric_index, info.group_id);
-                if (nullptr == end_iter)
-                {
-                    status = CHIP_ERROR_NO_MEMORY;
-                    break;
-                }
-                // Return endpoints in kMaxMembershipEndpoints chunks or less
-                size_t group_total = end_iter->Count();
-                size_t group_count = 0;
-                size_t split_count = 0;
-                GroupEndpoint mapping;
-                while (end_iter->Next(mapping) && (CHIP_NO_ERROR == status))
-                {
-                    group_count++;
-                    endpoints.entries[split_count++] = mapping.endpoint_id;
-                    if ((group_count == group_total) || (split_count == kMaxMembershipEndpoints))
-                    {
-                        Groupcast::Structs::MembershipStruct::Type group;
-                        group.fabricIndex     = fabric_index;
-                        group.groupID         = info.group_id;
-                        group.keySetID        = keyset_id;
-                        group.hasAuxiliaryACL = MakeOptional(info.HasAuxiliaryACL());
-                        group.mcastAddrPolicy = info.UsePerGroupAddress() ? Groupcast::MulticastAddrPolicyEnum::kPerGroup
-                                                                          : Groupcast::MulticastAddrPolicyEnum::kIanaAddr;
-                        group.endpoints = MakeOptional(DataModel::List<const chip::EndpointId>(endpoints.entries, split_count));
-                        status          = encoder.Encode(group);
-                        split_count     = 0;
-                    }
-                }
-                end_iter->Release();
+                break;
             }
+
+            // Endpoints
+            EndpointIterator * end_iter = groups->IterateEndpoints(fabric_index, info.group_id);
+            if (nullptr == end_iter)
+            {
+                status = CHIP_ERROR_NO_MEMORY;
+                break;
+            }
+
+            // Return endpoints in kMaxMembershipEndpoints chunks or less
+            size_t group_total = end_iter->Count();
+            size_t group_count = 0;
+            size_t split_count = 0;
+            GroupEndpoint mapping;
+            while (end_iter->Next(mapping) && (CHIP_NO_ERROR == status))
+            {
+                group_count++;
+                endpoints.entries[split_count++] = mapping.endpoint_id;
+                if ((group_count == group_total) || (split_count == kMaxMembershipEndpoints))
+                {
+                    Groupcast::Structs::MembershipStruct::Type group;
+                    group.fabricIndex     = fabric_index;
+                    group.groupID         = info.group_id;
+                    group.keySetID        = keyset_id;
+                    group.hasAuxiliaryACL = MakeOptional(info.HasAuxiliaryACL());
+                    group.mcastAddrPolicy = info.UsePerGroupAddress() ? Groupcast::MulticastAddrPolicyEnum::kPerGroup
+                                                                      : Groupcast::MulticastAddrPolicyEnum::kIanaAddr;
+                    group.endpoints       = MakeOptional(DataModel::List<const chip::EndpointId>(endpoints.entries, split_count));
+                    status                = encoder.Encode(group);
+                    split_count           = 0;
+                }
+            }
+            end_iter->Release();
         }
         group_iter->Release();
 


### PR DESCRIPTION
#### Summary

Group keys are managed by the GroupKeyManagement clusters. As a consequence, groups may exist without a corresponding keyset, including groups created by the Groupcast cluster.

When reading Groupcast Membership, if a group has no associated keyset, the attribute read fails for all groups. This fix a allows to read the membership for all groups. Groups without keysets will be read with `KeySetID` == 0xffff (`kInvalidKeysetId`)

TestGroupcastCluster updated to cover this case.

#### Related issues

N/A

#### Testing

Unit tests ran successfully:
* TestGeneralCommissioningCluster
* TestGeneralDiagnosticsCluster
* TestGroupcastCluster
* TestGroupDataProvider
* TestGroupedCallbackList
* TestGroupKeyManagementCluster
* TestGroupMessageCounter
* TestGroupOperationalCredentials

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
