### PR TITLE
[Ameba] Update docker image

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-185 : [Telink] Update Docker image (Zephyr update)
+186 : [Ameba] Update Docker image for C++ macro conflict resolution

--- a/integrations/docker/images/stage-2/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-ameba/Dockerfile
@@ -11,7 +11,7 @@ RUN set -x \
 
 # Setup Ameba
 ARG AMEBA_DIR=/opt/ameba
-ARG TAG_NAME=ameba_update_2025_10_07
+ARG TAG_NAME=ameba_update_2026_02_21
 RUN set -x \
     && apt-get update \
     && mkdir ${AMEBA_DIR} \


### PR DESCRIPTION
#### Summary

Update Ameba Docker image to ameba_update_2026_02_21
This docker image
- prevent macro conflicts with C++ standard definitions
- Guard custom ctype macros and remove true/false redefinitions to avoid clashes with C++ standard headers and built-in types.

#### Related issues

In #43193 there are macro conflicts with C++ standard in ameba platform.

#### Testing

Build pass when building with #43193 jadhavrohit924:cmake-sdk-build branch.