### PR TITLE
Remove NOLINT bugprone-unchecked-optional-access from tests

### DIFF
--- a/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <app/clusters/basic-information/BasicInformationCluster.h>
@@ -441,15 +442,13 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestKeepActiveCommand)
 
     // validate that an event is generated
     std::optional<LogOnlyEvents::EventInformation> eventInfo = mContext.EventsGenerator().GetNextEvent();
-    ASSERT_NE(eventInfo, std::nullopt);
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    ASSERT_TRUE(eventInfo.has_value());
     EXPECT_EQ(eventInfo->eventOptions.mPath.mClusterId, Id);
     EXPECT_EQ(eventInfo->eventOptions.mPath.mEventId, Events::ActiveChanged::Id);
 
     Events::ActiveChanged::DecodableType decodedEvent;
     ASSERT_EQ(eventInfo->GetEventData(decodedEvent), CHIP_NO_ERROR);
     EXPECT_EQ(decodedEvent.promisedActiveDuration, kStayActiveDurationMs);
-    // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestNotifyDeviceActiveWithoutRequestedDuration)
@@ -665,15 +664,13 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestReachableChangedEvent)
     cluster.SetReachable(true);
 
     std::optional<LogOnlyEvents::EventInformation> eventInfo = mContext.EventsGenerator().GetNextEvent();
-    ASSERT_NE(eventInfo, std::nullopt);
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    ASSERT_TRUE(eventInfo.has_value());
     EXPECT_EQ(eventInfo->eventOptions.mPath.mClusterId, Id);
     EXPECT_EQ(eventInfo->eventOptions.mPath.mEventId, Events::ReachableChanged::Id);
 
     Events::ReachableChanged::DecodableType decodedEvent;
     ASSERT_EQ(eventInfo->GetEventData(decodedEvent), CHIP_NO_ERROR);
     EXPECT_TRUE(decodedEvent.reachableNewValue);
-    // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestLeaveEvent)
@@ -693,11 +690,9 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestLeaveEvent)
     cluster.GenerateLeaveEvent();
 
     std::optional<LogOnlyEvents::EventInformation> eventInfo = mContext.EventsGenerator().GetNextEvent();
-    ASSERT_NE(eventInfo, std::nullopt);
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    ASSERT_TRUE(eventInfo.has_value());
     EXPECT_EQ(eventInfo->eventOptions.mPath.mClusterId, Id);
     EXPECT_EQ(eventInfo->eventOptions.mPath.mEventId, Events::Leave::Id);
-    // NOLINTEND(bugprone-unchecked-optional-access)
     // This event has no fields, so no data to decode.
 }
 

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <app/AttributeValueDecoder.h>
@@ -41,6 +42,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::CameraAvStreamManagement;
 using namespace chip::Testing;
+using namespace chip::Protocols::InteractionModel;
 
 static constexpr chip::EndpointId kTestEndpointId = 1;
 
@@ -90,9 +92,8 @@ public:
     MockCameraAVStreamManagementDelegate(std::vector<VideoStreamStruct> * videoStreams,
                                          std::vector<AudioStreamStruct> * audioStreams,
                                          std::vector<SnapshotStreamStruct> * snapshotStreams) :
-        mAllocatedVideoStreams(videoStreams),
-        mAllocatedAudioStreams(audioStreams), mAllocatedSnapshotStreams(snapshotStreams), mAudioStreamCount(0),
-        mVideoStreamCount(0), mSnapshotStreamCount(0)
+        mAllocatedVideoStreams(videoStreams), mAllocatedAudioStreams(audioStreams), mAllocatedSnapshotStreams(snapshotStreams),
+        mAudioStreamCount(0), mVideoStreamCount(0), mSnapshotStreamCount(0)
     {}
 
     Protocols::InteractionModel::Status VideoStreamAllocate(const VideoStreamStruct & allocateArgs, uint16_t & outStreamID) override
@@ -966,64 +967,47 @@ TEST_F(TestCameraAVStreamManagementCluster, TestAudioStreamAllocateCommand)
     request.bitDepth     = 24;
 
     auto result = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_EQ(result.response->audioStreamID, 1);
 
     // channelCount out of bounds
     request.channelCount = 0;
     result               = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
 
     request.channelCount = 9;
     result               = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.channelCount = 2; // Restore
 
     // sampleRate 0
     request.sampleRate = 0;
     result             = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.sampleRate = 48000; // Restore
 
     // bitRate 0
     request.bitRate = 0;
     result          = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.bitRate = 128000; // Restore
 
     // Invalid bitDepth
     request.bitDepth = 12;
     result           = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.bitDepth = 24; // Restore
 
     // streamUsage not supported by test fixture priorities
     request.streamUsage = StreamUsageEnum::kAnalysis;
     result              = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::InvalidInState);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::InvalidInState));
     request.streamUsage = StreamUsageEnum::kLiveView; // Restore
 
     // Attempt to allocate a second stream, expecting ResourceExhausted
     result = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ResourceExhausted);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ResourceExhausted));
 }
 
 TEST_F(TestCameraAVStreamManagementCluster, TestAudioStreamAllocateCommandUnsupportedBitDepth)
@@ -1044,9 +1028,7 @@ TEST_F(TestCameraAVStreamManagementCluster, TestAudioStreamAllocateCommandUnsupp
     request.bitDepth     = 8; // Unsupported bitDepth
 
     auto result = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::DynamicConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::DynamicConstraintError));
 }
 
 TEST_F(TestCameraAVStreamManagementCluster, TestAudioStreamDeallocateCommand)
@@ -1067,11 +1049,8 @@ TEST_F(TestCameraAVStreamManagementCluster, TestAudioStreamDeallocateCommand)
     allocRequest.bitDepth     = 24;
 
     auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
-    ASSERT_TRUE(allocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     ASSERT_TRUE(allocResult.IsSuccess());
     ASSERT_TRUE(allocResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     uint16_t streamId = allocResult.response->audioStreamID;
     EXPECT_EQ(mServer.GetAllocatedAudioStreams().size(), 1u);
 
@@ -1079,23 +1058,17 @@ TEST_F(TestCameraAVStreamManagementCluster, TestAudioStreamDeallocateCommand)
     DeallocateRequest deallocRequest;
     deallocRequest.audioStreamID = streamId;
     auto deallocResult           = mClusterTester.Invoke<DeallocateRequest, DataModel::NullObjectType>(deallocRequest);
-    ASSERT_TRUE(deallocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(deallocResult.IsSuccess());
     EXPECT_EQ(mServer.GetAllocatedAudioStreams().size(), 0u);
 
     // Attempt to deallocate again, should fail
     deallocResult = mClusterTester.Invoke<DeallocateRequest, DataModel::NullObjectType>(deallocRequest);
-    ASSERT_TRUE(deallocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(deallocResult.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(deallocResult.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 
     // Attempt to deallocate a non-existent ID
     deallocRequest.audioStreamID = 999;
     deallocResult                = mClusterTester.Invoke<DeallocateRequest, DataModel::NullObjectType>(deallocRequest);
-    ASSERT_TRUE(deallocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(deallocResult.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(deallocResult.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 }
 
 TEST_F(TestCameraAVStreamManagementCluster, TestVideoStreamAllocateCommand)
@@ -1120,67 +1093,50 @@ TEST_F(TestCameraAVStreamManagementCluster, TestVideoStreamAllocateCommand)
     request.watermarkEnabled = chip::MakeOptional(false);
 
     auto result = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_EQ(result.response->videoStreamID, 1);
     EXPECT_EQ(mServer.GetAllocatedVideoStreams().size(), 1u);
 
     // Invalid streamUsage
     request.streamUsage = StreamUsageEnum::kAnalysis;
     result              = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::InvalidInState);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::InvalidInState));
     request.streamUsage = StreamUsageEnum::kLiveView; // Restore
 
     // minFrameRate > maxFrameRate
     request.minFrameRate = 121;
     result               = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.minFrameRate = 30; // Restore
 
     // minResolution > maxResolution
     request.minResolution = { 1281, 720 };
     result                = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.minResolution = { 640, 480 }; // Restore
 
     // minBitRate > maxBitRate
     request.minBitRate = 10001;
     result             = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.minBitRate = 10000; // Restore
 
     // keyFrameInterval 65501
     request.keyFrameInterval = 65501;
     result                   = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.keyFrameInterval = 4; // Restore
 
     // Unsupported videoCodec
     request.videoCodec = VideoCodecEnum::kHevc;
     result             = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::DynamicConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::DynamicConstraintError));
     request.videoCodec = VideoCodecEnum::kH264; // Restore
 
     // Attempt to allocate a second stream, expecting ResourceExhausted
     result = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ResourceExhausted);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ResourceExhausted));
 }
 
 TEST_F(TestCameraAVStreamManagementCluster, TestVideoStreamDeallocateCommand)
@@ -1205,11 +1161,8 @@ TEST_F(TestCameraAVStreamManagementCluster, TestVideoStreamDeallocateCommand)
     allocRequest.watermarkEnabled = chip::MakeOptional(false);
 
     auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
