### PR TITLE
[Groupcast]Re-align TC_GCAST_2.2 with the Test plan.

### DIFF
--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -998,8 +998,9 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
                 .mcastAddrPolicy = Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,
             },
             {
-                .groupID         = 3,
-                .endpoints       = chip::NullOptional,
+                .groupID   = 3,
+                .endpoints = MakeOptional(
+                    DataModel::List<const chip::EndpointId>()), // Listener is supported, so an empty endpoints list is expected.
                 .keySetID        = 0xabcd,
                 .hasAuxiliaryACL = MakeOptional(true),
                 .mcastAddrPolicy = Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr,

--- a/src/python_testing/TC_GCAST_2_2.py
+++ b/src/python_testing/TC_GCAST_2_2.py
@@ -153,10 +153,10 @@ class TC_GCAST_2_2(MatterBaseTest):
                 group_id=groupID1, endpoints=[endpoint1], key_set_id=keySetID1, has_auxiliary_acl=False)
             membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 
-            # If DUT only support one non-root and non-aggregator endpoint, skip to step 5a
+            # If DUT only support one non-root and non-aggregator endpoint, skip to step 6a
             self.step("4a")
             if len(endpoints_list) < 2:
-                self.mark_step_range_skipped("4b", "4c")
+                self.mark_step_range_skipped("4b", "5b")
             else:
                 # Attempt to add EP2 to Group G1
                 self.step("4b")
@@ -170,23 +170,23 @@ class TC_GCAST_2_2(MatterBaseTest):
                 # TH awaits subscription report of new membership within max interval
                 self.step("4c")
                 membership_matcher = generate_membership_entry_matcher(
-                    group_id=groupID1, endpoints=endpoints_list[0:1], key_set_id=keySetID1, has_auxiliary_acl=False)
+                    group_id=groupID1, endpoints=endpoints_list[0:2], key_set_id=keySetID1, has_auxiliary_acl=False)
                 membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 
-            # Attempt to replace endpoints for Group G1 using ReplaceEndpoints:
-            self.step("5a")
-            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-                groupID=groupID1,
-                endpoints=[endpoint1],
-                keySetID=keySetID1,
-                replaceEndpoints=True)
-            )
+                # Attempt to replace endpoints for Group G1 using ReplaceEndpoints:
+                self.step("5a")
+                await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                    groupID=groupID1,
+                    endpoints=[endpoint1],
+                    keySetID=keySetID1,
+                    replaceEndpoints=True)
+                )
 
-            # TH awaits subscription report of new membership within max interval
-            self.step("5b")
-            membership_matcher = generate_membership_entry_matcher(
-                group_id=groupID1, endpoints=[endpoint1], key_set_id=keySetID1, has_auxiliary_acl=False)
-            membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+                # TH awaits subscription report of new membership within max interval
+                self.step("5b")
+                membership_matcher = generate_membership_entry_matcher(
+                    group_id=groupID1, endpoints=[endpoint1], key_set_id=keySetID1, has_auxiliary_acl=False)
+                membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 
             # Attempt to join Group G2 with existing Key1 and using Auxiliary ACL
             self.step("6a")

