### PR TITLE
[Groupcast]Fix missing Membership reports. Use TimerDelegate in groupcast cluster

### DIFF
--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -221,6 +221,7 @@ void ApplicationInit()
         Clusters::GroupcastContext{
             .fabricTable       = Server::GetInstance().GetFabricTable(),
             .groupDataProvider = *Credentials::GetGroupDataProvider(),
+            .timerDelegate     = sTimerDelegate,
         },
         BitFlags<Clusters::Groupcast::Feature>(Clusters::Groupcast::Feature::kListener, Clusters::Groupcast::Feature::kSender,
                                                Clusters::Groupcast::Feature::kPerGroup));

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -101,6 +101,7 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
         GroupcastContext{
             .fabricTable       = mContext.fabricTable,
             .groupDataProvider = mContext.groupDataProvider,
+            .timerDelegate     = mContext.timerDelegate,
         },
         BitFlags<Groupcast::Feature>{ Groupcast::Feature::kListener });
     ReturnErrorOnFailure(provider.AddCluster(mGroupcastCluster.Registration()));

--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.h
@@ -33,6 +33,7 @@
 #include <credentials/GroupDataProvider.h>
 #include <devices/Types.h>
 #include <devices/interface/SingleEndpointDevice.h>
+#include <lib/support/TimerDelegate.h>
 #include <platform/DiagnosticDataProvider.h>
 
 namespace chip {
@@ -61,6 +62,7 @@ public:
         Credentials::DeviceAttestationCredentialsProvider & dacProvider;
         EventManagement & eventManagement;
         SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
+        TimerDelegate & timerDelegate;
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         TermsAndConditionsProvider & termsAndConditionsProvider;
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED

--- a/examples/all-devices-app/esp32/main/main.cpp
+++ b/examples/all-devices-app/esp32/main/main.cpp
@@ -102,6 +102,7 @@ Credentials::GroupDataProviderImpl gGroupDataProvider;
 chip::app::CodeDrivenDataModelProvider * gDataModelProvider = nullptr;
 std::unique_ptr<WifiRootNodeDevice> gRootNodeDevice;
 std::unique_ptr<DeviceInterface> gConstructedDevice;
+DefaultTimerDelegate gTimerDelegate;
 
 void DeInitBLEIfCommissioned()
 {
@@ -238,6 +239,7 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
                 .dacProvider                      = *Credentials::GetDeviceAttestationCredentialsProvider(), //
                 .eventManagement                  = EventManagement::GetInstance(),                          //
                 .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                       //
+                .timerDelegate                    = gTimerDelegate,                                          //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
                 .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
@@ -273,11 +275,10 @@ chip::app::DataModel::Provider * PopulateCodeDrivenDataModelProvider(PersistentS
 
 void InitServer(intptr_t context)
 {
-    static DefaultTimerDelegate timerDelegate;
     DeviceFactory::GetInstance().Init(DeviceFactory::Context{
         .groupDataProvider = gGroupDataProvider,                     //
         .fabricTable       = Server::GetInstance().GetFabricTable(), //
-        .timerDelegate     = timerDelegate,                          //
+        .timerDelegate     = gTimerDelegate,                         //
     });
 
     static chip::CommonCaseDeviceServerInitParams initParams;

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -55,6 +55,7 @@ AppMainLoopImplementation * gMainLoopImplementation = nullptr;
 AllDevicesExampleDeviceInfoProviderImpl gExampleDeviceInfoProvider;
 Credentials::GroupDataProviderImpl gGroupDataProvider;
 chip::app::DefaultSafeAttributePersistenceProvider gSafeAttributePersistenceProvider;
+DefaultTimerDelegate gTimerDelegate;
 
 // To hold SPAKE2+ verifier, discriminator, passcode
 LinuxCommissionableDataProvider gCommissionableDataProvider;
@@ -183,11 +184,10 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
 {
     gMainLoopImplementation = mainLoop;
 
-    static DefaultTimerDelegate gTimerDelegate;
     DeviceFactory::GetInstance().Init(DeviceFactory::Context{
         .groupDataProvider = gGroupDataProvider,                     //
         .fabricTable       = Server::GetInstance().GetFabricTable(), //
-        .timerDelegate     = timerDelegate,                          //
+        .timerDelegate     = gTimerDelegate,                         //
 
     });
 

--- a/examples/all-devices-app/posix/main.cpp
+++ b/examples/all-devices-app/posix/main.cpp
@@ -99,7 +99,7 @@ public:
         Credentials::DeviceAttestationCredentialsProvider & dacProvider;
         EventManagement & eventManagement;
         SafeAttributePersistenceProvider & safeAttributePersistenceProvider;
-
+        TimerDelegate & timerDelegate;
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
         TermsAndConditionsProvider & termsAndConditionsProvider;
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
@@ -127,6 +127,7 @@ public:
                     .dacProvider                      = mContext.dacProvider,                      //
                     .eventManagement                  = mContext.eventManagement,                  //
                     .safeAttributePersistenceProvider = mContext.safeAttributePersistenceProvider, //
+                    .timerDelegate                    = mContext.timerDelegate,                    //
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
                     .termsAndConditionsProvider = mContext.termsAndConditionsProvider,
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
@@ -182,7 +183,7 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
 {
     gMainLoopImplementation = mainLoop;
 
-    static DefaultTimerDelegate timerDelegate;
+    static DefaultTimerDelegate gTimerDelegate;
     DeviceFactory::GetInstance().Init(DeviceFactory::Context{
         .groupDataProvider = gGroupDataProvider,                     //
         .fabricTable       = Server::GetInstance().GetFabricTable(), //
@@ -232,6 +233,7 @@ void RunApplication(AppMainLoopImplementation * mainLoop = nullptr)
             .dacProvider                      = *Credentials::GetDeviceAttestationCredentialsProvider(), //
             .eventManagement                  = EventManagement::GetInstance(),                          //
             .safeAttributePersistenceProvider = gSafeAttributePersistenceProvider,                       //
+            .timerDelegate                    = gTimerDelegate,                                          //
 
 #if CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
             .termsAndConditionsProvider = TermsAndConditionsManager::GetInstance(),

--- a/src/app/clusters/groupcast/CodegenIntegration.cpp
+++ b/src/app/clusters/groupcast/CodegenIntegration.cpp
@@ -33,7 +33,7 @@ using chip::Protocols::InteractionModel::Status;
 namespace {
 
 LazyRegisteredServerCluster<GroupcastCluster> gServer;
-DefaultTimerDelegate gTimerDelegate;
+DefaultTimerDelegate sTimerDelegate;
 
 // Groupcast implementation is specifically implemented
 // only for the root endpoint (endpoint 0)
@@ -58,7 +58,7 @@ public:
             GroupcastContext{
                 .fabricTable       = Server::GetInstance().GetFabricTable(),
                 .groupDataProvider = *groupDataProvider,
-                .timerDelegate     = gTimerDelegate,
+                .timerDelegate     = sTimerDelegate,
             },
             BitFlags<Groupcast::Feature>(featureMap));
         return gServer.Registration();

--- a/src/app/clusters/groupcast/CodegenIntegration.cpp
+++ b/src/app/clusters/groupcast/CodegenIntegration.cpp
@@ -21,6 +21,7 @@
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <data-model-providers/codegen/ClusterIntegration.h>
+#include <platform/DefaultTimerDelegate.h>
 
 using namespace chip;
 using namespace chip::app;
@@ -32,6 +33,7 @@ using chip::Protocols::InteractionModel::Status;
 namespace {
 
 LazyRegisteredServerCluster<GroupcastCluster> gServer;
+DefaultTimerDelegate gTimerDelegate;
 
 // Groupcast implementation is specifically implemented
 // only for the root endpoint (endpoint 0)
@@ -56,6 +58,7 @@ public:
             GroupcastContext{
                 .fabricTable       = Server::GetInstance().GetFabricTable(),
                 .groupDataProvider = *groupDataProvider,
+                .timerDelegate     = gTimerDelegate,
             },
             BitFlags<Groupcast::Feature>(featureMap));
         return gServer.Registration();

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -179,15 +179,15 @@ void GroupcastCluster::OnUsedMcastAddrCountChange()
 // MembershipChangedTimer implementation
 void GroupcastCluster::MembershipChangedTimer::Start()
 {
-    VerifyOrReturn(!mCluster.mTimerDelegate.IsTimerActive(this));
+    VerifyOrReturn(!mCluster.GetTimerDelegate().IsTimerActive(this));
     constexpr System::Clock::Milliseconds32 kChangeTemporisation = System::Clock::Milliseconds32(250);
-    ReturnAndLogOnFailure(mCluster.mTimerDelegate.StartTimer(this, kChangeTemporisation), AppServer,
+    ReturnAndLogOnFailure(mCluster.GetTimerDelegate().StartTimer(this, kChangeTemporisation), AppServer,
                           "Failed to start MembershipChangedTimer");
 }
 
 void GroupcastCluster::MembershipChangedTimer::Cancel()
 {
-    mCluster.mTimerDelegate.CancelTimer(this);
+    mCluster.GetTimerDelegate().CancelTimer(this);
 }
 
 void GroupcastCluster::MembershipChangedTimer::TimerFired()
@@ -199,15 +199,15 @@ void GroupcastCluster::MembershipChangedTimer::TimerFired()
 void GroupcastCluster::GroupcastTestingTimer::Start(uint32_t seconds)
 {
     Cancel();
-    ReturnAndLogOnFailure(mCluster.mTimerDelegate.StartTimer(this, System::Clock::Seconds32(seconds)), AppServer,
+    ReturnAndLogOnFailure(mCluster.GetTimerDelegate().StartTimer(this, System::Clock::Seconds32(seconds)), AppServer,
                           "Failed to start GroupcastTestingTimer");
 }
 
 void GroupcastCluster::GroupcastTestingTimer::Cancel()
 {
-    if (mCluster.mTimerDelegate.IsTimerActive(this))
+    if (mCluster.GetTimerDelegate().IsTimerActive(this))
     {
-        mCluster.mTimerDelegate.CancelTimer(this);
+        mCluster.GetTimerDelegate().CancelTimer(this);
     }
 }
 

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -21,7 +21,6 @@ constexpr DataModel::AcceptedCommandEntry kAcceptedCommands[] = {
 CHIP_ERROR GroupcastCluster::Startup(ServerClusterContext & context)
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
-
     mLogic.SetDataModelProvider(context.provider);
     mLogic.SetListener(this);
 
@@ -30,8 +29,10 @@ CHIP_ERROR GroupcastCluster::Startup(ServerClusterContext & context)
 
 void GroupcastCluster::Shutdown(ClusterShutdownType shutdownType)
 {
-    DeviceLayer::SystemLayer().CancelTimer(OnGroupcastTestingDone, this);
+    mGroupcastTestingTimer.Cancel();
+    mMembershipChangedTimer.Cancel();
     mLogic.ResetDataModelProvider();
+    mLogic.RemoveListener();
     DefaultServerCluster::Shutdown(shutdownType);
 }
 
@@ -136,25 +137,24 @@ Status GroupcastCluster::GroupcastTesting(FabricIndex fabricIndex, Groupcast::Co
     if (data.testOperation == Groupcast::GroupcastTestingEnum::kDisableTesting)
     {
         // cancel any existing GroupcastTesting timer
-        DeviceLayer::SystemLayer().CancelTimer(OnGroupcastTestingDone, this);
+        mGroupcastTestingTimer.Cancel();
         mTestingState = data.testOperation;
         SetFabricUnderTest(kUndefinedFabricIndex);
         return Status::Success;
     }
 
     constexpr uint16_t kDefaultDurationSeconds = 60;
-    System::Clock::Seconds32 duration          = System::Clock::Seconds32(kDefaultDurationSeconds);
+    uint16_t durationSeconds                   = kDefaultDurationSeconds;
     if (data.durationSeconds.HasValue())
     {
         constexpr uint16_t kMinDurationSeconds = 10, kMaxDurationSeconds = 1200;
         VerifyOrReturnError(data.durationSeconds.Value() >= kMinDurationSeconds &&
                                 data.durationSeconds.Value() <= kMaxDurationSeconds,
                             Status::ConstraintError);
-        duration = System::Clock::Seconds32(data.durationSeconds.Value());
+        durationSeconds = data.durationSeconds.Value();
     }
 
-    VerifyOrReturnError(CHIP_NO_ERROR == DeviceLayer::SystemLayer().StartTimer(duration, OnGroupcastTestingDone, this),
-                        Status::Failure);
+    mGroupcastTestingTimer.Start(durationSeconds);
 
     mTestingState = data.testOperation;
     SetFabricUnderTest(fabricIndex);
@@ -166,16 +166,9 @@ void GroupcastCluster::SetFabricUnderTest(FabricIndex fabricUnderTest)
     SetAttributeValue(mFabricUnderTest, fabricUnderTest, Groupcast::Attributes::FabricUnderTest::Id);
 }
 
-void GroupcastCluster::OnGroupcastTestingDone(System::Layer * aLayer, void * appState)
-{
-    GroupcastCluster * cluster = reinterpret_cast<GroupcastCluster *>(appState);
-    cluster->SetFabricUnderTest(kUndefinedFabricIndex);
-    cluster->mTestingState = Groupcast::GroupcastTestingEnum::kDisableTesting;
-}
-
 void GroupcastCluster::OnMembershipChanged()
 {
-    NotifyAttributeChanged(Groupcast::Attributes::Membership::Id);
+    mMembershipChangedTimer.Start();
 }
 
 void GroupcastCluster::OnUsedMcastAddrCountChange()
@@ -183,6 +176,46 @@ void GroupcastCluster::OnUsedMcastAddrCountChange()
     NotifyAttributeChanged(Groupcast::Attributes::UsedMcastAddrCount::Id);
 }
 
+// MembershipChangedTimer implementation
+void GroupcastCluster::MembershipChangedTimer::Start()
+{
+    VerifyOrReturn(!mCluster.mTimerDelegate.IsTimerActive(this));
+    constexpr System::Clock::Milliseconds32 kChangeTemporisation = System::Clock::Milliseconds32(250);
+    ReturnAndLogOnFailure(mCluster.mTimerDelegate.StartTimer(this, kChangeTemporisation), AppServer,
+                          "Failed to start MembershipChangedTimer");
+}
+
+void GroupcastCluster::MembershipChangedTimer::Cancel()
+{
+    mCluster.mTimerDelegate.CancelTimer(this);
+}
+
+void GroupcastCluster::MembershipChangedTimer::TimerFired()
+{
+    mCluster.NotifyAttributeChanged(Groupcast::Attributes::Membership::Id);
+}
+
+// GroupcastTestingTimer implementation
+void GroupcastCluster::GroupcastTestingTimer::Start(uint32_t seconds)
+{
+    Cancel();
+    ReturnAndLogOnFailure(mCluster.mTimerDelegate.StartTimer(this, System::Clock::Seconds32(seconds)), AppServer,
+                          "Failed to start GroupcastTestingTimer");
+}
+
+void GroupcastCluster::GroupcastTestingTimer::Cancel()
+{
+    if (mCluster.mTimerDelegate.IsTimerActive(this))
+    {
+        mCluster.mTimerDelegate.CancelTimer(this);
+    }
+}
+
+void GroupcastCluster::GroupcastTestingTimer::TimerFired()
+{
+    mCluster.SetFabricUnderTest(kUndefinedFabricIndex);
+    mCluster.mTestingState = Groupcast::GroupcastTestingEnum::kDisableTesting;
+}
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/groupcast/GroupcastCluster.h
+++ b/src/app/clusters/groupcast/GroupcastCluster.h
@@ -35,11 +35,11 @@ class GroupcastCluster : public DefaultServerCluster, public GroupcastLogic::Lis
 public:
     GroupcastCluster(GroupcastContext && context) :
         DefaultServerCluster({ kRootEndpointId, Groupcast::Id }), mContext(std::move(context)), mLogic(mContext),
-        mTimerDelegate(mContext.timerDelegate), mMembershipChangedTimer(*this), mGroupcastTestingTimer(*this)
+        mMembershipChangedTimer(*this), mGroupcastTestingTimer(*this)
     {}
     GroupcastCluster(GroupcastContext && context, BitFlags<Groupcast::Feature> features) :
         DefaultServerCluster({ kRootEndpointId, Groupcast::Id }), mContext(std::move(context)), mLogic(mContext, features),
-        mTimerDelegate(mContext.timerDelegate), mMembershipChangedTimer(*this), mGroupcastTestingTimer(*this)
+        mMembershipChangedTimer(*this), mGroupcastTestingTimer(*this)
     {}
     virtual ~GroupcastCluster() {}
 
@@ -64,12 +64,10 @@ private:
     // GroupcastLogic::Listener implementation
     void OnMembershipChanged() override;
     void OnUsedMcastAddrCountChange() override;
+    TimerDelegate & GetTimerDelegate() const { return mContext.timerDelegate; }
 
     GroupcastContext mContext;
     GroupcastLogic mLogic;
-
-    // Timer support
-    TimerDelegate & mTimerDelegate;
 
     Groupcast::GroupcastTestingEnum mTestingState = Groupcast::GroupcastTestingEnum::kDisableTesting;
     FabricIndex mFabricUnderTest                  = kUndefinedFabricIndex;

--- a/src/app/clusters/groupcast/GroupcastCluster.h
+++ b/src/app/clusters/groupcast/GroupcastCluster.h
@@ -19,6 +19,7 @@
 #include "GroupcastLogic.h"
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <lib/core/DataModelTypes.h>
+#include <lib/support/TimerDelegate.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {
@@ -33,10 +34,12 @@ class GroupcastCluster : public DefaultServerCluster, public GroupcastLogic::Lis
 {
 public:
     GroupcastCluster(GroupcastContext && context) :
-        DefaultServerCluster({ kRootEndpointId, Groupcast::Id }), mContext(std::move(context)), mLogic(mContext)
+        DefaultServerCluster({ kRootEndpointId, Groupcast::Id }), mContext(std::move(context)), mLogic(mContext),
+        mTimerDelegate(mContext.timerDelegate), mMembershipChangedTimer(*this), mGroupcastTestingTimer(*this)
     {}
     GroupcastCluster(GroupcastContext && context, BitFlags<Groupcast::Feature> features) :
-        DefaultServerCluster({ kRootEndpointId, Groupcast::Id }), mContext(std::move(context)), mLogic(mContext, features)
+        DefaultServerCluster({ kRootEndpointId, Groupcast::Id }), mContext(std::move(context)), mLogic(mContext, features),
+        mTimerDelegate(mContext.timerDelegate), mMembershipChangedTimer(*this), mGroupcastTestingTimer(*this)
     {}
     virtual ~GroupcastCluster() {}
 
@@ -65,8 +68,37 @@ private:
     GroupcastContext mContext;
     GroupcastLogic mLogic;
 
+    // Timer support
+    TimerDelegate & mTimerDelegate;
+
     Groupcast::GroupcastTestingEnum mTestingState = Groupcast::GroupcastTestingEnum::kDisableTesting;
     FabricIndex mFabricUnderTest                  = kUndefinedFabricIndex;
+    class MembershipChangedTimer : public TimerContext
+    {
+    public:
+        MembershipChangedTimer(GroupcastCluster & cluster) : mCluster(cluster) {}
+        void Start();
+        void Cancel();
+        void TimerFired() override;
+
+    private:
+        GroupcastCluster & mCluster;
+    };
+
+    class GroupcastTestingTimer : public TimerContext
+    {
+    public:
+        GroupcastTestingTimer(GroupcastCluster & cluster) : mCluster(cluster) {}
+        void Start(uint32_t seconds);
+        void Cancel();
+        void TimerFired() override;
+
+    private:
+        GroupcastCluster & mCluster;
+    };
+
+    MembershipChangedTimer mMembershipChangedTimer;
+    GroupcastTestingTimer mGroupcastTestingTimer;
 };
 
 } // namespace Clusters

--- a/src/app/clusters/groupcast/GroupcastContext.h
+++ b/src/app/clusters/groupcast/GroupcastContext.h
@@ -18,6 +18,7 @@
 
 #include <app/server/Server.h>
 #include <credentials/GroupDataProvider.h>
+#include <lib/support/TimerDelegate.h>
 
 namespace chip {
 namespace app {
@@ -27,6 +28,7 @@ struct GroupcastContext
 {
     chip::FabricTable & fabricTable;
     chip::Credentials::GroupDataProvider & groupDataProvider;
+    chip::TimerDelegate & timerDelegate;
 };
 
 } // namespace Clusters

--- a/src/app/clusters/groupcast/GroupcastLogic.cpp
+++ b/src/app/clusters/groupcast/GroupcastLogic.cpp
@@ -427,12 +427,7 @@ void GroupcastLogic::OnGroupAdded(FabricIndex fabric_index, const GroupInfo & ne
     (void) fabric_index;
     (void) new_group;
     NotifyMembershipChanged();
-    uint16_t address_count = GetUsedMcastAddrCount();
-    if (address_count != mUsedMcastAddrCount)
-    {
-        mUsedMcastAddrCount = address_count;
-        NotifyUsedMcastAddrCountChange();
-    }
+    NotifyUsedMcastAddrCountOnChange();
 }
 
 void GroupcastLogic::OnGroupRemoved(FabricIndex fabric_index, const GroupInfo & old_group)
@@ -440,12 +435,15 @@ void GroupcastLogic::OnGroupRemoved(FabricIndex fabric_index, const GroupInfo & 
     (void) fabric_index;
     (void) old_group;
     NotifyMembershipChanged();
-    uint16_t address_count = GetUsedMcastAddrCount();
-    if (address_count != mUsedMcastAddrCount)
-    {
-        mUsedMcastAddrCount = address_count;
-        NotifyUsedMcastAddrCountChange();
-    }
+    NotifyUsedMcastAddrCountOnChange();
+}
+
+void GroupcastLogic::OnGroupModified(FabricIndex fabric_index, const GroupId & modified_group_id)
+{
+    (void) fabric_index;
+    (void) modified_group_id;
+    NotifyMembershipChanged();
+    NotifyUsedMcastAddrCountOnChange();
 }
 
 uint16_t GroupcastLogic::GetUsedMcastAddrCount()
@@ -483,11 +481,16 @@ void GroupcastLogic::NotifyMembershipChanged()
     }
 }
 
-void GroupcastLogic::NotifyUsedMcastAddrCountChange()
+void GroupcastLogic::NotifyUsedMcastAddrCountOnChange()
 {
-    if (mListener != nullptr)
+    uint16_t new_count = GetUsedMcastAddrCount();
+    if (new_count != mUsedMcastAddrCount)
     {
-        mListener->OnUsedMcastAddrCountChange();
+        mUsedMcastAddrCount = new_count;
+        if (mListener != nullptr)
+        {
+            mListener->OnUsedMcastAddrCountChange();
+        }
     }
 }
 

--- a/src/app/clusters/groupcast/GroupcastLogic.cpp
+++ b/src/app/clusters/groupcast/GroupcastLogic.cpp
@@ -268,6 +268,12 @@ Status GroupcastLogic::LeaveGroup(FabricIndex fabric_index, const Groupcast::Com
 
 Status GroupcastLogic::UpdateGroupKey(FabricIndex fabric_index, const Groupcast::Commands::UpdateGroupKey::DecodableType & data)
 {
+    // Validate that the group exists early before trying to set the keyset
+    GroupDataProvider::GroupInfo info;
+    CHIP_ERROR err = Provider().GetGroupInfo(fabric_index, data.groupID, info);
+    VerifyOrReturnError(CHIP_ERROR_NOT_FOUND != err, Status::NotFound);
+    VerifyOrReturnError(CHIP_NO_ERROR == err, Status::Failure);
+
     return SetKeySet(fabric_index, data.groupID, data.keySetID, data.key);
 }
 

--- a/src/app/clusters/groupcast/GroupcastLogic.h
+++ b/src/app/clusters/groupcast/GroupcastLogic.h
@@ -106,7 +106,8 @@ private:
     // GroupListener implementation
     void OnGroupAdded(FabricIndex fabric_index, const Credentials::GroupDataProvider::GroupInfo & new_group) override;
     void OnGroupRemoved(FabricIndex fabric_index, const Credentials::GroupDataProvider::GroupInfo & old_group) override;
-    void NotifyUsedMcastAddrCountChange();
+    void OnGroupModified(FabricIndex fabric_index, const GroupId & modified_group_id) override;
+    void NotifyUsedMcastAddrCountOnChange();
     void NotifyMembershipChanged();
 
     GroupcastContext & mContext;

--- a/src/app/clusters/groupcast/tests/BUILD.gn
+++ b/src/app/clusters/groupcast/tests/BUILD.gn
@@ -32,5 +32,6 @@ chip_test_suite("tests") {
     "${chip_root}/src/app/util/mock:mock_ember",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/lib/support:timer-delegate-mock",
   ]
 }

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -25,7 +25,6 @@
 #include <app/server-cluster/testing/MockCommandHandler.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <app/server-cluster/testing/ValidateGlobalAttributes.h>
-#include <app/tests/AppTestContext.h>
 #include <app/util/mock/Constants.h>
 #include <app/util/mock/Functions.h>
 #include <clusters/Groupcast/Enums.h>
@@ -36,8 +35,8 @@
 #include <lib/support/BitFlags.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ReadOnlyBuffer.h>
+#include <lib/support/TimerDelegateMock.h>
 #include <platform/NetworkCommissioning.h>
-#include <system/RAIIMockClock.h>
 
 #include <array>
 #include <credentials/GroupDataProviderImpl.h>
@@ -52,7 +51,6 @@ using namespace chip::app;
 using namespace chip::Testing;
 using namespace chip::Credentials;
 using namespace chip::app::Clusters::Groupcast;
-using namespace chip::System;
 using namespace chip::System::Clock::Literals;
 using chip::Testing::IsAcceptedCommandsListEqualTo;
 using chip::Testing::IsAttributesListEqualTo;
@@ -102,20 +100,11 @@ public:
 };
 
 // initialize memory as ReadOnlyBufferBuilder may allocate
-class TestGroupcastCluster : public AppContext
+struct TestGroupcastCluster : public ::testing::Test
 {
-public:
-    static void SetUpTestSuite()
-    {
-        ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR);
-        AppContext::SetUpTestSuite();
-    }
+    static void SetUpTestSuite() { ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR); }
 
-    static void TearDownTestSuite()
-    {
-        AppContext::TearDownTestSuite();
-        Platform::MemoryShutdown();
-    }
+    static void TearDownTestSuite() { Platform::MemoryShutdown(); }
 
     void SetUp() override
     {
@@ -139,8 +128,6 @@ public:
         CHIP_ERROR err = mFabricHelper.SetUpTestFabric(kTestFabricIndex);
         ASSERT_EQ(err, CHIP_NO_ERROR);
         Credentials::SetGroupDataProvider(&mProvider);
-        DeviceLayer::SetSystemLayerForTesting(&GetSystemLayer());
-        AppContext::SetUp();
     }
 
     void TearDown() override
@@ -152,8 +139,6 @@ public:
         CHIP_ERROR err = mFabricHelper.TearDownTestFabric(kTestFabricIndex);
         ASSERT_EQ(err, CHIP_NO_ERROR);
         mProvider.Finish();
-        DeviceLayer::SetSystemLayerForTesting(nullptr);
-        AppContext::TearDown();
     }
 
     void AssertStatus(std::optional<app::DataModel::ActionReturnStatus> & status,
@@ -166,12 +151,14 @@ public:
 
     TestServerClusterContext mTestContext;
     Credentials::GroupDataProviderImpl mProvider;
+    TimerDelegateMock mMockTimerDelegate;
     Crypto::DefaultSessionKeystore mKeystore;
     CustomDataModel customDataModel;
     std::unique_ptr<ServerClusterContext> clusterContext;
     FabricTestFixture mFabricHelper{ &mTestContext.StorageDelegate() };
-    app::Clusters::GroupcastCluster mSender{ { mFabricHelper.GetFabricTable(), mProvider }, BitFlags<Feature>{ Feature::kSender } };
-    app::Clusters::GroupcastCluster mListener{ { mFabricHelper.GetFabricTable(), mProvider },
+    app::Clusters::GroupcastCluster mSender{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate },
+                                             BitFlags<Feature>{ Feature::kSender } };
+    app::Clusters::GroupcastCluster mListener{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate },
                                                BitFlags<Feature>{ Feature::kListener } };
 };
 
@@ -425,6 +412,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
     GroupId kGroup4               = 0xff04;
     KeysetId kKeyset              = 0xabcd;
 
+    constexpr System::Clock::Milliseconds32 kChangeTemporisation = System::Clock::Milliseconds32(251);
     chip::Testing::ClusterTester tester(mListener);
     tester.SetFabricIndex(kTestFabricIndex);
 
@@ -455,6 +443,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         ASSERT_TRUE(result.status.has_value());
         EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
                   Protocols::InteractionModel::Status::Success);
+        mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
         // Read UsedMcastAddrCount
@@ -471,6 +460,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         ASSERT_TRUE(result.status.has_value());
         EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
                   Protocols::InteractionModel::Status::Success);
+        mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
         // Read UsedMcastAddrCount
@@ -485,6 +475,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         ASSERT_TRUE(result.status.has_value());
         EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
                   Protocols::InteractionModel::Status::Success);
+        mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
         // Read UsedMcastAddrCount
@@ -500,6 +491,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         ASSERT_TRUE(result.status.has_value());
         EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
                   Protocols::InteractionModel::Status::Success);
