### PR TITLE
Concurrent connection builds compiled NonConcurrent connection method

### DIFF
--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -647,6 +647,7 @@ NetworkCommissioningCluster::HandleConnectNetwork(CommandHandler & handler, cons
     return std::nullopt;
 }
 
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
 std::optional<ActionReturnStatus> NetworkCommissioningCluster::HandleNonConcurrentConnectNetwork()
 {
     ByteSpan nonConcurrentNetworkID = ByteSpan(mConnectingNetworkID, mConnectingNetworkIDLen);
@@ -655,6 +656,7 @@ std::optional<ActionReturnStatus> NetworkCommissioningCluster::HandleNonConcurre
     mpWirelessDriver->ConnectNetwork(nonConcurrentNetworkID, this);
     return std::nullopt;
 }
+#endif
 
 std::optional<ActionReturnStatus>
 NetworkCommissioningCluster::HandleReorderNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
@@ -911,6 +913,7 @@ void NetworkCommissioningCluster::OnPlatformEventHandler(const DeviceLayer::Chip
     {
         this_->OnFailSafeTimerExpired();
     }
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
     else if ((event->Type == DeviceLayer::DeviceEventType::kWiFiDeviceAvailable) ||
              (event->Type == DeviceLayer::DeviceEventType::kOperationalNetworkStarted))
 
@@ -918,6 +921,7 @@ void NetworkCommissioningCluster::OnPlatformEventHandler(const DeviceLayer::Chip
         // In Non-Concurrent mode connect the operational channel, as BLE has been stopped
         this_->HandleNonConcurrentConnectNetwork();
     }
+#endif
 }
 
 void NetworkCommissioningCluster::OnCommissioningComplete()

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
@@ -275,7 +275,9 @@ private:
     std::optional<DataModel::ActionReturnStatus>
     HandleReorderNetwork(CommandHandler & handler, const ConcreteCommandPath & commandPath,
                          const NetworkCommissioning::Commands::ReorderNetwork::DecodableType & req);
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
     std::optional<DataModel::ActionReturnStatus> HandleNonConcurrentConnectNetwork();
+#endif
 };
 
 } // namespace Clusters


### PR DESCRIPTION
… connections

#### Summary

Do not compile code performing non concurrent network connection, when we do support concurrent network connection. Inspired by the other usages of CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION compile switch which effectively cuts our NonConcurrent function calls and definitions.

It needs extra confirmation that the naming is not misleading and the code is in fact dedicated **only** for NonConcurrent usages and the fact that it was not covered by this compile switch was in fact intentional.

#### Related issues

1. Any issues addressing flash size optimizations.
2. It prevents the execution of HandleNonConcurrentConnectNetwork() When Device::Layer::DeviceEventType::kWifiDeviceAvailable and kOperationalNetworkStarted when the code is compiled with the CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION

#### Testing

Test ConcurrentConnection scenario

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