--- a/src/python_testing/TC_GCAST_2_2.py
+++ b/src/python_testing/TC_GCAST_2_2.py
@@ -59,39 +59,37 @@ class TC_GCAST_2_2(MatterBaseTest):
         return [TestStep("1a", "Commission DUT to TH (can be skipped if done in a preceding test)", is_commissioning=True),
                 TestStep("1b", "TH removes any existing group and KeySetID on the DUT"),
                 TestStep("1c", "Th subscribes to Membership attribute with min interval 0s and max interval 30s"),
-                TestStep(2, "If GCAST.S.F00(LN) feature is not supported on the cluster, skip to step 12"),
+                TestStep(2, "If GCAST.S.F00(LN) feature is not supported on the cluster, skip to step 14"),
                 TestStep("3a", "Attempt to join Group G1 with a new Key with KeySetID K1 on Endpoint EP1"),
                 TestStep("3b", "TH awaits subscription report of new membership within max interval"),
-                TestStep("4a", "If DUT only support one non-root and non-aggregator endpoint, skip to step 5a"),
+                TestStep("4a", "If DUT only support one non-root and non-aggregator endpoint, skip to step 6a"),
                 TestStep("4b", "Attempt to add EP2 to Group G1"),
                 TestStep("4c", "TH awaits subscription report of new membership within max interval"),
-                TestStep("5a", "Attempt to join Group G2 with existing Key1 and using Auxiliary ACL"),
+                TestStep("5a", "Attempt to replace endpoints with only EP1 for Group G1 using ReplaceEndpoints"),
                 TestStep("5b", "TH awaits subscription report of new membership within max interval"),
-                TestStep("6a", "Attempt to join Group G2 with new Key"),
+                TestStep("6a", "Attempt to join Group G2 with existing Key1 and using Auxiliary ACL"),
                 TestStep("6b", "TH awaits subscription report of new membership within max interval"),
                 TestStep(7, "Attempt to join Group G3 using a new Key but providing existing KeySetID (result: already exists)"),
                 TestStep(8, "Attempt to join Group G3 using a new KeySetID, but without providing InputKey (result: not found)"),
                 TestStep(9, "Attempt to join Group G3 with invalid endpoint (result: unsupported endpoint)"),
-                TestStep(10, "If Sender is supported in DUT, skip this step. Else, attempt to join Group G3 with an empty endpoints list (result: constraint error)"),
-                TestStep(11, "If DUT has more than 20 endpoints, attempt to join Group G3 with 21 endpoints (result: constraint error)"),
-                TestStep(12, "If Sender is not supported in DUT, skip to step 18"),
-                TestStep("13a", "Attempt to join Group G4 as Sender (no endpoints) and a new key"),
-                TestStep("13b", "TH awaits subscription report of new membership within max interval"),
-                TestStep("14a", "Attempt to join Group G5 as Sender using existing KeySetID"),
-                TestStep("14b", "TH awaits subscription report of new membership within max interval"),
-                TestStep("15a", "Attempt to join Group G5 with new Key but providing existing KeySetID (result: already exists)"),
-                TestStep("15b", "Attempt to join Group G5 with new Key but without providing InputKey (result: not found)"),
-                TestStep("16a", "Attempt to join Group G5 with new Key"),
-                TestStep("16b", "TH awaits subscription report of new membership within max interval"),
-                TestStep(17, "Confirm If Listener featIsSupported, skip this step. Else attempt to add endpoints to Group G5 (result: constraint error)"),
-                TestStep(18, "If Listener feature is not supported, attempt to join a group with AuxiliaryACL (result: constraint error)"),
-                TestStep(19, "JoinGroup with invalid GroupID (result: constraint error)"),
-                TestStep(20, "JoinGroup with Key length != 16 (result: constraint error)"),
-                TestStep("21a", "Test JoinGroup with ReplaceEndpoints=True: Add EP1 to Group G6"),
-                TestStep("21b", "TH awaits subscription report for Group G6 with EP1"),
-                TestStep("21c", "Test JoinGroup with ReplaceEndpoints=True: Replace EP1 with EP2 in Group G6"),
-                TestStep("21d", "TH awaits subscription report for Group G6 with only EP2"),
-                TestStep(22, "JoinGroup with Endpoint 0 (result: constraint error)")]
+                TestStep(10, "Attempt to join Group G3 with Root endpoint 0 (result: unsupported endpoint)"),
+                TestStep(11, "If Sender is supported in DUT, skip this step. Else, attempt to join Group G3 with an empty endpoints list (result: constraint error)"),
+                TestStep(12, "If DUT has more than 20 endpoints, attempt to join Group G3 with 21 endpoints (result: constraint error)"),
+                TestStep(13, "If PerGroupAddress is supported on the cluster skip this step, else attempt to join Group G3 with McastAddrPolicy=PerGroup (result: constraint error)"),
+                TestStep(14, "If Sender is not supported in DUT, skip to step 20"),
+                TestStep("15a", "Attempt to join Group G4 as Sender (no endpoints) and a new key"),
+                TestStep("15b", "If Listener is not supported, skip this step. Else TH awaits subscription report of new membership within max interval with Endpoints list empty and HasAuxiliaryACL=False"),
+                TestStep("15c", "If Listener is supported, skip this step. Else, TH awaits subscription report of new membership within max interval with Endpoints list and HasAuxiliaryACL ommited"),
+                TestStep("16a", "Attempt to join Group G5 as Sender using existing KeySetID"),
+                TestStep("16b", "If Listener is not supported, skip this step. Else, TH awaits subscription report of new membership within max interval with Endpoints list empty and HasAuxiliaryACL=False"),
+                TestStep("16c", "If Listener is supported, skip this step. Else, TH awaits subscription report of new membership within max interval with Endpoints list and HasAuxiliaryACL ommited"),
+                TestStep("17a", "Attempt to join Group G5 with new Key but providing existing KeySetID (result: already exists)"),
+                TestStep("17b", "Attempt to join Group G5 with new KeySetID but without providing InputKey (result: not found)"),
+                TestStep(18, "If Listener feature is supported, skip this step. Else, attempt to join a group with ReplaceEndpoints=True (result: constraint error)"),
+                TestStep(
+                    19, "If Listener feature is supported, skip this step. Else, attempt to join a group with AuxiliaryACL true (result: constraint error)"),
+                TestStep(20, "JoinGroup with invalid GroupID (result: constraint error)"),
+                TestStep(21, "JoinGroup with Key length != 16 (result: constraint error)")]
 
     def pics_TC_GCAST_2_2(self) -> list[str]:
         return ["GCAST.S"]
