### PR TITLE
[SIlabs] Fix CHIP_ERROR_INTERNAL return in smoke-co-alarm HandleEventTrigger

### DIFF
--- a/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
@@ -264,12 +264,12 @@ CHIP_ERROR SmokeCoAlarmManager::HandleEventTrigger(uint64_t eventTrigger)
         break;
     case SmokeCOTrigger::kForceUnmountedState:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force Unmounted State");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(kSmokeCoAlarmEndpointId, true), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(kSmokeCoAlarmEndpointId, true), CHIP_ERROR_INTERNAL);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearUnmountedState:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear Unmounted State");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(kSmokeCoAlarmEndpointId, false), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetUnmountedState(kSmokeCoAlarmEndpointId, false), CHIP_ERROR_INTERNAL);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(kSmokeCoAlarmEndpointId, sPriorityOrder);
         break;
     default:


### PR DESCRIPTION
#### Summary

PR #43323 fixed the build failure in the Silabs smoke-co-alarm app by 
replacing the bool return with CHIP_NO_ERROR in VerifyOrReturnValue. 
However, this introduces a logical error — when SetUnmountedState fails 
and returns false, the function incorrectly returns CHIP_NO_ERROR 
(success) to the caller.

This PR corrects that by returning CHIP_ERROR_INTERNAL instead, ensuring 
failures are properly propagated.

Changes:
- kForceUnmountedState: CHIP_NO_ERROR → CHIP_ERROR_INTERNAL
- kClearUnmountedState: CHIP_NO_ERROR → CHIP_ERROR_INTERNAL

#### Related Issues
Addresses the logical bug introduced in #43323

#### Testing
- Verified the fix aligns with the error handling pattern used across 
  the rest of the file
- No binary size impact expected (pure logic fix)