### PR TITLE
 [Telink] Add system reboot if BLE functionality is lost after deep sleep retention & Update Telink builds to docker version 190

### DIFF
--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -145,7 +145,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-telink:185
+            image: ghcr.io/project-chip/chip-build-telink:190
             volumes:
                 - "/:/runner-root-volume"
             options: --user root

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-telink:185
+            image: ghcr.io/project-chip/chip-build-telink:190
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
@@ -393,7 +393,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-telink-zephyr_3_3:181
+            image: ghcr.io/project-chip/chip-build-telink-zephyr_3_3:190
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -58,6 +58,13 @@ extern __attribute__((noinline)) int tlx_bt_blc_mac_init(uint8_t * bt_mac);
 #elif defined(CONFIG_BT_W91)
 extern __attribute__((noinline)) void telink_bt_blc_mac_init(uint8_t * bt_mac);
 #endif
+
+#if defined(CONFIG_PM) && \
+    (defined(CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION) || defined(CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION))
+#include <zephyr/sys/reboot.h>
+
+extern bool pm_has_deep_sleep_retention_occurred(void);
+#endif
 }
 
 #if defined(CONFIG_PM) && !defined(CONFIG_CHIP_ENABLE_PM_DURING_BLE)
@@ -349,6 +356,15 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 CHIP_ERROR BLEManagerImpl::StartAdvertisingProcess(void)
 {
     int err;
+
+#if defined(CONFIG_PM) && \
+    (defined(CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION) || defined(CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION))
+    if(pm_has_deep_sleep_retention_occurred()) {
+        ChipLogError(DeviceLayer, "BLE functionality in non-retention RAM corrupted after deep sleep retention."
+            "Reboot system to start BLE advertising...");
+        sys_reboot(SYS_REBOOT_WARM);
+    }
+#endif
 
     if (!mBLERadioInitialized)
     {

--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -59,7 +59,7 @@ extern __attribute__((noinline)) int tlx_bt_blc_mac_init(uint8_t * bt_mac);
 extern __attribute__((noinline)) void telink_bt_blc_mac_init(uint8_t * bt_mac);
 #endif
 
-#if defined(CONFIG_PM) && \
+#if defined(CONFIG_PM) &&                                                                                                          \
     (defined(CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION) || defined(CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION))
 #include <zephyr/sys/reboot.h>
 
@@ -357,11 +357,13 @@ CHIP_ERROR BLEManagerImpl::StartAdvertisingProcess(void)
 {
     int err;
 
-#if defined(CONFIG_PM) && \
+#if defined(CONFIG_PM) &&                                                                                                          \
     (defined(CONFIG_SOC_SERIES_RISCV_TELINK_B9X_RETENTION) || defined(CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION))
-    if(pm_has_deep_sleep_retention_occurred()) {
-        ChipLogError(DeviceLayer, "BLE functionality in non-retention RAM corrupted after deep sleep retention."
-            "Reboot system to start BLE advertising...");
+    if (pm_has_deep_sleep_retention_occurred())
+    {
+        ChipLogError(DeviceLayer,
+                     "BLE functionality in non-retention RAM corrupted after deep sleep retention."
+                     "Reboot system to start BLE advertising...");
         sys_reboot(SYS_REBOOT_WARM);
     }
 #endif


### PR DESCRIPTION
### Change overview:
- Add system reboot if BLE functionality is lost after deep sleep retention.
- Update Telink builds to docker version 190 (from 185)
  - 190: [Telink] Update Docker image (Zephyr update) #43309

### Testing:
1. Run any Telink retention board.
2. Wait 15 minutes for the commissioning window to close (performing BLE layer deinitialization).
3. Push the start BLE advertising button (opening the commissioning window andperforming BLE layer initialization).

4. The board should reboot automatically.
5. Execute the commissioning.