### PR TITLE
[Tizen] Simplify DNS-SD context handling

### DIFF
--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -404,8 +404,8 @@ DnssdTizen DnssdTizen::sInstance;
 
 RegisterContext::RegisterContext(DnssdTizen & instance, const char * type, const DnssdService & service,
                                  DnssdPublishCallback callback, void * context) :
-    mInstance(instance), mInterfaceId(service.mInterface.GetPlatformInterface()), mPort(service.mPort), mCallback(callback),
-    mCbContext(context)
+    mInstance(instance),
+    mInterfaceId(service.mInterface.GetPlatformInterface()), mPort(service.mPort), mCallback(callback), mCbContext(context)
 {
     Platform::CopyString(mName, service.mName);
     Platform::CopyString(mType, type);
@@ -425,7 +425,8 @@ RegisterContext::~RegisterContext()
 
 BrowseContext::BrowseContext(DnssdTizen & instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
                              DnssdBrowseCallback callback, void * context) :
-    mInstance(instance), mProtocol(protocol), mInterfaceId(interfaceId), mCallback(callback), mCbContext(context)
+    mInstance(instance),
+    mProtocol(protocol), mInterfaceId(interfaceId), mCallback(callback), mCbContext(context)
 {
     Platform::CopyString(mType, type);
 }
@@ -441,7 +442,8 @@ BrowseContext::~BrowseContext()
 
 ResolveContext::ResolveContext(DnssdTizen & instance, const char * name, const char * type, uint32_t interfaceId,
                                DnssdResolveCallback callback, void * context) :
-    mInstance(instance), mInterfaceId(interfaceId), mCallback(callback), mCbContext(context)
+    mInstance(instance),
+    mInterfaceId(interfaceId), mCallback(callback), mCbContext(context)
 {
     Platform::CopyString(mName, name);
     Platform::CopyString(mType, type);

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -668,22 +668,34 @@ ResolveContext * DnssdTizen::CreateResolveContext(const char * name, const char 
 void DnssdTizen::RemoveContext(RegisterContext * context)
 {
     std::lock_guard<std::mutex> lock(mMutex);
-    mRegisterContexts.erase(std::find_if(mRegisterContexts.begin(), mRegisterContexts.end(),
-                                         [context](const auto & ctx) { return ctx.get() == context; }));
+    auto it = std::find_if(mRegisterContexts.begin(), mRegisterContexts.end(),
+                           [context](const auto & ctx) { return ctx.get() == context; });
+    if (it != mRegisterContexts.end())
+    {
+        mRegisterContexts.erase(it);
+    }
 }
 
 void DnssdTizen::RemoveContext(BrowseContext * context)
 {
     std::lock_guard<std::mutex> lock(mMutex);
-    mBrowseContexts.erase(
-        std::find_if(mBrowseContexts.begin(), mBrowseContexts.end(), [context](const auto & ctx) { return ctx.get() == context; }));
+    auto it =
+        std::find_if(mBrowseContexts.begin(), mBrowseContexts.end(), [context](const auto & ctx) { return ctx.get() == context; });
+    if (it != mBrowseContexts.end())
+    {
+        mBrowseContexts.erase(it);
+    }
 }
 
 void DnssdTizen::RemoveContext(ResolveContext * context)
 {
     std::lock_guard<std::mutex> lock(mMutex);
-    mResolveContexts.erase(std::find_if(mResolveContexts.begin(), mResolveContexts.end(),
-                                        [context](const auto & ctx) { return ctx.get() == context; }));
+    auto it = std::find_if(mResolveContexts.begin(), mResolveContexts.end(),
+                           [context](const auto & ctx) { return ctx.get() == context; });
+    if (it != mResolveContexts.end())
+    {
+        mResolveContexts.erase(it);
+    }
 }
 
 CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -89,7 +89,7 @@ void OnRegister(dnssd_error_e result, dnssd_service_h service, void * data)
         ChipLogError(DeviceLayer, "DNSsd %s: Error: %s", __func__, get_error_message(result));
         rCtx->mCallback(rCtx->mCbContext, nullptr, nullptr, MATTER_PLATFORM_ERROR(result));
         // After this point, the context might be no longer valid
-        TEMPORARY_RETURN_IGNORED rCtx->mInstance->RemoveContext(rCtx);
+        rCtx->mInstance.RemoveContext(rCtx);
         return;
     }
 
@@ -117,7 +117,7 @@ gboolean OnBrowseTimeout(void * userData)
     bCtx->mCallback(bCtx->mCbContext, bCtx->mServices.data(), bCtx->mServices.size(), true, CHIP_NO_ERROR);
 
     // After this point the context might be no longer valid
-    TEMPORARY_RETURN_IGNORED bCtx->mInstance->RemoveContext(bCtx);
+    bCtx->mInstance.RemoveContext(bCtx);
 
     // This is a one-shot timer
     return G_SOURCE_REMOVE;
@@ -210,7 +210,7 @@ exit:
     {
         bCtx->mCallback(bCtx->mCbContext, nullptr, 0, true, MATTER_PLATFORM_ERROR(ret));
         // After this point the context might be no longer valid
-        TEMPORARY_RETURN_IGNORED bCtx->mInstance->RemoveContext(bCtx);
+        bCtx->mInstance.RemoveContext(bCtx);
     }
 }
 
@@ -344,7 +344,7 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * userData)
         ChipLogProgress(DeviceLayer, "DNSsd Handle resolve task on schedule lambda");
 
         rCtx->Finalize(CHIP_NO_ERROR);
