### PR TITLE
[Thermostat-app] FeatureMap updated from 0x1A3 to 0x5A3 for Thermostat cluster to match the spec

### DIFF
--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -2987,7 +2987,7 @@ endpoint 1 {
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute attributeList;
-    ram      attribute featureMap default = 0x1A3;
+    ram      attribute featureMap default = 0x5A3;
     callback attribute clusterRevision;
 
     handle command SetpointRaiseLower;

--- a/examples/thermostat/thermostat-common/thermostat.zap
+++ b/examples/thermostat/thermostat-common/thermostat.zap
@@ -5404,7 +5404,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x1A3",
+              "defaultValue": "0x5A3",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,


### PR DESCRIPTION
#### Summary

- Enable TSUGGEST (Thermostat Suggestions) feature in thermostat-app by updating FeatureMap to include bit 10.
- FeatureMap updated from 0x1A3 to 0x5A3.

#### Related issues

Fix for: https://github.com/project-chip/connectedhomeip/issues/42197

#### Testing

- **Regenerated the zap**: ./scripts/tools/zap/generate.py examples/thermostat/thermostat-common/thermostat-app.zap
- **Built the thermostat-app:** scripts/examples/gn_build_example.sh examples/thermostat/linux/ examples/thermostat/linux/out/thermostat chip_inet_config_enable_ipv4=false
- Tested with chip-tool and verified the FeatureMap values is 1443

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
