### PR TITLE
[Groupcast]Fix step skips in the TC_GCAST test scripts

### DIFF
--- a/src/python_testing/TC_GCAST_2_4.py
+++ b/src/python_testing/TC_GCAST_2_4.py
@@ -144,51 +144,51 @@ class TC_GCAST_2_4(MatterBaseTest):
         self.step(3)
         if not ln_enabled:
             self.mark_step_range_skipped("4a", "4f")
-
-        self.step("4a")
-        groupID3 = 3
-        await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-            groupID=groupID3,
-            endpoints=endpoints_list,
-            keySetID=keySetID1)
-        )
-
-        self.step("4b")
-        if len(endpoints_list) == 1:
-            self.mark_step_range_skipped("4c", "4d")
-
-        self.step("4c")
-        endpoint_2 = [endpoints_list[1]]
-        resp: Clusters.Groupcast.Commands.LeaveGroupResponse = await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(
-            groupID=groupID3,
-            endpoints=endpoint_2)
-        )
-        asserts.assert_is_not_none(resp.endpoints, "LeaveGroupResponse endpoints should not be None")
-        asserts.assert_equal(resp.endpoints, endpoint_2,
-                             f"LeaveGroupResponse cmd endpoints list {resp.endpoints} is not equal to {endpoint_2}")
-
-        self.step("4d")
-        sub.reset()
-        membership_matcher = generate_membership_entry_matcher(groupID3, endpoints=[endpoints_list[0]])
-        sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
-
-        self.step("4e")
-        endpoint_1 = [endpoints_list[0]]
-        resp: Clusters.Groupcast.Commands.LeaveGroupResponse = await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(
-            groupID=groupID3,
-            endpoints=endpoint_1)
-        )
-        asserts.assert_is_not_none(resp.endpoints, "LeaveGroupResponse endpoints should not be None")
-        asserts.assert_equal(resp.endpoints, endpoint_1,
-                             f"LeaveGroupResponse cmd endpoints list {resp.endpoints} is not equal to {endpoint_1}")
-
-        self.step("4f")
-        if sd_enabled:
-            membership_matcher = generate_membership_entry_matcher(groupID3, endpoints=[])
-            sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
         else:
-            membership_matcher = generate_membership_entry_matcher(groupID3, test_for_exists=False)
-            sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+            self.step("4a")
+            groupID3 = 3
+            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                groupID=groupID3,
+                endpoints=endpoints_list,
+                keySetID=keySetID1)
+            )
+
+            self.step("4b")
+            if len(endpoints_list) == 1:
+                self.mark_step_range_skipped("4c", "4d")
+            else:
+                self.step("4c")
+                endpoint_2 = [endpoints_list[1]]
+                resp: Clusters.Groupcast.Commands.LeaveGroupResponse = await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(
+                    groupID=groupID3,
+                    endpoints=endpoint_2)
+                )
+                asserts.assert_is_not_none(resp.endpoints, "LeaveGroupResponse endpoints should not be None")
+                asserts.assert_equal(resp.endpoints, endpoint_2,
+                                     f"LeaveGroupResponse cmd endpoints list {resp.endpoints} is not equal to {endpoint_2}")
+
+                self.step("4d")
+                sub.reset()
+                membership_matcher = generate_membership_entry_matcher(groupID3, endpoints=[endpoints_list[0]])
+                sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+
+            self.step("4e")
+            endpoint_1 = [endpoints_list[0]]
+            resp: Clusters.Groupcast.Commands.LeaveGroupResponse = await self.send_single_cmd(Clusters.Groupcast.Commands.LeaveGroup(
+                groupID=groupID3,
+                endpoints=endpoint_1)
+            )
+            asserts.assert_is_not_none(resp.endpoints, "LeaveGroupResponse endpoints should not be None")
+            asserts.assert_equal(resp.endpoints, endpoint_1,
+                                 f"LeaveGroupResponse cmd endpoints list {resp.endpoints} is not equal to {endpoint_1}")
+
+            self.step("4f")
+            if sd_enabled:
+                membership_matcher = generate_membership_entry_matcher(groupID3, endpoints=[])
+                sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+            else:
+                membership_matcher = generate_membership_entry_matcher(groupID3, test_for_exists=False)
+                sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 
         self.step(5)
         groupIDUnknown = 100

--- a/src/python_testing/TC_GCAST_2_5.py
+++ b/src/python_testing/TC_GCAST_2_5.py
@@ -83,6 +83,8 @@ class TC_GCAST_2_5(MatterBaseTest):
         if not ln_enabled:
             logger.info("Listener feature is not enabled, skip remaining steps.")
             self.mark_all_remaining_steps_skipped("1b")
+            return
+
         endpoints_list = await valid_endpoints_list(self, ln_enabled)
         endpoints_list = [endpoints_list[0]]
 
@@ -152,6 +154,7 @@ class TC_GCAST_2_5(MatterBaseTest):
 
         if not sd_enabled:
             self.mark_all_remaining_steps_skipped("7")
+            return
 
         self.step(7)
         groupID2 = 2


### PR DESCRIPTION
#### Summary
The steps skips are not properly implemented in the `TC_GCAST` tests as the step is still called leading to such failure:
`Details=Unexpected test step: 11 - steps not called in order, or step does not exist, Extras=None`

Fix is to use 
```
If X:
  mark_step_range_skipped("a")
else:
  execute steps
```
  
 or in the skip  all remaining
```
 If X
    mark_all_remaining_steps_skipped("z")
    return
```

#### Related issues
N/A

#### Testing
Run modified TC_GCAST (2.4,2.5 and 2.7)against Darwin all cluster app and Silabs Lighting-app.
Confirm skips are done when appropiated and do not fail the test.