### PR TITLE
[ESP32] Move all-devices-app esp32 to main CI

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -156,6 +156,11 @@ jobs:
                 scripts/examples/esp_example.sh lighting-app sdkconfig.ext_plat.defaults
                 rm -rf examples/lighting-app/esp32/{build,managed_components}
 
+            - name: Build example All Devices App
+              run: |
+                scripts/examples/esp_example.sh all-devices-app sdkconfig.defaults
+                rm -rf examples/all-devices-app/esp32/{build,managed_components}
+
             - name: Build example Energy Gateway App
               if: steps.changed_paths.outputs.energy_gateway == 'true'
               run: |
@@ -202,9 +207,6 @@ jobs:
 
             - name: Build example Bridge App
               run: scripts/examples/esp_example.sh bridge-app
-
-            - name: Build example All Devices App
-              run: scripts/examples/esp_example.sh all-devices-app sdkconfig.defaults
 
             - name: Build example Persistent Storage App
               run: scripts/examples/esp_example.sh persistent-storage sdkconfig.defaults

--- a/examples/all-devices-app/all-devices-common/devices/speaker/impl/LoggingSpeakerDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/speaker/impl/LoggingSpeakerDevice.cpp
@@ -15,8 +15,8 @@
  *    limitations under the License.
  */
 #include <devices/speaker/impl/LoggingSpeakerDevice.h>
-#include <lib/support/logging/CHIPLogging.h>
 #include <inttypes.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip::app::Clusters;
 

--- a/examples/all-devices-app/all-devices-common/devices/speaker/impl/LoggingSpeakerDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/speaker/impl/LoggingSpeakerDevice.cpp
@@ -16,6 +16,7 @@
  */
 #include <devices/speaker/impl/LoggingSpeakerDevice.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <inttypes.h>
 
 using namespace chip::app::Clusters;
 
@@ -33,7 +34,7 @@ void LoggingSpeakerDevice::OnLevelChanged(uint8_t value)
     uint8_t min  = LevelControlCluster().GetMinLevel();
     uint8_t max  = LevelControlCluster().GetMaxLevel();
     uint32_t pct = (max > min) ? (static_cast<uint32_t>(value - min) * 100) / (max - min) : 0;
-    ChipLogProgress(AppServer, "LoggingSpeakerDevice: Volume set to %u (%u%%)", value, pct);
+    ChipLogProgress(AppServer, "LoggingSpeakerDevice: Volume set to %u (%" PRIu32 "%%)", value, pct);
 }
 
 void LoggingSpeakerDevice::OnOptionsChanged(BitMask<Clusters::LevelControl::OptionsBitmap> value)

--- a/examples/all-devices-app/esp32/main/CMakeLists.txt
+++ b/examples/all-devices-app/esp32/main/CMakeLists.txt
@@ -107,6 +107,8 @@ set(CLUSTER_SRCS
     "${CHIP_ROOT}/src/app/clusters/general-commissioning-server/GeneralCommissioningCluster.cpp"
     "${CHIP_ROOT}/src/app/clusters/general-diagnostics-server/GeneralDiagnosticsCluster.cpp"
     "${CHIP_ROOT}/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp"
+    "${CHIP_ROOT}/src/app/clusters/groupcast/GroupcastCluster.cpp"
+    "${CHIP_ROOT}/src/app/clusters/groupcast/GroupcastLogic.cpp"
     "${CHIP_ROOT}/src/app/clusters/groups-server/GroupsCluster.cpp"
     "${CHIP_ROOT}/src/app/clusters/identify-server/IdentifyCluster.cpp"
     "${CHIP_ROOT}/src/app/clusters/level-control/LevelControlCluster.cpp"

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -235,7 +235,7 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
                 .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                 //
                 .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),               //
                 .testEventTriggerDelegate         = testEventTriggerDelegate,                               //
-                .dacProvider                      = Credentials::GetDeviceAttestationCredentialsProvider(), //
+                .dacProvider                      = *Credentials::GetDeviceAttestationCredentialsProvider(), //
                 .eventManagement                  = EventManagement::GetInstance(),                         //
                 .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                      //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -220,24 +220,24 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
 
     gRootNodeDevice = std::make_unique<WifiRootNodeDevice>(
         RootNodeDevice::Context {
-            .commissioningWindowManager           = Server::GetInstance().GetCommissioningWindowManager(),  //
-                .configurationManager             = DeviceLayer::ConfigurationMgr(),                        //
-                .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),   //
-                .fabricTable                      = Server::GetInstance().GetFabricTable(),                 //
-                .accessControl                    = Server::GetInstance().GetAccessControl(),               //
-                .persistentStorage                = Server::GetInstance().GetPersistentStorage(),           //
-                .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),             //
-                .deviceInstanceInfoProvider       = *provider,                                              //
-                .platformManager                  = DeviceLayer::PlatformMgr(),                             //
-                .groupDataProvider                = gGroupDataProvider,                                     //
-                .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),        //
-                .dnssdServer                      = DnssdServer::Instance(),                                //
-                .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                 //
-                .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),               //
-                .testEventTriggerDelegate         = testEventTriggerDelegate,                               //
+            .commissioningWindowManager           = Server::GetInstance().GetCommissioningWindowManager(),   //
+                .configurationManager             = DeviceLayer::ConfigurationMgr(),                         //
+                .deviceControlServer              = DeviceLayer::DeviceControlServer::DeviceControlSvr(),    //
+                .fabricTable                      = Server::GetInstance().GetFabricTable(),                  //
+                .accessControl                    = Server::GetInstance().GetAccessControl(),                //
+                .persistentStorage                = Server::GetInstance().GetPersistentStorage(),            //
+                .failSafeContext                  = Server::GetInstance().GetFailSafeContext(),              //
+                .deviceInstanceInfoProvider       = *provider,                                               //
+                .platformManager                  = DeviceLayer::PlatformMgr(),                              //
+                .groupDataProvider                = gGroupDataProvider,                                      //
+                .sessionManager                   = Server::GetInstance().GetSecureSessionManager(),         //
+                .dnssdServer                      = DnssdServer::Instance(),                                 //
+                .deviceLoadStatusProvider         = *InteractionModelEngine::GetInstance(),                  //
+                .diagnosticDataProvider           = DeviceLayer::GetDiagnosticDataProvider(),                //
+                .testEventTriggerDelegate         = testEventTriggerDelegate,                                //
                 .dacProvider                      = *Credentials::GetDeviceAttestationCredentialsProvider(), //
-                .eventManagement                  = EventManagement::GetInstance(),                         //
-                .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                      //
+                .eventManagement                  = EventManagement::GetInstance(),                          //
+                .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                       //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
                 .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED


### PR DESCRIPTION
#### Summary

Move all-devices-app esp32 to main CI (esp32).

#### Related issues

We would not know if anything breaks in esp32_1.

#### Testing

CI should pass