### PR TITLE
[SIlabs] [Docker] :  include lwip

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-188 : [Silabs] Fix Dockerfile paths
+189 : [Silabs] Keep lwip directories in Docker image

--- a/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
+++ b/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
@@ -37,6 +37,7 @@ common_15_4
 devices
 freertos
 glib
+lwip
 openthread
 openthread_stack
 platform

--- a/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
+++ b/integrations/docker/images/stage-2/chip-build-efr32/files-slt/simplicity_sdk_keep_folders.txt
@@ -151,6 +151,7 @@ common_15_4
 devices
 freertos
 glib
+lwip
 openthread
 openthread_stack
 platform


### PR DESCRIPTION
#### Summary
Problem: Docker image version 188 missing lwip contents

Resolution:
Added lwip directory in the simplicity_sdk_keep_folders.txt

#### Related issues

#### Testing
Ran ./integrations/docker/images/stage-2/chip-build-efr32/run.sh locally and validated contents.
Ran CI on a test package for Silabs https://github.com/project-chip/connectedhomeip/pull/42981

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
