### PR TITLE
[Java] Support both LIT and SIT in Android Chiptool

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/AddressCommissioningFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/AddressCommissioningFragment.kt
@@ -52,6 +52,7 @@ class AddressCommissioningFragment : Fragment() {
       val discriminator = binding.discriminatorEditText.text.toString()
       val pincode = binding.pincodeEditText.text.toString()
       val port = binding.portEditText.text.toString()
+      val isLIT = binding.enableLITCommissioningSwitchInAddress.isChecked
 
       if (address.isEmpty() || discriminator.isEmpty() || pincode.isEmpty()) {
         Log.e(TAG, "Address, discriminator, or pincode was empty: $address $discriminator $pincode")
@@ -64,7 +65,8 @@ class AddressCommissioningFragment : Fragment() {
             discriminator = discriminator.toInt(),
             setupPinCode = pincode.toLong(),
             ipAddress = address,
-            port = port.toInt()
+            port = port.toInt(),
+            isLIT = isLIT
           )
         )
     }

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -168,13 +168,28 @@ class DeviceProvisioningFragment : Fragment() {
 
     setAttestationDelegate()
 
+    val icdRegistrationInfo = if (deviceInfo.isLIT) {
+      Log.d(TAG, "icdRegistrationInfo : true")
+      ICDRegistrationInfo.createForDeferredConfiguration()
+    }
+    else {
+      Log.d(TAG, "icdRegistrationInfo : false")
+      null
+    }
+
+    val params =
+      CommissionParameters.Builder()
+        .setCsrNonce(null)
+        .setICDRegistrationInfo(icdRegistrationInfo)
+        .build()
+
     deviceController.pairDeviceWithAddress(
       id,
       deviceInfo.ipAddress,
       deviceInfo.port,
       deviceInfo.discriminator,
       deviceInfo.setupPinCode,
-      null
+      params
     )
   }
 
