### PR TITLE
[Linux Bridge] switch BrigedDeviceBasicInfo cluster from ember/custom to code-driven implementation

### DIFF
--- a/examples/bridge-app/linux/BUILD.gn
+++ b/examples/bridge-app/linux/BUILD.gn
@@ -31,6 +31,7 @@ executable("chip-bridge-app") {
   deps = [
     "${chip_root}/examples/bridge-app/bridge-common",
     "${chip_root}/examples/platform/linux:app-main",
+    "${chip_root}/src/app/clusters/bridged-device-basic-information-server",
     "${chip_root}/src/lib",
   ]
 

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -112,7 +112,7 @@ void Device::SetUniqueId(const char * szDeviceUniqueId)
     if (mBridgedDevice.IsConstructed())
     {
         // TODO: We could implement a version bump here if this functionality is required.
-        ChipLogError(DeviceLayer, "Unique id is FIXED and cannot be changed after bridged device startup.") return;
+        ChipLogError(DeviceLayer, "Unique id is FIXED and cannot be changed after bridged device startup.");
         return;
     }
 

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -99,14 +99,11 @@ void Device::SetReachable(bool aReachable)
 void Device::SetName(const char * szName)
 {
     ChipLogProgress(DeviceLayer, "Device[%s]: New Name=\"%s\"", mName, szName);
+    chip::Platform::CopyString(mName, szName);
 
     if (mBridgedDevice.IsConstructed())
     {
         mBridgedDevice.Cluster().SetNodeLabel(CharSpan::fromCharString(szName));
-    }
-    else
-    {
-        chip::Platform::CopyString(mName, szName);
     }
 }
 
@@ -114,24 +111,27 @@ void Device::SetUniqueId(const char * szDeviceUniqueId)
 {
     if (mBridgedDevice.IsConstructed())
     {
+        // TODO: We could implement a version bump here if this functionality is required.
         ChipLogError(DeviceLayer, "Unique id is FIXED and cannot be changed after bridged device startup.") return;
+        return;
     }
+
     chip::Platform::CopyString(mUniqueId, szDeviceUniqueId);
     ChipLogProgress(DeviceLayer, "Device[%s]: New UniqueId=\"%s\"", mName, mUniqueId);
 }
 
 void Device::SetLocation(std::string szLocation)
 {
-    if (mBridgedDevice.IsConstructed())
-    {
-        // TODO: set location in bridge device
-    }
-    else
-    {
-        // retain for when the cluster is constructed
-        mLocation = szLocation;
-    }
+    bool changed = (mLocation.compare(szLocation) != 0);
+
+    mLocation = szLocation;
+
     ChipLogProgress(DeviceLayer, "Device[%s]: Location=\"%s\"", mName, mLocation.c_str());
+
+    if (changed)
+    {
+        HandleDeviceChange(this, kChanged_Location);
+    }
 }
 
 void Device::GenerateUniqueId()

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -21,6 +21,7 @@
 
 #include <app/clusters/basic-information/CodegenIntegration.h>
 #include <crypto/RandUtils.h>
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DefaultTimerDelegate.h>
 
@@ -52,6 +53,15 @@ Device::Device(const char * szDeviceName, std::string szLocation)
     chip::Platform::CopyString(mName, szDeviceName);
     chip::Platform::CopyString(mUniqueId, "");
     mLocation = szLocation;
+}
+
+void Device::Unregister()
+{
+    if (mBridgedDevice.IsConstructed())
+    {
+        LogErrorOnFailure(chip::app::CodegenDataModelProvider::Instance().Registry().Unregister(&mBridgedDevice.Cluster()));
+        mBridgedDevice.Destroy();
+    }
 }
 
 Status Device::OnNodeLabelChanged(const std::string & newNodeLabel)

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -58,7 +58,7 @@ Status Device::OnNodeLabelChanged(const std::string & newNodeLabel)
 {
     VerifyOrReturnValue(mName != newNodeLabel, Status::Success);
     chip::Platform::CopyString(mName, newNodeLabel.c_str());
-    // NOTE: WE do NOT call device change as that handles attribute chance callbacks and those
+    // NOTE: WE do NOT call device change as that handles attribute change callbacks and those
     //       are handled by the cluster code.
     // HandleDeviceChange(this, kChanged_Name);
     return chip::Protocols::InteractionModel::Status::Success;

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -122,7 +122,7 @@ void Device::SetUniqueId(const char * szDeviceUniqueId)
 
 void Device::SetLocation(std::string szLocation)
 {
-    bool changed = (mLocation.compare(szLocation) != 0);
+    bool changed = (mLocation != szLocation);
 
     mLocation = szLocation;
 
@@ -153,7 +153,7 @@ void Device::GenerateUniqueId()
 
 uint32_t Device::GetConfigurationVersion()
 {
-    VerifyOrReturnValue(mBridgedDevice.IsConstructed(), 0);
+    VerifyOrReturnValue(mBridgedDevice.IsConstructed(), 1);
     return mBridgedDevice.Cluster().GetConfigurationVersion();
 }
 

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -31,7 +31,7 @@ using namespace chip;
 using namespace chip::app::Clusters::Actions;
 
 // We cannot use the proxy since we need ember support.
-// As a result we update the version at runtime by fetching the basicinfo cluster
+// As a result we update the version at runtime by fetching the Basic Information cluster
 // during processing.
 class EmberBridgeVersionUpdate : public chip::app::Clusters::ConfigurationVersionDelegate
 {

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -94,7 +94,6 @@ void Device::SetReachable(bool aReachable)
 
     mBridgedDevice.Cluster().SetReachable(aReachable);
     ChipLogProgress(DeviceLayer, "Device[%s]: %s", mName, aReachable ? "ONLINE" : "OFFLINE");
-    HandleDeviceChange(this, kChanged_Reachable);
 }
 
 void Device::SetName(const char * szName)
@@ -113,22 +112,26 @@ void Device::SetName(const char * szName)
 
 void Device::SetUniqueId(const char * szDeviceUniqueId)
 {
+    if (mBridgedDevice.IsConstructed())
+    {
+        ChipLogError(DeviceLayer, "Unique id is FIXED and cannot be changed after bridged device startup.") return;
+    }
     chip::Platform::CopyString(mUniqueId, szDeviceUniqueId);
     ChipLogProgress(DeviceLayer, "Device[%s]: New UniqueId=\"%s\"", mName, mUniqueId);
 }
 
 void Device::SetLocation(std::string szLocation)
 {
-    bool changed = (mLocation.compare(szLocation) != 0);
-
-    mLocation = szLocation;
-
-    ChipLogProgress(DeviceLayer, "Device[%s]: Location=\"%s\"", mName, mLocation.c_str());
-
-    if (changed)
+    if (mBridgedDevice.IsConstructed())
     {
-        HandleDeviceChange(this, kChanged_Location);
+        // TODO: set location in bridge device
     }
+    else
+    {
+        // retain for when the cluster is constructed
+        mLocation = szLocation;
+    }
+    ChipLogProgress(DeviceLayer, "Device[%s]: Location=\"%s\"", mName, mLocation.c_str());
 }
 
 void Device::GenerateUniqueId()
@@ -150,21 +153,16 @@ void Device::GenerateUniqueId()
 
 uint32_t Device::GetConfigurationVersion()
 {
-    return mConfigurationVersion;
+    VerifyOrReturnValue(mBridgedDevice.IsConstructed(), 0);
+    return mBridgedDevice.Cluster().GetConfigurationVersion();
 }
 
-void Device::SetConfigurationVersion(uint32_t configurationVersion)
+void Device::IncreaseConfigurationVersion()
 {
-    bool changed = (mConfigurationVersion != configurationVersion);
-
-    mConfigurationVersion = configurationVersion;
-
-    ChipLogProgress(DeviceLayer, "Device[%s]: New Configuration Version=\"%d\"", mName, mConfigurationVersion);
-
-    if (changed)
-    {
-        HandleDeviceChange(this, kChanged_ConfigurationVersion);
-    }
+    VerifyOrReturn(mBridgedDevice.IsConstructed());
+    LogErrorOnFailure(mBridgedDevice.Cluster().IncreaseConfigurationVersion());
+    ChipLogProgress(DeviceLayer, "Device[%s]: New Configuration Version=\"%d\"", mName,
+                    mBridgedDevice.Cluster().GetConfigurationVersion());
 }
 
 DeviceOnOff::DeviceOnOff(const char * szDeviceName, std::string szLocation) : Device(szDeviceName, szLocation)

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -29,6 +29,7 @@
 
 using namespace chip;
 using namespace chip::app::Clusters::Actions;
+using chip::Protocols::InteractionModel::Status;
 
 // We cannot use the proxy since we need ember support.
 // As a result we update the version at runtime by fetching the Basic Information cluster
@@ -51,6 +52,16 @@ Device::Device(const char * szDeviceName, std::string szLocation)
     chip::Platform::CopyString(mName, szDeviceName);
     chip::Platform::CopyString(mUniqueId, "");
     mLocation = szLocation;
+}
+
+Status Device::OnNodeLabelChanged(const std::string & newNodeLabel)
+{
+    VerifyOrReturnValue(mName != newNodeLabel, Status::Success);
+    chip::Platform::CopyString(mName, newNodeLabel.c_str());
+    // NOTE: WE do NOT call device change as that handles attribute chance callbacks and those
+    //       are handled by the cluster code.
+    // HandleDeviceChange(this, kChanged_Name);
+    return chip::Protocols::InteractionModel::Status::Success;
 }
 
 app::ServerClusterRegistration &
@@ -88,15 +99,15 @@ void Device::SetReachable(bool aReachable)
 
 void Device::SetName(const char * szName)
 {
-    bool changed = (strncmp(mName, szName, sizeof(mName)) != 0);
-
     ChipLogProgress(DeviceLayer, "Device[%s]: New Name=\"%s\"", mName, szName);
 
-    chip::Platform::CopyString(mName, szName);
-
-    if (changed)
+    if (mBridgedDevice.IsConstructed())
     {
-        HandleDeviceChange(this, kChanged_Name);
+        mBridgedDevice.Cluster().SetNodeLabel(CharSpan::fromCharString(szName));
+    }
+    else
+    {
+        chip::Platform::CopyString(mName, szName);
     }
 }
 

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -30,7 +30,7 @@
 using namespace chip;
 using namespace chip::app::Clusters::Actions;
 
-// We cannot use the prox since we need ember support.
+// We cannot use the proxy since we need ember support.
 // As a result we update the version at runtime by fetching the basicinfo cluster
 // during processing.
 class EmberBridgeVersionUpdate : public chip::app::Clusters::ConfigurationVersionDelegate

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -19,9 +19,10 @@
 
 #include "Device.h"
 
+#include <app/clusters/basic-information/CodegenIntegration.h>
 #include <crypto/RandUtils.h>
-#include <cstdio>
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/DefaultTimerDelegate.h>
 
 #include <string>
 #include <sys/types.h>
@@ -29,40 +30,60 @@
 using namespace chip;
 using namespace chip::app::Clusters::Actions;
 
+// We cannot use the prox since we need ember support.
+// As a result we update the version at runtime by fetching the basicinfo cluster
+// during processing.
+class EmberBridgeVersionUpdate : public chip::app::Clusters::ConfigurationVersionDelegate
+{
+public:
+    CHIP_ERROR IncreaseConfigurationVersion() override
+    {
+        auto cluster = app::Clusters::BasicInformation::GetClusterInstance();
+        VerifyOrReturnError(cluster != nullptr, CHIP_ERROR_NOT_FOUND);
+        return cluster->IncreaseConfigurationVersion();
+    }
+};
+
+static EmberBridgeVersionUpdate gEmberVersionUpdate;
+
 Device::Device(const char * szDeviceName, std::string szLocation)
 {
     chip::Platform::CopyString(mName, szDeviceName);
     chip::Platform::CopyString(mUniqueId, "");
-    mLocation             = szLocation;
-    mReachable            = false;
-    mConfigurationVersion = 1;
-    mEndpointId           = 0;
+    mLocation = szLocation;
+}
+
+app::ServerClusterRegistration &
+Device::CreateBridgedDeviceInfo(chip::EndpointId endpointId,
+                                chip::app::Clusters::BridgedDeviceBasicInformationCluster::RequiredData && required,
+                                chip::app::Clusters::BridgedDeviceBasicInformationCluster::FixedData && fixed)
+{
+    VerifyOrDie(!mBridgedDevice.IsConstructed());
+
+    static chip::app::DefaultTimerDelegate timerDelegate;
+
+    mBridgedDevice.Create(endpointId, std::move(required), std::move(fixed),
+                          app::Clusters::BridgedDeviceBasicInformationCluster::Context{
+                              .parentVersionConfiguration = gEmberVersionUpdate,
+                              .delegate                   = *this,
+                              .timerDelegate              = timerDelegate,
+                          });
+    return mBridgedDevice.Registration();
 }
 
 bool Device::IsReachable()
 {
-    return mReachable;
+    return mBridgedDevice.IsConstructed() && mBridgedDevice.Cluster().GetReachable();
 }
 
 void Device::SetReachable(bool aReachable)
 {
-    bool changed = (mReachable != aReachable);
+    VerifyOrReturn(mBridgedDevice.IsConstructed());
+    VerifyOrReturn(mBridgedDevice.Cluster().GetReachable() != aReachable);
 
-    mReachable = aReachable;
-
-    if (aReachable)
-    {
-        ChipLogProgress(DeviceLayer, "Device[%s]: ONLINE", mName);
-    }
-    else
-    {
-        ChipLogProgress(DeviceLayer, "Device[%s]: OFFLINE", mName);
-    }
-
-    if (changed)
-    {
-        HandleDeviceChange(this, kChanged_Reachable);
-    }
+    mBridgedDevice.Cluster().SetReachable(aReachable);
+    ChipLogProgress(DeviceLayer, "Device[%s]: %s", mName, aReachable ? "ONLINE" : "OFFLINE");
+    HandleDeviceChange(this, kChanged_Reachable);
 }
 
 void Device::SetName(const char * szName)
@@ -241,8 +262,7 @@ void DeviceSwitch::HandleDeviceChange(Device * device, Device::Changed_t changeM
 
 DeviceTempSensor::DeviceTempSensor(const char * szDeviceName, std::string szLocation, int16_t min, int16_t max,
                                    int16_t measuredValue) :
-    Device(szDeviceName, szLocation),
-    mMin(min), mMax(max), mMeasurement(measuredValue)
+    Device(szDeviceName, szLocation), mMin(min), mMax(max), mMeasurement(measuredValue)
 {}
 
 void DeviceTempSensor::SetMeasuredValue(int16_t measurement)

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -262,7 +262,8 @@ void DeviceSwitch::HandleDeviceChange(Device * device, Device::Changed_t changeM
 
 DeviceTempSensor::DeviceTempSensor(const char * szDeviceName, std::string szLocation, int16_t min, int16_t max,
                                    int16_t measuredValue) :
-    Device(szDeviceName, szLocation), mMin(min), mMax(max), mMeasurement(measuredValue)
+    Device(szDeviceName, szLocation),
+    mMin(min), mMax(max), mMeasurement(measuredValue)
 {}
 
 void DeviceTempSensor::SetMeasuredValue(int16_t measurement)

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -85,7 +85,7 @@ protected:
     char mName[kDeviceNameSize + 1]         = { 0 };
     char mUniqueId[kDeviceUniqueIdSize + 1] = { 0 };
     std::string mLocation;
-    chip::EndpointId mEndpointId       = 0;
+    chip::EndpointId mEndpointId       = kInvalidEndpointId;
     chip::EndpointId mParentEndpointId = chip::kInvalidEndpointId;
     std::string mZone;
 

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -45,7 +45,6 @@ public:
     } Changed;
 
     Device(const char * szDeviceName, std::string szLocation);
-    ~Device() override = default;
 
     bool IsReachable();
     void SetReachable(bool aReachable);

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -72,7 +72,7 @@ public:
 
     );
 
-    // BridedDeviceBasicInformationDelegate
+    // BridgedDeviceBasicInformationDelegate
     chip::Protocols::InteractionModel::Status OnNodeLabelChanged(const std::string & newNodeLabel) override
     {
         chip::Platform::CopyString(mName, newNodeLabel.c_str());

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -37,11 +37,9 @@ public:
 
     enum Changed_t
     {
-        kChanged_Reachable            = 1u << 0,
-        kChanged_Location             = 1u << 1,
-        kChanged_Name                 = 1u << 2,
-        kChanged_ConfigurationVersion = 1u << 3,
-        kChanged_Last                 = kChanged_ConfigurationVersion,
+        // NOTE: device changes are handled automatically by the cluster, there
+        //       is no separate notification needed
+        kChanged_Last = 0,
     } Changed;
 
     Device(const char * szDeviceName, std::string szLocation);
@@ -54,7 +52,7 @@ public:
     void SetLocation(std::string szLocation);
     void GenerateUniqueId();
     uint32_t GetConfigurationVersion();
-    void SetConfigurationVersion(uint32_t configurationVersion);
+    void IncreaseConfigurationVersion();
     inline void SetEndpointId(chip::EndpointId id) { mEndpointId = id; };
     inline chip::EndpointId GetEndpointId() { return mEndpointId; };
     inline void SetParentEndpointId(chip::EndpointId id) { mParentEndpointId = id; };
@@ -81,7 +79,6 @@ private:
 protected:
     char mName[kDeviceNameSize + 1]         = { 0 };
     char mUniqueId[kDeviceUniqueIdSize + 1] = { 0 };
-    uint32_t mConfigurationVersion          = 1;
     std::string mLocation;
     chip::EndpointId mEndpointId = 0;
     chip::EndpointId mParentEndpointId;

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -72,11 +72,9 @@ public:
 
     );
 
-    chip::app::ServerClusterInterface * GetBridgedDeviceInfoCluster()
-    {
-        VerifyOrReturnValue(mBridgedDevice.IsConstructed(), nullptr);
-        return &mBridgedDevice.Cluster();
-    }
+    /// Clears internal status: unregisters dynamic endpoints and resets internal
+    /// state.
+    void Unregister();
 
     // BridgedDeviceBasicInformationDelegate
     chip::Protocols::InteractionModel::Status OnNodeLabelChanged(const std::string & newNodeLabel) override;

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -39,7 +39,7 @@ public:
     {
         // NOTE: device changes are handled automatically by the cluster, there
         //       is no separate notification needed
-        // Only remaining nontifications are non-cluster changes
+        // Only remaining notifications are non-cluster changes
         kChanged_Location = 1,
         kChanged_Last     = kChanged_Location,
     } Changed;

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -73,11 +73,7 @@ public:
     );
 
     // BridgedDeviceBasicInformationDelegate
