### PR TITLE
[Silabs][Docker] : Update Silabs Docker

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-186 : [Ameba] Update Docker image for C++ macro conflict resolution
+187 : [Silabs] Update Silabs sdks

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -2,48 +2,9 @@ ARG VERSION=1
 FROM ghcr.io/project-chip/chip-build:${VERSION} as build
 LABEL org.opencontainers.image.source https://github.com/project-chip/connectedhomeip
 
-# Requirements to clone SDKs in temporary container
-RUN set -x \
-    && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-    git \
-    git-lfs \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/ \
-    && : # last line
-
-# Download Simplicity SDK v2025.6.2 (9932cb1)
-RUN git clone --depth=1 --single-branch --branch=v2025.6.2 https://github.com/SiliconLabs/simplicity_sdk.git /tmp/simplicity_sdk \
-    # Deleting files that are not needed to save space
-    && rm -rf /tmp/simplicity_sdk/.git /tmp/simplicity_sdk/protocol/flex /tmp/simplicity_sdk/protocol/z-wave /tmp/simplicity_sdk/protocol/zigbee /tmp/simplicity_sdk/protocol/wisun /tmp/simplicity_sdk/util/third_party/tensorflow_extra \
-    /tmp/simplicity_sdk/util/third_party/sqlite /tmp/simplicity_sdk/util/third_party/ot-br-posix /tmp/simplicity_sdk/util/third_party/tflite-micro /tmp/simplicity_sdk/util/third_party/tflite-fatfs /tmp/simplicity_sdk/util/third_party/unity_test_framework \
-    /tmp/simplicity_sdk/platform/radio/efr32_multiphy_configurator \
-    && find /tmp/simplicity_sdk/protocol/bluetooth /tmp/simplicity_sdk/platform -name "*.a" -type f -delete \
-    && find /tmp/simplicity_sdk/protocol/openthread -name "*efr32mg21*" -delete \
-    && find /tmp/simplicity_sdk \( -name "libsl_platform_ftd_efr32mg2*" -o -name "libsl_ot_stack_mtd_efr32mg2*" \) -type f -delete \
-    && find /tmp/simplicity_sdk/hardware/board/config -mindepth 1 -maxdepth 1 -type d ! \( -name '*brd4186c*' -o -name '*brd4187c*' -o -name '*brd4186a*' -o -name '*brd4187a*' -o -name '*brd2601b*' -o -name '*brd2703a*' -o -name '*brd2704a*' -o -name '*component*' \
-    -o -name '*brd4316a*' -o -name '*brd4317a*' -o -name '*brd4318a*' -o -name '*brd4319a*' -o -name '*brd4116a*' -o -name '*brd4117a*' -o -name '*brd4118a*' -o -name '*brd2608a*' -o -name '*brd4350a*' -o -name '*brd4351a*' -o -name '*brd2709a*' \) -exec rm -rf {} + \
-    && find /tmp/simplicity_sdk/platform/Device/SiliconLabs  -mindepth 1 -maxdepth 1 -type d ! \( -name 'EFR32MG24' -o -name 'EFR32MG26' -o -name 'MGM24' -o -name 'MGM26' \) -exec rm -rf {} + \
-    && : # last line
-
-# Clone WiSeConnect SDK v3.5.2 (02e004c)
-RUN git clone --depth=1 --single-branch --branch=v3.5.2 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
-    cd /tmp/wifi_sdk && \
-    rm -rf .git examples components/device/stm32 \
-    && : # last line
-
-# SLC-cli install
-# TODO: figure out a way to make this a fixed version. Currently a moving target.
-
-RUN wget https://www.silabs.com/documents/public/software/slc_cli_linux.zip && \
-    unzip ./slc_cli_linux.zip -d /tmp && \
-    rm ./slc_cli_linux.zip \
-    && : # last line
-
-# Final SDK container for compiling using Silabs SDK
-FROM ghcr.io/project-chip/chip-build:${VERSION}
-
-ADD requirements.txt /tmp/requirements.txt
+# Copy SLT manifests (sisdk-pkg.lock, wiseconnect-pkg.slt), requirements.txt, and Simplicity SDK keep-list (build context must be repo root)
+COPY scripts/setup/silabs/sisdk-pkg.lock scripts/setup/silabs/wiseconnect-pkg.slt docker/requirements.txt /tmp/
+COPY scripts/setup/silabs/simplicity_sdk_keep_folders.txt /tmp/keep_folders.txt
 
 # GNU ARM Embedded toolchain, cross compiler for various platform builds
 RUN set -x \
@@ -59,6 +20,55 @@ RUN set -x \
     && pip3 install --break-system-packages -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt \
     && : # last line
