### PR TITLE
[NXP] Adding the possibility to redefine FactoryDataPrvdImpl instance

### DIFF
--- a/config/nxp/cmake/Kconfig.matter.nxp
+++ b/config/nxp/cmake/Kconfig.matter.nxp
@@ -116,6 +116,15 @@ config CHIP_ENABLE_SECURE_WHOLE_FACTORY_DATA
 	help
 		This mode allows to protect the matter factory dataset with a AES key protected in the secure element.
 
+config CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
+	bool "Custom factory data provider singleton implementation"
+	default y if CHIP_SE05X_SPAKE_VERIFIER_USE_TP_VALUES || CHIP_SE05X_DEVICE_ATTESTATION
+	help
+		Allows to use a custom factory data provider singleton implementation.
+		If enabled, the user must define a custom singleton implementation.
+		Such feature could be useful when only a subset of the platform factory data module needs to be replaced.
+		Application may in this case override only method(s) that need to be customized.
+
 endif
 
 if CHIP_FACTORY_DATA_BUILD

--- a/config/nxp/cmake/Kconfig.matter.nxp
+++ b/config/nxp/cmake/Kconfig.matter.nxp
@@ -122,8 +122,9 @@ config CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 	help
 		Allows to use a custom factory data provider singleton implementation.
 		If enabled, the user must define a custom singleton implementation.
-		Such feature could be useful when only a subset of the platform factory data module needs to be replaced.
-		Application may in this case override only method(s) that need to be customized.
+		Such feature is useful when an application needs to customize the factory data provider behavior.
+		The application can provide its own singleton, for example by creating
+		a class that inherits from FactoryDataProviderImpl and overrides only the methods that need customization.
 
 endif
 

--- a/src/platform/nxp/common/factory_data/FactoryDataProviderFwkImpl.cpp
+++ b/src/platform/nxp/common/factory_data/FactoryDataProviderFwkImpl.cpp
@@ -112,10 +112,12 @@ CHIP_ERROR FactoryDataProviderImpl::SetEncryptionMode(EncryptionMode mode)
     return error;
 }
 
+#ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
     return FactoryDataProviderImpl::sInstance;
 }