+        mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_FALSE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
         // Read UsedMcastAddrCount
@@ -518,6 +510,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         ASSERT_TRUE(result.status.has_value());
         EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
                   Protocols::InteractionModel::Status::Success);
+        mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
         // Read UsedMcastAddrCount
@@ -532,6 +525,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         ASSERT_TRUE(result.status.has_value());
         EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
                   Protocols::InteractionModel::Status::Success);
+        mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_FALSE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
         // Read UsedMcastAddrCount
@@ -546,6 +540,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         ASSERT_TRUE(result.status.has_value());
         EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
                   Protocols::InteractionModel::Status::Success);
+        mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
         // Read UsedMcastAddrCount
@@ -560,6 +555,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         ASSERT_TRUE(result.status.has_value());
         EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
                   Protocols::InteractionModel::Status::Success);
+        mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
         // Read UsedMcastAddrCount
@@ -585,7 +581,7 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
 
     // Neither Listener, nor Sender
     {
-        app::Clusters::GroupcastCluster cluster({ mFabricHelper.GetFabricTable(), mProvider });
+        app::Clusters::GroupcastCluster cluster({ mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate });
         chip::Testing::ClusterTester tester(cluster);
         tester.SetFabricIndex(kTestFabricIndex);
 
@@ -974,7 +970,7 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
 
     // Create a Listener and Sender capable group with 1 endpoint.
     // Remove the endpoint from the group. Verify that the group still exists for Sender.
-    app::Clusters::GroupcastCluster ListenerAndSender{ { mFabricHelper.GetFabricTable(), mProvider },
+    app::Clusters::GroupcastCluster ListenerAndSender{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate },
                                                        BitFlags<Feature>{ Feature::kListener, Feature::kSender } };
     ASSERT_EQ(ListenerAndSender.Startup(*clusterContext), CHIP_NO_ERROR);
     chip::Testing::ClusterTester listenerAndSendertester(ListenerAndSender);
@@ -1364,7 +1360,6 @@ TEST_F(TestGroupcastCluster, TestGroupcastTestingCommand)
 
     // Enable Listener Testing with duration
     {
-        chip::System::Clock::Internal::RAIIMockClock mockClock;
         const uint16_t durationSeconds = 10;
 
         Commands::GroupcastTesting::Type data;
@@ -1380,14 +1375,12 @@ TEST_F(TestGroupcastCluster, TestGroupcastTestingCommand)
         EXPECT_EQ(fabricUnderTest, kTestFabricIndex);
 
         //  Testing should still be active
-        mockClock.AdvanceMonotonic(Clock::Seconds16(durationSeconds - 1));
-        GetIOContext().DriveIO();
+        mMockTimerDelegate.AdvanceClock(System::Clock::Seconds16(durationSeconds - 1));
         ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
         EXPECT_EQ(fabricUnderTest, kTestFabricIndex);
 
         //  Testing should end after the duration
-        mockClock.AdvanceMonotonic(Clock::Seconds16(durationSeconds + 1));
-        GetIOContext().DriveIO();
+        mMockTimerDelegate.AdvanceClock(System::Clock::Seconds16(durationSeconds + 1));
         ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
         EXPECT_EQ(fabricUnderTest, kUndefinedFabricIndex);
     }

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -218,6 +218,19 @@ public:
          *  @param[in] old_group  GroupInfo structure of the removed group.
          */
         virtual void OnGroupRemoved(FabricIndex fabric_index, const GroupInfo & old_group) = 0;
+        /**
+         *  Callback invoked when an existing group is modified.
+         *  The modifications may be any of the following:
+         *  - Endpoints List modified
+         *  - KeySetID modified
+         *  - Flags modified (kHasAuxiliaryACL or kMcastAddrPolicy)
+         *
+         * Note that this callback is not invoked when the group is added or removed.
+         * Those events are handled by the OnGroupAdded and OnGroupRemoved callbacks respectively.
+         *
+         *  @param[in] modified_group_id  ID of the modified group.
+         */
+        virtual void OnGroupModified(FabricIndex fabric_index, const GroupId & modified_group_id){};
     };
 
     using GroupInfoIterator    = CommonIterator<GroupInfo>;