-    ASSERT_TRUE(allocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     ASSERT_TRUE(allocResult.IsSuccess());
     ASSERT_TRUE(allocResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     uint16_t streamId = allocResult.response->videoStreamID;
     EXPECT_EQ(mServer.GetAllocatedVideoStreams().size(), 1u);
 
@@ -1217,23 +1170,17 @@ TEST_F(TestCameraAVStreamManagementCluster, TestVideoStreamDeallocateCommand)
     DeallocateRequest deallocRequest;
     deallocRequest.videoStreamID = streamId;
     auto deallocResult           = mClusterTester.Invoke<DeallocateRequest, DataModel::NullObjectType>(deallocRequest);
-    ASSERT_TRUE(deallocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(deallocResult.IsSuccess());
     EXPECT_EQ(mServer.GetAllocatedVideoStreams().size(), 0u);
 
     // Attempt to deallocate again, should fail
     deallocResult = mClusterTester.Invoke<DeallocateRequest, DataModel::NullObjectType>(deallocRequest);
-    ASSERT_TRUE(deallocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(deallocResult.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(deallocResult.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 
     // Attempt to deallocate a non-existent ID
     deallocRequest.videoStreamID = 999;
     deallocResult                = mClusterTester.Invoke<DeallocateRequest, DataModel::NullObjectType>(deallocRequest);
-    ASSERT_TRUE(deallocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(deallocResult.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(deallocResult.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 }
 
 TEST_F(TestCameraAVStreamManagementCluster, TestVideoStreamModifyCommand)
@@ -1258,11 +1205,8 @@ TEST_F(TestCameraAVStreamManagementCluster, TestVideoStreamModifyCommand)
     allocRequest.watermarkEnabled = chip::MakeOptional(false);
 
     auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
-    ASSERT_TRUE(allocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     ASSERT_TRUE(allocResult.IsSuccess());
     ASSERT_TRUE(allocResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     uint16_t streamId = allocResult.response->videoStreamID;
     EXPECT_EQ(mServer.GetAllocatedVideoStreams().size(), 1u);
 
@@ -1272,8 +1216,6 @@ TEST_F(TestCameraAVStreamManagementCluster, TestVideoStreamModifyCommand)
     modifyRequest.watermarkEnabled = chip::MakeOptional(true);
 
     auto modifyResult = mClusterTester.Invoke<ModifyRequest, DataModel::NullObjectType>(modifyRequest);
-    ASSERT_TRUE(modifyResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(modifyResult.IsSuccess());
 
     // Verify the changes
@@ -1291,8 +1233,6 @@ TEST_F(TestCameraAVStreamManagementCluster, TestVideoStreamModifyCommand)
     modifyRequest.watermarkEnabled = chip::MakeOptional(false);
     modifyRequest.OSDEnabled       = chip::Optional<bool>::Missing();
     modifyResult                   = mClusterTester.Invoke<ModifyRequest, DataModel::NullObjectType>(modifyRequest);
-    ASSERT_TRUE(modifyResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(modifyResult.IsSuccess());
 
     EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedVideoStreams::Id, allocatedVideoStreams), CHIP_NO_ERROR);
@@ -1307,9 +1247,7 @@ TEST_F(TestCameraAVStreamManagementCluster, TestVideoStreamModifyCommand)
     // Attempt to modify a non-existent ID
     modifyRequest.videoStreamID = 999;
     modifyResult                = mClusterTester.Invoke<ModifyRequest, DataModel::NullObjectType>(modifyRequest);
-    ASSERT_TRUE(modifyResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(modifyResult.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(modifyResult.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 }
 
 TEST_F(TestCameraAVStreamManagementCluster, TestSnapshotStreamAllocateCommand)
@@ -1330,59 +1268,44 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSnapshotStreamAllocateCommand)
     request.watermarkEnabled = chip::MakeOptional(false);
 
     auto result = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_EQ(result.response->snapshotStreamID, 1);
     EXPECT_EQ(mServer.GetAllocatedSnapshotStreams().size(), 1u);
 
     // maxFrameRate 0
     request.maxFrameRate = 0;
     result               = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.maxFrameRate = 30; // Restore
 
     // minResolution > maxResolution
     request.minResolution = { 1281, 720 };
     result                = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.minResolution = { 640, 480 }; // Restore
 
     // quality 0
     request.quality = 0;
     result          = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.quality = 80; // Restore
 
     // quality 101
     request.quality = 101;
     result          = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     request.quality = 80; // Restore
 
     // Unsupported maxFrameRate
     request.maxFrameRate = 200;
     result               = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::DynamicConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::DynamicConstraintError));
     request.maxFrameRate = 30; // Restore
 
     // Attempt to allocate a second stream, expecting ResourceExhausted
     result = mClusterTester.Invoke<Request, Response>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ResourceExhausted);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ResourceExhausted));
 }
 
 TEST_F(TestCameraAVStreamManagementCluster, TestSnapshotStreamDeallocateCommand)
@@ -1403,11 +1326,8 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSnapshotStreamDeallocateCommand)
     allocRequest.watermarkEnabled = chip::MakeOptional(false);
 
     auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
-    ASSERT_TRUE(allocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     ASSERT_TRUE(allocResult.IsSuccess());
     ASSERT_TRUE(allocResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     uint16_t streamId = allocResult.response->snapshotStreamID;
     EXPECT_EQ(mServer.GetAllocatedSnapshotStreams().size(), 1u);
 
@@ -1415,23 +1335,17 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSnapshotStreamDeallocateCommand)
     DeallocateRequest deallocRequest;
     deallocRequest.snapshotStreamID = streamId;
     auto deallocResult              = mClusterTester.Invoke<DeallocateRequest, DataModel::NullObjectType>(deallocRequest);
-    ASSERT_TRUE(deallocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(deallocResult.IsSuccess());
     EXPECT_EQ(mServer.GetAllocatedSnapshotStreams().size(), 0u);
 
     // Attempt to deallocate again, should fail
     deallocResult = mClusterTester.Invoke<DeallocateRequest, DataModel::NullObjectType>(deallocRequest);
-    ASSERT_TRUE(deallocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(deallocResult.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(deallocResult.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 
     // Attempt to deallocate a non-existent ID
     deallocRequest.snapshotStreamID = 999;
     deallocResult                   = mClusterTester.Invoke<DeallocateRequest, DataModel::NullObjectType>(deallocRequest);
-    ASSERT_TRUE(deallocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(deallocResult.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(deallocResult.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 }
 
 TEST_F(TestCameraAVStreamManagementCluster, TestSnapshotStreamModifyCommand)
@@ -1452,11 +1366,8 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSnapshotStreamModifyCommand)
     allocRequest.watermarkEnabled = chip::MakeOptional(false);
 
     auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
-    ASSERT_TRUE(allocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     ASSERT_TRUE(allocResult.IsSuccess());
     ASSERT_TRUE(allocResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     uint16_t streamId = allocResult.response->snapshotStreamID;
     EXPECT_EQ(mServer.GetAllocatedSnapshotStreams().size(), 1u);
 
@@ -1466,8 +1377,6 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSnapshotStreamModifyCommand)
     modifyRequest.watermarkEnabled = chip::MakeOptional(true);
 
     auto modifyResult = mClusterTester.Invoke<ModifyRequest, DataModel::NullObjectType>(modifyRequest);
-    ASSERT_TRUE(modifyResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(modifyResult.IsSuccess());
 
     // Verify the changes
@@ -1485,8 +1394,6 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSnapshotStreamModifyCommand)
     modifyRequest.watermarkEnabled = chip::MakeOptional(false);
     modifyRequest.OSDEnabled       = chip::Optional<bool>::Missing();
     modifyResult                   = mClusterTester.Invoke<ModifyRequest, DataModel::NullObjectType>(modifyRequest);
-    ASSERT_TRUE(modifyResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(modifyResult.IsSuccess());
 
     EXPECT_EQ(mClusterTester.ReadAttribute(Attributes::AllocatedSnapshotStreams::Id, allocatedSnapshotStreams), CHIP_NO_ERROR);
@@ -1501,9 +1408,7 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSnapshotStreamModifyCommand)
     // Attempt to modify a non-existent ID
     modifyRequest.snapshotStreamID = 999;
     modifyResult                   = mClusterTester.Invoke<ModifyRequest, DataModel::NullObjectType>(modifyRequest);
-    ASSERT_TRUE(modifyResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(modifyResult.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(modifyResult.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 }
 
 TEST_F(TestCameraAVStreamManagementCluster, TestSetStreamPrioritiesCommand)
@@ -1522,8 +1427,6 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSetStreamPrioritiesCommand)
     priorities.push_back(StreamUsageEnum::kLiveView);
     request.streamPriorities = DataModel::List<const StreamUsageEnum>(priorities.data(), priorities.size());
     auto result              = mClusterTester.Invoke<Request, DataModel::NullObjectType>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(result.IsSuccess());
 
     Attributes::StreamUsagePriorities::TypeInfo::DecodableType readPriorities;
@@ -1541,9 +1444,7 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSetStreamPrioritiesCommand)
     priorities.push_back(static_cast<StreamUsageEnum>(0xFF));
     request.streamPriorities = DataModel::List<const StreamUsageEnum>(priorities.data(), priorities.size());
     result                   = mClusterTester.Invoke<Request, DataModel::NullObjectType>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::InvalidCommand);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::InvalidCommand));
 
     // Duplicate enum value
     priorities.clear();
@@ -1551,18 +1452,14 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSetStreamPrioritiesCommand)
     priorities.push_back(StreamUsageEnum::kLiveView);
     request.streamPriorities = DataModel::List<const StreamUsageEnum>(priorities.data(), priorities.size());
     result                   = mClusterTester.Invoke<Request, DataModel::NullObjectType>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::AlreadyExists);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::AlreadyExists));
 
     // Unsupported enum value
     priorities.clear();
     priorities.push_back(StreamUsageEnum::kAnalysis);
     request.streamPriorities = DataModel::List<const StreamUsageEnum>(priorities.data(), priorities.size());
     result                   = mClusterTester.Invoke<Request, DataModel::NullObjectType>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::DynamicConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::DynamicConstraintError));
 
     // Invalid state - stream allocated
     {
@@ -1584,8 +1481,6 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSetStreamPrioritiesCommand)
         allocRequest.watermarkEnabled = chip::MakeOptional(false);
 
         auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
-        ASSERT_TRUE(allocResult.status.has_value());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         ASSERT_TRUE(allocResult.IsSuccess());
         EXPECT_EQ(mServer.GetAllocatedVideoStreams().size(), 1u);
     }
@@ -1594,9 +1489,7 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSetStreamPrioritiesCommand)
     priorities.push_back(StreamUsageEnum::kLiveView);
     request.streamPriorities = DataModel::List<const StreamUsageEnum>(priorities.data(), priorities.size());
     result                   = mClusterTester.Invoke<Request, DataModel::NullObjectType>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::InvalidInState);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::InvalidInState));
 
     // Clean up
     {
@@ -1604,8 +1497,6 @@ TEST_F(TestCameraAVStreamManagementCluster, TestSetStreamPrioritiesCommand)
         DeallocateRequest deallocRequest;
         deallocRequest.videoStreamID = 1;
         auto deallocResult           = mClusterTester.Invoke<DeallocateRequest, DataModel::NullObjectType>(deallocRequest);
-        ASSERT_TRUE(deallocResult.status.has_value());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         EXPECT_TRUE(deallocResult.IsSuccess());
         EXPECT_EQ(mServer.GetAllocatedVideoStreams().size(), 0u);
 
@@ -1632,11 +1523,8 @@ TEST_F(TestCameraAVStreamManagementCluster, TestCaptureSnapshotCommand)
     allocRequest.watermarkEnabled = chip::MakeOptional(false);
 
     auto allocResult = mClusterTester.Invoke<AllocateRequest, AllocateResponse>(allocRequest);
-    ASSERT_TRUE(allocResult.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     ASSERT_TRUE(allocResult.IsSuccess());
     ASSERT_TRUE(allocResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     uint16_t streamId = allocResult.response->snapshotStreamID;
     EXPECT_EQ(mServer.GetAllocatedSnapshotStreams().size(), 1u);
 
@@ -1649,21 +1537,13 @@ TEST_F(TestCameraAVStreamManagementCluster, TestCaptureSnapshotCommand)
     request.requestedResolution = { 640, 480 };
 
     auto result = mClusterTester.Invoke<CaptureRequest, CaptureResponse>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_EQ(result.response->imageCodec, ImageCodecEnum::kJpeg);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_EQ(result.response->resolution.width, 640);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_EQ(result.response->resolution.height, 480);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_GT(result.response->data.size(), 0u);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_EQ(result.response->data.data()[0], 0xFF); // Basic check on dummy data
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_EQ(result.response->data.data()[1], 0xD8); // Basic check on dummy data
 
     // Restore privacy modes
@@ -1672,16 +1552,12 @@ TEST_F(TestCameraAVStreamManagementCluster, TestCaptureSnapshotCommand)
 
     // Check for InvalidInState error
     result = mClusterTester.Invoke<CaptureRequest, CaptureResponse>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::InvalidInState);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::InvalidInState));
 
     // Check for NotFound error with invalid stream ID
     request.snapshotStreamID.SetNonNull(999);
     result = mClusterTester.Invoke<CaptureRequest, CaptureResponse>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 }
 
 TEST_F(TestCameraAVStreamManagementCluster, TestCaptureSnapshotCommand_NoStreamAllocated)
@@ -1700,9 +1576,7 @@ TEST_F(TestCameraAVStreamManagementCluster, TestCaptureSnapshotCommand_NoStreamA
     request.requestedResolution = { 640, 480 };
 
     auto result = mClusterTester.Invoke<CaptureRequest, CaptureResponse>(request);
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 }
 
 } // namespace

--- a/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/tests/TestCameraAVStreamManagementCluster.cpp
@@ -92,8 +92,9 @@ public:
     MockCameraAVStreamManagementDelegate(std::vector<VideoStreamStruct> * videoStreams,
                                          std::vector<AudioStreamStruct> * audioStreams,
                                          std::vector<SnapshotStreamStruct> * snapshotStreams) :
-        mAllocatedVideoStreams(videoStreams), mAllocatedAudioStreams(audioStreams), mAllocatedSnapshotStreams(snapshotStreams),
-        mAudioStreamCount(0), mVideoStreamCount(0), mSnapshotStreamCount(0)
+        mAllocatedVideoStreams(videoStreams),
+        mAllocatedAudioStreams(audioStreams), mAllocatedSnapshotStreams(snapshotStreams), mAudioStreamCount(0),
+        mVideoStreamCount(0), mSnapshotStreamCount(0)
     {}
 
     Protocols::InteractionModel::Status VideoStreamAllocate(const VideoStreamStruct & allocateArgs, uint16_t & outStreamID) override

--- a/src/app/clusters/diagnostic-logs-server/tests/TestDiagnosticLogsCluster.cpp
+++ b/src/app/clusters/diagnostic-logs-server/tests/TestDiagnosticLogsCluster.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
@@ -104,8 +105,8 @@ TEST_F(TestDiagnosticLogsCluster, ResponsePayload_WithDelegate_Success)
     auto result = tester.Invoke(request);
     ASSERT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kSuccess); // NOLINT(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.response->logContent.size(), sizeof(buffer));            // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kSuccess);
+    EXPECT_EQ(result.response->logContent.size(), sizeof(buffer));
 }
 
 // If request is BDX but logs can fit in the response payload, the response should be kExhausted
