### PR TITLE
Disallow ONLY LIT ICD in v1.3

### DIFF
--- a/src/app/icd/server/ICDServerConfig.h
+++ b/src/app/icd/server/ICDServerConfig.h
@@ -21,6 +21,6 @@
 #include <app/icd/server/ICDServerBuildConfig.h>
 #endif
 
-#if CHIP_CONFIG_ENABLE_ICD_SERVER
-#error "The ICD feature is not ready and cannot be enabled in v1.3. Please set chip_enable_icd_server=false."
+#if CHIP_CONFIG_ENABLE_ICD_LIT
+#error "The LIT ICD feature is not ready and cannot be enabled in v1.3. Please set chip_enable_icd_lit=false."
 #endif


### PR DESCRIPTION
#### Summary

Similar to https://github.com/project-chip/connectedhomeip/pull/43298 but actually ONLY DISABLES LIT. The previous PR disabled too much.

#### Testing

Tested lit-icd app fails to build