### PR TITLE
[NXP][SE05x] Moving SE05x management in a dedicated application files

### DIFF
--- a/examples/platform/nxp/common/app_common.cmake
+++ b/examples/platform/nxp/common/app_common.cmake
@@ -102,12 +102,8 @@ if (CONFIG_DIAG_LOGS_DEMO)
     )
 endif()
 
-if(CONFIG_CHIP_SE05X)
-    list(FIND EXTRA_MCUX_MODULES "${CHIP_ROOT}/third_party/simw-top-mini/repo/matter" se_index)
-    if(se_index EQUAL -1)
-        message(FATAL_ERROR "MCUX_MODULES must include ${CHIP_ROOT}/third_party/simw-top-mini/repo/matter in the application when CONFIG_CHIP_SE05X is enabled")
-    endif()
-endif()
+# Include SE05X configuration
+include(${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/app_se05x.cmake)
 
 if (CONFIG_CHIP_APP_FACTORY_DATA)
     if (CONFIG_CHIP_APP_FACTORY_DATA_IMPL_PLATFORM)

--- a/examples/platform/nxp/common/app_se05x.cmake
+++ b/examples/platform/nxp/common/app_se05x.cmake
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ****************************************************************
+# SE05X Application Files
+# ****************************************************************
+
+if(CONFIG_CHIP_SE05X)
+    list(FIND EXTRA_MCUX_MODULES "${CHIP_ROOT}/third_party/simw-top-mini/repo/matter" se_index)
+    if(se_index EQUAL -1)
+        message(FATAL_ERROR "MCUX_MODULES must include ${CHIP_ROOT}/third_party/simw-top-mini/repo/matter in the application when CONFIG_CHIP_SE05X is enabled")
+    endif()
+
+    target_include_directories(app PRIVATE
+        ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/app_se05x/include
+    )
+
+    target_sources(app PRIVATE
+        ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/app_se05x/source/AppSe05x.cpp
+    )
+
+endif()

--- a/examples/platform/nxp/common/app_se05x/include/AppSe05x.h
+++ b/examples/platform/nxp/common/app_se05x/include/AppSe05x.h
@@ -1,0 +1,67 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace NXP {
+namespace App {
+namespace Se05x {
+
+/**
+ * @brief Initializes the NXP SE05x Secure Element.
+ *
+ * This function performs all required low‑level setup to make the SE05x
+ * available for use by the application. Typical operations may include:
+ * - Establishing communication with the SE05x (I2C/SPI)
+ * - Verifying the presence and readiness of the secure element
+ * - Configuring internal SE05x contexts or session handles
+ *
+ * This routine should be called once during system startup, before any
+ * SE05x‑dependent functionality is used.
+ *
+ * @retval CHIP_NO_ERROR       Initialization completed successfully.
+ * @retval CHIP_ERROR_xxx      A specific error describing why initialization
+ *                              failed (communication failure, device not found,
+ *                              unsupported configuration, etc.).
+ */
+CHIP_ERROR Init();
+
+/**
+ * @brief Performs post‑initialization tasks for the SE05x Secure Element.
+ *
+ * This function finalizes configuration after the SE05x has been initialized.
+ * It may include steps such as:
+ * - Creating or opening secure sessions
+ * - Loading keys, certificates, or policies
+ * - Running device integrity checks
+ * - Preparing features required by higher‑level services
+ *
+ * This routine must be invoked only after a successful call to @ref Init().
+ *
+ * @retval CHIP_NO_ERROR       Post‑initialization completed successfully.
+ * @retval CHIP_ERROR_xxx      A specific error indicating which post‑init
+ *                              operation failed.
+ */
+CHIP_ERROR PostInit();
+
+} // namespace Se05x
+} // namespace App
+} // namespace NXP
+} // namespace chip

--- a/examples/platform/nxp/common/app_se05x/source/AppSe05x.cpp
+++ b/examples/platform/nxp/common/app_se05x/source/AppSe05x.cpp
@@ -1,0 +1,60 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "AppSe05x.h"
+
+namespace chip {
+namespace NXP {
+namespace App {
+namespace Se05x {
+
+/**
+ * @brief Template for initializing the SE05x secure element.
+ *
+ * This placeholder implementation simply returns success. When integrating
+ * with actual hardware, this function should be expanded.
+ *
+ * @retval CHIP_NO_ERROR   Default behavior in this example implementation.
+ * @retval CHIP_ERROR_xxx  Should be returned by a real implementation when
+ *                          initialization failures occur.
+ */
+CHIP_ERROR Init()
+{
+    return CHIP_NO_ERROR;
+}
+
+/**
+ * @brief Template for SE05x post‑initialization tasks.
+ *
+ * This function is provided as a stub for developers to customize. In a
+ * complete implementation, it may handle tasks such as session creation,
+ * loading credentials, running integrity checks, or preparing secure
+ * services used by the higher layers of the system.
+ *
+ * @retval CHIP_NO_ERROR   Default behavior in this example implementation.
+ * @retval CHIP_ERROR_xxx  Should be used by integrators to signal real
+ *                          post‑initialization failures.
+ */
+CHIP_ERROR PostInit()
+{
+    return CHIP_NO_ERROR;
+}
+
+} // namespace Se05x
+} // namespace App
+} // namespace NXP
+} // namespace chip

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -377,7 +377,7 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
     err = chip::NXP::App::Se05x::PostInit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Error during chip::NXP::App::Se05x::PostInit()");
+        ChipLogError(DeviceLayer, "Error during chip::NXP::App::Se05x::PostInit(): %s", ErrorStr(err));
     }
 #endif
 

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -114,6 +114,10 @@
 #include <app/reporting/SynchronizedReportSchedulerImpl.h>
 #endif
 
+#if CONFIG_CHIP_SE05X
+#include "AppSe05x.h"
+#endif
+
 #if CONFIG_NXP_USE_POWER_DOWN
 #include "ICDUtil.h"
 #endif // CONFIG_NXP_USE_POWER_DOWN
@@ -324,6 +328,11 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
     }
 #endif
 
+#if CONFIG_CHIP_SE05X
+    err = chip::NXP::App::Se05x::Init();
+    SuccessOrExit(err);
+#endif
+
 #if CONFIG_CHIP_WIFI || CHIP_DEVICE_CONFIG_ENABLE_WPA
     TEMPORARY_RETURN_IGNORED sNetworkCommissioningInstance.Init();
 #ifdef ENABLE_CHIP_SHELL
@@ -361,6 +370,14 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Error during ThreadStackMgrImpl().StartThreadTask()");
+    }
+#endif
+
+#if CONFIG_CHIP_SE05X
+    err = chip::NXP::App::Se05x::PostInit();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Error during chip::NXP::App::Se05x::PostInit()");
     }
 #endif
 


### PR DESCRIPTION
#### Summary

Refactored the NXP application structure to better isolate the SE05x application logic into dedicated custom files.
This enhancement provides a separation of responsibilities and introduces a example template that developers can extend for their specific Matter + SE05x use cases.

#### Testing

These changes are minimal and non‑functional.
Successful build validation is ensured through the existing GitHub CI workflow, which covers the NXP MCU + SE05x Matter example build.