### PR TITLE
[NXP] Exclude the EVSE example tests for NXP platform

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -234,7 +234,7 @@ if (chip_build_tests) {
     tests = []
 
     if (chip_device_platform != "esp32" && chip_device_platform != "efr32" &&
-        current_os != "android") {
+        chip_device_platform != "nxp" && current_os != "android") {
       tests += [ "${chip_root}/examples/evse-app/evse-common/tests" ]
     }
   }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -233,6 +233,8 @@ if (chip_build_tests) {
     deps = []
     tests = []
 
+    # NXP: EVSE tests depend on ot-simulation; missing headers
+    # in ot-nxp OpenThread cause build failure, so we exclude them here.
     if (chip_device_platform != "esp32" && chip_device_platform != "efr32" &&
         chip_device_platform != "nxp" && current_os != "android") {
       tests += [ "${chip_root}/examples/evse-app/evse-common/tests" ]


### PR DESCRIPTION
#### Summary

This PR is removing the EVSE example tests for NXP platform unit tests build.

#### Why This Change Is Needed

With recent updates, the EVSE test suite now pulls in the dependency openthread:simulation. Introduced in PR: https://github.com/project-chip/connectedhomeip/pull/42336/changes#diff-75a783c47e3b2956c4983e4ff33aadb9e89c15683a08a17a298101e12bc34772 . This target relies on source files that exist only in the OpenThread version bundled with the main ConnectedHomeIP repository.
However, NXP platforms use a different OpenThread submodule:
- NXP platforms depend on ot-nxp, which itself contains its own OpenThread submodule.
- The ot-nxp OpenThread version does not include the files required by openthread:simulation.

Because the EVSE tests include Linux-specific components, including this simulation target, the dependency is currently added unconditionally when doing: "tests += [ "${chip_root}/examples/evse-app/evse-common/tests" ]"
See: https://github.com/project-chip/connectedhomeip/blob/master/examples/evse-app/evse-common/tests/BUILD.gn#L35 

As a result, the NXP unit test build fails due to missing OpenThread files that should only be required for Linux.

#### Testing

Tested by building the Unit Tests example for FRDM-MCXW72 board:

- command: "west build -p always src/test_driver/nxp -b frdmmcxw72 -Dcore_id=cm33_core0 -DCONFIG_MCUX_COMPONENT_middleware.freertos-kernel.config=n"