+#endif
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/common/factory_data/FactoryDataProviderFwkImpl.cpp
+++ b/src/platform/nxp/common/factory_data/FactoryDataProviderFwkImpl.cpp
@@ -22,8 +22,6 @@
 namespace chip {
 namespace DeviceLayer {
 
-FactoryDataProviderImpl FactoryDataProviderImpl::sInstance;
-
 CHIP_ERROR FactoryDataProviderImpl::SearchForId(uint8_t searchedType, uint8_t * pBuf, size_t bufLength, uint16_t & length,
                                                 uint32_t * contentAddr)
 {
@@ -115,7 +113,8 @@ CHIP_ERROR FactoryDataProviderImpl::SetEncryptionMode(EncryptionMode mode)
 #ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
-    return FactoryDataProviderImpl::sInstance;
+    static FactoryDataProviderImpl sInstance;
+    return sInstance;
 }
 #endif
 

--- a/src/platform/nxp/common/factory_data/FactoryDataProviderFwkImpl.h
+++ b/src/platform/nxp/common/factory_data/FactoryDataProviderFwkImpl.h
@@ -34,8 +34,6 @@ namespace DeviceLayer {
 class FactoryDataProviderImpl : public FactoryDataProvider
 {
 public:
-    static FactoryDataProviderImpl sInstance;
-
     CHIP_ERROR SearchForId(uint8_t searchedType, uint8_t * pBuf, size_t bufLength, uint16_t & length,
                            uint32_t * contentAddr = NULL);
     ~FactoryDataProviderImpl(){};

--- a/src/platform/nxp/common/factory_data/legacy/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/common/factory_data/legacy/FactoryDataProviderImpl.cpp
@@ -354,10 +354,12 @@ void FactoryDataProviderImpl::SSS_RunApiTest()
 #endif // CHIP_DEVICE_CONFIG_ENABLE_SSS_API_TEST
 #endif // CHIP_USE_PLAIN_DAC_KEY
 
+#ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
     return FactoryDataProviderImpl::sInstance;
 }
+#endif
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/common/factory_data/legacy/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/common/factory_data/legacy/FactoryDataProviderImpl.cpp
@@ -34,8 +34,6 @@ static constexpr size_t kPrivateKeyBlobLength  = Crypto::kP256_PrivateKey_Length
 
 uint32_t FactoryDataProvider::kFactoryDataMaxSize = 0x800;
 
-FactoryDataProviderImpl FactoryDataProviderImpl::sInstance;
-
 FactoryDataProviderImpl::FactoryDataProviderImpl()
 {
 #if CONFIG_CHIP_OTA_FACTORY_DATA_PROCESSOR
@@ -357,7 +355,8 @@ void FactoryDataProviderImpl::SSS_RunApiTest()
 #ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
-    return FactoryDataProviderImpl::sInstance;
+    static FactoryDataProviderImpl sInstance;
+    return sInstance;
 }
 #endif
 

--- a/src/platform/nxp/common/factory_data/legacy/FactoryDataProviderImpl.h
+++ b/src/platform/nxp/common/factory_data/legacy/FactoryDataProviderImpl.h
@@ -47,8 +47,6 @@ namespace DeviceLayer {
 class FactoryDataProviderImpl : public FactoryDataProvider
 {
 public:
-    static FactoryDataProviderImpl sInstance;
-
     FactoryDataProviderImpl();
     ~FactoryDataProviderImpl();
 

--- a/src/platform/nxp/rt/rt1060/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/rt/rt1060/FactoryDataProviderImpl.cpp
@@ -55,8 +55,6 @@ extern uint32_t __FACTORY_DATA_SIZE[];
 namespace chip {
 namespace DeviceLayer {
 
-FactoryDataProviderImpl FactoryDataProviderImpl::sInstance;
-
 CHIP_ERROR FactoryDataProviderImpl::SearchForId(uint8_t searchedType, uint8_t * pBuf, size_t bufLength, uint16_t & length,
                                                 uint32_t * contentAddr)
 {
@@ -342,7 +340,8 @@ CHIP_ERROR FactoryDataProviderImpl::Hash256(const uint8_t * input, size_t inputS
 #ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
-    return FactoryDataProviderImpl::sInstance;
+    static FactoryDataProviderImpl sInstance;
+    return sInstance;
 }
 #endif
 

--- a/src/platform/nxp/rt/rt1060/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/rt/rt1060/FactoryDataProviderImpl.cpp
@@ -339,10 +339,12 @@ CHIP_ERROR FactoryDataProviderImpl::Hash256(const uint8_t * input, size_t inputS
     return CHIP_NO_ERROR;
 }
 
+#ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
     return FactoryDataProviderImpl::sInstance;
 }
+#endif
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/rt/rt1060/FactoryDataProviderImpl.h
+++ b/src/platform/nxp/rt/rt1060/FactoryDataProviderImpl.h
@@ -49,8 +49,6 @@ namespace DeviceLayer {
 class FactoryDataProviderImpl : public FactoryDataProvider
 {
 public:
-    static FactoryDataProviderImpl sInstance;
-
     CHIP_ERROR SearchForId(uint8_t searchedType, uint8_t * pBuf, size_t bufLength, uint16_t & length,
                            uint32_t * contentAddr = NULL);
     ~FactoryDataProviderImpl(){};

--- a/src/platform/nxp/rt/rw61x/FactoryDataProviderEl2GoImpl.cpp
+++ b/src/platform/nxp/rt/rw61x/FactoryDataProviderEl2GoImpl.cpp
@@ -260,10 +260,12 @@ CHIP_ERROR FactoryDataProviderImpl::Init(void)
     return CHIP_NO_ERROR;
 }
 
+#ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
     return FactoryDataProviderImpl::sInstance;
 }
+#endif
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/rt/rw61x/FactoryDataProviderEl2GoImpl.cpp
+++ b/src/platform/nxp/rt/rw61x/FactoryDataProviderEl2GoImpl.cpp
@@ -63,8 +63,6 @@ using namespace ::chip::Crypto;
 namespace chip {
 namespace DeviceLayer {
 
-FactoryDataProviderImpl FactoryDataProviderImpl::sInstance;
-
 CHIP_ERROR FactoryDataProviderImpl::SearchForId(uint8_t searchedType, uint8_t * pBuf, size_t bufLength, uint16_t & length,
                                                 uint32_t * contentAddr)
 {
@@ -263,7 +261,8 @@ CHIP_ERROR FactoryDataProviderImpl::Init(void)
 #ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
-    return FactoryDataProviderImpl::sInstance;
+    static FactoryDataProviderImpl sInstance;
+    return sInstance;
 }
 #endif
 

--- a/src/platform/nxp/rt/rw61x/FactoryDataProviderEl2GoImpl.h
+++ b/src/platform/nxp/rt/rw61x/FactoryDataProviderEl2GoImpl.h
@@ -41,8 +41,6 @@ namespace DeviceLayer {
 class FactoryDataProviderImpl : public FactoryDataProvider
 {
 public:
-    static FactoryDataProviderImpl sInstance;
-
     ~FactoryDataProviderImpl(){};
 
     CHIP_ERROR Init(void) override;

--- a/src/platform/nxp/rt/rw61x/FactoryDataProviderEncImpl.cpp
+++ b/src/platform/nxp/rt/rw61x/FactoryDataProviderEncImpl.cpp
@@ -66,8 +66,6 @@ using namespace ::chip::Crypto;
 namespace chip {
 namespace DeviceLayer {
 
-FactoryDataProviderImpl FactoryDataProviderImpl::sInstance;
-
 static constexpr size_t kAesKeyBlobLength = Crypto::kP256_PrivateKey_Length + ELS_BLOB_METADATA_SIZE + ELS_WRAP_OVERHEAD;
 
 #define TAG_ID_FOR_AES_KEY_BOLB 0xFE
@@ -543,7 +541,8 @@ CHIP_ERROR FactoryDataProviderImpl::Validate()
 #ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
-    return FactoryDataProviderImpl::sInstance;
+    static FactoryDataProviderImpl sInstance;
+    return sInstance;
 }
 #endif
 

--- a/src/platform/nxp/rt/rw61x/FactoryDataProviderEncImpl.cpp
+++ b/src/platform/nxp/rt/rw61x/FactoryDataProviderEncImpl.cpp
@@ -540,10 +540,12 @@ CHIP_ERROR FactoryDataProviderImpl::Validate()
     return CHIP_NO_ERROR;
 }
 
+#ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
     return FactoryDataProviderImpl::sInstance;
 }
+#endif
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/rt/rw61x/FactoryDataProviderEncImpl.h
+++ b/src/platform/nxp/rt/rw61x/FactoryDataProviderEncImpl.h
@@ -44,8 +44,6 @@ namespace DeviceLayer {
 class FactoryDataProviderImpl : public FactoryDataProvider
 {
 public:
-    static FactoryDataProviderImpl sInstance;
-
     FactoryDataProviderImpl();
     ~FactoryDataProviderImpl(){};
 

--- a/src/platform/nxp/rt/rw61x/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/rt/rw61x/FactoryDataProviderImpl.cpp
@@ -63,8 +63,6 @@ using namespace ::chip::Crypto;
 namespace chip {
 namespace DeviceLayer {
 
-FactoryDataProviderImpl FactoryDataProviderImpl::sInstance;
-
 static constexpr size_t kPrivateKeyBlobLength = Crypto::kP256_PrivateKey_Length + ELS_BLOB_METADATA_SIZE + ELS_WRAP_OVERHEAD;
 
 CHIP_ERROR FactoryDataProviderImpl::DecryptAesEcb(uint8_t * dest, uint8_t * source)
@@ -421,7 +419,8 @@ CHIP_ERROR FactoryDataProviderImpl::ReplaceWithBlob(uint8_t * data, uint8_t * bl
 #ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
-    return FactoryDataProviderImpl::sInstance;
+    static FactoryDataProviderImpl sInstance;
+    return sInstance;
 }
 #endif
 

--- a/src/platform/nxp/rt/rw61x/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/rt/rw61x/FactoryDataProviderImpl.cpp
@@ -418,10 +418,12 @@ CHIP_ERROR FactoryDataProviderImpl::ReplaceWithBlob(uint8_t * data, uint8_t * bl
     return CHIP_NO_ERROR;
 }
 
+#ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
     return FactoryDataProviderImpl::sInstance;
 }
+#endif
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/rt/rw61x/FactoryDataProviderImpl.h
+++ b/src/platform/nxp/rt/rw61x/FactoryDataProviderImpl.h
@@ -37,8 +37,6 @@ namespace DeviceLayer {
 class FactoryDataProviderImpl : public FactoryDataProvider
 {
 public:
-    static FactoryDataProviderImpl sInstance;
-
     CHIP_ERROR SearchForId(uint8_t searchedType, uint8_t * pBuf, size_t bufLength, uint16_t & length,
                            uint32_t * contentAddr = NULL);
 

--- a/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/zephyr/FactoryDataProviderImpl.cpp
@@ -38,8 +38,6 @@
 namespace chip {
 namespace DeviceLayer {
 
-FactoryDataProviderImpl FactoryDataProviderImpl::sInstance;
-
 CHIP_ERROR FactoryDataProviderImpl::SearchForId(uint8_t searchedType, uint8_t * pBuf, size_t bufLength, uint16_t & length,
                                                 uint32_t * contentAddr)
 {
@@ -222,10 +220,13 @@ CHIP_ERROR FactoryDataProviderImpl::ReadEncryptedData(uint8_t * dest, uint8_t * 
     return CHIP_NO_ERROR;
 }
 
+#ifndef CONFIG_CHIP_FACTORY_DATA_PROVIDER_CUSTOM_SINGLETON_IMPL
 FactoryDataProvider & FactoryDataPrvdImpl()
 {
-    return FactoryDataProviderImpl::sInstance;
+    static FactoryDataProviderImpl sInstance;
+    return sInstance;
 }
+#endif
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/zephyr/FactoryDataProviderImpl.h
+++ b/src/platform/nxp/zephyr/FactoryDataProviderImpl.h
@@ -36,8 +36,6 @@ namespace DeviceLayer {
 class FactoryDataProviderImpl : public FactoryDataProvider
 {
 public:
-    static FactoryDataProviderImpl sInstance;
-
     CHIP_ERROR Init(void);
     CHIP_ERROR SearchForId(uint8_t searchedType, uint8_t * pBuf, size_t bufLength, uint16_t & length,
                            uint32_t * contentAddr = NULL);


### PR DESCRIPTION
#### Summary

A new KCONFIG option has been added to allow applications to override FactoryDataPrvdImpl outside of the Matter platform port library. This is useful when an application needs to provide its own customized implementation of FactoryDataPrvdImpl.
By default, this new KCONFIG option is enabled when an SE05x secure element is used. A separate PR will later introduce a dedicated implementation (Se05xDataProviderImpl) that inherits from FactoryDataProviderImpl to demonstrate how this override mechanism can be leveraged.
The purpose of this PR is to prepare the codebase for this upcoming integration.

#### Testing
Testing was performed by creating an application-level implementation derived from FactoryDataProviderImpl and overriding specific methods. Runtime checks confirmed that the redefinition mechanism functions correctly.