+
+# Setup SLT CLI (same as scripts/setup/silabs/install-packages.py)
+RUN set -x \
+    && mkdir -p /tmp/slt_install \
+    && wget -q https://www.silabs.com/documents/public/software/slt-cli-1.0.1-linux-x64.zip -O /tmp/slt.zip \
+    && unzip -q /tmp/slt.zip -d /tmp/slt_install \
+    && rm /tmp/slt.zip \
+    && chmod +x /tmp/slt_install/slt \
+    && : # last line
+
+# Install packages via SLT (simplicity-sdk, wiseconnect, slc-cli) and copy to /tmp for final image
+RUN set -x \
+    && /tmp/slt_install/slt update --self \
+    && /tmp/slt_install/slt install -f /tmp/wiseconnect-pkg.slt \
+    && /tmp/slt_install/slt install slc-cli \
+    && cp -a $(/tmp/slt_install/slt where wiseconnect) /tmp/wifi_sdk \
+    && cp -a $(/tmp/slt_install/slt where slc-cli) /tmp/slc_cli \
+    && /tmp/slt_install/slt install -f /tmp/sisdk-pkg.lock \
+    && cp -a $(/tmp/slt_install/slt where simplicity-sdk/2025.12.1-alpha) /tmp/simplicity_sdk \
+    && rm -rf /tmp/slt_install /tmp/sisdk-pkg.lock /tmp/wiseconnect-pkg.slt \
+    && : # last line
+
+# Trim Simplicity SDK: keep only folders and .a libs from simplicity_sdk_keep_folders.txt
+RUN grep -v '^#' /tmp/keep_folders.txt | grep -v '^$' | grep -v '\.a$' | sort -u > /tmp/keep_list.txt \
+    && for d in /tmp/simplicity_sdk/*/ ; do \
+    name=$(basename "$d"); \
+    grep -qFx "$name" /tmp/keep_list.txt || rm -rf "$d"; \
+    done \
+    && grep -v '^#' /tmp/keep_folders.txt | grep -v '^$' | grep '\.a$' | sort -u > /tmp/keep_libs.txt \
+    && ( cd /tmp/simplicity_sdk && find . -name "*.a" -type f | while read f; do \
+    rel="${f#./}"; \
+    grep -qFx "$rel" /tmp/keep_libs.txt || rm -f "$f"; \
+    done ) \
+    && rm /tmp/keep_folders.txt /tmp/keep_list.txt /tmp/keep_libs.txt \
+    && find /tmp/simplicity_sdk/openthread -name "*efr32mg21*" -delete \
+    && find /tmp/simplicity_sdk/boards/hardware/board/config -mindepth 1 -maxdepth 1 -type d ! \( -name '*brd4186c*' -o -name '*brd4187c*' -o -name '*brd4186a*' -o -name '*brd4187a*' -o -name '*brd2601b*' -o -name '*brd2703a*' -o -name '*brd2704a*' -o -name '*component*' \
+    -o -name '*brd4316a*' -o -name '*brd4317a*' -o -name '*brd4318a*' -o -name '*brd4319a*' -o -name '*brd4116a*' -o -name '*brd4117a*' -o -name '*brd4118a*' -o -name '*brd2608a*' -o -name '*brd4350a*' -o -name '*brd4351a*' -o -name '*brd2709a*' \
+    -o -name '*brd1019a*' -o -name '*brd2719a*' -o -name '*brd4407a*' -o -name '*brd4408a*' \) -exec rm -rf {} + \
+    && find /tmp/simplicity_sdk/devices/platform/Device/SiliconLabs  -mindepth 1 -maxdepth 1 -type d ! \( -name 'EFR32MG24' -o -name 'EFR32MG26' -o -name 'MGM24' -o -name 'MGM26' -o -name 'SIMG301' \) -exec rm -rf {} + \
+    && : # last line
+
+# Trim WiSeConnect SDK (from SLT install above) to save space
+RUN rm -rf /tmp/wifi_sdk/.git /tmp/wifi_sdk/examples /tmp/wifi_sdk/components/device/stm32 \
+    && : # last line
+
+# Final SDK container for compiling using Silabs SDK
+FROM ghcr.io/project-chip/chip-build:${VERSION}
+
+ADD docker/requirements.txt /tmp/requirements.txt
 
 # Keep GSDK_ROOT name until rename transition to SISDK is completed
 ENV GSDK_ROOT=/opt/silabs/simplicity_sdk/

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -3,23 +3,8 @@ FROM ghcr.io/project-chip/chip-build:${VERSION} as build
 LABEL org.opencontainers.image.source https://github.com/project-chip/connectedhomeip
 
 # Copy SLT manifests (sisdk-pkg.lock, wiseconnect-pkg.slt), requirements.txt, and Simplicity SDK keep-list (build context must be repo root)
-COPY scripts/setup/silabs/sisdk-pkg.lock scripts/setup/silabs/wiseconnect-pkg.slt docker/requirements.txt /tmp/
+COPY scripts/setup/silabs/sisdk-pkg.lock scripts/setup/silabs/wiseconnect-pkg.slt /tmp/
 COPY scripts/setup/silabs/simplicity_sdk_keep_folders.txt /tmp/keep_folders.txt
-
-# GNU ARM Embedded toolchain, cross compiler for various platform builds
-RUN set -x \
-    && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-    gcc-arm-none-eabi \
-    binutils-arm-none-eabi \
-    openjdk-17-jdk-headless \
-    ccache \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/ \
-    # Install Python Packages
-    && pip3 install --break-system-packages -r /tmp/requirements.txt \
-    && rm /tmp/requirements.txt \
-    && : # last line
 
 # Setup SLT CLI (same as scripts/setup/silabs/install-packages.py)
 RUN set -x \
@@ -68,7 +53,22 @@ RUN rm -rf /tmp/wifi_sdk/.git /tmp/wifi_sdk/examples /tmp/wifi_sdk/components/de
 # Final SDK container for compiling using Silabs SDK
 FROM ghcr.io/project-chip/chip-build:${VERSION}
 
-ADD docker/requirements.txt /tmp/requirements.txt
+ADD requirements.txt /tmp/requirements.txt
+
+# GNU ARM Embedded toolchain, cross compiler for various platform builds
+RUN set -x \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+    gcc-arm-none-eabi \
+    binutils-arm-none-eabi \
+    openjdk-17-jdk-headless \
+    ccache \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/ \
+    # Install Python Packages
+    && pip3 install --break-system-packages -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt \
+    && : # last line
 
 # Keep GSDK_ROOT name until rename transition to SISDK is completed
 ENV GSDK_ROOT=/opt/silabs/simplicity_sdk/

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -17,7 +17,6 @@ RUN set -x \
 
 # Install packages via SLT (simplicity-sdk, wiseconnect, slc-cli) and copy to /tmp for final image
 RUN set -x \
-    && /tmp/slt_install/slt update --self \
     && /tmp/slt_install/slt install -f /tmp/wiseconnect-pkg.slt \
     && /tmp/slt_install/slt install slc-cli \
     && cp -a $(/tmp/slt_install/slt where wiseconnect) /tmp/wifi_sdk \
@@ -34,11 +33,9 @@ RUN grep -v '^#' /tmp/keep_folders.txt | grep -v '^$' | grep -v '\.a$' | sort -u
     grep -qFx "$name" /tmp/keep_list.txt || rm -rf "$d"; \
     done \
     && grep -v '^#' /tmp/keep_folders.txt | grep -v '^$' | grep '\.a$' | sort -u > /tmp/keep_libs.txt \
-    && ( cd /tmp/simplicity_sdk && find . -name "*.a" -type f | while read f; do \
-    rel="${f#./}"; \
-    grep -qFx "$rel" /tmp/keep_libs.txt || rm -f "$f"; \
-    done ) \
-    && rm /tmp/keep_folders.txt /tmp/keep_list.txt /tmp/keep_libs.txt \
+    && ( cd /tmp/simplicity_sdk && find . -name "*.a" -type f | sed 's|^\./||' > /tmp/all_libs.txt ) \
+    && grep -vFxf /tmp/keep_libs.txt /tmp/all_libs.txt | sed 's|^|/tmp/simplicity_sdk/|' | xargs -r rm -f \
+    && rm /tmp/keep_folders.txt /tmp/keep_list.txt /tmp/keep_libs.txt /tmp/all_libs.txt \
     && find /tmp/simplicity_sdk/openthread -name "*efr32mg21*" -delete \
     && find /tmp/simplicity_sdk/boards/hardware/board/config -mindepth 1 -maxdepth 1 -type d ! \( -name '*brd4186c*' -o -name '*brd4187c*' -o -name '*brd4186a*' -o -name '*brd4187a*' -o -name '*brd2601b*' -o -name '*brd2703a*' -o -name '*brd2704a*' -o -name '*component*' \
     -o -name '*brd4316a*' -o -name '*brd4317a*' -o -name '*brd4318a*' -o -name '*brd4319a*' -o -name '*brd4116a*' -o -name '*brd4117a*' -o -name '*brd4118a*' -o -name '*brd2608a*' -o -name '*brd4350a*' -o -name '*brd4351a*' -o -name '*brd2709a*' \

--- a/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt
+++ b/integrations/docker/images/stage-2/chip-build-efr32/requirements.txt
@@ -7,3 +7,5 @@ myst-parser==2.0.0
 Sphinx==7.2.6
 sphinx-rtd-theme==1.3.0
 sphinx-tabs==3.4.1
+# scripts/setup/silabs/install-packages.py
+dload

--- a/scripts/setup/silabs/install-packages.py
+++ b/scripts/setup/silabs/install-packages.py
@@ -95,6 +95,13 @@ def download_slt_cli():
     try:
         dload.save(slt_cli_url, slt_zip_path)
         with ZipFile(slt_zip_path, 'r') as zObject:
+            # Check for path traversal vulnerabilities before extracting
+            for member in zObject.infolist():
+                resolved_path = os.path.realpath(os.path.join(tools_folder_path, member.filename))
+                if not resolved_path.startswith(os.path.realpath(tools_folder_path)):
+                    logger.error("Zip file contains unsafe path: %s", member.filename)
+                    sys.exit(1)
+            # If all paths are safe, extract
             zObject.extractall(path=tools_folder_path)
         os.remove(slt_zip_path)
         make_executable(slt_cli_path)

--- a/scripts/setup/silabs/install-packages.py
+++ b/scripts/setup/silabs/install-packages.py
@@ -63,23 +63,6 @@ def make_executable(path):
     else:
         logger.warning("Path %s does not exist to make executable.", path)
 
-
-def find_slt_in_path():
-    """Return path to slt if found in PATH, else None."""
-    try:
-        result = subprocess.run(
-            ["which", "slt"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
-    except (subprocess.SubprocessError, FileNotFoundError):
-        pass
-    return None
-
-
 def download_slt_cli():
     """Download and extract SLT CLI tool to script directory."""
     platform_name, slt_cli_url = get_platform_vars()

--- a/scripts/setup/silabs/install-packages.py
+++ b/scripts/setup/silabs/install-packages.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+"""
+Download and setup SLT (Silicon Labs Tools) CLI for Matter development.
+
+This script downloads and installs the SLT CLI tool which is used to manage
+Silicon Labs development tools required for Matter development.
+"""
+
+import argparse
+import logging
+import os
+import stat
+import subprocess
+import sys
+from zipfile import ZipFile
+
+logger = logging.getLogger(__name__)
+
+try:
+    import dload
+except ImportError:
+    logger.error("dload package is required. Install it with: pip install dload")
+    sys.exit(1)
+
+
+def setup_logging(verbose=False):
+    """Configure logging level and format based on verbosity setting."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format='[%(levelname)s] %(message)s')
+
+
+def get_platform_vars():
+    """Set platform-specific variables and URLs for SLT CLI download. Linux and macOS only."""
+    platform = sys.platform
+    if platform == "darwin":
+        platform_name = "mac"
+    elif platform == "linux":
+        platform_name = "linux"
+    else:
+        logger.error("Platform %s is not supported (Linux and macOS only)", platform)
+        sys.exit(1)
+
+    slt_cli_url = f"https://www.silabs.com/documents/public/software/slt-cli-1.0.1-{platform_name}-x64.zip"
+    return platform_name, slt_cli_url
+
+
+def get_tools_path():
+    """Return the script directory as the download location."""
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    os.makedirs(script_dir, exist_ok=True)
+    return script_dir
+
+
+def make_executable(path):
+    """Make a file executable on Unix-like systems."""
+    if path and os.path.exists(path):
+        try:
+            st = os.stat(path)
+            os.chmod(path, st.st_mode | stat.S_IEXEC)
+        except OSError as e:
+            logger.warning("Could not make %s executable: %s", path, e)
+    else:
+        logger.warning("Path %s does not exist to make executable.", path)
+
+
+def find_slt_in_path():
+    """Return path to slt if found in PATH, else None."""
+    try:
+        result = subprocess.run(
+            ["which", "slt"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+    return None
+
+
+def download_slt_cli():
+    """Download and extract SLT CLI tool to script directory."""
+    platform_name, slt_cli_url = get_platform_vars()
+    tools_folder_path = get_tools_path()
+    slt_cli_path = os.path.join(tools_folder_path, "slt")
+
+    if os.path.isfile(slt_cli_path):
+        logger.info("SLT CLI already exists at %s", slt_cli_path)
+        return slt_cli_path
+
+    logger.info("Downloading and unzipping slt-cli...")
+    slt_zip_path = os.path.join(tools_folder_path, "slt.zip")
+    try:
+        dload.save(slt_cli_url, slt_zip_path)
+        with ZipFile(slt_zip_path, 'r') as zObject:
+            zObject.extractall(path=tools_folder_path)
+        os.remove(slt_zip_path)
+        make_executable(slt_cli_path)
+        logger.info("SLT CLI installed at %s", slt_cli_path)
+        return slt_cli_path
+    except Exception as e:
+        logger.error("Failed to download/extract slt-cli: %s", e)
+        sys.exit(1)
+
+
+def update_slt_cli(slt_cli_path):
+    """Update SLT CLI to latest version."""
+    update_cmd = [slt_cli_path, "update", "--self"]
+    try:
+        logger.info("Updating SLT CLI to latest version...")
+        subprocess.run(update_cmd, check=True)
+        logger.info("SLT CLI updated successfully")
+    except subprocess.CalledProcessError as e:
+        logger.warning("Failed to update slt-cli: %s", e)
+    except FileNotFoundError:
+        logger.warning("SLT CLI not found at %s, skipping update", slt_cli_path)
+
+
+def get_pkg_manifest_paths():
+    """Return paths to sisdk-pkg.lock and wiseconnect-pkg.slt (lock files used automatically alongside)."""
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    return [
+        os.path.join(script_dir, "wiseconnect-pkg.slt"),
+        os.path.join(script_dir, "sisdk-pkg.lock"),
+    ]
+
+
+def install_sdk_packages(slt_cli_path):
+    """Install packages from sisdk-pkg.lock and wiseconnect-pkg.slt."""
+    for pkg_path in get_pkg_manifest_paths():
+        if not os.path.isfile(pkg_path):
+            logger.error("Package manifest not found at %s", pkg_path)
+            sys.exit(1)
+
+    for pkg_path in get_pkg_manifest_paths():
+        install_cmd = [slt_cli_path, "install", "-f", pkg_path]
+        try:
+            logger.info("Installing packages from %s...", os.path.basename(pkg_path))
+            subprocess.run(install_cmd, check=True)
+            logger.info("Packages from %s installed successfully", os.path.basename(pkg_path))
+        except subprocess.CalledProcessError as e:
+            logger.error("Failed to install packages from %s: %s", pkg_path, e)
+            sys.exit(1)
+
+
+def slt_where(slt_cli_path, package):
+    """Run 'slt where <package>' and return the path, or None if not found."""
+    try:
+        result = subprocess.run(
+            [slt_cli_path, "where", package],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+    return None
+
+
+def get_repo_root():
+    """Return the repository root (three levels up from this script)."""
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.normpath(os.path.join(script_dir, "..", "..", ".."))
+
+
+def create_sdk_symlinks(simplicity_sdk_path, wiseconnect_path):
+    """Create symlinks: third_party/silabs/simplicity_sdk and wifi_sdk to SLT SDK locations."""
+    repo_root = get_repo_root()
+    silabs_dir = os.path.join(repo_root, "third_party", "silabs")
+
+    def create_symlink(target_path, link_name):
+        if not target_path or not os.path.isdir(target_path):
+            logger.warning("Target path does not exist or is not a directory: %s", target_path)
+            return
+        link_path = os.path.join(silabs_dir, link_name)
+        try:
+            os.makedirs(silabs_dir, exist_ok=True)
+            if os.path.lexists(link_path):
+                if os.path.islink(link_path):
+                    current = os.path.realpath(link_path)
+                    if os.path.realpath(target_path) == current:
+                        logger.info("Symlink already up to date: %s", link_path)
+                        return
+                    os.remove(link_path)
+                else:
+                    logger.warning("Path exists and is not a symlink, skipping: %s", link_path)
+                    return
+            os.symlink(target_path, link_path)
+            logger.info("Created symlink %s -> %s", link_path, target_path)
+        except OSError as e:
+            logger.warning("Could not create symlink %s: %s", link_path, e)
+
+    create_symlink(simplicity_sdk_path, "simplicity_sdk")
+    create_symlink(wiseconnect_path, "wifi_sdk")
+
+
+def setup_slt_environment(verbose=False):
+    """Main function to setup SLT CLI and install required packages."""
+    setup_logging(verbose)
+
+    slt_cli_path = download_slt_cli()
+    update_slt_cli(slt_cli_path)
+    install_sdk_packages(slt_cli_path)
+
+    simplicity_sdk_path = slt_where(slt_cli_path, "simplicity-sdk/2025.12.1-alpha")
+    wiseconnect_path = slt_where(slt_cli_path, "wiseconnect")
+    create_sdk_symlinks(simplicity_sdk_path, wiseconnect_path)
+
+    return slt_cli_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download and setup SLT (Silicon Labs Tools) CLI for Matter development."
+    )
+    parser.add_argument(
+        '--verbose', '-v',
+        action='store_true',
+        help='Enable verbose (debug) logging'
+    )
+    args = parser.parse_args()
+
+    slt_path = setup_slt_environment(verbose=args.verbose)
+    logger.info("\nSLT CLI setup completed successfully")
+    logger.info("SLT CLI location: %s", slt_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup/silabs/install-packages.py
+++ b/scripts/setup/silabs/install-packages.py
@@ -63,6 +63,7 @@ def make_executable(path):
     else:
         logger.warning("Path %s does not exist to make executable.", path)
 
+
 def download_slt_cli():
     """Download and extract SLT CLI tool to script directory."""
     platform_name, slt_cli_url = get_platform_vars()

--- a/scripts/setup/silabs/simplicity_sdk_keep_folders.txt
+++ b/scripts/setup/silabs/simplicity_sdk_keep_folders.txt
@@ -1,0 +1,164 @@
+# Top-level Simplicity SDK folders to keep when trimming (referenced by SiWx917_sdk.gni and efr32_sdk.gni).
+# One folder per line (no path). Library paths (lines ending .a) are used only to keep those .a files; other .a are removed.
+# Parse folders: grep -v '^#' simplicity_sdk_keep_folders.txt | grep -v '^$' | grep -v '\.a$'
+# Parse kept libraries: grep -v '^#' simplicity_sdk_keep_folders.txt | grep -v '^$' | grep '\.a$'
+# Sections: SiWx917_sdk.gni, efr32_sdk.gni, then "all" (combined unique).
+
+# SiWx917_sdk.gni
+board_drivers
+cmsis
+cmsis_common
+freertos
+glib
+openthread_stack
+platform_common
+platform_core
+segger
+security_mbedtls
+security_mbedtls_source
+security_se_manager
+
+# efr32_sdk.gni
+app
+bgapi_protocol
+bluetooth_apploader
+bluetooth_common
+bluetooth_le_controller
+bluetooth_le_host
+bluetooth_le_middleware
+bluetooth_mesh
+board_drivers
+boards
+bootloader
+bootloader_interface
+cmsis
+cmsis_common
+common_15_4
+devices
+freertos
+glib
+openthread
+openthread_stack
+platform
+platform_common
+platform_core
+rail_library
+security_mbedtls
+security_mbedtls_source
+security_se_manager
+segger
+util
+
+# efr32_sdk.gni libraries (.a)
+openthread/build/gcc/cortex-m33/cmake/sl-openthread-library/Release/libsl_openthread.a
+# openthread/libs (all .a from connectedhomeip_silabs)
+openthread/libs/libsl_ot_stack_ftd_coap_efr32mg21_gcc.a
+openthread/libs/libsl_ot_stack_ftd_coap_efr32mg24_gcc.a
+openthread/libs/libsl_ot_stack_ftd_coap_efr32mg26_gcc.a
+openthread/libs/libsl_ot_stack_ftd_coap_simg301_gcc.a
+openthread/libs/libsl_ot_stack_ftd_efr32mg21_gcc.a
+openthread/libs/libsl_ot_stack_ftd_efr32mg24_gcc.a
+openthread/libs/libsl_ot_stack_ftd_efr32mg26_gcc.a
+openthread/libs/libsl_ot_stack_ftd_mi_coap_efr32mg21_gcc.a
+openthread/libs/libsl_ot_stack_ftd_mi_coap_efr32mg24_gcc.a
+openthread/libs/libsl_ot_stack_ftd_mi_coap_efr32mg26_gcc.a
+openthread/libs/libsl_ot_stack_ftd_mi_coap_simg301_gcc.a
+openthread/libs/libsl_ot_stack_ftd_simg301_gcc.a
+openthread/libs/libsl_ot_stack_mtd_coap_efr32mg21_gcc.a
+openthread/libs/libsl_ot_stack_mtd_coap_efr32mg24_gcc.a
+openthread/libs/libsl_ot_stack_mtd_coap_efr32mg26_gcc.a
+openthread/libs/libsl_ot_stack_mtd_coap_simg301_gcc.a
+openthread/libs/libsl_ot_stack_mtd_efr32mg21_gcc.a
+openthread/libs/libsl_ot_stack_mtd_efr32mg24_gcc.a
+openthread/libs/libsl_ot_stack_mtd_efr32mg26_gcc.a
+openthread/libs/libsl_ot_stack_mtd_mi_coap_efr32mg21_gcc.a
+openthread/libs/libsl_ot_stack_mtd_mi_coap_efr32mg24_gcc.a
+openthread/libs/libsl_ot_stack_mtd_mi_coap_efr32mg26_gcc.a
+openthread/libs/libsl_ot_stack_mtd_mi_coap_simg301_gcc.a
+openthread/libs/libsl_ot_stack_mtd_simg301_gcc.a
+openthread/libs/libsl_ot_stack_tcp_efr32mg21_gcc.a
+openthread/libs/libsl_ot_stack_tcp_efr32mg24_gcc.a
+openthread/libs/libsl_ot_stack_tcp_efr32mg26_gcc.a
+openthread/libs/libsl_ot_stack_tcp_simg301_gcc.a
+# bluetooth_apploader/build/gcc/cortex-m33/release
+bluetooth_apploader/build/gcc/cortex-m33/release/libapploader.a
+# bluetooth_common/lib/build/gcc/cortex-m33/bgcommon/release
+bluetooth_common/lib/build/gcc/cortex-m33/bgcommon/release/libbgcommon.a
+# bluetooth_le_controller/build/gcc (all variants)
+bluetooth_le_controller/build/gcc/x301/release/liblinklayer.a
+bluetooth_le_controller/build/gcc/xg21/release/liblinklayer.a
+bluetooth_le_controller/build/gcc/xg22/release/liblinklayer.a
+bluetooth_le_controller/build/gcc/xg24/release/liblinklayer.a
+bluetooth_le_controller/build/gcc/xg26/release/liblinklayer.a
+bluetooth_le_controller/build/gcc/xg27/release/liblinklayer.a
+bluetooth_le_controller/build/gcc/xg28/release/liblinklayer.a
+bluetooth_le_controller/build/gcc/xg29/release/liblinklayer.a
+# bluetooth_le_host/build/gcc/cortex-m33
+bluetooth_le_host/build/gcc/cortex-m33/accept_list/release/libble_host_accept_list.a
+bluetooth_le_host/build/gcc/cortex-m33/accept_list/release/libble_host_accept_list_stub.a
+bluetooth_le_host/build/gcc/cortex-m33/bgstack/release/libble_host.a
+bluetooth_le_host/build/gcc/cortex-m33/bgstack/release/libbondingdb.a
+bluetooth_le_host/build/gcc/cortex-m33/bgstack/release/libbondingdb_stub.a
+bluetooth_le_host/build/gcc/cortex-m33/ble_bgapi/release/libble_bgapi.a
+bluetooth_le_host/build/gcc/cortex-m33/ble_bgapi/release/libble_bgapi_gatt_client.a
+bluetooth_le_host/build/gcc/cortex-m33/ble_bgapi/release/libble_bgapi_gatt_server.a
+bluetooth_le_host/build/gcc/cortex-m33/ble_bgapi/release/libble_bgapi_stub_gatt_client.a
+bluetooth_le_host/build/gcc/cortex-m33/ble_bgapi/release/libble_bgapi_stub_gatt_server.a
+bluetooth_le_host/build/gcc/cortex-m33/ble_system/release/libble_system.a
+bluetooth_le_host/build/gcc/cortex-m33/channel_classification/release/libble_host_channel_classification.a
+bluetooth_le_host/build/gcc/cortex-m33/connection_subrating/release/libble_host_connection_subrating.a
+bluetooth_le_host/build/gcc/cortex-m33/connection_subrating/release/libble_host_connection_subrating_stub.a
+bluetooth_le_host/build/gcc/cortex-m33/core/release/libble_host_core.a
+bluetooth_le_host/build/gcc/cortex-m33/cte_transmitter/release/libble_host_cte_transmitter.a
+bluetooth_le_host/build/gcc/cortex-m33/hal/release/libble_host_hal_series2.a
+bluetooth_le_host/build/gcc/cortex-m33/hal/release/libble_host_hal_series3.a
+bluetooth_le_host/build/gcc/cortex-m33/hci/release/libble_host_hci.a
+bluetooth_le_host/build/gcc/cortex-m33/linklayer_interface/release/libble_host_linklayer_interface.a
+bluetooth_le_host/build/gcc/cortex-m33/system/release/libble_host_system.a
+# bgapi_protocol/build/gcc/cortex-m33 (all .a from connectedhomeip_silabs)
+bgapi_protocol/build/gcc/cortex-m33/bgapi_service/release/libbgapi_service.a
+bgapi_protocol/build/gcc/cortex-m33/bgapi_service/system/release/libbgapi_service_system.a
+bgapi_protocol/build/gcc/cortex-m33/bgapi_trace/release/libbgapi_trace_stub.a
+bgapi_protocol/build/gcc/cortex-m33/protocol/command/release/libbgapi_command.a
+bgapi_protocol/build/gcc/cortex-m33/protocol/core/release/libbgapi_core.a
+bgapi_protocol/build/gcc/cortex-m33/protocol/device/release/libbgapi_device.a
+bgapi_protocol/build/gcc/cortex-m33/protocol/event/release/libbgapi_event.a
+bgapi_protocol/build/gcc/cortex-m33/protocol/release/libbgapi_protocol.a
+bgapi_protocol/build/gcc/cortex-m33/rtos_adaptation/release/libbgapi_protocol_rtos_adaptation_stub.a
+rail_library/autogen/librail_release/librail_multiprotocol_efr32xg24_gcc_release.a
+rail_library/autogen/librail_release/librail_multiprotocol_module_efr32xg24_gcc_release.a
+rail_library/autogen/librail_release/librail_multiprotocol_efr32xg26_gcc_release.a
+rail_library/autogen/librail_release/librail_config_mgm240pb32vna_gcc.a
+rail_library/autogen/librail_release/librail_config_mgm240pb22vna_gcc.a
+rail_library/autogen/librail_release/librail_config_mgm240l022rnf_gcc.a
+rail_library/autogen/librail_release/librail_config_mgm240sd22vna_gcc.a
+
+# all (combined unique, alphabetical)
+bgapi_protocol
+bluetooth_apploader
+bluetooth_common
+bluetooth_le_controller
+bluetooth_le_host
+bluetooth_le_middleware
+bluetooth_mesh
+board_drivers
+boards
+bootloader
+bootloader_interface
+cmsis
+cmsis_common
+common_15_4
+devices
+freertos
+glib
+openthread
+openthread_stack
+platform
+platform_common
+platform_core
+rail_library
+segger
+security_mbedtls
+security_mbedtls_source
+security_se_manager
+util

--- a/scripts/setup/silabs/sisdk-pkg.lock
+++ b/scripts/setup/silabs/sisdk-pkg.lock
@@ -1,0 +1,7 @@
+version = "0"
+
+[dependency]
+  simplicity-sdk = [{ installer = "conan", ref = "simplicity-sdk/2025.12.1-alpha@silabs#9f22e7efe2ff3fe28eabf4c78d205883", type = "sdk", version = "2025.12.1-alpha" }]
+
+[engine]
+  conan-repos = ["https://conan-prerelease.silabs.net/"]

--- a/scripts/setup/silabs/sisdk-pkg.slt
+++ b/scripts/setup/silabs/sisdk-pkg.slt
@@ -1,0 +1,7 @@
+# Version defaults to "0" if not defined
+version = "0"
+ 
+ 
+[dependency]
+# Get a specific version of the package
+simplicity-sdk = { version = "2025.12.1-alpha@silabs", installer ="conan", prerelease=true }

--- a/scripts/setup/silabs/wiseconnect-pkg.slt
+++ b/scripts/setup/silabs/wiseconnect-pkg.slt
@@ -1,0 +1,7 @@
+# Version defaults to "0" if not defined
+version = "0"
+ 
+ 
+[dependency]
+# Get a specific version of the package
+wiseconnect = { version = "4.0.0", installer ="conan", prerelease=true }


### PR DESCRIPTION
####  Summary

This PR migrates Silicon Labs (Silabs) EFR32 Docker and repo setup from git submodules to SLT-based SDK installation, updates SDK versions, and adds a local install script and trim list for the Simplicity SDK.

---

## 1. SLT-based SDK installation (replacing git submodules)

Previously the Simplicity SDK and WiseConnect SDK were pulled as git submodules:

- `third_party/silabs/simplicity_sdk` from `SiliconLabs/simplicity_sdk.git` (e.g. v2025.6.0)
- `third_party/silabs/wifi_sdk` from `SiliconLabs/wiseconnect.git` (e.g. v3.5.0)

The repo now uses the SLT CLI to install SDKs from package manifests.

**Package manifests:**

- `sisdk-pkg.lock` – Locks Simplicity SDK 2025.12.1-alpha (Conan ref from Silabs prerelease repo).
- `sisdk-pkg.slt` – Simplicity SDK 2025.12.1-alpha.
- `wiseconnect-pkg.slt` – WiseConnect 4.0.0.

**Keep list:** `simplicity_sdk_keep_folders.txt` – Lists which top-level Simplicity SDK folders (and specific `.a` files) to keep when trimming the Docker image. Aligned with `SiWx917_sdk.gni` and `efr32_sdk.gni`.
Follow Up changes in : https://github.com/project-chip/connectedhomeip/pull/42981

---

## 2. Local setup script

- **`scripts/setup/silabs/install-packages.py`** – Downloads and installs the SLT CLI (Linux/macOS), runs `slt install -f` for `wiseconnect-pkg.slt` and `sisdk-pkg.lock`, and creates symlinks `third_party/silabs/simplicity_sdk` and `third_party/silabs/wifi_sdk` to the SLT-installed SDKs. Depends on the `dload` Python package (added to the Docker image `requirements.txt`).

---

## 3. Docker image changes

**`integrations/docker/images/stage-2/chip-build-efr32/Dockerfile`:**

- **SDK acquisition:** Uses SLT (`slt install -f`) with the repo’s `.slt`/`.lock` manifests instead of `git clone` for Simplicity SDK and WiseConnect.
- **SLC-CLI:** Installed via SLT (`slt install slc-cli`) instead of a direct zip URL.
- **Build stage:** Copies `sisdk-pkg.lock`, `wiseconnect-pkg.slt`, `docker/requirements.txt`, and `simplicity_sdk_keep_folders.txt` into the image; APT packages and pip requirements (including `dload`) are installed in the build stage before SLT install.
- **SDK trimming:** Uses `simplicity_sdk_keep_folders.txt` to prune the Simplicity SDK (folders and `.a` files). Board config trimming keeps the same pattern as before and adds boards: `brd1019a`, `brd2719a`, `brd4407a`, `brd4408a`. Device family `SIMG301` is kept. WiSeConnect is trimmed (e.g. remove `.git`, `examples`, `components/device/stm32`).
- **Final stage:** Pip install uses `docker/requirements.txt`; `GSDK_ROOT` remains `/opt/silabs/simplicity_sdk/` for compatibility.

**Base image version:** `integrations/docker/images/base/chip-build/version` is bumped to 187 with description "[Silabs] Update Silabs sdks".

---

## 4. New and updated files

| Path | Change |
|------|--------|
| `scripts/setup/silabs/install-packages.py` | New – SLT CLI + SDK install and symlinks |
| `scripts/setup/silabs/simplicity_sdk_keep_folders.txt` | New – Simplicity SDK trim list |
| `scripts/setup/silabs/sisdk-pkg.lock` | New – Simplicity SDK 2025.12.1-alpha lock |
| `scripts/setup/silabs/sisdk-pkg.slt` | New – Simplicity SDK manifest |
| `scripts/setup/silabs/wiseconnect-pkg.slt` | New – WiseConnect 4.0.0 manifest |
| `integrations/docker/images/stage-2/chip-build-efr32/Dockerfile` | Reworked for SLT and trimming |
| `integrations/docker/images/stage-2/chip-build-efr32/requirements.txt` | Added `dload` (for `install-packages.py`) |
| `integrations/docker/images/base/chip-build/version` | Bumped to 187 |

---

####  Related issues


#### Testing


---

#### Readability checklist

- [x] PR title is [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
- [x] Apply the [_"When in Rome…"_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html) rule (coding style)
- [x] PR size is short
- [x] Try to avoid "squashing" and "force-update" in commit history
- [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
