### PR TITLE
Move GetPanId out of ThreadNetworkDiagnosticsProvider into OpenThreadUtils

### DIFF
--- a/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
@@ -31,7 +31,6 @@
 #include <platform/ThreadStackManager.h>
 #endif // (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
 
-
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;

--- a/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
@@ -177,16 +177,14 @@ void ThreadNetworkDiagnosticsCluster::OnConnectionStatusChanged(ConnectionStatus
     if (newConnectionStatus == ConnectionStatusEnum::kConnected)
     {
 #if (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
-        chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
-        ChipLogDetail(Zcl, "ThdDiag: Conn, PAN: 0x%04x", chip::DeviceLayer::Internal::GetOpenThreadPanId(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance()));
-        chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
+        ChipLogProgress(Zcl, "ThdDiag: Conn, PAN: 0x%04x", chip::DeviceLayer::Internal::GetOpenThreadPanId(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance()));
 #else
-        ChipLogDetail(Zcl, "ThdDiag: Conn");
+        ChipLogProgress(Zcl, "ThdDiag: Conn");
 #endif // (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
     }
     else
     {
-        ChipLogDetail(Zcl, "ThdDiag: Disconn");
+        ChipLogProgress(Zcl, "ThdDiag: Disconn");
     }
 
     VerifyOrReturn(mContext != nullptr);

--- a/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
@@ -176,15 +176,17 @@ void ThreadNetworkDiagnosticsCluster::OnConnectionStatusChanged(ConnectionStatus
 {
     if (newConnectionStatus == ConnectionStatusEnum::kConnected)
     {
-        uint16_t panId = 0xffff;
 #if (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
-        panId = chip::DeviceLayer::Internal::GetOpenThreadPanId(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance());
+        chip::DeviceLayer::ThreadStackMgr().LockThreadStack();
+        ChipLogDetail(Zcl, "ThdDiag: Conn, PAN: 0x%04x", chip::DeviceLayer::Internal::GetOpenThreadPanId(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance()));
+        chip::DeviceLayer::ThreadStackMgr().UnlockThreadStack();
+#else
+        ChipLogDetail(Zcl, "ThdDiag: Conn");
 #endif // (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
-        ChipLogProgress(Zcl, "ThdDiag: Conn, PAN: 0x%04x", panId);
     }
     else
     {
-        ChipLogProgress(Zcl, "ThdDiag: Disconn");
+        ChipLogDetail(Zcl, "ThdDiag: Disconn");
     }
 
     VerifyOrReturn(mContext != nullptr);
@@ -199,11 +201,11 @@ void ThreadNetworkDiagnosticsCluster::OnNetworkFaultChanged(const GeneralFaults<
     if (current.size() > 0)
     {
         [[maybe_unused]] uint8_t latestFault = current.data()[current.size() - 1];
-        ChipLogProgress(Zcl, "ThdDiag: Fault. Latest: %s (%u)", GetNetworkFaultString(latestFault), latestFault);
+        ChipLogDetail(Zcl, "ThdDiag: Fault. Latest: %s (%u)", GetNetworkFaultString(latestFault), latestFault);
     }
     else
     {
-        ChipLogProgress(Zcl, "ThdDiag: No faults");
+        ChipLogDetail(Zcl, "ThdDiag: No faults");
     }
 
     /* Verify that the data size matches the expected one. */

--- a/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
@@ -26,6 +26,12 @@
 #include <lib/support/BitFlags.h>
 #include <platform/CHIPDeviceLayer.h>
 
+#if (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
+#include <platform/OpenThread/OpenThreadUtils.h>
+#include <platform/ThreadStackManager.h>
+#endif // (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
+
+
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
@@ -171,7 +177,11 @@ void ThreadNetworkDiagnosticsCluster::OnConnectionStatusChanged(ConnectionStatus
 {
     if (newConnectionStatus == ConnectionStatusEnum::kConnected)
     {
-        ChipLogProgress(Zcl, "ThdDiag: Conn, PAN: 0x%04x", GetPanId());
+        uint16_t panId = 0xffff;
+#if (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
+        panId = chip::DeviceLayer::Internal::GetOpenThreadPanId(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance());
+#endif // (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
+        ChipLogProgress(Zcl, "ThdDiag: Conn, PAN: 0x%04x", panId);
     }
     else
     {

--- a/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
@@ -177,7 +177,8 @@ void ThreadNetworkDiagnosticsCluster::OnConnectionStatusChanged(ConnectionStatus
     if (newConnectionStatus == ConnectionStatusEnum::kConnected)
     {
 #if (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
-        ChipLogProgress(Zcl, "ThdDiag: Conn, PAN: 0x%04x", chip::DeviceLayer::Internal::GetOpenThreadPanId(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance()));
+        ChipLogProgress(Zcl, "ThdDiag: Conn, PAN: 0x%04x",
+                        chip::DeviceLayer::Internal::GetOpenThreadPanId(chip::DeviceLayer::ThreadStackMgrImpl().OTInstance()));
 #else
         ChipLogProgress(Zcl, "ThdDiag: Conn");
 #endif // (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)

--- a/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsProvider.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsProvider.cpp
@@ -732,21 +732,4 @@ CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, a
     return err;
 }
 
-uint16_t GetPanId()
-{
-#if (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
-    otInstance * otInst = ThreadStackMgrImpl().OTInstance();
-    if (otInst != nullptr)
-    {
-        otOperationalDataset aDataset;
-        otError otErr = otDatasetGetActive(otInst, &aDataset);
-        if (otErr == OT_ERROR_NONE && aDataset.mComponents.mIsPanIdPresent)
-        {
-            return aDataset.mPanId;
-        }
-    }
-#endif             // (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
-    return 0xffff; // 0xFFFF is an invalid PAN ID and indicates it is unconfigured/unavailable
-}
-
 } // namespace chip::app::Clusters::ThreadNetworkDiagnostics

--- a/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsProvider.h
+++ b/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsProvider.h
@@ -26,11 +26,4 @@ namespace chip::app::Clusters::ThreadNetworkDiagnostics {
 
 CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, app::AttributeValueEncoder & encoder);
 
-/*
- * @brief Get the Thread PAN ID.
- *        Returns 0xFFFF (invalid PAN ID) if the Thread instance is unavailable,
- *        Thread is not enabled, or there is no active dataset with a PAN ID present.
- */
-uint16_t GetPanId();
-
 } // namespace chip::app::Clusters::ThreadNetworkDiagnostics

--- a/src/platform/OpenThread/OpenThreadUtils.cpp
+++ b/src/platform/OpenThread/OpenThreadUtils.cpp
@@ -30,6 +30,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include <openthread/dataset.h>
 #include <openthread/error.h>
 
 #include <cstdio>
@@ -85,6 +86,20 @@ void RegisterOpenThreadErrorFormatter()
     static ErrorFormatter sOpenThreadErrorFormatter = { FormatOpenThreadError, NULL };
 
     RegisterErrorFormatter(&sOpenThreadErrorFormatter);
+}
+
+uint16_t GetOpenThreadPanId(otInstance * otInst)
+{
+    if (otInst != nullptr)
+    {
+        otOperationalDataset aDataset;
+        otError otErr = otDatasetGetActive(otInst, &aDataset);
+        if (otErr == OT_ERROR_NONE && aDataset.mComponents.mIsPanIdPresent)
+        {
+            return aDataset.mPanId;
+        }
+    }
+    return 0xffff; // 0xFFFF is an invalid PAN ID and indicates it is unconfigured/unavailable
 }
 
 void LogOpenThreadStateChange(otInstance * otInst, uint32_t flags)

--- a/src/platform/OpenThread/OpenThreadUtils.cpp
+++ b/src/platform/OpenThread/OpenThreadUtils.cpp
@@ -88,20 +88,6 @@ void RegisterOpenThreadErrorFormatter()
     RegisterErrorFormatter(&sOpenThreadErrorFormatter);
 }
 
-uint16_t GetOpenThreadPanId(otInstance * otInst)
-{
-    if (otInst != nullptr)
-    {
-        otOperationalDataset aDataset;
-        otError otErr = otDatasetGetActive(otInst, &aDataset);
-        if (otErr == OT_ERROR_NONE && aDataset.mComponents.mIsPanIdPresent)
-        {
-            return aDataset.mPanId;
-        }
-    }
-    return 0xffff; // 0xFFFF is an invalid PAN ID and indicates it is unconfigured/unavailable
-}
-
 void LogOpenThreadStateChange(otInstance * otInst, uint32_t flags)
 {
 #if CHIP_DETAIL_LOGGING
@@ -164,6 +150,20 @@ void LogOpenThreadStateChange(otInstance * otInst, uint32_t flags)
     }
 
 #endif // CHIP_DETAIL_LOGGING
+}
+
+uint16_t GetOpenThreadPanId(otInstance * otInst)
+{
+    if (otInst != nullptr)
+    {
+        otOperationalDataset aDataset;
+        otError otErr = otDatasetGetActive(otInst, &aDataset);
+        if (otErr == OT_ERROR_NONE && aDataset.mComponents.mIsPanIdPresent)
+        {
+            return aDataset.mPanId;
+        }
+    }
+    return 0xffff; // 0xFFFF is an invalid PAN ID and indicates it is unconfigured/unavailable
 }
 
 void LogOpenThreadPacket(const char * titleStr, otMessage * pkt)

--- a/src/platform/OpenThread/OpenThreadUtils.h
+++ b/src/platform/OpenThread/OpenThreadUtils.h
@@ -66,6 +66,12 @@ extern void RegisterOpenThreadErrorFormatter();
  *
  * NB: This function *must* be called with the Thread stack lock held.
  */
+/**
+ * @brief Get the Thread PAN ID.
+ *        Returns 0xFFFF (invalid PAN ID) if the Thread instance is unavailable,
+ *        Thread is not enabled, or there is no active dataset with a PAN ID present.
+ */
+extern uint16_t GetOpenThreadPanId(otInstance * otInst);
 extern void LogOpenThreadStateChange(otInstance * otInst, uint32_t flags);
 extern void LogOpenThreadPacket(const char * titleStr, otMessage * pkt);
 extern bool IsOpenThreadMeshLocalAddress(otInstance * otInst, const Inet::IPAddress & addr);

--- a/src/platform/OpenThread/OpenThreadUtils.h
+++ b/src/platform/OpenThread/OpenThreadUtils.h
@@ -66,13 +66,14 @@ extern void RegisterOpenThreadErrorFormatter();
  *
  * NB: This function *must* be called with the Thread stack lock held.
  */
+extern void LogOpenThreadStateChange(otInstance * otInst, uint32_t flags);
+
 /**
  * @brief Get the Thread PAN ID.
  *        Returns 0xFFFF (invalid PAN ID) if the Thread instance is unavailable,
  *        Thread is not enabled, or there is no active dataset with a PAN ID present.
  */
 extern uint16_t GetOpenThreadPanId(otInstance * otInst);
-extern void LogOpenThreadStateChange(otInstance * otInst, uint32_t flags);
 extern void LogOpenThreadPacket(const char * titleStr, otMessage * pkt);
 extern bool IsOpenThreadMeshLocalAddress(otInstance * otInst, const Inet::IPAddress & addr);
 extern const char * OpenThreadRoleToStr(otDeviceRole role);


### PR DESCRIPTION

Follow up from PR #43317. Moves GetPanID out of the provider and into a more generic location.


#### Testing

Ran unit tests and confirmed the logs show up as before.