### PR TITLE
[Darwin] use namespace.so for macos build jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -432,7 +432,7 @@ jobs:
 
     build_darwin:
         name: Build on Darwin (clang, simulated)
-        runs-on: macos-26
+        runs-on: namespace-profile-macos-26
         if: github.actor != 'restyled-io[bot]'  && inputs.run-codeql != true
 
         steps:

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -57,7 +57,10 @@ jobs:
 
     if: github.actor != 'restyled-io[bot]'
     # Namespace MacOS 26 profile is configued as "26.3 with Xcode 26.2" currently
-    runs-on: namespace-profile-macos-26
+    # This is not yet enabled since namespace still has high concurrency limit: we have
+    # 48 cores and are forced to 6 cores minimum.
+    # runs-on: namespace-profile-macos-26
+    runs-on: macos-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -56,7 +56,7 @@ jobs:
       LSAN_OPTIONS: detect_leaks=1 malloc_context_size=40 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
     if: github.actor != 'restyled-io[bot]'
-    # Namespace MacOS 26 profile is configued as "26.3 with Xcode 26.2" currently
+    # Namespace MacOS 26 profile is configured as "26.3 with Xcode 26.2" currently
     # This is not yet enabled since namespace still has high concurrency limit: we have
     # 48 cores and are forced to 6 cores minimum.
     # runs-on: namespace-profile-macos-26

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: macos-26
+        - os: macos-26    # NOTE: must match `runs-on`
           arch: arm64     # observed, not configured
           dry-run: true
           build_variant: no-ble-no-shell-asan-clang
@@ -56,7 +56,8 @@ jobs:
       LSAN_OPTIONS: detect_leaks=1 malloc_context_size=40 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
     if: github.actor != 'restyled-io[bot]'
-    runs-on: ${{matrix.os}}
+    # Namespace MacOS 26 profile is configued as "26.3 with Xcode 26.2" currently
+    runs-on: namespace-profile-macos-26
 
     steps:
       - name: Checkout


### PR DESCRIPTION
#### Summary

MacOS jobs seem to be queueing in github due to less resources. Move some jobs to namespace.so

This is still limited as namespace is also more limited on macos and enforces at least 6 cores for mac, so effectively we have up to 8 concurrent builds there as well. However hopefully this will share some load.

Expect:
  - parallelism improvement - less queueing on github side since we are not running some long jobs there anymore
  - For this job, first test shows a decrease from 75 minutes to 14 minutes
  
#### Testing

CI will validate that things still pass. 