### PR TITLE
[NXP][SE05X] SE05x session close after every crypto operations

### DIFF
--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hkdf.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hkdf.cpp
@@ -83,7 +83,10 @@ exit:
     {
         sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
     return error;
 }
 

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hkdf.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hkdf.cpp
@@ -35,6 +35,8 @@ CHIP_ERROR HKDF_sha_SE05x::HKDF_SHA256(const uint8_t * secret, const size_t secr
     CHIP_ERROR error       = CHIP_ERROR_INTERNAL;
     uint32_t keyid         = kKeyId_hkdf_sha256_hmac_keyid;
     sss_object_t keyObject = { 0 };
+    smStatus_t smstatus    = SM_NOT_OK;
+    sss_status_t status    = kStatus_SSS_Fail;
 
     if (salt_length > 64 || info_length > 80 || secret_length > 256 || out_length > 768)
     {
@@ -56,22 +58,22 @@ CHIP_ERROR HKDF_sha_SE05x::HKDF_SHA256(const uint8_t * secret, const size_t secr
     VerifyOrReturnError(secret != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(gex_sss_chip_ctx.session.subsystem != kType_SSS_SubSystem_NONE, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(gex_sss_chip_ctx.session.subsystem != kType_SSS_SubSystem_NONE, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
-    sss_status_t status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Default, kSSS_CipherType_HMAC, secret_length,
                                             kKeyObject_Mode_Transient);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, secret, secret_length, secret_length * 8, NULL, 0);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    const smStatus_t smstatus = Se05x_API_HKDF_Extended(
-        &((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyObject.keyId, kSE05x_DigestMode_SHA256,
-        kSE05x_HkdfMode_ExtractExpand, salt, salt_length, 0, info, info_length, 0, (uint16_t) out_length, out_buffer, &out_length);
+    smstatus = Se05x_API_HKDF_Extended(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyObject.keyId,
+                                       kSE05x_DigestMode_SHA256, kSE05x_HkdfMode_ExtractExpand, salt, salt_length, 0, info,
+                                       info_length, 0, (uint16_t) out_length, out_buffer, &out_length);
     VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
 
     error = CHIP_NO_ERROR;
@@ -81,6 +83,7 @@ exit:
     {
         sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
     return error;
 }
 

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hmac.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hmac.cpp
@@ -110,7 +110,10 @@ exit:
     {
         sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
     return error;
 }
 

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hmac.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_hmac.cpp
@@ -38,6 +38,7 @@ CHIP_ERROR HMAC_sha_SE05x::HMAC_SHA256(const uint8_t * key, size_t key_length, c
     uint32_t keyid         = kKeyId_hmac_sha256_keyid;
     sss_mac_t ctx_mac      = { 0 };
     sss_object_t keyObject = { 0 };
+    sss_status_t status    = kStatus_SSS_Fail;
 
     ChipLogDetail(Crypto, "HMAC_SHA256 : Using se05x for HMAC");
 
@@ -56,17 +57,17 @@ CHIP_ERROR HMAC_sha_SE05x::HMAC_SHA256(const uint8_t * key, size_t key_length, c
     VerifyOrReturnError(keyid != kKeyId_NotInitialized, CHIP_ERROR_HSM);
 
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
-    sss_status_t status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Default, kSSS_CipherType_HMAC, key_length,
                                             kKeyObject_Mode_Transient);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &keyObject, key, key_length, key_length * 8, NULL, 0);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = sss_mac_context_init(&ctx_mac, &gex_sss_chip_ctx.session, &keyObject, kAlgorithm_SSS_HMAC_SHA256, kMode_SSS_Mac);
     VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
@@ -109,7 +110,7 @@ exit:
     {
         sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
-
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
     return error;
 }
 

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_p256.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_p256.cpp
@@ -184,7 +184,10 @@ CHIP_ERROR P256KeypairSE05x::Initialize(ECPKeyTarget key_target)
 
     error = CHIP_NO_ERROR;
 exit:
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
     return error;
 }
 
@@ -246,7 +249,10 @@ exit:
     {
         sss_asymmetric_context_free(&asymm_ctx);
     }
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
     return error;
 }
 
@@ -349,7 +355,10 @@ CHIP_ERROR P256KeypairSE05x::ECDH_derive_secret(const P256PublicKey & remote_pub
 
     error = CHIP_NO_ERROR;
 exit:
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
     return error;
 }
 
@@ -391,7 +400,10 @@ CHIP_ERROR SE05X_Set_ECDSA_Public_Key(sss_object_t * keyObject, const uint8_t * 
 
     error = CHIP_NO_ERROR;
 exit:
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
     return error;
 }
 
@@ -449,7 +461,10 @@ exit:
     {
         sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
     return error;
 }
 
@@ -501,7 +516,10 @@ exit:
     {
         sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
     return error;
 }
 
@@ -736,7 +754,10 @@ exit:
     {
         sss_asymmetric_context_free(&asymm_ctx);
     }
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
     return error;
 }
 

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_p256.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_p256.cpp
@@ -107,6 +107,7 @@ CHIP_ERROR P256KeypairSE05x::Initialize(ECPKeyTarget key_target)
     size_t pbKeyBitLen = sizeof(pubkey) * 8;
     uint32_t keyid     = 0;
     uint32_t options   = kKeyObject_Mode_Transient;
+    CHIP_ERROR error   = CHIP_NO_ERROR;
 
     if (key_target == ECPKeyTarget::ECDH)
     {
@@ -126,7 +127,7 @@ CHIP_ERROR P256KeypairSE05x::Initialize(ECPKeyTarget key_target)
     if (keyid == 0)
     {
         ChipLogDetail(Crypto, "se05x::Generating nist256 key on host (no key id slot found)");
-        CHIP_ERROR error = Initialize_H(this, &mPublicKey, &mKeypair);
+        error = Initialize_H(this, &mPublicKey, &mKeypair);
         if (CHIP_NO_ERROR == error)
         {
             mInitialized = true;
@@ -139,36 +140,39 @@ CHIP_ERROR P256KeypairSE05x::Initialize(ECPKeyTarget key_target)
     ChipLogDetail(Crypto, "se05x::Generate nist256 key using se05x (at id = 0x%" PRIx32 ")", keyid);
 
     status = sss_key_object_init(&keyObject, &gex_sss_chip_ctx.ks);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = sss_key_object_allocate_handle(&keyObject, keyid, kSSS_KeyPart_Pair, kSSS_CipherType_EC_NIST_P, 256, options);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = sss_key_store_generate_key(&gex_sss_chip_ctx.ks, &keyObject, 256, 0);
     if (status != kStatus_SSS_Success)
     {
 #ifdef ENABLE_GENERATE_EC_KEY_HOST_ON_FAILURE
         ChipLogDetail(Crypto, "se05x::Generating nist256 key on se05x failed. Generating key on host");
-        CHIP_ERROR error = Initialize_H(this, &mPublicKey, &mKeypair);
+        error = Initialize_H(this, &mPublicKey, &mKeypair);
         if (CHIP_NO_ERROR == error)
         {
             mInitialized = true;
         }
-        return error;
+        goto exit;
 #else
         ChipLogError(Crypto, "se05x::Generating nist256 key on se05x failed.");
-        return CHIP_ERROR_INTERNAL;
+        error = CHIP_ERROR_INTERNAL;
+        goto exit;
 #endif
     }
 
     status = sss_key_store_get_key(&gex_sss_chip_ctx.ks, &keyObject, pubkey, &pubKeyLen, &pbKeyBitLen);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    /* Set the public key */
-    P256PublicKey & public_key = const_cast<P256PublicKey &>(Pubkey());
-    VerifyOrReturnError(pubKeyLen > NIST256_HEADER_OFFSET, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError((pubKeyLen - NIST256_HEADER_OFFSET) <= kP256_PublicKey_Length, CHIP_ERROR_INTERNAL);
-    memcpy((void *) Uint8::to_const_uchar(public_key), pubkey + NIST256_HEADER_OFFSET, pubKeyLen - NIST256_HEADER_OFFSET);
+    {
+        /* Set the public key */
+        P256PublicKey & public_key = const_cast<P256PublicKey &>(Pubkey());
+        VerifyOrExit(pubKeyLen > NIST256_HEADER_OFFSET, error = CHIP_ERROR_INTERNAL);
+        VerifyOrExit((pubKeyLen - NIST256_HEADER_OFFSET) <= kP256_PublicKey_Length, error = CHIP_ERROR_INTERNAL);
+        memcpy((void *) Uint8::to_const_uchar(public_key), pubkey + NIST256_HEADER_OFFSET, pubKeyLen - NIST256_HEADER_OFFSET);
+    }
 
     memcpy(&mKeypair.mBytes[0], se05x_magic_no, sizeof(se05x_magic_no));
     mKeypair.mBytes[CRYPTO_KEYPAIR_KEYID_OFFSET]     = (keyid >> (3 * 8)) & 0x000000FF;
@@ -178,7 +182,10 @@ CHIP_ERROR P256KeypairSE05x::Initialize(ECPKeyTarget key_target)
 
     mInitialized = true;
 
-    return CHIP_NO_ERROR;
+    error = CHIP_NO_ERROR;
+exit:
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    return error;
 }
 
 CHIP_ERROR P256KeypairSE05x::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P256ECDSASignature & out_signature) const
@@ -239,6 +246,7 @@ exit:
     {
         sss_asymmetric_context_free(&asymm_ctx);
     }
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
     return error;
 }
 
@@ -313,6 +321,8 @@ CHIP_ERROR P256KeypairSE05x::ECDH_derive_secret(const P256PublicKey & remote_pub
 
     size_t secret_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
     uint32_t keyid       = 0;
+    CHIP_ERROR error     = CHIP_ERROR_INTERNAL;
+    smStatus_t smstatus  = SM_NOT_OK;
 
     if (CHIP_NO_ERROR != parse_se05x_keyid_from_keypair(mKeypair, &keyid))
     {
@@ -323,19 +333,24 @@ CHIP_ERROR P256KeypairSE05x::ECDH_derive_secret(const P256PublicKey & remote_pub
     ChipLogDetail(Crypto, "ECDH_derive_secret : Using se05x for ecdh");
 
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
     const uint8_t * const rem_pubKey = Uint8::to_const_uchar(remote_public_key);
     const size_t rem_pubKeyLen       = remote_public_key.Length();
 
-    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != nullptr, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(gex_sss_chip_ctx.ks.session != nullptr, error = CHIP_ERROR_INTERNAL);
 
-    const smStatus_t smstatus =
-        Se05x_API_ECGenSharedSecret(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyid, rem_pubKey, rem_pubKeyLen,
-                                    out_secret.Bytes() /*Uint8::to_uchar(out_secret)*/, &secret_length);
-    VerifyOrReturnError(smstatus == SM_OK, CHIP_ERROR_INTERNAL);
+    smstatus = Se05x_API_ECGenSharedSecret(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyid, rem_pubKey,
+                                           rem_pubKeyLen, out_secret.Bytes() /*Uint8::to_uchar(out_secret)*/, &secret_length);
+    VerifyOrExit(smstatus == SM_OK, error = CHIP_ERROR_INTERNAL);
 
-    return out_secret.SetLength(secret_length);
+    error = out_secret.SetLength(secret_length);
+    VerifyOrExit(error == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+
+    error = CHIP_NO_ERROR;
+exit:
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    return error;
 }
 
 /* EC Public key HSM implementation */
@@ -346,23 +361,25 @@ CHIP_ERROR SE05X_Set_ECDSA_Public_Key(sss_object_t * keyObject, const uint8_t * 
         0,
     };
     size_t public_key_len = 0;
+    CHIP_ERROR error      = CHIP_ERROR_INTERNAL;
+    sss_status_t status   = kStatus_SSS_Fail;
 
     /* ECC NIST-256 Public Key header */
     const uint8_t nist256_header[] = { 0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,
                                        0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00 };
 
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
     /* Set public key */
-    sss_status_t status = sss_key_object_init(keyObject, &gex_sss_chip_ctx.ks);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    status = sss_key_object_init(keyObject, &gex_sss_chip_ctx.ks);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = sss_key_object_allocate_handle(keyObject, kKeyId_sha256_ecc_pub_keyid, kSSS_KeyPart_Public, kSSS_CipherType_EC_NIST_P,
                                             256, kKeyObject_Mode_Transient);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    VerifyOrReturnError((sizeof(nist256_header) + keylen) <= sizeof(public_key), CHIP_ERROR_INTERNAL);
+    VerifyOrExit((sizeof(nist256_header) + keylen) <= sizeof(public_key), error = CHIP_ERROR_INTERNAL);
 
     memcpy(public_key, nist256_header, sizeof(nist256_header));
     public_key_len = sizeof(nist256_header);
@@ -370,9 +387,12 @@ CHIP_ERROR SE05X_Set_ECDSA_Public_Key(sss_object_t * keyObject, const uint8_t * 
     public_key_len = public_key_len + keylen;
 
     status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, keyObject, public_key, public_key_len, 256, NULL, 0);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    return CHIP_NO_ERROR;
+    error = CHIP_NO_ERROR;
+exit:
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    return error;
 }
 
 CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_msg_signature(const uint8_t * msg, size_t msg_length,
@@ -396,7 +416,7 @@ CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_msg_signature(const uint8_t * msg,
     ChipLogDetail(Crypto, "ECDSA_validate_msg_signature: Using se05x for ECDSA verify (msg) !");
 
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
     error = Hash_SHA256(msg, msg_length, hash);
     SuccessOrExit(error);
@@ -429,7 +449,7 @@ exit:
     {
         sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
-
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
     return error;
 }
 
@@ -450,7 +470,7 @@ CHIP_ERROR P256PublicKeySE05x::ECDSA_validate_hash_signature(const uint8_t * has
     ChipLogDetail(Crypto, "ECDSA_validate_msg_signature: Using se05x for ECDSA verify (hash) !");
 
     VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
     error = SE05X_Set_ECDSA_Public_Key(&keyObject, bytes, kP256_PublicKey_Length);
     SuccessOrExit(error);
@@ -481,7 +501,7 @@ exit:
     {
         sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &keyObject);
     }
-
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
     return error;
 }
 
@@ -574,6 +594,9 @@ CHIP_ERROR P256KeypairSE05x::NewCertificateSigningRequest(uint8_t * csr, size_t 
     }
 
     ChipLogDetail(Crypto, "NewCertificateSigningRequest : Using se05x for CSR");
+
+    VerifyOrExit(se05x_session_open() == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
 
     // No extensions are copied
     buffer_index -= kTlvHeader;
@@ -713,7 +736,7 @@ exit:
     {
         sss_asymmetric_context_free(&asymm_ctx);
     }
-
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
     return error;
 }
 

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_pbkdf.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_pbkdf.cpp
@@ -97,7 +97,10 @@ exit:
     {
         sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &hmacKeyObj);
     }
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
     return error;
 }
 

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_pbkdf.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_pbkdf.cpp
@@ -64,24 +64,28 @@ CHIP_ERROR PBKDF2_sha256_SE05x::pbkdf2_sha256(const uint8_t * password, size_t p
     policy_for_hmac_key.policies[0] = &hmac_withPol;
     policy_for_hmac_key.policies[1] = &commonPol;
 
-    VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(gex_sss_chip_ctx.ks.session != NULL, CHIP_ERROR_INTERNAL);
-
     sss_object_t hmacKeyObj = {
         0,
     };
-    sss_status_t status = sss_key_object_init(&hmacKeyObj, &gex_sss_chip_ctx.ks);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+
+    smStatus_t smStatus = SM_NOT_OK;
+    sss_status_t status = kStatus_SSS_Fail;
+
+    VerifyOrReturnError(se05x_session_open() == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(gex_sss_chip_ctx.ks.session != NULL, error = CHIP_ERROR_INTERNAL);
+
+    status = sss_key_object_init(&hmacKeyObj, &gex_sss_chip_ctx.ks);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = sss_key_object_allocate_handle(&hmacKeyObj, keyid, kSSS_KeyPart_Default, kSSS_CipherType_HMAC, sizeof(password),
                                             kKeyObject_Mode_Transient);
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
     status = sss_key_store_set_key(&gex_sss_chip_ctx.ks, &hmacKeyObj, password, plen, plen * 8, &policy_for_hmac_key,
                                    sizeof(policy_for_hmac_key));
-    VerifyOrReturnError(status == kStatus_SSS_Success, CHIP_ERROR_INTERNAL);
+    VerifyOrExit(status == kStatus_SSS_Success, error = CHIP_ERROR_INTERNAL);
 
-    const smStatus_t smStatus = Se05x_API_PBKDF2_extended(
+    smStatus = Se05x_API_PBKDF2_extended(
         &((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyid, salt, slen, 0, /*saltID*/
         (uint16_t) iteration_count, kSE05x_MACAlgo_HMAC_SHA256, (uint16_t) key_length, 0,  /* derivedSessionKeyID */
         output, (size_t *) &key_length);
@@ -93,7 +97,7 @@ exit:
     {
         sss_key_store_erase_key(&gex_sss_chip_ctx.ks, &hmacKeyObj);
     }
-
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
     return error;
 }
 

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_spake2p.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_spake2p.cpp
@@ -571,7 +571,7 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::KeyConfirm(const uint8_t * in, size
     }
 
     Spake2p_Finish_HSM(&hsm_pake_context);
-
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
     return error;
 }
 

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_spake2p.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_spake2p.cpp
@@ -571,7 +571,10 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::KeyConfirm(const uint8_t * in, size
     }
 
     Spake2p_Finish_HSM(&hsm_pake_context);
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
     return error;
 }
 

--- a/src/platform/nxp/crypto/se05x/PersistentStorageOperationalKeystore_se05x.cpp
+++ b/src/platform/nxp/crypto/se05x/PersistentStorageOperationalKeystore_se05x.cpp
@@ -106,6 +106,8 @@ CHIP_ERROR PersistentStorageOpKeystorese05x::RemoveOpKeypairForFabric(FabricInde
         keyId);
     Se05x_API_DeleteSecureObject(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyId);
 
+    TEMPORARY_RETURN_IGNORED se05x_close_session();
+
     // remove key from secure element
     if ((mPendingKeypair != nullptr) && (fabricIndex == mPendingFabricIndex))
     {

--- a/src/platform/nxp/crypto/se05x/PersistentStorageOperationalKeystore_se05x.cpp
+++ b/src/platform/nxp/crypto/se05x/PersistentStorageOperationalKeystore_se05x.cpp
@@ -106,7 +106,10 @@ CHIP_ERROR PersistentStorageOpKeystorese05x::RemoveOpKeypairForFabric(FabricInde
         keyId);
     Se05x_API_DeleteSecureObject(&((sss_se05x_session_t *) &gex_sss_chip_ctx.session)->s_ctx, keyId);
 
-    TEMPORARY_RETURN_IGNORED se05x_close_session();
+    if (se05x_close_session() != CHIP_NO_ERROR)
+    {
+        ChipLogError(Crypto, "se05x::Error in se05x_close_session.");
+    }
 
     // remove key from secure element
     if ((mPendingKeypair != nullptr) && (fabricIndex == mPendingFabricIndex))


### PR DESCRIPTION
#### Summary
The PR contains 
1. SE05x crypto kayer updated to ensure session close to SE05x is done after all crypto operations, to ensur

#### Testing
Testing is done by using following example and ensured successful commissioning is done
1. Thermostat example (examples\thermostat\nxp\linux-se05x) and chip tool