### PR TITLE
Rename UnRegister -> Unregister in DeviceInterface

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.cpp
@@ -34,7 +34,7 @@ CHIP_ERROR BooleanStateSensorDevice::Register(chip::EndpointId endpoint, CodeDri
     return provider.AddEndpoint(mEndpointRegistration);
 }
 
-void BooleanStateSensorDevice::UnRegister(CodeDrivenDataModelProvider & provider)
+void BooleanStateSensorDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
     SingleEndpointUnregistration(provider);
     if (mBooleanStateCluster.IsConstructed())

--- a/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/boolean-state-sensor/BooleanStateSensorDevice.h
@@ -40,7 +40,7 @@ public:
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
                         EndpointId parentId = kInvalidEndpointId) override;
-    void UnRegister(CodeDrivenDataModelProvider & provider) override;
+    void Unregister(CodeDrivenDataModelProvider & provider) override;
 
     Clusters::BooleanStateCluster & BooleanState() { return mBooleanStateCluster.Cluster(); }
 

--- a/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.cpp
@@ -46,7 +46,7 @@ CHIP_ERROR ChimeDevice::Register(chip::EndpointId endpoint, CodeDrivenDataModelP
     return provider.AddEndpoint(mEndpointRegistration);
 }
 
-void ChimeDevice::UnRegister(CodeDrivenDataModelProvider & provider)
+void ChimeDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
     SingleEndpointUnregistration(provider);
     if (mChimeCluster.IsConstructed())

--- a/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/chime/ChimeDevice.h
@@ -33,7 +33,7 @@ public:
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
                         EndpointId parentId = kInvalidEndpointId) override;
-    void UnRegister(CodeDrivenDataModelProvider & provider) override;
+    void Unregister(CodeDrivenDataModelProvider & provider) override;
 
     Clusters::ChimeCluster & ChimeCluster();
 

--- a/examples/all-devices-app/all-devices-common/devices/interface/DeviceInterface.h
+++ b/examples/all-devices-app/all-devices-common/devices/interface/DeviceInterface.h
@@ -43,7 +43,7 @@ public:
     /// must only be called when register has succeeded before. Expected
     /// usage of this function is for when the device is no longer needed
     /// (for example, on shutown), to destory the device's clusters.
-    virtual void UnRegister(CodeDrivenDataModelProvider & provider) = 0;
+    virtual void Unregister(CodeDrivenDataModelProvider & provider) = 0;
 
     // Endpoint interface implementation
     CHIP_ERROR DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const override;

--- a/examples/all-devices-app/all-devices-common/devices/interface/DeviceInterface.h
+++ b/examples/all-devices-app/all-devices-common/devices/interface/DeviceInterface.h
@@ -42,7 +42,7 @@ public:
     /// Removes a device's clusters from the given provider. This
     /// must only be called when register has succeeded before. Expected
     /// usage of this function is for when the device is no longer needed
-    /// (for example, on shutown), to destory the device's clusters.
+    /// (for example, on shutdown), to destroy the device's clusters.
     virtual void Unregister(CodeDrivenDataModelProvider & provider) = 0;
 
     // Endpoint interface implementation

--- a/examples/all-devices-app/all-devices-common/devices/interface/SingleEndpointDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/interface/SingleEndpointDevice.h
@@ -52,7 +52,7 @@ protected:
 
     /// Internal function to unregister a single endpoint device. This will destroy the clusters part of
     /// this class, and must be called in a subclass' device-specific Unregister() function. This allows
-    /// for the destruction of the general SingleEndpointDevice clusters and device-specifc clusters from
+    /// for the destruction of the general SingleEndpointDevice clusters and device-specific clusters from
     /// the subclass, as well as removal of the device endpoint from the provider to happen together.
     void SingleEndpointUnregistration(CodeDrivenDataModelProvider & provider);
 

