### PR TITLE
Remove redundant assignment in ICD monitoring table getter

### DIFF
--- a/src/app/icd/server/ICDMonitoringTable.cpp
+++ b/src/app/icd/server/ICDMonitoringTable.cpp
@@ -235,9 +235,7 @@ CHIP_ERROR ICDMonitoringTable::Get(uint16_t index, ICDMonitoringEntry & entry) c
 {
     entry.fabricIndex = this->mFabric;
     entry.index       = index;
-    ReturnErrorOnFailure(entry.Load(this->mStorage));
-    entry.fabricIndex = this->mFabric;
-    return CHIP_NO_ERROR;
+    return entry.Load(this->mStorage);
 }
 
 CHIP_ERROR ICDMonitoringTable::Find(NodeId id, ICDMonitoringEntry & entry)


### PR DESCRIPTION
#### Summary

The `entry.fabricIndex = this->mFabric;` is done twice in the `Get()` function.

#### Testing

CI will verify.