@@ -227,11 +242,20 @@ class DeviceProvisioningFragment : Fragment() {
 
       setAttestationDelegate()
 
+      val icdRegistrationInfo = if (deviceInfo.isLIT) {
+        Log.d(TAG, "icdRegistrationInfo : true")
+        ICDRegistrationInfo.createForDeferredConfiguration()
+      }
+      else {
+        Log.d(TAG, "icdRegistrationInfo : false")
+        null
+      }
+
       val params =
         CommissionParameters.Builder()
           .setCsrNonce(null)
           .setNetworkCredentials(network)
-          .setICDRegistrationInfo(null)
+          .setICDRegistrationInfo(icdRegistrationInfo)
           .build()
 
       deviceController.pairDeviceThroughBLE(gatt, connId, deviceId, deviceInfo.setupPinCode, params)

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -168,14 +168,12 @@ class DeviceProvisioningFragment : Fragment() {
 
     setAttestationDelegate()
 
-    val icdRegistrationInfo = if (deviceInfo.isLIT) {
-      Log.d(TAG, "icdRegistrationInfo : true")
-      ICDRegistrationInfo.createForDeferredConfiguration()
-    }
-    else {
-      Log.d(TAG, "icdRegistrationInfo : false")
-      null
-    }
+    val icdRegistrationInfo =
+      if (deviceInfo.isLIT) {
+        ICDRegistrationInfo.createForDeferredConfiguration()
+      } else {
+        null
+      }
 
     val params =
       CommissionParameters.Builder()
@@ -242,14 +240,12 @@ class DeviceProvisioningFragment : Fragment() {
 
       setAttestationDelegate()
 
-      val icdRegistrationInfo = if (deviceInfo.isLIT) {
-        Log.d(TAG, "icdRegistrationInfo : true")
-        ICDRegistrationInfo.createForDeferredConfiguration()
-      }
-      else {
-        Log.d(TAG, "icdRegistrationInfo : false")
-        null
-      }
+      val icdRegistrationInfo =
+        if (deviceInfo.isLIT) {
+          ICDRegistrationInfo.createForDeferredConfiguration()
+        } else {
+          null
+        }
 
       val params =
         CommissionParameters.Builder()

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
@@ -198,8 +198,7 @@ class BarcodeFragment : Fragment() {
   }
 
   private fun handleScannedQrCode(barcode: Barcode) {
-    if (_binding == null)
-    {
+    if (_binding == null) {
       Log.d(TAG, "Already onDestory is called in Barcode Fragment.")
       return
     }

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
@@ -138,8 +138,9 @@ class BarcodeFragment : Fragment() {
     // workaround: can not use gms to scan the code in China, added a EditText to debug
     binding.manualCodeBtn.setOnClickListener {
       val code = binding.manualCodeEditText.text.toString()
+      val isLIT = binding.enableLITCommissioningSwitchInBarcode.isChecked
       Log.d(TAG, "Submit Code:$code")
-      handleInputCode(code)
+      handleInputCode(code, isLIT)
     }
   }
 
@@ -176,7 +177,7 @@ class BarcodeFragment : Fragment() {
     }
   }
 
-  private fun handleInputCode(code: String) {
+  private fun handleInputCode(code: String, isLIT: Boolean) {
     try {
       val payload =
         if (code.startsWith("MT:")) {
@@ -186,7 +187,7 @@ class BarcodeFragment : Fragment() {
         }
 
       FragmentUtil.getHost(this@BarcodeFragment, Callback::class.java)
-        ?.onCHIPDeviceInfoReceived(CHIPDeviceInfo.fromSetupPayload(payload))
+        ?.onCHIPDeviceInfoReceived(CHIPDeviceInfo.fromSetupPayload(payload, isLIT))
     } catch (ex: UnrecognizedQrCodeException) {
       Log.e(TAG, "Unrecognized Code", ex)
       Toast.makeText(requireContext(), "Unrecognized QR Code", Toast.LENGTH_SHORT).show()
@@ -197,13 +198,19 @@ class BarcodeFragment : Fragment() {
   }
 
   private fun handleScannedQrCode(barcode: Barcode) {
+    if (_binding == null)
+    {
+      Log.d(TAG, "Already onDestory is called in Barcode Fragment.")
+      return
+    }
+    val isLIT = binding.enableLITCommissioningSwitchInBarcode.isChecked
     Handler(Looper.getMainLooper()).post {
       try {
         val payload =
           barcode.displayValue?.let { OnboardingPayloadParser().parseQrCode(it) } ?: return@post
 
         FragmentUtil.getHost(this@BarcodeFragment, Callback::class.java)
-          ?.onCHIPDeviceInfoReceived(CHIPDeviceInfo.fromSetupPayload(payload))
+          ?.onCHIPDeviceInfoReceived(CHIPDeviceInfo.fromSetupPayload(payload, isLIT))
       } catch (ex: UnrecognizedQrCodeException) {
         Log.e(TAG, "Unrecognized QR Code", ex)
         Toast.makeText(requireContext(), "Unrecognized QR Code", Toast.LENGTH_SHORT).show()

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/BarcodeFragment.kt
@@ -199,7 +199,7 @@ class BarcodeFragment : Fragment() {
 
   private fun handleScannedQrCode(barcode: Barcode) {
     if (_binding == null) {
-      Log.d(TAG, "Already onDestory is called in Barcode Fragment.")
+      Log.d(TAG, "onDestroyView has already been called in BarcodeFragment.")
       return
     }
     val isLIT = binding.enableLITCommissioningSwitchInBarcode.isChecked

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceInfo.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceInfo.kt
@@ -40,7 +40,8 @@ data class CHIPDeviceInfo(
   val isShortDiscriminator: Boolean = false,
   val serialNumber: String = "",
   val ipAddress: String? = null,
-  val port: Int = 5540
+  val port: Int = 5540,
+  val isLIT: Boolean = true
 ) : Parcelable {
 
   fun toSetupPayload(): OnboardingPayload {
@@ -71,7 +72,7 @@ data class CHIPDeviceInfo(
   companion object {
     private const val TAG = "CHIPDeviceInfo"
 
-    fun fromSetupPayload(setupPayload: OnboardingPayload): CHIPDeviceInfo {
+    fun fromSetupPayload(setupPayload: OnboardingPayload, isLIT: Boolean = true): CHIPDeviceInfo {
       val serialNumber =
         try {
           setupPayload.getSerialNumber()
@@ -91,7 +92,10 @@ data class CHIPDeviceInfo(
         },
         setupPayload.discoveryCapabilities,
         setupPayload.hasShortDiscriminator,
-        serialNumber
+        serialNumber,
+        null,
+        5540,
+        isLIT
       )
     }
   }

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceInfo.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceInfo.kt
@@ -93,9 +93,7 @@ data class CHIPDeviceInfo(
         setupPayload.discoveryCapabilities,
         setupPayload.hasShortDiscriminator,
         serialNumber,
-        null,
-        5540,
-        isLIT
+        isLIT = isLIT
       )
     }
   }

--- a/examples/android/CHIPTool/app/src/main/res/layout/address_commissioning_fragment.xml
+++ b/examples/android/CHIPTool/app/src/main/res/layout/address_commissioning_fragment.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
@@ -129,6 +130,16 @@
         android:padding="8dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
+
+    <Switch
+        android:id="@+id/enableLITCommissioningSwitchInAddress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:textSize="16sp"
+        android:checked="true"
+        android:text="@string/enable_lit_commissioning_text"
+        tools:ignore="UseSwitchCompatOrMaterialXml" />
 
   </LinearLayout>
   <Button

--- a/examples/android/CHIPTool/app/src/main/res/layout/barcode_fragment.xml
+++ b/examples/android/CHIPTool/app/src/main/res/layout/barcode_fragment.xml
@@ -1,5 +1,6 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -11,7 +12,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/manualCodeEditText"
+        app:layout_constraintBottom_toTopOf="@id/enableLITCommissioningSwitchInBarcode"
         android:layout_gravity="center"
         android:gravity="center"
         android:orientation="vertical" />
@@ -25,6 +26,18 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <Switch
+        android:id="@+id/enableLITCommissioningSwitchInBarcode"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:padding="8dp"
+        android:checked="true"
+        android:text="@string/enable_lit_commissioning_text"
+        app:layout_constraintTop_toBottomOf="@id/cameraView"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:ignore="UseSwitchCompatOrMaterialXml" />
+
     <Button
         android:id="@+id/manualCodeBtn"
         android:layout_width="wrap_content"
@@ -32,7 +45,7 @@
         android:layout_weight="1"
         android:text="Submit"
         android:padding="8dp"
-        app:layout_constraintTop_toBottomOf="@id/cameraView"
+        app:layout_constraintTop_toBottomOf="@id/enableLITCommissioningSwitchInBarcode"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
@@ -43,7 +56,7 @@
         android:inputType="text"
         android:padding="8dp"
         android:text="MT:YNJV7VSC00KA0648G00"
-        app:layout_constraintTop_toBottomOf="@id/cameraView"
+        app:layout_constraintTop_toBottomOf="@id/enableLITCommissioningSwitchInBarcode"
         app:layout_constraintEnd_toStartOf="@id/manualCodeBtn"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/examples/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/examples/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="camera_unavailable_alert_subtitle">Error launching camera to scan the QR code.</string>
     <string name="camera_unavailable_alert_exit">Exit</string>
     <string name="input_address_btn_text">Input device address</string>
+    <string name="enable_lit_commissioning_text">Enable LIT Commissioning</string>
 
     <string name="scan_qr_code_btn_text">Scan QR Code</string>
     <string name="provision_wifi_credentials_btn_text">Provision CHIP device with Wi-Fi</string>

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -578,14 +578,22 @@ CHIP_ERROR AndroidDeviceControllerWrapper::ApplyICDRegistrationInfo(chip::Contro
     if (jSymmetricKey != nullptr)
     {
         JniByteArray jniSymmetricKey(env, jSymmetricKey);
-        VerifyOrReturnError(jniSymmetricKey.size() == sizeof(mICDSymmetricKey), CHIP_ERROR_INVALID_ARGUMENT);
-        memcpy(mICDSymmetricKey, jniSymmetricKey.data(), sizeof(mICDSymmetricKey));
+        if (jniSymmetricKey.size() > 0)
+        {
+            VerifyOrReturnError(jniSymmetricKey.size() == sizeof(mICDSymmetricKey), CHIP_ERROR_INVALID_ARGUMENT);
+            memcpy(mICDSymmetricKey, jniSymmetricKey.data(), sizeof(mICDSymmetricKey));
+            params.SetICDSymmetricKey(chip::ByteSpan(mICDSymmetricKey));
+        }
+        else
+        {
+            ChipLogDetail(Controller, "Skip ICD Symmetric Key.");
+        }
     }
     else
     {
-        TEMPORARY_RETURN_IGNORED chip::Crypto::DRBG_get_bytes(mICDSymmetricKey, sizeof(mICDSymmetricKey));
+        ReturnErrorOnFailure(chip::Crypto::DRBG_get_bytes(mICDSymmetricKey, sizeof(mICDSymmetricKey)));
+        params.SetICDSymmetricKey(chip::ByteSpan(mICDSymmetricKey));
     }
-    params.SetICDSymmetricKey(chip::ByteSpan(mICDSymmetricKey));
 
     chip::app::Clusters::IcdManagement::ClientTypeEnum clientType = chip::app::Clusters::IcdManagement::ClientTypeEnum::kPermanent;
     if (jClientType != nullptr)

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -635,8 +635,16 @@ JNI_METHOD(void, commissionDevice)
         VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
-    TEMPORARY_RETURN_IGNORED wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
+    if (icdRegistrationInfo != nullptr)
+    {
+        commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
+        err = wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
+        VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_INVALID_ARGUMENT);
+    }
+    else
+    {
+        commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kIgnore);
+    }
 
     if (wrapper->GetDeviceAttestationDelegateBridge() != nullptr)
     {
@@ -697,8 +705,20 @@ static void PairDevice(JNIEnv * env, AndroidDeviceControllerWrapper * wrapper, c
         commissioningParams.SetCSRNonce(jniCsrNonce.byteSpan());
     }
 
-    commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
-    TEMPORARY_RETURN_IGNORED wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
+    if (icdRegistrationInfo != nullptr)
+    {
+        commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
+        err = wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Controller, "ApplyICDRegistrationInfo failed.");
+            JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
+        }
+    }
+    else
+    {
+        commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kIgnore);
+    }
 
     if (wrapper->GetDeviceAttestationDelegateBridge() != nullptr)
     {
@@ -767,8 +787,20 @@ JNI_METHOD(void, pairDeviceWithAddress)
         commissioningParams.SetCSRNonce(jniCsrNonce.byteSpan());
     }
 
-    commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
-    TEMPORARY_RETURN_IGNORED wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
+    if (icdRegistrationInfo != nullptr)
+    {
+        commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
+        err = wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Controller, "ApplyICDRegistrationInfo failed.");
+            JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
+        }
+    }
+    else
+    {
+        commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kIgnore);
+    }
 
     if (wrapper->GetDeviceAttestationDelegateBridge() != nullptr)
     {
@@ -819,8 +851,20 @@ JNI_METHOD(void, pairDeviceWithCode)
         TEMPORARY_RETURN_IGNORED wrapper->ApplyNetworkCredentials(commissioningParams, networkCredentials);
     }
 
-    commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
-    TEMPORARY_RETURN_IGNORED wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
+    if (icdRegistrationInfo != nullptr)
+    {
+        commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
+        err = wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Controller, "ApplyICDRegistrationInfo failed.");
+            JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
+        }
+    }
+    else
+    {
+        commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kIgnore);
+    }
 
     if (wrapper->GetDeviceAttestationDelegateBridge() != nullptr)
     {

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -638,8 +638,7 @@ JNI_METHOD(void, commissionDevice)
     if (icdRegistrationInfo != nullptr)
     {
         commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
-        err = wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
-        VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorOnFailure(wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo));
     }
     else
     {
@@ -711,7 +710,7 @@ static void PairDevice(JNIEnv * env, AndroidDeviceControllerWrapper * wrapper, c
         err = wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(Controller, "ApplyICDRegistrationInfo failed.");
+            ChipLogError(Controller, "ApplyICDRegistrationInfo failed. %" CHIP_ERROR_FORMAT, err.Format());
             JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
             return;
         }

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -713,6 +713,7 @@ static void PairDevice(JNIEnv * env, AndroidDeviceControllerWrapper * wrapper, c
         {
             ChipLogError(Controller, "ApplyICDRegistrationInfo failed.");
             JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
+            return;
         }
     }
     else
@@ -795,6 +796,7 @@ JNI_METHOD(void, pairDeviceWithAddress)
         {
             ChipLogError(Controller, "ApplyICDRegistrationInfo failed.");
             JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
+            return;
         }
     }
     else
@@ -859,6 +861,7 @@ JNI_METHOD(void, pairDeviceWithCode)
         {
             ChipLogError(Controller, "ApplyICDRegistrationInfo failed.");
             JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
+            return;
         }
     }
     else

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -859,7 +859,7 @@ JNI_METHOD(void, pairDeviceWithCode)
         err = wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(Controller, "ApplyICDRegistrationInfo failed.");
+            ChipLogError(Controller, "ApplyICDRegistrationInfo failed: %" CHIP_ERROR_FORMAT, err.Format());
             JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
             return;
         }

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -794,7 +794,7 @@ JNI_METHOD(void, pairDeviceWithAddress)
         err = wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(Controller, "ApplyICDRegistrationInfo failed.");
+            ChipLogError(Controller, "ApplyICDRegistrationInfo failed: %s", err.Format());
             JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
             return;
         }

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -638,7 +638,8 @@ JNI_METHOD(void, commissionDevice)
     if (icdRegistrationInfo != nullptr)
     {
         commissioningParams.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
-        ReturnErrorOnFailure(wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo));
+        err = wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
+        VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_INVALID_ARGUMENT);
     }
     else
     {

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -793,7 +793,7 @@ JNI_METHOD(void, pairDeviceWithAddress)
         err = wrapper->ApplyICDRegistrationInfo(commissioningParams, icdRegistrationInfo);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(Controller, "ApplyICDRegistrationInfo failed: %s", err.Format());
+            ChipLogError(Controller, "ApplyICDRegistrationInfo failed: %" CHIP_ERROR_FORMAT, err.Format());
             JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
             return;
         }

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -302,6 +302,7 @@ public class ChipDeviceController {
   }
 
   /* This method was deprecated. Please use {@link ChipDeviceController.pairDeviceWithAddress(long, String, int, int, long, CommissionParameters)}. */
+  @Deprecated
   public void pairDeviceWithAddress(
       long deviceId,
       String address,

--- a/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
+++ b/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
@@ -49,13 +49,13 @@ public final class CommissionParameters {
    *   <li><b>LIT mode, immediate configuration</b>: If LIT mode for commissioning is used and
    *       {@link CompletionListener.onICDRegistrationInfoRequired} is not needed, all required
    *       values in {@link ICDRegistrationInfo} must be provided directly.
-   *   <li><b>LIT mode, deferred configuration</b>: If LIT mode for commissioning is used and
-   *       {@link CompletionListener.onICDRegistrationInfoRequired} should be invoked to obtain
-   *       registration information later, set the value using
-   *       {@link ICDRegistrationInfo#createForDeferredConfiguration()}.
-   *   <li><b>SIT mode</b>: For SIT mode for commissioning, set this value to {@code null}. A null
-   *       value results in {@code ICDRegistrationStrategy::kIgnore} and will <b>not</b> cause
-   *       {@link CompletionListener.onICDRegistrationInfoRequired} to be called.
+   *   <li><b>LIT mode, deferred configuration</b>: If LIT mode for commissioning is used and {@link
+   *       CompletionListener.onICDRegistrationInfoRequired} should be invoked to obtain
+   *       registration information later, set this value to an instance created with {@link
+   *       ICDRegistrationInfo#createForDeferredConfiguration()}.
+   *       value to {@code null}. A {@code null} value results in {@code
+   *       ICDRegistrationStrategy::kIgnore} and will <b>not</b> cause {@link
+   *       CompletionListener.onICDRegistrationInfoRequired} to be called.
    * </ul>
    */
   public ICDRegistrationInfo getICDRegistrationInfo() {

--- a/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
+++ b/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
@@ -41,16 +41,22 @@ public final class CommissionParameters {
   }
 
   /**
-   * The informations for ICD registration. For detailed information {@link ICDRegistrationInfo}. If
-   * this value is null when commissioning an ICD device, {@link
-   * CompletionListener.onICDRegistrationInfoRequired} is called to request the ICDRegistrationInfo
-   * value.
+   * The information for ICD registration. For detailed information see {@link ICDRegistrationInfo}.
    *
-   * <p>- If LIT mode for Commissioning and {@link CompletionListener.onICDRegistrationInfoRequired}
-   * are not needed, all values must be set. - If LIT mode for Commissioning and {@link
-   * CompletionListener.onICDRegistrationInfoRequired} need to be called, set the value using {@link
-   * ICDRegistrationInfo.createForDeferredConfiguration}. - For SIT mode for Commissioning, set the
-   * value to null.
+   * <p>Behavior depends on the commissioning mode and how this value is set:
+   *
+   * <ul>
+   *   <li><b>LIT mode, immediate configuration</b>: If LIT mode for commissioning is used and
+   *       {@link CompletionListener.onICDRegistrationInfoRequired} is not needed, all required
+   *       values in {@link ICDRegistrationInfo} must be provided directly.
+   *   <li><b>LIT mode, deferred configuration</b>: If LIT mode for commissioning is used and
+   *       {@link CompletionListener.onICDRegistrationInfoRequired} should be invoked to obtain
+   *       registration information later, set the value using
+   *       {@link ICDRegistrationInfo#createForDeferredConfiguration()}.
+   *   <li><b>SIT mode</b>: For SIT mode for commissioning, set this value to {@code null}. A null
+   *       value results in {@code ICDRegistrationStrategy::kIgnore} and will <b>not</b> cause
+   *       {@link CompletionListener.onICDRegistrationInfoRequired} to be called.
+   * </ul>
    */
   public ICDRegistrationInfo getICDRegistrationInfo() {
     return icdRegistrationInfo;

--- a/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
+++ b/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
@@ -49,14 +49,14 @@ public final class CommissionParameters {
    *   <li><b>LIT mode, immediate configuration</b>: If LIT mode for commissioning is used and
    *       {@link CompletionListener.onICDRegistrationInfoRequired} is not needed, all required
    *       values in {@link ICDRegistrationInfo} must be provided directly.
-   *   <li><b>LIT mode, deferred configuration</b>: If LIT mode for commissioning is used and
-   *       {@link CompletionListener.onICDRegistrationInfoRequired} should be invoked to obtain
-   *       registration information later, set this value to an instance created with
-   *       {@link ICDRegistrationInfo#createForDeferredConfiguration()}.
+   *   <li><b>LIT mode, deferred configuration</b>: If LIT mode for commissioning is used and {@link
+   *       CompletionListener.onICDRegistrationInfoRequired} should be invoked to obtain
+   *       registration information later, set this value to an instance created with {@link
+   *       ICDRegistrationInfo#createForDeferredConfiguration()}.
    *   <li><b>No ICD registration (e.g., SIT mode)</b>: If ICD registration is not used, set this
-   *       value to {@code null}. A {@code null} value results in
-   *       {@code ICDRegistrationStrategy::kIgnore} and will <b>not</b> cause
-   *       {@link CompletionListener.onICDRegistrationInfoRequired} to be called.
+   *       value to {@code null}. A {@code null} value results in {@code
+   *       ICDRegistrationStrategy::kIgnore} and will <b>not</b> cause {@link
+   *       CompletionListener.onICDRegistrationInfoRequired} to be called.
    * </ul>
    */
   public ICDRegistrationInfo getICDRegistrationInfo() {

--- a/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
+++ b/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
@@ -39,7 +39,16 @@ public final class CommissionParameters {
   public NetworkCredentials getNetworkCredentials() {
     return networkCredentials;
   }
-  /* the informations for ICD registration. For detailed information {@link ICDRegistrationInfo}. If this value is null when commissioning an ICD device, {@link CompletionListener.onICDRegistrationInfoRequired} is called to request the ICDRegistrationInfo value. */
+
+  /**
+   * The informations for ICD registration. For detailed information {@link ICDRegistrationInfo}.
+   * If this value is null when commissioning an ICD device, {@link CompletionListener.onICDRegistrationInfoRequired}
+   * is called to request the ICDRegistrationInfo value.
+   *
+   * - If LIT mode for Commissioning and {@link CompletionListener.onICDRegistrationInfoRequired} are not needed, all values must be set.
+   * - If LIT mode for Commissioning and {@link CompletionListener.onICDRegistrationInfoRequired} need to be called, set the value using {@link ICDRegistrationInfo.createForDeferredConfiguration}.
+   * - For SIT mode for Commissioning, set the value to null.
+   */
   public ICDRegistrationInfo getICDRegistrationInfo() {
     return icdRegistrationInfo;
   }

--- a/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
+++ b/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
@@ -41,13 +41,16 @@ public final class CommissionParameters {
   }
 
   /**
-   * The informations for ICD registration. For detailed information {@link ICDRegistrationInfo}.
-   * If this value is null when commissioning an ICD device, {@link CompletionListener.onICDRegistrationInfoRequired}
-   * is called to request the ICDRegistrationInfo value.
+   * The informations for ICD registration. For detailed information {@link ICDRegistrationInfo}. If
+   * this value is null when commissioning an ICD device, {@link
+   * CompletionListener.onICDRegistrationInfoRequired} is called to request the ICDRegistrationInfo
+   * value.
    *
-   * - If LIT mode for Commissioning and {@link CompletionListener.onICDRegistrationInfoRequired} are not needed, all values must be set.
-   * - If LIT mode for Commissioning and {@link CompletionListener.onICDRegistrationInfoRequired} need to be called, set the value using {@link ICDRegistrationInfo.createForDeferredConfiguration}.
-   * - For SIT mode for Commissioning, set the value to null.
+   * <p>- If LIT mode for Commissioning and {@link CompletionListener.onICDRegistrationInfoRequired}
+   * are not needed, all values must be set. - If LIT mode for Commissioning and {@link
+   * CompletionListener.onICDRegistrationInfoRequired} need to be called, set the value using {@link
+   * ICDRegistrationInfo.createForDeferredConfiguration}. - For SIT mode for Commissioning, set the
+   * value to null.
    */
   public ICDRegistrationInfo getICDRegistrationInfo() {
     return icdRegistrationInfo;

--- a/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
+++ b/src/controller/java/src/chip/devicecontroller/CommissionParameters.java
@@ -51,10 +51,11 @@ public final class CommissionParameters {
    *       values in {@link ICDRegistrationInfo} must be provided directly.
    *   <li><b>LIT mode, deferred configuration</b>: If LIT mode for commissioning is used and
    *       {@link CompletionListener.onICDRegistrationInfoRequired} should be invoked to obtain
-   *       registration information later, set the value using
+   *       registration information later, set this value to an instance created with
    *       {@link ICDRegistrationInfo#createForDeferredConfiguration()}.
-   *   <li><b>SIT mode</b>: For SIT mode for commissioning, set this value to {@code null}. A null
-   *       value results in {@code ICDRegistrationStrategy::kIgnore} and will <b>not</b> cause
+   *   <li><b>No ICD registration (e.g., SIT mode)</b>: If ICD registration is not used, set this
+   *       value to {@code null}. A {@code null} value results in
+   *       {@code ICDRegistrationStrategy::kIgnore} and will <b>not</b> cause
    *       {@link CompletionListener.onICDRegistrationInfoRequired} to be called.
    * </ul>
    */

--- a/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
+++ b/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
@@ -56,8 +56,8 @@ public class ICDRegistrationInfo {
    * <p>Typically returns a 16-byte key. However:
    *
    * <ul>
-   *   <li>If deferred ICD configuration is supported, this may return an empty array as a
-   *       sentinel value.
+   *   <li>If deferred ICD configuration is supported, this may return an empty array as a sentinel
+   *       value.
    *   <li>If no symmetric key was explicitly set in the builder, this may return {@code null},
    *       indicating that a 16-byte key will be randomly generated in native code.
    * </ul>

--- a/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
+++ b/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
@@ -51,9 +51,8 @@ public class ICDRegistrationInfo {
   }
 
   /**
-   * Gets the ICD symmetric key.
-   * Typically returns a 16-byte key. However, if deferred ICD configuration is supported,
-   * this may return an empty array as a sentinel value.
+   * Gets the ICD symmetric key. Typically returns a 16-byte key. However, if deferred ICD
+   * configuration is supported, this may return an empty array as a sentinel value.
    */
   public byte[] getSymmetricKey() {
     return symmetricKey;
@@ -102,9 +101,9 @@ public class ICDRegistrationInfo {
     }
 
     /**
-     * Sets the ICD symmetric key.
-     * Typically, this is a 16-byte key. If not set, a 16-byte key will be randomly generated.
-     * Note that an empty array is a valid sentinel value for deferred ICD configuration.
+     * Sets the ICD symmetric key. Typically, this is a 16-byte key. If not set, a 16-byte key will
+     * be randomly generated. Note that an empty array is a valid sentinel value for deferred ICD
+     * configuration.
      */
     public Builder setSymmetricKey(byte[] symmetricKey) {
       this.symmetricKey = symmetricKey;

--- a/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
+++ b/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
@@ -64,9 +64,9 @@ public class ICDRegistrationInfo {
   }
 
   /**
-   * Creates an ICDRegistrationInfo instance with an empty symmetric key.
-   * This configuration enables the kBeforeComplete feature but intentionally omits the key
-   * to defer the configuration and trigger the OnICDRegistrationInfoRequired callback during commissioning.
+   * Creates an ICDRegistrationInfo instance with an empty symmetric key. This configuration enables
+   * the kBeforeComplete feature but intentionally omits the key to defer the configuration and
+   * trigger the OnICDRegistrationInfoRequired callback during commissioning.
    */
   public static ICDRegistrationInfo createForDeferredConfiguration() {
     return newBuilder().setSymmetricKey(new byte[0]).build();

--- a/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
+++ b/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
@@ -51,8 +51,16 @@ public class ICDRegistrationInfo {
   }
 
   /**
-   * Gets the ICD symmetric key. Typically returns a 16-byte key. However, if deferred ICD
-   * configuration is supported, this may return an empty array as a sentinel value.
+   * Gets the ICD symmetric key.
+   *
+   * <p>Typically returns a 16-byte key. However:
+   *
+   * <ul>
+   *   <li>If deferred ICD configuration is supported, this may return an empty array as a
+   *       sentinel value.
+   *   <li>If no symmetric key was explicitly set in the builder, this may return {@code null},
+   *       indicating that a 16-byte key will be randomly generated in native code.
+   * </ul>
    */
   public byte[] getSymmetricKey() {
     return symmetricKey;

--- a/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
+++ b/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
@@ -50,7 +50,11 @@ public class ICDRegistrationInfo {
     return monitoredSubject;
   }
 
-  /** Returns the 16 bytes ICD symmetric key. */
+  /**
+   * Gets the ICD symmetric key.
+   * Typically returns a 16-byte key. However, if deferred ICD configuration is supported,
+   * this may return an empty array as a sentinel value.
+   */
   public byte[] getSymmetricKey() {
     return symmetricKey;
   }
@@ -98,7 +102,9 @@ public class ICDRegistrationInfo {
     }
 
     /**
-     * The 16 bytes ICD symmetric key, If not set this value, this value will be randomly generated.
+     * Sets the ICD symmetric key.
+     * Typically, this is a 16-byte key. If not set, a 16-byte key will be randomly generated.
+     * Note that an empty array is a valid sentinel value for deferred ICD configuration.
      */
     public Builder setSymmetricKey(byte[] symmetricKey) {
       this.symmetricKey = symmetricKey;

--- a/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
+++ b/src/controller/java/src/chip/devicecontroller/ICDRegistrationInfo.java
@@ -63,6 +63,15 @@ public class ICDRegistrationInfo {
     return new Builder();
   }
 
+  /**
+   * Creates an ICDRegistrationInfo instance with an empty symmetric key.
+   * This configuration enables the kBeforeComplete feature but intentionally omits the key
+   * to defer the configuration and trigger the OnICDRegistrationInfoRequired callback during commissioning.
+   */
+  public static ICDRegistrationInfo createForDeferredConfiguration() {
+    return newBuilder().setSymmetricKey(new byte[0]).build();
+  }
+
   /** Builder for {@link ICDRegistrationInfo}. */
   public static class Builder {
     @Nullable private Long checkInNodeId = null;


### PR DESCRIPTION
#### Summary

Support both LIT and SIT commissioning in Android Chiptool.
 1. Add "Enable LIT Commissioning" switch button in read QR Code fragment.
 2. Update the API to support both LIT and SIT commissioning modes.
 - If LIT mode for Commissioning and OnICDRegistrationInfoRequired are not needed, all values must be set.
 - If LIT mode for Commissioning and OnICDRegistrationInfoRequired need to be called, set the value using createForDeferredConfiguration.
 - For SIT mode for Commissioning, set the value to null.
 
#### Related issues
#42382 

#### Testing
1. If the switch is not checked, commissioning can be completed in SIT mode.
2. If the switch is checked, commissioning can be completed in LIT mode.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ X ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ X ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ X ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
