### PR TITLE
fix null pointer crashes (#43150)

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -391,6 +391,8 @@ deployable
 depottools
 deps
 der
+dereference
+dereferencing
 desc
 descheduled
 detokenization

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1337,6 +1337,7 @@ showDocumentation
 showsdks
 shubhamdp
 SIGINT
+SIGSEGV
 SiLabs
 Silabs's
 SiliconLabs

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -210,7 +210,14 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                             ChipLogProgress(AppServer,
                                             "CastingPlayer::VerifyOrEstablishConnection() FindOrEstablishSession Connection to "
                                             "CastingPlayer successful");
-                            CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_CONNECTED;
+                            CastingPlayer * targetCastingPlayer = CastingPlayer::GetTargetCastingPlayer();
+                            VerifyOrReturn(
+                                targetCastingPlayer != nullptr,
+                                ChipLogError(AppServer,
+                                             "CastingPlayer::VerifyOrEstablishConnection() Target CastingPlayer no longer exists, "
+                                             "skipping connection handling"));
+
+                            targetCastingPlayer->mConnectionState = CASTING_PLAYER_CONNECTED;
 
                             // this async call will Load all the endpoints with their respective attributes into the
                             // TargetCastingPlayer.
@@ -223,16 +230,25 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                             ChipLogError(AppServer,
                                          "CastingPlayer::VerifyOrEstablishConnection() FindOrEstablishSession Connection to "
                                          "CastingPlayer failed");
-                            CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
-                            CastingPlayer::GetTargetCastingPlayer()->RemoveFabric();
-                            CHIP_ERROR e = support::CastingStore::GetInstance()->Delete(*CastingPlayer::GetTargetCastingPlayer());
+                            CastingPlayer * targetCastingPlayer = CastingPlayer::GetTargetCastingPlayer();
+                            VerifyOrReturn(
+                                targetCastingPlayer != nullptr,
+                                ChipLogError(AppServer,
+                                             "CastingPlayer::VerifyOrEstablishConnection() Target CastingPlayer no longer exists, "
+                                             "skipping cleanup"));
+
+                            targetCastingPlayer->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
+                            targetCastingPlayer->RemoveFabric();
+                            CHIP_ERROR e = support::CastingStore::GetInstance()->Delete(*targetCastingPlayer);
                             if (e != CHIP_NO_ERROR)
                             {
                                 ChipLogError(AppServer, "CastingStore::Delete() failed. Err: %" CHIP_ERROR_FORMAT, e.Format());
                             }
 
-                            VerifyOrReturn(CastingPlayer::GetTargetCastingPlayer()->mOnCompleted);
-                            CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(error, nullptr);
+                            if (targetCastingPlayer->mOnCompleted)
+                            {
+                                targetCastingPlayer->mOnCompleted(error, nullptr);
+                            }
                             mTargetCastingPlayer.reset();
                         });
                     return; // FindOrEstablishSession called. Return early.

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -332,16 +332,19 @@ public:
     void OnCommissioningWindowOpened() override;
     void OnCommissioningWindowClosed() override;
 
-private:
-    std::vector<memory::Strong<Endpoint>> mEndpoints;
-    ConnectionState mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
-    CastingPlayerAttributes mAttributes;
-    IdentificationDeclarationOptions mIdOptions;
+protected:
+    // Exposed for testing - allows test code to simulate the crash scenario
     // This is a std::weak_ptr. A std::weak_ptr is a non-owning reference to an object managed by one
     // or more std::shared_ptr instances. When the last std::shared_ptr instance that owns the managed
     // object is destroyed or reset, the object itself is automatically destroyed, and all
     // std::weak_ptr instances that reference that object become expired.
     static memory::Weak<CastingPlayer> mTargetCastingPlayer;
+
+private:
+    std::vector<memory::Strong<Endpoint>> mEndpoints;
+    ConnectionState mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
+    CastingPlayerAttributes mAttributes;
+    IdentificationDeclarationOptions mIdOptions;
     uint16_t mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
     ConnectCallback mOnCompleted            = {};
     bool mClientProvidedCommissionerDeclarationCallback;

--- a/examples/tv-casting-app/tv-casting-common/core/tests/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/core/tests/BUILD.gn
@@ -14,20 +14,29 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
-# Unit tests for CastingPlayer fabric cleanup functionality
 chip_test_suite("tests") {
   output_name = "libTvCastingCommonTests"
 
-  test_sources = [ "TestCastingPlayerFabricCleanup.cpp" ]
+  test_sources = [
+    "TestCastingPlayerFabricCleanup.cpp",
+    "TestCastingPlayerNullPointerFix.cpp",
+  ]
+
+  cflags = [ "-Wconversion" ]
 
   public_deps = [
+    "$dir_pw_unit_test",
     "${chip_root}/examples/tv-casting-app/tv-casting-common",
+    "${chip_root}/src/app",
     "${chip_root}/src/app/server",
     "${chip_root}/src/credentials",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/platform",
   ]
 }
 