@@ -127,8 +128,8 @@ TEST_F(TestDiagnosticLogsCluster, Bdx_WithDelegate_kExhausted)
     auto result = tester.Invoke(request);
     ASSERT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kExhausted); // NOLINT(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.response->logContent.size(), sizeof(buffer));              // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kExhausted);
+    EXPECT_EQ(result.response->logContent.size(), sizeof(buffer));
 }
 
 TEST_F(TestDiagnosticLogsCluster, Bdx_WithDelegate_kExhausted_with_buffer_greater_than_kMaxLogContentSize)
@@ -149,8 +150,8 @@ TEST_F(TestDiagnosticLogsCluster, Bdx_WithDelegate_kExhausted_with_buffer_greate
     auto result = tester.Invoke(request);
     ASSERT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kExhausted); // NOLINT(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.response->logContent.size(),                               // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kExhausted);
+    EXPECT_EQ(result.response->logContent.size(),
               static_cast<size_t>(chip::bdx::DiagnosticLogs::kMaxLogContentSize));
 }
 
@@ -166,7 +167,7 @@ TEST_F(TestDiagnosticLogsCluster, ResponsePayload_NoDelegate_NoLogs)
     auto result = tester.Invoke(request);
     ASSERT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kNoLogs); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kNoLogs);
 }
 
 TEST_F(TestDiagnosticLogsCluster, ResponsePayload_ZeroBufferSize_NoLogs)
@@ -186,7 +187,7 @@ TEST_F(TestDiagnosticLogsCluster, ResponsePayload_ZeroBufferSize_NoLogs)
     auto result = tester.Invoke(request);
     ASSERT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kNoLogs); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kNoLogs);
 }
 
 TEST_F(TestDiagnosticLogsCluster, Bdx_NoDelegate_NoLogs)
@@ -202,7 +203,7 @@ TEST_F(TestDiagnosticLogsCluster, Bdx_NoDelegate_NoLogs)
     auto result = tester.Invoke(request);
     ASSERT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kNoLogs); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kNoLogs);
 }
 
 } // namespace app

--- a/src/app/clusters/diagnostic-logs-server/tests/TestDiagnosticLogsCluster.cpp
+++ b/src/app/clusters/diagnostic-logs-server/tests/TestDiagnosticLogsCluster.cpp
@@ -151,8 +151,7 @@ TEST_F(TestDiagnosticLogsCluster, Bdx_WithDelegate_kExhausted_with_buffer_greate
     ASSERT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
     EXPECT_EQ(result.response->status, DiagnosticLogs::StatusEnum::kExhausted);
-    EXPECT_EQ(result.response->logContent.size(),
-              static_cast<size_t>(chip::bdx::DiagnosticLogs::kMaxLogContentSize));
+    EXPECT_EQ(result.response->logContent.size(), static_cast<size_t>(chip::bdx::DiagnosticLogs::kMaxLogContentSize));
 }
 
 TEST_F(TestDiagnosticLogsCluster, ResponsePayload_NoDelegate_NoLogs)

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h>
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <app/server-cluster/testing/ClusterTester.h>
@@ -350,15 +351,11 @@ TEST_F(TestElectricalEnergyMeasurementCluster, SnapshotsSetValuesAndGenerateEven
 
         using CumulativeEventType = chip::app::Clusters::ElectricalEnergyMeasurement::Events::CumulativeEnergyMeasured::Type;
         ASSERT_TRUE(event.has_value());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_EQ(event.value().eventOptions.mPath,
+        EXPECT_EQ((*event).eventOptions.mPath,
                   ConcreteEventPath(kTestEndpointId, CumulativeEventType::GetClusterId(), CumulativeEventType::GetEventId()));
         chip::app::Clusters::ElectricalEnergyMeasurement::Events::CumulativeEnergyMeasured::DecodableType decodedEvent;
 
-        // Check again for Tidy
-        ASSERT_TRUE(event.has_value());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        ASSERT_EQ(event.value().GetEventData(decodedEvent), CHIP_NO_ERROR);
+        ASSERT_EQ((*event).GetEventData(decodedEvent), CHIP_NO_ERROR);
 
         ASSERT_TRUE(decodedEvent.energyImported.HasValue());
         EXPECT_EQ(decodedEvent.energyImported.Value().energy, 10000);
@@ -386,15 +383,11 @@ TEST_F(TestElectricalEnergyMeasurementCluster, SnapshotsSetValuesAndGenerateEven
 
         using PeriodicEventType = chip::app::Clusters::ElectricalEnergyMeasurement::Events::PeriodicEnergyMeasured::Type;
         ASSERT_TRUE(event.has_value());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_EQ(event.value().eventOptions.mPath,
+        EXPECT_EQ((*event).eventOptions.mPath,
                   ConcreteEventPath(kTestEndpointId, PeriodicEventType::GetClusterId(), PeriodicEventType::GetEventId()));
         chip::app::Clusters::ElectricalEnergyMeasurement::Events::PeriodicEnergyMeasured::DecodableType decodedEvent;
 
-        // Check again for Tidy
-        ASSERT_TRUE(event.has_value());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        ASSERT_EQ(event.value().GetEventData(decodedEvent), CHIP_NO_ERROR);
+        ASSERT_EQ((*event).GetEventData(decodedEvent), CHIP_NO_ERROR);
 
         ASSERT_TRUE(decodedEvent.energyImported.HasValue());
         EXPECT_EQ(decodedEvent.energyImported.Value().energy, 10000);

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -147,8 +147,7 @@ struct TestGroupcastCluster : public ::testing::Test
                       const Protocols::InteractionModel::Status expected)
     {
         ASSERT_TRUE(status.has_value());
-        EXPECT_EQ(status->GetStatusCode().GetStatus(),
-                  expected);
+        EXPECT_EQ(status->GetStatusCode().GetStatus(), expected);
     }
 
     TestServerClusterContext mTestContext;

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <app/MessageDef/CommandDataIB.h>
@@ -52,6 +53,7 @@ using namespace chip::Testing;
 using namespace chip::Credentials;
 using namespace chip::app::Clusters::Groupcast;
 using namespace chip::System::Clock::Literals;
+using namespace chip::Protocols::InteractionModel;
 using chip::Testing::IsAcceptedCommandsListEqualTo;
 using chip::Testing::IsAttributesListEqualTo;
 
@@ -145,7 +147,7 @@ struct TestGroupcastCluster : public ::testing::Test
                       const Protocols::InteractionModel::Status expected)
     {
         ASSERT_TRUE(status.has_value());
-        EXPECT_EQ(status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
+        EXPECT_EQ(status->GetStatusCode().GetStatus(),
                   expected);
     }
 
@@ -292,17 +294,13 @@ TEST_F(TestGroupcastCluster, TestReadMembership)
         data.endpoints       = DataModel::List<const EndpointId>(kEndpoints[0], kMaxEndpoints);
 
         auto result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         data.key.ClearValue();
         for (int i = 1; i < kIntervals; i++)
         {
             data.endpoints = DataModel::List<const EndpointId>(kEndpoints[i], kMaxEndpoints);
             result         = tester.Invoke(Commands::JoinGroup::Id, data);
-            ASSERT_TRUE(result.status.has_value());
-            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                      Protocols::InteractionModel::Status::Success);
+            EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         }
         // Join group 2
         data.groupID         = kGroup2;
@@ -312,9 +310,7 @@ TEST_F(TestGroupcastCluster, TestReadMembership)
         {
             data.endpoints = DataModel::List<const EndpointId>(kEndpoints[i], kMaxEndpoints);
             result         = tester.Invoke(Commands::JoinGroup::Id, data);
-            ASSERT_TRUE(result.status.has_value());
-            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                      Protocols::InteractionModel::Status::Success);
+            EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         }
 
         // Join group 3
@@ -325,9 +321,7 @@ TEST_F(TestGroupcastCluster, TestReadMembership)
         data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kPerGroup);
         data.endpoints       = DataModel::List<const EndpointId>(kEndpoints[4], 8);
         result               = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 
     // Remove keyset used by Group 2
@@ -440,9 +434,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         data.endpoints       = chip::app::DataModel::List<const EndpointId>(kEndpoints);
 
         auto result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
@@ -457,9 +449,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         data.key.ClearValue();
         data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kPerGroup);
         result               = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
@@ -472,9 +462,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         // Group 3 (PerGroup)
         data.groupID = kGroup3;
         result       = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
@@ -488,9 +476,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         data.groupID         = kGroup4;
         data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
         result               = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_FALSE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
@@ -507,9 +493,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         Commands::LeaveGroup::Type data;
         data.groupID = kGroup2;
         auto result  = tester.Invoke(Commands::LeaveGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
@@ -522,9 +506,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         // Group 1 (IanaAddr)
         data.groupID = kGroup1;
         result       = tester.Invoke(Commands::LeaveGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_FALSE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
@@ -537,9 +519,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         // Group 3 (PerGroup)
         data.groupID = kGroup3;
         result       = tester.Invoke(Commands::LeaveGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
@@ -552,9 +532,7 @@ TEST_F(TestGroupcastCluster, TestReadUsedMcastAddrCount)
         // Group 4 (IanaAddr)
         data.groupID = kGroup4;
         result       = tester.Invoke(Commands::LeaveGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         mMockTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(kChangeTemporisation));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(membershipAttributePath));
         ASSERT_TRUE(mTestContext.ChangeListener().IsDirty(usedMcastAddrCountAttributePath));
@@ -586,9 +564,7 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
         tester.SetFabricIndex(kTestFabricIndex);
 
         auto result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::ConstraintError);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     }
 
     // Listener
@@ -598,50 +574,38 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
 
         // Join group: New keyset and key
         auto result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         // Join group: Existing keyset and key (invalid)
         data.groupID = 2;
         result       = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::AlreadyExists);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::AlreadyExists));
 
         // Join group: Existing keyset but no key
         data.groupID = 2;
         data.key.ClearValue();
         result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         // Join group: Existing keyset but no key
         data.groupID = 2;
         data.key.ClearValue();
         result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         // Join group with root endpoint: Invalid Endpoint
         const EndpointId kRootEndpoint[] = { kRootEndpointId };
         data.groupID                     = 3;
         data.endpoints                   = DataModel::List<const EndpointId>(kRootEndpoint, MATTER_ARRAY_SIZE(kRootEndpoint));
         result                           = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::UnsupportedEndpoint);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::UnsupportedEndpoint));
 
         // Join group with an invalid endpoint in the data model
         const EndpointId kInvalidEndpoint[] = { 301 };
         data.groupID                        = 3;
         data.endpoints = DataModel::List<const EndpointId>(kInvalidEndpoint, MATTER_ARRAY_SIZE(kInvalidEndpoint));
         result         = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::UnsupportedEndpoint);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::UnsupportedEndpoint));
     }
 
     // Sender
@@ -652,24 +616,18 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
 
         // Join group: UseAuxiliaryACL can't be set
         auto result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::ConstraintError);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
 
         // Join group: UseAuxiliaryACL unset
         data.useAuxiliaryACL.ClearValue();
         result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         // Join group: Non-empty endpoints
         data.groupID   = 3;
         data.endpoints = DataModel::List<const EndpointId>(kEndpoints, MATTER_ARRAY_SIZE(kEndpoints));
         result         = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::ConstraintError);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     }
 }
 
@@ -717,17 +675,13 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
         data.endpoints       = DataModel::List<const EndpointId>(kEndpoints[0], kMaxEndpoints);
 
         auto result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         data.key.ClearValue();
         for (int i = 1; i < kIntervals; i++)
         {
             data.endpoints = DataModel::List<const EndpointId>(kEndpoints[i], kMaxEndpoints);
             result         = tester.Invoke(Commands::JoinGroup::Id, data);
-            ASSERT_TRUE(result.status.has_value());
-            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                      Protocols::InteractionModel::Status::Success);
+            EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         }
         // Group 2
         data.groupID         = kGroup2;
@@ -736,9 +690,7 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
         {
             data.endpoints = DataModel::List<const EndpointId>(kEndpoints[i], kMaxEndpoints);
             result         = tester.Invoke(Commands::JoinGroup::Id, data);
-            ASSERT_TRUE(result.status.has_value());
-            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                      Protocols::InteractionModel::Status::Success);
+            EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         }
     }
 