@@ -105,8 +103,9 @@ class TC_GCAST_2_2(MatterBaseTest):
         self.step("1a")
         ln_enabled, sd_enabled, pga_enabled = await get_feature_map(self)
         endpoints_list = await valid_endpoints_list(self, ln_enabled)
-        if not endpoints_list:
-            self.mark_step_range_skipped("1b", 8)
+        if endpoints_list[0] is None:
+            self.mark_all_remaining_steps_skipped("1b")
+            return
 
         self.step("1b")
         # Check if there are any groups on the DUT.
@@ -130,157 +129,162 @@ class TC_GCAST_2_2(MatterBaseTest):
 
         # If GCAST.S.F00(LN) feature is not supported on the cluster, skip to step 12
         self.step(2)
-        if endpoints_list[0] is None:
-            self.mark_step_range_skipped("3a", 8)
         if not ln_enabled:
-            self.mark_step_range_skipped("3a", 11)
-
-        # Attempt to join Group G1 with a new Key with KeySetID K1 on Endpoint EP1
-        self.step("3a")
-        groupID1 = 1
-        keySetID1 = 1
-        inputKey1 = secrets.token_bytes(16)
-        endpoint1 = endpoints_list[0]
-
-        await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-            groupID=groupID1,
-            endpoints=[endpoint1],
-            keySetID=keySetID1,
-            key=inputKey1,
-            useAuxiliaryACL=False)
-        )
-
-        # TH awaits subscription report of new membership within max interval
-        self.step("3b")
-        membership_matcher = generate_membership_entry_matcher(
-            group_id=groupID1, endpoints=[endpoint1], key_set_id=keySetID1, has_auxiliary_acl=False)
-        membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
-
-        # If DUT only support one non-root and non-aggregator endpoint, skip to step 5a
-        self.step("4a")
-        if len(endpoints_list) < 2:
-            self.mark_step_range_skipped("4b", "4c")
-
-        # Attempt to add EP2 to Group G1
-        self.step("4b")
-        await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-            groupID=groupID1,
-            endpoints=endpoints_list[0:2],
-            keySetID=keySetID1,
-            useAuxiliaryACL=False)
-        )
-
-        # TH awaits subscription report of new membership within max interval
-        self.step("4c")
-        membership_matcher = generate_membership_entry_matcher(
-            group_id=groupID1, endpoints=endpoints_list[0:2], key_set_id=keySetID1, has_auxiliary_acl=False)
-        membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
-
-        # Attempt to join Group G2 with existing Key1 and using Auxiliary ACL
-        self.step("5a")
-        groupID2 = 2
-
-        await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-            groupID=groupID2,
-            endpoints=[endpoint1],
-            keySetID=keySetID1,
-            useAuxiliaryACL=True)
-        )
-
-        # TH awaits subscription report of new membership within max interval
-        self.step("5b")
-        membership_matcher = generate_membership_entry_matcher(
-            group_id=groupID2, endpoints=[endpoint1], key_set_id=keySetID1, has_auxiliary_acl=True)
-        membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
-
-        # Attempt to join Group G2 with new Key
-        self.step("6a")
-        keySetID2 = 2
-        inputKey2 = secrets.token_bytes(16)
-
-        await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-            groupID=groupID2,
-            endpoints=[endpoint1],
-            keySetID=keySetID2,
-            key=inputKey2,
-            useAuxiliaryACL=True)
-        )
-
-        # TH awaits subscription report of new membership within max interval
-        self.step("6b")
-        membership_matcher = generate_membership_entry_matcher(
-            group_id=groupID2, key_set_id=keySetID2, endpoints=[endpoint1], has_auxiliary_acl=True)
-        membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
-
-        # Attempt to join Group G3 using a new Key but providing existing KeySetID (result: already exists)
-        self.step(7)
-        groupID3 = 3
-        inputKey3 = secrets.token_bytes(16)
-
-        try:
-            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-                groupID=groupID3,
-                endpoints=[endpoint1],
-                keySetID=keySetID2,
-                key=inputKey3)
-            )
-            asserts.fail(
-                "JoinGroup command should have failed because Group with keySetID already exists and does not match key, but it still succeeded")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.AlreadyExists,
-                                 f"Send JoinGroup command error should be {Status.AlreadyExists} instead of {e.status}")
-
-        # Attempt to join Group G3 using a new KeySetID, but without providing InputKey (result: not found)
-        self.step(8)
-        keySetID3 = 3
-        try:
-            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-                groupID=groupID3,
-                endpoints=[uint(endpoint1)],
-                keySetID=keySetID3)
-            )
-            asserts.fail("JoinGroup command should have failed because no Key found, but it still succeeded")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.NotFound,
-                                 f"Send JoinGroup command error should be {Status.NotFound} instead of {e.status}")
-
-        # Attempt to join Group G3 with invalid endpoint (result: unsupported endpoint)
-        self.step(9)
-        endpoint_invalid = uint(0xFFFF)
-        try:
-            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-                groupID=groupID3,
-                endpoints=[endpoint_invalid],
-                keySetID=keySetID1)
-            )
-            asserts.fail("JoinGroup command should have failed because endpoint is invalid, but it still succeeded")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.UnsupportedEndpoint,
-                                 f"Send JoinGroup command error should be {Status.UnsupportedEndpoint} instead of {e.status}")
-
-        # If Sender is supported in DUT, skip this step. Else, attempt to join Group G3 with an empty endpoints list (result: constraint error)
-        self.step(10)
-        endpoints_list_empty = []
-        if sd_enabled:
-            self.skip_step(10)
+            self.mark_step_range_skipped("3a", 13)
         else:
