### PR TITLE
 Fix test discovery failures that caused several Python test cases to be silently excluded from the TH UI

### DIFF
--- a/src/python_testing/TC_BINFO_3_1.py
+++ b/src/python_testing/TC_BINFO_3_1.py
@@ -45,7 +45,7 @@ class TC_BINFO_3_1(ProductAppearanceBase):
         return self.steps()
 
     def pics_TC_BINFO_3_1(self) -> list[str]:
-        return self.steps('BINFO')
+        return self.pics('BINFO')
 
     @run_if_endpoint_matches(has_attribute(Clusters.BasicInformation.Attributes.ProductAppearance))
     async def test_TC_BINFO_3_1(self):

--- a/src/python_testing/TC_BRBINFO_3_1.py
+++ b/src/python_testing/TC_BRBINFO_3_1.py
@@ -31,7 +31,7 @@ class TC_BRBINFO_3_1(ProductAppearanceBase):
         return self.steps()
 
     def pics_TC_BRBINFO_3_1(self) -> list[str]:
-        return self.steps('BRBINFO')
+        return self.pics('BRBINFO')
 
     @run_if_endpoint_matches(has_attribute(Clusters.BridgedDeviceBasicInformation.Attributes.ProductAppearance))
     async def test_TC_BRBINFO_3_1(self):

--- a/src/python_testing/TC_JFDS_2_1.py
+++ b/src/python_testing/TC_JFDS_2_1.py
@@ -115,8 +115,7 @@ class TC_JFDS_2_1(MatterBaseTest):
 
         # Commission JF-ADMIN app with JF-Controller on Fabric A
         self.fabric_a_ctrl.send(
-            message=f"pairing onnetwork-long {self.jfadmin_fabric_a_node_id} {self.jfadmin_fabric_a_passcode} {
-                self.jfadmin_fabric_a_discriminator} --anchor true",
+            message=f"pairing onnetwork-long {self.jfadmin_fabric_a_node_id} {self.jfadmin_fabric_a_passcode} {self.jfadmin_fabric_a_discriminator} --anchor true",
             expected_output=f"[JF] Anchor Administrator (nodeId={self.jfadmin_fabric_a_node_id}) commissioned with success",
             timeout=30)
 

--- a/src/python_testing/support_modules/product_appearance.py
+++ b/src/python_testing/support_modules/product_appearance.py
@@ -23,7 +23,7 @@ from matter.testing.runner import TestStep
 
 
 class ProductAppearanceBase(MatterBaseTest):
-    def steps(self) -> list[TestStep]:
+    def steps(self, test=None) -> list[TestStep]:
         return [
             TestStep(0, "DUT commissioned if not already done", is_commissioning=True),
             TestStep(1, "TH reads ProductAppearance attribute from the DUT.",

--- a/src/python_testing/support_modules/product_appearance.py
+++ b/src/python_testing/support_modules/product_appearance.py
@@ -23,7 +23,7 @@ from matter.testing.runner import TestStep
 
 
 class ProductAppearanceBase(MatterBaseTest):
-    def steps(self, test=None) -> list[TestStep]:
+    def steps(self) -> list[TestStep]:
         return [
             TestStep(0, "DUT commissioned if not already done", is_commissioning=True),
             TestStep(1, "TH reads ProductAppearance attribute from the DUT.",


### PR DESCRIPTION
#### Summary
 Fix test discovery failures that caused several Python test cases to be silently excluded from the TH UI in TH v2.15-beta2.1+spring2026 version.

  TC_BINFO_3_1.py / TC_BRBINFO_3_1.py
  - Fixed copy-paste bug in pics_TC_BINFO_3_1() and pics_TC_BRBINFO_3_1() where both methods were calling
  self.steps(cluster_pics) instead of self.pics(cluster_pics). 

  TC_JFDS_2_1.py
  - Fixed a Python syntax error caused by an f-string expression spanning multiple lines using implicit line
  continuation inside {} braces. T

#### Related issues
https://github.com/project-chip/certification-tool/issues/880

#### Testing
The missing test cases (TC_BINFO_3_1.py / TC_BRBINFO_3_1.py and  TC_JFDS_2_1.py) are now listed in UI. The other missing test case are addressed in this TH backend [PR](https://github.com/project-chip/certification-tool-backend/pull/300)
<img width="996" height="386" alt="Screenshot 2026-02-23 at 18 27 00" src="https://github.com/user-attachments/assets/504075ab-8d60-4291-9520-d5a4b412acf1" />
<img width="1007" height="534" alt="Screenshot 2026-02-23 at 18 26 19" src="https://github.com/user-attachments/assets/de195027-af32-46f5-a381-95fc6b561df3" />

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