--- a/examples/all-devices-app/all-devices-common/devices/interface/SingleEndpointDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/interface/SingleEndpointDevice.h
@@ -51,7 +51,7 @@ protected:
     CHIP_ERROR SingleEndpointRegistration(EndpointId endpoint, CodeDrivenDataModelProvider & provider, EndpointId parentId);
 
     /// Internal function to unregister a single endpoint device. This will destroy the clusters part of
-    /// this class, and must be called in a subclass' device-specific UnRegister() function. This allows
+    /// this class, and must be called in a subclass' device-specific Unregister() function. This allows
     /// for the destruction of the general SingleEndpointDevice clusters and device-specifc clusters from
     /// the subclass, as well as removal of the device endpoint from the provider to happen together.
     void SingleEndpointUnregistration(CodeDrivenDataModelProvider & provider);

--- a/examples/all-devices-app/all-devices-common/devices/occupancy-sensor/OccupancySensorDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/occupancy-sensor/OccupancySensorDevice.cpp
@@ -46,7 +46,7 @@ CHIP_ERROR OccupancySensorDevice::Register(chip::EndpointId endpoint, CodeDriven
     return provider.AddEndpoint(mEndpointRegistration);
 }
 
-void OccupancySensorDevice::UnRegister(CodeDrivenDataModelProvider & provider)
+void OccupancySensorDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
     SingleEndpointUnregistration(provider);
     if (mOccupancySensingCluster.IsConstructed())

--- a/examples/all-devices-app/all-devices-common/devices/occupancy-sensor/OccupancySensorDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/occupancy-sensor/OccupancySensorDevice.h
@@ -34,7 +34,7 @@ public:
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
                         EndpointId parentId = kInvalidEndpointId) override;
-    void UnRegister(CodeDrivenDataModelProvider & provider) override;
+    void Unregister(CodeDrivenDataModelProvider & provider) override;
 
     Clusters::OccupancySensingCluster & OccupancySensingCluster() { return mOccupancySensingCluster.Cluster(); }
 

--- a/examples/all-devices-app/all-devices-common/devices/occupancy-sensor/impl/TogglingOccupancySensorDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/occupancy-sensor/impl/TogglingOccupancySensorDevice.cpp
@@ -58,10 +58,10 @@ CHIP_ERROR TogglingOccupancySensorDevice::Register(EndpointId endpoint, CodeDriv
     return mTimerDelegate.StartTimer(this, kOccupancyStateChangeIntervalSec);
 }
 
-void TogglingOccupancySensorDevice::UnRegister(CodeDrivenDataModelProvider & provider)
+void TogglingOccupancySensorDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
     mTimerDelegate.CancelTimer(this);
-    OccupancySensorDevice::UnRegister(provider);
+    OccupancySensorDevice::Unregister(provider);
 }
 
 void TogglingOccupancySensorDevice::OnOccupancyChanged(bool occupied)

--- a/examples/all-devices-app/all-devices-common/devices/occupancy-sensor/impl/TogglingOccupancySensorDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/occupancy-sensor/impl/TogglingOccupancySensorDevice.h
@@ -39,7 +39,7 @@ public:
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider,
                         EndpointId parentId = kInvalidEndpointId) override;
-    void UnRegister(CodeDrivenDataModelProvider & provider) override;
+    void Unregister(CodeDrivenDataModelProvider & provider) override;
 
     // OccupancySensingDelegate
     void OnOccupancyChanged(bool occupied) override;

--- a/examples/all-devices-app/all-devices-common/devices/on-off-light/LoggingOnOffLightDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/on-off-light/LoggingOnOffLightDevice.cpp
@@ -170,7 +170,7 @@ CHIP_ERROR LoggingOnOffLightDevice::Register(chip::EndpointId endpoint, CodeDriv
     return provider.AddEndpoint(mEndpointRegistration);
 }
 
-void LoggingOnOffLightDevice::UnRegister(CodeDrivenDataModelProvider & provider)
+void LoggingOnOffLightDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
     SingleEndpointUnregistration(provider);
 

--- a/examples/all-devices-app/all-devices-common/devices/on-off-light/LoggingOnOffLightDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/on-off-light/LoggingOnOffLightDevice.h
@@ -45,7 +45,7 @@ public:
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
                         EndpointId parentId = kInvalidEndpointId) override;