@@ -776,9 +728,7 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
         data.groupID   = kGroup1;
         data.endpoints = MakeOptional(DataModel::List<const EndpointId>(kLeaveEndpoints1, MATTER_ARRAY_SIZE(kLeaveEndpoints1)));
         auto result    = tester.Invoke(Commands::LeaveGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 
     // Read Membership
@@ -827,9 +777,7 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
         data.groupID   = 0;
         data.endpoints = MakeOptional(DataModel::List<const EndpointId>(kLeaveEndpoints2, MATTER_ARRAY_SIZE(kLeaveEndpoints2)));
         auto result    = tester.Invoke(Commands::LeaveGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 
     // Read Membership
@@ -885,9 +833,7 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
         Commands::LeaveGroup::Type data;
         data.groupID = 0;
         auto result  = tester.Invoke(Commands::LeaveGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 
     // Read Membership
@@ -909,15 +855,11 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
         data.keySetID        = kKeyset;
         data.useAuxiliaryACL = MakeOptional(true);
         auto result          = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
         // JoinGroup for GroupID 2
         data.groupID = kGroup2;
         result       = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         // Read Membership
         app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
@@ -949,9 +891,7 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
         data.groupID = kGroup2;
         data.endpoints.ClearValue();
         auto result = tester.Invoke(Commands::LeaveGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         // Read Membership
         Attributes::Membership::TypeInfo::DecodableType memberships;
@@ -983,9 +923,7 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
         data.keySetID        = kKeyset;
         data.useAuxiliaryACL = MakeOptional(true);
         auto result          = listenerAndSendertester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         // Read Membership
         app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
@@ -1017,9 +955,7 @@ TEST_F(TestGroupcastCluster, TestLeaveGroup)
         data.groupID   = kGroup3;
         data.endpoints = MakeOptional(DataModel::List<const EndpointId>(kEndpoints[0], 1));
         auto result    = listenerAndSendertester.Invoke(Commands::LeaveGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         app::Clusters::Groupcast::Attributes::Membership::TypeInfo::DecodableType memberships;
         ASSERT_EQ(listenerAndSendertester.ReadAttribute(Attributes::Membership::Id, memberships), CHIP_NO_ERROR);
@@ -1071,17 +1007,13 @@ TEST_F(TestGroupcastCluster, TestUpdateGroupKey)
         data.endpoints       = DataModel::List<const EndpointId>(kEndpoints, MATTER_ARRAY_SIZE(kEndpoints));
 
         auto result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         data.groupID  = kGroup2;
         data.keySetID = kKeyset2;
         data.key      = MakeOptional(ByteSpan(key2));
         result        = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 
     // Read Membership
@@ -1117,27 +1049,21 @@ TEST_F(TestGroupcastCluster, TestUpdateGroupKey)
         data.keySetID = kKeyset1;
         data.key      = MakeOptional(ByteSpan(key1));
         auto result   = tester.Invoke(Commands::UpdateGroupKey::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::AlreadyExists);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::AlreadyExists));
 
         // Update to non-existing keyset (invalid)
         data.groupID  = kGroup2;
         data.keySetID = kKeyset3;
         data.key.ClearValue();
         result = tester.Invoke(Commands::UpdateGroupKey::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::NotFound);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 
         // Update without key (always valid)
         data.groupID  = kGroup2;
         data.keySetID = kKeyset1;
         data.key.ClearValue();
         result = tester.Invoke(Commands::UpdateGroupKey::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         // Create a new key (valid, if i <= mProvider.GetMaxGroupKeysPerFabric())
         // 2 keysets already in use
@@ -1146,10 +1072,9 @@ TEST_F(TestGroupcastCluster, TestUpdateGroupKey)
         {
             data.keySetID = kKeyset2 + i;
             result        = tester.Invoke(Commands::UpdateGroupKey::Id, data);
-            ASSERT_TRUE(result.status.has_value());
-            EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                      i > mProvider.GetMaxGroupKeysPerFabric() ? Protocols::InteractionModel::Status::ResourceExhausted
-                                                               : Protocols::InteractionModel::Status::Success);
+            EXPECT_EQ(result.GetStatusCode(),
+                      i > mProvider.GetMaxGroupKeysPerFabric() ? ClusterStatusCode(Status::ResourceExhausted)
+                                                               : ClusterStatusCode(Status::Success));
         }
     }
 
@@ -1199,9 +1124,7 @@ TEST_F(TestGroupcastCluster, TestConfigureAuxiliaryACL)
         data.endpoints       = DataModel::List<const EndpointId>(kEndpoints, MATTER_ARRAY_SIZE(kEndpoints));
 
         auto result = tester.Invoke(Commands::JoinGroup::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 
     // Read Membership
@@ -1230,9 +1153,7 @@ TEST_F(TestGroupcastCluster, TestConfigureAuxiliaryACL)
         data.useAuxiliaryACL = true;
 
         auto result = sender_tester.Invoke(Commands::ConfigureAuxiliaryACL::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::ConstraintError);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
     }
 
     // Update (false to true)
@@ -1242,9 +1163,7 @@ TEST_F(TestGroupcastCluster, TestConfigureAuxiliaryACL)
         data.useAuxiliaryACL = true;
 
         auto result = tester.Invoke(Commands::ConfigureAuxiliaryACL::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 
     // Read Membership
@@ -1270,9 +1189,7 @@ TEST_F(TestGroupcastCluster, TestConfigureAuxiliaryACL)
         data.useAuxiliaryACL = false;
 
         auto result = tester.Invoke(Commands::ConfigureAuxiliaryACL::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
     }
 
     // Read Membership
@@ -1310,9 +1227,7 @@ TEST_F(TestGroupcastCluster, TestGroupcastTestingCommand)
         data.durationSeconds = MakeOptional(static_cast<uint16_t>(9));
 
         auto result = tester.Invoke(Commands::GroupcastTesting::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::ConstraintError);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
 
         // Command failed; should not have changed.
         ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
@@ -1321,9 +1236,7 @@ TEST_F(TestGroupcastCluster, TestGroupcastTestingCommand)
         // Too large
         data.durationSeconds = MakeOptional(static_cast<uint16_t>(1201));
         result               = tester.Invoke(Commands::GroupcastTesting::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::ConstraintError);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
 
         // Command failed; should not have changed from enabled state.
         ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
@@ -1336,9 +1249,7 @@ TEST_F(TestGroupcastCluster, TestGroupcastTestingCommand)
         data.testOperation = GroupcastTestingEnum::kEnableListenerTesting;
 
         auto result = tester.Invoke(Commands::GroupcastTesting::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
         EXPECT_EQ(fabricUnderTest, kTestFabricIndex);
@@ -1350,9 +1261,7 @@ TEST_F(TestGroupcastCluster, TestGroupcastTestingCommand)
         data.testOperation = GroupcastTestingEnum::kDisableTesting;
 
         auto result = tester.Invoke(Commands::GroupcastTesting::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
         EXPECT_EQ(fabricUnderTest, kUndefinedFabricIndex);
@@ -1367,9 +1276,7 @@ TEST_F(TestGroupcastCluster, TestGroupcastTestingCommand)
         data.durationSeconds = MakeOptional(durationSeconds);
 
         auto result = tester.Invoke(Commands::GroupcastTesting::Id, data);
-        ASSERT_TRUE(result.status.has_value());
-        EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         ASSERT_EQ(tester.ReadAttribute(Attributes::FabricUnderTest::Id, fabricUnderTest), CHIP_NO_ERROR);
         EXPECT_EQ(fabricUnderTest, kTestFabricIndex);

--- a/src/app/clusters/groups-server/tests/TestGroupsCluster.cpp
+++ b/src/app/clusters/groups-server/tests/TestGroupsCluster.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <app/clusters/groups-server/GroupsCluster.h>
@@ -35,6 +36,7 @@ using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::Credentials;
 using namespace chip::Testing;
+using namespace chip::Protocols::InteractionModel;
 
 namespace {
 
@@ -47,9 +49,13 @@ constexpr FabricIndex kFabricIndex4  = kTestFabricIndex + 4;
 constexpr FabricIndex kFabricIndex5  = kTestFabricIndex + 5;
 constexpr FabricIndex kFabricIndex6  = kTestFabricIndex + 6;
 
-Protocols::InteractionModel::Status CodeFor(uint8_t response_code)
+// Helper to extract the status field embedded in a command response payload,
+// without requiring an explicit has_value() guard.
+template <typename ResponseType>
+std::optional<Status> ResponseStatus(const chip::Testing::ClusterTester::InvokeResult<ResponseType> & result)
 {
-    return static_cast<Protocols::InteractionModel::Status>(response_code);
+    VerifyOrReturnValue(result.response.has_value(), std::nullopt);
+    return static_cast<Status>(result.response->status);
 }
 
 class MockIdentifyIntegrationDelegate : public IdentifyIntegrationDelegate
@@ -199,9 +205,7 @@ TEST_F(TestGroupsCluster, TestAddGroup)
     auto result = InvokeAddGroup(kGroupId, "Test Group");
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_EQ(ResponseStatus(result), Status::Success);
     EXPECT_EQ(result.response->groupID, kGroupId);
 
     // Verify the group was added
@@ -214,9 +218,7 @@ TEST_F(TestGroupsCluster, TestAddGroupInvalidId)
 {
     auto result = InvokeAddGroup(0, "Invalid Group");
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(ResponseStatus(result), Status::ConstraintError);
 }
 
 // Tests the AddGroup command with a GroupName exceeding the maximum length (16).
@@ -225,9 +227,7 @@ TEST_F(TestGroupsCluster, TestAddGroupLongName)
 {
     auto result = InvokeAddGroup(2, "This Group Name Is Way Too Long");
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(ResponseStatus(result), Status::ConstraintError);
 }
 
 // Tests the AddGroup command when the group table is full.
@@ -251,9 +251,7 @@ TEST_F(TestGroupsCluster, TestAddGroupMaxGroups)
         groupName.AddFormat("Group %d", i);
         auto result = InvokeAddGroup(kGroupId, groupName.c_str());
         EXPECT_TRUE(result.IsSuccess());
-        ASSERT_TRUE(result.response.has_value());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(ResponseStatus(result), Status::Success);
     }
 
     // Now GroupInfo table is full. GroupKey table is also full.
@@ -261,9 +259,7 @@ TEST_F(TestGroupsCluster, TestAddGroupMaxGroups)
     auto extraGroupId = static_cast<GroupId>(max_groups + 1);
     auto result       = InvokeAddGroup(extraGroupId, "Max Group");
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::UnsupportedAccess);
+    EXPECT_EQ(ResponseStatus(result), Status::UnsupportedAccess);
 }
 
 // Tests the AddGroup command for a group without prior key setup.
@@ -278,9 +274,7 @@ TEST_F(TestGroupsCluster, TestAddGroup_UnsupportedAccess)
     auto result = InvokeAddGroup(kGroupId, "Test Group");
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::UnsupportedAccess);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_EQ(ResponseStatus(result), Status::UnsupportedAccess);
     EXPECT_EQ(result.response->groupID, kGroupId);
 
     // Verify the group was not added
@@ -299,36 +293,27 @@ TEST_F(TestGroupsCluster, TestViewGroup)
     // 1. Test NotFound
     auto result = InvokeViewGroup(kGroupId);
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(ResponseStatus(result), Status::NotFound);
 
     // 2. Add the group
     SetupKeySet(kFabricIndex2, kKeysetId);
     MapGroupToKeyset(kFabricIndex2, kGroupId, kKeysetId);
     auto addResult = InvokeAddGroup(kGroupId, kGroupName);
     ASSERT_TRUE(addResult.IsSuccess());
-    ASSERT_TRUE(addResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(addResult.response->status), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(ResponseStatus(addResult), Status::Success);
 
     // 3. Test Success
     result = InvokeViewGroup(kGroupId);
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_EQ(ResponseStatus(result), Status::Success);
     EXPECT_EQ(result.response->groupID, kGroupId);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(result.response->groupName.data_equal(CharSpan::fromCharString(kGroupName)));
 
     // 4. Test Invalid ID
     result = InvokeViewGroup(0);
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(ResponseStatus(result), Status::ConstraintError);
 }
 
 // Tests the RemoveGroup command.
@@ -345,43 +330,33 @@ TEST_F(TestGroupsCluster, TestRemoveGroup)
     MapGroupToKeyset(kFabricIndex3, kGroupId, kKeysetId);
     auto addResult = InvokeAddGroup(kGroupId, "RemoveTest");
     ASSERT_TRUE(addResult.IsSuccess());
-    ASSERT_TRUE(addResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(addResult.response->status), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(ResponseStatus(addResult), Status::Success);
 
     // 2. Test NotFound on a different GroupId
     Groups::Commands::RemoveGroup::Type removeRequest;
     removeRequest.groupID = kOtherGroupId;
     auto result           = mClusterTester->Invoke<Groups::Commands::RemoveGroup::Type>(removeRequest);
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(ResponseStatus(result), Status::NotFound);
 
     // 3. Test Success on the added group
     removeRequest.groupID = kGroupId;
     result                = mClusterTester->Invoke<Groups::Commands::RemoveGroup::Type>(removeRequest);
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_EQ(ResponseStatus(result), Status::Success);
     EXPECT_EQ(result.response->groupID, kGroupId);
 
     // Verify group is removed
     auto viewResult = InvokeViewGroup(kGroupId);
     EXPECT_TRUE(viewResult.IsSuccess());
-    ASSERT_TRUE(viewResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(viewResult.response->status), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(ResponseStatus(viewResult), Status::NotFound);
 
     // 4. Test Invalid ID
     removeRequest.groupID = 0;
     result                = mClusterTester->Invoke<Groups::Commands::RemoveGroup::Type>(removeRequest);
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(ResponseStatus(result), Status::ConstraintError);
 }
 
 // Tests the GetGroupMembership command.
@@ -402,12 +377,9 @@ TEST_F(TestGroupsCluster, TestGetGroupMembership)
     MapGroupToKeyset(kFabricIndex4, kGroupId2, kKeysetId, 1);
     MapGroupToKeyset(kFabricIndex4, kGroupId3, kKeysetId, 2);
 
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(InvokeAddGroup(kGroupId1, "G1").response->status), Protocols::InteractionModel::Status::Success);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(InvokeAddGroup(kGroupId2, "G2").response->status), Protocols::InteractionModel::Status::Success);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(InvokeAddGroup(kGroupId3, "G3").response->status), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(ResponseStatus(InvokeAddGroup(kGroupId1, "G1")), Status::Success);
+    EXPECT_EQ(ResponseStatus(InvokeAddGroup(kGroupId2, "G2")), Status::Success);
+    EXPECT_EQ(ResponseStatus(InvokeAddGroup(kGroupId3, "G3")), Status::Success);
 
     // Test cases
     Groups::Commands::GetGroupMembership::Type request;
@@ -418,9 +390,7 @@ TEST_F(TestGroupsCluster, TestGetGroupMembership)
     auto result       = mClusterTester->Invoke<Groups::Commands::GetGroupMembership::Type>(request);
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(result.response->capacity.IsNull()); // Capacity is allowed to be null
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     auto iter = result.response->groupList.begin();
     EXPECT_TRUE(iter.Next());
     EXPECT_EQ(iter.GetValue(), kGroupId1);
@@ -436,7 +406,6 @@ TEST_F(TestGroupsCluster, TestGetGroupMembership)
     result                     = mClusterTester->Invoke<Groups::Commands::GetGroupMembership::Type>(request);
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     iter = result.response->groupList.begin();
     EXPECT_FALSE(iter.Next());
 
@@ -446,7 +415,6 @@ TEST_F(TestGroupsCluster, TestGetGroupMembership)
     result                     = mClusterTester->Invoke<Groups::Commands::GetGroupMembership::Type>(request);
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     iter = result.response->groupList.begin();
     ASSERT_TRUE(iter.Next());
     EXPECT_EQ(iter.GetValue(), kGroupId1);
@@ -460,7 +428,6 @@ TEST_F(TestGroupsCluster, TestGetGroupMembership)
     result                     = mClusterTester->Invoke<Groups::Commands::GetGroupMembership::Type>(request);
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     iter = result.response->groupList.begin();
     ASSERT_TRUE(iter.Next());
     EXPECT_EQ(iter.GetValue(), kGroupId1);
@@ -485,10 +452,8 @@ TEST_F(TestGroupsCluster, TestRemoveAllGroups)
     MapGroupToKeyset(kFabricIndex5, kGroupId1, kKeysetId, 0);
     MapGroupToKeyset(kFabricIndex5, kGroupId2, kKeysetId, 1);
 
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(InvokeAddGroup(kGroupId1, "G1").response->status), Protocols::InteractionModel::Status::Success);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(InvokeAddGroup(kGroupId2, "G2").response->status), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(ResponseStatus(InvokeAddGroup(kGroupId1, "G1")), Status::Success);
+    EXPECT_EQ(ResponseStatus(InvokeAddGroup(kGroupId2, "G2")), Status::Success);
 
     // Call RemoveAllGroups
     Groups::Commands::RemoveAllGroups::Type removeAllRequest;
