### PR TITLE
Groupcast: Notify UsedMcastAddrCount changes.

### DIFF
--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -23,6 +23,7 @@ CHIP_ERROR GroupcastCluster::Startup(ServerClusterContext & context)
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
 
     mLogic.SetDataModelProvider(context.provider);
+    mLogic.SetListener(this);
 
     return CHIP_NO_ERROR;
 }
@@ -119,11 +120,6 @@ std::optional<DataModel::ActionReturnStatus> GroupcastCluster::InvokeCommand(con
         break;
     }
 
-    if (status == Protocols::InteractionModel::Status::Success)
-    {
-        NotifyAttributeChanged(Groupcast::Attributes::Membership::Id);
-    }
-
     return status;
 }
 
@@ -175,6 +171,16 @@ void GroupcastCluster::OnGroupcastTestingDone(System::Layer * aLayer, void * app
     GroupcastCluster * cluster = reinterpret_cast<GroupcastCluster *>(appState);
     cluster->SetFabricUnderTest(kUndefinedFabricIndex);
     cluster->mTestingState = Groupcast::GroupcastTestingEnum::kDisableTesting;
+}
+
+void GroupcastCluster::OnMembershipChanged()
+{
+    NotifyAttributeChanged(Groupcast::Attributes::Membership::Id);
+}
+
+void GroupcastCluster::OnUsedMcastAddrCountChange()
+{
+    NotifyAttributeChanged(Groupcast::Attributes::UsedMcastAddrCount::Id);
 }
 
 } // namespace Clusters

--- a/src/app/clusters/groupcast/GroupcastCluster.h
+++ b/src/app/clusters/groupcast/GroupcastCluster.h
@@ -29,7 +29,7 @@ using Status = chip::Protocols::InteractionModel::Status;
 /**
  * @brief Provides code-driven implementation for the Groupcast cluster server.
  */
-class GroupcastCluster : public DefaultServerCluster
+class GroupcastCluster : public DefaultServerCluster, public GroupcastLogic::Listener
 {
 public:
     GroupcastCluster(GroupcastContext && context) :
@@ -58,6 +58,9 @@ public:
 private:
     void SetFabricUnderTest(FabricIndex fabricUnderTest);
     static void OnGroupcastTestingDone(System::Layer * aLayer, void * appState);
+    // GroupcastLogic::Listener implementation
+    void OnMembershipChanged() override;
+    void OnUsedMcastAddrCountChange() override;
 
     GroupcastContext mContext;
     GroupcastLogic mLogic;

--- a/src/app/server-cluster/testing/TestProviderChangeListener.h
+++ b/src/app/server-cluster/testing/TestProviderChangeListener.h
@@ -33,6 +33,24 @@ public:
     std::vector<app::AttributePathParams> & DirtyList() { return mDirtyList; }
     const std::vector<app::AttributePathParams> & DirtyList() const { return mDirtyList; }
 
+    /**
+     * @brief Check if a specific attribute path is dirty.
+     *
+     * @param path The concrete attribute path to check
+     * @return true if the path is dirty, false otherwise
+     */
+    bool IsDirty(const app::ConcreteAttributePath & path) const
+    {
+        for (const auto & dirtyPath : mDirtyList)
+        {
+            if (dirtyPath.IsAttributePathSupersetOf(path))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
 private:
     std::vector<app::AttributePathParams> mDirtyList;
 };


### PR DESCRIPTION
#### Summary

* Increase the number of Listeners of GroupDataProvider from 1 to 2.
* `GroupcastLogic` listens for groups added, and removed, and calculate changes in the number of multicast addresses used.
* `GroupcastCluster` now listens and report changes in `Membership` and `UsedMcastAddrCount`
* Test cases added

#### Related issues

N/A

#### Testing

* TestGeneralCommissioningCluster
* TestGeneralDiagnosticsCluster
* TestGroupcastCluster
* TestGroupDataProvider
* TestGroupedCallbackList
* TestGroupKeyManagementCluster
* TestGroupMessageCounter
* TestGroupOperationalCredentials

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