-        TEMPORARY_RETURN_IGNORED rCtx->mInstance->RemoveContext(rCtx);
+        rCtx->mInstance.RemoveContext(rCtx);
     });
     VerifyOrExit(err == CHIP_NO_ERROR,
                  ChipLogError(DeviceLayer, "Failed to schedule resolve task: %" CHIP_ERROR_FORMAT, err.Format()));
@@ -353,7 +353,7 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * userData)
 
 exit:
     rCtx->Finalize(ret != DNSSD_ERROR_NONE ? MATTER_PLATFORM_ERROR(ret) : err);
-    TEMPORARY_RETURN_IGNORED rCtx->mInstance->RemoveContext(rCtx);
+    rCtx->mInstance.RemoveContext(rCtx);
 }
 
 CHIP_ERROR ResolveAsync(chip::Dnssd::ResolveContext * rCtx)
@@ -402,17 +402,13 @@ namespace Dnssd {
 
 DnssdTizen DnssdTizen::sInstance;
 
-RegisterContext::RegisterContext(DnssdTizen * instance, const char * type, const DnssdService & service,
+RegisterContext::RegisterContext(DnssdTizen & instance, const char * type, const DnssdService & service,
                                  DnssdPublishCallback callback, void * context) :
-    GenericContext(ContextType::Register, instance)
+    mInstance(instance), mInterfaceId(service.mInterface.GetPlatformInterface()), mPort(service.mPort), mCallback(callback),
+    mCbContext(context)
 {
     Platform::CopyString(mName, service.mName);
     Platform::CopyString(mType, type);
-    mInterfaceId = service.mInterface.GetPlatformInterface();
-    mPort        = service.mPort;
-
-    mCallback  = callback;
-    mCbContext = context;
 }
 
 RegisterContext::~RegisterContext()
@@ -427,16 +423,11 @@ RegisterContext::~RegisterContext()
     }
 }
 
-BrowseContext::BrowseContext(DnssdTizen * instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
+BrowseContext::BrowseContext(DnssdTizen & instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
                              DnssdBrowseCallback callback, void * context) :
-    GenericContext(ContextType::Browse, instance)
+    mInstance(instance), mProtocol(protocol), mInterfaceId(interfaceId), mCallback(callback), mCbContext(context)
 {
     Platform::CopyString(mType, type);
-    mProtocol    = protocol;
-    mInterfaceId = interfaceId;
-
-    mCallback  = callback;
-    mCbContext = context;
 }
 
 BrowseContext::~BrowseContext()
@@ -448,16 +439,12 @@ BrowseContext::~BrowseContext()
     }
 }
 
