### PR TITLE
Fixing time sync issue on Darwin

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -6327,7 +6327,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         MTRAttributePathKey : [MTRAttributePath attributePathWithEndpointID:@(0)
                                                                   clusterID:@(MTRClusterIDTypeTimeSynchronizationID)
                                                                 attributeID:@(MTRAttributeIDTypeClusterTimeSynchronizationAttributeUTCTimeID)],
-        MTRDataKey : @{
+        MTRDataKey : @ {
             MTRTypeKey : MTRNullValueType,
         }
     } ];

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -6308,6 +6308,72 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     }
 }
 
+// Tests that time synchronization loss is detected even when the cached CurrentTime
+// value has not changed (i.e. when the device power-cycles repeatedly and always
+// reports null, matching what we already have in cache from the previous cycle).
+- (void)test049b_TimeSyncLossDetectedWhenCacheUnchanged
+{
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    __auto_type * device = [MTRDevice deviceWithNodeID:kDeviceId1 deviceController:sController];
+    __auto_type * delegate = [[MTRDeviceTestDelegateWithSubscriptionSetupOverride alloc] init];
+    delegate.skipSetupSubscription = YES;
+    delegate.forceTimeSynchronizationLossDetectionCadenceToZero = YES;
+
+    [device setDelegate:delegate queue:queue];
+
+    // Build a null CurrentTime report (UTCTime = null means the device has no time).
+    NSArray * nullTimeSyncReport = @[ @{
+        MTRAttributePathKey : [MTRAttributePath attributePathWithEndpointID:@(0)
+                                                                  clusterID:@(MTRClusterIDTypeTimeSynchronizationID)
+                                                                attributeID:@(MTRAttributeIDTypeClusterTimeSynchronizationAttributeUTCTimeID)],
+        MTRDataKey : @{
+            MTRTypeKey : MTRNullValueType,
+        }
+    } ];
+
+    // Step 1: First injection primes the cache with null CurrentTime and should
+    // detect time sync loss (null UTCTime => device has no time).
+    XCTestExpectation * firstLossDetected = [self expectationWithDescription:@"First time sync loss detected"];
+    XCTestExpectation * firstReportEnd = [self expectationWithDescription:@"First report end"];
+    delegate.onTimeSynchronizationLossDetected = ^{
+        [firstLossDetected fulfill];
+    };
+    delegate.onReportEnd = ^{
+        [firstReportEnd fulfill];
+    };
+    [device unitTestInjectAttributeReport:nullTimeSyncReport fromSubscription:YES];
+    [self waitForExpectations:@[ firstLossDetected, firstReportEnd ] timeout:kTimeoutInSeconds];
+
+    // Step 2: Reset the detection callback and inject the same null report again.
+    // The cache still holds null from step 1, so readCacheValueChanged == NO.
+    // The fix ensures we still detect the time sync loss unconditionally.
+    XCTestExpectation * secondLossDetected = [self expectationWithDescription:@"Second time sync loss detected (cache unchanged)"];
+    XCTestExpectation * secondReportEnd = [self expectationWithDescription:@"Second report end"];
+    delegate.onTimeSynchronizationLossDetected = ^{
+        [secondLossDetected fulfill];
+    };
+    delegate.onReportEnd = ^{
+        [secondReportEnd fulfill];
+    };
+    [device unitTestInjectAttributeReport:nullTimeSyncReport fromSubscription:YES];
+    [self waitForExpectations:@[ secondLossDetected, secondReportEnd ] timeout:kTimeoutInSeconds];
+
+    // Step 3: Verify that a non-subscription injection does NOT trigger detection.
+    XCTestExpectation * nonSubscriptionReportEnd = [self expectationWithDescription:@"Non-subscription report end"];
+    XCTestExpectation * noLossFromRead = [self expectationWithDescription:@"No time sync loss from non-subscription report"];
+    noLossFromRead.inverted = YES;
+    delegate.onTimeSynchronizationLossDetected = ^{
+        [noLossFromRead fulfill];
+    };
+    delegate.onReportEnd = ^{
+        [nonSubscriptionReportEnd fulfill];
+    };
+    [device unitTestInjectAttributeReport:nullTimeSyncReport fromSubscription:NO];
+    [self waitForExpectations:@[ nonSubscriptionReportEnd ] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ noLossFromRead ] timeout:2];
+}
+
 - (void)test050_readAttributePaths_withWildCardPath
 {
     __auto_type * device = [MTRDevice deviceWithNodeID:kDeviceId1 deviceController:sController];

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
@@ -42,6 +42,7 @@ typedef void (^MTRDeviceTestDelegateHandler)(NSError * error);
 @property (atomic, copy, nullable) dispatch_block_t onSubscriptionReset;
 @property (atomic, nullable) NSNumber * subscriptionMaxIntervalOverride;
 @property (atomic, copy, nullable) MTRDeviceTestDelegateHandler onUTCTimeSet;
+@property (atomic, copy, nullable) dispatch_block_t onTimeSynchronizationLossDetected;
 @property (atomic) BOOL forceTimeUpdateShortDelayToZero;
 @property (atomic) BOOL forceTimeSynchronizationLossDetectionCadenceToZero;
 @end

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.m
@@ -161,6 +161,13 @@
     return self.forceTimeSynchronizationLossDetectionCadenceToZero;
 }
 
+- (void)unitTestTimeSynchronizationLossDetectedForDevice:(MTRDevice *)device
+{
+    if (self.onTimeSynchronizationLossDetected != nil) {
+        self.onTimeSynchronizationLossDetected();
+    }
+}
+
 @end
 
 @implementation MTRDeviceTestDelegateWithSubscriptionSetupOverride


### PR DESCRIPTION
#### Summary

The code that checks for “did the accessory lose time sync?” only runs when we are doing a subscription and the value we receive from the accessory is different from the cached value.  This is broken.

Consider the following sequence of events:

1. We commission the accessory and set time on it as part of commissioning.
2. The accessory power-cycles and loses track of its time.  When we set up our subscription, we get null reported for the CurrentTime attribute, and cache that value.
3. We notice that the accessory does not have time and perform a time sync.  Because the CurrentTime attribute has the C quality, the accessory does not report the updated value.  Our cached value continues to be null, even though the accessory now has a valid CurrentTime.
4. The accessory power-cycles (maybe hours or days later than step 3) and loses track of its time.  When we set up our subscription, we get null reported for the CurrentTime attribute.  This matches our cache, so we don’t perform time sync on it as part of the subscription setup.

What we should do is move the check for “did the accessory lose time sync?” out of the “did the value change from our cache?” condition and do it unconditionally.


#### Testing

Added unit tests.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