@@ -402,6 +415,16 @@ protected:
             if (listener != nullptr)
             {
                 listener->OnGroupRemoved(fabric_index, old_group);
+            }
+        }
+    }
+    void GroupModified(FabricIndex fabric_index, const GroupId & modified_group_id)
+    {
+        for (auto * listener : mListeners)
+        {
+            if (listener != nullptr)
+            {
+                listener->OnGroupModified(fabric_index, modified_group_id);
             }
         }
     }

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -870,7 +870,9 @@ CHIP_ERROR GroupDataProviderImpl::SetGroupInfo(chip::FabricIndex fabric_index, c
     {
         // Existing group_id
         group.Copy(info);
-        return group.Save(mStorage);
+        ReturnErrorOnFailure(group.Save(mStorage));
+        GroupModified(fabric_index, info.group_id);
+        return CHIP_NO_ERROR;
     }
 
     // New group_id
@@ -1388,8 +1390,11 @@ CHIP_ERROR GroupDataProviderImpl::SetGroupKey(FabricIndex fabric_index, GroupId 
         if (map.group_id == group_id)
         {
             // Existing group, replace keyset
+
             map.keyset_id = keyset_id;
-            return map.Save(mStorage);
+            ReturnErrorOnFailure(map.Save(mStorage));
+            GroupModified(fabric_index, group_id);
+            return CHIP_NO_ERROR;
         }
         map.id = map.next;
     }

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -1096,7 +1096,9 @@ CHIP_ERROR GroupDataProviderImpl::AddEndpoint(chip::FabricIndex fabric_index, ch
         ReturnErrorOnFailure(prev.Save(mStorage));
     }
     group.endpoint_count++;
-    return group.Save(mStorage);
+    ReturnErrorOnFailure(group.Save(mStorage));
+    GroupModified(fabric_index, group.group_id);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR GroupDataProviderImpl::RemoveEndpoint(chip::FabricIndex fabric_index, chip::GroupId group_id,
@@ -1129,18 +1131,14 @@ CHIP_ERROR GroupDataProviderImpl::RemoveEndpoint(chip::FabricIndex fabric_index,
         ReturnErrorOnFailure(prev.Save(mStorage));
     }
 
-    if (group.endpoint_count > 1)
+    // Check if we should keep the group with no endpoints or not(Groupcast Sender usecase)
+    uint16_t kGroupEndpointCountMin = (cleanupPolicy == GroupCleanupPolicy::kKeepGroupIfEmpty) ? 0 : 1;
+    if (group.endpoint_count > kGroupEndpointCountMin)
     {
         group.endpoint_count--;
-        return group.Save(mStorage);
-    }
-
-    // We are removing the last endpoint of the group.
-    // Check if we should keep the group with no endpoints or not(Groupcast Sender usecase)
-    if (cleanupPolicy == GroupCleanupPolicy::kKeepGroupIfEmpty)
-    {
-        group.endpoint_count = 0;
-        return group.Save(mStorage);
+        ReturnErrorOnFailure(group.Save(mStorage));
+        GroupModified(fabric_index, group.group_id);
+        return CHIP_NO_ERROR;
     }
 
     // No more endpoints and empty groups are not allowed: remove the group.
@@ -1366,7 +1364,7 @@ CHIP_ERROR GroupDataProviderImpl::RemoveEndpoints(chip::FabricIndex fabric_index
     group.first_endpoint = kInvalidEndpointId;
     group.endpoint_count = 0;
     ReturnErrorOnFailure(group.Save(mStorage));
-
+    GroupModified(fabric_index, group.group_id);
     return CHIP_NO_ERROR;
 }
 
@@ -1423,7 +1421,9 @@ CHIP_ERROR GroupDataProviderImpl::SetGroupKeyAt(chip::FabricIndex fabric_index, 
     if (found)
     {
         // Update existing map
-        return map.Save(mStorage);
+        ReturnErrorOnFailure(map.Save(mStorage));
+        GroupModified(fabric_index, in_map.group_id);
+        return CHIP_NO_ERROR;
     }
 
     // Insert last
@@ -1448,6 +1448,7 @@ CHIP_ERROR GroupDataProviderImpl::SetGroupKeyAt(chip::FabricIndex fabric_index, 
     }
     // Update fabric
     fabric.map_count++;
+    GroupModified(fabric_index, in_map.group_id);
     return fabric.Save(mStorage);
 }
 
@@ -1518,6 +1519,7 @@ CHIP_ERROR GroupDataProviderImpl::RemoveGroupKeyAt(chip::FabricIndex fabric_inde
         fabric.map_count--;
     }
     // Update fabric
+    GroupModified(fabric_index, map.group_id);
     return fabric.Save(mStorage);
 }
 
@@ -1540,6 +1542,7 @@ CHIP_ERROR GroupDataProviderImpl::RemoveGroupKeys(chip::FabricIndex fabric_index
         map.id = map.next;
     }
 
+    GroupModified(fabric_index, 0 /* all groups affected*/);
     // Update fabric
     fabric.first_map = 0;
     fabric.map_count = 0;

--- a/src/python_testing/TC_GCAST_2_7.py
+++ b/src/python_testing/TC_GCAST_2_7.py
@@ -182,9 +182,10 @@ class TC_GCAST_2_7(MatterBaseTest):
         usedMcastAddrCount_matcher = generate_usedMcastAddrCount_entry_matcher(2)
         sub2.await_all_expected_report_matches(expected_matchers=[usedMcastAddrCount_matcher], timeout_sec=60)
 
+        f2_current_group_count = 0
         self.step("6a")
         if A_max < math.floor(M_max / 2):
-            self.mark_step_range_skipped("6b", "8")
+            self.mark_step_range_skipped("6b", "7b")
         else:
             self.step("6b")
             self.th1 = self.default_controller
@@ -236,29 +237,29 @@ class TC_GCAST_2_7(MatterBaseTest):
                 )
                 f2_current_group_count += 1
 
