### PR TITLE
[Platform][Thread] Fix kLinkDown fault not removed when thread network link is up

### DIFF
--- a/src/include/platform/GeneralFaults.h
+++ b/src/include/platform/GeneralFaults.h
@@ -89,7 +89,7 @@ template <size_t N>
 inline CHIP_ERROR GeneralFaults<N>::remove(const uint8_t value)
 {
     int originalSize = mSize;
-    mSize = 0;
+    mSize            = 0;
     for (int i = 0; i < originalSize; ++i)
     {
         if (mData[i] != value)

--- a/src/include/platform/GeneralFaults.h
+++ b/src/include/platform/GeneralFaults.h
@@ -54,6 +54,7 @@ public:
     ~GeneralFaults() { mSize = 0; }
 
     CHIP_ERROR add(const uint8_t value);
+    CHIP_ERROR remove(const uint8_t value);
 
     const uint8_t * data() const { return mData; }
     size_t size() const;
@@ -82,6 +83,22 @@ inline CHIP_ERROR GeneralFaults<N>::add(const uint8_t value)
     mData[mSize] = value;
     ++mSize;
     return CHIP_NO_ERROR;
+}
+
+template <size_t N>
+inline CHIP_ERROR GeneralFaults<N>::remove(const uint8_t value)
+{
+    int originalSize = mSize;
+    mSize = 0;
+    for (int i = 0; i < originalSize; ++i)
+    {
+        if (mData[i] != value)
+        {
+            mData[mSize++] = mData[i];
+        }
+    }
+
+    return (mSize != originalSize) ? CHIP_NO_ERROR : CHIP_ERROR_KEY_NOT_FOUND;
 }
 
 template <size_t N>

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -225,6 +225,14 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnPlatformEvent(const
                 if (mIsAttached)
                 {
                     delegate->OnConnectionStatusChanged(app::Clusters::ThreadNetworkDiagnostics::ConnectionStatusEnum::kConnected);
+
+                    // Remove kLinkDown fault if it was set, as the device is now connected.
+                    GeneralFaults<kMaxNetworkFaults> current = mNetworkFaults;
+                    if (current.remove(to_underlying(chip::app::Clusters::ThreadNetworkDiagnostics::NetworkFaultEnum::kLinkDown)) == CHIP_NO_ERROR)
+                    {
+                        delegate->OnNetworkFaultChanged(mNetworkFaults, current);
+                        mNetworkFaults = current;
+                    }
                 }
                 else
                 {

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -228,7 +228,8 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnPlatformEvent(const
 
                     // Remove kLinkDown fault if it was set, as the device is now connected.
                     GeneralFaults<kMaxNetworkFaults> current = mNetworkFaults;
-                    if (current.remove(to_underlying(chip::app::Clusters::ThreadNetworkDiagnostics::NetworkFaultEnum::kLinkDown)) == CHIP_NO_ERROR)
+                    if (current.remove(to_underlying(chip::app::Clusters::ThreadNetworkDiagnostics::NetworkFaultEnum::kLinkDown)) ==
+                        CHIP_NO_ERROR)
                     {
                         delegate->OnNetworkFaultChanged(mNetworkFaults, current);
                         mNetworkFaults = current;

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -29,7 +29,7 @@ if (chip_device_platform != "none" && chip_device_platform != "fake") {
   chip_test_suite("tests") {
     output_name = "libPlatformTests"
 
-    test_sources = []
+    test_sources = [ "TestGeneralFaults.cpp" ]
     defines = [ "CALLER_HANDLES_CRITICAL_FAILURE=1" ]
 
     if (current_os != "zephyr") {

--- a/src/platform/tests/TestGeneralFaults.cpp
+++ b/src/platform/tests/TestGeneralFaults.cpp
@@ -1,0 +1,78 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+#include <platform/GeneralFaults.h>
+
+using namespace chip;
+using namespace chip::DeviceLayer;
+
+TEST(TestGeneralFaults, TestAddAndRemove)
+{
+    GeneralFaults<4> faults;
+
+    EXPECT_EQ(faults.size(), 0u);
+
+    // Add faults
+    EXPECT_EQ(faults.add(1), CHIP_NO_ERROR);
+    EXPECT_EQ(faults.add(2), CHIP_NO_ERROR);
+    EXPECT_EQ(faults.add(3), CHIP_NO_ERROR);
+    EXPECT_EQ(faults.add(1), CHIP_NO_ERROR);
+
+    EXPECT_EQ(faults.size(), 4u);
+    EXPECT_EQ(faults[0], 1);
+    EXPECT_EQ(faults[1], 2);
+    EXPECT_EQ(faults[2], 3);
+    EXPECT_EQ(faults[3], 1);
+
+    // Exceed capacity
+    EXPECT_EQ(faults.add(4), CHIP_ERROR_NO_MEMORY);
+
+    // Remove non-existent fault
+    EXPECT_EQ(faults.remove(4), CHIP_ERROR_KEY_NOT_FOUND);
+    EXPECT_EQ(faults.size(), 4u);
+
+    // Remove an existing fault (which appears twice)
+    EXPECT_EQ(faults.remove(1), CHIP_NO_ERROR);
+    EXPECT_EQ(faults.size(), 2u);
+    EXPECT_EQ(faults[0], 2);
+    EXPECT_EQ(faults[1], 3);
+
+    // Remove remaining faults
+    EXPECT_EQ(faults.remove(2), CHIP_NO_ERROR);
+    EXPECT_EQ(faults.size(), 1u);
+    EXPECT_EQ(faults[0], 3);
+
+    EXPECT_EQ(faults.remove(3), CHIP_NO_ERROR);
+    EXPECT_EQ(faults.size(), 0u);
+}
+
+TEST(TestGeneralFaults, TestIterator)
+{
+    GeneralFaults<3> faults;
+    EXPECT_EQ(faults.add(10), CHIP_NO_ERROR);
+    EXPECT_EQ(faults.add(20), CHIP_NO_ERROR);
+
+    auto it = faults.begin();
+    EXPECT_TRUE(it != faults.end());
+    EXPECT_EQ(*it, 10);
+    ++it;
+    EXPECT_TRUE(it != faults.end());
+    EXPECT_EQ(*it, 20);
+    ++it;
+    EXPECT_FALSE(it != faults.end());
+}

--- a/src/platform/tests/TestGeneralFaults.cpp
+++ b/src/platform/tests/TestGeneralFaults.cpp
@@ -15,8 +15,8 @@
  *    limitations under the License.
  */
 
-#include <pw_unit_test/framework.h>
 #include <platform/GeneralFaults.h>
+#include <pw_unit_test/framework.h>
 
 using namespace chip;
 using namespace chip::DeviceLayer;


### PR DESCRIPTION
This PR fixes an issue where the `kLinkDown` fault in `GenericThreadStackManagerImpl_OpenThread::_OnPlatformEvent` was correctly added when the thread connection state detached, but wasn't removed when the thread connection state reattached.

#### Changes
* Add a `remove` method to `GeneralFaults`
* Add unit tests `GeneralFaults`
* Use this new method in utilized in `GenericThreadStackManagerImpl_OpenThread` to clear the `kLinkDown` fault when a Thread network connection is re-established 

Fixes #43287

#### Testing

Added unit tests