+            # Attempt to join Group G1 with a new Key with KeySetID K1 on Endpoint EP1
+            self.step("3a")
+            groupID1 = 1
+            keySetID1 = 1
+            inputKey1 = secrets.token_bytes(16)
+            endpoint1 = endpoints_list[0]
+
+            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                groupID=groupID1,
+                endpoints=[endpoint1],
+                keySetID=keySetID1,
+                key=inputKey1,
+                useAuxiliaryACL=False)
+            )
+
+            # TH awaits subscription report of new membership within max interval
+            self.step("3b")
+            membership_matcher = generate_membership_entry_matcher(
+                group_id=groupID1, endpoints=[endpoint1], key_set_id=keySetID1, has_auxiliary_acl=False)
+            membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+
+            # If DUT only support one non-root and non-aggregator endpoint, skip to step 5a
+            self.step("4a")
+            if len(endpoints_list) < 2:
+                self.mark_step_range_skipped("4b", "4c")
+            else:
+                # Attempt to add EP2 to Group G1
+                self.step("4b")
+                await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                    groupID=groupID1,
+                    endpoints=[endpoints_list[1]],
+                    keySetID=keySetID1,
+                    useAuxiliaryACL=False)
+                )
+
+                # TH awaits subscription report of new membership within max interval
+                self.step("4c")
+                membership_matcher = generate_membership_entry_matcher(
+                    group_id=groupID1, endpoints=endpoints_list[0:1], key_set_id=keySetID1, has_auxiliary_acl=False)
+                membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+
+            # Attempt to replace endpoints for Group G1 using ReplaceEndpoints:
+            self.step("5a")
+            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                groupID=groupID1,
+                endpoints=[endpoint1],
+                keySetID=keySetID1,
+                replaceEndpoints=True)
+            )
+
+            # TH awaits subscription report of new membership within max interval
+            self.step("5b")
+            membership_matcher = generate_membership_entry_matcher(
+                group_id=groupID1, endpoints=[endpoint1], key_set_id=keySetID1, has_auxiliary_acl=False)
+            membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+
+            # Attempt to join Group G2 with existing Key1 and using Auxiliary ACL
+            self.step("6a")
+            groupID2 = 2
+
+            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                groupID=groupID2,
+                endpoints=[endpoint1],
+                keySetID=keySetID1,
+                useAuxiliaryACL=True)
+            )
+
+            # TH awaits subscription report of new membership within max interval
+            self.step("6b")
+            membership_matcher = generate_membership_entry_matcher(
+                group_id=groupID2, endpoints=[endpoint1], key_set_id=keySetID1, has_auxiliary_acl=True)
+            membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+
+            # Attempt to join Group G3 using a new Key but providing existing KeySetID (result: already exists)
+            self.step(7)
+            groupID3 = 3
+            inputKey2 = secrets.token_bytes(16)
+
             try:
                 await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
                     groupID=groupID3,