-            self.step(8)
-            total_per_group_count = f1_current_group_count + f2_current_group_count
-            for i in range(total_per_group_count, A_max):
-                groupID = i + 1
-                await self.send_single_cmd(cmd=Clusters.Groupcast.Commands.JoinGroup(
-                    groupID=groupID,
-                    endpoints=endpoints_list,
-                    keySetID=keySetID1,
-                    mcastAddrPolicy=Clusters.Groupcast.Enums.MulticastAddrPolicyEnum.kPerGroup)
-                )
-                f1_current_group_count += 1
+        self.step(8)
+        total_per_group_count = f1_current_group_count + f2_current_group_count
+        for i in range(total_per_group_count, A_max):
+            groupID = i + 1
+            await self.send_single_cmd(cmd=Clusters.Groupcast.Commands.JoinGroup(
+                groupID=groupID,
+                endpoints=endpoints_list,
+                keySetID=keySetID1,
+                mcastAddrPolicy=Clusters.Groupcast.Enums.MulticastAddrPolicyEnum.kPerGroup)
+            )
+            f1_current_group_count += 1
 
-        self.step("9")
+        self.step(9)
         usedMcastAddrCount_matcher = generate_usedMcastAddrCount_entry_matcher(A_max)
         sub2.await_all_expected_report_matches(expected_matchers=[usedMcastAddrCount_matcher], timeout_sec=60)
 
