### PR TITLE
Thread: common openthread.gni for Linux target

### DIFF
--- a/examples/air-purifier-app/linux/args.gni
+++ b/examples/air-purifier-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/air-quality-sensor-app/linux/args.gni
+++ b/examples/air-quality-sensor-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/all-clusters-app/linux/args.gni
+++ b/examples/all-clusters-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"
@@ -32,22 +33,3 @@ chip_enable_boolean_state_configuration_trigger = true
 chip_enable_software_diagnostics_trigger = true
 chip_enable_wifi_diagnostics_trigger = true
 chip_minmdns_high_verbosity = true
-
-_openthread_config_file =
-    rebase_path(
-        get_path_info("${chip_root}/third_party/openthread/openthread-config.h",
-                      "abspath"))
-openthread_config_file = "\"$_openthread_config_file\""
-openthread_config_ecdsa_enable = true
-openthread_config_ip6_slaac_enable = true
-openthread_config_full_logs = true
-openthread_config_joiner_enable = true
-openthread_config_log_output = "platform_defined"
-openthread_config_srp_client_enable = true
-openthread_config_tcp_enable = false
-openthread_config_tmf_netdata_service_enable = true
-openthread_enable_core_config_args = true
-openthread_project_core_config_file = rebase_path(
-        get_path_info(
-            "${chip_root}/third_party/openthread/repo/examples/platforms/simulation/openthread-core-simulation-config.h",
-            "abspath"))

--- a/examples/all-clusters-minimal-app/linux/args.gni
+++ b/examples/all-clusters-minimal-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/bridge-app/linux/args.gni
+++ b/examples/bridge-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/camera-app/linux/args.gni
+++ b/examples/camera-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/closure-app/linux/args.gni
+++ b/examples/closure-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/contact-sensor-app/linux/args.gni
+++ b/examples/contact-sensor-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/dishwasher-app/linux/args.gni
+++ b/examples/dishwasher-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/energy-gateway-app/linux/args.gni
+++ b/examples/energy-gateway-app/linux/args.gni
@@ -19,6 +19,7 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/pigweed.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/evse-app/linux/args.gni
+++ b/examples/evse-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/fabric-bridge-app/linux/args.gni
+++ b/examples/fabric-bridge-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/jf-admin-app/linux/args.gni
+++ b/examples/jf-admin-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 import("//with_pw_rpc.gni")
 

--- a/examples/lighting-app-data-mode-no-unique-id/linux/args.gni
+++ b/examples/lighting-app-data-mode-no-unique-id/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/lighting-app/linux/args.gni
+++ b/examples/lighting-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/lit-icd-app/linux/args.gni
+++ b/examples/lit-icd-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/lock-app/linux/args.gni
+++ b/examples/lock-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/log-source-app/linux/args.gni
+++ b/examples/log-source-app/linux/args.gni
@@ -15,5 +15,6 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 matter_enable_tracing_support = true

--- a/examples/microwave-oven-app/linux/args.gni
+++ b/examples/microwave-oven-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/network-manager-app/linux/args.gni
+++ b/examples/network-manager-app/linux/args.gni
@@ -14,6 +14,7 @@
 
 import("//build_overrides/chip.gni")
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include_dirs = [

--- a/examples/ota-provider-app/linux/args.gni
+++ b/examples/ota-provider-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/ota-requestor-app/linux/args.gni
+++ b/examples/ota-requestor-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/persistent-storage/linux/args.gni
+++ b/examples/persistent-storage/linux/args.gni
@@ -15,4 +15,5 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 matter_enable_tracing_support = true

--- a/examples/placeholder/linux/args.gni
+++ b/examples/placeholder/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectConfig.h>"
 chip_project_config_include = "<CHIPProjectConfig.h>"

--- a/examples/platform/linux/openthread.gni
+++ b/examples/platform/linux/openthread.gni
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+_openthread_config_file =
+    rebase_path(
+        get_path_info("${chip_root}/third_party/openthread/openthread-config.h",
+                      "abspath"))
+openthread_config_file = "\"$_openthread_config_file\""
+openthread_config_ecdsa_enable = true
+openthread_config_ip6_slaac_enable = true
+openthread_config_full_logs = true
+openthread_config_joiner_enable = true
+openthread_config_log_output = "platform_defined"
+openthread_config_srp_client_enable = true
+openthread_config_tcp_enable = false
+openthread_config_tmf_netdata_service_enable = true
+openthread_enable_core_config_args = true
+openthread_project_core_config_file = rebase_path(
+        get_path_info(
+            "${chip_root}/third_party/openthread/repo/examples/platforms/simulation/openthread-core-simulation-config.h",
+            "abspath"))

--- a/examples/refrigerator-app/linux/args.gni
+++ b/examples/refrigerator-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/rvc-app/linux/args.gni
+++ b/examples/rvc-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/terms-and-conditions-app/linux/args.gni
+++ b/examples/terms-and-conditions-app/linux/args.gni
@@ -14,5 +14,6 @@
 
 import("//build_overrides/chip.gni")
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_terms_and_conditions_required = true

--- a/examples/thermostat/linux/args.gni
+++ b/examples/thermostat/linux/args.gni
@@ -15,4 +15,5 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 matter_enable_tracing_support = true

--- a/examples/tv-app/linux/args.gni
+++ b/examples/tv-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/tv-casting-app/linux/args.gni
+++ b/examples/tv-casting-app/linux/args.gni
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/water-heater-app/linux/args.gni
+++ b/examples/water-heater-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"

--- a/examples/water-leak-detector-app/linux/args.gni
+++ b/examples/water-leak-detector-app/linux/args.gni
@@ -17,6 +17,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+import("${chip_root}/examples/platform/linux/openthread.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_project_config_include = "<CHIPProjectAppConfig.h>"


### PR DESCRIPTION
#### Summary

This commit adds an common gn import file that shared by all linux platform targets, so that we don't need to add the default configuration for Thread on Linux platform one by one.

#### Related issues

This is purely enhancement.

#### Testing

This change is going to be covered by Thread related CI tests, including the BLE-Thread and Thread-MeshCoP tests.
