### PR TITLE
Fix chip-cert-bins Docker build: rename energy-management to evse and add libevent-dev

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -64,6 +64,7 @@ RUN set -x \
     libdbus-1-dev \
     libdbus-glib-1-dev \
     libdmalloc-dev \
+    libevent-dev \
     libgif-dev \
     libgirepository1.0-dev \
     libglib2.0-dev \
@@ -174,7 +175,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-simulated-app1-ipv6only \
     --target linux-x64-lit-icd-ipv6only \
     --target linux-x64-energy-gateway-ipv6only \
-    --target linux-x64-energy-management-ipv6only \
+    --target linux-x64-evse-ipv6only \
     --target linux-x64-microwave-oven-ipv6only \
     --target linux-x64-rvc-ipv6only \
     --target linux-x64-fabric-bridge-rpc-ipv6only \
@@ -207,7 +208,7 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-x64-simulated-app1-ipv6only/chip-app1 out/chip-app1 \
     && mv out/linux-x64-lit-icd-ipv6only/lit-icd-app out/lit-icd-app \
     && mv out/linux-x64-energy-gateway-ipv6only/chip-energy-gateway-app out/chip-energy-gateway-app \
-    && mv out/linux-x64-energy-management-ipv6only/chip-energy-management-app out/chip-energy-management-app \
+    && mv out/linux-x64-evse-ipv6only/chip-evse-app out/chip-evse-app \
     && mv out/linux-x64-microwave-oven-ipv6only/chip-microwave-oven-app out/chip-microwave-oven-app \
     && mv out/linux-x64-rvc-ipv6only/chip-rvc-app out/chip-rvc-app \
     && mv out/linux-x64-fabric-bridge-rpc-ipv6only/fabric-bridge-app out/fabric-bridge-app \
@@ -244,7 +245,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-arm64-simulated-app1-ipv6only \
     --target linux-arm64-lit-icd-ipv6only \
     --target linux-arm64-energy-gateway-ipv6only \
-    --target linux-arm64-energy-management-ipv6only \
+    --target linux-arm64-evse-ipv6only \
     --target linux-arm64-microwave-oven-ipv6only \
     --target linux-arm64-rvc-ipv6only \
     --target linux-arm64-fabric-bridge-rpc-ipv6only \
@@ -277,7 +278,7 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-arm64-simulated-app1-ipv6only/chip-app1 out/chip-app1 \
     && mv out/linux-arm64-lit-icd-ipv6only/lit-icd-app out/lit-icd-app \
     && mv out/linux-arm64-energy-gateway-ipv6only/chip-energy-gateway-app out/chip-energy-gateway-app \
-    && mv out/linux-arm64-energy-management-ipv6only/chip-energy-management-app out/chip-energy-management-app \
+    && mv out/linux-arm64-evse-ipv6only/chip-evse-app out/chip-evse-app \
     && mv out/linux-arm64-microwave-oven-ipv6only/chip-microwave-oven-app out/chip-microwave-oven-app \
     && mv out/linux-arm64-rvc-ipv6only/chip-rvc-app out/chip-rvc-app \
     && mv out/linux-arm64-fabric-bridge-rpc-ipv6only/fabric-bridge-app out/fabric-bridge-app \
@@ -365,7 +366,7 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-lock-app apps/ch
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-app1 apps/chip-app1
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/lit-icd-app apps/lit-icd-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-energy-gateway-app apps/chip-energy-gateway-app
-COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-energy-management-app apps/chip-energy-management-app
+COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-evse-app apps/chip-evse-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-microwave-oven-app apps/chip-microwave-oven-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-rvc-app apps/chip-rvc-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/examples/fabric-admin/scripts/fabric-sync-app.py apps/fabric-sync-app


### PR DESCRIPTION
#### Summary
Fix chip-cert-bins Docker image build by updating the energy-management app target to evse and adding missing libevent-dev dependency.


Motivation

  This PR addresses two side effects from recent changes that broke the chip-cert-bins Docker build:

  1. Energy Management → EVSE Rename (PR [#42711](https://github.com/project-chip/connectedhomeip/pull/42711))
The energy-management app was renamed to EVSE but the chip-cert-bins Dockerfile wasn't updated, causing:
  Error: Invalid value for '--target': 'linux-x64-energy-management-ipv6only' is not a valid target name.

  2. Missing libevent-dev Dependency (PR [#42578](https://github.com/project-chip/connectedhomeip/pull/42578))
  OpenThread Commissioner support introduced a libevent dependency that was added to chip-build (#42663) but not to chip-cert-bins, which builds from scratch.


#### Related issues
https://github.com/project-chip/certification-tool/issues/875

#### Testing
 Built locally and verified successful completion using this command: `docker buildx build --load --build-arg COMMITHASH=58568d5d306f9a5a86f4638dc97e2799bd988bd6 --tag connectedhomeip/chip-cert-bins:58568d5d306f9a5a86f4638dc97e2799bd988bd6 .`
 
<img width="1337" height="31" alt="Screenshot 2026-02-18 at 08 50 25" src="https://github.com/user-attachments/assets/5ac8461c-42e6-4c74-ae96-437662b2e8eb" />


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
