### PR TITLE
Thread: clean commissioning proxy thread

### DIFF
--- a/src/controller/ThreadMeshcopCommissionProxy.cpp
+++ b/src/controller/ThreadMeshcopCommissionProxy.cpp
@@ -76,9 +76,14 @@ ThreadMeshcopCommissionProxy::ThreadMeshcopCommissionProxy() : mState(State::kCo
 
 ThreadMeshcopCommissionProxy::~ThreadMeshcopCommissionProxy()
 {
+    std::lock_guard<std::recursive_mutex> lock(mMutex);
     if (mProxyFd != -1)
     {
-        close(mProxyFd);
+        if (shutdown(mProxyFd, SHUT_RDWR) == 0 || errno != EBADF)
+        {
+            close(mProxyFd);
+        }
+
         mProxyFd = -1;
     }
 


### PR DESCRIPTION
#### Summary

This commit correctly notifies commissioning proxy Thread to stop by shutting down the proxy file descriptor. `close()` doesn't work because it only decreases the fd counter.

#### Related issues

#43321

#### Testing

Locally verified the `chip-tool` exits at the end of the commissioning. 