### PR TITLE
[ESP32]: fix overloaded-virtual warning in ESP32P256Keypair

### DIFF
--- a/src/platform/ESP32/ESP32CHIPCryptoPAL.h
+++ b/src/platform/ESP32/ESP32CHIPCryptoPAL.h
@@ -30,6 +30,8 @@ namespace Crypto {
 class ESP32P256Keypair : public P256Keypair
 {
 public:
+    using P256Keypair::Initialize;
+
     /**
      * @brief Initialize the keypair with efuse block key
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise


### PR DESCRIPTION
#### Summary
Fix overloaded-virtual warning caused by class ESP32P256Keypair

warning log:
```
In file included from ../../../../../../config/esp32/third_party/connectedhomeip/src/credentials/CHIPCert.h:33,
                 from ../../../../../../config/esp32/third_party/connectedhomeip/src/platform/ESP32/ESP32SecureCertDACProvider.cpp:18:
../../../../../../config/esp32/third_party/connectedhomeip/src/crypto/CHIPCryptoPAL.h:572:16: error: 'virtual CHIP_ERROR chip::Crypto::P256Keypair::Initialize(chip::Crypto::ECPKeyTarget)' was hidden [-Werror=overloaded-virtual=]
  572 |     CHIP_ERROR Initialize(ECPKeyTarget key_target) override;
      |                ^~~~~~~~~~
In file included from ../../../../../../config/esp32/third_party/connectedhomeip/src/platform/ESP32/ESP32SecureCertDACProvider.cpp:27:
../../../../../../config/esp32/third_party/connectedhomeip/src/platform/ESP32/ESP32CHIPCryptoPAL.h:39:16: note:   by 'CHIP_ERROR chip::Crypto::ESP32P256Keypair::Initialize(chip::Crypto::ECPKeyTarget, int)'
   39 |     CHIP_ERROR Initialize(ECPKeyTarget keyTarget, int efuseBlock);
   ```

#### Testing
Test lighting example on esp32c5 with CONFIG_SEC_CERT_DAC_PROVIDER and CONFIG_USE_ESP32_ECDSA_PERIPHERAL enabled.