-                    endpoints=endpoints_list_empty,
+                    endpoints=[endpoint1],
+                    keySetID=keySetID1,
+                    key=inputKey2)
+                )
+                asserts.fail(
+                    "JoinGroup command should have failed because Group with keySetID already exists and does not match key, but it still succeeded")
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.AlreadyExists,
+                                     f"Send JoinGroup command error should be {Status.AlreadyExists} instead of {e.status}")
+
+            # Attempt to join Group G3 using a new KeySetID, but without providing InputKey (result: not found)
+            self.step(8)
+            keySetID2 = 2
+            try:
+                await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                    groupID=groupID3,
+                    endpoints=[endpoint1],
+                    keySetID=keySetID2)
+                )
+                asserts.fail("JoinGroup command should have failed because no Key found, but it still succeeded")
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.NotFound,
+                                     f"Send JoinGroup command error should be {Status.NotFound} instead of {e.status}")
+
+            # Attempt to join Group G3 with invalid endpoint (result: unsupported endpoint)
+            self.step(9)
+            endpoint_invalid = uint(0xFFFF)
+            try:
+                await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                    groupID=groupID3,
+                    endpoints=[endpoint_invalid],
                     keySetID=keySetID1)
                 )
-                asserts.fail("JoinGroup command should have failed because endpoints list is empty, but it still succeeded")
+                asserts.fail("JoinGroup command should have failed because endpoint is invalid, but it still succeeded")
             except InteractionModelError as e:
-                asserts.assert_equal(e.status, Status.ConstraintError,
-                                     f"Send JoinGroup command error should be {Status.ConstraintError} instead of {e.status}")
+                asserts.assert_equal(e.status, Status.UnsupportedEndpoint,
+                                     f"Send JoinGroup command error should be {Status.UnsupportedEndpoint} instead of {e.status}")
 
-        # If DUT has more than 20 endpoints, attempt to join Group G3 with 21 endpoints (result: constraint error)
-        self.step(11)
-        if sd_enabled:
-            self.skip_step(11)
-        else:
+            # Attempt to join Group G3 with root endpoint (result: unsupported endpoint)
+            self.step(10)
+            endpoint_root = uint(0)
+            try:
+                await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                    groupID=groupID3,
+                    endpoints=[endpoint_root],
+                    keySetID=keySetID1)
+                )
+                asserts.fail("JoinGroup command should have failed because endpoint is invalid, but it still succeeded")
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.UnsupportedEndpoint,
+                                     f"Send JoinGroup command error should be {Status.UnsupportedEndpoint} instead of {e.status}")
+
+            # If Sender is supported in DUT, skip this step. Else, attempt to join Group G3 with an empty endpoints list (result: constraint error)
+            endpoints_list_empty = []
+            if sd_enabled:
+                self.skip_step(11)
+            else:
+                self.step(11)
+                try:
+                    await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                        groupID=groupID3,
+                        endpoints=endpoints_list_empty,
+                        keySetID=keySetID1)
+                    )
+                    asserts.fail("JoinGroup command should have failed because endpoints list is empty, but it still succeeded")
+                except InteractionModelError as e:
+                    asserts.assert_equal(e.status, Status.ConstraintError,
+                                         f"Send JoinGroup command error should be {Status.ConstraintError} instead of {e.status}")
+
+            # If DUT has more than 20 endpoints, attempt to join Group G3 with 21 endpoints (result: constraint error)
             if len(endpoints_list) > 20:
+                self.step(12)
                 exceeding_endpoint = 21
                 while exceeding_endpoint in endpoints_list:
                     exceeding_endpoint += 1
@@ -292,133 +296,159 @@ class TC_GCAST_2_2(MatterBaseTest):
                         keySetID=keySetID2)
                     )
                     asserts.fail(
-                        "JoinGroup command should have failed because endpoints list has more endpoints than DUT provides, but it still succeeded")
+                        "JoinGroup command should have failed because endpoints list has more endpoints than supported by the command, but it still succeeded")
                 except InteractionModelError as e:
-                    asserts.assert_equal(e.status, Status.UnsupportedEndpoint,
-                                         f"Send JoinGroup command error should be {Status.UnsupportedEndpoint} instead of {e.status}")
+                    asserts.assert_equal(e.status, Status.ConstraintError,
+                                         f"Send JoinGroup command error should be {Status.ConstraintError} instead of {e.status}")
+            else:
+                self.skip_step(12)
 
