### PR TITLE
[nrfconnect] Optimize NVM usage for nRF52840dk 

### DIFF
--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -143,10 +143,8 @@ jobs:
                     /tmp/bloat_reports/
                   rm -rf examples/shell/nrfconnect/build/nrfconnect
             - name: Build example nRF Connect SDK All Clusters App on nRF52840 DK
-              # Matter log level 2 == log_error only (no progress, no detail). We do this for all-clusters
-              # to reduce flash usage a bit.
               run: |
-                  scripts/examples/nrfconnect_example.sh all-clusters-app nrf52840dk/nrf52840 -DCONFIG_MATTER_LOG_LEVEL=2
+                  scripts/examples/nrfconnect_example.sh all-clusters-app nrf52840dk/nrf52840
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf52840dk_nrf52840 all-clusters-app \
                     examples/all-clusters-app/nrfconnect/build/nrfconnect/zephyr/zephyr.elf \
@@ -154,10 +152,8 @@ jobs:
                   rm -rf examples/all-clusters-app/nrfconnect/build/nrfconnect
             - name: Build example nRF Connect SDK All Clusters App on nRF54L15 DK
               if: github.event_name == 'push' || steps.changed_paths.outputs.nrfconnect == 'true'
-              # Matter log level 2 == log_error only (no progress, no detail). We do this for all-clusters
-              # to reduce flash usage a bit.
               run: |
-                  scripts/examples/nrfconnect_example.sh all-clusters-app nrf54l15dk/nrf54l15/cpuapp -DCONFIG_MATTER_LOG_LEVEL=2
+                  scripts/examples/nrfconnect_example.sh all-clusters-app nrf54l15dk/nrf54l15/cpuapp
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     nrfconnect nrf54l15dk_nrf54l15_cpuapp all-clusters-app \
                     examples/all-clusters-app/nrfconnect/build/nrfconnect/zephyr/zephyr.elf \

--- a/examples/all-clusters-app/nrfconnect/boards/nrf52840dk_nrf52840.conf
+++ b/examples/all-clusters-app/nrfconnect/boards/nrf52840dk_nrf52840.conf
@@ -1,0 +1,19 @@
+#
+#    Copyright (c) 2026 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Enable LTO to reduce the flash usage
+CONFIG_LTO=y
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y


### PR DESCRIPTION
#### Summary

Reducing NVM usage by ~100k with LTO enabled by default. Additionally, removed the temporary workaround that reduced log verbosity (for both nRF52840 and nRF54L15).

#### Testing

Compiled, flashed, and successfully completed Matter commissioning on the nRF52840DK.