-ResolveContext::ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId,
+ResolveContext::ResolveContext(DnssdTizen & instance, const char * name, const char * type, uint32_t interfaceId,
                                DnssdResolveCallback callback, void * context) :
-    GenericContext(ContextType::Resolve, instance)
+    mInstance(instance), mInterfaceId(interfaceId), mCallback(callback), mCbContext(context)
 {
     Platform::CopyString(mName, name);
     Platform::CopyString(mType, type);
-    mInterfaceId = interfaceId;
-
-    mCallback  = callback;
-    mCbContext = context;
 }
 
 void ResolveContext::Finalize(CHIP_ERROR error)
@@ -508,16 +495,16 @@ CHIP_ERROR DnssdTizen::RegisterService(const DnssdService & service, DnssdPublis
     { // If the service was already registered, update it
         std::lock_guard<std::mutex> lock(mMutex);
 
-        auto iServiceCtx = std::find_if(mContexts.begin(), mContexts.end(), [fullType, service, interfaceId](const auto & ctx) {
-            VerifyOrReturnValue(ctx->mContextType == ContextType::Register, false);
-            auto * rCtx = static_cast<RegisterContext *>(ctx.get());
-            return strcmp(rCtx->mName, service.mName) == 0 && strcmp(rCtx->mType, fullType.c_str()) == 0 &&
-                rCtx->mPort == service.mPort && rCtx->mInterfaceId == interfaceId;
-        });
-        if (iServiceCtx != mContexts.end())
+        auto iServiceCtx =
+            std::find_if(mRegisterContexts.begin(), mRegisterContexts.end(), [fullType, &service, interfaceId](const auto & ctx) {
+                RegisterContext * rCtx = ctx.get();
+                return strcmp(rCtx->mName, service.mName) == 0 && strcmp(rCtx->mType, fullType.c_str()) == 0 &&
+                    rCtx->mPort == service.mPort && rCtx->mInterfaceId == interfaceId;
+            });
+        if (iServiceCtx != mRegisterContexts.end())
         {
             ChipLogDetail(DeviceLayer, "DNSsd %s: Updating TXT records", __func__);
-            auto serviceHandle = static_cast<RegisterContext *>(iServiceCtx->get())->mServiceHandle;
+            auto serviceHandle = iServiceCtx->get()->mServiceHandle;
 
             for (size_t i = 0; i < service.mTextEntrySize; ++i)
             {
@@ -582,7 +569,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     { // Notify caller about error
         callback(context, nullptr, nullptr, err);
-        TEMPORARY_RETURN_IGNORED RemoveContext(serviceCtx);
+        RemoveContext(serviceCtx);
     }
     return err;
 }
@@ -591,17 +578,10 @@ CHIP_ERROR DnssdTizen::UnregisterAllServices()
 {
     std::lock_guard<std::mutex> lock(mMutex);
 
-    unsigned int numServices = 0;
-    for (auto it = mContexts.begin(); it != mContexts.end(); it++)
-    {
-        if ((*it)->mContextType == ContextType::Register)
-        {
-            mContexts.erase(it--);
-            numServices++;
-        }
-    }
+    ChipLogDetail(DeviceLayer, "DNSsd %s: Removing %u registered services", __func__,
+                  static_cast<unsigned int>(mRegisterContexts.size()));
+    mRegisterContexts.clear();
 
-    ChipLogDetail(DeviceLayer, "DNSsd %s: %u", __func__, numServices);
     return CHIP_NO_ERROR;
 }
 
@@ -621,7 +601,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     { // Notify caller about error
         callback(context, nullptr, 0, true, err);
-        TEMPORARY_RETURN_IGNORED RemoveContext(browseCtx);
+        RemoveContext(browseCtx);
     }
     return err;
 }
@@ -643,18 +623,18 @@ CHIP_ERROR DnssdTizen::Resolve(const DnssdService & browseResult, chip::Inet::In
 
 exit:
     if (err != CHIP_NO_ERROR)
-        TEMPORARY_RETURN_IGNORED RemoveContext(resolveCtx);
+        RemoveContext(resolveCtx);
     return err;
 }
 
 RegisterContext * DnssdTizen::CreateRegisterContext(const char * type, const DnssdService & service, DnssdPublishCallback callback,
                                                     void * context)
 {
-    auto ctx    = std::make_unique<RegisterContext>(this, type, service, callback, context);
+    auto ctx    = std::make_unique<RegisterContext>(*this, type, service, callback, context);
     auto ctxPtr = ctx.get();
 
     std::lock_guard<std::mutex> lock(mMutex);
-    mContexts.emplace(std::move(ctx));
+    mRegisterContexts.emplace(std::move(ctx));
 
     return ctxPtr;
 }
@@ -662,11 +642,11 @@ RegisterContext * DnssdTizen::CreateRegisterContext(const char * type, const Dns
 BrowseContext * DnssdTizen::CreateBrowseContext(const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
                                                 DnssdBrowseCallback callback, void * context)
 {
-    auto ctx    = std::make_unique<BrowseContext>(this, type, protocol, interfaceId, callback, context);
+    auto ctx    = std::make_unique<BrowseContext>(*this, type, protocol, interfaceId, callback, context);
     auto ctxPtr = ctx.get();
 
     std::lock_guard<std::mutex> lock(mMutex);
-    mContexts.emplace(std::move(ctx));
+    mBrowseContexts.emplace(std::move(ctx));
 
     return ctxPtr;
 }
@@ -674,20 +654,34 @@ BrowseContext * DnssdTizen::CreateBrowseContext(const char * type, Dnssd::DnssdS
 ResolveContext * DnssdTizen::CreateResolveContext(const char * name, const char * type, uint32_t interfaceId,
                                                   DnssdResolveCallback callback, void * context)
 {
-    auto ctx    = std::make_unique<ResolveContext>(this, name, type, interfaceId, callback, context);
+    auto ctx    = std::make_unique<ResolveContext>(*this, name, type, interfaceId, callback, context);
     auto ctxPtr = ctx.get();
 
     std::lock_guard<std::mutex> lock(mMutex);
-    mContexts.emplace(std::move(ctx));
+    mResolveContexts.emplace(std::move(ctx));
 
     return ctxPtr;
 }
 
-CHIP_ERROR DnssdTizen::RemoveContext(GenericContext * context)
+void DnssdTizen::RemoveContext(RegisterContext * context)
 {
     std::lock_guard<std::mutex> lock(mMutex);
-    mContexts.erase(std::find_if(mContexts.begin(), mContexts.end(), [context](const auto & ctx) { return ctx.get() == context; }));
-    return CHIP_NO_ERROR;
+    mRegisterContexts.erase(std::find_if(mRegisterContexts.begin(), mRegisterContexts.end(),
+                                         [context](const auto & ctx) { return ctx.get() == context; }));
+}
+
+void DnssdTizen::RemoveContext(BrowseContext * context)
+{
+    std::lock_guard<std::mutex> lock(mMutex);
+    mBrowseContexts.erase(
+        std::find_if(mBrowseContexts.begin(), mBrowseContexts.end(), [context](const auto & ctx) { return ctx.get() == context; }));
+}
+
+void DnssdTizen::RemoveContext(ResolveContext * context)
+{
+    std::lock_guard<std::mutex> lock(mMutex);
+    mResolveContexts.erase(std::find_if(mResolveContexts.begin(), mResolveContexts.end(),
+                                        [context](const auto & ctx) { return ctx.get() == context; }));
 }
 
 CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -39,24 +39,9 @@ namespace Dnssd {
 
 class DnssdTizen;
 
-enum class ContextType
+struct RegisterContext
 {
-    Register,
-    Browse,
-    Resolve,
-};
-
-struct GenericContext
-{
-    ContextType mContextType;
-    DnssdTizen * mInstance;
-
-    GenericContext(ContextType contextType, DnssdTizen * instance) : mContextType(contextType), mInstance(instance) {}
-    virtual ~GenericContext() = default;
-};
-
-struct RegisterContext : public GenericContext
-{
+    DnssdTizen & mInstance;
     char mName[Common::kInstanceNameMaxLength + 1];
     char mType[kDnssdTypeAndProtocolMaxSize + 1];
     uint32_t mInterfaceId;
@@ -68,13 +53,14 @@ struct RegisterContext : public GenericContext
     dnssd_service_h mServiceHandle = 0;
     bool mIsRegistered             = false;
 
-    RegisterContext(DnssdTizen * instance, const char * type, const DnssdService & service, DnssdPublishCallback callback,
+    RegisterContext(DnssdTizen & instance, const char * type, const DnssdService & service, DnssdPublishCallback callback,
                     void * context);
-    ~RegisterContext() override;
+    ~RegisterContext();
 };
 
-struct BrowseContext : public GenericContext
+struct BrowseContext
 {
+    DnssdTizen & mInstance;
     char mType[kDnssdTypeAndProtocolMaxSize + 1];
     Dnssd::DnssdServiceProtocol mProtocol;
     uint32_t mInterfaceId;
@@ -89,13 +75,14 @@ struct BrowseContext : public GenericContext
     std::vector<DnssdService> mServices;
     bool mIsBrowsing = false;
 
-    BrowseContext(DnssdTizen * instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
+    BrowseContext(DnssdTizen & instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
                   DnssdBrowseCallback callback, void * context);
-    ~BrowseContext() override;
+    ~BrowseContext();
 };
 
-struct ResolveContext : public GenericContext
+struct ResolveContext
 {
+    DnssdTizen & mInstance;
     char mName[Common::kInstanceNameMaxLength + 1];
     char mType[kDnssdTypeAndProtocolMaxSize + 1];
     uint32_t mInterfaceId;
@@ -111,9 +98,9 @@ struct ResolveContext : public GenericContext
     GAutoPtr<char> mResultTxtRecord;
     unsigned short mResultTxtRecordLen = 0;
 
-    ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId, DnssdResolveCallback callback,
+    ResolveContext(DnssdTizen & instance, const char * name, const char * type, uint32_t interfaceId, DnssdResolveCallback callback,
                    void * context);
-    ~ResolveContext() override = default;
+    ~ResolveContext() = default;
 
     void Finalize(CHIP_ERROR error);
 };
@@ -136,8 +123,13 @@ public:
     CHIP_ERROR Resolve(const DnssdService & browseResult, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
                        void * context);
 
-    // TODO (a.bokowy): Make this method private
-    CHIP_ERROR RemoveContext(GenericContext * context);
+    // TODO (a.bokowy): Make these methods private
+    friend class RegisterContext;
+    void RemoveContext(RegisterContext * context);
+    friend class BrowseContext;
+    void RemoveContext(BrowseContext * context);
+    friend class ResolveContext;
+    void RemoveContext(ResolveContext * context);
 
     static DnssdTizen & GetInstance() { return sInstance; }
 
@@ -153,7 +145,9 @@ private:
                                           void * context);
 
     std::mutex mMutex;
-    std::set<std::unique_ptr<GenericContext>> mContexts;
+    std::set<std::unique_ptr<RegisterContext>> mRegisterContexts;
+    std::set<std::unique_ptr<BrowseContext>> mBrowseContexts;
+    std::set<std::unique_ptr<ResolveContext>> mResolveContexts;
 };
 
 } // namespace Dnssd

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -124,11 +124,8 @@ public:
                        void * context);
 
     // TODO (a.bokowy): Make these methods private
-    friend class RegisterContext;
     void RemoveContext(RegisterContext * context);
-    friend class BrowseContext;
     void RemoveContext(BrowseContext * context);
-    friend class ResolveContext;
     void RemoveContext(ResolveContext * context);
 
     static DnssdTizen & GetInstance() { return sInstance; }


### PR DESCRIPTION
#### Summary

This commit fixes undefined behavior (causing segmentation fault on Tizen 10.0) where `std::set` iterator is modified during the iteration.

#### Testing

Verified locally that lighting app does not crash on Tizen 10.0.
CI will verify potential breaks on Tizen 9.0.