### PR TITLE
Bump mobly to 1.13 for Python 3.13 support

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -106,7 +106,7 @@ markupsafe==2.1.2
     # via jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mobly==1.12.1
+mobly==1.13.0
     # via -r requirements.all.txt
 mypy==1.16.0
     # via


### PR DESCRIPTION
#### Summary

Mobly 1.12 uses `pipes` module which was removed in Python 3.13.

```
[2026-02-19 17:05:30.235785][TEST][STDERR]    from mobly import utils                                                                                                                                                
[2026-02-19 17:05:30.235825][TEST][STDERR]  File ".../connectedhomeip/.environment/pigweed-venv/lib/python3.13/site-packages/mobly/utils.py", line 23, in <module>                                        
[2026-02-19 17:05:30.235831][TEST][STDERR]    import pipes                                                                                                                                                           
[2026-02-19 17:05:30.235846][TEST][STDERR]ModuleNotFoundError: No module named 'pipes'     
```

#### Testing

Verified locally that it's possible to run tests on Ubuntu 25.10.
CI will verify for potential breaks.