### PR TITLE
[NXP] Allow KeyValueStoreManagerImpl::_Get to only check key existence

### DIFF
--- a/examples/persistent-storage/KeyValueStorageTest.cpp
+++ b/examples/persistent-storage/KeyValueStorageTest.cpp
@@ -61,6 +61,18 @@ CHIP_ERROR TestEmptyString()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR TestKeyExistence()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    static const char kTestKey[]   = "str_key";
+    static const char kTestValue[] = "test_value";
+    ReturnErrorOnFailure(KeyValueStoreMgr().Put(kTestKey, kTestValue));
+    err = KeyValueStoreMgr().Get(kTestKey, nullptr, 0);
+    VerifyOrReturnError(err == CHIP_NO_ERROR || err == CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_ERROR_INTERNAL);
+    ReturnErrorOnFailure(KeyValueStoreMgr().Delete(kTestKey));
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR TestString()
 {
     static const char kTestKey[]   = "str_key";
@@ -155,6 +167,7 @@ CHIP_ERROR TestMultiRead()
 void RunKvsTest(TestConfigurations test_config)
 {
     RUN_TEST(TestEmptyString());
+    RUN_TEST(TestKeyExistence());
     RUN_TEST(TestString());
     RUN_TEST(TestUint32());
     RUN_TEST(TestArray());

--- a/examples/persistent-storage/KeyValueStorageTest.cpp
+++ b/examples/persistent-storage/KeyValueStorageTest.cpp
@@ -63,7 +63,7 @@ CHIP_ERROR TestEmptyString()
 
 CHIP_ERROR TestKeyExistence()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err                 = CHIP_NO_ERROR;
     static const char kTestKey[]   = "str_key";
     static const char kTestValue[] = "test_value";
     ReturnErrorOnFailure(KeyValueStoreMgr().Put(kTestKey, kTestValue));

--- a/src/platform/nxp/common/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/nxp/common/KeyValueStoreManagerImpl.cpp
@@ -40,7 +40,9 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     CHIP_ERROR err = CHIP_NO_ERROR;
     size_t read_bytes;
 
-    VerifyOrExit((key != NULL) && (value != NULL), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(key != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    /* Allow call with value == NULL && value_size == 0 to check key existence */
+    VerifyOrExit(!(value == NULL && value_size != 0), err = CHIP_ERROR_INVALID_ARGUMENT);
 
     ChipLogProgress(DeviceLayer, "KVS, get key id:: %s", key);
 


### PR DESCRIPTION
#### Summary

 * Allow KeyValueStoreManagerImpl::_Get to be passed a null buffer with zero size to enable the function to check the existence of the key without retrieving the value.
 * This is needed for some matter stack functions such as GenericThreadDriver::BackupExists

#### Testing

Ran TC-CNET-4.12 on MCXW72 lock-app which uses  GenericThreadDriver::BackupExists