@@ -534,9 +499,7 @@ TEST_F(TestGroupsCluster, TestAddGroupIfIdentifying)
     auto viewResult = InvokeViewGroup(kGroupId);
     EXPECT_TRUE(viewResult.IsSuccess());
     ASSERT_TRUE(viewResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(viewResult.response->status), Protocols::InteractionModel::Status::Success);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_EQ(ResponseStatus(viewResult), Status::Success);
     EXPECT_EQ(viewResult.response->groupID, kGroupId);
 
     // 4. Stop identifying
@@ -563,24 +526,18 @@ TEST_F(TestGroupsCluster, TestAddGroupUpdateName)
 
     auto result = InvokeAddGroup(kGroupId, "Original Name");
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(ResponseStatus(result), Status::Success);
 
     // Update the group name
     result = InvokeAddGroup(kGroupId, "Updated Name");
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(ResponseStatus(result), Status::Success);
 
     // Verify the group name was updated
     auto viewResult = InvokeViewGroup(kGroupId);
     EXPECT_TRUE(viewResult.IsSuccess());
+    EXPECT_EQ(ResponseStatus(viewResult), Status::Success);
     ASSERT_TRUE(viewResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(viewResult.response->status), Protocols::InteractionModel::Status::Success);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(viewResult.response->groupName.data_equal("Updated Name"_span));
 }
 
@@ -595,17 +552,13 @@ TEST_F(TestGroupsCluster, TestAddGroupEmptyName)
 
     auto result = InvokeAddGroup(kGroupId, "");
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(ResponseStatus(result), Status::Success);
 
     // Verify the group name is empty
     auto viewResult = InvokeViewGroup(kGroupId);
     EXPECT_TRUE(viewResult.IsSuccess());
     ASSERT_TRUE(viewResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(viewResult.response->status), Protocols::InteractionModel::Status::Success);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_EQ(ResponseStatus(viewResult), Status::Success);
     EXPECT_TRUE(viewResult.response->groupName.empty());
 }
 
@@ -620,17 +573,13 @@ TEST_F(TestGroupsCluster, TestAddGroupMaxLengthName)
 
     auto result = InvokeAddGroup(kGroupId, "1234567890123456"); // 16 characters
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(ResponseStatus(result), Status::Success);
 
     // Verify the group name
     auto viewResult = InvokeViewGroup(kGroupId);
     EXPECT_TRUE(viewResult.IsSuccess());
     ASSERT_TRUE(viewResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(viewResult.response->status), Protocols::InteractionModel::Status::Success);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    EXPECT_EQ(ResponseStatus(viewResult), Status::Success);
     EXPECT_TRUE(viewResult.response->groupName.data_equal("1234567890123456"_span));
 }
 
@@ -695,9 +644,7 @@ TEST_F(TestGroupsCluster, TestAddGroupIfIdentifying_ResourceExhausted)
         MapGroupToKeyset(kFabricIndex1, kGroupId, kKeysetId, i);
         StringBuilder<16> groupName;
         groupName.AddFormat("Group %d", i);
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_EQ(CodeFor(InvokeAddGroup(kGroupId, groupName.c_str()).response->status),
-                  Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(ResponseStatus(InvokeAddGroup(kGroupId, groupName.c_str())), Status::Success);
     }
 
     // Now GroupInfo table is full. GroupKey table is also full.
@@ -739,32 +686,26 @@ TEST_F(TestGroupsCluster, TestFabricScoping)
     mClusterTester->SetFabricIndex(kFabricIndex1);
     SetupKeySet(kFabricIndex1, kKeysetId1);
     MapGroupToKeyset(kFabricIndex1, kGroupId1, kKeysetId1);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(InvokeAddGroup(kGroupId1, "Fabric1Group").response->status), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(ResponseStatus(InvokeAddGroup(kGroupId1, "Fabric1Group")), Status::Success);
 
     // Fabric 2 setup
     mClusterTester->SetFabricIndex(kFabricIndex2);
     SetupKeySet(kFabricIndex2, kKeysetId2);
     MapGroupToKeyset(kFabricIndex2, kGroupId2, kKeysetId2);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(InvokeAddGroup(kGroupId2, "Fabric2Group").response->status), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(ResponseStatus(InvokeAddGroup(kGroupId2, "Fabric2Group")), Status::Success);
 
     // Check isolation
     // Group1 should not be in Fabric 2
     mClusterTester->SetFabricIndex(kFabricIndex2);
     auto viewResult = InvokeViewGroup(kGroupId1);
     EXPECT_TRUE(viewResult.IsSuccess());
-    ASSERT_TRUE(viewResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(viewResult.response->status), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(ResponseStatus(viewResult), Status::NotFound);
 
     // Group2 should not be in Fabric 1
     mClusterTester->SetFabricIndex(kFabricIndex1);
     viewResult = InvokeViewGroup(kGroupId2);
     EXPECT_TRUE(viewResult.IsSuccess());
-    ASSERT_TRUE(viewResult.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(viewResult.response->status), Protocols::InteractionModel::Status::NotFound);
+    EXPECT_EQ(ResponseStatus(viewResult), Status::NotFound);
 
     // GetGroupMembership for Fabric 1 - Should only contain GroupId1
     mClusterTester->SetFabricIndex(kFabricIndex1);
@@ -773,7 +714,6 @@ TEST_F(TestGroupsCluster, TestFabricScoping)
     auto result       = mClusterTester->Invoke<Groups::Commands::GetGroupMembership::Type>(request);
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     auto iter = result.response->groupList.begin();
     EXPECT_TRUE(iter.Next());
     EXPECT_EQ(iter.GetValue(), kGroupId1);
@@ -784,7 +724,6 @@ TEST_F(TestGroupsCluster, TestFabricScoping)
     result = mClusterTester->Invoke<Groups::Commands::GetGroupMembership::Type>(request);
     EXPECT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     iter = result.response->groupList.begin();
     EXPECT_TRUE(iter.Next());
     EXPECT_EQ(iter.GetValue(), kGroupId2);
@@ -820,8 +759,7 @@ TEST_F(TestGroupsCluster, TestGroupNameNodeWide)
         Groups::Commands::AddGroup::Type request = { kGroupId, "Group Name 1"_span };
         auto result                              = tester1.Invoke<Groups::Commands::AddGroup::Type>(request);
         ASSERT_TRUE(result.IsSuccess());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(ResponseStatus(result), Status::Success);
     }
 
     // Add group to Endpoint 2
@@ -829,8 +767,7 @@ TEST_F(TestGroupsCluster, TestGroupNameNodeWide)
         Groups::Commands::AddGroup::Type request = { kGroupId, "Group Name 1"_span };
         auto result                              = tester2.Invoke<Groups::Commands::AddGroup::Type>(request);
         ASSERT_TRUE(result.IsSuccess());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(ResponseStatus(result), Status::Success);
     }
 
     // Update group name from Endpoint 1
@@ -838,8 +775,7 @@ TEST_F(TestGroupsCluster, TestGroupNameNodeWide)
         Groups::Commands::AddGroup::Type request = { kGroupId, "Updated Name"_span };
         auto result                              = tester1.Invoke<Groups::Commands::AddGroup::Type>(request);
         ASSERT_TRUE(result.IsSuccess());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
+        EXPECT_EQ(ResponseStatus(result), Status::Success);
     }
 
     // Verify name change on Endpoint 1
