### PR TITLE
[Tizen] Fix platform version parsing for Tizen >= 10.0

### DIFF
--- a/src/platform/Tizen/SystemInfo.cpp
+++ b/src/platform/Tizen/SystemInfo.cpp
@@ -50,9 +50,11 @@ CHIP_ERROR SystemInfo::GetPlatformVersion(PlatformVersion & version)
         return MATTER_PLATFORM_ERROR(ret);
     }
 
-    sInstance.mMajor = version.mMajor = (uint8_t) (platformVersion[0] - '0');
-    sInstance.mMinor = version.mMinor = (uint8_t) (platformVersion[2] - '0');
+    sscanf(platformVersion, "%hhu.%hhu", &sInstance.mMajor, &sInstance.mMinor);
     free(platformVersion);
+
+    version.mMajor = sInstance.mMajor;
+    version.mMinor = sInstance.mMinor;
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/Tizen/SystemInfo.cpp
+++ b/src/platform/Tizen/SystemInfo.cpp
@@ -44,14 +44,13 @@ CHIP_ERROR SystemInfo::GetPlatformVersion(PlatformVersion & version)
     }
 
     ret = system_info_get_platform_string("http://tizen.org/feature/platform.version", &platformVersion);
-    if (ret != SYSTEM_INFO_ERROR_NONE)
-    {
-        ChipLogError(DeviceLayer, "system_info_get_platform_string() failed: %s", get_error_message(ret));
-        return MATTER_PLATFORM_ERROR(ret);
-    }
+    VerifyOrReturnError(ret == SYSTEM_INFO_ERROR_NONE, MATTER_PLATFORM_ERROR(ret));
 
-    sscanf(platformVersion, "%hhu.%hhu", &sInstance.mMajor, &sInstance.mMinor);
+    ret = sscanf(platformVersion, "%hhu.%hhu", &sInstance.mMajor, &sInstance.mMinor);
     free(platformVersion);
+
+    // Make sure we got both major and minor version numbers.
+    VerifyOrReturnError(ret == 2, CHIP_ERROR_INVALID_ARGUMENT);
 
     version.mMajor = sInstance.mMajor;
     version.mMinor = sInstance.mMinor;


### PR DESCRIPTION
#### Summary

For Tizen SDK >= 10.0 the version parser does not work properly:
```
[1772447902.113] [635:635] [DL] Tizen Version: 1.254 
```

#### Testing

Verified locally on Tizen 10.0:
```
...
INFO    [1772449730.868] [638:660] [DL] Set WiFi IP conflict callback
INFO    [1772449730.878] [638:638] [DL] Tizen Version: 10.0
...
```