### PR TITLE
support establish PASE only for Thread meshcop commissioning

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -343,36 +343,33 @@ CHIP_ERROR PairingCommand::Pair(NodeId remoteId, PeerAddress address)
     }
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    if (mPaseOnly.ValueOr(false))
+    if (address.GetTransportType() == Transport::Type::kThreadMeshcop && mOnboardingPayload)
     {
-        if (address.GetTransportType() == Transport::Type::kThreadMeshcop && mOnboardingPayload)
+        SetUpCodePairer::ThreadMeshcopCommissionParameters meshcopParams;
+        ReturnErrorOnFailure(GetMeshcopCommissionParams(meshcopParams));
+        CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
+        if (mPaseOnly.ValueOr(false))
         {
-            CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
-            SetUpCodePairer::ThreadMeshcopCommissionParameters meshcopParams;
-            ReturnErrorOnFailure(GetMeshcopCommissionParams(meshcopParams));
             err = CurrentCommissioner().EstablishPASEConnection(remoteId, mOnboardingPayload, DiscoveryType::kAll, NullOptional,
                                                                 MakeOptional(meshcopParams));
-            CurrentCommissioner().RegisterDeviceDiscoveryDelegate(nullptr);
         }
         else
         {
-            err = CurrentCommissioner().EstablishPASEConnection(remoteId, params);
+            auto commissioningParams = GetCommissioningParameters();
+            err = CurrentCommissioner().PairDevice(remoteId, mOnboardingPayload, commissioningParams, DiscoveryType::kAll,
+                                                   NullOptional, MakeOptional(meshcopParams));
         }
+        CurrentCommissioner().RegisterDeviceDiscoveryDelegate(nullptr);
     }
     else
     {
-        auto commissioningParams = GetCommissioningParameters();
-        if (address.GetTransportType() == Transport::Type::kThreadMeshcop && mOnboardingPayload)
+        if (mPaseOnly.ValueOr(false))
         {
-            CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
-            SetUpCodePairer::ThreadMeshcopCommissionParameters meshcopParams;
-            ReturnErrorOnFailure(GetMeshcopCommissionParams(meshcopParams));
-            err = CurrentCommissioner().PairDevice(remoteId, mOnboardingPayload, commissioningParams, DiscoveryType::kAll,
-                                                   NullOptional, MakeOptional(meshcopParams));
-            CurrentCommissioner().RegisterDeviceDiscoveryDelegate(nullptr);
+            err = CurrentCommissioner().EstablishPASEConnection(remoteId, params);
         }
         else
         {
+            auto commissioningParams = GetCommissioningParameters();
             err = CurrentCommissioner().PairDevice(remoteId, params, commissioningParams);
         }
     }

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -370,7 +370,7 @@ CHIP_ERROR PairingCommand::Pair(NodeId remoteId, PeerAddress address)
         else
         {
             auto commissioningParams = GetCommissioningParameters();
-            err = CurrentCommissioner().PairDevice(remoteId, params, commissioningParams);
+            err                      = CurrentCommissioner().PairDevice(remoteId, params, commissioningParams);
         }
     }
     return err;

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -280,6 +280,7 @@ CHIP_ERROR PairingCommand::PaseWithCode(NodeId remoteId)
 CHIP_ERROR
 PairingCommand::GetMeshcopCommissionParams(chip::Controller::SetUpCodePairer::ThreadMeshcopCommissionParameters & meshcopParams)
 {
+#if CHIP_SUPPORT_THREAD_MESHCOP
     Inet::IPAddress ipAddr;
     VerifyOrReturnError(Inet::IPAddress::FromString(mThreadBaHost.Value(), ipAddr), CHIP_ERROR_INVALID_ADDRESS);
     meshcopParams.mBorderAgentAddress = PeerAddress::ThreadMeshcop(ipAddr, mThreadBaPort.Value());
@@ -287,6 +288,9 @@ PairingCommand::GetMeshcopCommissionParams(chip::Controller::SetUpCodePairer::Th
     ReturnErrorOnFailure(dataset.Init(mOperationalDataset));
     ReturnErrorOnFailure(dataset.GetPSKc(meshcopParams.mPSKcBuffer));
     return CHIP_NO_ERROR;
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // CHIP_SUPPORT_THREAD_MESHCOP
 }
 
 CHIP_ERROR PairingCommand::PairWithCode(NodeId remoteId)

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -277,6 +277,17 @@ CHIP_ERROR PairingCommand::PaseWithCode(NodeId remoteId)
     return CurrentCommissioner().EstablishPASEConnection(remoteId, mOnboardingPayload, discoveryType);
 }
 
+CHIP_ERROR PairingCommand::GetMeshcopCommissionParams(chip::Controller::SetUpCodePairer::ThreadMeshcopCommissionParameters & meshcopParams)
+{
+    Inet::IPAddress ipAddr;
+    VerifyOrReturnError(Inet::IPAddress::FromString(mThreadBaHost.Value(), ipAddr), CHIP_ERROR_INVALID_ADDRESS);
+    meshcopParams.mBorderAgentAddress = PeerAddress::ThreadMeshcop(ipAddr, mThreadBaPort.Value());
+    Thread::OperationalDatasetView dataset;
+    ReturnErrorOnFailure(dataset.Init(mOperationalDataset));
+    ReturnErrorOnFailure(dataset.GetPSKc(meshcopParams.mPSKcBuffer));
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR PairingCommand::PairWithCode(NodeId remoteId)
 {
     CommissioningParameters commissioningParams = GetCommissioningParameters();
@@ -326,28 +337,39 @@ CHIP_ERROR PairingCommand::Pair(NodeId remoteId, PeerAddress address)
         }
     }
 
-#if CHIP_SUPPORT_THREAD_MESHCOP
-    if (address.GetTransportType() == Transport::Type::kThreadMeshcop)
-    {
-        CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
-        CommissioningParameters commissioningParams = GetCommissioningParameters();
-
-        commissioningParams.SetThreadOperationalDataset(mOperationalDataset);
-        auto error = CurrentCommissioner().PairDevice(remoteId, params, commissioningParams);
-        CurrentCommissioner().RegisterDeviceDiscoveryDelegate(nullptr);
-        return error;
-    }
-#endif // CHIP_SUPPORT_THREAD_MESHCOP
-
     CHIP_ERROR err = CHIP_NO_ERROR;
     if (mPaseOnly.ValueOr(false))
     {
-        err = CurrentCommissioner().EstablishPASEConnection(remoteId, params);
+        if (address.GetTransportType() == Transport::Type::kThreadMeshcop && mOnboardingPayload)
+        {
+            CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
+            SetUpCodePairer::ThreadMeshcopCommissionParameters meshcopParams;
+            ReturnErrorOnFailure(GetMeshcopCommissionParams(meshcopParams));
+            err = CurrentCommissioner().EstablishPASEConnection(remoteId, mOnboardingPayload, DiscoveryType::kAll,
+                                                                NullOptional, MakeOptional(meshcopParams));
+            CurrentCommissioner().RegisterDeviceDiscoveryDelegate(nullptr);
+        }
+        else
+        {
+            err = CurrentCommissioner().EstablishPASEConnection(remoteId, params);
+        }
     }
     else
     {
         auto commissioningParams = GetCommissioningParameters();
-        err                      = CurrentCommissioner().PairDevice(remoteId, params, commissioningParams);
+        if (address.GetTransportType() == Transport::Type::kThreadMeshcop && mOnboardingPayload)
+        {
+            CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
+            SetUpCodePairer::ThreadMeshcopCommissionParameters meshcopParams;
+            ReturnErrorOnFailure(GetMeshcopCommissionParams(meshcopParams));
+            err = CurrentCommissioner().PairDevice(remoteId, mOnboardingPayload, commissioningParams, DiscoveryType::kAll,
+                                                   NullOptional, MakeOptional(meshcopParams));
+            CurrentCommissioner().RegisterDeviceDiscoveryDelegate(nullptr);
+        }
+        else
+        {
+            err = CurrentCommissioner().PairDevice(remoteId, params, commissioningParams);
+        }
     }
     return err;
 }

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -277,7 +277,8 @@ CHIP_ERROR PairingCommand::PaseWithCode(NodeId remoteId)
     return CurrentCommissioner().EstablishPASEConnection(remoteId, mOnboardingPayload, discoveryType);
 }
 
