### PR TITLE
[Tizen] Fix return code for not found POSIX configs

### DIFF
--- a/src/platform/Tizen/PosixConfig.cpp
+++ b/src/platform/Tizen/PosixConfig.cpp
@@ -26,7 +26,9 @@
 
 #include "PosixConfig.h"
 
+#include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceError.h>
 #include <platform/KeyValueStoreManager.h>
 
 namespace chip {
@@ -78,23 +80,43 @@ CHIP_ERROR PosixConfig::Init()
 
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, bool & val)
 {
-    return PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
+    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+    return err;
 }
 
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint16_t & val)
 
 {
-    return PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
+    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+    return err;
 }
 
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint32_t & val)
 {
-    return PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
+    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+    return err;
 }
 
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint64_t & val)
 {
-    return PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
+    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+    return err;
 }
 
 CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
@@ -102,6 +124,11 @@ CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, 
     VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, buf, bufSize, &outLen);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+
     VerifyOrReturnError(err == CHIP_NO_ERROR, err);
 
     // We are storing string values in the config store without
@@ -115,7 +142,12 @@ CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, 
 CHIP_ERROR PosixConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    return PersistedStorage::KeyValueStoreMgr().Get(key.Name, buf, bufSize, &outLen);
+    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, buf, bufSize, &outLen);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+    return err;
 }
 
 CHIP_ERROR PosixConfig::WriteConfigValue(Key key, bool val)

--- a/src/platform/Tizen/PosixConfig.cpp
+++ b/src/platform/Tizen/PosixConfig.cpp
@@ -73,6 +73,17 @@ const PosixConfig::Key PosixConfig::kCounterKey_TotalOperationalHours = { kConfi
                                                                           "total-operational-hours" };
 const PosixConfig::Key PosixConfig::kCounterKey_BootReason            = { kConfigNamespace_ChipCounters, "boot-reason" };
 
+namespace {
+CHIP_ERROR MapToDeviceError(CHIP_ERROR err)
+{
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+    return err;
+}
+} // namespace
+
 CHIP_ERROR PosixConfig::Init()
 {
     return CHIP_NO_ERROR;
@@ -80,55 +91,30 @@ CHIP_ERROR PosixConfig::Init()
 
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, bool & val)
 {
-    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
-    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
-    {
-        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    }
-    return err;
+    return MapToDeviceError(PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val));
 }
 
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint16_t & val)
 
 {
-    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
-    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
-    {
-        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    }
-    return err;
+    return MapToDeviceError(PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val));
 }
 
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint32_t & val)
 {
-    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
-    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
-    {
-        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    }
-    return err;
+    return MapToDeviceError(PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val));
 }
 
 CHIP_ERROR PosixConfig::ReadConfigValue(Key key, uint64_t & val)
 {
-    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val);
-    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
-    {
-        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    }
-    return err;
+    return MapToDeviceError(PersistedStorage::KeyValueStoreMgr().Get(key.Name, &val));
 }
 
 CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, buf, bufSize, &outLen);
-    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
-    {
-        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    }
-
+    auto err = MapToDeviceError(PersistedStorage::KeyValueStoreMgr().Get(key.Name, buf, bufSize, &outLen));
     VerifyOrReturnError(err == CHIP_NO_ERROR, err);
 
     // We are storing string values in the config store without
@@ -142,12 +128,7 @@ CHIP_ERROR PosixConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, 
 CHIP_ERROR PosixConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
     VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    auto err = PersistedStorage::KeyValueStoreMgr().Get(key.Name, buf, bufSize, &outLen);
-    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
-    {
-        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    }
-    return err;
+    return MapToDeviceError(PersistedStorage::KeyValueStoreMgr().Get(key.Name, buf, bufSize, &outLen));
 }
 
 CHIP_ERROR PosixConfig::WriteConfigValue(Key key, bool val)


### PR DESCRIPTION
#### Summary

Tizen returns `CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND` in case when POSIX config value was not found. However, `src/include/platform/internal/GenericDeviceInstanceInfoProvider.ipp` expects `CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND` in such case. This PR fixes that issue (aligns Tizen code with Linux implementation).

#### Testing

Verified locally that `E/CHIP    (  446): DL: Invalid manufacturing date: O  ` log message (with a garbage value, in this case `O`) is not longer printed.
Smoke test on CI will verify potential breaks.