### PR TITLE
Python testing framework: Fix bug in print hex

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/matter/testing/conversions.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/conversions.py
@@ -84,7 +84,10 @@ def format_decimal_and_hex(number):
         >>> format_decimal_and_hex(255)
         '255 (0xff)'
     """
-    return f'{number} (0x{number:02x})'
+    try:
+        return f'{number} (0x{number:02x})'
+    except (TypeError, ValueError):
+        return f'{number}'
 
 
 def cluster_id_with_name(id):

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/conversions.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/conversions.py
@@ -107,17 +107,12 @@ def cluster_id_with_name(id):
         '6 (0x06) OnOff'
         >>> cluster_id_with_name(999999)  # Unknown cluster
         '999999 (0xf423f) Unknown cluster'
-        >>> cluster_id_with_name("invalid")  # Invalid input
-        'HERE IS THE PROBLEM'
     """
     if id in Clusters.ClusterObjects.ALL_CLUSTERS:
         s = Clusters.ClusterObjects.ALL_CLUSTERS[id].__name__
     else:
         s = "Unknown cluster"
-    try:
-        return f'{format_decimal_and_hex(id)} {s}'
-    except (TypeError, ValueError):
-        return 'HERE IS THE PROBLEM'
+    return f'{format_decimal_and_hex(id)} {s}'
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

#### Summary
If the value passed in is expected to be a number, but is actually an error, this will fail. Instead, just print directly.

#### Related issues

#### Testing
Tested with a failing device, saw error

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