-CHIP_ERROR PairingCommand::GetMeshcopCommissionParams(chip::Controller::SetUpCodePairer::ThreadMeshcopCommissionParameters & meshcopParams)
+CHIP_ERROR
+PairingCommand::GetMeshcopCommissionParams(chip::Controller::SetUpCodePairer::ThreadMeshcopCommissionParameters & meshcopParams)
 {
     Inet::IPAddress ipAddr;
     VerifyOrReturnError(Inet::IPAddress::FromString(mThreadBaHost.Value(), ipAddr), CHIP_ERROR_INVALID_ADDRESS);
@@ -345,8 +346,8 @@ CHIP_ERROR PairingCommand::Pair(NodeId remoteId, PeerAddress address)
             CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
             SetUpCodePairer::ThreadMeshcopCommissionParameters meshcopParams;
             ReturnErrorOnFailure(GetMeshcopCommissionParams(meshcopParams));
-            err = CurrentCommissioner().EstablishPASEConnection(remoteId, mOnboardingPayload, DiscoveryType::kAll,
-                                                                NullOptional, MakeOptional(meshcopParams));
+            err = CurrentCommissioner().EstablishPASEConnection(remoteId, mOnboardingPayload, DiscoveryType::kAll, NullOptional,
+                                                                MakeOptional(meshcopParams));
             CurrentCommissioner().RegisterDeviceDiscoveryDelegate(nullptr);
         }
         else

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -71,6 +71,20 @@ namespace {
     return CHIP_NO_ERROR;
 }
 
+class DeviceDiscoveryDelegateRegistery
+{
+public:
+    DeviceDiscoveryDelegateRegistery() = delete;
+    DeviceDiscoveryDelegateRegistery(DeviceController & controller, DeviceDiscoveryDelegate * delegate) : mController(controller)
+    {
+        mController.RegisterDeviceDiscoveryDelegate(delegate);
+    }
+    ~DeviceDiscoveryDelegateRegistery() { mController.RegisterDeviceDiscoveryDelegate(nullptr); }
+
+private:
+    DeviceController & mController;
+};
+
 } // namespace
 
 CHIP_ERROR PairingCommand::RunCommand()
@@ -342,38 +356,26 @@ CHIP_ERROR PairingCommand::Pair(NodeId remoteId, PeerAddress address)
         }
     }
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
     if (address.GetTransportType() == Transport::Type::kThreadMeshcop && mOnboardingPayload)
     {
         SetUpCodePairer::ThreadMeshcopCommissionParameters meshcopParams;
+        DeviceDiscoveryDelegateRegistery registery(CurrentCommissioner(), this);
         ReturnErrorOnFailure(GetMeshcopCommissionParams(meshcopParams));
-        CurrentCommissioner().RegisterDeviceDiscoveryDelegate(this);
         if (mPaseOnly.ValueOr(false))
         {
-            err = CurrentCommissioner().EstablishPASEConnection(remoteId, mOnboardingPayload, DiscoveryType::kAll, NullOptional,
-                                                                MakeOptional(meshcopParams));
+            return CurrentCommissioner().EstablishPASEConnection(remoteId, mOnboardingPayload, DiscoveryType::kAll, NullOptional,
+                                                                 MakeOptional(meshcopParams));
         }
-        else
-        {
-            auto commissioningParams = GetCommissioningParameters();
-            err = CurrentCommissioner().PairDevice(remoteId, mOnboardingPayload, commissioningParams, DiscoveryType::kAll,
-                                                   NullOptional, MakeOptional(meshcopParams));
-        }
-        CurrentCommissioner().RegisterDeviceDiscoveryDelegate(nullptr);
+        auto commissioningParams = GetCommissioningParameters();
+        return CurrentCommissioner().PairDevice(remoteId, mOnboardingPayload, commissioningParams, DiscoveryType::kAll,
+                                                NullOptional, MakeOptional(meshcopParams));
     }
-    else
+    if (mPaseOnly.ValueOr(false))
     {
-        if (mPaseOnly.ValueOr(false))
-        {
-            err = CurrentCommissioner().EstablishPASEConnection(remoteId, params);
-        }
-        else
-        {
-            auto commissioningParams = GetCommissioningParameters();
-            err                      = CurrentCommissioner().PairDevice(remoteId, params, commissioningParams);
-        }
+        return CurrentCommissioner().EstablishPASEConnection(remoteId, params);
     }
-    return err;
+    auto commissioningParams = GetCommissioningParameters();
+    return CurrentCommissioner().PairDevice(remoteId, params, commissioningParams);
 }
 
 CHIP_ERROR PairingCommand::PairWithMdnsOrBleByIndex(NodeId remoteId, uint16_t index)

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -71,15 +71,15 @@ namespace {
     return CHIP_NO_ERROR;
 }
 
-class DeviceDiscoveryDelegateRegistery
+class DeviceDiscoveryDelegateRegistry
 {
 public:
-    DeviceDiscoveryDelegateRegistery() = delete;
-    DeviceDiscoveryDelegateRegistery(DeviceController & controller, DeviceDiscoveryDelegate * delegate) : mController(controller)
+    DeviceDiscoveryDelegateRegistry() = delete;
+    DeviceDiscoveryDelegateRegistry(DeviceController & controller, DeviceDiscoveryDelegate * delegate) : mController(controller)
     {
         mController.RegisterDeviceDiscoveryDelegate(delegate);
     }
-    ~DeviceDiscoveryDelegateRegistery() { mController.RegisterDeviceDiscoveryDelegate(nullptr); }
+    ~DeviceDiscoveryDelegateRegistry() { mController.RegisterDeviceDiscoveryDelegate(nullptr); }
 
 private:
     DeviceController & mController;
@@ -359,7 +359,7 @@ CHIP_ERROR PairingCommand::Pair(NodeId remoteId, PeerAddress address)
     if (address.GetTransportType() == Transport::Type::kThreadMeshcop && mOnboardingPayload)
     {
         SetUpCodePairer::ThreadMeshcopCommissionParameters meshcopParams;
-        DeviceDiscoveryDelegateRegistery registery(CurrentCommissioner(), this);
+        DeviceDiscoveryDelegateRegistry registry(CurrentCommissioner(), this);
         ReturnErrorOnFailure(GetMeshcopCommissionParams(meshcopParams));
         if (mPaseOnly.ValueOr(false))
         {

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -280,7 +280,8 @@ private:
     CHIP_ERROR Unpair(NodeId remoteId);
     chip::Controller::CommissioningParameters GetCommissioningParameters();
     CHIP_ERROR MaybeDisplayTermsAndConditions(chip::Controller::CommissioningParameters & params);
-    CHIP_ERROR GetMeshcopCommissionParams(chip::Controller::SetUpCodePairer::ThreadMeshcopCommissionParameters & meshcopCommissionParams);
+    CHIP_ERROR
+    GetMeshcopCommissionParams(chip::Controller::SetUpCodePairer::ThreadMeshcopCommissionParameters & meshcopCommissionParams);
 
     const PairingMode mPairingMode;
     const PairingNetworkType mNetworkType;

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -113,6 +113,7 @@ public:
         case PairingMode::ThreadMeshcop:
             AddArgument("thread-ba-host", &mThreadBaHost, "Thread Border Agent host");
             AddArgument("thread-ba-port", 0, UINT16_MAX, &mThreadBaPort, "Thread Border Agent port");
+            AddArgument("pase-only", 0, 1, &mPaseOnly);
             FALLTHROUGH;
 #endif
         case PairingMode::Code:
@@ -279,6 +280,7 @@ private:
     CHIP_ERROR Unpair(NodeId remoteId);
     chip::Controller::CommissioningParameters GetCommissioningParameters();
     CHIP_ERROR MaybeDisplayTermsAndConditions(chip::Controller::CommissioningParameters & params);
+    CHIP_ERROR GetMeshcopCommissionParams(chip::Controller::SetUpCodePairer::ThreadMeshcopCommissionParameters & meshcopCommissionParams);
 
     const PairingMode mPairingMode;
     const PairingNetworkType mNetworkType;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -874,7 +874,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
             ExitNow(err = mSystemState->BleLayer()->NewBleConnectionByObject(
                         params.GetDiscoveredObject(), this, OnDiscoveredDeviceOverBleSuccess, OnDiscoveredDeviceOverBleError));
         }
-        else if (params.HasDiscriminator())
+        else if (params.GetSetupDiscriminator().has_value())
         {
             // The RendezvousParameters argument needs to be recovered if the search succeed, so save them
             // for later.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -74,6 +74,10 @@
 #include <platform/internal/NFCCommissioningManager.h>
 #endif
 
+#if CHIP_SUPPORT_THREAD_MESHCOP
+#include <controller/ThreadMeshcopCommissionProxy.h>
+#endif
+
 #include <algorithm>
 #include <array>
 #include <errno.h>
@@ -676,14 +680,15 @@ CHIP_ERROR DeviceCommissioner::GetDeviceBeingCommissioned(NodeId deviceId, Commi
 }
 
 CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * setUpCode, const CommissioningParameters & params,
-                                          DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData)
+                                          DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData,
+                                          Optional<SetUpCodePairer::ThreadMeshcopCommissionParameters> meshcopCommissionParams)
 {
     MATTER_TRACE_SCOPE("PairDevice", "DeviceCommissioner");
 
     ReturnErrorOnFailure(mDefaultCommissioner->SetCommissioningParameters(params));
 
     return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kCommission, discoveryType,
-                                       resolutionData);
+                                       resolutionData, meshcopCommissionParams);
 }
 
 CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType,
