### PR TITLE
[Groupcast] Implement GroupcastTesting command handling and FabricUnderTest attribute

### DIFF
--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -135,25 +135,33 @@ CHIP_ERROR GroupcastCluster::AcceptedCommands(const ConcreteClusterPath & path,
 
 Status GroupcastCluster::GroupcastTesting(FabricIndex fabricIndex, Groupcast::Commands::GroupcastTesting::DecodableType data)
 {
-    if (data.durationSeconds.HasValue() && data.testOperation != Groupcast::GroupcastTestingEnum::kDisableTesting)
+    VerifyOrReturnError(mFabricUnderTest == kUndefinedFabricIndex || mFabricUnderTest == fabricIndex, Status::ConstraintError);
+
+    if (data.testOperation == Groupcast::GroupcastTestingEnum::kDisableTesting)
+    {
+        // cancel any existing GroupcastTesting timer
+        DeviceLayer::SystemLayer().CancelTimer(OnGroupcastTestingDone, this);
+        mTestingState = data.testOperation;
+        SetFabricUnderTest(kUndefinedFabricIndex);
+        return Status::Success;
+    }
+
+    constexpr uint16_t kDefaultDurationSeconds = 60;
+    System::Clock::Seconds32 duration          = System::Clock::Seconds32(kDefaultDurationSeconds);
+    if (data.durationSeconds.HasValue())
     {
         constexpr uint16_t kMinDurationSeconds = 10, kMaxDurationSeconds = 1200;
         VerifyOrReturnError(data.durationSeconds.Value() >= kMinDurationSeconds &&
                                 data.durationSeconds.Value() <= kMaxDurationSeconds,
                             Status::ConstraintError);
-        VerifyOrReturnError(CHIP_NO_ERROR ==
-                                DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(data.durationSeconds.Value()),
-                                                                      OnGroupcastTestingDone, this),
-                            Status::Failure);
-    }
-    else
-    {
-        // cancel any existing GroupcastTesting timer
-        DeviceLayer::SystemLayer().CancelTimer(OnGroupcastTestingDone, this);
+        duration = System::Clock::Seconds32(data.durationSeconds.Value());
     }
 
+    VerifyOrReturnError(CHIP_NO_ERROR == DeviceLayer::SystemLayer().StartTimer(duration, OnGroupcastTestingDone, this),
+                        Status::Failure);
+
     mTestingState = data.testOperation;
-    SetFabricUnderTest((mTestingState == Groupcast::GroupcastTestingEnum::kDisableTesting) ? kUndefinedFabricIndex : fabricIndex);
+    SetFabricUnderTest(fabricIndex);
     return Status::Success;
 }
 

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -29,6 +29,7 @@ CHIP_ERROR GroupcastCluster::Startup(ServerClusterContext & context)
 
 void GroupcastCluster::Shutdown(ClusterShutdownType shutdownType)
 {
+    DeviceLayer::SystemLayer().CancelTimer(OnGroupcastTestingDone, this);
     mLogic.ResetDataModelProvider();
     DefaultServerCluster::Shutdown(shutdownType);
 }