@@ -847,9 +783,8 @@ TEST_F(TestGroupsCluster, TestGroupNameNodeWide)
         Groups::Commands::ViewGroup::Type request = { kGroupId };
         auto viewResult                           = tester1.Invoke<Groups::Commands::ViewGroup::Type>(request);
         ASSERT_TRUE(viewResult.IsSuccess());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_EQ(CodeFor(viewResult.response->status), Protocols::InteractionModel::Status::Success);
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+        EXPECT_EQ(ResponseStatus(viewResult), Status::Success);
+        ASSERT_TRUE(viewResult.response.has_value());
         EXPECT_TRUE(viewResult.response->groupName.data_equal("Updated Name"_span));
     }
 
@@ -858,9 +793,8 @@ TEST_F(TestGroupsCluster, TestGroupNameNodeWide)
         Groups::Commands::ViewGroup::Type request = { kGroupId };
         auto viewResult                           = tester2.Invoke<Groups::Commands::ViewGroup::Type>(request);
         ASSERT_TRUE(viewResult.IsSuccess());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        EXPECT_EQ(CodeFor(viewResult.response->status), Protocols::InteractionModel::Status::Success);
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+        EXPECT_EQ(ResponseStatus(viewResult), Status::Success);
+        ASSERT_TRUE(viewResult.response.has_value());
         EXPECT_TRUE(viewResult.response->groupName.data_equal("Updated Name"_span));
     }
 }
@@ -894,9 +828,7 @@ TEST_F(TestGroupsCluster, TestAddGroupResourceExhaustedKeyExists)
 
     auto result = InvokeAddGroup(kExistingKeyGroupId, "FinalOverflow");
     EXPECT_TRUE(result.IsSuccess());
-    ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::ResourceExhausted);
+    EXPECT_EQ(ResponseStatus(result), Status::ResourceExhausted);
 }
 
 // Tests that ScenesIntegrationDelegate is called when a group is removed.
@@ -907,16 +839,14 @@ TEST_F(TestGroupsCluster, TestRemoveGroupScenesCleanup)
 
     SetupKeySet(kFabricIndex3, kKeysetId);
     MapGroupToKeyset(kFabricIndex3, kGroupId, kKeysetId);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    ASSERT_EQ(CodeFor(InvokeAddGroup(kGroupId, "SceneTest").response->status), Protocols::InteractionModel::Status::Success);
+    ASSERT_EQ(ResponseStatus(InvokeAddGroup(kGroupId, "SceneTest")), Status::Success);
     EXPECT_EQ(mScenesDelegate.mGroupWillBeRemovedCallCount, 0u);
 
     Groups::Commands::RemoveGroup::Type removeRequest;
     removeRequest.groupID = kGroupId;
     auto result           = mClusterTester->Invoke<Groups::Commands::RemoveGroup::Type>(removeRequest);
     ASSERT_TRUE(result.IsSuccess());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(CodeFor(result.response->status), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(ResponseStatus(result), Status::Success);
 
     EXPECT_EQ(mScenesDelegate.mGroupWillBeRemovedCallCount, 1u);
     EXPECT_EQ(mScenesDelegate.mLastFabricIndex, kFabricIndex3);
@@ -935,10 +865,8 @@ TEST_F(TestGroupsCluster, TestRemoveAllGroupsScenesCleanup)
     MapGroupToKeyset(kFabricIndex5, kGroupId1, kKeysetId, 0);
     MapGroupToKeyset(kFabricIndex5, kGroupId2, kKeysetId, 1);
 
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    ASSERT_EQ(CodeFor(InvokeAddGroup(kGroupId1, "G1").response->status), Protocols::InteractionModel::Status::Success);
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    ASSERT_EQ(CodeFor(InvokeAddGroup(kGroupId2, "G2").response->status), Protocols::InteractionModel::Status::Success);
+    ASSERT_EQ(ResponseStatus(InvokeAddGroup(kGroupId1, "G1")), Status::Success);
+    ASSERT_EQ(ResponseStatus(InvokeAddGroup(kGroupId2, "G2")), Status::Success);
 
     EXPECT_EQ(mScenesDelegate.mGroupWillBeRemovedCallCount, 0u);
 

--- a/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
+++ b/src/app/clusters/scenes-server/tests/TestScenesManagementCluster.cpp
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <app/clusters/scenes-server/SceneTableImpl.h>
@@ -401,11 +402,9 @@ struct TestScenesManagementCluster : public ::testing::Test
         ASSERT_TRUE(response.IsSuccess());
         ASSERT_TRUE(response.response.has_value());
 
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
         ASSERT_EQ(response.response->status, to_underlying(Status::Success));
         EXPECT_EQ(response.response->groupID, groupID);
         EXPECT_EQ(response.response->sceneID, sceneID);
-        // NOLINTEND(bugprone-unchecked-optional-access)
     }
 
     void VerifySceneInfoCount(ClusterTester & tester, FabricIndex fabricIndex, uint16_t expectedCount)
@@ -433,7 +432,6 @@ struct TestScenesManagementCluster : public ::testing::Test
     {
         ASSERT_TRUE(response.IsSuccess());
         ASSERT_TRUE(response.response.has_value());
-        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         EXPECT_EQ(response.response->status, to_underlying(expectedStatus));
     }
 