@@ -733,7 +738,7 @@ CHIP_ERROR DeviceCommissioner::PairThreadMeshcop(RendezvousParameters & rendezvo
 
     {
         Dnssd::DiscoveredNodeData discoveredNodeData;
-        ReturnErrorOnFailure(mThreadMeshcopCommissionProxy.Discover(pskc, rendezvousParams.GetPeerAddress(), code, discriminator,
+        ReturnErrorOnFailure(ThreadMeshcopCommissionProxy::GetInstance().Discover(pskc, rendezvousParams.GetPeerAddress(), code, discriminator,
                                                                     discoveredNodeData, 30));
 
         ChipLogProgress(Controller, "Joiner discovered");
@@ -760,11 +765,12 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
 }
 
 CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType,
-                                                       Optional<Dnssd::CommonResolutionData> resolutionData)
+                                                       Optional<Dnssd::CommonResolutionData> resolutionData,
+                                                       Optional<SetUpCodePairer::ThreadMeshcopCommissionParameters> meshcopCommissionParams)
 {
     MATTER_TRACE_SCOPE("EstablishPASEConnection", "DeviceCommissioner");
     return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kPaseOnly, discoveryType,
-                                       resolutionData);
+                                       resolutionData, meshcopCommissionParams);
 }
 
 CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, RendezvousParameters & params)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -738,8 +738,8 @@ CHIP_ERROR DeviceCommissioner::PairThreadMeshcop(RendezvousParameters & rendezvo
 
     {
         Dnssd::DiscoveredNodeData discoveredNodeData;
-        ReturnErrorOnFailure(ThreadMeshcopCommissionProxy::GetInstance().Discover(pskc, rendezvousParams.GetPeerAddress(), code, discriminator,
-                                                                    discoveredNodeData, 30));
+        ReturnErrorOnFailure(ThreadMeshcopCommissionProxy::GetInstance().Discover(pskc, rendezvousParams.GetPeerAddress(), code,
+                                                                                  discriminator, discoveredNodeData, 30));
 
         ChipLogProgress(Controller, "Joiner discovered");
         OnNodeDiscovered(discoveredNodeData);
@@ -764,9 +764,10 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     return errorCode;
 }
 
-CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType,
-                                                       Optional<Dnssd::CommonResolutionData> resolutionData,
-                                                       Optional<SetUpCodePairer::ThreadMeshcopCommissionParameters> meshcopCommissionParams)
+CHIP_ERROR
+DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType,
+                                            Optional<Dnssd::CommonResolutionData> resolutionData,
+                                            Optional<SetUpCodePairer::ThreadMeshcopCommissionParameters> meshcopCommissionParams)
 {
     MATTER_TRACE_SCOPE("EstablishPASEConnection", "DeviceCommissioner");
     return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kPaseOnly, discoveryType,

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -74,10 +74,6 @@
 #include <platform/internal/NFCCommissioningManager.h>
 #endif
 
-#if CHIP_SUPPORT_THREAD_MESHCOP
-#include <controller/ThreadMeshcopCommissionProxy.h>
-#endif
-
 #include <algorithm>
 #include <array>
 #include <errno.h>
@@ -684,7 +680,12 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * se
                                           Optional<SetUpCodePairer::ThreadMeshcopCommissionParameters> meshcopCommissionParams)
 {
     MATTER_TRACE_SCOPE("PairDevice", "DeviceCommissioner");
-
+#if CHIP_SUPPORT_THREAD_MESHCOP
+    if (meshcopCommissionParams.HasValue())
+    {
+        mSetUpCodePairer.SetThreadMeshcopCommissionProxy(&mThreadMeshcopCommissionProxy);
+    }
+#endif
     ReturnErrorOnFailure(mDefaultCommissioner->SetCommissioningParameters(params));
 
     return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kCommission, discoveryType,
@@ -738,8 +739,8 @@ CHIP_ERROR DeviceCommissioner::PairThreadMeshcop(RendezvousParameters & rendezvo
 
     {
         Dnssd::DiscoveredNodeData discoveredNodeData;
-        ReturnErrorOnFailure(ThreadMeshcopCommissionProxy::GetInstance().Discover(pskc, rendezvousParams.GetPeerAddress(), code,
-                                                                                  discriminator, discoveredNodeData, 30));
+        ReturnErrorOnFailure(mThreadMeshcopCommissionProxy.Discover(pskc, rendezvousParams.GetPeerAddress(), code, discriminator,
+                                                                    discoveredNodeData, 30));
 
         ChipLogProgress(Controller, "Joiner discovered");
         OnNodeDiscovered(discoveredNodeData);
@@ -770,6 +771,12 @@ DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, const char * 
                                             Optional<SetUpCodePairer::ThreadMeshcopCommissionParameters> meshcopCommissionParams)
 {
     MATTER_TRACE_SCOPE("EstablishPASEConnection", "DeviceCommissioner");
+#if CHIP_SUPPORT_THREAD_MESHCOP
+    if (meshcopCommissionParams.HasValue())
+    {
+        mSetUpCodePairer.SetThreadMeshcopCommissionProxy(&mThreadMeshcopCommissionProxy);
+    }
+#endif
     return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kPaseOnly, discoveryType,
                                        resolutionData, meshcopCommissionParams);
 }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -683,13 +683,13 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * se
 #if CHIP_SUPPORT_THREAD_MESHCOP
     if (meshcopCommissionParams.HasValue())
     {
-        mSetUpCodePairer.SetThreadMeshcopCommissionProxy(&mThreadMeshcopCommissionProxy);
+        mSetUpCodePairer.SetThreadMeshcopCommissionParamsAndProxy(meshcopCommissionParams.Value(), &mThreadMeshcopCommissionProxy);
     }
 #endif
     ReturnErrorOnFailure(mDefaultCommissioner->SetCommissioningParameters(params));
 
     return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kCommission, discoveryType,
-                                       resolutionData, meshcopCommissionParams);
+                                       resolutionData);
 }
 
 CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType,
@@ -774,11 +774,11 @@ DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, const char * 
 #if CHIP_SUPPORT_THREAD_MESHCOP
     if (meshcopCommissionParams.HasValue())
     {
-        mSetUpCodePairer.SetThreadMeshcopCommissionProxy(&mThreadMeshcopCommissionProxy);
+        mSetUpCodePairer.SetThreadMeshcopCommissionParamsAndProxy(meshcopCommissionParams.Value(), &mThreadMeshcopCommissionProxy);
     }
 #endif
     return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kPaseOnly, discoveryType,
-                                       resolutionData, meshcopCommissionParams);
+                                       resolutionData);
 }
 
 CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, RendezvousParameters & params)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -71,6 +71,10 @@
 #include <platform/CHIPDeviceLayer.h>
 #endif
 
+#if CHIP_SUPPORT_THREAD_MESHCOP
+#include <controller/ThreadMeshcopCommissionProxy.h>
+#endif
+
 #if CONFIG_NETWORK_LAYER_BLE
 #include <ble/Ble.h>
 #endif
@@ -1149,6 +1153,8 @@ private:
 
 #if CHIP_SUPPORT_THREAD_MESHCOP
     CHIP_ERROR PairThreadMeshcop(RendezvousParameters & rendezvousParams, CommissioningParameters & commissioningParams);
+
+    ThreadMeshcopCommissionProxy mThreadMeshcopCommissionProxy;
 #endif
 
     chip::Callback::Callback<OnDeviceConnected> mOnDeviceConnectedCallback;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -76,10 +76,6 @@
 #endif
 #include <controller/DeviceDiscoveryDelegate.h>
 
-#if CHIP_SUPPORT_THREAD_MESHCOP
-#include <controller/ThreadMeshcopCommissionProxy.h>
-#endif
-
 namespace chip {
 
 namespace Testing {
@@ -535,7 +531,8 @@ public:
                           Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional);
     CHIP_ERROR PairDevice(NodeId remoteDeviceId, const char * setUpCode, const CommissioningParameters & CommissioningParameters,
                           DiscoveryType discoveryType                          = DiscoveryType::kAll,
-                          Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional);
+                          Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional,
+                          Optional<SetUpCodePairer::ThreadMeshcopCommissionParameters> meshcopCommissionParams = NullOptional);
 
     /**
      * @brief
@@ -602,7 +599,8 @@ public:
      */
     CHIP_ERROR EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode,
                                        DiscoveryType discoveryType                          = DiscoveryType::kAll,