@@ -70,7 +71,7 @@ std::optional<DataModel::ActionReturnStatus> GroupcastCluster::InvokeCommand(con
     VerifyOrReturnValue(nullptr != handler, Protocols::InteractionModel::Status::InvalidAction);
     FabricIndex fabric_index = handler->GetAccessingFabricIndex();
 
-    [[maybe_unused]] Protocols::InteractionModel::Status status = Protocols::InteractionModel::Status::UnsupportedCommand;
+    Protocols::InteractionModel::Status status = Protocols::InteractionModel::Status::UnsupportedCommand;
 
     switch (request.path.mCommandId)
     {
@@ -134,12 +135,12 @@ CHIP_ERROR GroupcastCluster::AcceptedCommands(const ConcreteClusterPath & path,
 
 Status GroupcastCluster::GroupcastTesting(FabricIndex fabricIndex, Groupcast::Commands::GroupcastTesting::DecodableType data)
 {
-    if (data.durationSeconds.HasValue())
+    if (data.durationSeconds.HasValue() && data.testOperation != Groupcast::GroupcastTestingEnum::kDisableTesting)
     {
-        constexpr uint16_t kMinDuration = 10, kMaxDuration = 1200;
-        VerifyOrReturnError(data.durationSeconds.Value() >= kMinDuration && data.durationSeconds.Value() <= kMaxDuration,
+        constexpr uint16_t kMinDurationSeconds = 10, kMaxDurationSeconds = 1200;
+        VerifyOrReturnError(data.durationSeconds.Value() >= kMinDurationSeconds &&
+                                data.durationSeconds.Value() <= kMaxDurationSeconds,
                             Status::ConstraintError);
-        DeviceLayer::SystemLayer().CancelTimer(OnGroupcastTestingDone, this);
         VerifyOrReturnError(CHIP_NO_ERROR ==
                                 DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(data.durationSeconds.Value()),
                                                                       OnGroupcastTestingDone, this),
@@ -158,11 +159,7 @@ Status GroupcastCluster::GroupcastTesting(FabricIndex fabricIndex, Groupcast::Co
 
 void GroupcastCluster::SetFabricUnderTest(FabricIndex fabricUnderTest)
 {
-    if (mFabricUnderTest != fabricUnderTest)
-    {
-        mFabricUnderTest = fabricUnderTest;
-        NotifyAttributeChanged(Groupcast::Attributes::FabricUnderTest::Id);
-    }
+    SetAttributeValue(mFabricUnderTest, fabricUnderTest, Groupcast::Attributes::FabricUnderTest::Id);
 }
 
 void GroupcastCluster::OnGroupcastTestingDone(System::Layer * aLayer, void * appState)

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -12,10 +12,9 @@ namespace Clusters {
 namespace {
 
 constexpr DataModel::AcceptedCommandEntry kAcceptedCommands[] = {
-    Groupcast::Commands::JoinGroup::kMetadataEntry,
-    Groupcast::Commands::LeaveGroup::kMetadataEntry,
-    Groupcast::Commands::UpdateGroupKey::kMetadataEntry,
-    Groupcast::Commands::ConfigureAuxiliaryACL::kMetadataEntry,
+    Groupcast::Commands::JoinGroup::kMetadataEntry,        Groupcast::Commands::LeaveGroup::kMetadataEntry,
+    Groupcast::Commands::UpdateGroupKey::kMetadataEntry,   Groupcast::Commands::ConfigureAuxiliaryACL::kMetadataEntry,
+    Groupcast::Commands::GroupcastTesting::kMetadataEntry,
 };
 } // namespace
 
@@ -52,7 +51,7 @@ DataModel::ActionReturnStatus GroupcastCluster::ReadAttribute(const DataModel::R
     case Groupcast::Attributes::UsedMcastAddrCount::Id:
         return mLogic.ReadUsedMcastAddrCount(request.path.mEndpointId, encoder);
     case Groupcast::Attributes::FabricUnderTest::Id:
-        return mLogic.ReadFabricUnderTest(request.path.mEndpointId, encoder);
+        return encoder.Encode(mFabricUnderTest);
     }
     return Protocols::InteractionModel::Status::UnsupportedAttribute;
 }
@@ -109,6 +108,12 @@ std::optional<DataModel::ActionReturnStatus> GroupcastCluster::InvokeCommand(con
         status = mLogic.ConfigureAuxiliaryACL(fabric_index, data);
     }
     break;
+    case Groupcast::Commands::GroupcastTesting::Id: {
+        Groupcast::Commands::GroupcastTesting::DecodableType data;
+        ReturnErrorOnFailure(data.Decode(arguments, fabric_index));
+        status = GroupcastTesting(fabric_index, data);
+    }
+    break;
     default:
         break;
     }
@@ -125,6 +130,40 @@ CHIP_ERROR GroupcastCluster::AcceptedCommands(const ConcreteClusterPath & path,
                                               ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder)
 {
     return builder.ReferenceExisting(kAcceptedCommands);
+}
+
+Status GroupcastCluster::GroupcastTesting(FabricIndex fabricIndex, Groupcast::Commands::GroupcastTesting::DecodableType data)
+{
+    if (data.durationSeconds.HasValue())
+    {
+        constexpr uint16_t kMinDuration = 10, kMaxDuration = 1200;
+        VerifyOrReturnError(data.durationSeconds.Value() >= kMinDuration && data.durationSeconds.Value() <= kMaxDuration,
+                            Status::ConstraintError);
+        VerifyOrReturnError(CHIP_NO_ERROR ==
+                                DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(data.durationSeconds.Value()),
+                                                                      OnGroupcastTestingDone, this),
+                            Status::Failure);
+    }
+
+    mTestingState = data.testOperation;
+    SetFabricUnderTest((mTestingState == Groupcast::GroupcastTestingEnum::kDisableTesting) ? kUndefinedFabricIndex : fabricIndex);
+    return Status::Success;
+}
+
+void GroupcastCluster::SetFabricUnderTest(FabricIndex fabricUnderTest)
+{
+    if (mFabricUnderTest != fabricUnderTest)
+    {
+        mFabricUnderTest = fabricUnderTest;
+        NotifyAttributeChanged(Groupcast::Attributes::FabricUnderTest::Id);
+    }
+}
+
+void GroupcastCluster::OnGroupcastTestingDone(System::Layer * aLayer, void * appState)
+{
+    GroupcastCluster * cluster = reinterpret_cast<GroupcastCluster *>(appState);
+    cluster->SetFabricUnderTest(kUndefinedFabricIndex);
+    cluster->mTestingState = Groupcast::GroupcastTestingEnum::kDisableTesting;
 }
 
 } // namespace Clusters

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -70,7 +70,7 @@ std::optional<DataModel::ActionReturnStatus> GroupcastCluster::InvokeCommand(con
     VerifyOrReturnValue(nullptr != handler, Protocols::InteractionModel::Status::InvalidAction);
     FabricIndex fabric_index = handler->GetAccessingFabricIndex();
 
-    Protocols::InteractionModel::Status status = Protocols::InteractionModel::Status::UnsupportedCommand;
+    [[maybe_unused]] Protocols::InteractionModel::Status status = Protocols::InteractionModel::Status::UnsupportedCommand;
 
     switch (request.path.mCommandId)
     {
@@ -111,7 +111,7 @@ std::optional<DataModel::ActionReturnStatus> GroupcastCluster::InvokeCommand(con
     case Groupcast::Commands::GroupcastTesting::Id: {
         Groupcast::Commands::GroupcastTesting::DecodableType data;
         ReturnErrorOnFailure(data.Decode(arguments, fabric_index));
-        status = GroupcastTesting(fabric_index, data);
+        return GroupcastTesting(fabric_index, data);
     }
     break;
     default:
@@ -139,10 +139,16 @@ Status GroupcastCluster::GroupcastTesting(FabricIndex fabricIndex, Groupcast::Co
         constexpr uint16_t kMinDuration = 10, kMaxDuration = 1200;
         VerifyOrReturnError(data.durationSeconds.Value() >= kMinDuration && data.durationSeconds.Value() <= kMaxDuration,
                             Status::ConstraintError);
+        DeviceLayer::SystemLayer().CancelTimer(OnGroupcastTestingDone, this);
         VerifyOrReturnError(CHIP_NO_ERROR ==
                                 DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(data.durationSeconds.Value()),
                                                                       OnGroupcastTestingDone, this),
                             Status::Failure);
+    }
+    else
+    {
+        // cancel any existing GroupcastTesting timer
+        DeviceLayer::SystemLayer().CancelTimer(OnGroupcastTestingDone, this);
     }
 
     mTestingState = data.testOperation;

--- a/src/app/clusters/groupcast/GroupcastCluster.h
+++ b/src/app/clusters/groupcast/GroupcastCluster.h
@@ -25,6 +25,7 @@ namespace chip {
 namespace app {
 namespace Clusters {
 
+using Status = chip::Protocols::InteractionModel::Status;
 /**
  * @brief Provides code-driven implementation for the Groupcast cluster server.
  */
@@ -50,9 +51,19 @@ public:
     CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path,
                                 ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder) override;
 
+    Status GroupcastTesting(FabricIndex fabricIndex, Groupcast::Commands::GroupcastTesting::DecodableType data);
+
+    inline FabricIndex GetFabricUnderTest() const { return mFabricUnderTest; }
+
 private:
+    void SetFabricUnderTest(FabricIndex fabricUnderTest);
+    static void OnGroupcastTestingDone(System::Layer * aLayer, void * appState);
+
     GroupcastContext mContext;
     GroupcastLogic mLogic;
+
+    Groupcast::GroupcastTestingEnum mTestingState = Groupcast::GroupcastTestingEnum::kDisableTesting;
+    FabricIndex mFabricUnderTest                  = kUndefinedFabricIndex;
 };
 
 } // namespace Clusters

--- a/src/app/clusters/groupcast/GroupcastLogic.cpp
+++ b/src/app/clusters/groupcast/GroupcastLogic.cpp
@@ -114,12 +114,6 @@ CHIP_ERROR GroupcastLogic::ReadUsedMcastAddrCount(EndpointId endpoint, Attribute
     return aEncoder.Encode(count);
 }
 
-CHIP_ERROR GroupcastLogic::ReadFabricUnderTest(EndpointId endpoint, AttributeValueEncoder & aEncoder)
-{
-    FabricIndex fabric_index = kUndefinedFabricIndex;
-    return aEncoder.Encode(fabric_index);
-}
-
 Status GroupcastLogic::JoinGroup(FabricIndex fabric_index, const Groupcast::Commands::JoinGroup::DecodableType & data)
 {
     GroupDataProvider & groups = Provider();

--- a/src/app/clusters/groupcast/GroupcastLogic.h
+++ b/src/app/clusters/groupcast/GroupcastLogic.h
@@ -61,7 +61,6 @@ public:
     CHIP_ERROR ReadMaxMembershipCount(EndpointId endpoint, AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadMaxMcastAddrCount(EndpointId endpoint, AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadUsedMcastAddrCount(EndpointId endpoint, AttributeValueEncoder & aEncoder);
-    CHIP_ERROR ReadFabricUnderTest(EndpointId endpoint, AttributeValueEncoder & aEncoder);
 
     Status JoinGroup(FabricIndex fabric_index, const Groupcast::Commands::JoinGroup::DecodableType & data);
     Status LeaveGroup(FabricIndex fabric_index, const Groupcast::Commands::LeaveGroup::DecodableType & data,

--- a/src/app/clusters/groupcast/tests/BUILD.gn
+++ b/src/app/clusters/groupcast/tests/BUILD.gn
@@ -27,6 +27,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/app/clusters/groupcast",
     "${chip_root}/src/app/server-cluster/testing",
+    "${chip_root}/src/app/tests:helpers",
     "${chip_root}/src/app/util/mock:mock_codegen_data_model",
     "${chip_root}/src/app/util/mock:mock_ember",
     "${chip_root}/src/lib/core:string-builder-adapters",

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -25,6 +25,7 @@
 #include <app/server-cluster/testing/MockCommandHandler.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
+#include <app/tests/AppTestContext.h>
 #include <app/util/mock/Constants.h>
 #include <app/util/mock/Functions.h>
 #include <clusters/Groupcast/Enums.h>
@@ -36,6 +37,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ReadOnlyBuffer.h>
 #include <platform/NetworkCommissioning.h>
+#include <system/RAIIMockClock.h>
 
 #include <array>
 #include <credentials/GroupDataProviderImpl.h>
@@ -49,6 +51,8 @@ using namespace chip::app;
 using namespace chip::Testing;
 using namespace chip::Credentials;
 using namespace chip::app::Clusters::Groupcast;
+using namespace chip::System;
+using namespace chip::System::Clock::Literals;
 using chip::Testing::IsAcceptedCommandsListEqualTo;
 using chip::Testing::IsAttributesListEqualTo;
 
@@ -96,20 +100,20 @@ public:
 };
 
 // initialize memory as ReadOnlyBufferBuilder may allocate
-struct TestGroupcastCluster : public ::testing::Test
+class TestGroupcastCluster : public chip::Testing::AppContext
 {
-    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
-    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+public:
+    static void SetUpTestSuite()
+    {
+        ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR);
+        AppContext::SetUpTestSuite();
+    }
 
-    TestServerClusterContext mTestContext;
-    Credentials::GroupDataProviderImpl mProvider;
-    Crypto::DefaultSessionKeystore mKeystore;
-    CustomDataModel customDataModel;
-    std::unique_ptr<ServerClusterContext> clusterContext;
-    FabricTestFixture mFabricHelper{ &mTestContext.StorageDelegate() };
-    app::Clusters::GroupcastCluster mSender{ { mFabricHelper.GetFabricTable(), mProvider }, BitFlags<Feature>{ Feature::kSender } };
-    app::Clusters::GroupcastCluster mListener{ { mFabricHelper.GetFabricTable(), mProvider },
-                                               BitFlags<Feature>{ Feature::kListener } };
+    static void TearDownTestSuite()
+    {
+        AppContext::TearDownTestSuite();
+        Platform::MemoryShutdown();
+    }
 
     void SetUp() override
     {
@@ -133,6 +137,8 @@ struct TestGroupcastCluster : public ::testing::Test
         CHIP_ERROR err = mFabricHelper.SetUpTestFabric(kTestFabricIndex);
         ASSERT_EQ(err, CHIP_NO_ERROR);
         Credentials::SetGroupDataProvider(&mProvider);
+        DeviceLayer::SetSystemLayerForTesting(&GetSystemLayer());
+        AppContext::SetUp();
     }
 
     void TearDown() override
@@ -144,6 +150,8 @@ struct TestGroupcastCluster : public ::testing::Test
         CHIP_ERROR err = mFabricHelper.TearDownTestFabric(kTestFabricIndex);
         ASSERT_EQ(err, CHIP_NO_ERROR);
         mProvider.Finish();
+        DeviceLayer::SetSystemLayerForTesting(nullptr);
+        AppContext::TearDown();
     }
 
     void AssertStatus(std::optional<app::DataModel::ActionReturnStatus> & status,
@@ -153,6 +161,16 @@ struct TestGroupcastCluster : public ::testing::Test
         EXPECT_EQ(status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
                   expected);
     }
+
+    TestServerClusterContext mTestContext;
+    Credentials::GroupDataProviderImpl mProvider;
+    Crypto::DefaultSessionKeystore mKeystore;
+    CustomDataModel customDataModel;
+    std::unique_ptr<ServerClusterContext> clusterContext;
+    FabricTestFixture mFabricHelper{ &mTestContext.StorageDelegate() };
+    app::Clusters::GroupcastCluster mSender{ { mFabricHelper.GetFabricTable(), mProvider }, BitFlags<Feature>{ Feature::kSender } };
+    app::Clusters::GroupcastCluster mListener{ { mFabricHelper.GetFabricTable(), mProvider },
+                                               BitFlags<Feature>{ Feature::kListener } };
 };
 
 TEST_F(TestGroupcastCluster, TestAttributes)
@@ -191,6 +209,7 @@ TEST_F(TestGroupcastCluster, TestAcceptedCommands)
                                                   Commands::LeaveGroup::kMetadataEntry,
                                                   Commands::UpdateGroupKey::kMetadataEntry,
                                                   Commands::ConfigureAuxiliaryACL::kMetadataEntry,
+                                                  Commands::GroupcastTesting::kMetadataEntry,
                                               }));
 }
 
@@ -859,6 +878,105 @@ TEST_F(TestGroupcastCluster, TestConfigureAuxiliaryACL)
             ASSERT_FALSE(item.hasAuxiliaryACL.Value());
         }
     }
+}
+
+TEST_F(TestGroupcastCluster, TestGroupcastTestingCommand)
+{
+    chip::Testing::ClusterTester tester(mListener);
+    tester.SetFabricIndex(kTestFabricIndex);
+
+    // Default should be "no fabric under test"
+    FabricIndex fabricUnderTest = kUndefinedFabricIndex;
+    ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
+    EXPECT_EQ(fabricUnderTest, kUndefinedFabricIndex);
+
+    // Test invalid duration
+    {
+        Commands::GroupcastTesting::Type data;
+        data.testOperation = GroupcastTestingEnum::kEnableListenerTesting;
+        // Too small
+        data.durationSeconds = MakeOptional(static_cast<uint16_t>(9));
+
+        auto result = tester.Invoke(Commands::GroupcastTesting::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::ConstraintError);
+
+        // Command failed; should not have changed.
+        ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricUnderTest, kUndefinedFabricIndex);
+
+        // Too large
+        data.durationSeconds = MakeOptional(static_cast<uint16_t>(1201));
+        result               = tester.Invoke(Commands::GroupcastTesting::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::ConstraintError);
+
+        // Command failed; should not have changed from enabled state.
+        ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricUnderTest, kUndefinedFabricIndex);
+    }
+
+    // Enable testing (no duration)
+    {
+        Commands::GroupcastTesting::Type data;
+        data.testOperation = GroupcastTestingEnum::kEnableListenerTesting;
+
+        auto result = tester.Invoke(Commands::GroupcastTesting::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+
+        ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricUnderTest, kTestFabricIndex);
+    }
+
+    // Disable testing should clear the fabric under test
+    {
+        Commands::GroupcastTesting::Type data;
+        data.testOperation = GroupcastTestingEnum::kDisableTesting;
+
+        auto result = tester.Invoke(Commands::GroupcastTesting::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+
+        ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricUnderTest, kUndefinedFabricIndex);
+    }
+
+    // Enable Listener Testing with duration
+    {
+        chip::System::Clock::Internal::RAIIMockClock mockClock;
+        const uint16_t durationSeconds = 10;
+
+        Commands::GroupcastTesting::Type data;
+        data.testOperation   = GroupcastTestingEnum::kEnableListenerTesting;
+        data.durationSeconds = MakeOptional(durationSeconds);
+
+        auto result = tester.Invoke(Commands::GroupcastTesting::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::Success);
+
+        ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricUnderTest, kTestFabricIndex);
+
+        //  Testing should still be active
+        mockClock.AdvanceMonotonic(Clock::Seconds16(durationSeconds - 1));
+        GetIOContext().DriveIO();
+        ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricUnderTest, kTestFabricIndex);
+
+        //  Testing should end after the duration
+        mockClock.AdvanceMonotonic(Clock::Seconds16(durationSeconds + 1));
+        GetIOContext().DriveIO();
+        ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricUnderTest, kUndefinedFabricIndex);
+    }
+
+    // Enable Sender Testing with duration
 }
 
 } // namespace

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -100,7 +100,7 @@ public:
 };
 
 // initialize memory as ReadOnlyBufferBuilder may allocate