--- a/examples/tv-casting-app/tv-casting-common/core/tests/TestCastingPlayerNullPointerFix.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/tests/TestCastingPlayerNullPointerFix.cpp
@@ -1,0 +1,289 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for the CastingPlayer null pointer
+ *      dereference fix. These tests verify that connection callbacks properly
+ *      handle the case where the target CastingPlayer has been deleted before
+ *      the callback executes.
+ *
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <app/server/Server.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPMem.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#include "../../support/CastingStore.h"
+#include "../CastingPlayer.h"
+
+using namespace chip;
+using namespace matter::casting::core;
+using namespace matter::casting::support;
+
+namespace matter {
+namespace casting {
+namespace core {
+namespace tests {
+
+// Test helper class that provides access to protected members for testing
+class CastingPlayerTestHelper : public CastingPlayer
+{
+public:
+    CastingPlayerTestHelper() : CastingPlayer(CastingPlayerAttributes()) {}
+
+    // Static helper methods to access protected members for testing
+    static void ResetTargetCastingPlayer() { CastingPlayer::mTargetCastingPlayer.reset(); }
+
+    static void SetTargetCastingPlayer(std::shared_ptr<CastingPlayer> player) { CastingPlayer::mTargetCastingPlayer = player; }
+};
+
+class TestCastingPlayerNullPointer : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite()
+    {
+        ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
+        ASSERT_EQ(DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
+    }
+
+    static void TearDownTestSuite()
+    {
+        DeviceLayer::PlatformMgr().Shutdown();
+        chip::Platform::MemoryShutdown();
+    }
+
+    void SetUp() override
+    {
+        mCallbackExecuted = false;
+        mCallbackError    = CHIP_NO_ERROR;
+    }
+
+    void TearDown() override
+    {
+        // Reset the target casting player
+        CastingPlayerTestHelper::ResetTargetCastingPlayer();
+    }
+
+protected:
+    static bool mCallbackExecuted;
+    static CHIP_ERROR mCallbackError;
+};
+
+bool TestCastingPlayerNullPointer::mCallbackExecuted    = false;
+CHIP_ERROR TestCastingPlayerNullPointer::mCallbackError = CHIP_NO_ERROR;
+
+// =================================
+//      Unit tests
+// =================================
+
+/**
+ * Test that GetTargetCastingPlayer returns nullptr when the weak_ptr has expired
+ */
+TEST_F(TestCastingPlayerNullPointer, TestGetTargetCastingPlayerReturnsNull)
+{
+    // Create a CastingPlayer and set it as target
+    CastingPlayerAttributes attrs;
+    auto castingPlayer = std::make_shared<CastingPlayer>(attrs);
+    CastingPlayerTestHelper::SetTargetCastingPlayer(castingPlayer);
+
+    // Verify we can get the target
+    EXPECT_NE(CastingPlayer::GetTargetCastingPlayer(), nullptr);
+
+    // Reset the shared pointer to simulate deletion
+    castingPlayer.reset();
+
+    // Verify GetTargetCastingPlayer returns nullptr
+    EXPECT_EQ(CastingPlayer::GetTargetCastingPlayer(), nullptr);
+}
+
+/**
+ * Test that connection failure callback handles null target gracefully
+ * This simulates the crash scenario from the bug report
+ */
+TEST_F(TestCastingPlayerNullPointer, TestConnectionFailureCallbackWithNullTarget)
+{
+    bool callbackInvoked     = false;
+    CHIP_ERROR capturedError = CHIP_NO_ERROR;
+
+    // Create a lambda that simulates the fixed failure callback
+    auto failureCallback = [&callbackInvoked, &capturedError](const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
+        callbackInvoked = true;
+        capturedError   = error;
+
+        // This is the critical fix: check for null before dereferencing
+        CastingPlayer * targetCastingPlayer = CastingPlayer::GetTargetCastingPlayer();
+        if (targetCastingPlayer == nullptr)
+        {
+            // Should handle gracefully without crashing
+            return;
+        }
+
+        // If we got here, the target exists - in real code this would call methods
+        // We can't test the actual state change without friend access, but we verify no crash
+    };
+
+    // Create a CastingPlayer and set it as target
+    CastingPlayerAttributes attrs;
+    auto castingPlayer = std::make_shared<CastingPlayer>(attrs);
+    CastingPlayerTestHelper::SetTargetCastingPlayer(castingPlayer);
+
+    // Simulate the first failure that deletes the CastingPlayer
+    castingPlayer.reset();
+    CastingPlayerTestHelper::ResetTargetCastingPlayer();
+
+    // Now invoke the callback (simulating a second queued failure)
+    chip::ScopedNodeId peerId(0x123, 1);
+    failureCallback(peerId, CHIP_ERROR_TIMEOUT);
+
+    // Verify the callback was invoked and handled the null gracefully
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_EQ(capturedError, CHIP_ERROR_TIMEOUT);
+}
+
+/**
+ * Test that connection success callback handles null target gracefully
+ */
+TEST_F(TestCastingPlayerNullPointer, TestConnectionSuccessCallbackWithNullTarget)
+{
+    bool callbackInvoked = false;
+
+    // Create a lambda that simulates the fixed success callback
+    auto successCallback = [&callbackInvoked]() {
+        callbackInvoked = true;
+
+        // This is the critical fix: check for null before dereferencing
+        CastingPlayer * targetCastingPlayer = CastingPlayer::GetTargetCastingPlayer();
+        if (targetCastingPlayer == nullptr)
+        {
+            // Should handle gracefully without crashing
+            return;
+        }
+
+        // If we got here, the target exists - in real code this would call methods
+    };
+
+    // Simulate the CastingPlayer being deleted before callback
+    CastingPlayerTestHelper::ResetTargetCastingPlayer();
+
+    // Invoke the callback
+    successCallback();
+
+    // Verify the callback was invoked and handled the null gracefully
+    EXPECT_TRUE(callbackInvoked);
+}
+
+/**
+ * Test multiple sequential callback invocations with null target
+ * This simulates the scenario where multiple connection attempts fail
+ */
+TEST_F(TestCastingPlayerNullPointer, TestMultipleCallbacksWithNullTarget)
+{
+    int callbackCount = 0;
+
+    auto failureCallback = [&callbackCount](CHIP_ERROR error) {
+        callbackCount++;
+
+        CastingPlayer * targetCastingPlayer = CastingPlayer::GetTargetCastingPlayer();
+        if (targetCastingPlayer == nullptr)
+        {
+            return;
+        }
+
+        // Would access target here in real code
+    };
+
+    // Ensure target is null
+    CastingPlayerTestHelper::ResetTargetCastingPlayer();
+
+    // Invoke callback multiple times (simulating multiple queued failures)
+    failureCallback(CHIP_ERROR_TIMEOUT);
+    failureCallback(CHIP_ERROR_TIMEOUT);
+    failureCallback(CHIP_ERROR_TIMEOUT);
+
+    // All callbacks should have executed without crashing
+    EXPECT_EQ(callbackCount, 3);
+}
+
+/**
+ * Test that valid target is accessed correctly in callback
+ */
+TEST_F(TestCastingPlayerNullPointer, TestCallbackWithValidTarget)
+{
+    bool callbackInvoked = false;
+    bool targetWasValid  = false;
+
+    auto failureCallback = [&callbackInvoked, &targetWasValid]() {
+        callbackInvoked = true;
+
+        CastingPlayer * targetCastingPlayer = CastingPlayer::GetTargetCastingPlayer();
+        if (targetCastingPlayer == nullptr)
+        {
+            return;
+        }
+
+        // Target is valid
+        targetWasValid = true;
+    };
+
+    // Create a valid CastingPlayer and set it as target
+    CastingPlayerAttributes attrs;
+    auto castingPlayer = std::make_shared<CastingPlayer>(attrs);
+    CastingPlayerTestHelper::SetTargetCastingPlayer(castingPlayer);
+
+    // Invoke the callback
+    failureCallback();
+
+    // Verify the callback executed and found a valid target
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_TRUE(targetWasValid);
+}
+
+/**
+ * Test the race condition scenario: target deleted between null check and usage
+ * This is a theoretical test to document the expected behavior
+ */
+TEST_F(TestCastingPlayerNullPointer, TestRaceConditionDocumentation)
+{
+    // This test documents that while we check for null, there's still a theoretical
+    // race condition where the target could be deleted between the null check and usage.
+    // However, in practice, this is prevented by the single-threaded event loop model
+    // used by the CHIP stack.
+
+    CastingPlayerAttributes attrs;
+    auto castingPlayer = std::make_shared<CastingPlayer>(attrs);
+    CastingPlayerTestHelper::SetTargetCastingPlayer(castingPlayer);
+
+    CastingPlayer * rawPtr = CastingPlayer::GetTargetCastingPlayer();
+    EXPECT_NE(rawPtr, nullptr);
+
+    // In a multi-threaded scenario, the target could be deleted here
+    // But CHIP's event loop model prevents this
+
+    // The pointer is still valid because we're single-threaded
+    // We can verify it's not null but can't access private members without friend access
+    EXPECT_NE(rawPtr, nullptr);
+}
+
+} // namespace tests
+} // namespace core
+} // namespace casting
+} // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -107,12 +107,6 @@ void ChipDeviceEventHandler::Handle(const chip::DeviceLayer::ChipDeviceEvent * e
                                  "ChipDeviceEventHandler::Handle() Target CastingPlayer no longer exists, skipping cleanup"));
 
                 targetCastingPlayer->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
-                CHIP_ERROR err                        = support::CastingStore::GetInstance()->Delete(*targetCastingPlayer);
-                if (err != CHIP_NO_ERROR)
-                {
-                    ChipLogError(AppServer, "CastingStore::Delete() failed. Err: %" CHIP_ERROR_FORMAT, err.Format());
-                }
-
                 if (targetCastingPlayer->mOnCompleted)
                 {
                     targetCastingPlayer->mOnCompleted(error, nullptr);


### PR DESCRIPTION
#### Summary

* fix null pointer crashes

* add unit tests

* address feedback

* clang

(cherry picked from commit d3ec6d14cdc637280466b5e1c7b56b8534245c48)

#### Testing

build and unit tests