-        # If Sender is not supported in DUT, skip to step 18
-        self.step(12)
+            # If PerGroupAddress is supported on the cluster skip this step, else attempt to join Group G3 with McastAddrPolicy=PerGroup (result: constraint error)
+            if pga_enabled:
+                self.skip_step(13)
+            else:
+                self.step(13)
+                try:
+                    await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                        groupID=groupID3,
+                        endpoints=[endpoint1],
+                        keySetID=keySetID1,
+                        mcastAddrPolicy=Clusters.Groupcast.McastAddrPolicy.PerGroup)
+                    )
+                    asserts.fail(
+                        "JoinGroup command should have failed because McastAddrPolicy is not supported, but it still succeeded")
+                except InteractionModelError as e:
+                    asserts.assert_equal(e.status, Status.ConstraintError,
+                                         f"Send JoinGroup command error should be {Status.ConstraintError} instead of {e.status}")
+
+        # If Sender is not supported in DUT, skip to step 20
+        self.step(14)
         if not sd_enabled:
-            self.mark_step_range_skipped(13, 17)
+            self.mark_step_range_skipped("15a", 19)
+        else:
+            self.step("15a")
+            # Attempt to join Group G4 as Sender (no endpoints) and a new key
+            groupID4 = 4
+            keySetID2 = 2
+            inputKey2 = secrets.token_bytes(16)
+            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                groupID=groupID4,
+                endpoints=endpoints_list_empty,
+                keySetID=keySetID2,
+                key=inputKey2)
+            )
 
-        # Attempt to join Group G4 as Sender (no endpoints) and a new key
-        self.step("13a")
-        groupID4 = 4
-        keySetID4 = 4
-        inputKey4 = secrets.token_bytes(16)
-        await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-            groupID=groupID4,
-            endpoints=endpoints_list_empty,
-            keySetID=keySetID4,
-            key=inputKey4)
-        )
+            if ln_enabled:
+                # TH awaits subscription report of new membership within max interval
+                self.step("15b")
+                membership_matcher = generate_membership_entry_matcher(
+                    group_id=groupID4, key_set_id=keySetID2, endpoints=endpoints_list_empty, has_auxiliary_acl=False)
+                membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+                self.skip_step("15c")
+            else:
+                self.skip_step("15b")
+                self.step("15c")
+                membership_matcher = generate_membership_entry_matcher(
+                    group_id=groupID4, key_set_id=keySetID2, endpoints=None)
+                membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 
-        # TH awaits subscription report of new membership within max interval
-        self.step("13b")
-        membership_matcher = generate_membership_entry_matcher(
-            group_id=groupID4, key_set_id=keySetID4, endpoints=endpoints_list_empty)
-        membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
-
-        # Attempt to join Group G5 as Sender using existing KeySetID
-        self.step("14a")
-        groupID5 = 5
-        await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-            groupID=groupID5,
-            endpoints=endpoints_list_empty,
-            keySetID=keySetID4)
-        )
-
-        # TH awaits subscription report of new membership within max interval
-        self.step("14b")
-        membership_matcher = generate_membership_entry_matcher(
-            group_id=groupID5, key_set_id=keySetID4, endpoints=endpoints_list_empty)
-        membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
-
-        # Attempt to join Group G5 with new Key but providing existing KeySetID (result: already exists)
-        self.step("15a")
-        inputKey6 = secrets.token_bytes(16)
-        try:
+            # Attempt to join Group G5 as Sender using existing KeySetID
+            self.step("16a")
+            groupID5 = 5
             await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
                 groupID=groupID5,
                 endpoints=endpoints_list_empty,
-                keySetID=keySetID4,
-                key=inputKey6)
+                keySetID=keySetID2)
             )
-            asserts.fail(
-                "JoinGroup command should have failed because Group with keySetID already exists and does not match key, but it still succeeded")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.AlreadyExists,
-                                 f"Send JoinGroup command error should be {Status.AlreadyExists} instead of {e.status}")
 
-        # Attempt to join Group G5 with new Key but without providing InputKey (result: not found)
-        self.step("15b")
-        keySetID5 = 5
-        try:
-            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-                groupID=groupID5,
-                endpoints=endpoints_list_empty,
-                keySetID=keySetID5)
-            )
-            asserts.fail("JoinGroup command should have failed because no Key found, but it still succeeded")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.NotFound,
-                                 f"Send JoinGroup command error should be {Status.NotFound} instead of {e.status}")
+            # TH awaits subscription report of new membership within max interval
+            if ln_enabled:
+                self.step("16b")
+                membership_matcher = generate_membership_entry_matcher(
+                    group_id=groupID5, key_set_id=keySetID2, endpoints=endpoints_list_empty, has_auxiliary_acl=False)
+                membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+                self.skip_step("16c")
+            else:
+                self.skip_step("16b")
+                self.step("16c")
+                membership_matcher = generate_membership_entry_matcher(
+                    group_id=groupID5, key_set_id=keySetID2, endpoints=None)
+                membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
 
