### PR TITLE
Update BUILDING.md to include libevent-dev

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -91,7 +91,7 @@ satisfied with the following command:
 sudo apt-get install git gcc g++ pkg-config cmake curl libssl-dev libdbus-1-dev \
      libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev \
      python3-pip unzip libgirepository1.0-dev libcairo2-dev libreadline-dev \
-     default-jre
+     libevent-dev default-jre
 ```
 
 #### Upgrading Python on Ubuntu 22.04


### PR DESCRIPTION
#### Summary

ot-commissioner introduced via PR #43029 for Thread MeshCoP commissioning links against system libevent libraries (libevent_core, libevent_pthreads) on Linux.  But docs/guides/BUILDING.md does not list libevent-dev in the “Installing prerequisites on Linux” apt-get command.

This mismatch causes fresh local linux builds of chip-tool / Python controller (and other controller targets) to fail at link time.

#### Related issues

https://github.com/project-chip/connectedhomeip/issues/43198

#### Testing

Documentation-only change (no functional code changes). Adding it to the Linux prerequisites aligns local developer setup prerequisites.