### PR TITLE
[nxp][mcxw72] Add support for PowerDown low power state

### DIFF
--- a/config/nxp/chip-cmake-freertos/Kconfig
+++ b/config/nxp/chip-cmake-freertos/Kconfig
@@ -264,6 +264,27 @@ config NXP_USE_LOW_POWER
 	help
 	  Enables low power support
 
+if NXP_USE_LOW_POWER
+
+config NXP_USE_POWER_DOWN
+	bool "Use PowerDown to reduce power consumption"
+	help
+	  Uses PowerDown to reduce power consumption during idle times
+
+if NXP_USE_POWER_DOWN
+
+config NXP_POWER_DOWN_POLL_THRESHOLD
+	int "Data poll interval threshold, in seconds, for power down"
+	depends on NXP_USE_POWER_DOWN
+	range 1 60
+	help
+	  Minimum data poll interval, in seconds, from which the device will
+	  start using power down as a low power state, instead of deep sleep
+
+endif # NXP_USE_POWER_DOWN
+
+endif # NXP_USE_LOW_POWER
+
 config NXP_USE_PLAIN_DAC_KEY
 	bool "Store DAC private key in plaintext"
 	help

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -114,6 +114,10 @@
 #include <app/reporting/SynchronizedReportSchedulerImpl.h>
 #endif
 
+#if CONFIG_NXP_USE_POWER_DOWN
+#include "ICDUtil.h"
+#endif // CONFIG_NXP_USE_POWER_DOWN
+
 using namespace chip;
 using namespace chip::TLV;
 using namespace ::chip::Credentials;
@@ -226,6 +230,10 @@ void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
 #if CONFIG_CHIP_APP_WIFI_CONNECT_AT_BOOT
     VerifyOrDie(WifiConnectAtboot(chip::NXP::App::GetAppTask().GetWifiDriverInstance()) == CHIP_NO_ERROR);
 #endif
+
+#if CONFIG_NXP_USE_POWER_DOWN
+    VerifyOrDie(chip::Server::GetInstance().GetICDManager().RegisterObserver(&chip::NXP::App::GetAppICDObserver()));
+#endif // CONFIG_NXP_USE_POWER_DOWN
 }
 
 CHIP_ERROR chip::NXP::App::AppTaskBase::Init()

--- a/examples/platform/nxp/common/icd/include/ICDUtil.h
+++ b/examples/platform/nxp/common/icd/include/ICDUtil.h
@@ -18,6 +18,9 @@
 #pragma once
 
 #include <app/ReadHandler.h>
+#if CONFIG_NXP_USE_POWER_DOWN
+#include <app/icd/server/ICDStateObserver.h>
+#endif // CONFIG_NXP_USE_POWER_DOWN
 
 namespace chip {
 namespace NXP {
@@ -34,6 +37,35 @@ inline ICDUtil & GetICDUtil()
 {
     return ICDUtil::sICDUtil;
 }
+
+#if CONFIG_NXP_USE_POWER_DOWN
+class NxpICDObserver : public chip::app::ICDStateObserver
+{
+    enum LowPowerState : uint8_t
+    {
+        DeepSleep,
+        PowerDown
+    };
+
+    LowPowerState mLPState = DeepSleep;
+
+    ~NxpICDObserver();
+
+    void OnEnterIdleMode() override;
+    void OnEnterActiveMode() override;
+    void OnTransitionToIdle() override;
+    void OnICDModeChange() override;
+
+    friend NxpICDObserver & GetAppICDObserver();
+    static NxpICDObserver sICDObserver;
+};
+
+inline NxpICDObserver & GetAppICDObserver()
+{
+    return NxpICDObserver::sICDObserver;
+}
+#endif // CONFIG_NXP_USE_POWER_DOWN
+
 } // namespace App
 } // namespace NXP
 } // namespace chip

--- a/examples/platform/nxp/common/icd/source/ICDUtil.cpp
+++ b/examples/platform/nxp/common/icd/source/ICDUtil.cpp
@@ -26,6 +26,13 @@
 #endif /* CONFIG_APP_FREERTOS_OS */
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR */
 