-    chip::Protocols::InteractionModel::Status OnNodeLabelChanged(const std::string & newNodeLabel) override
-    {
-        chip::Platform::CopyString(mName, newNodeLabel.c_str());
-        return chip::Protocols::InteractionModel::Status::Success;
-    }
+    chip::Protocols::InteractionModel::Status OnNodeLabelChanged(const std::string & newNodeLabel) override;
 
 private:
     virtual void HandleDeviceChange(Device * device, Device::Changed_t changeMask) = 0;

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -82,8 +82,8 @@ protected:
     char mName[kDeviceNameSize + 1]         = { 0 };
     char mUniqueId[kDeviceUniqueIdSize + 1] = { 0 };
     std::string mLocation;
-    chip::EndpointId mEndpointId = 0;
-    chip::EndpointId mParentEndpointId;
+    chip::EndpointId mEndpointId       = 0;
+    chip::EndpointId mParentEndpointId = chip::kInvalidEndpointId;
     std::string mZone;
 
     chip::app::LazyRegisteredServerCluster<chip::app::Clusters::BridgedDeviceBasicInformationCluster> mBridgedDevice;

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -72,6 +72,12 @@ public:
 
     );
 
+    chip::app::ServerClusterInterface * GetBridgedDeviceInfoCluster()
+    {
+        VerifyOrReturnValue(mBridgedDevice.IsConstructed(), nullptr);
+        return &mBridgedDevice.Cluster();
+    }
+
     // BridgedDeviceBasicInformationDelegate
     chip::Protocols::InteractionModel::Status OnNodeLabelChanged(const std::string & newNodeLabel) override;
 

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -85,7 +85,7 @@ protected:
     char mName[kDeviceNameSize + 1]         = { 0 };
     char mUniqueId[kDeviceUniqueIdSize + 1] = { 0 };
     std::string mLocation;