-        # Attempt to join Group G5 with new Key
-        self.step("16a")
-        inputKey5 = secrets.token_bytes(16)
+            # Attempt to join Group G5 with new Key but providing existing KeySetID (result: already exists)
+            self.step("17a")
+            inputKey3 = secrets.token_bytes(16)
+            try:
+                await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                    groupID=groupID5,
+                    endpoints=endpoints_list_empty,
+                    keySetID=keySetID2,
+                    key=inputKey3)
+                )
+                asserts.fail(
+                    "JoinGroup command should have failed because Group with keySetID already exists and does not match key, but it still succeeded")
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.AlreadyExists,
+                                     f"Send JoinGroup command error should be {Status.AlreadyExists} instead of {e.status}")
 
-        await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-            groupID=groupID5,
-            endpoints=endpoints_list_empty,
-            keySetID=keySetID5,
-            key=inputKey5)
-        )
+            # Attempt to join Group G5 with new Key but without providing InputKey (result: not found)
+            self.step("17b")
+            keySetID3 = 3
+            try:
+                await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                    groupID=groupID5,
+                    endpoints=endpoints_list_empty,
+                    keySetID=keySetID3)
+                )
+                asserts.fail("JoinGroup command should have failed because no Key found, but it still succeeded")
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.NotFound,
+                                     f"Send JoinGroup command error should be {Status.NotFound} instead of {e.status}")
 
-        # TH awaits subscription report of new membership within max interval
-        self.step("16b")
-        membership_matcher = generate_membership_entry_matcher(
-            group_id=groupID5, key_set_id=keySetID5, endpoints=endpoints_list_empty)
-        membership_sub.await_all_expected_report_matches(expected_matchers=[membership_matcher], timeout_sec=60)
+            if ln_enabled:
+                self.skip_step(18)
+            else:
+                self.step(18)
+                try:
+                    await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                        groupID=groupID5,
+                        endpoints=endpoints_list_empty,
+                        keySetID=keySetID2,
+                        replaceEndpoints=True)
+                    )
+                    asserts.fail("JoinGroup command should have failed because listener cannot do JoinGroup commands, but it still succeeded")
+                except InteractionModelError as e:
+                    asserts.assert_equal(e.status, Status.ConstraintError,
+                                         f"Send JoinGroup command error should be {Status.ConstraintError} instead of {e.status}")
 
-        # Confirm If Listener featIsSupported, skip this step. Else attempt to add endpoints to Group G5 (result: constraint error)
-        self.step(17)
+            # If Listener feature is not supported, attempt to join a group with AuxiliaryACL (result: constraint error)
+            if ln_enabled:
+                self.skip_step(19)
+            else:
+                self.step(19)
+                try:
+                    await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
+                        groupID=groupID5,
+                        endpoints=endpoints_list_empty,
+                        keySetID=keySetID2,
+                        useAuxiliaryACL=True)
+                    )
+                    asserts.fail("JoinGroup command should have failed because listener cannot do JoinGroup commands, but it still succeeded")
+                except InteractionModelError as e:
+                    asserts.assert_equal(e.status, Status.ConstraintError,
+                                         f"Send JoinGroup command error should be {Status.ConstraintError} instead of {e.status}")
+
+        # conditional endpoints list for step 20 and 21
+        valid_endpoints = endpoints_list_empty
         if ln_enabled:
-            self.skip_step(17)  # go to step 18
+            valid_endpoints = [endpoint1]
 
-        try:
-            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-                groupID=groupID5,
-                endpoints=[endpoint1],
-                keySetID=keySetID5,
-                key=inputKey5)
-            )
-            asserts.fail("JoinGroup command should have failed because listener cannot do JoinGroup commands, but it still succeeded")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.ConstraintError,
-                                 f"Send JoinGroup command error should be {Status.ConstraintError} instead of {e.status}")
-
-        # If Listener feature is not supported, attempt to join a group with AuxiliaryACL (result: constraint error)
-        self.step(18)
-        try:
-            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-                groupID=groupID5,
-                endpoints=endpoints_list_empty,
-                keySetID=keySetID5,
-                useAuxiliaryACL=True)
-            )
-            asserts.fail("JoinGroup command should have failed because listener cannot do JoinGroup commands, but it still succeeded")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.ConstraintError,
-                                 f"Send JoinGroup command error should be {Status.ConstraintError} instead of {e.status}")
-
-        # JoinGroup with invalid GroupID (result: constraint error)
-        self.step(19)
+        # JoinGroup with invalid GroupID=0 (result: constraint error)
+        self.step(20)
         groupID0 = 0
         try:
             await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-                groupID=groupID0, keySetID=1, key=secrets.token_bytes(16))
