### PR TITLE
[Camera App] Unregister cluster in shutdown to fix heap-use-after-free

### DIFF
--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -341,6 +341,13 @@ void CameraApp::ShutdownCameraDeviceClusters()
         ChipLogError(Camera, "CameraAVStreamMgmt Server unregister error: %" CHIP_ERROR_FORMAT, err.Format());
     }
     mAVStreamMgmtServer.Destroy();
+
+    err = CodegenDataModelProvider::Instance().Registry().Unregister(&mAVSettingsUserLevelMgmtServer.Cluster());
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Camera, "CameraAVSettingsUserLevelMgmt Server unregister error: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+    mAVSettingsUserLevelMgmtServer.Destroy();
 }
 
 static constexpr EndpointId kCameraEndpointId = 1;


### PR DESCRIPTION
#### Summary

- When shutting down the example Camera App, we get a heap-use-after-free since the `mAVSettingsUserLevelMgmtServer`  `ServerClusterInterface` was not unregistered.
- This was detected using an asan-clang sanitized Camera app

#### Testing

- running and shutting down the camera app before and after the fix showed that ASAN stopped complaining
```
scripts/build/build_examples.py --target linux-x64-camera-asan-clang build
```