### PR TITLE
[SIlabs] Fixing the build for the smoke co alarm app

### DIFF
--- a/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
@@ -264,12 +264,12 @@ CHIP_ERROR SmokeCoAlarmManager::HandleEventTrigger(uint64_t eventTrigger)
         break;
     case SmokeCOTrigger::kForceUnmountedState:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force Unmounted State");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(kSmokeCoAlarmEndpointId, true), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(kSmokeCoAlarmEndpointId, true), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearUnmountedState:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear Unmounted State");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(kSmokeCoAlarmEndpointId, false), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(kSmokeCoAlarmEndpointId, false), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     default:


### PR DESCRIPTION
#### Summary
The build on the Silabs smoke-co-alarm app was failing from the PR https://github.com/project-chip/connectedhomeip/pull/43170 
HandleEventTrigger was expecting to return a CHIP_ERROR hence VerifyOrReturnValue on bool it was failing
Corrected the CHIP_ERROR return instead of bool for the added cases 

#### Related issues
NA

#### Testing
Local build of the smoke-co-alarm app and running