-    chip::EndpointId mEndpointId       = kInvalidEndpointId;
+    chip::EndpointId mEndpointId       = chip::kInvalidEndpointId;
     chip::EndpointId mParentEndpointId = chip::kInvalidEndpointId;
     std::string mZone;
 

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -18,18 +18,18 @@
 
 #pragma once
 
+#include <app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h>
+#include <app/server-cluster/ServerClusterInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 #include <cstdint>
-#include <stdbool.h>
-#include <stdint.h>
 
 #include <functional>
 #include <string>
 #include <sys/types.h>
 #include <vector>
 
-class Device
+class Device : public chip::app::Clusters::BridgedDeviceBasicInformationDelegate
 {
 public:
     static const int kDeviceNameSize     = 32;
@@ -45,7 +45,7 @@ public:
     } Changed;
 
     Device(const char * szDeviceName, std::string szLocation);
-    virtual ~Device() {}
+    ~Device() override = default;
 
     bool IsReachable();
     void SetReachable(bool aReachable);
@@ -65,18 +65,33 @@ public:
     inline std::string GetZone() { return mZone; };
     inline void SetZone(std::string zone) { mZone = zone; };
 
+    chip::app::ServerClusterRegistration &
+    CreateBridgedDeviceInfo(chip::EndpointId endpointId,
+                            chip::app::Clusters::BridgedDeviceBasicInformationCluster::RequiredData && required,
+                            chip::app::Clusters::BridgedDeviceBasicInformationCluster::FixedData && fixed
+
+    );
+
+    // BridedDeviceBasicInformationDelegate
+    chip::Protocols::InteractionModel::Status OnNodeLabelChanged(const std::string & newNodeLabel) override
+    {
+        chip::Platform::CopyString(mName, newNodeLabel.c_str());
+        return chip::Protocols::InteractionModel::Status::Success;
+    }
+
 private:
     virtual void HandleDeviceChange(Device * device, Device::Changed_t changeMask) = 0;
 
 protected:
-    bool mReachable                         = false;
     char mName[kDeviceNameSize + 1]         = { 0 };
     char mUniqueId[kDeviceUniqueIdSize + 1] = { 0 };
-    uint32_t mConfigurationVersion;
+    uint32_t mConfigurationVersion          = 1;
     std::string mLocation;
-    chip::EndpointId mEndpointId;
+    chip::EndpointId mEndpointId = 0;
     chip::EndpointId mParentEndpointId;
     std::string mZone;
+
+    chip::app::LazyRegisteredServerCluster<chip::app::Clusters::BridgedDeviceBasicInformationCluster> mBridgedDevice;
 };
 
 class DeviceOnOff : public Device
@@ -169,7 +184,7 @@ private:
 class ComposedDevice : public Device
 {
 public:
-    ComposedDevice(const char * szDeviceName, std::string szLocation) : Device(szDeviceName, szLocation){};
+    ComposedDevice(const char * szDeviceName, std::string szLocation) : Device(szDeviceName, szLocation) {};
 
     using DeviceCallback_fn = std::function<void(ComposedDevice *, ComposedDevice::Changed_t)>;
 
@@ -194,8 +209,7 @@ public:
 
     DevicePowerSource(const char * szDeviceName, std::string szLocation,
                       chip::BitFlags<chip::app::Clusters::PowerSource::Feature> aFeatureMap) :
-        Device(szDeviceName, szLocation),
-        mFeatureMap(aFeatureMap){};
+        Device(szDeviceName, szLocation), mFeatureMap(aFeatureMap) {};
 
     using DeviceCallback_fn = std::function<void(DevicePowerSource *, DevicePowerSource::Changed_t)>;
     void SetChangeCallback(DeviceCallback_fn aChanged_CB) { mChanged_CB = aChanged_CB; }

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -39,7 +39,9 @@ public:
     {
         // NOTE: device changes are handled automatically by the cluster, there
         //       is no separate notification needed
-        kChanged_Last = 0,
+        // Only remaining nontifications are non-cluster changes
+        kChanged_Location = 1,
+        kChanged_Last     = kChanged_Location,
     } Changed;
 
     Device(const char * szDeviceName, std::string szLocation);

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -184,7 +184,7 @@ private:
 class ComposedDevice : public Device
 {
 public:
-    ComposedDevice(const char * szDeviceName, std::string szLocation) : Device(szDeviceName, szLocation) {};
+    ComposedDevice(const char * szDeviceName, std::string szLocation) : Device(szDeviceName, szLocation){};
 
     using DeviceCallback_fn = std::function<void(ComposedDevice *, ComposedDevice::Changed_t)>;
 
@@ -209,7 +209,8 @@ public:
 
     DevicePowerSource(const char * szDeviceName, std::string szLocation,
                       chip::BitFlags<chip::app::Clusters::PowerSource::Feature> aFeatureMap) :
-        Device(szDeviceName, szLocation), mFeatureMap(aFeatureMap) {};
+        Device(szDeviceName, szLocation),
+        mFeatureMap(aFeatureMap){};
 
     using DeviceCallback_fn = std::function<void(DevicePowerSource *, DevicePowerSource::Changed_t)>;
     void SetChangeCallback(DeviceCallback_fn aChanged_CB) { mChanged_CB = aChanged_CB; }

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -72,7 +72,6 @@ namespace {
 NamedPipeCommands sChipNamedPipeCommands;
 BridgeCommandDelegate sBridgeCommandDelegate;
 
-const int kNodeLabelSize = 32;
 // Current ZCL implementation of Struct uses a max-size array of 254 bytes
 const int kDescriptorAttributeArraySize = 254;
 
@@ -290,6 +289,8 @@ int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const E
                     {
                         dev->GenerateUniqueId();
                     }
+                    // NOTE: log only for now: this generally has no reason for failing and if it fails,
+                    //       cluster registration fails, however the rest of the device shows up.
                     LogErrorOnFailure(CodegenDataModelProvider::Instance().Registry().Register(
                         dev->CreateBridgedDeviceInfo(gCurrentEndpointId,
                                                      {
@@ -406,26 +407,8 @@ void ScheduleReportingCallback(Device * dev, ClusterId cluster, AttributeId attr
 }
 } // anonymous namespace
 
-void HandleDeviceStatusChanged(Device * dev, Device::Changed_t itemChangedMask)
-{
-    if (itemChangedMask & Device::kChanged_Reachable)
-    {
-        ScheduleReportingCallback(dev, BridgedDeviceBasicInformation::Id, BridgedDeviceBasicInformation::Attributes::Reachable::Id);
-    }
-
-    if (itemChangedMask & Device::kChanged_Name)
-    {
-        ScheduleReportingCallback(dev, BridgedDeviceBasicInformation::Id, BridgedDeviceBasicInformation::Attributes::NodeLabel::Id);
-    }
-}
-
 void HandleDeviceOnOffStatusChanged(DeviceOnOff * dev, DeviceOnOff::Changed_t itemChangedMask)
 {
-    if (itemChangedMask & (DeviceOnOff::kChanged_Reachable | DeviceOnOff::kChanged_Name | DeviceOnOff::kChanged_Location))
-    {
-        HandleDeviceStatusChanged(static_cast<Device *>(dev), (Device::Changed_t) itemChangedMask);
-    }
-
     if (itemChangedMask & DeviceOnOff::kChanged_OnOff)
     {
         ScheduleReportingCallback(dev, OnOff::Id, OnOff::Attributes::OnOff::Id);
@@ -435,11 +418,6 @@ void HandleDeviceOnOffStatusChanged(DeviceOnOff * dev, DeviceOnOff::Changed_t it
 void HandleDevicePowerSourceStatusChanged(DevicePowerSource * dev, DevicePowerSource::Changed_t itemChangedMask)
 {
     using namespace app::Clusters;
-    if (itemChangedMask &
-        (DevicePowerSource::kChanged_Reachable | DevicePowerSource::kChanged_Name | DevicePowerSource::kChanged_Location))
-    {
-        HandleDeviceStatusChanged(static_cast<Device *>(dev), (Device::Changed_t) itemChangedMask);
-    }
 
     if (itemChangedMask & DevicePowerSource::kChanged_BatLevel)
     {
@@ -458,11 +436,6 @@ void HandleDevicePowerSourceStatusChanged(DevicePowerSource * dev, DevicePowerSo
 
 void HandleDeviceTempSensorStatusChanged(DeviceTempSensor * dev, DeviceTempSensor::Changed_t itemChangedMask)
 {
-    if (itemChangedMask &
-        (DeviceTempSensor::kChanged_Reachable | DeviceTempSensor::kChanged_Name | DeviceTempSensor::kChanged_Location))
-    {
-        HandleDeviceStatusChanged(static_cast<Device *>(dev), (Device::Changed_t) itemChangedMask);
-    }
     if (itemChangedMask & DeviceTempSensor::kChanged_MeasurementValue)
     {
         ScheduleReportingCallback(dev, TemperatureMeasurement::Id, TemperatureMeasurement::Attributes::MeasuredValue::Id);
@@ -510,30 +483,6 @@ Protocols::InteractionModel::Status HandleWriteOnOffAttribute(DeviceOnOff * dev,
     {
         return Protocols::InteractionModel::Status::Failure;
     }
-
-    return Protocols::InteractionModel::Status::Success;
-}
-
-Protocols::InteractionModel::Status HandleWriteBridgedDeviceBasicAttribute(Device * dev, AttributeId attributeId, uint8_t * buffer)
-{
-    ChipLogProgress(DeviceLayer, "HandleWriteBridgedDeviceBasicAttribute: attrId=" ChipLogFormatMEI, ChipLogValueMEI(attributeId));
-
-    if (attributeId != BridgedDeviceBasicInformation::Attributes::NodeLabel::Id)
-    {
-        return Protocols::InteractionModel::Status::UnsupportedWrite;
-    }
-
-    CharSpan nameSpan = CharSpan::fromZclString(buffer);
-
-    if (nameSpan.size() > kNodeLabelSize)
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-
-    std::string name(nameSpan.data(), nameSpan.size());
-    dev->SetName(name.c_str());
-
-    HandleDeviceStatusChanged(dev, Device::kChanged_Name);
 
     return Protocols::InteractionModel::Status::Success;
 }
@@ -672,7 +621,7 @@ Protocols::InteractionModel::Status emberAfExternalAttributeWriteCallback(Endpoi
 
     VerifyOrReturnValue(endpointIndex < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT, Protocols::InteractionModel::Status::Failure);
     Device * dev = gDevices[endpointIndex];
-    VerifyOrReturnValue(dev->IsReachable(), Protocols::InteractionModel::Status::Failure);
+    VerifyOrReturnValue(dev && dev->IsReachable(), Protocols::InteractionModel::Status::Failure);
 
     if (clusterId == OnOff::Id)
     {

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -817,8 +817,7 @@ void * bridge_polling_thread(void * context)
             if (ch == 'w')
             {
                 // TC-BRBINFO-3.2 step 3
-                uint32_t configVersion = Light1.GetConfigurationVersion() + 1;
-                Light1.SetConfigurationVersion(configVersion);
+                Light1.IncreaseConfigurationVersion();
             }
             continue;
         }
@@ -1029,8 +1028,7 @@ void BridgeAppCommandHandler::HandleCommand(intptr_t context)
 
     if (name == "SimulateConfigurationVersionChange")
     {
-        uint32_t configVersion = Light1.GetConfigurationVersion() + 1;
-        Light1.SetConfigurationVersion(configVersion);
+        Light1.IncreaseConfigurationVersion();
     }
     else
     {

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -330,6 +330,10 @@ int RemoveDeviceEndpoint(Device * dev)
         {
             // Todo: Update this to schedule the work rather than use this lock
             DeviceLayer::StackLock lock;
+
+            LogErrorOnFailure(
+                CodegenDataModelProvider::Instance().Registry().Unregister(gDevices[index]->GetBridgedDeviceInfoCluster()));
+
             // Silence complaints about unused ep when progress logging
             // disabled.
             [[maybe_unused]] EndpointId ep = emberAfClearDynamicEndpoint(index);

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -33,6 +33,7 @@
 #include <app/util/util.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ZclString.h>
@@ -72,7 +73,6 @@ NamedPipeCommands sChipNamedPipeCommands;
 BridgeCommandDelegate sBridgeCommandDelegate;
 
 const int kNodeLabelSize = 32;
-const int kUniqueIdSize  = 32;
 // Current ZCL implementation of Struct uses a max-size array of 254 bytes
 const int kDescriptorAttributeArraySize = 254;
 
@@ -133,17 +133,6 @@ DECLARE_DYNAMIC_ATTRIBUTE(Descriptor::Attributes::DeviceTypeList::Id, ARRAY, kDe
 #endif
     DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
-// Declare Bridged Device Basic Information cluster attributes
-DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(bridgedDeviceBasicAttrs)
-DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::NodeLabel::Id, CHAR_STRING, kNodeLabelSize,
-                          ZAP_ATTRIBUTE_MASK(WRITABLE) | ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE)),         /* NodeLabel */
-    DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::Reachable::Id, BOOLEAN, 1, 0), /* Reachable */
-    DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::UniqueID::Id, CHAR_STRING, kUniqueIdSize, 0),
-    DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::ConfigurationVersion::Id, INT32U, 4,
-                              0), /* Configuration Version */
-    DECLARE_DYNAMIC_ATTRIBUTE(BridgedDeviceBasicInformation::Attributes::FeatureMap::Id, BITMAP32, 4, 0), /* feature map */
-    DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
-
 // Declare Cluster List for Bridged Light endpoint
 // TODO: It's not clear whether it would be better to get the command lists from
 // the ZAP config on our last fixed endpoint instead.
@@ -160,8 +149,7 @@ constexpr CommandId onOffIncomingCommands[] = {
 DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(bridgedLightClusters)
 DECLARE_DYNAMIC_CLUSTER(OnOff::Id, onOffAttrs, ZAP_CLUSTER_MASK(SERVER), onOffIncomingCommands, nullptr),
     DECLARE_DYNAMIC_CLUSTER(Descriptor::Id, descriptorAttrs, ZAP_CLUSTER_MASK(SERVER), nullptr, nullptr),
-    DECLARE_DYNAMIC_CLUSTER(BridgedDeviceBasicInformation::Id, bridgedDeviceBasicAttrs, ZAP_CLUSTER_MASK(SERVER), nullptr,
-                            nullptr) DECLARE_DYNAMIC_CLUSTER_LIST_END;
+    DECLARE_DYNAMIC_CLUSTER_LIST_END;
 
 // Declare Bridged Light endpoint
 DECLARE_DYNAMIC_ENDPOINT(bridgedLightEndpoint, bridgedLightClusters);
@@ -217,7 +205,6 @@ DECLARE_DYNAMIC_ATTRIBUTE(TemperatureMeasurement::Attributes::MeasuredValue::Id,
 DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(bridgedTempSensorClusters)
 DECLARE_DYNAMIC_CLUSTER(TemperatureMeasurement::Id, tempSensorAttrs, ZAP_CLUSTER_MASK(SERVER), nullptr, nullptr),
     DECLARE_DYNAMIC_CLUSTER(Descriptor::Id, descriptorAttrs, ZAP_CLUSTER_MASK(SERVER), nullptr, nullptr),
-    DECLARE_DYNAMIC_CLUSTER(BridgedDeviceBasicInformation::Id, bridgedDeviceBasicAttrs, ZAP_CLUSTER_MASK(SERVER), nullptr, nullptr),
     DECLARE_DYNAMIC_CLUSTER_LIST_END;
 
 // Declare Bridged Light endpoint
@@ -245,7 +232,6 @@ DECLARE_DYNAMIC_ATTRIBUTE(PowerSource::Attributes::BatChargeLevel::Id, ENUM8, 1,
 
 DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(bridgedComposedDeviceClusters)
 DECLARE_DYNAMIC_CLUSTER(Descriptor::Id, descriptorAttrs, ZAP_CLUSTER_MASK(SERVER), nullptr, nullptr),
-    DECLARE_DYNAMIC_CLUSTER(BridgedDeviceBasicInformation::Id, bridgedDeviceBasicAttrs, ZAP_CLUSTER_MASK(SERVER), nullptr, nullptr),
     DECLARE_DYNAMIC_CLUSTER(PowerSource::Id, powerSourceAttrs, ZAP_CLUSTER_MASK(SERVER), nullptr, nullptr),
     DECLARE_DYNAMIC_CLUSTER_LIST_END;
 
@@ -260,8 +246,6 @@ DataVersion gComposedTempSensor2DataVersions[MATTER_ARRAY_SIZE(bridgedTempSensor
 // =================================================================================
 
 #define ZCL_DESCRIPTOR_CLUSTER_REVISION (1u)
-#define ZCL_BRIDGED_DEVICE_BASIC_INFORMATION_CLUSTER_REVISION (2u)
-#define ZCL_BRIDGED_DEVICE_BASIC_INFORMATION_FEATURE_MAP (0u)
 #define ZCL_FIXED_LABEL_CLUSTER_REVISION (1u)
 #define ZCL_ON_OFF_CLUSTER_REVISION (4u)
 #define ZCL_TEMPERATURE_SENSOR_CLUSTER_REVISION (1u)
@@ -306,6 +290,15 @@ int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const E
                     {
                         dev->GenerateUniqueId();
                     }
+                    LogErrorOnFailure(CodegenDataModelProvider::Instance().Registry().Register(
+                        dev->CreateBridgedDeviceInfo(gCurrentEndpointId,
+                                                     {
+                                                         .uniqueId             = dev->GetUniqueId(),
+                                                         .reachable            = true,
+                                                         .nodeLabel            = dev->GetName(),
+                                                         .configurationVersion = dev->GetConfigurationVersion(),
+                                                     },
+                                                     {})));
 
                     return index;
                 }
@@ -476,50 +469,6 @@ void HandleDeviceTempSensorStatusChanged(DeviceTempSensor * dev, DeviceTempSenso
     }
 }
 
-Protocols::InteractionModel::Status HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::AttributeId attributeId,
-                                                                          uint8_t * buffer, uint16_t maxReadLength)
-{
-    using namespace BridgedDeviceBasicInformation::Attributes;
-
-    ChipLogProgress(DeviceLayer, "HandleReadBridgedDeviceBasicAttribute: attrId=%d, maxReadLength=%d", attributeId, maxReadLength);
-
-    if ((attributeId == Reachable::Id) && (maxReadLength == 1))
-    {
-        *buffer = dev->IsReachable() ? 1 : 0;
-    }
-    else if ((attributeId == NodeLabel::Id) && (maxReadLength == 32))
-    {
-        MutableByteSpan zclNameSpan(buffer, maxReadLength);
-        TEMPORARY_RETURN_IGNORED MakeZclCharString(zclNameSpan, dev->GetName());
-    }
-    else if ((attributeId == UniqueID::Id) && (maxReadLength == 32))
-    {
-        MutableByteSpan zclUniqueIdSpan(buffer, maxReadLength);
-        TEMPORARY_RETURN_IGNORED MakeZclCharString(zclUniqueIdSpan, dev->GetUniqueId());
-    }
-    else if ((attributeId == ConfigurationVersion::Id) && (maxReadLength == 4))
-    {
-        uint32_t configVersion = dev->GetConfigurationVersion();
-        memcpy(buffer, &configVersion, sizeof(configVersion));
-    }
-    else if ((attributeId == ClusterRevision::Id) && (maxReadLength == 2))
-    {
-        uint16_t rev = ZCL_BRIDGED_DEVICE_BASIC_INFORMATION_CLUSTER_REVISION;
-        memcpy(buffer, &rev, sizeof(rev));
-    }
-    else if ((attributeId == FeatureMap::Id) && (maxReadLength == 4))
-    {
-        uint32_t featureMap = ZCL_BRIDGED_DEVICE_BASIC_INFORMATION_FEATURE_MAP;
-        memcpy(buffer, &featureMap, sizeof(featureMap));
-    }
-    else
-    {
-        return Protocols::InteractionModel::Status::Failure;
-    }
-
-    return Protocols::InteractionModel::Status::Success;
-}
-
 Protocols::InteractionModel::Status HandleReadOnOffAttribute(DeviceOnOff * dev, chip::AttributeId attributeId, uint8_t * buffer,
                                                              uint16_t maxReadLength)
 {
@@ -639,11 +588,7 @@ Protocols::InteractionModel::Status emberAfExternalAttributeReadCallback(Endpoin
     {
         Device * dev = gDevices[endpointIndex];
 
-        if (clusterId == BridgedDeviceBasicInformation::Id)
-        {
-            ret = HandleReadBridgedDeviceBasicAttribute(dev, attributeMetadata->attributeId, buffer, maxReadLength);
-        }
-        else if (clusterId == OnOff::Id)
+        if (clusterId == OnOff::Id)
         {
             ret = HandleReadOnOffAttribute(static_cast<DeviceOnOff *>(dev), attributeMetadata->attributeId, buffer, maxReadLength);
         }
@@ -725,25 +670,16 @@ Protocols::InteractionModel::Status emberAfExternalAttributeWriteCallback(Endpoi
 {
     uint16_t endpointIndex = emberAfGetDynamicIndexFromEndpoint(endpoint);
 
-    Protocols::InteractionModel::Status ret = Protocols::InteractionModel::Status::Failure;
+    VerifyOrReturnValue(endpointIndex < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT, Protocols::InteractionModel::Status::Failure);
+    Device * dev = gDevices[endpointIndex];
+    VerifyOrReturnValue(dev->IsReachable(), Protocols::InteractionModel::Status::Failure);
 
-    // ChipLogProgress(DeviceLayer, "emberAfExternalAttributeWriteCallback: ep=%d", endpoint);
-
-    if (endpointIndex < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+    if (clusterId == OnOff::Id)
     {
-        Device * dev = gDevices[endpointIndex];
-
-        if ((dev->IsReachable()) && (clusterId == OnOff::Id))
-        {
-            ret = HandleWriteOnOffAttribute(static_cast<DeviceOnOff *>(dev), attributeMetadata->attributeId, buffer);
-        }
-        else if ((dev->IsReachable()) && (clusterId == BridgedDeviceBasicInformation::Id))
-        {
-            ret = HandleWriteBridgedDeviceBasicAttribute(dev, attributeMetadata->attributeId, buffer);
-        }
+        return HandleWriteOnOffAttribute(static_cast<DeviceOnOff *>(dev), attributeMetadata->attributeId, buffer);
     }
 
-    return ret;
+    return Protocols::InteractionModel::Status::Failure;
 }
 
 void runOnOffRoomAction(Room * room, bool actionOn, EndpointId endpointId, uint16_t actionID, uint32_t invokeID, bool hasInvokeID)

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -331,8 +331,7 @@ int RemoveDeviceEndpoint(Device * dev)
             // Todo: Update this to schedule the work rather than use this lock
             DeviceLayer::StackLock lock;
 
-            LogErrorOnFailure(
-                CodegenDataModelProvider::Instance().Registry().Unregister(gDevices[index]->GetBridgedDeviceInfoCluster()));
+            gDevices[index]->Unregister();
 
             // Silence complaints about unused ep when progress logging
             // disabled.


### PR DESCRIPTION
#### Summary

This enables the usage of the new cluster. This should result in simpler code as well as more spec-compilant one (since we have a lot of unit tests on the existing cluster)

#### Testing

CI will validate that no breakages. We have several tests that use the bridge BRBINFO 2.1 and 3.2.
Checked locally that linux bridge app compiles, is commissionable and returns data when using `devCtrl.ReadAttribute`

Endpoint 3 for example contains:

```
ENDPOINT 3:
  OnOff:
    DataVersion                   : 3913491135
    AttributeList / 65531         : [0, 65533, 65528, 65529, 65531]
    ClusterRevision / 65533       : 4
    OnOff / 0                     : False
    AcceptedCommandList / 65529   : [0, 1, 2, 64, 65, 66]
    GeneratedCommandList / 65528  : []
  Descriptor:
    DataVersion                   : 2731750714
    PartsList / 3                 : []
    DeviceTypeList / 0            : [Descriptor.Structs.DeviceTypeStruct(deviceType=256, revision=1), Descriptor.Structs.DeviceTypeStruct(deviceType=19, revision=1)]
    AcceptedCommandList / 65529   : []
    FeatureMap / 65532            : 0
    EndpointUniqueID / 5          : ValueDecodeFailure(TLVValue=None, Reason=InteractionModelError(<Status.Failure: 1>))
    ClientList / 2                : []
    GeneratedCommandList / 65528  : []
    AttributeList / 65531         : [0, 1, 2, 3, 5, 65532, 65533, 65528, 65529, 65531]
    ServerList / 1                : [57, 29, 6]
    ClusterRevision / 65533       : 3
  BridgedDeviceBasicInformation:
    DataVersion                   : 1360356046
    ClusterRevision / 65533       : 6
    UniqueID / 18                 : GEN-9YMZFBH83RNT9DNAPDMVA2BCKO83
    ConfigurationVersion / 24     : 1
    AcceptedCommandList / 65529   : []
    FeatureMap / 65532            : 0
    NodeLabel / 5                 : Light 1
    Reachable / 17                : True
    GeneratedCommandList / 65528  : []
    AttributeList / 65531         : [17, 5, 18, 24, 65532, 65533, 65528, 65529, 65531]
```

BridgedDeviceInfo seems valid (and it actually has a reasonable uniqueid, which was not the case in the previous version...)