+                groupID=groupID0, endpoints=valid_endpoints, keySetID=1)
             )
             asserts.fail("JoinGroup command should have failed because GroupID cannot be 0, but it still succeeded")
         except InteractionModelError as e:
@@ -426,71 +456,18 @@ class TC_GCAST_2_2(MatterBaseTest):
                                  f"Send JoinGroup command error should be {Status.ConstraintError} instead of {e.status}")
 
         # JoinGroup with Key length != 16 (result: constraint error)
-        self.step(20)
+        self.step(21)
         inputKeyLong = secrets.token_bytes(17)
+        keySetID4 = 4
+        groupID6 = 6
         try:
             await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-                groupID=groupID5,
+                groupID=groupID6,
+                endpoints=valid_endpoints,
+                keySetID=keySetID4,
                 key=inputKeyLong)
             )
             asserts.fail("JoinGroup command should have failed because Key length is not 16 bytes, but it still succeeded")
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.ConstraintError,
-                                 f"Send JoinGroup command error should be {Status.ConstraintError} instead of {e.status}")
-
-        # Test JoinGroup with ReplaceEndpoints=True: Add EP1 to Group G6
-        self.step("21a")
-        if not ln_enabled:
-            self.mark_step_range_skipped("21a", "21d")
-
-        groupID6 = 6
-        keySetID6 = 6
-        key6 = secrets.token_bytes(16)
-
-        await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-            groupID=groupID6,
-            endpoints=[endpoint1],
-            keySetID=keySetID6,
-            key=key6)
-        )
-
-        # TH awaits subscription report for Group G6 with EP1
-        self.step("21b")
-        membership_sub.await_all_expected_report_matches([generate_membership_entry_matcher(
-            group_id=groupID6, key_set_id=keySetID6, endpoints=[endpoint1])], timeout_sec=60)
-
-        # Test JoinGroup with ReplaceEndpoints=True: Replace EP1 with EP2 in Group G6
-        self.step("21c")
-        endpoint2 = endpoints_list[1]
-        if endpoint2 is None:
-            self.mark_step_range_skipped("21c", "21d")
-        if not (endpoint2 and endpoint1 != endpoint2):
-            self.mark_step_range_skipped("21c", "21d")
-
-        await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-            groupID=groupID6,
-            endpoints=[endpoint2],
-            keySetID=keySetID6,
-            replaceEndpoints=True)
-        )
-
-        # TH awaits subscription report for Group G6 with only EP2
-        self.step("21d")
-        membership_sub.await_all_expected_report_matches([generate_membership_entry_matcher(
-            group_id=groupID6, key_set_id=keySetID6, endpoints=[endpoint2])], timeout_sec=60)
-
-        # JoinGroup with Endpoint 0 (result: constraint error)
-        self.step(22)
-        if not ln_enabled:
-            self.skip_step(22)
-
-        try:
-            await self.send_single_cmd(Clusters.Groupcast.Commands.JoinGroup(
-                groupID=1,
-                endpoints=[0],
-                keySetID=1)
-            )
-            asserts.fail("JoinGroup command should have failed for Endpoint 0, but it succeeded")
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.ConstraintError,
                                  f"Send JoinGroup command error should be {Status.ConstraintError} instead of {e.status}")


### PR DESCRIPTION
#### Summary
The Groupcast `TC_GCAST_2.2` test script was out of sync with the Test plan with multiple invalid or misaligned test steps.
https://github.com/CHIP-Specifications/chip-test-plans/blob/master/src/cluster/groupcast.adoc#312-tc-gc-22-joingroup-as-listener-or-sender-with-dut_server---provisional
(alignment for the PIC name GCAST->GC will be done in a separate PR)

Test updated steps 15b/c and 16b/c also allowed to catch and implementation issue:
The Membership attribute endpoint and Use hasAuxiliaryACL conformance, at encoding, were not respected for the Listener feature.
This is now fixed where those elements are properly omitted or encoded based on the feature map.

#### Related issues
Address #43238 TC_GCAST_2.2 misalignment

#### Testing
Build the test environment. and run TC_GCAST_2.2.py against darwin all-cluster-app
[test_summary.yaml](https://github.com/user-attachments/files/25529293/test_summary.yaml)
[test_log.INFO.txt](https://github.com/user-attachments/files/25529300/test_log.INFO.txt)