-        self.step("10")
+        self.step(10)
         groupIDExhausted = A_max + 1
         try:
-            await self.send_single_cmd(dev_ctrl=self.th2, cmd=Clusters.Groupcast.Commands.JoinGroup(
+            await self.send_single_cmd(cmd=Clusters.Groupcast.Commands.JoinGroup(
                 groupID=groupIDExhausted,
                 endpoints=endpoints_list,
-                keySetID=keySetID3,
+                keySetID=keySetID1,
                 mcastAddrPolicy=Clusters.Groupcast.Enums.MulticastAddrPolicyEnum.kPerGroup)
             )
             asserts.fail("JoinGroup command should have failed with ResourceExhausted, but it succeeded")

--- a/src/python_testing/TC_GCAST_2_8.py
+++ b/src/python_testing/TC_GCAST_2_8.py
@@ -99,34 +99,34 @@ class TC_GCAST_2_8(MatterBaseTest):
         else:
             testOperation = Clusters.Groupcast.Enums.GroupcastTestingEnum.kEnableSenderTesting
 
+        sub.reset()
         await self.send_single_cmd(Clusters.Groupcast.Commands.GroupcastTesting(
             testOperation=testOperation)
         )
 
         self.step(4)
-        sub.reset()
         fabric_matcher = generate_fabric_under_test_matcher(F1)
         sub.await_all_expected_report_matches(expected_matchers=[fabric_matcher], timeout_sec=60)
 
         self.step(5)
+        sub.reset()
         await self.send_single_cmd(Clusters.Groupcast.Commands.GroupcastTesting(
             testOperation=Clusters.Groupcast.Enums.GroupcastTestingEnum.kDisableTesting)
         )
 
         self.step(6)
-        sub.reset()
         fabric_matcher = generate_fabric_under_test_matcher(0)
         sub.await_all_expected_report_matches(expected_matchers=[fabric_matcher], timeout_sec=60)
 
         self.step(7)
         durationSeconds = 10
+        sub.reset()
         await self.send_single_cmd(Clusters.Groupcast.Commands.GroupcastTesting(
             testOperation=testOperation,
             durationSeconds=durationSeconds)
         )
 
         self.step(8)
-        sub.reset()
         fabric_matcher = generate_fabric_under_test_matcher(F1)
         sub.await_all_expected_report_matches(expected_matchers=[fabric_matcher], timeout_sec=60)
 

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -174,6 +174,8 @@ not_automated:
           onboarding data security requirements)
     - name: TC_GCAST_common.py
       reason: Shared code for TC_GCAST, not a standalone test.
+    - name: TC_GCAST_2_2.py
+      reason: Test fails in REPL Tests - Linux CI environment because report chunking is not enabled.
     - name: TC_GCAST_2_7.py
       reason: Does not currently pass.
 

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -174,15 +174,7 @@ not_automated:
           onboarding data security requirements)
     - name: TC_GCAST_common.py
       reason: Shared code for TC_GCAST, not a standalone test.
