### PR TITLE
Fix PSA HMAC_SHA256 and pbkdf2_sha256 return value

### DIFF
--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -538,7 +538,7 @@ exit:
     psa_destroy_key(keyId);
     psa_reset_key_attributes(&attrs);
 
-    return CHIP_NO_ERROR;
+    return error;
 }
 
 CHIP_ERROR HMAC_sha::HMAC_SHA256(const Hmac128KeyHandle & key, const uint8_t * message, size_t message_length, uint8_t * out_buffer,
@@ -648,7 +648,7 @@ exit:
     psa_destroy_key(keyId);
     psa_reset_key_attributes(&attrs);
 
-    return CHIP_NO_ERROR;
+    return error;
 }
 
 CHIP_ERROR add_entropy_source(entropy_source /* fn_source */, void * /* p_source */, size_t /* threshold */)


### PR DESCRIPTION
#### Summary

HMAC_SHA256 and pbkdf2_sha256 are always returning CHIP_NO_ERROR in PSA implementation

#### Testing

Check NXP unit test build, no more test done, issue identify during code review

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
