### PR TITLE
Adding commissioning "True" variable in TC-IDM-2.3 python automated test script

### DIFF
--- a/src/python_testing/TC_IDM_2_3.py
+++ b/src/python_testing/TC_IDM_2_3.py
@@ -65,7 +65,7 @@ class TC_IDM_2_3(BasicCompositionTests):
 
     def steps_TC_IDM_2_3(self) -> list[TestStep]:
         return [
-            TestStep(1, "TH reads from the DUT the CapabilityMinima attribute from the Basic Information Cluster."),
+            TestStep(1, "TH reads from the DUT the CapabilityMinima attribute from the Basic Information Cluster.", is_commissioning=True),
             TestStep(2, "TH reads from the DUT all attributes from all clusters on all endpoints, to collect valid AttributePaths."),
             TestStep(3, "TH sends a Read Request Message to the DUT with a number of paths up to the ReadPathsSupported value."),
             TestStep(4, "TH sends a Subscribe Request Message to the DUT with a number of paths up to the SubscribePathsSupported value. TH then modifies one of the subscribed attributes and waits for a Report Data Action."),


### PR DESCRIPTION
#### Summary

The `is_commissioning=True` variable was missed in the test script. So in TH image this test is considered as "No commissioning required". But actually we need to commission the Th and DUT before executing the test steps.
This update will solve the problem mentioned above.

#### Testing

Side-loaded the updated script to the 1.6 TE2 Th image and validated. The test is passed as expected.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