+#if CONFIG_NXP_USE_POWER_DOWN
+#include "PWR_Interface.h"
+#include <app/icd/server/ICDConfigurationData.h>
+
+chip::NXP::App::NxpICDObserver chip::NXP::App::NxpICDObserver::sICDObserver;
+#endif // CONFIG_NXP_USE_POWER_DOWN
+
 chip::NXP::App::ICDUtil chip::NXP::App::ICDUtil::sICDUtil;
 
 CHIP_ERROR chip::NXP::App::ICDUtil::OnSubscriptionRequested(chip::app::ReadHandler & aReadHandler,
@@ -47,3 +54,46 @@ CHIP_ERROR chip::NXP::App::ICDUtil::OnSubscriptionRequested(chip::app::ReadHandl
 #endif
     return CHIP_NO_ERROR;
 }
+
+#if CONFIG_NXP_USE_POWER_DOWN
+chip::NXP::App::NxpICDObserver::~NxpICDObserver()
+{
+    // Ensure low-power constraints are released
+    OnEnterActiveMode();
+}
+
+void chip::NXP::App::NxpICDObserver::OnEnterIdleMode()
+{
+    // In Idle Mode remove the DeepSleep constraint and let the device go into
+    // PowerDown if the polling period exceeds CONFIG_NXP_POWER_DOWN_POLL_THRESHOLD
+    System::Clock::Milliseconds32 slowPollInterval = chip::ICDConfigurationData::GetInstance().GetSlowPollingInterval();
+    if ((slowPollInterval >= chip::System::Clock::Seconds32(CONFIG_NXP_POWER_DOWN_POLL_THRESHOLD)) && (mLPState != PowerDown))
+    {
+        ::PWR_SetLowPowerModeConstraint(PWR_PowerDown);
+        ::PWR_ReleaseLowPowerModeConstraint(PWR_DeepSleep);
+        mLPState = PowerDown;
+    }
+}
+
+void chip::NXP::App::NxpICDObserver::OnEnterActiveMode()
+{
+    // In Active Mode add a DeepSleep constraint to prevent the device from
+    // going all the way to PowerDown state
+    if (mLPState != DeepSleep)
+    {
+        ::PWR_SetLowPowerModeConstraint(PWR_DeepSleep);
+        ::PWR_ReleaseLowPowerModeConstraint(PWR_PowerDown);
+        mLPState = DeepSleep;
+    }
+}
+
+void chip::NXP::App::NxpICDObserver::OnTransitionToIdle()
+{
+    // Do nothing.
+}
+
+void chip::NXP::App::NxpICDObserver::OnICDModeChange()
+{
+    // Do nothing.
+}
+#endif // CONFIG_NXP_USE_POWER_DOWN

--- a/src/platform/nxp/common/crypto/S200/PersistentStorageOpKeystoreS200.cpp
+++ b/src/platform/nxp/common/crypto/S200/PersistentStorageOpKeystoreS200.cpp
@@ -101,7 +101,12 @@ CHIP_ERROR PersistentStorageOpKeystoreS200::SignWithOpKeypair(FabricIndex fabric
     uint16_t keyBlobLen = keyBlob.Capacity();
     TEMPORARY_RETURN_IGNORED keyBlob.SetLength(keyBlobLen);
 
+#if CONFIG_NXP_USE_POWER_DOWN
+    // When using PowerDown force the key to be loaded all the time from the
+    // persistent storage in order to make sure it exists in the S200 keystore
+#else
     if (fabricIndex != mCachedFabricIndex)
+#endif // CONFIG_NXP_USE_POWER_DOWN
     {
         error =
             mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricOpKey(fabricIndex).KeyName(), keyBlob.Bytes(), keyBlobLen);
@@ -122,7 +127,17 @@ CHIP_ERROR PersistentStorageOpKeystoreS200::SignWithOpKeypair(FabricIndex fabric
         VerifyOrReturnError(mCachedKeypair->ImportBlob(keyBlob) == CHIP_NO_ERROR, CHIP_ERROR_INTERNAL);
     }
 
-    return mCachedKeypair->ECDSA_sign_msg(message.data(), message.size(), outSignature);
+    error = mCachedKeypair->ECDSA_sign_msg(message.data(), message.size(), outSignature);
+
+#if CONFIG_NXP_USE_POWER_DOWN
+    // In order to trigger the ImportBlob() call to reinitialize the S200 key
+    // handle each time we need to clean up the cached keypair once we're done
+    // with this crypto operation.
+    delete mCachedKeypair;
+    mCachedKeypair = nullptr;
+#endif // CONFIG_NXP_USE_POWER_DOWN
+
+    return error;
 }
 
 } // namespace chip

--- a/src/platform/nxp/mcxw72/CHIPPlatformConfig.h
+++ b/src/platform/nxp/mcxw72/CHIPPlatformConfig.h
@@ -54,5 +54,12 @@
 
 #define CHIP_CONFIG_MAX_FABRICS 5
 
+#if CONFIG_NXP_USE_POWER_DOWN
+// When enabling PowerDown as a low power state we need to increase the default
+// size of the ICD observers pool by one to accommodate the low power states
+// manager
+#define CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE 4
+#endif // CONFIG_NXP_USE_POWER_DOWN
+
 // Include default nxp platform configurations
 #include "platform/nxp/common/CHIPNXPPlatformDefaultConfig.h"


### PR DESCRIPTION
#### Summary

This pull request adds the application level support for using the _PowerDown_ low power state for NXP MCXW72 devices in order to lower the platform power consumption. The feature can be enabled at build time for NXP platforms that support this low power state. An _ICDObserver_ is used to monitor the states of the ICD and adjust device low power states for an optimal power consumption.

#### Testing

Manually tested on the MCXW72 platform using the _contact-sensor_ application and a power measurement tool (such as the [Joulescope JS220](joulescope.com/products/js220-joulescope-precision-energy-analyzer?srsltid=AfmBOoqjsvfue-pUXQEHOaO48KT4dHZS24p9sIapBzdzbZS9V055-XU3)).