-                                       Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional);
+                                       Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional,
+                          Optional<SetUpCodePairer::ThreadMeshcopCommissionParameters> meshcopCommissionParams = NullOptional);
 
     /**
      * @brief
@@ -1177,10 +1175,6 @@ private:
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     Optional<Crypto::P256PublicKey> mTrustedIcacPublicKeyB;
     EndpointId mPeerAdminJFAdminClusterEndpointId = kInvalidEndpointId;
-#endif
-
-#if CHIP_SUPPORT_THREAD_MESHCOP
-    ThreadMeshcopCommissionProxy mThreadMeshcopCommissionProxy;
 #endif
 };
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -597,10 +597,10 @@ public:
      * @param[in] discoveryType         The network discovery type, defaults to DiscoveryType::kAll.
      * @param[in] resolutionData        Optional resolution data previously discovered on the network for the target device.
      */
-    CHIP_ERROR EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode,
-                                       DiscoveryType discoveryType                          = DiscoveryType::kAll,
-                                       Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional,
-                          Optional<SetUpCodePairer::ThreadMeshcopCommissionParameters> meshcopCommissionParams = NullOptional);
+    CHIP_ERROR
+    EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType = DiscoveryType::kAll,
+                            Optional<Dnssd::CommonResolutionData> resolutionData                                 = NullOptional,
+                            Optional<SetUpCodePairer::ThreadMeshcopCommissionParameters> meshcopCommissionParams = NullOptional);
 
     /**
      * @brief

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -35,6 +35,10 @@
 #include <tracing/metric_event.h>
 #include <vector>
 
+#if CHIP_SUPPORT_THREAD_MESHCOP
+#include <controller/ThreadMeshcopCommissionProxy.h>
+#endif
+
 constexpr uint32_t kDeviceDiscoveredTimeout = CHIP_CONFIG_SETUP_CODE_PAIRER_DISCOVERY_TIMEOUT_SECS * chip::kMillisecondsPerSecond;
 
 using namespace chip::Tracing;
@@ -43,7 +47,8 @@ namespace chip {
 namespace Controller {
 
 CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, SetupCodePairerBehaviour commission,
-                                       DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData)
+                                       DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData,
+                                       Optional<ThreadMeshcopCommissionParameters> meshcopCommissioningParams)
 {
     VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, remoteId != kUndefinedNodeId, CHIP_ERROR_INVALID_ARGUMENT);
@@ -86,6 +91,11 @@ CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, 
         // is good because we don't have a full discriminator here anyway.
         NotifyCommissionableDeviceDiscovered(resolutionData.Value(), /* matchedLongDiscriminator = */ std::nullopt);
         return CHIP_NO_ERROR;
+    }
+
+    if (meshcopCommissioningParams.HasValue())
+    {
+        mThreadMeshcopCommissionParams = meshcopCommissioningParams.Value();
     }
 
     ReturnErrorOnFailureWithMetric(kMetricSetupCodePairerPairDevice, Connect());
@@ -146,6 +156,20 @@ CHIP_ERROR SetUpCodePairer::Connect()
             else if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(Controller, "Failed to start commissionable node discovery over NFC: %" CHIP_ERROR_FORMAT,
+                             err.Format());
+            }
+        }
+        if (ShouldDiscoverUsing(RendezvousInformationFlag::kThread))
+        {
+            CHIP_ERROR err = StartDiscoveryOverThreadMeshcop();
+            if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
+            {
+                ChipLogProgress(Controller,
+                                "Skipping commissionable node discovery over ThreadMeshcop since not supported by the controller!");
+            }
+            else if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Controller, "Failed to start commissionable node discovery over ThreadMeshcop: %" CHIP_ERROR_FORMAT,
                              err.Format());
             }
         }