-class TestGroupcastCluster : public chip::Testing::AppContext
+class TestGroupcastCluster : public AppContext
 {
 public:
     static void SetUpTestSuite()
@@ -882,7 +882,7 @@ TEST_F(TestGroupcastCluster, TestConfigureAuxiliaryACL)
 
 TEST_F(TestGroupcastCluster, TestGroupcastTestingCommand)
 {
-    chip::Testing::ClusterTester tester(mListener);
+    ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
 
     // Default should be "no fabric under test"

--- a/src/python_testing/TC_GCAST_2_2.py
+++ b/src/python_testing/TC_GCAST_2_2.py
@@ -20,7 +20,7 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
-#     app: ${LIGHTING_APP_NO_UNIQUE_ID}
+#     app: ${ALL_CLUSTERS_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_GCAST_2_5.py
+++ b/src/python_testing/TC_GCAST_2_5.py
@@ -126,7 +126,7 @@ class TC_GCAST_2_5(MatterBaseTest):
         )
 
         self.step(3)
-        membership_matcher = generate_membership_entry_matcher(groupID1, has_auxiliary_acl="true")
+        membership_matcher = generate_membership_entry_matcher(groupID1, has_auxiliary_acl=True)
         sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 
         self.step(4)
@@ -137,7 +137,7 @@ class TC_GCAST_2_5(MatterBaseTest):
 
         self.step(5)
         sub.reset()
-        membership_matcher = generate_membership_entry_matcher(groupID1, has_auxiliary_acl="false")
+        membership_matcher = generate_membership_entry_matcher(groupID1, has_auxiliary_acl=False)
         sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 
         self.step(6)

--- a/src/python_testing/TC_GCAST_2_8.py
+++ b/src/python_testing/TC_GCAST_2_8.py
@@ -20,7 +20,7 @@
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
-#     app: ${LIGHTING_APP_NO_UNIQUE_ID}
+#     app: ${ALL_CLUSTERS_APP}
 #     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_GCAST_2_8.py
+++ b/src/python_testing/TC_GCAST_2_8.py
@@ -43,7 +43,7 @@ import matter.clusters as Clusters
 from matter.testing.decorators import has_cluster, run_if_endpoint_matches
 from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
 from matter.testing.matter_testing import MatterBaseTest
-from matter.testing.runner import TestStep
+from matter.testing.runner import TestStep, default_matter_test_main
 
 logger = logging.getLogger(__name__)
 
@@ -134,3 +134,7 @@ class TC_GCAST_2_8(MatterBaseTest):
         sub.reset()
         fabric_matcher = generate_fabric_under_test_matcher(0)
         sub.await_all_expected_report_matches(expected_matchers=[fabric_matcher], timeout_sec=60)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -198,10 +198,16 @@ not_automated:
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.
+    - name: TC_GCAST_2_5.py
+      reason:
+          Test script relies on a attrribute report matcher which is currently flaky in CI.
     - name: TC_GCAST_2_7.py
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.
+    - name: TC_GCAST_2_8.py
+      reason:
+          Test script relies on a attrribute report matcher which is currently flaky in CI.
     - name: TC_ACL_2_10.py
       reason:
           Flaky, see

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -198,15 +198,7 @@ not_automated:
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.
-    - name: TC_GCAST_2_5.py
-      reason:
-          Cluster not finalized. Will re-enable before 1.6TE2. CI is not
-          supported.
     - name: TC_GCAST_2_7.py
-      reason:
-          Cluster not finalized. Will re-enable before 1.6TE2. CI is not
-          supported.
-    - name: TC_GCAST_2_8.py
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -200,14 +200,16 @@ not_automated:
           supported.
     - name: TC_GCAST_2_5.py
       reason:
-          Test script relies on a attrribute report matcher which is currently flaky in CI.
+          Test script relies on a attrribute report matcher which is currently
+          flaky in CI.
     - name: TC_GCAST_2_7.py
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.
     - name: TC_GCAST_2_8.py
       reason:
-          Test script relies on a attrribute report matcher which is currently flaky in CI.
+          Test script relies on a attrribute report matcher which is currently
+          flaky in CI.
     - name: TC_ACL_2_10.py
       reason:
           Flaky, see


### PR DESCRIPTION
#### Summary
- Implement GroupcastTesting command handling
- Implement FabricUnderTest attribute update logic and report on change.
- Add a unit test for GroupcastTesting
- Fix TC_GCAST_2_5.py and TC_GCAST_2_8.py

#### Related issues
address GroupcastTesting portion of #43224

#### Testing
Run Unit test with TestGroupcastCluster.cpp new `TestGroupcastTestingCommand`
Run `TC_GCAST_2_8.py` with darwin all-cluster-app
Run `TC_GCAST_2_5.py` with darwin all-cluster-app
