### PR TITLE
[Telink] Fix stale DTS on rebuild

### DIFF
--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -213,8 +213,7 @@ class TelinkBuilder(Builder):
         return cmd
 
     def generate(self):
-        if os.path.exists(self.output_dir):
-            return
+        os.makedirs(self.output_dir, exist_ok=True)
 
         flags = []
         if self.enable_ota:


### PR DESCRIPTION
#### Summary

Removes early return in generate() to ensure CMake configure stage runs on every build.
Fixes stale devicetree (DTS) when rebuilding with OTA+LZMA enabled without cleaning the build directory.
   
#### Testing

- Built with OTA+LZMA enabled
- Changed OTA version in `prj.conf`
- Rebuilt without removing build directory
- Verified correct `_flash_lzma.overlay` is applied in `zephyr.dts`