### PR TITLE
[CodeCov] Fix Build: Remove broken symlinks from repo 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -547,6 +547,8 @@ jobs:
                 apt-get update
                 apt-get install -y --no-install-recommends gnupg
             - name: Upload coverage reports to Codecov with GitHub Action
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+              with:
+                fail_ci_if_error: true
               env:
                 CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/examples/platform/esp32/external_platform/ESP32_custom/LwIPCoreLock.cpp
+++ b/examples/platform/esp32/external_platform/ESP32_custom/LwIPCoreLock.cpp
@@ -1,1 +1,0 @@
-../../../../../src/platform/ESP32/LwIPCoreLock.cpp

--- a/examples/platform/esp32/external_platform/ESP32_custom/SystemTimeSupport.h
+++ b/examples/platform/esp32/external_platform/ESP32_custom/SystemTimeSupport.h
@@ -1,1 +1,0 @@
-../../../../../src/platform/ESP32/SystemTimeSupport.h


### PR DESCRIPTION
#### Summary

- couple of broken symlinks were blocking codecov from uploading report, removing these.
- in CI, the Step of uploading the report was failing silently, make it turn RED if that step fails

- Fixes https://github.com/project-chip/connectedhomeip/issues/36556
#### Testing

CI