@@ -376,6 +400,57 @@ CHIP_ERROR SetUpCodePairer::StopDiscoveryOverNFC()
     ChipLogProgress(Controller, "Stopping commissionable node discovery over NFC by removing delegate");
     readerTransport->SetDelegate(nullptr);
 #endif
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SetUpCodePairer::StartDiscoveryOverThreadMeshcop()
+{
+#if CHIP_SUPPORT_THREAD_MESHCOP
+    if (mSetupPayloads.size() != 1)
+    {
+        ChipLogError(Controller, "Thread Meshcop commissioning does not support concatenated QR codes yet.");
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
+
+    auto & payload = mSetupPayloads[0];
+
+    ChipLogProgress(Controller, "Starting commissionable node discovery over Thread Meshcop");
+    VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    const SetupDiscriminator connDiscriminator(payload.discriminator);
+    Thread::DiscoveryCode code;
+    if (connDiscriminator.IsShortDiscriminator())
+    {
+        code = Thread::DiscoveryCode(connDiscriminator.GetShortValue());
+        ChipLogProgress(Controller, "Discovery code from short discriminator: 0x%" PRIx64, code.AsUInt64());
+    }
+    else
+    {
+        code = Thread::DiscoveryCode(connDiscriminator.GetLongValue());
+        ChipLogProgress(Controller, "Discovery code from long discriminator: 0x%" PRIx64, code.AsUInt64());
+    }
+
+    ByteSpan pskc(mThreadMeshcopCommissionParams.mPSKcBuffer);
+    {
+        mWaitingForDiscovery[kThreadMeshcopTransport] = true;
+        Dnssd::DiscoveredNodeData discoveredNodeData;
+        ReturnErrorOnFailure(ThreadMeshcopCommissionProxy::GetInstance().Discover(pskc, mThreadMeshcopCommissionParams.mBorderAgentAddress,
+                                                                    code, connDiscriminator, discoveredNodeData, 30));
+
+        mWaitingForDiscovery[kThreadMeshcopTransport] = false;
+        mCommissioner->OnNodeDiscovered(discoveredNodeData);
+        ChipLogProgress(Controller, "Joiner discovered");
+    }
+    return CHIP_NO_ERROR;
+#else
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif // CHIP_SUPPORT_THREAD_MESHCOP
+}
+
+CHIP_ERROR SetUpCodePairer::StopDiscoveryOverThreadMeshcop()
+{
+    // Currently we don't have any methods to stop discovery Over Thread Meshcop.
+    // Still return no error here to prevent error logs.
     return CHIP_NO_ERROR;
 }
 
@@ -722,6 +797,7 @@ void SetUpCodePairer::StopAllDiscoveryAttempts()
     LogErrorOnFailure(StopDiscoveryOverDNSSD());
     LogErrorOnFailure(StopDiscoveryOverWiFiPAF());
     LogErrorOnFailure(StopDiscoveryOverNFC().NoErrorIf(CHIP_ERROR_NOT_FOUND));
+    LogErrorOnFailure(StopDiscoveryOverThreadMeshcop());
 
     // Just in case any of those failed to reset the waiting state properly.
     for (auto & waiting : mWaitingForDiscovery)

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -35,10 +35,6 @@
 #include <tracing/metric_event.h>
 #include <vector>
 
-#if CHIP_SUPPORT_THREAD_MESHCOP
-#include <controller/ThreadMeshcopCommissionProxy.h>
-#endif
-
 constexpr uint32_t kDeviceDiscoveredTimeout = CHIP_CONFIG_SETUP_CODE_PAIRER_DISCOVERY_TIMEOUT_SECS * chip::kMillisecondsPerSecond;
 
 using namespace chip::Tracing;
@@ -409,6 +405,12 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverThreadMeshcop()
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
 
+    if (!mThreadMeshcopCommissionProxy)
+    {
+        ChipLogError(Controller, "The meshcopCommissioningProxy is not set");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
     if (!mThreadMeshcopCommissionParams.HasValue() ||
         mThreadMeshcopCommissionParams.Value().mBorderAgentAddress.GetTransportType() != Transport::Type::kThreadMeshcop)
     {
@@ -439,8 +441,8 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverThreadMeshcop()
         mWaitingForDiscovery[kThreadMeshcopTransport] = true;
         Dnssd::DiscoveredNodeData discoveredNodeData;
 
-        CHIP_ERROR err = ThreadMeshcopCommissionProxy::GetInstance().Discover(
-            pskc, mThreadMeshcopCommissionParams.Value().mBorderAgentAddress, code, connDiscriminator, discoveredNodeData, 30);
+        CHIP_ERROR err = mThreadMeshcopCommissionProxy->Discover(pskc, mThreadMeshcopCommissionParams.Value().mBorderAgentAddress,
+                                                                 code, connDiscriminator, discoveredNodeData, 30);
 
         mWaitingForDiscovery[kThreadMeshcopTransport] = false;
         ReturnErrorOnFailure(err);

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -409,7 +409,7 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverThreadMeshcop()
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
 
-    if (mThreadMeshcopCommissionParams.HasValue() &&
+    if (!mThreadMeshcopCommissionParams.HasValue() ||
         mThreadMeshcopCommissionParams.Value().mBorderAgentAddress.GetTransportType() != Transport::Type::kThreadMeshcop)
     {
         ChipLogError(Controller, "The meshcopCommissioningParams is not set");

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -438,7 +438,7 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverThreadMeshcop()
     {
         mWaitingForDiscovery[kThreadMeshcopTransport] = true;
         Dnssd::DiscoveredNodeData discoveredNodeData;
-        
+
         CHIP_ERROR err = ThreadMeshcopCommissionProxy::GetInstance().Discover(
             pskc, mThreadMeshcopCommissionParams.Value().mBorderAgentAddress, code, connDiscriminator, discoveredNodeData, 30);
 

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -434,8 +434,8 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverThreadMeshcop()
     {
         mWaitingForDiscovery[kThreadMeshcopTransport] = true;
         Dnssd::DiscoveredNodeData discoveredNodeData;
-        ReturnErrorOnFailure(ThreadMeshcopCommissionProxy::GetInstance().Discover(pskc, mThreadMeshcopCommissionParams.mBorderAgentAddress,
-                                                                    code, connDiscriminator, discoveredNodeData, 30));
+        ReturnErrorOnFailure(ThreadMeshcopCommissionProxy::GetInstance().Discover(
+            pskc, mThreadMeshcopCommissionParams.mBorderAgentAddress, code, connDiscriminator, discoveredNodeData, 30));
 
         mWaitingForDiscovery[kThreadMeshcopTransport] = false;
         mCommissioner->OnNodeDiscovered(discoveredNodeData);

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -438,10 +438,12 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverThreadMeshcop()
     {
         mWaitingForDiscovery[kThreadMeshcopTransport] = true;
         Dnssd::DiscoveredNodeData discoveredNodeData;
-        ReturnErrorOnFailure(ThreadMeshcopCommissionProxy::GetInstance().Discover(
-            pskc, mThreadMeshcopCommissionParams.Value().mBorderAgentAddress, code, connDiscriminator, discoveredNodeData, 30));
+        
+        CHIP_ERROR err = ThreadMeshcopCommissionProxy::GetInstance().Discover(
+            pskc, mThreadMeshcopCommissionParams.Value().mBorderAgentAddress, code, connDiscriminator, discoveredNodeData, 30);
 
         mWaitingForDiscovery[kThreadMeshcopTransport] = false;
+        ReturnErrorOnFailure(err);
         mCommissioner->OnNodeDiscovered(discoveredNodeData);
         ChipLogProgress(Controller, "Joiner discovered");
     }

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -93,10 +93,7 @@ CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, 
         return CHIP_NO_ERROR;
     }
 
-    if (meshcopCommissioningParams.HasValue())
-    {
-        mThreadMeshcopCommissionParams = meshcopCommissioningParams.Value();
-    }
+    mThreadMeshcopCommissionParams = meshcopCommissioningParams;
 
     ReturnErrorOnFailureWithMetric(kMetricSetupCodePairerPairDevice, Connect());
     auto errorCode =
@@ -412,6 +409,13 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverThreadMeshcop()
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
 
+    if (mThreadMeshcopCommissionParams.HasValue() &&
+        mThreadMeshcopCommissionParams.Value().mBorderAgentAddress.GetTransportType() != Transport::Type::kThreadMeshcop)
+    {
+        ChipLogError(Controller, "The meshcopCommissioningParams is not set");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
     auto & payload = mSetupPayloads[0];
 
     ChipLogProgress(Controller, "Starting commissionable node discovery over Thread Meshcop");
@@ -430,12 +434,12 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverThreadMeshcop()
         ChipLogProgress(Controller, "Discovery code from long discriminator: 0x%" PRIx64, code.AsUInt64());
     }
 
-    ByteSpan pskc(mThreadMeshcopCommissionParams.mPSKcBuffer);
+    ByteSpan pskc(mThreadMeshcopCommissionParams.Value().mPSKcBuffer);
     {
         mWaitingForDiscovery[kThreadMeshcopTransport] = true;
         Dnssd::DiscoveredNodeData discoveredNodeData;
         ReturnErrorOnFailure(ThreadMeshcopCommissionProxy::GetInstance().Discover(
-            pskc, mThreadMeshcopCommissionParams.mBorderAgentAddress, code, connDiscriminator, discoveredNodeData, 30));
+            pskc, mThreadMeshcopCommissionParams.Value().mBorderAgentAddress, code, connDiscriminator, discoveredNodeData, 30));
 
         mWaitingForDiscovery[kThreadMeshcopTransport] = false;
         mCommissioner->OnNodeDiscovered(discoveredNodeData);

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -43,8 +43,7 @@ namespace chip {
 namespace Controller {
 
 CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, SetupCodePairerBehaviour commission,
-                                       DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData,
-                                       Optional<ThreadMeshcopCommissionParameters> meshcopCommissioningParams)
+                                       DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData)
 {
     VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, remoteId != kUndefinedNodeId, CHIP_ERROR_INVALID_ARGUMENT);
@@ -88,8 +87,6 @@ CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, 
         NotifyCommissionableDeviceDiscovered(resolutionData.Value(), /* matchedLongDiscriminator = */ std::nullopt);
         return CHIP_NO_ERROR;
     }
-
-    mThreadMeshcopCommissionParams = meshcopCommissioningParams;
 
     ReturnErrorOnFailureWithMetric(kMetricSetupCodePairerPairDevice, Connect());
     auto errorCode =

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -270,7 +270,7 @@ private:
     // mLastPASEError is the error from the last OnPairingComplete call we got.
     CHIP_ERROR mLastPASEError = CHIP_NO_ERROR;
 
-    ThreadMeshcopCommissionParameters mThreadMeshcopCommissionParams;
+    Optional<ThreadMeshcopCommissionParameters> mThreadMeshcopCommissionParams;
 };
 
 } // namespace Controller

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -30,6 +30,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/NodeId.h>
 #include <lib/support/DLLUtil.h>
+#include <lib/support/ThreadOperationalDataset.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <protocols/secure_channel/RendezvousParameters.h>
 #include <setup_payload/ManualSetupPayloadParser.h>

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -99,13 +99,19 @@ class DLL_EXPORT SetUpCodePairer : public DevicePairingDelegate
 #endif
 {
 public:
+    struct ThreadMeshcopCommissionParameters
+    {
+        Transport::PeerAddress mBorderAgentAddress;
+        uint8_t mPSKcBuffer[Thread::kSizePSKc];
+    };
     SetUpCodePairer(DeviceCommissioner * commissioner) : mCommissioner(commissioner) {}
     virtual ~SetUpCodePairer() {}
 
     CHIP_ERROR PairDevice(chip::NodeId remoteId, const char * setUpCode,
                           SetupCodePairerBehaviour connectionType              = SetupCodePairerBehaviour::kCommission,
                           DiscoveryType discoveryType                          = DiscoveryType::kAll,
-                          Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional);
+                          Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional,
+                          Optional<ThreadMeshcopCommissionParameters> meshcopCommissionParams = NullOptional);
 
     // Called by the DeviceCommissioner to notify that we have discovered a new device.
     void NotifyCommissionableDeviceDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData);
@@ -143,6 +149,8 @@ private:
     CHIP_ERROR StopDiscoveryOverWiFiPAF();
     CHIP_ERROR StartDiscoveryOverNFC();
     CHIP_ERROR StopDiscoveryOverNFC();
+    CHIP_ERROR StartDiscoveryOverThreadMeshcop();
+    CHIP_ERROR StopDiscoveryOverThreadMeshcop();
 
     // Returns whether we have kicked off a new connection attempt.
     bool ConnectToDiscoveredDevice();
@@ -189,6 +197,7 @@ private:
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
         kNFCTransport,
 #endif
+        kThreadMeshcopTransport,
         kTransportTypeCount,
     };
 
@@ -259,6 +268,8 @@ private:
 
     // mLastPASEError is the error from the last OnPairingComplete call we got.
     CHIP_ERROR mLastPASEError = CHIP_NO_ERROR;
+
+    ThreadMeshcopCommissionParameters mThreadMeshcopCommissionParams;
 };
 
 } // namespace Controller

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -280,7 +280,7 @@ private:
 
     Optional<ThreadMeshcopCommissionParameters> mThreadMeshcopCommissionParams;
 #if CHIP_SUPPORT_THREAD_MESHCOP
-    ThreadMeshcopCommissionProxy * mThreadMeshcopCommissionProxy;
+    ThreadMeshcopCommissionProxy * mThreadMeshcopCommissionProxy = nullptr;
 #endif
 };
 

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -44,6 +44,10 @@
 #include <nfc/NFC.h>
 #endif // CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
 
