### PR TITLE
[v1.5][Scene][LevelControl] Fix scene issue about optional MaxLevel attribute

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -173,9 +173,6 @@ public:
 
         AttributeValuePair pairs[kLevelMaxScenableAttributes];
 
-        uint8_t maxLevel;
-        VerifyOrReturnError(Status::Success == Attributes::MaxLevel::Get(endpoint, &maxLevel), CHIP_ERROR_READ_FAILED);
-
         pairs[0].attributeID = Attributes::CurrentLevel::Id;
         if (!level.IsNull())
         {


### PR DESCRIPTION
#### Summary

In the level control cluster, the max level attribute is optional and may not exist in the device. However, in the SerializeSave() function of the scene, if retrieving the max level attribute fails, it will cause the function to return an error.

https://github.com/project-chip/connectedhomeip/blob/d0538c5dfb1fb7e6a8c91c29bf45fdf7516ba7af/src/app/clusters/level-control/level-control.cpp#L177


#### Testing

Built and flashed the lighting example without implementing the MaxLevel attribute.

Verified that scene operations:

Add Scene

Store Scene

Recall Scene

Delete Scene
all complete successfully.

Confirmed no regression when MaxLevel is implemented (normal behavior preserved).

Manually validated scene serialization and recall behavior using standard controller commands.
