### PR TITLE
Linux/Dnssd: StopResolve detaches resolves before invoking cancel callbacks

### DIFF
--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -844,18 +844,14 @@ void MdnsAvahi::StopResolve(const char * name)
     // Note: callbacks may re-enter into dnssd logic, so first detach matching contexts from
     // `mAllocatedResolves`, then invoke callbacks and delete outside of the list iteration.
     std::vector<ResolveContext *> contexts;
-    for (auto it = mAllocatedResolves.begin(); it != mAllocatedResolves.end();)
-    {
-        if (strcmp((*it)->mName, name) == 0)
+    mAllocatedResolves.remove_if([&contexts, name](ResolveContext * ctx) {
+        if (strcmp(ctx->mName, name) == 0)
         {
-            contexts.push_back(*it);
-            it = mAllocatedResolves.erase(it);
+            contexts.push_back(ctx);
+            return true;
         }
-        else
-        {
-            ++it;
-        }
-    }
+        return false;
+    });
 
     for (auto * context : contexts)
     {

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -839,16 +839,20 @@ void MdnsAvahi::FreeResolveContext(size_t handle)
 
 void MdnsAvahi::StopResolve(const char * name)
 {
-    auto truncate_end = std::remove_if(mAllocatedResolves.begin(), mAllocatedResolves.end(),
-                                       [name](ResolveContext * ctx) { return strcmp(ctx->mName, name) == 0; });
-
-    for (auto it = truncate_end; it != mAllocatedResolves.end(); it++)
+    // Cancel and immediately delete any pending resolves for this instance name.
+    for (auto it = mAllocatedResolves.begin(); it != mAllocatedResolves.end();)
     {
-        (*it)->mCallback((*it)->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_CANCELLED);
-        chip::Platform::Delete(*it);
+        if (strcmp((*it)->mName, name) == 0)
+        {
+            (*it)->mCallback((*it)->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_CANCELLED);
+            chip::Platform::Delete(*it);
+            it = mAllocatedResolves.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
     }
-
-    mAllocatedResolves.erase(truncate_end, mAllocatedResolves.end());
 }
 
 CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdServiceProtocol protocol, Inet::IPAddressType addressType,

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -839,23 +839,28 @@ void MdnsAvahi::FreeResolveContext(size_t handle)
 
 void MdnsAvahi::StopResolve(const char * name)
 {
-    // Cancel and immediately delete any pending resolves for this instance name.
+    // Cancel and delete any pending resolves for this instance name.
+    //
+    // Note: callbacks may re-enter into dnssd logic, so first detach matching contexts from
+    // `mAllocatedResolves`, then invoke callbacks and delete outside of the list iteration.
+    std::vector<ResolveContext *> contexts;
     for (auto it = mAllocatedResolves.begin(); it != mAllocatedResolves.end();)
     {
         if (strcmp((*it)->mName, name) == 0)
         {
-            ResolveContext * context = *it;
-            // Remove from the allocated list before invoking the callback to avoid
-            // re-entrant use-after-free or double-free if the callback calls back
-            // into resolve cancellation logic.
+            contexts.push_back(*it);
             it = mAllocatedResolves.erase(it);
-            context->mCallback(context->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_CANCELLED);
-            chip::Platform::Delete(context);
         }
         else
         {
             ++it;
         }
+    }
+
+    for (auto * context : contexts)
+    {
+        context->mCallback(context->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_CANCELLED);
+        chip::Platform::Delete(context);
     }
 }
 

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -844,9 +844,13 @@ void MdnsAvahi::StopResolve(const char * name)
     {
         if (strcmp((*it)->mName, name) == 0)
         {
-            (*it)->mCallback((*it)->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_CANCELLED);
-            chip::Platform::Delete(*it);
+            ResolveContext * context = *it;
+            // Remove from the allocated list before invoking the callback to avoid
+            // re-entrant use-after-free or double-free if the callback calls back
+            // into resolve cancellation logic.
             it = mAllocatedResolves.erase(it);
+            context->mCallback(context->mContext, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_CANCELLED);
+            chip::Platform::Delete(context);
         }
         else
         {


### PR DESCRIPTION
#### Summary

Refactored `MdnsAvahi::StopResolve()` on Linux to make resolve cancellation more robust against re-entrant callbacks by separating “remove” from “notify/free”.

- Replaced the prior `std::remove_if(...)` + “iterate removed range and delete” + `erase(range)` approach on `mAllocatedResolves` with:
  - Detach pass: removes matching `ResolveContext *` entries from `mAllocatedResolves` (collecting them into a temporary vector).
  - Notify/free pass: invokes each callback with `CHIP_ERROR_CANCELLED`, then deletes the context.

During stress tests intermittent crashes were observed ("double free detected in tcache 2"). The old implementation could invoke callbacks while `mAllocatedResolves` was still in an intermediate “removed but not yet erased” state, increasing the likelihood of re-entrant cancellation/cleanup acting on stale entries. Detaching all matching contexts before invoking callbacks reduces that risk.

#### Related issues

Fixes: #36990

#### Testing

Tested by running 8000 iterations of the matter stress tests, with test case [TC_Darwin_Pair](https://github.com/CHIP-Specifications/matter-qa/blob/main/src/matter_qa/scripts/reliability_scripts/TC_Darwin_Pair.py).

Platform:  Two Raspi 4B 8GB.
Method: BLE-WiFi

Previously a crash would be observed roughly once per 300 iterations.  After this change I've run 8000 iterations with no crash.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
