### PR TITLE
devcontainer: `docker build` is deprecated and is replaced by `docker buildx build`

### DIFF
--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -76,7 +76,7 @@ if [ "$USER_UID" = "0" ]; then
     USER_UID=1000
 fi
 
-docker build \
+docker buildx build \
     -t "$IMAGE_TAG" \
     --pull \
     --build-arg USER_UID="$USER_UID" \


### PR DESCRIPTION
#### Summary

The `docker build` command is now effectively equivalent to `docker buildx build` as the legacy builder is deprecated (see https://docs.docker.com/engine/deprecated/#legacy-builder-for-linux-images). Adjust command to reflect that.

#### Testing

Building of the devcontainer in vscode.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
