### PR TITLE
Allow to use ASan with GCC

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -447,11 +447,15 @@ config("runtime_default") {
 config("sanitize_address") {
   defines = []
   cflags = [
-    "-fsanitize-coverage=inline-8bit-counters,trace-cmp",
-    "-fno-sanitize-coverage=pc-table",
     "-fsanitize=address",
     "-fno-omit-frame-pointer",
   ]
+  if (is_clang) {
+    cflags += [
+      "-fsanitize-coverage=inline-8bit-counters,trace-cmp",
+      "-fno-sanitize-coverage=pc-table",
+    ]
+  }
   ldflags = cflags
 
   if ((target_os == "mac" || target_os == "ios") && !is_clang) {
@@ -478,6 +482,7 @@ config("sanitize_undefined_behavior") {
     "-fvisibility=hidden",
     "-fsanitize=undefined",
     "-fsanitize=float-divide-by-zero",
+    "-fsanitize=integer-divide-by-zero",
   ]
   if (is_clang) {
     cflags += [


### PR DESCRIPTION
#### Summary

It was not possible to use ASan with GCC due to usage of not available options (only available on Clang).
Also enabled one more UBsan check.

#### Testing

Locally tested that it's possible to use ASan with GCC and Clang:
```
scripts/build/build_examples.py --target linux-x64-light-asan-ubsan build
scripts/build/build_examples.py --target linux-x64-light-asan-ubsan-clang build
```

CI will verify integration tests with additional UBsan option enabled.
