### PR TITLE
Fix TC_TMP_2_1.py tolerance attribute check from PICS

### DIFF
--- a/src/python_testing/TC_TMP_2_1.py
+++ b/src/python_testing/TC_TMP_2_1.py
@@ -107,7 +107,7 @@ class TC_TMP_2_1(MatterBaseTest):
                 measured_value, max_bound, "Measured value is greater than max bound")
 
         self.step(7)
-        if self.pics_guard("TMP.S.A0003"):
+        if self.pics_guard(self.check_pics("TMP.S.A0003")):
             tolerance = await self.read_single_attribute_check_success(cluster=cluster, attribute=attr.Tolerance)
             asserts.assert_greater_equal(tolerance, 0, "Tolerance is less than 0")
             asserts.assert_less_equal(tolerance, 2048, "Tolerance is greater than 2048")


### PR DESCRIPTION
#### Summary
 Read tolerance attribute test step only executes if its enabled in PICS file.

#### Testing
Tested by side loading test into Test Harness.

Read tolerance attribute failed even if it is not supported.
After the fix, the test step is correctly skipped.

