### PR TITLE
[ICDMonitoringTable] Choose correct array length for nonce

### DIFF
--- a/src/app/icd/server/ICDMonitoringTable.cpp
+++ b/src/app/icd/server/ICDMonitoringTable.cpp
@@ -178,15 +178,15 @@ bool ICDMonitoringEntry::IsKeyEquivalent(ByteSpan keyData)
     VerifyOrReturnValue(tempEntry.SetKey(keyData) == CHIP_NO_ERROR, false);
 
     // Challenge
-    uint8_t mic[Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES]  = { 0 };
-    uint8_t aead[Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES] = { 0 };
+    uint8_t mic[Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES]     = { 0 };
+    uint8_t nonce[Crypto::CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES] = { 0 };
 
     CHIP_ERROR err;
 
     uint64_t data = Crypto::GetRandU64(), validation, encrypted;
     validation    = data;
 
-    err = Crypto::AES_CCM_encrypt(reinterpret_cast<uint8_t *>(&data), sizeof(data), nullptr, 0, tempEntry.aesKeyHandle, aead,
+    err = Crypto::AES_CCM_encrypt(reinterpret_cast<uint8_t *>(&data), sizeof(data), nullptr, 0, tempEntry.aesKeyHandle, nonce,
                                   Crypto::CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES, reinterpret_cast<uint8_t *>(&encrypted), mic,
                                   Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES);
 
@@ -194,7 +194,7 @@ bool ICDMonitoringEntry::IsKeyEquivalent(ByteSpan keyData)
     if (err == CHIP_NO_ERROR)
     {
         err = Crypto::AES_CCM_decrypt(reinterpret_cast<uint8_t *>(&encrypted), sizeof(encrypted), nullptr, 0, mic,
-                                      Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES, aesKeyHandle, aead,
+                                      Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES, aesKeyHandle, nonce,
                                       Crypto::CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES, reinterpret_cast<uint8_t *>(&data));
     }
     TEMPORARY_RETURN_IGNORED tempEntry.DeleteKey();

--- a/src/app/icd/server/ICDMonitoringTable.cpp
+++ b/src/app/icd/server/ICDMonitoringTable.cpp
@@ -180,6 +180,7 @@ bool ICDMonitoringEntry::IsKeyEquivalent(ByteSpan keyData)
     // Challenge
     uint8_t mic[Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES]     = { 0 };
     uint8_t nonce[Crypto::CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES] = { 0 };
+    VerifyOrReturnValue(Crypto::DRBG_get_bytes(nonce, sizeof(nonce)) == CHIP_NO_ERROR, false);
 
     CHIP_ERROR err;
 


### PR DESCRIPTION
#### Summary

- the nonce in the method is defined as an array with 16 bytes (using the MIC's constant), while it should be just 13 bytes (for nonce).

- This shouldn't have any impact, because Nonce length is less that MIC length
#### Testing

- CI