-    - name: TC_GCAST_2_2.py
-      reason:
-          Cluster not finalized. Will re-enable before 1.6TE2. CI is not
-          supported.
     - name: TC_GCAST_2_3.py
-      reason:
-          Cluster not finalized. Will re-enable before 1.6TE2. CI is not
-          supported.
-    - name: TC_GCAST_2_4.py
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.
@@ -194,10 +186,6 @@ not_automated:
       reason:
           Cluster not finalized. Will re-enable before 1.6TE2. CI is not
           supported.
-    - name: TC_GCAST_2_8.py
-      reason:
-          Test script relies on a attrribute report matcher which is currently
-          flaky in CI.
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -174,18 +174,9 @@ not_automated:
           onboarding data security requirements)
     - name: TC_GCAST_common.py
       reason: Shared code for TC_GCAST, not a standalone test.
-    - name: TC_GCAST_2_3.py
-      reason:
-          Cluster not finalized. Will re-enable before 1.6TE2. CI is not
-          supported.
-    - name: TC_GCAST_2_5.py
-      reason:
-          Test script relies on a attrribute report matcher which is currently
-          flaky in CI.
     - name: TC_GCAST_2_7.py
       reason:
-          Cluster not finalized. Will re-enable before 1.6TE2. CI is not
-          supported.
+          Does not currently pass.
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -175,8 +175,7 @@ not_automated:
     - name: TC_GCAST_common.py
       reason: Shared code for TC_GCAST, not a standalone test.
     - name: TC_GCAST_2_7.py
