### PR TITLE
Fixing pairing failure, where auto commissioner, when used back to back will fail pairings for devices on the network already

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -788,6 +788,10 @@ void AutoCommissioner::CleanupCommissioning()
     mDeviceCommissioningInfo = ReadCommissioningInfo();
     mNeedsDST                = false;
     mNeedsNetworkSetup       = false;
+    mNeedIcdRegistration     = false;
+    mStopCommissioning       = false;
+    mAttestationElementsLen  = 0;
+    mAttestationSignatureLen = 0;
 }
 
 CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, CommissioningDelegate::CommissioningReport report)

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -787,6 +787,7 @@ void AutoCommissioner::CleanupCommissioning()
     mOperationalDeviceProxy  = OperationalDeviceProxy();
     mDeviceCommissioningInfo = ReadCommissioningInfo();
     mNeedsDST                = false;
+    mNeedsNetworkSetup       = false;
 }
 
 CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, CommissioningDelegate::CommissioningReport report)


### PR DESCRIPTION

#### Summary

The mNeedsNetworkSetup flag never Gets Reset in CleanupCommissioning()

Location: connectedhomeip/src/controller/AutoCommissioner.cpp:781-790

  void AutoCommissioner::CleanupCommissioning()
  {
      ResetNetworkAttemptType();
      mPAI.Free();
      mDAC.Free();
      mCommissioneeDeviceProxy = nullptr;
      mOperationalDeviceProxy  = OperationalDeviceProxy();
      mDeviceCommissioningInfo = ReadCommissioningInfo();
      mNeedsDST                = false;
      // ❌ mNeedsNetworkSetup is NOT reset here!
  }

This may be possible given that there was a previous pairing attempt to a device over BLE, which might have setup mNeedsNetworkSetup.


#### Testing

Ran through manual testing of pairing of two devices. 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
