### PR TITLE
[ICD] Add delayed requirement removal ICD Commissioning

### DIFF
--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -535,6 +535,12 @@ void ICDManager::SetKeepActiveModeRequirements(KeepActiveFlags flag, bool state)
         UpdateOperationState(OperationalState::IdleMode);
     }
 }
+void ICDManager::OnCommissioningDone(System::Layer * aLayer, void * appState)
+{
+    ICDManager * pICDManager = reinterpret_cast<ICDManager *>(appState);
+    KeepActiveFlags request(KeepActiveFlag::kCommissioningWindowOpen);
+    pICDManager->SetKeepActiveModeRequirements(request, false);
+}
 
 void ICDManager::OnIdleModeDone(System::Layer * aLayer, void * appState)
 {
@@ -633,6 +639,15 @@ void ICDManager::OnActiveRequestWithdrawal(KeepActiveFlags request)
         }
     }
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
+
+    if (request.Has(KeepActiveFlag::kCommissioningWindowOpen))
+    {
+        // Only 1 request per type (kCommissioningWindowOpen)
+        // delay the requirement removal for more responsiveness post commissioning.
+        DeviceLayer::SystemLayer().CancelTimer(OnCommissioningDone, this);
+        DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(60), OnCommissioningDone, this);
+        return;
+    }
 
     if (request.Has(KeepActiveFlag::kCommissioningWindowOpen) || request.Has(KeepActiveFlag::kFailSafeArmed))
     {

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -644,9 +644,13 @@ void ICDManager::OnActiveRequestWithdrawal(KeepActiveFlags request)
     {
         // Only 1 request per type (kCommissioningWindowOpen)
         // delay the requirement removal for more responsiveness post commissioning.
-        DeviceLayer::SystemLayer().CancelTimer(OnCommissioningDone, this);
-        DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(60), OnCommissioningDone, this);
-        return;
+        RETURN_SAFELY_IGNORED DeviceLayer::SystemLayer().CancelTimer(OnCommissioningDone, this);
+        if (CHIP_NO_ERROR == DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(60), OnCommissioningDone, this))
+        {
+            // if we fail to start the timer, we will remove the requirement immediately to avoid staying in active mode
+            // indefinitely. Otherwise wait for the timer to expire.
+            return;
+        }
     }
 
     if (request.Has(KeepActiveFlag::kCommissioningWindowOpen) || request.Has(KeepActiveFlag::kFailSafeArmed))

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -333,6 +333,7 @@ private:
      * @param appState pointer to the ICDManager
      */
     static void OnActiveModeDone(System::Layer * aLayer, void * appState);
+    static void OnCommissioningDone(System::Layer * aLayer, void * appState);
 
     /**
      * @brief Timer Callback function called shortly before the device enters idle mode to allow checks to be made.

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -618,9 +618,9 @@ void CommissioningWindowManager::UpdateWindowStatus(CommissioningWindowStatusEnu
 {
     CommissioningWindowStatusEnum oldClusterStatus = CommissioningWindowStatusForCluster();
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    // BugFix, The commissioning window is open before the initialisation of the ICD Manager
-    // trigger a request notification everytime the status is updated to make sure the ICDManager
-    // is in sync the the commissioning window status.
+    // BugFix: The commissioning window can be open before the initialization of the ICD Manager.
+    // Trigger a request notification every time this function is called with an open status
+    // to ensure the ICDManager is in sync with the commissioning window status.
     if (aNewStatus == CommissioningWindowStatusEnum::kEnhancedWindowOpen ||
         aNewStatus == CommissioningWindowStatusEnum::kBasicWindowOpen)
     {

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -617,16 +617,24 @@ void CommissioningWindowManager::ExpireFailSafeIfHeldByOpenPASESession()
 void CommissioningWindowManager::UpdateWindowStatus(CommissioningWindowStatusEnum aNewStatus)
 {
     CommissioningWindowStatusEnum oldClusterStatus = CommissioningWindowStatusForCluster();
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    // BugFix, The commissioning window is open before the initialisation of the ICD Manager
+    // trigger a request notification everytime the status is updated to make sure the ICDManager
+    // is in sync the the commissioning window status.
+    if (aNewStatus == CommissioningWindowStatusEnum::kEnhancedWindowOpen ||
+        aNewStatus == CommissioningWindowStatusEnum::kBasicWindowOpen)
+    {
+        app::ICDListener::KeepActiveFlags request = app::ICDListener::KeepActiveFlag::kCommissioningWindowOpen;
+        app::ICDNotifier::GetInstance().NotifyActiveRequestNotification(request);
+    }
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
     if (mWindowStatus != aNewStatus)
     {
         mWindowStatus = aNewStatus;
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
         app::ICDListener::KeepActiveFlags request = app::ICDListener::KeepActiveFlag::kCommissioningWindowOpen;
-        if (mWindowStatus != CommissioningWindowStatusEnum::kWindowNotOpen)
-        {
-            app::ICDNotifier::GetInstance().NotifyActiveRequestNotification(request);
-        }
-        else
+        if (mWindowStatus == CommissioningWindowStatusEnum::kWindowNotOpen)
         {
             app::ICDNotifier::GetInstance().NotifyActiveRequestWithdrawal(request);
         }


### PR DESCRIPTION
#### Summary
Add a sixty second delay post-commissioning before removing the active mode requirement

#### Related issues
Fix #43315
#### Testing
Tested with a MG24. Commissioning triggers the timer and the requirement is removed after sixty second. 
