### PR TITLE
[ICD][[Server] Improve NotifySendCheckIn to cover all check-in nodes

### DIFF
--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -505,7 +505,7 @@ public:
         TEMPORARY_RETURN_IGNORED chip::DeviceLayer::PlatformMgr().ScheduleWork(
             [](intptr_t) {
                 ChipLogDetail(AppServer, "Being triggered to send ICD check-in message to subscriber");
-                chip::app::ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
+                chip::app::ICDNotifier::GetInstance().NotifySendCheckIn(Optional<chip::Access::SubjectDescriptor>());
             },
             reinterpret_cast<intptr_t>(nullptr));
         return pw::OkStatus();

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -421,7 +421,7 @@ void ReadHandler::OnResponseTimeout(Messaging::ExchangeContext * apExchangeConte
             ChipLogError(DataManagement, "Trigger check-in message when non-priming subscription report times out");
             if (mSessionHandle)
             {
-                ICDNotifier::GetInstance().NotifySendCheckIn(GetSubjectDescriptor());
+                ICDNotifier::GetInstance().NotifySendCheckIn(MakeOptional(GetSubjectDescriptor()));
             }
             else
             {

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -687,10 +687,9 @@ void ICDManager::OnSubscriptionReport()
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-void ICDManager::OnSendCheckIn(const Access::SubjectDescriptor & subject)
+void ICDManager::OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubject)
 {
-    ChipLogProgress(AppServer, "Received OnSendCheckIn for subject: " ChipLogFormatX64, ChipLogValueX64(subject.subject));
-    SendCheckInMsgs(MakeOptional(subject));
+    SendCheckInMsgs(specificSubject);
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -264,7 +264,7 @@ public:
     void OnSubscriptionReport() override;
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-    void OnSendCheckIn(const Access::SubjectDescriptor & subject) override;
+    void OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubject) override;
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
 private:

--- a/src/app/icd/server/ICDNotifier.cpp
+++ b/src/app/icd/server/ICDNotifier.cpp
@@ -136,13 +136,13 @@ void ICDNotifier::NotifySubscriptionReport()
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-void ICDNotifier::NotifySendCheckIn(const chip::Access::SubjectDescriptor & subject)
+void ICDNotifier::NotifySendCheckIn(Optional<Access::SubjectDescriptor> specificSubject)
 {
     for (auto subscriber : mSubscribers)
     {
         if (subscriber != nullptr)
         {
-            subscriber->OnSendCheckIn(subject);
+            subscriber->OnSendCheckIn(specificSubject);
         }
     }
 }

--- a/src/app/icd/server/ICDNotifier.h
+++ b/src/app/icd/server/ICDNotifier.h
@@ -19,8 +19,8 @@
 #include <access/SubjectDescriptor.h>
 #include <app/icd/server/ICDServerConfig.h>
 #include <lib/core/CHIPError.h>
-#include <lib/support/BitFlags.h>
 #include <lib/core/Optional.h>
+#include <lib/support/BitFlags.h>
 
 namespace chip {
 namespace app {
@@ -144,7 +144,7 @@ public:
     void NotifySubscriptionReport();
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
-    void NotifySendCheckIn(const chip::Access::SubjectDescriptor & subject);
+    void NotifySendCheckIn(Optional<Access::SubjectDescriptor> specificSubject);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 
     inline void BroadcastActiveRequest(ICDListener::KeepActiveFlags request, bool notify)

--- a/src/app/icd/server/ICDNotifier.h
+++ b/src/app/icd/server/ICDNotifier.h
@@ -20,6 +20,8 @@
 #include <app/icd/server/ICDServerConfig.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/BitFlags.h>
+#include <lib/core/Optional.h>
+
 namespace chip {
 namespace app {
 
@@ -113,8 +115,9 @@ public:
      * It informs the subscriber that a Check-In message needs to be sent for the provided subject.
      *
      * @param subject : The subject descriptor for which the Check-In message needs to be sent.
+     *                  If not provided, Check-In messages should be sent for all subjects that require it.
      */
-    virtual void OnSendCheckIn(const chip::Access::SubjectDescriptor & subject) = 0;
+    virtual void OnSendCheckIn(Optional<Access::SubjectDescriptor> specificSubject) = 0;
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_ENABLE_ICD_CHECK_IN_ON_REPORT_TIMEOUT
 };
 


### PR DESCRIPTION
#### Summary
Improve NotifySendCheckIn to send check-in message for all check-in nodes. During virtual test, we see device is alway active so that we cannot send check-in message for e2e test using virtual chef-app, we need use NotifySendCheckIn to forcibly send out check-in messages.

#### Related issues
N/A

#### Testing
local testing with chef-app

#### Readability checklist
N/A