### PR TITLE
Groupcast: Fix missing validation in UpdateGroupKey.

### DIFF
--- a/src/app/clusters/groupcast/GroupcastLogic.cpp
+++ b/src/app/clusters/groupcast/GroupcastLogic.cpp
@@ -328,7 +328,8 @@ Status GroupcastLogic::SetKeySet(FabricIndex fabric_index, GroupId group_id, Key
     else
     {
         // No key provided, the keyset must exist
-        VerifyOrReturnError(CHIP_NO_ERROR == err, Status::NotFound);
+        VerifyOrReturnError(CHIP_ERROR_NOT_FOUND != err, Status::NotFound);
+        VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
     }
 
     // Assign keyset to group

--- a/src/app/clusters/groupcast/GroupcastLogic.cpp
+++ b/src/app/clusters/groupcast/GroupcastLogic.cpp
@@ -185,22 +185,8 @@ Status GroupcastLogic::JoinGroup(FabricIndex fabric_index, const Groupcast::Comm
     VerifyOrReturnError(new_count <= max_fabric_memberships, Status::ResourceExhausted);
 
     // Key handling
-    if (data.key.HasValue())
-    {
-        // Create a new keyset
-        Status stat = SetKeySet(fabric_index, data.keySetID, data.key.Value());
-        VerifyOrReturnError(Status::Success == stat, stat);
-    }
-    else
-    {
-        // The keyset must exist
-        GroupDataProvider::KeySet ks;
-        err = groups.GetKeySet(fabric_index, data.keySetID, ks);
-        VerifyOrReturnError(CHIP_NO_ERROR == err, Status::NotFound);
-    }
-    // Assign keyset to group
-    err = groups.SetGroupKey(fabric_index, data.groupID, data.keySetID);
-    VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
+    Status stat = SetKeySet(fabric_index, data.groupID, data.keySetID, data.key);
+    VerifyOrReturnError(Status::Success == stat, stat);
 
     // Add/update entry in the group table
     info.group_id = data.groupID;
@@ -271,18 +257,7 @@ Status GroupcastLogic::LeaveGroup(FabricIndex fabric_index, const Groupcast::Com
 
 Status GroupcastLogic::UpdateGroupKey(FabricIndex fabric_index, const Groupcast::Commands::UpdateGroupKey::DecodableType & data)
 {
-    GroupDataProvider & groups = Provider();
-
-    // Key handling
-    if (data.key.HasValue())
-    {
-        // Create a new keyset
-        Status stat = SetKeySet(fabric_index, data.keySetID, data.key.Value());
-        VerifyOrReturnError(Status::Success == stat, stat);
-    }
-    // Assign keyset to group
-    CHIP_ERROR err = groups.SetGroupKey(fabric_index, data.groupID, data.keySetID);
-    return CHIP_NO_ERROR == err ? Status::Success : Status::Failure;
+    return SetKeySet(fabric_index, data.groupID, data.keySetID, data.key);
 }
 
 Status GroupcastLogic::ConfigureAuxiliaryACL(FabricIndex fabric_index,
@@ -314,17 +289,20 @@ Status GroupcastLogic::ConfigureAuxiliaryACL(FabricIndex fabric_index,
     return Status::Success;
 }
 
-Status GroupcastLogic::SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, const chip::ByteSpan & key)
+Status GroupcastLogic::SetKeySet(FabricIndex fabric_index, GroupId group_id, KeysetId keyset_id,
+                                 const chip::Optional<chip::ByteSpan> & key)
 {
     GroupDataProvider & groups = Provider();
     GroupDataProvider::KeySet ks;
 
     CHIP_ERROR err = groups.GetKeySet(fabric_index, keyset_id, ks);
-    VerifyOrReturnError(CHIP_NO_ERROR != err, Status::AlreadyExists); // Cannot set an existing key
-
-    if (CHIP_ERROR_NOT_FOUND == err)
+    if (key.HasValue())
     {
-        // New key
+        // Key provided, the keyset must not exist
+        VerifyOrReturnError(CHIP_NO_ERROR != err, Status::AlreadyExists);
+        VerifyOrReturnError(CHIP_ERROR_NOT_FOUND == err, Status::Failure);
+
+        // Create new key
         const FabricInfo * fabric = Fabrics().FindFabricWithIndex(fabric_index);
         VerifyOrReturnValue(nullptr != fabric, Status::NotFound);
 
@@ -333,9 +311,8 @@ Status GroupcastLogic::SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, c
         ks.num_keys_used = 1;
 
         GroupDataProvider::EpochKey & epoch = ks.epoch_keys[0];
-        VerifyOrReturnValue(key.size() == GroupDataProvider::EpochKey::kLengthBytes, Status::ConstraintError);
-        memcpy(epoch.key, key.data(), GroupDataProvider::EpochKey::kLengthBytes);
-
+        VerifyOrReturnValue(key.Value().size() == GroupDataProvider::EpochKey::kLengthBytes, Status::ConstraintError);
+        memcpy(epoch.key, key.Value().data(), GroupDataProvider::EpochKey::kLengthBytes);
         {
             // Get compressed fabric
             uint8_t compressed_fabric_id_buffer[sizeof(uint64_t)];
@@ -347,10 +324,18 @@ Status GroupcastLogic::SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, c
             VerifyOrReturnError(CHIP_ERROR_INVALID_LIST_LENGTH != err, Status::ResourceExhausted);
             VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
         }
-        return Status::Success;
+    }
+    else
+    {
+        // No key provided, the keyset must exist
+        VerifyOrReturnError(CHIP_NO_ERROR == err, Status::NotFound);
     }
 
-    return Status::Failure;
+    // Assign keyset to group
+    err = groups.SetGroupKey(fabric_index, group_id, keyset_id);
+    VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
+
+    return Status::Success;
 }
 
 Status GroupcastLogic::RemoveGroup(FabricIndex fabric_index, GroupId group_id,

--- a/src/app/clusters/groupcast/GroupcastLogic.h
+++ b/src/app/clusters/groupcast/GroupcastLogic.h
@@ -76,7 +76,7 @@ private:
     Credentials::GroupDataProvider & Provider() { return mContext.groupDataProvider; }
     chip::FabricTable & Fabrics() { return mContext.fabricTable; }
 
-    Status SetKeySet(FabricIndex fabric_index, KeysetId keyset_id, const chip::ByteSpan & key);
+    Status SetKeySet(FabricIndex fabric_index, GroupId group_id, KeysetId keyset_id, const chip::Optional<chip::ByteSpan> & key);
     Status RemoveGroup(FabricIndex fabric_index, GroupId group_id, const Groupcast::Commands::LeaveGroup::DecodableType & data,
                        EndpointList & endpoints);
     Status RemoveGroupEndpoint(FabricIndex fabric_index, GroupId group_id, EndpointId endpoint_id, EndpointList & endpoints);

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -655,6 +655,7 @@ TEST_F(TestGroupcastCluster, TestUpdateGroupKey)
     const EndpointId kEndpoints[] = { 1 };
     const KeysetId kKeyset1       = 0xabcd;
     const KeysetId kKeyset2       = 0xcafe;
+    const KeysetId kKeyset3       = 0xface;
 
     chip::Testing::ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
@@ -710,6 +711,15 @@ TEST_F(TestGroupcastCluster, TestUpdateGroupKey)
         ASSERT_TRUE(result.status.has_value());
         EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
                   Protocols::InteractionModel::Status::AlreadyExists);
+
+        // Update to non-existing keyset (invalid)
+        data.groupID  = 2;
+        data.keySetID = kKeyset3;
+        data.key.ClearValue();
+        result = tester.Invoke(Commands::UpdateGroupKey::Id, data);
+        ASSERT_TRUE(result.status.has_value());
+        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+                  Protocols::InteractionModel::Status::NotFound);
 
         // Update without key (always valid)
         data.groupID  = 2;


### PR DESCRIPTION
#### Summary

* Fixes failure in [TC_GCAST_2_3 Step 7](https://github.com/project-chip/connectedhomeip/blob/00b8d1c482cb010648c0e0b649858570d440f85b/src/python_testing/TC_GCAST_2_3.py#L170)
* The SetKeySet method now perform the common validations, and is fully shared between JoinGroup and UpdateGroupKey.
* Check added to TestGropucastCluster unit tests.

#### Related issues

N/A

#### Testing

* TestGeneralCommissioningCluster
* TestGeneralDiagnosticsCluster
* TestGroupcastCluster
* TestGroupDataProvider
* TestGroupedCallbackList
* TestGroupKeyManagementCluster
* TestGroupMessageCounter
* TestGroupOperationalCredentials

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