+#if CHIP_SUPPORT_THREAD_MESHCOP
+#include <controller/ThreadMeshcopCommissionProxy.h>
+#endif // CHIP_SUPPORT_THREAD_MESHCOP
+
 #include <controller/DeviceDiscoveryDelegate.h>
 
 #include <deque>
@@ -122,6 +126,10 @@ public:
 #if CONFIG_NETWORK_LAYER_BLE
     void SetBleLayer(Ble::BleLayer * bleLayer) { mBleLayer = bleLayer; };
 #endif // CONFIG_NETWORK_LAYER_BLE
+
+#if CHIP_SUPPORT_THREAD_MESHCOP
+    void SetThreadMeshcopCommissionProxy(ThreadMeshcopCommissionProxy * proxy) { mThreadMeshcopCommissionProxy = proxy; }
+#endif
 
     // Stop ongoing discovery / pairing of the specified node, or of
     // whichever node we're pairing if kUndefinedNodeId is passed.
@@ -271,6 +279,9 @@ private:
     CHIP_ERROR mLastPASEError = CHIP_NO_ERROR;
 
     Optional<ThreadMeshcopCommissionParameters> mThreadMeshcopCommissionParams;
+#if CHIP_SUPPORT_THREAD_MESHCOP
+    ThreadMeshcopCommissionProxy * mThreadMeshcopCommissionProxy;
+#endif
 };
 
 } // namespace Controller

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -115,8 +115,7 @@ public:
     CHIP_ERROR PairDevice(chip::NodeId remoteId, const char * setUpCode,
                           SetupCodePairerBehaviour connectionType              = SetupCodePairerBehaviour::kCommission,
                           DiscoveryType discoveryType                          = DiscoveryType::kAll,
-                          Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional,
-                          Optional<ThreadMeshcopCommissionParameters> meshcopCommissionParams = NullOptional);
+                          Optional<Dnssd::CommonResolutionData> resolutionData = NullOptional);
 
     // Called by the DeviceCommissioner to notify that we have discovered a new device.
     void NotifyCommissionableDeviceDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData);
@@ -128,7 +127,11 @@ public:
 #endif // CONFIG_NETWORK_LAYER_BLE
 
 #if CHIP_SUPPORT_THREAD_MESHCOP
-    void SetThreadMeshcopCommissionProxy(ThreadMeshcopCommissionProxy * proxy) { mThreadMeshcopCommissionProxy = proxy; }
+    void SetThreadMeshcopCommissionParamsAndProxy(ThreadMeshcopCommissionParameters &meshcopCommissionParams, ThreadMeshcopCommissionProxy * proxy)
+    {
+        mThreadMeshcopCommissionProxy = proxy;
+        mThreadMeshcopCommissionParams.SetValue(meshcopCommissionParams);
+    }
 #endif
 
     // Stop ongoing discovery / pairing of the specified node, or of
@@ -206,7 +209,9 @@ private:
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
         kNFCTransport,
 #endif
+#if CHIP_SUPPORT_THREAD_MESHCOP
         kThreadMeshcopTransport,
+#endif
         kTransportTypeCount,
     };
 
@@ -278,8 +283,8 @@ private:
     // mLastPASEError is the error from the last OnPairingComplete call we got.
     CHIP_ERROR mLastPASEError = CHIP_NO_ERROR;
 
-    Optional<ThreadMeshcopCommissionParameters> mThreadMeshcopCommissionParams;
 #if CHIP_SUPPORT_THREAD_MESHCOP
+    Optional<ThreadMeshcopCommissionParameters> mThreadMeshcopCommissionParams;
     ThreadMeshcopCommissionProxy * mThreadMeshcopCommissionProxy = nullptr;
 #endif
 };

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -127,7 +127,8 @@ public:
 #endif // CONFIG_NETWORK_LAYER_BLE
 
 #if CHIP_SUPPORT_THREAD_MESHCOP
