### PR TITLE
Enhance Laundry Dryer Controls cluster with  delegate methods

### DIFF
--- a/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-delegate.h
+++ b/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-delegate.h
@@ -19,6 +19,8 @@
 #pragma once
 
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/AttributeValueEncoder.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {
 namespace app {
@@ -41,6 +43,22 @@ public:
      * @return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED if the index is out of range for the list of supported dryness.
      */
     virtual CHIP_ERROR GetSupportedDrynessLevelAtIndex(size_t index, DrynessLevelEnum & supportedDryness) = 0;
+
+    /**
+     * Optional method to allow apps to enforce additional checks before setting the dryness level if required.
+     * @param newSelectedDrynessLevel The targetted dryness level.
+     * @return Protocols::InteractionModel::Status::Success if the action is allowed, an error code otherwise.
+     */
+    virtual Protocols::InteractionModel::Status CanSetSelectedDrynessLevel(const DrynessLevelEnum & newSelectedDrynessLevel);
+
+    /**
+     * Optional API to get the SelectedDrynessLevel attribute from delegate.
+     * @param selectedDrynessLevel To store the read result.
+     * @return Protocols::InteractionModel::Status::Success if the read was successful, Protocols::InteractionModel::Status::Failure
+     * otherwise.
+     */
+    virtual Protocols::InteractionModel::Status
+    GetSelectedDrynessLevel(DataModel::Nullable<DrynessLevelEnum> & selectedDrynessLevel);
 };
 
 } // namespace LaundryDryerControls

--- a/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-delegate.h
+++ b/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-delegate.h
@@ -49,7 +49,7 @@ public:
      * @param newSelectedDrynessLevel The targetted dryness level.
      * @return Protocols::InteractionModel::Status::Success if the action is allowed, an error code otherwise.
      */
-    virtual Protocols::InteractionModel::Status CanSetSelectedDrynessLevel(const DrynessLevelEnum & newSelectedDrynessLevel);
+    virtual Protocols::InteractionModel::Status CanSetSelectedDrynessLevel(DrynessLevelEnum newSelectedDrynessLevel);
 
     /**
      * Optional API to get the SelectedDrynessLevel attribute from delegate.

--- a/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-delegate.h
+++ b/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-delegate.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app/AttributeValueEncoder.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {

--- a/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-server.cpp
+++ b/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-server.cpp
@@ -48,7 +48,7 @@ static constexpr size_t kLaundryDryerControlsDelegateTableSize =
 // Delegate Implementation
 //
 
-Status Delegate::CanSetSelectedDrynessLevel(const DrynessLevelEnum & newSelectedDrynessLevel)
+Status Delegate::CanSetSelectedDrynessLevel(DrynessLevelEnum newSelectedDrynessLevel)
 {
     return Status::Success;
 }

--- a/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-server.cpp
+++ b/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-server.cpp
@@ -47,6 +47,17 @@ static constexpr size_t kLaundryDryerControlsDelegateTableSize =
 // -----------------------------------------------------------------------------
 // Delegate Implementation
 //
+
+Status Delegate::CanSetSelectedDrynessLevel(const DrynessLevelEnum & newSelectedDrynessLevel)
+{
+    return Status::Success;
+}
+
+Status Delegate::GetSelectedDrynessLevel(DataModel::Nullable<DrynessLevelEnum> & selectedDrynessLevel)
+{
+    return Status::Failure;
+}
+
 namespace {
 Delegate * gDelegateTable[kLaundryDryerControlsDelegateTableSize] = { nullptr };
 }
@@ -98,6 +109,14 @@ Status LaundryDryerControlsServer::SetSelectedDrynessLevel(EndpointId endpointId
 Status LaundryDryerControlsServer::GetSelectedDrynessLevel(EndpointId endpointId,
                                                            DataModel::Nullable<DrynessLevelEnum> & selectedDrynessLevel)
 {
+    Delegate * delegate = GetDelegate(endpointId);
+    if (delegate != nullptr)
+    {
+        Status res = delegate->GetSelectedDrynessLevel(selectedDrynessLevel);
+        if (res == Status::Success)
+            return res;
+    }
+
     return SelectedDrynessLevel::Get(endpointId, selectedDrynessLevel);
 }
 
@@ -113,6 +132,15 @@ CHIP_ERROR LaundryDryerControlsServer::Read(const ConcreteReadAttributePath & aP
     }
     switch (aPath.mAttributeId)
     {
+    case Attributes::SelectedDrynessLevel::Id: {
+        DataModel::Nullable<DrynessLevelEnum> selectedDrynessLevel;
+        Status status = GetSelectedDrynessLevel(aPath.mEndpointId, selectedDrynessLevel);
+        if (status != Status::Success)
+        {
+            return CHIP_ERROR_IM_GLOBAL_STATUS_VALUE(status);
+        }
+        return aEncoder.Encode(selectedDrynessLevel);
+    }
     case Attributes::SupportedDrynessLevels::Id:
         return ReadSupportedDrynessLevels(aPath, aEncoder);
     default:
@@ -167,6 +195,11 @@ Status MatterLaundryDryerControlsClusterServerPreAttributeChangedCallback(const 
     switch (attributePath.mAttributeId)
     {
     case Attributes::SelectedDrynessLevel::Id: {
+        Status canSet = delegate->CanSetSelectedDrynessLevel(static_cast<DrynessLevelEnum>(*value));
+        if (canSet != Status::Success)
+        {
+            return canSet;
+        }
         uint8_t drynessLevelIdx = 0;
         if (NumericAttributeTraits<uint8_t>::IsNullValue(*value))
         {


### PR DESCRIPTION
…ness level validation  and dynamic read overrides.

#### Summary

This PR introduces two new virtual methods to the LaundryDryerControls::Delegate class:
  CanSetSelectedDrynessLevel and GetSelectedDrynessLevel. These additions allow
  application-specific logic to override the default behavior for the SelectedDrynessLevel
  attribute, enabling scenarios such as:
   - Restricting dryness level changes during an active operational cycle.
   - Dynamically returning a null value for the dryness level when the device is powered
     off.

  The server implementation has been updated to integrate these delegate methods into both
  the attribute read and write paths.

#### Testing

Tested in CI.