### PR TITLE
[Groupcast]Use All-cluster-app to run the TC_GCAST test in CI. 

### DIFF
--- a/src/python_testing/TC_GCAST_2_1.py
+++ b/src/python_testing/TC_GCAST_2_1.py
@@ -20,7 +20,7 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
-#     app: ${LIGHTING_APP_NO_UNIQUE_ID}
+#     app: ${ALL_CLUSTERS_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_GCAST_2_3.py
+++ b/src/python_testing/TC_GCAST_2_3.py
@@ -20,7 +20,7 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
-#     app: ${LIGHTING_APP_NO_UNIQUE_ID}
+#     app: ${ALL_CLUSTERS_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_GCAST_2_4.py
+++ b/src/python_testing/TC_GCAST_2_4.py
@@ -20,7 +20,7 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
-#     app: ${LIGHTING_APP_NO_UNIQUE_ID}
+#     app: ${ALL_CLUSTERS_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_GCAST_2_5.py
+++ b/src/python_testing/TC_GCAST_2_5.py
@@ -20,7 +20,7 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
-#     app: ${LIGHTING_APP_NO_UNIQUE_ID}
+#     app: ${ALL_CLUSTERS_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_GCAST_2_6.py
+++ b/src/python_testing/TC_GCAST_2_6.py
@@ -20,7 +20,7 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
-#     app: ${LIGHTING_APP_NO_UNIQUE_ID}
+#     app: ${ALL_CLUSTERS_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_GCAST_2_7.py
+++ b/src/python_testing/TC_GCAST_2_7.py
@@ -20,7 +20,7 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
-#     app: ${LIGHTING_APP_NO_UNIQUE_ID}
+#     app: ${ALL_CLUSTERS_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -186,7 +186,7 @@ not_automated:
           onboarding data security requirements)
     - name: TC_GCAST_common.py
       reason: Shared code for TC_GCAST, not a standalone test.
-    - name: TC_GCAST_2_1.py
+    - name: TC_GCAST_2_2.py
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.
@@ -202,11 +202,11 @@ not_automated:
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.
-    - name: TC_GCAST_2_6.py
+    - name: TC_GCAST_2_7.py
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.
-    - name: TC_GCAST_2_7.py
+    - name: TC_GCAST_2_8.py
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.


### PR DESCRIPTION
#### Summary
- Target All-cluster-app as the app to use for TC_GCAST tests
- Enable GCAST_2.1 and 2.6 runs on CI. 
- Preemptively disable 2.2 and 2.8 from ci until they are fully supported/passing (will fix ci for #42880)

#### Related issues
N/A

#### Testing
CI should run the 2.1  and 2.6 successfully on all-cluster-app.


