### PR TITLE
[Silabs] Bugfix: DAC provider initialization.

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -191,11 +191,6 @@ void ApplicationStart(void * unused)
     if (err != CHIP_NO_ERROR)
         appError(err);
 
-    chip::DeviceLayer::PlatformMgr().LockChipStack();
-    // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(&Provision::Manager::GetInstance().GetStorage());
-    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
-
     ChipLogProgress(DeviceLayer, "Starting App Task");
     err = AppTask::GetAppTask().StartAppTask();
     if (err != CHIP_NO_ERROR)
@@ -269,6 +264,7 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     ReturnErrorOnFailure(provision.Init());
     SetDeviceInstanceInfoProvider(&provision.GetStorage());
     SetCommissionableDataProvider(&provision.GetStorage());
+    SetDeviceAttestationCredentialsProvider(&provision.GetStorage());
     ChipLogProgress(DeviceLayer, "Provision mode %s", provision.IsProvisionRequired() ? "ENABLED" : "disabled");
 
     // Create initParams with SDK example defaults here


### PR DESCRIPTION
#### Summary

[A recent refactor of the `OperationalCredentialsCluster`](https://github.com/project-chip/connectedhomeip/pull/42918) causes Silicon labs devices to fail during commissioning.

The reason is the time when the `GetDeviceAttestationCredentialsProvider()` method is called. Previously, this method was called during commissioning, as needed, while now is called very early during the initialization, [before we call `SetDeviceAttestationCredentialsProvider()` ](https://github.com/project-chip/connectedhomeip/blob/1b1f83e17e92a8bd9513fdd24f49c9a90045a5f8/examples/platform/silabs/MatterConfig.cpp#L196). As a consequence, OperationalCredentialsCluster gets [the default implementation instead](https://github.com/project-chip/connectedhomeip/blob/1b1f83e17e92a8bd9513fdd24f49c9a90045a5f8/src/credentials/DeviceAttestationCredsProvider.cpp#L63).

This PR just move the call to `SetDeviceAttestationCredentialsProvider()` earlier in the initialization, so `OperationalCredentialsCluster` gets initialized correctly. 

#### Related issues

N/A

#### Testing

Devices commissioned successfully: BRD4187C (MG24), BRD4116A (MG26).

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