@@ -495,7 +493,6 @@ TEST_F(TestScenesManagementCluster, AddSceneCommandModifyExistingScene)
     auto view_response   = tester.Invoke<ViewScene::Type, ViewSceneResponse::DecodableType>(ViewScene::Id, view_request);
     ASSERT_TRUE(view_response.IsSuccess());
     ASSERT_TRUE(view_response.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     auto & data = *view_response.response;
     EXPECT_EQ(data.groupID, kTestGroupId);
     EXPECT_EQ(data.sceneID, kTestSceneId);
@@ -563,7 +560,6 @@ TEST_F(TestScenesManagementCluster, ViewSceneCommandSuccess)
 
     ExpectCommandStatus(view_response, Status::Success);
     ASSERT_TRUE(view_response.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     auto & data = *view_response.response;
 
     EXPECT_EQ(data.groupID, kTestGroupId);
@@ -618,10 +614,8 @@ TEST_F(TestScenesManagementCluster, RemoveSceneCommandSuccess)
 
     ExpectCommandStatus(remove_response, Status::Success);
     ASSERT_TRUE(remove_response.response.has_value());
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_EQ(remove_response.response->groupID, remove_request.groupID);
     EXPECT_EQ(remove_response.response->sceneID, remove_request.sceneID);
-    // NOLINTEND(bugprone-unchecked-optional-access)
 
     SceneTable<ExtensionFieldSetsImpl>::SceneStorageId sceneStorageId(kTestSceneId, kTestGroupId);
     SceneTable<ExtensionFieldSetsImpl>::SceneTableEntry sceneEntry(sceneStorageId);
@@ -663,7 +657,6 @@ TEST_F(TestScenesManagementCluster, RemoveAllScenesCommandSuccess)
 
     ExpectCommandStatus(remove_all_response, Status::Success);
     ASSERT_TRUE(remove_all_response.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_EQ(remove_all_response.response->groupID, kTestGroupId);
 
     // Verify scenes based on toBeRemoved flag
@@ -735,7 +728,6 @@ TEST_F(TestScenesManagementCluster, GetSceneMembershipCommandSuccess)
 
     ExpectCommandStatus(response, Status::Success);
     ASSERT_TRUE(response.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     auto & data = *response.response;
     EXPECT_EQ(data.groupID, kTestGroupId);
     ASSERT_FALSE(data.capacity.IsNull());
@@ -808,10 +800,8 @@ TEST_F(TestScenesManagementCluster, StoreSceneCommandSuccess)
 
     ExpectCommandStatus(response, Status::Success);
     ASSERT_TRUE(response.response.has_value());
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_EQ(response.response->groupID, kTestGroupId);
     EXPECT_EQ(response.response->sceneID, kTestSceneId);
-    // NOLINTEND(bugprone-unchecked-optional-access)
 
     SceneTable<ExtensionFieldSetsImpl>::SceneStorageId sceneStorageId(kTestSceneId, kTestGroupId);
     SceneTable<ExtensionFieldSetsImpl>::SceneTableEntry sceneEntry(sceneStorageId);
@@ -847,11 +837,9 @@ TEST_F(TestScenesManagementCluster, StoreSceneCommandCreatesSceneIfNotFound)
 
     ASSERT_TRUE(response.IsSuccess());
     ASSERT_TRUE(response.response.has_value());
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_EQ(response.response->status, to_underlying(Status::Success));
     EXPECT_EQ(response.response->groupID, kTestGroupId);
     EXPECT_EQ(response.response->sceneID, kTestSceneId);
-    // NOLINTEND(bugprone-unchecked-optional-access)
 
     ViewScene::Type view_request;
     view_request.groupID = kTestGroupId;
@@ -860,10 +848,8 @@ TEST_F(TestScenesManagementCluster, StoreSceneCommandCreatesSceneIfNotFound)
     auto view_response = tester.Invoke<ViewScene::Type, ViewSceneResponse::DecodableType>(ViewScene::Id, view_request);
     ASSERT_TRUE(view_response.IsSuccess());
     ASSERT_TRUE(view_response.response.has_value());
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_EQ(view_response.response->status, to_underlying(Status::Success));
     auto & data = view_response.response.value();
-    // NOLINTEND(bugprone-unchecked-optional-access)
 
     // Per Matter Spec 1.4 - 1.10.6.9, when creating a scene via StoreScene,
     // the transition time is 0 and the scene name is an empty string.
@@ -939,9 +925,7 @@ TEST_F(TestScenesManagementCluster, RecallSceneNotFound)
     auto recall_response = tester.Invoke<RecallScene::Type, NullObjectType>(RecallScene::Id, recall_request);
 
     ASSERT_FALSE(recall_response.IsSuccess());
-    ASSERT_TRUE(recall_response.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(recall_response.status.value(), Status::NotFound);
+    EXPECT_EQ(recall_response.GetStatusCode(), ClusterStatusCode(Status::NotFound));
 }
 
 TEST_F(TestScenesManagementCluster, CopySceneCommandSuccess)
@@ -970,10 +954,8 @@ TEST_F(TestScenesManagementCluster, CopySceneCommandSuccess)
     auto copy_response = tester.Invoke<CopyScene::Type, CopySceneResponse::DecodableType>(CopyScene::Id, copy_request);
     ExpectCommandStatus(copy_response, Status::Success);
     ASSERT_TRUE(copy_response.response.has_value());
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_EQ(copy_response.response->groupIdentifierFrom, kTestGroupId);
     EXPECT_EQ(copy_response.response->sceneIdentifierFrom, kTestSceneId);
-    // NOLINTEND(bugprone-unchecked-optional-access)
 
     // 3. Verify the copied scene exists and is identical to the source.
     SceneTable<ExtensionFieldSetsImpl>::SceneStorageId destSceneId(kTestOtherSceneId, kTestOtherGroupId);
@@ -1186,10 +1168,8 @@ TEST_F(TestScenesManagementCluster, SceneNamesFeatureEnabledTest)
 
     ExpectCommandStatus(view_response, Status::Success);
     ASSERT_TRUE(view_response.response.has_value());
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     ASSERT_TRUE(view_response.response->sceneName.HasValue());
     EXPECT_TRUE(view_response.response->sceneName.Value().data_equal("MySceneName"_span));
-    // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST_F(TestScenesManagementCluster, SceneNamesFeatureDisabledTest)
@@ -1221,7 +1201,6 @@ TEST_F(TestScenesManagementCluster, SceneNamesFeatureDisabledTest)
     ExpectCommandStatus(view_response, Status::Success);
     ASSERT_TRUE(view_response.response.has_value());
     // When kSceneNames is not supported, the Scene Name must be an empty string.
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(!view_response.response.value().sceneName.HasValue() || view_response.response.value().sceneName.Value().empty());
     clusterWithoutSceneNames.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -1249,7 +1228,6 @@ TEST_F(TestScenesManagementCluster, CopyAllScenesCommandSuccess)
     auto copy_response = tester.Invoke<CopyScene::Type, CopySceneResponse::DecodableType>(CopyScene::Id, copy_request);
     ExpectCommandStatus(copy_response, Status::Success);
     ASSERT_TRUE(copy_response.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_EQ(copy_response.response->groupIdentifierFrom, kTestGroupId);
 
     // 3. Verify that all scenes were copied to the destination group.
@@ -1296,10 +1274,8 @@ TEST_F(TestScenesManagementCluster, CopySceneOverwriteExisting)
     auto view_response   = tester.Invoke<ViewScene::Type, ViewSceneResponse::DecodableType>(ViewScene::Id, view_request);
     ExpectCommandStatus(view_response, Status::Success);
     ASSERT_TRUE(view_response.response.has_value());
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_TRUE(view_response.response->sceneName.Value().data_equal("SourceScene"_span));
     EXPECT_EQ(view_response.response->transitionTime.Value(), 1234u);
-    // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST_F(TestScenesManagementCluster, FabricScopingAddScene)
@@ -1322,7 +1298,6 @@ TEST_F(TestScenesManagementCluster, FabricScopingAddScene)
     auto view_response1   = tester.Invoke<ViewScene::Type, ViewSceneResponse::DecodableType>(ViewScene::Id, view_request1);
     ExpectCommandStatus(view_response1, Status::Success);
     ASSERT_TRUE(view_response1.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(view_response1.response->sceneName.Value().data_equal("Fabric1Scene"_span));
 
     // Verify fabric 2 scene
@@ -1333,7 +1308,6 @@ TEST_F(TestScenesManagementCluster, FabricScopingAddScene)
     auto view_response2   = tester.Invoke<ViewScene::Type, ViewSceneResponse::DecodableType>(ViewScene::Id, view_request2);
     ExpectCommandStatus(view_response2, Status::Success);
     ASSERT_TRUE(view_response2.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     EXPECT_TRUE(view_response2.response->sceneName.Value().data_equal("Fabric2Scene"_span));
 
     // Verify scene counts for both fabrics
@@ -1647,7 +1621,6 @@ TEST_F(TestScenesManagementCluster, DuplicateFieldSets)
     ExpectCommandStatus(view_response, Status::Success);
     ASSERT_TRUE(view_response.response.has_value());
 
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     auto & data = *view_response.response;
     ASSERT_TRUE(data.extensionFieldSetStructs.HasValue());
     auto responseEfsList = data.extensionFieldSetStructs.Value();

--- a/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
+++ b/src/app/clusters/software-diagnostics-server/tests/TestSoftwareDiagnosticsCluster.cpp
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <app/clusters/software-diagnostics-server/SoftwareDiagnosticsCluster.h>
@@ -274,7 +275,7 @@ TEST_F(TestSoftwareDiagnosticsCluster, TestEventGeneration)
     Events::SoftwareFault::DecodableType decodedFault;
     auto event = tester.GetNextGeneratedEvent();
     ASSERT_TRUE(event.has_value());
-    ASSERT_EQ(event->GetEventData(decodedFault), CHIP_NO_ERROR); // NOLINT(bugprone-unchecked-optional-access)
+    ASSERT_EQ(event->GetEventData(decodedFault), CHIP_NO_ERROR);
 
     EXPECT_EQ(decodedFault.id, fault.id);
     ASSERT_TRUE(decodedFault.name.HasValue());

--- a/src/app/clusters/valve-configuration-and-control-server/tests/TestValveConfigurationAndControlCluster.cpp
+++ b/src/app/clusters/valve-configuration-and-control-server/tests/TestValveConfigurationAndControlCluster.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.h>
@@ -37,6 +38,7 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ValveConfigurationAndControl;
 using namespace chip::app::Clusters::ValveConfigurationAndControl::Attributes;
 using namespace chip::Testing;
+using namespace chip::Protocols::InteractionModel;
 
 class DummyDelegate : public Delegate
 {
@@ -429,9 +431,7 @@ TEST_F(TestValveConfigurationAndControlCluster, OpenCommandFieldsValidation)
 
     auto result = tester.Invoke(request);
     ASSERT_FALSE(result.IsSuccess());
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
 
     // Validate "min 1" constraint in TargetLevel field.
     request.openDuration = Optional<uint32_t>::Missing();
@@ -439,9 +439,7 @@ TEST_F(TestValveConfigurationAndControlCluster, OpenCommandFieldsValidation)
 
     result = tester.Invoke(request);
     ASSERT_FALSE(result.IsSuccess());
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
 }
 
 // Test Open command in a no-Level Valve with a DummyDelegate (non instant change).

--- a/src/app/clusters/wifi-network-management-server/tests/TestWiFiNetworkManagementCluster.cpp
+++ b/src/app/clusters/wifi-network-management-server/tests/TestWiFiNetworkManagementCluster.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <app/clusters/wifi-network-management-server/WiFiNetworkManagementCluster.h>
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 #include <access/SubjectDescriptor.h>
@@ -29,6 +30,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WiFiNetworkManagement;
 using namespace chip::app::Clusters::WiFiNetworkManagement::Attributes;
+using namespace chip::Protocols::InteractionModel;
 using namespace chip::Testing;
 
 namespace {
@@ -222,11 +224,7 @@ TEST_F(TestWiFiNetworkManagementCluster, NetworkPassphraseRequestRequiresCaseSes
 
     Commands::NetworkPassphraseRequest::Type request;
     auto result = tester.Invoke(request);
-
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode(),
-              Protocols::InteractionModel::ClusterStatusCode(Protocols::InteractionModel::Status::UnsupportedAccess));
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::UnsupportedAccess));
 }
 
 TEST_F(TestWiFiNetworkManagementCluster, NetworkPassphraseRequestRequiresCredentials)
@@ -239,11 +237,7 @@ TEST_F(TestWiFiNetworkManagementCluster, NetworkPassphraseRequestRequiresCredent
 
     Commands::NetworkPassphraseRequest::Type request;
     auto result = tester.Invoke(request);
-
-    ASSERT_TRUE(result.status.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_EQ(result.status.value().GetStatusCode(),
-              Protocols::InteractionModel::ClusterStatusCode(Protocols::InteractionModel::Status::InvalidInState));
+    EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::InvalidInState));
 }
 
 TEST_F(TestWiFiNetworkManagementCluster, NetworkPassphraseRequestSuccess)
@@ -263,6 +257,5 @@ TEST_F(TestWiFiNetworkManagementCluster, NetworkPassphraseRequestSuccess)
 
     ASSERT_TRUE(result.IsSuccess());
     ASSERT_TRUE(result.response.has_value());
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    EXPECT_TRUE(result.response.value().passphrase.data_equal(ByteSpan(passphraseData)));
+    EXPECT_TRUE(result.response->passphrase.data_equal(ByteSpan(passphraseData)));
 }

--- a/src/app/data-model-provider/tests/TestEventEmitting.cpp
+++ b/src/app/data-model-provider/tests/TestEventEmitting.cpp
@@ -23,6 +23,7 @@
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 
+#include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
 namespace {
@@ -50,12 +51,12 @@ TEST(TestInteractionModelEventEmitting, TestBasicType)
 
     auto eventInfo = logOnlyEvents.GetNextEvent();
     ASSERT_TRUE(eventInfo.has_value());
-    ASSERT_EQ(n1, eventInfo->eventNumber);   // NOLINT(bugprone-unchecked-optional-access)
-    ASSERT_EQ(eventInfo->eventOptions.mPath, // NOLINT(bugprone-unchecked-optional-access)
+    ASSERT_EQ(n1, eventInfo->eventNumber);
+    ASSERT_EQ(eventInfo->eventOptions.mPath,
               ConcreteEventPath(0 /* endpointId */, StartUpEventType::GetClusterId(), StartUpEventType::GetEventId()));
 
     chip::app::Clusters::BasicInformation::Events::StartUp::DecodableType decoded_event;
-    CHIP_ERROR err = eventInfo->GetEventData(decoded_event); // NOLINT(bugprone-unchecked-optional-access)
+    CHIP_ERROR err = eventInfo->GetEventData(decoded_event);
 
     if (err != CHIP_NO_ERROR)
     {
@@ -67,9 +68,9 @@ TEST(TestInteractionModelEventEmitting, TestBasicType)
     std::optional<EventNumber> n2 = events->GenerateEvent(event, /* endpointId = */ 1);
     eventInfo                     = logOnlyEvents.GetNextEvent();
     ASSERT_TRUE(eventInfo.has_value());
-    ASSERT_EQ(n2, eventInfo->eventNumber); // NOLINT(bugprone-unchecked-optional-access)
+    ASSERT_EQ(n2, eventInfo->eventNumber);
 
-    ASSERT_EQ(eventInfo->eventOptions.mPath, // NOLINT(bugprone-unchecked-optional-access)
+    ASSERT_EQ(eventInfo->eventOptions.mPath,
               ConcreteEventPath(1 /* endpointId */, StartUpEventType::GetClusterId(), StartUpEventType::GetEventId()));
 }
 
@@ -95,13 +96,14 @@ TEST(TestInteractionModelEventEmitting, TestFabricScoped)
     n1                = events->GenerateEvent(event, /* endpointId = */ 0);
 
     auto eventInfo = logOnlyEvents.GetNextEvent();
-    ASSERT_EQ(n1, eventInfo->eventNumber);   // NOLINT(bugprone-unchecked-optional-access)
-    ASSERT_EQ(eventInfo->eventOptions.mPath, // NOLINT(bugprone-unchecked-optional-access)
+    ASSERT_TRUE(eventInfo.has_value());
+    ASSERT_EQ(n1, eventInfo->eventNumber);
+    ASSERT_EQ(eventInfo->eventOptions.mPath,
               ConcreteEventPath(0 /* endpointId */, AccessControlEntryChangedType::GetClusterId(),
                                 AccessControlEntryChangedType::GetEventId()));
 
     chip::app::Clusters::AccessControl::Events::AccessControlEntryChanged::DecodableType decoded_event;
-    CHIP_ERROR err = eventInfo->GetEventData(decoded_event); // NOLINT(bugprone-unchecked-optional-access)
+    CHIP_ERROR err = eventInfo->GetEventData(decoded_event);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -207,6 +207,15 @@ public:
             else
                 return status.has_value() && status->IsSuccess() && response.has_value();
         }
+
+        // Returns the ClusterStatusCode if available, otherwise returns std::nullopt.
+        // This allows tests to check the status code with a single EXPECT_EQ()
+        // (i.e. without having to ASSERT_TRUE(status.has_value()) first).
+        std::optional<Protocols::InteractionModel::ClusterStatusCode> GetStatusCode() const
+        {
+            VerifyOrReturnValue(status.has_value(), std::nullopt);
+            return status->GetStatusCode();
+        }
     };
 
     // Invoke a command and return the decoded result.

--- a/src/controller/tests/data_model/TestWrite.cpp
+++ b/src/controller/tests/data_model/TestWrite.cpp
@@ -456,8 +456,7 @@ TEST_F(TestWrite, TestWriteClusterSpecificStatuses)
 
         StatusIB pathStatus = writeCb->GetPathStatus();
         EXPECT_EQ(pathStatus.mStatus, Protocols::InteractionModel::Status::Success);
-        ASSERT_TRUE(pathStatus.mClusterStatus.has_value());
-        EXPECT_EQ(*pathStatus.mClusterStatus, kExampleClusterSpecificSuccess); // NOLINT(bugprone-unchecked-optional-access)
+        EXPECT_EQ(pathStatus.mClusterStatus, ClusterStatus(kExampleClusterSpecificSuccess));
 
         EXPECT_EQ(chip::app::InteractionModelEngine::GetInstance()->GetNumActiveWriteHandlers(), 0u);
         EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
@@ -489,8 +488,7 @@ TEST_F(TestWrite, TestWriteClusterSpecificStatuses)
 
         StatusIB pathStatus = writeCb->GetPathStatus();
         EXPECT_EQ(pathStatus.mStatus, Protocols::InteractionModel::Status::Failure);
-        ASSERT_TRUE(pathStatus.mClusterStatus.has_value());
-        EXPECT_EQ(*pathStatus.mClusterStatus, kExampleClusterSpecificFailure); // NOLINT(bugprone-unchecked-optional-access)
+        EXPECT_EQ(pathStatus.mClusterStatus, ClusterStatus(kExampleClusterSpecificFailure));
 
         EXPECT_EQ(chip::app::InteractionModelEngine::GetInstance()->GetNumActiveWriteHandlers(), 0u);
         EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -1300,25 +1300,25 @@ TEST_F(TestCodegenModelViaMocks, FindAttribute)
     // valid info
     std::optional<AttributeEntry> info1 = finder.Find(ConcreteAttributePath(kMockEndpoint1, MockClusterId(1), FeatureMap::Id));
     ASSERT_TRUE(info1.has_value());
-    EXPECT_FALSE(info1->HasFlags(AttributeQualityFlags::kListAttribute)); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_FALSE(info1->HasFlags(AttributeQualityFlags::kListAttribute));
 
     // Mocks always set everything as R/W with administrative privileges
-    EXPECT_EQ(info1->GetReadPrivilege(), chip::Access::Privilege::kAdminister);  // NOLINT(bugprone-unchecked-optional-access)
-    EXPECT_EQ(info1->GetWritePrivilege(), chip::Access::Privilege::kAdminister); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(info1->GetReadPrivilege(), chip::Access::Privilege::kAdminister);
+    EXPECT_EQ(info1->GetWritePrivilege(), chip::Access::Privilege::kAdminister);
 
     std::optional<AttributeEntry> info2 = finder.Find(ConcreteAttributePath(kMockEndpoint2, MockClusterId(2), MockAttributeId(2)));
     ASSERT_TRUE(info2.has_value());
-    EXPECT_TRUE(info2->HasFlags(AttributeQualityFlags::kListAttribute));         // NOLINT(bugprone-unchecked-optional-access)
-    EXPECT_EQ(info2->GetReadPrivilege(), chip::Access::Privilege::kAdminister);  // NOLINT(bugprone-unchecked-optional-access)
-    EXPECT_EQ(info2->GetWritePrivilege(), chip::Access::Privilege::kAdminister); // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_TRUE(info2->HasFlags(AttributeQualityFlags::kListAttribute));
+    EXPECT_EQ(info2->GetReadPrivilege(), chip::Access::Privilege::kAdminister);
+    EXPECT_EQ(info2->GetWritePrivilege(), chip::Access::Privilege::kAdminister);
 
     // test a read-only attribute, which will not have a write privilege
     std::optional<AttributeEntry> info3 =
         finder.Find(ConcreteAttributePath(kMockEndpoint3, MockClusterId(3), kReadOnlyAttributeId));
     ASSERT_TRUE(info3.has_value());
-    EXPECT_FALSE(info3->HasFlags(AttributeQualityFlags::kListAttribute));       // NOLINT(bugprone-unchecked-optional-access)
-    EXPECT_EQ(info3->GetReadPrivilege(), chip::Access::Privilege::kAdminister); // NOLINT(bugprone-unchecked-optional-access)
-    EXPECT_FALSE(info3->GetWritePrivilege().has_value());                       // NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_FALSE(info3->HasFlags(AttributeQualityFlags::kListAttribute));
+    EXPECT_EQ(info3->GetReadPrivilege(), chip::Access::Privilege::kAdminister);
+    EXPECT_FALSE(info3->GetWritePrivilege().has_value());
 }
 
 // global attributes are EXPLICITLY supported

--- a/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
@@ -268,7 +268,6 @@ TEST(TestActiveResolveAttempts, TestLRU)
         std::optional<ActiveResolveAttempts::ScheduledAttempt> s = attempts.NextScheduled();
         while (s.has_value())
         {
-            // NOLINTNEXTLINE(bugprone-unchecked-optional-access): this is checked in the while loop
             EXPECT_NE(s->ResolveData().peerId.GetNodeId(), 9999u);
             s = attempts.NextScheduled();
         }

--- a/src/lib/support/tests/ExtraPwTestMacros.h
+++ b/src/lib/support/tests/ExtraPwTestMacros.h
@@ -94,18 +94,15 @@
 // only two possible values, we can directly evaluate the expression in the
 // if() condition, and still generate a good message.
 
-// clang-format off
 #if defined(_PW_TEST) // pw_unit_test:light
-#define _CHIP_TEST_ASSERT_FAILURE(expr, expected, actual)                     \
-    return ::pw::unit_test::internal::ReturnHelper() =                        \
-        ::pw::unit_test::internal::Framework::Get().CurrentTestExpectSimple(  \
-        #expr " is " #expected, #actual, __FILE__, __LINE__, false)
+#define _CHIP_TEST_ASSERT_FAILURE(expr, expected, actual)                                                                          \
+    return ::pw::unit_test::internal::ReturnHelper() = ::pw::unit_test::internal::Framework::Get().CurrentTestExpectSimple(        \
+               #expr " is " #expected, #actual, __FILE__, __LINE__, false)
 #else // googletest
-#define _CHIP_TEST_ASSERT_FAILURE(expr, expected, actual)                     \
-    GTEST_FAIL() <<                                                           \
-        "Value of: " #expr "\n"                                               \
-        "  Actual: " #actual "\n"                                             \
-        "Expected: " #expected
+#define _CHIP_TEST_ASSERT_FAILURE(expr, expected, actual)                                                                          \
+    GTEST_FAIL() << "Value of: " #expr "\n"                                                                                        \
+                    "  Actual: " #actual "\n"                                                                                      \
+                    "Expected: " #expected
 #endif
 
 /// @def ASSERT_TRUE
@@ -113,12 +110,19 @@
 ///
 /// @param[in] expr The expression to evaluate.
 #undef ASSERT_TRUE
-#define ASSERT_TRUE(expr) if ((expr)) ; else _CHIP_TEST_ASSERT_FAILURE(expr, true, false)
+#define ASSERT_TRUE(expr)                                                                                                          \
+    if ((expr))                                                                                                                    \
+        ;                                                                                                                          \
+    else                                                                                                                           \
+        _CHIP_TEST_ASSERT_FAILURE(expr, true, false)
 
 /// @def ASSERT_FALSE
 /// Verifies that @p expr evaluates to false, otherwise the current function will be aborted.
 ///
 /// @param[in] expr The expression to evaluate.
 #undef ASSERT_FALSE
-#define ASSERT_FALSE(expr) if (!(expr)) ; else _CHIP_TEST_ASSERT_FAILURE(expr, false, true)
-// clang-format off
+#define ASSERT_FALSE(expr)                                                                                                         \
+    if (!(expr))                                                                                                                   \
+        ;                                                                                                                          \
+    else                                                                                                                           \
+        _CHIP_TEST_ASSERT_FAILURE(expr, false, true)

--- a/src/lib/support/tests/ExtraPwTestMacros.h
+++ b/src/lib/support/tests/ExtraPwTestMacros.h
@@ -82,35 +82,43 @@
 #define ASSERT_SUCCESS(expr) ASSERT_EQ((expr), CHIP_NO_ERROR)
 
 // Override ASSERT_TRUE and ASSERT_FALSE from pw_unit_test in a way that
-// is friendly to static analysis tools like clang-tidy.
-//
-// The pw_unit_test implementation wraps all expression evaluation in a lambda
-// to be able to capture expression results for logging purposes, but this hides
-// the relationship between the expression being asserted and the function's
-// control flow. Since boolean expressions have only two possible values, we can
-// avoid this problem and directly evaluate the expression in the if() condition.
+// is friendly to static analysis tools like clang-tidy. The problem with
+// the default implementation (in both the light and googletest backends)
+// is that even though an ASSERT_TRUE(expr) behaves similar to
+//      if (!(expr)) return;
+// the connection between the value of the expression and the control flow
+// is obscured from static analysis tools by the testing infrastructure --
+// the actual implementations feed the expression result through a function
+// and / or hide the evaluation within a lambda to be able to generate
+// good messages in the failure case. However since boolean expressions have
+// only two possible values, we can directly evaluate the expression in the
+// if() condition, and still generate a good message.
 
 // clang-format off
-#define ADD_SIMPLE_EXPECTATION(expression, evaluated, success)               \
-    ::pw::unit_test::internal::ReturnHelper() =                              \
-        ::pw::unit_test::internal::Framework::Get().CurrentTestExpectSimple( \
-            expression, evaluated, __FILE__, __LINE__, success)
+#if defined(_PW_TEST) // pw_unit_test:light
+#define _CHIP_TEST_ASSERT_FAILURE(expr, expected, actual)                     \
+    return ::pw::unit_test::internal::ReturnHelper() =                        \
+        ::pw::unit_test::internal::Framework::Get().CurrentTestExpectSimple(  \
+        #expr " is " #expected, #actual, __FILE__, __LINE__, false)
+#else // googletest
+#define _CHIP_TEST_ASSERT_FAILURE(expr, expected, actual)                     \
+    GTEST_FAIL() <<                                                           \
+        "Value of: " #expr "\n"                                               \
+        "  Actual: " #actual "\n"                                             \
+        "Expected: " #expected
+#endif
 
 /// @def ASSERT_TRUE
 /// Verifies that @p expr evaluates to true, otherwise the current function will be aborted.
 ///
 /// @param[in] expr The expression to evaluate.
 #undef ASSERT_TRUE
-#define ASSERT_TRUE(expr)                                                          \
-    if (expr)   ADD_SIMPLE_EXPECTATION(#expr " is true", #expr " is true", true);  \
-    else return ADD_SIMPLE_EXPECTATION(#expr " is true", #expr " is false", false)
+#define ASSERT_TRUE(expr) if ((expr)) ; else _CHIP_TEST_ASSERT_FAILURE(expr, true, false)
 
 /// @def ASSERT_FALSE
 /// Verifies that @p expr evaluates to false, otherwise the current function will be aborted.
 ///
 /// @param[in] expr The expression to evaluate.
 #undef ASSERT_FALSE
-#define ASSERT_FALSE(expr)                                                           \
-    if (!(expr)) ADD_SIMPLE_EXPECTATION(#expr " is false", #expr " is false", true); \
-    else return  ADD_SIMPLE_EXPECTATION(#expr " is false", #expr " is true", false)
-// clang-format on
+#define ASSERT_FALSE(expr) if (!(expr)) ; else _CHIP_TEST_ASSERT_FAILURE(expr, false, true)
+// clang-format off

--- a/src/lib/support/tests/ExtraPwTestMacros.h
+++ b/src/lib/support/tests/ExtraPwTestMacros.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <pw_unit_test/framework.h>
+
 /**
  * Run Fixture's class function as a test.
  *
@@ -78,3 +80,37 @@
  * Shorthand for ASSERT_EQ(expr, CHIP_NO_ERROR)
  */
 #define ASSERT_SUCCESS(expr) ASSERT_EQ((expr), CHIP_NO_ERROR)
+
+// Override ASSERT_TRUE and ASSERT_FALSE from pw_unit_test in a way that
+// is friendly to static analysis tools like clang-tidy.
+//
+// The pw_unit_test implementation wraps all expression evaluation in a lambda
+// to be able to capture expression results for logging purposes, but this hides
+// the relationship between the expression being asserted and the function's
+// control flow. Since boolean expressions have only two possible values, we can
+// avoid this problem and directly evaluate the expression in the if() condition.
+
+// clang-format off
+#define ADD_SIMPLE_EXPECTATION(expression, evaluated, success)               \
+    ::pw::unit_test::internal::ReturnHelper() =                              \
+        ::pw::unit_test::internal::Framework::Get().CurrentTestExpectSimple( \
+            expression, evaluated, __FILE__, __LINE__, success)
+
+/// @def ASSERT_TRUE
+/// Verifies that @p expr evaluates to true, otherwise the current function will be aborted.
+///
+/// @param[in] expr The expression to evaluate.
+#undef ASSERT_TRUE
+#define ASSERT_TRUE(expr)                                                          \
+    if (expr)   ADD_SIMPLE_EXPECTATION(#expr " is true", #expr " is true", true);  \
+    else return ADD_SIMPLE_EXPECTATION(#expr " is true", #expr " is false", false)
+
+/// @def ASSERT_FALSE
+/// Verifies that @p expr evaluates to false, otherwise the current function will be aborted.
+///
+/// @param[in] expr The expression to evaluate.
+#undef ASSERT_FALSE
+#define ASSERT_FALSE(expr)                                                           \
+    if (!(expr)) ADD_SIMPLE_EXPECTATION(#expr " is false", #expr " is false", true); \
+    else return  ADD_SIMPLE_EXPECTATION(#expr " is false", #expr " is true", false)
+// clang-format on


### PR DESCRIPTION
#### Summary

Remove NOLINT bugprone-unchecked-optional-access from tests by making Make ASSERT_{TRUE,FALSE} clang-tidy friendly, and also simplifying some common cases by replacing an ASSERT_TRUE(has_value) plus dereference with a direct ASSERT_EQ of an std::optional.

#### Testing

All refactored tests still pass and are now clang-tidy.
