### PR TITLE
Disallow icd in branch-v1.3

### DIFF
--- a/src/app/icd/server/ICDServerConfig.h
+++ b/src/app/icd/server/ICDServerConfig.h
@@ -20,3 +20,7 @@
 #if CHIP_HAVE_CONFIG_H
 #include <app/icd/server/ICDServerBuildConfig.h>
 #endif
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#error "The ICD feature is not ready and cannot be enabled in v1.3. Please set chip_enable_icd_server=false."
+#endif


### PR DESCRIPTION
#### Summary

Fixes #43291

SDK should not allow incomplete features to be enabled like LIT ICD in v1.3.

We should have a build error in 1.3 branch when LIT ICD feature is enabled because it's not ready.
This may cause issues to clients when interacting with "partial" LIT ICD 1.3

#### Testing
Verified lit_icd app fails to build
