### PR TITLE
[OT] [SRP] Add more precision in srp Log

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1368,7 +1368,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_RemoveInvalidSr
     {
         if (service.IsUsed() && service.mIsInvalid)
         {
-            ChipLogProgress(DeviceLayer, "removing srp service: %s.%s", service.mService.mInstanceName, service.mService.mName);
+            ChipLogProgress(DeviceLayer, "removing invalid srp service: %s.%s", service.mService.mInstanceName,
+                            service.mService.mName);
             error = MapOpenThreadError(otSrpClientRemoveService(mOTInst, &service.mService));
             SuccessOrExit(error);
         }


### PR DESCRIPTION
#### Summary
in GenericThreadStackManagerImpl_OpenThread.hpp upon calling `_RemoveSrpService` or `_RemoveInvalidSrpServices` the same log was produce, limiting the amount of information available to the user.
#### Related issues

None

#### Testing

Logging string change. 