-    void UnRegister(CodeDrivenDataModelProvider & provider) override;
+    void Unregister(CodeDrivenDataModelProvider & provider) override;
 
 private:
     class OnOffDelegate : public Clusters::OnOffDelegate

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -135,7 +135,7 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
     return provider.AddEndpoint(mEndpointRegistration);
 }
 
-void RootNodeDevice::UnRegister(CodeDrivenDataModelProvider & provider)
+void RootNodeDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
     SingleEndpointUnregistration(provider);
 

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
@@ -73,7 +73,7 @@ public:
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider,
                         EndpointId parentId = kInvalidEndpointId) override;
-    void UnRegister(CodeDrivenDataModelProvider & provider) override;
+    void Unregister(CodeDrivenDataModelProvider & provider) override;
 
 protected:
     Context mContext;

--- a/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.cpp
@@ -47,9 +47,9 @@ CHIP_ERROR WifiRootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataMod
     return CHIP_NO_ERROR;
 }
 
-void WifiRootNodeDevice::UnRegister(CodeDrivenDataModelProvider & provider)
+void WifiRootNodeDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
-    RootNodeDevice::UnRegister(provider);
+    RootNodeDevice::Unregister(provider);
     if (mNetworkCommissioningCluster.IsConstructed())
     {
         LogErrorOnFailure(provider.RemoveCluster(&mNetworkCommissioningCluster.Cluster()));

--- a/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/WifiRootNodeDevice.h
@@ -39,7 +39,7 @@ public:
 
     CHIP_ERROR Register(EndpointId endpoint, CodeDrivenDataModelProvider & provider,
                         EndpointId parentId = kInvalidEndpointId) override;
-    void UnRegister(CodeDrivenDataModelProvider & provider) override;
+    void Unregister(CodeDrivenDataModelProvider & provider) override;
 
 private:
     LazyRegisteredServerCluster<Clusters::NetworkCommissioningCluster> mNetworkCommissioningCluster;

--- a/examples/all-devices-app/all-devices-common/devices/speaker/SpeakerDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/speaker/SpeakerDevice.cpp
@@ -66,7 +66,7 @@ CHIP_ERROR SpeakerDevice::Register(chip::EndpointId endpoint, CodeDrivenDataMode
     return provider.AddEndpoint(mEndpointRegistration);
 }
 
-void SpeakerDevice::UnRegister(CodeDrivenDataModelProvider & provider)
+void SpeakerDevice::Unregister(CodeDrivenDataModelProvider & provider)
 {
     SingleEndpointUnregistration(provider);
     if (mLevelControlCluster.IsConstructed())

--- a/examples/all-devices-app/all-devices-common/devices/speaker/SpeakerDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/speaker/SpeakerDevice.h
@@ -37,7 +37,7 @@ public:
 
     CHIP_ERROR Register(chip::EndpointId endpoint, CodeDrivenDataModelProvider & provider,
                         EndpointId parentId = kInvalidEndpointId) override;
-    void UnRegister(CodeDrivenDataModelProvider & provider) override;
+    void Unregister(CodeDrivenDataModelProvider & provider) override;
 
     // Accessors for subclasses/implementations to interact with clusters
     Clusters::OnOffCluster & OnOffCluster();

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -160,10 +160,10 @@ public:
     {
         for (auto & device : mConstructedDevices)
         {
-            device->UnRegister(mDataModelProvider);
+            device->Unregister(mDataModelProvider);
         }
         mConstructedDevices.clear();
-        mRootNode.RootDevice().UnRegister(mDataModelProvider);
+        mRootNode.RootDevice().Unregister(mDataModelProvider);
     }
 
     chip::app::CodeDrivenDataModelProvider & DataModelProvider() { return mDataModelProvider; }


### PR DESCRIPTION
#### Summary

Rename UnRegister -> Unregister in DeviceInterface
This is the correct spelling used in the rest of the code base.

#### Testing

Existing tests.