### PR TITLE
[TLV Read] - fix read resetting empty TLV data

### DIFF
--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -378,7 +378,7 @@ CHIP_ERROR TLVReader::Get(Optional<LocalizedStringIdentifier> & lsid)
     if (bytes == nullptr)
     {
         // Calling memchr further down with bytes == nullptr would have undefined behaviour, exiting early.
-        lsid = {}; // empty data
+        // This treats null/empty LSID as a NullOptional (we clear the value at the start)
         return CHIP_NO_ERROR;
     }
 
@@ -387,6 +387,7 @@ CHIP_ERROR TLVReader::Get(Optional<LocalizedStringIdentifier> & lsid)
     const uint8_t * infoSeparator1 = static_cast<const uint8_t *>(memchr(bytes, kUnicodeInformationSeparator1, len));
     if (infoSeparator1 == nullptr)
     {
+        // This treats null/empty LSID as a NullOptional (we clear the value at the start)
         return CHIP_NO_ERROR;
     }
 
@@ -400,6 +401,7 @@ CHIP_ERROR TLVReader::Get(Optional<LocalizedStringIdentifier> & lsid)
     }
     if (len == 0)
     {
+        // This treats null/empty LSID as a NullOptional (we clear the value at the start)
         return CHIP_NO_ERROR;
     }
     VerifyOrReturnError(len <= kMaxLocalizedStringIdentifierLen, CHIP_ERROR_INVALID_TLV_ELEMENT);

--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -331,6 +331,7 @@ CHIP_ERROR TLVReader::Get(CharSpan & v) const
     if (bytes == nullptr)
     {
         // Calling memchr further down with bytes == nullptr would have undefined behaviour, exiting early.
+        v = {}; // empty data
         return CHIP_NO_ERROR;
     }
 
@@ -377,6 +378,7 @@ CHIP_ERROR TLVReader::Get(Optional<LocalizedStringIdentifier> & lsid)
     if (bytes == nullptr)
     {
         // Calling memchr further down with bytes == nullptr would have undefined behaviour, exiting early.
+        lsid = {}; // empty data
         return CHIP_NO_ERROR;
     }
 

--- a/src/lib/core/tests/TestTLV.cpp
+++ b/src/lib/core/tests/TestTLV.cpp
@@ -2815,8 +2815,15 @@ TEST_F(TestTLV, CheckTLVCharSpan)
         {  "This is a test case #3" IS1_CHAR,                                    "This is a test case #3"  },
         {  "Thé" IS1_CHAR,                                                       "Thé"                     },
         {  IS1_CHAR " abc " IS1_CHAR " def",                                     ""                        },
+        {"", ""},
+        {"Post empty", "Post empty"},
+        {"", ""},
     };
     // clang-format on
+
+    // Important: declared in the outer scope to ensure that each read correctly
+    // resets the values.
+    chip::CharSpan readerSpan;
 
     for (auto & testCase : sCharSpanTestCases)
     {
@@ -2837,9 +2844,8 @@ TEST_F(TestTLV, CheckTLVCharSpan)
         err = reader.Next();
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
-        chip::CharSpan readerSpan;
         err = reader.Get(readerSpan);
-        EXPECT_EQ(err, CHIP_NO_ERROR);
+        ASSERT_EQ(err, CHIP_NO_ERROR);
 
         EXPECT_EQ(strlen(testCase.expectedString), readerSpan.size());
         EXPECT_EQ(memcmp(readerSpan.data(), testCase.expectedString, strlen(testCase.expectedString)), 0);

--- a/src/lib/core/tests/TestTLV.cpp
+++ b/src/lib/core/tests/TestTLV.cpp
@@ -2848,7 +2848,7 @@ TEST_F(TestTLV, CheckTLVCharSpan)
         ASSERT_EQ(err, CHIP_NO_ERROR);
 
         EXPECT_EQ(strlen(testCase.expectedString), readerSpan.size());
-        EXPECT_EQ(memcmp(readerSpan.data(), testCase.expectedString, strlen(testCase.expectedString)), 0);
+        EXPECT_TRUE(readerSpan.data_equal(CharSpan::fromCharString(testCase.expectedString)));
     }
 }
 


### PR DESCRIPTION
#### Summary

- TLV getting data pointer returns null on empty length:

```cpp
CHIP_ERROR TLVReader::GetDataPtr(const uint8_t *& data) const
{
    VerifyOrReturnError(TLVTypeIsString(ElementType()), CHIP_ERROR_WRONG_TLV_TYPE);

    if (GetLength() == 0)
    {
        data = nullptr;
        return CHIP_NO_ERROR;
    }
    ...
```

This results in checks for data pointer to early return and were failing to reset the CharSpan to an empty value. This breaks any code that assumes a successful read will reset the data (which seems reasonable).

We mostly did not see it because we often initialize `CharSpan` and then read. Correctness-wise though, a successfull read should update the read target.

#### Testing

CI tests updated to a test that would catch this bug (tested that it would fail before the fix)