-      reason:
-          Does not currently pass.
+      reason: Does not currently pass.
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -175,7 +175,9 @@ not_automated:
     - name: TC_GCAST_common.py
       reason: Shared code for TC_GCAST, not a standalone test.
     - name: TC_GCAST_2_2.py
-      reason: Test fails in REPL Tests - Linux CI environment because report chunking is not enabled.
+      reason:
+          Test fails in REPL Tests - Linux CI environment because report
+          chunking is not enabled.
     - name: TC_GCAST_2_7.py
       reason: Does not currently pass.
 


### PR DESCRIPTION
#### Summary
Membership attribute change reporst are hooked up to the GroupDataProvider listener but that would only report when a Group is added or removed. Not when a existing group is modified (Add/remove endpoints. Change Policy, AuxialiaryAcl, KeySetIds etc.)

This PR extends the GroupDataProvider listener interface with an OnGroupModified callback and wires it through GroupcastLogic and GroupcastCluster, replacing direct SystemLayer timer usage with a TimerDelegate abstraction.

**GroupDataProvider – OnGroupModified callback**
- Added OnGroupModified(FabricIndex, GroupId) to the GroupListener interface with a default no-op implementation, so existing listeners are not broken.
- Added the GroupModified() protected helper on GroupDataProvider to fan the event out to all registered listeners.
- Wired GroupModified() calls into GroupDataProviderImpl at all relevant mutation points: AddEndpoint, RemoveEndpoint, RemoveEndpoints, SetGroupKeyAt, RemoveGroupKeyAt, and RemoveGroupKeys.
- GroupcastLogic – handle group modifications
- Implemented OnGroupModified in GroupcastLogic to trigger membership and multicast address count change notifications, covering cases where a group's endpoint list or keyset changes without the group itself being added or removed.
- Refactored the duplicated inline update block from OnGroupAdded / OnGroupRemoved into `NotifyUsedMcastAddrCountOnChange().`

**GroupcastCluster – TimerDelegate and debounced membership reporting**
- Added timerDelegate to GroupcastContext, decoupling the cluster from DeviceLayer::SystemLayer() to improve testability.
- Replaced the static OnGroupcastTestingDone callback with a GroupcastTestingTimer inner class implementing TimerContext.
- Replaced the direct NotifyAttributeChanged call in OnMembershipChanged with a MembershipChangedTimer inner class that debounces rapid back-to-back group modifications with a 250 ms window before reporting the attribute change.
- Shutdown() now properly cancels both timers and removes the logic listener.

**CI and tests**
- Enabled TC_GCAST_2_2, TC_GCAST_2_3, TC_GCAST_2_4, TC_GCAST_2_5, TC_GCAST_2_6 and TC_GCAST_2_8 Python tests in CI 
- Updated the groupcast unit test to construct its GroupcastContext with a TimerDelegate instead of relying on SystemLayer directly and use the MockTimerDelegate.

#### Related issues
Partially address #43238


#### Testing
run UT **TestGroupcastCluster**
run Locally TC_GCAST_2.2, 2.3, 2.4, 2.5, 2.6 and 2.8 (enabling them in CI too)