-    void SetThreadMeshcopCommissionParamsAndProxy(ThreadMeshcopCommissionParameters &meshcopCommissionParams, ThreadMeshcopCommissionProxy * proxy)
+    void SetThreadMeshcopCommissionParamsAndProxy(ThreadMeshcopCommissionParameters & meshcopCommissionParams,
+                                                  ThreadMeshcopCommissionProxy * proxy)
     {
         mThreadMeshcopCommissionProxy = proxy;
         mThreadMeshcopCommissionParams.SetValue(meshcopCommissionParams);

--- a/src/controller/ThreadMeshcopCommissionProxy.h
+++ b/src/controller/ThreadMeshcopCommissionProxy.h
@@ -70,6 +70,7 @@ public:
 
     /**
      * Entry point to start the Thread commissioning and discover the device.
+     * TODO: this function is synchronous, we need to make it asynchronous
      */
     CHIP_ERROR Discover(ByteSpan & pskc, const Transport::PeerAddress & peerAddr, const Thread::DiscoveryCode code,
                         chip::SetupDiscriminator expectedDiscriminator, Dnssd::DiscoveredNodeData & nodeData, uint16_t timeout);

--- a/src/controller/ThreadMeshcopCommissionProxy.h
+++ b/src/controller/ThreadMeshcopCommissionProxy.h
@@ -62,6 +62,12 @@ public:
     ThreadMeshcopCommissionProxy();
     ~ThreadMeshcopCommissionProxy() override;
 
+    static ThreadMeshcopCommissionProxy & GetInstance()
+    {
+        static ThreadMeshcopCommissionProxy instance;
+        return instance;
+    }
+
     /**
      * Entry point to start the Thread commissioning and discover the device.
      */

--- a/src/controller/ThreadMeshcopCommissionProxy.h
+++ b/src/controller/ThreadMeshcopCommissionProxy.h
@@ -62,12 +62,6 @@ public:
     ThreadMeshcopCommissionProxy();
     ~ThreadMeshcopCommissionProxy() override;
 
-    static ThreadMeshcopCommissionProxy & GetInstance()
-    {
-        static ThreadMeshcopCommissionProxy instance;
-        return instance;
-    }
-
     /**
      * Entry point to start the Thread commissioning and discover the device.
      * TODO: this function is synchronous, we need to make it asynchronous

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -519,6 +519,7 @@ struct UnpairDeviceCallback
     chip::Controller::CurrentFabricRemover * mRemover;
 };
 
+#if CHIP_SUPPORT_THREAD_MESHCOP
 CHIP_ERROR GetSetupPasscodeFromOnboardingPayload(const char * onboardingPayload, uint32_t & setupPasscode)
 {
     SetupPayload setupPayload;
@@ -535,6 +536,7 @@ CHIP_ERROR GetSetupPasscodeFromOnboardingPayload(const char * onboardingPayload,
     }
     return CHIP_NO_ERROR;
 }
+#endif // CHIP_SUPPORT_THREAD_MESHCOP
 } // anonymous namespace
 
 PyChipError pychip_DeviceController_UnpairDevice(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid,

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -880,6 +880,7 @@ PyChipError pychip_DeviceController_EstablishPASESessionThreadMeshcop(chip::Cont
     err = dataset.Init(sCommissioningParameters.GetThreadOperationalDataset().Value());
     VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
     err = dataset.GetPSKc(meshcopParams.mPSKcBuffer);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
     return ToPyChipError(
         devCtrl->EstablishPASEConnection(nodeId, setUpCode, DiscoveryType::kAll, NullOptional, MakeOptional(meshcopParams)));
 #else

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -527,13 +527,12 @@ CHIP_ERROR GetSetupPasscodeFromOnboardingPayload(const char * onboardingPayload,
     if (isQRCode)
     {
         ReturnErrorOnFailure(QRCodeSetupPayloadParser(onboardingPayload).populatePayload(setupPayload));
-        setupPasscode = setupPayload.setUpPINCode;
     }
     else
     {
         ReturnErrorOnFailure(ManualSetupPayloadParser(onboardingPayload).populatePayload(setupPayload));
-        setupPasscode = setupPayload.setUpPINCode;
     }
+    setupPasscode = setupPayload.setUpPINCode;
     return CHIP_NO_ERROR;
 }
 #endif // CHIP_SUPPORT_THREAD_MESHCOP

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -177,6 +177,9 @@ PyChipError pychip_DeviceController_EstablishPASESessionIP(chip::Controller::Dev
                                                            uint32_t setupPINCode, chip::NodeId nodeid, uint16_t port);
 PyChipError pychip_DeviceController_EstablishPASESessionBLE(chip::Controller::DeviceCommissioner * devCtrl, uint32_t setupPINCode,
                                                             uint16_t discriminator, chip::NodeId nodeid);
+PyChipError pychip_DeviceController_EstablishPASESessionThreadMeshcop(chip::Controller::DeviceCommissioner * devCtrl,
+                                                                      const char * baHost, uint16_t port, const char * setUpCode,
+                                                                      chip::NodeId nodeid);
 PyChipError pychip_DeviceController_EstablishPASESession(chip::Controller::DeviceCommissioner * devCtrl, const char * setUpCode,
                                                          chip::NodeId nodeid);
 PyChipError pychip_DeviceController_Commission(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid);
@@ -515,6 +518,23 @@ struct UnpairDeviceCallback
     DeviceUnpairingCompleteFunct mCallback;
     chip::Controller::CurrentFabricRemover * mRemover;
 };
+
+CHIP_ERROR GetSetupPasscodeFromOnboardingPayload(const char *onboardingPayload, uint32_t & setupPasscode)
+{
+    SetupPayload setupPayload;
+    bool isQRCode = strncmp(onboardingPayload, kQRCodePrefix, strlen(kQRCodePrefix)) == 0;
+    if (isQRCode)
+    {
+        ReturnErrorOnFailure(QRCodeSetupPayloadParser(onboardingPayload).populatePayload(setupPayload));
+        setupPasscode = setupPayload.setUpPINCode;
+    }
+    else
+    {
+        ReturnErrorOnFailure(ManualSetupPayloadParser(onboardingPayload).populatePayload(setupPayload));
+        setupPasscode = setupPayload.setUpPINCode;
+    }
+    return CHIP_NO_ERROR;
+}
 } // anonymous namespace
 
 PyChipError pychip_DeviceController_UnpairDevice(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid,
@@ -832,6 +852,36 @@ PyChipError pychip_DeviceController_EstablishPASESessionBLE(chip::Controller::De
     addr.SetTransportType(chip::Transport::Type::kBle);
     params.SetPeerAddress(addr).SetDiscriminator(discriminator);
     return ToPyChipError(devCtrl->EstablishPASEConnection(nodeid, params));
+}
+
+PyChipError pychip_DeviceController_EstablishPASESessionThreadMeshcop(chip::Controller::DeviceCommissioner * devCtrl,
+                                                                      const char * baHost, uint16_t baPort, const char * setUpCode,
+                                                                      chip::NodeId nodeId)
+{
+#if CHIP_SUPPORT_THREAD_MESHCOP
+    const uint32_t kDefaultDiscoveryTimeoutMsec = 1000000;
+    uint32_t setupPasscode = 0;
+
+    CHIP_ERROR err = GetSetupPasscodeFromOnboardingPayload(setUpCode, setupPasscode);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
+    err = sPairingDeviceDiscoveryDelegate.Init(nodeId, setupPasscode, sCommissioningParameters, nullptr, devCtrl,
+                                                          kDefaultDiscoveryTimeoutMsec, true);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
+
+    VerifyOrReturnError(sCommissioningParameters.GetThreadOperationalDataset().HasValue(), ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+    chip::Inet::IPAddress baAddr;
+    SetUpCodePairer::ThreadMeshcopCommissionParameters meshcopParams;
+    VerifyOrReturnError(chip::Inet::IPAddress::FromString(baHost, baAddr),
+                        ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+    meshcopParams.mBorderAgentAddress.SetTransportType(chip::Transport::Type::kThreadMeshcop).SetIPAddress(baAddr).SetPort(baPort);
+    Thread::OperationalDatasetView dataset;
+    err = dataset.Init(sCommissioningParameters.GetThreadOperationalDataset().Value());
+    VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
+    err = dataset.GetPSKc(meshcopParams.mPSKcBuffer);
+    return ToPyChipError(devCtrl->EstablishPASEConnection(nodeId, setUpCode, DiscoveryType::kAll, NullOptional, MakeOptional(meshcopParams)));
+#else
+    return ToPyChipError(CHIP_ERROR_NOT_IMPLEMENTED);
+#endif
 }
 
 PyChipError pychip_DeviceController_EstablishPASESession(chip::Controller::DeviceCommissioner * devCtrl, const char * setUpCode,

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -519,7 +519,7 @@ struct UnpairDeviceCallback
     chip::Controller::CurrentFabricRemover * mRemover;
 };
 
-CHIP_ERROR GetSetupPasscodeFromOnboardingPayload(const char *onboardingPayload, uint32_t & setupPasscode)
+CHIP_ERROR GetSetupPasscodeFromOnboardingPayload(const char * onboardingPayload, uint32_t & setupPasscode)
 {
     SetupPayload setupPayload;
     bool isQRCode = strncmp(onboardingPayload, kQRCodePrefix, strlen(kQRCodePrefix)) == 0;
@@ -860,25 +860,26 @@ PyChipError pychip_DeviceController_EstablishPASESessionThreadMeshcop(chip::Cont
 {
 #if CHIP_SUPPORT_THREAD_MESHCOP
     const uint32_t kDefaultDiscoveryTimeoutMsec = 1000000;
-    uint32_t setupPasscode = 0;
+    uint32_t setupPasscode                      = 0;
 
     CHIP_ERROR err = GetSetupPasscodeFromOnboardingPayload(setUpCode, setupPasscode);
     VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
     err = sPairingDeviceDiscoveryDelegate.Init(nodeId, setupPasscode, sCommissioningParameters, nullptr, devCtrl,
-                                                          kDefaultDiscoveryTimeoutMsec, true);
+                                               kDefaultDiscoveryTimeoutMsec, true);
     VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
 
-    VerifyOrReturnError(sCommissioningParameters.GetThreadOperationalDataset().HasValue(), ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+    VerifyOrReturnError(sCommissioningParameters.GetThreadOperationalDataset().HasValue(),
+                        ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
     chip::Inet::IPAddress baAddr;
     SetUpCodePairer::ThreadMeshcopCommissionParameters meshcopParams;
-    VerifyOrReturnError(chip::Inet::IPAddress::FromString(baHost, baAddr),
-                        ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
+    VerifyOrReturnError(chip::Inet::IPAddress::FromString(baHost, baAddr), ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT));
     meshcopParams.mBorderAgentAddress.SetTransportType(chip::Transport::Type::kThreadMeshcop).SetIPAddress(baAddr).SetPort(baPort);
     Thread::OperationalDatasetView dataset;
     err = dataset.Init(sCommissioningParameters.GetThreadOperationalDataset().Value());
     VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
     err = dataset.GetPSKc(meshcopParams.mPSKcBuffer);
-    return ToPyChipError(devCtrl->EstablishPASEConnection(nodeId, setUpCode, DiscoveryType::kAll, NullOptional, MakeOptional(meshcopParams)));
+    return ToPyChipError(
+        devCtrl->EstablishPASEConnection(nodeId, setUpCode, DiscoveryType::kAll, NullOptional, MakeOptional(meshcopParams)));
 #else
     return ToPyChipError(CHIP_ERROR_NOT_IMPLEMENTED);
 #endif

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -607,7 +607,7 @@ PyChipError pychip_DeviceController_ThreadMeshcopCommission(chip::Controller::De
                                                             const char * borderAgentIPAddrStr, uint16_t borderAgentPort)
 {
 #if CHIP_SUPPORT_THREAD_MESHCOP
-    const uint32_t kDefaultDiscoveryTimeoutMsec = 1000000;
+    const uint32_t kDefaultDiscoveryTimeoutMsec = 15 * 60 * 1000; // 15 mins
     CHIP_ERROR err = sPairingDeviceDiscoveryDelegate.Init(nodeId, setupPasscode, sCommissioningParameters, pairingDelegate, devCtrl,
                                                           kDefaultDiscoveryTimeoutMsec);
     VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));

--- a/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
@@ -46,7 +46,15 @@ void ScriptPairingDeviceDiscoveryDelegate::OnDiscoveredDevice(const Dnssd::Commi
 
     RendezvousParameters keyExchangeParams = RendezvousParameters().SetSetupPINCode(mSetupPasscode).SetPeerAddress(peerAddress);
 
-    CHIP_ERROR err = mActiveDeviceCommissioner->PairDevice(mNodeId, keyExchangeParams, mParams);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (mEstablishPaseOnly)
+    {
+        err = mActiveDeviceCommissioner->EstablishPASEConnection(mNodeId, keyExchangeParams);
+    }
+    else
+    {
+        err = mActiveDeviceCommissioner->PairDevice(mNodeId, keyExchangeParams, mParams);
+    }
     if (err != CHIP_NO_ERROR)
     {
         VerifyOrReturn(mPairingDelegate != nullptr);

--- a/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.h
+++ b/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.h
@@ -32,13 +32,14 @@ class ScriptPairingDeviceDiscoveryDelegate : public DeviceDiscoveryDelegate
 public:
     CHIP_ERROR Init(NodeId nodeId, uint32_t setupPasscode, CommissioningParameters commissioningParams,
                     ScriptDevicePairingDelegate * pairingDelegate, DeviceCommissioner * activeDeviceCommissioner,
-                    uint32_t discoveryTimeoutMsec)
+                    uint32_t discoveryTimeoutMsec, bool establishPaseOnly = false)
     {
         mNodeId                   = nodeId;
         mSetupPasscode            = setupPasscode;
         mParams                   = commissioningParams;
         mPairingDelegate          = pairingDelegate;
         mActiveDeviceCommissioner = activeDeviceCommissioner;
+        mEstablishPaseOnly        = establishPaseOnly;
         VerifyOrReturnError(mActiveDeviceCommissioner != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
         mActiveDeviceCommissioner->RegisterDeviceDiscoveryDelegate(this);
         return chip::DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(discoveryTimeoutMsec), OnDiscoveredTimeout,
@@ -65,6 +66,7 @@ private:
     CommissioningParameters mParams;
     NodeId mNodeId;
     uint32_t mSetupPasscode;
+    bool mEstablishPaseOnly;
 };
 
 } // namespace Controller

--- a/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.h
+++ b/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.h
@@ -66,7 +66,7 @@ private:
     CommissioningParameters mParams;
     NodeId mNodeId;
     uint32_t mSetupPasscode;
-    bool mEstablishPaseOnly;
+    bool mEstablishPaseOnly = false;
 };
 
 } // namespace Controller

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -1005,6 +1005,27 @@ class ChipDeviceControllerBase():
                 self.devCtrl, ipaddr.encode("utf-8"), setupPinCode, nodeId, port)
         )
 
+    async def EstablishPASESessionThreadMeshcop(self, baAddr: str, setupCode: str, nodeId: int, baPort: int) -> None:
+        '''
+        Establish a PASE session over Thread MeshCoP.
+
+        Warning: This method attempts to establish a new PASE session, even if an open session already exists.
+        For safer session management that reuses existing sessions, see `FindOrEstablishPASESession`.
+
+        Args:
+            baAddr (str): IP address of BorderAgent.
+            baPort (int): IP port of BorderAgent.
+            setupCode (str): The setup code of the device.
+            nodeId (int): The node ID of the device.
+
+        Returns:
+            None
+        '''
+        await self._establishPASESession(
+            lambda: self._dmLib.pychip_DeviceController_EstablishPASESessionThreadMeshcop(
+                self.devCtrl, baAddr.encode("utf-8"), baPort, setupCode.encode("utf-8"), nodeId)
+        )
+
     async def EstablishPASESession(self, setUpCode: str, nodeId: int) -> None:
         '''
         Establish a PASE session using setUpCode.
@@ -2650,6 +2671,10 @@ class ChipDeviceControllerBase():
             self._dmLib.pychip_DeviceController_EstablishPASESessionIP.argtypes = [
                 c_void_p, c_char_p, c_uint32, c_uint64, c_uint16]
             self._dmLib.pychip_DeviceController_EstablishPASESessionIP.restype = PyChipError
+
+            self._dmLib.pychip_DeviceController_EstablishPASESessionThreadMeshcop.argtypes = [
+                c_void_p, c_char_p, c_uint16, c_char_p, c_uint64]
+            self._dmLib.pychip_DeviceController_EstablishPASESessionThreadMeshcop.restype = PyChipError
 
             self._dmLib.pychip_DeviceController_EstablishPASESessionBLE.argtypes = [
                 c_void_p, c_uint32, c_uint16, c_uint64]

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -1014,9 +1014,9 @@ class ChipDeviceControllerBase():
 
         Args:
             baAddr (str): IP address of BorderAgent.
-            baPort (int): IP port of BorderAgent.
             setupCode (str): The setup code of the device.
             nodeId (int): The node ID of the device.
+            baPort (int): IP port of BorderAgent.
 
         Returns:
             None

--- a/src/python_testing/provisional/TC_SC_TC_4_1.py
+++ b/src/python_testing/provisional/TC_SC_TC_4_1.py
@@ -50,17 +50,21 @@ class TC_SC_TC_4_1(MatterBaseTest):
 
     def steps_TC_SC_TC_4_1(self) -> list[TestStep]:
         return [
-            TestStep(1, "Commissioner petitions the Thread Border Agent to become the Thread Commissioner with a 12-bit discriminator"),
-            TestStep(2, 'Validate the discriminator and perform the commissioning')
+            TestStep(1, "DUT is ready to be discovered", is_commissioning=False),
+            TestStep(2, "TH establishs PASE session over Thread Meshcop with DUT", is_commissioning=False),
         ]
 
     @async_test_body
     async def test_TC_SC_TC_4_1(self):
-        commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
         self.step(1)
-        commissioner.SetSkipCommissioningComplete(True)
+        self.wait_for_user_input("Power on the DUT")
         self.step(2)
-        await self.commission_devices()
+        commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
+        commissioner.SetThreadOperationalDataset(self.matter_test_config.thread_operational_dataset)
+        await commissioner.EstablishPASESessionThreadMeshcop(baAddr = self.matter_test_config.thread_ba_host,
+                                                       setupCode = self.matter_test_config.qr_code_content[0],
+                                                       nodeId = self.matter_test_config.dut_node_ids[0],
+                                                       baPort = self.matter_test_config.thread_ba_port);
 
 
 if __name__ == "__main__":

--- a/src/python_testing/provisional/TC_SC_TC_4_1.py
+++ b/src/python_testing/provisional/TC_SC_TC_4_1.py
@@ -61,10 +61,10 @@ class TC_SC_TC_4_1(MatterBaseTest):
         self.step(2)
         commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
         commissioner.SetThreadOperationalDataset(self.matter_test_config.thread_operational_dataset)
-        await commissioner.EstablishPASESessionThreadMeshcop(baAddr = self.matter_test_config.thread_ba_host,
-                                                       setupCode = self.matter_test_config.qr_code_content[0],
-                                                       nodeId = self.matter_test_config.dut_node_ids[0],
-                                                       baPort = self.matter_test_config.thread_ba_port)
+        await commissioner.EstablishPASESessionThreadMeshcop(baAddr=self.matter_test_config.thread_ba_host,
+                                                             setupCode=self.matter_test_config.qr_code_content[0],
+                                                             nodeId=self.matter_test_config.dut_node_ids[0],
+                                                             baPort=self.matter_test_config.thread_ba_port)
 
 
 if __name__ == "__main__":

--- a/src/python_testing/provisional/TC_SC_TC_4_1.py
+++ b/src/python_testing/provisional/TC_SC_TC_4_1.py
@@ -64,7 +64,7 @@ class TC_SC_TC_4_1(MatterBaseTest):
         await commissioner.EstablishPASESessionThreadMeshcop(baAddr = self.matter_test_config.thread_ba_host,
                                                        setupCode = self.matter_test_config.qr_code_content[0],
                                                        nodeId = self.matter_test_config.dut_node_ids[0],
-                                                       baPort = self.matter_test_config.thread_ba_port);
+                                                       baPort = self.matter_test_config.thread_ba_port)
 
 
 if __name__ == "__main__":

--- a/src/python_testing/provisional/TC_SC_TC_4_1.py
+++ b/src/python_testing/provisional/TC_SC_TC_4_1.py
@@ -62,7 +62,7 @@ class TC_SC_TC_4_1(MatterBaseTest):
         commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
         commissioner.SetThreadOperationalDataset(self.matter_test_config.thread_operational_dataset)
         await commissioner.EstablishPASESessionThreadMeshcop(baAddr=self.matter_test_config.thread_ba_host,
-                                                             setupCode=self.matter_test_config.qr_code_content[0],
+                                                             setupCode=self.first_setup_code(),
                                                              nodeId=self.matter_test_config.dut_node_ids[0],
                                                              baPort=self.matter_test_config.thread_ba_port)
 

--- a/src/python_testing/provisional/TC_SC_TC_4_1.py
+++ b/src/python_testing/provisional/TC_SC_TC_4_1.py
@@ -51,7 +51,7 @@ class TC_SC_TC_4_1(MatterBaseTest):
     def steps_TC_SC_TC_4_1(self) -> list[TestStep]:
         return [
             TestStep(1, "DUT is ready to be discovered", is_commissioning=False),
-            TestStep(2, "TH establishs PASE session over Thread Meshcop with DUT", is_commissioning=False),
+            TestStep(2, "TH establishes PASE session over Thread Meshcop with DUT", is_commissioning=False),
         ]
 
     @async_test_body


### PR DESCRIPTION
#### Summary

- Add establish PASE session only for thread meshcop commissioning in chip-tool and python controller
- Change the TC_SC_TC_4_1.py to establish PASE session

#### Testing

- Test commissioning and establishing PASE session using chip-tool
- Run the TC_SC_TC_4_1.py to establish PASE session with commissionee that supports Thread commissioning,