### PR TITLE
[coverage] increase coverage job RAM from 8GB to 16GB

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -526,7 +526,10 @@ jobs:
         if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
         # Use namespace to get more disk space and slightly better performance (Compile and unit tests
         # are CPU bound)
-        runs-on: namespace-profile-4x8
+        #
+        # Extra RAM is to try to avoid "Killed by exit code 137" which seems to occur during test runs
+        # on a 4x8 machine.
+        runs-on: namespace-profile-4x16
 
         container:
             image: ghcr.io/project-chip/chip-build:181


### PR DESCRIPTION
#### Summary

We seem to get "terminated with exit code 137" which seems to indicate a kill due to OOM, so try to allocate more RAM.

Examples:

https://github.com/project-chip/connectedhomeip/actions/runs/22511129776/job/65220393105
https://github.com/project-chip/connectedhomeip/actions/runs/22509854409/job/65216625316

#### Testing

CI will run coverage.