### PR TITLE
[Energy] EEM Accuracy Range Buffer Fix

### DIFF
--- a/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.cpp
@@ -31,12 +31,14 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <zap-generated/gen_config.h>
 
-namespace {
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ElectricalEnergyMeasurement;
+using namespace chip::app::Clusters::ElectricalEnergyMeasurement::Attributes;
+using namespace chip::app::Clusters::ElectricalEnergyMeasurement::Structs;
 
+namespace {
 SingleLinkedListNode<ElectricalEnergyMeasurementCluster *> * EEMFirstInstance = nullptr;
 
 inline void RegisterLegacyEEM(SingleLinkedListNode<ElectricalEnergyMeasurementCluster *> * inst)
@@ -70,19 +72,14 @@ inline void UnregisterLegacyEEM(SingleLinkedListNode<ElectricalEnergyMeasurement
     }
 }
 
+// Default empty accuracy used at construction time; real values are set later via SetMeasurementAccuracy.
+const MeasurementAccuracyStruct::Type kDefaultAccuracy = {};
 } // namespace
 
 namespace chip {
 namespace app {
 namespace Clusters {
 namespace ElectricalEnergyMeasurement {
-
-using namespace chip;
-using namespace chip::app;
-using namespace chip::app::Clusters;
-using namespace chip::app::Clusters::ElectricalEnergyMeasurement;
-using namespace chip::app::Clusters::ElectricalEnergyMeasurement::Attributes;
-using namespace chip::app::Clusters::ElectricalEnergyMeasurement::Structs;
 
 ElectricalEnergyMeasurementAttrAccess::ElectricalEnergyMeasurementAttrAccess(BitMask<Feature> aFeature,
                                                                              BitMask<OptionalAttributes> aOptionalAttrs,
@@ -91,6 +88,7 @@ ElectricalEnergyMeasurementAttrAccess::ElectricalEnergyMeasurementAttrAccess(Bit
         .endpointId         = endpointId,
         .featureFlags       = aFeature,
         .optionalAttributes = aOptionalAttrs,
+        .accuracyStruct     = kDefaultAccuracy,
     })
 {
     mClusterListNode.mValue = &mCluster.Cluster();

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -101,6 +101,27 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::GetCumulativeEnergyImported(Optio
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ElectricalEnergyMeasurementCluster::SetMeasurementAccuracy(const MeasurementAccuracyStruct & value)
+{
+    if (ValueChanged(mMeasurementData.measurementAccuracy, value))
+    {
+        mMeasurementData.measurementAccuracy.measurementType  = value.measurementType;
+        mMeasurementData.measurementAccuracy.measured         = value.measured;
+        mMeasurementData.measurementAccuracy.minMeasuredValue = value.minMeasuredValue;
+        mMeasurementData.measurementAccuracy.maxMeasuredValue = value.maxMeasuredValue;
+        NotifyAttributeChanged(Accuracy::Id);
+    }
+
+    // Always update ranges since ValueChanged intentionally skips comparing them
+    using RangeType = MeasurementAccuracyRangeStruct::Type;
+    ReadOnlyBufferBuilder<RangeType> rangesBuilder;
+    ReturnErrorOnFailure(rangesBuilder.AppendElements(value.accuracyRanges));
+    mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer();
+    mMeasurementData.measurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ElectricalEnergyMeasurementCluster::GetCumulativeEnergyExported(Optional<EnergyMeasurementStruct> & outValue) const
 {
     if (!mFeatureFlags.HasAll(ElectricalEnergyMeasurement::Feature::kCumulativeEnergy,
@@ -148,16 +169,6 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::GetCumulativeEnergyReset(Optional
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
     outValue = mMeasurementData.cumulativeReset;
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR ElectricalEnergyMeasurementCluster::SetMeasurementAccuracy(const MeasurementAccuracyStruct & value)
-{
-    if (ValueChanged(mMeasurementData.measurementAccuracy, value))
-    {
-        mMeasurementData.measurementAccuracy = value;
-        NotifyAttributeChanged(Accuracy::Id);
-    }
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -112,12 +112,14 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetMeasurementAccuracy(const Meas
         NotifyAttributeChanged(Accuracy::Id);
     }
 
-    // Always update ranges since ValueChanged intentionally skips comparing them
-    using RangeType = MeasurementAccuracyRangeStruct::Type;
-    ReadOnlyBufferBuilder<RangeType> rangesBuilder;
-    ReturnErrorOnFailure(rangesBuilder.AppendElements(value.accuracyRanges));
-    mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer();
-    mMeasurementData.measurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
+    // Always update ranges if they are present since ValueChanged intentionally skips comparing them
+    if (!value.accuracyRanges.empty())
+    {
+        ReadOnlyBufferBuilder<MeasurementAccuracyRangeStruct::Type> rangesBuilder;
+        ReturnErrorOnFailure(rangesBuilder.AppendElements(value.accuracyRanges));
+        mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer(); 
+        mMeasurementData.measurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
+    }
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -117,7 +117,7 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetMeasurementAccuracy(const Meas
     {
         ReadOnlyBufferBuilder<MeasurementAccuracyRangeStruct::Type> rangesBuilder;
         ReturnErrorOnFailure(rangesBuilder.AppendElements(value.accuracyRanges));
-        mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer(); 
+        mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer();
         mMeasurementData.measurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
     }
 

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
@@ -23,6 +23,7 @@
 #include <clusters/ElectricalEnergyMeasurement/ClusterId.h>
 #include <clusters/ElectricalEnergyMeasurement/Structs.h>
 #include <lib/core/Optional.h>
+#include <lib/support/ReadOnlyBuffer.h>
 
 namespace chip {
 namespace app {
@@ -66,8 +67,12 @@ public:
         EndpointId endpointId;
         BitMask<ElectricalEnergyMeasurement::Feature> featureFlags;
         BitMask<ElectricalEnergyMeasurement::OptionalAttributes> optionalAttributes;
+        const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyStruct::Type & accuracyStruct;
     };
 
+    /// @brief Constructor for ElectricalEnergyMeasurementCluster.
+    /// @param config The configuration for the cluster.
+    /// @note The accuracyStruct must outlive the cluster to avoid dangling pointers.
     ElectricalEnergyMeasurementCluster(const Config & config) :
         DefaultServerCluster({ config.endpointId, ElectricalEnergyMeasurement::Id }), mFeatureFlags(config.featureFlags),
         mEnabledOptionalAttributes([&]() {
@@ -86,7 +91,19 @@ public:
                 config.featureFlags.Has(ElectricalEnergyMeasurement::Feature::kCumulativeEnergy));
             return attrs;
         }())
-    {}
+    {
+        mMeasurementData.measurementAccuracy.measurementType  = config.accuracyStruct.measurementType;
+        mMeasurementData.measurementAccuracy.measured         = config.accuracyStruct.measured;
+        mMeasurementData.measurementAccuracy.minMeasuredValue = config.accuracyStruct.minMeasuredValue;
+        mMeasurementData.measurementAccuracy.maxMeasuredValue = config.accuracyStruct.maxMeasuredValue;
+
+        // ReferenceExisting: caller's accuracyRanges data must outlive the cluster
+        using RangeType = ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type;
+        ReadOnlyBufferBuilder<RangeType> rangesBuilder;
+        VerifyOrDie(rangesBuilder.ReferenceExisting(config.accuracyStruct.accuracyRanges) == CHIP_NO_ERROR);
+        mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer();
+        mMeasurementData.measurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
+    }
 
     const OptionalAttributesSet & OptionalAttributes() const { return mEnabledOptionalAttributes; }
     const BitFlags<ElectricalEnergyMeasurement::Feature> & Features() const { return mFeatureFlags; }
@@ -102,7 +119,10 @@ public:
     CHIP_ERROR GetPeriodicEnergyExported(Optional<EnergyMeasurementStruct> & outValue) const;
     CHIP_ERROR GetCumulativeEnergyReset(Optional<CumulativeEnergyResetStruct> & outValue) const;
 
-    // Setters - update values and notify data model
+    /// @brief Sets the measurement accuracy.
+    /// @param value The new measurement accuracy value.
+    /// @return CHIP_ERROR_NO_MEMORY if the deep copy of accuracyRanges fails to allocate.
+    /// @note Use the constructor with Config::accuracyStruct for zero-copy reference to long-lived (e.g. flash) data.
     CHIP_ERROR SetMeasurementAccuracy(const MeasurementAccuracyStruct & value);
     CHIP_ERROR SetCumulativeEnergyReset(const Optional<CumulativeEnergyResetStruct> & value);
 
@@ -127,6 +147,9 @@ private:
     const BitFlags<ElectricalEnergyMeasurement::Feature> mFeatureFlags;
     const OptionalAttributesSet mEnabledOptionalAttributes;
     ElectricalEnergyMeasurement::MeasurementData mMeasurementData;
+
+    // Owns the accuracyRanges backing store; either references long-lived data (ReferenceExisting) or an allocated copy.
+    ReadOnlyBuffer<ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type> mAccuracyRangesStorage;
 };
 
 } // namespace Clusters

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -39,6 +39,21 @@ namespace {
 
 constexpr EndpointId kTestEndpointId = 1;
 
+const Structs::MeasurementAccuracyRangeStruct::Type kTestAccuracyRanges[] = {
+    { .rangeMin   = 0,
+      .rangeMax   = 1'000'000'000'000'000, // 1 million Mwh
+      .percentMax = MakeOptional(static_cast<chip::Percent100ths>(500)),
+      .percentMin = MakeOptional(static_cast<chip::Percent100ths>(50)) }
+};
+
+const Structs::MeasurementAccuracyStruct::Type kTestAccuracy = {
+    .measurementType  = MeasurementTypeEnum::kElectricalEnergy,
+    .measured         = true,
+    .minMeasuredValue = 0,
+    .maxMeasuredValue = 1'000'000'000'000'000,
+    .accuracyRanges   = DataModel::List<const Structs::MeasurementAccuracyRangeStruct::Type>(kTestAccuracyRanges)
+};
+
 struct TestElectricalEnergyMeasurementCluster : public ::testing::Test
 {
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
@@ -59,6 +74,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, AttributeListTest)
             .endpointId         = kTestEndpointId,
             .featureFlags       = noFeatures,
             .optionalAttributes = static_cast<ElectricalEnergyMeasurement::OptionalAttributes>(0),
+            .accuracyStruct     = kTestAccuracy,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -78,6 +94,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, AttributeListTest)
             .endpointId         = kTestEndpointId,
             .featureFlags       = allFeatures,
             .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+            .accuracyStruct     = kTestAccuracy,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -105,6 +122,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, AttributeListTest)
             .endpointId         = kTestEndpointId,
             .featureFlags       = noFeatures,
             .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+            .accuracyStruct     = kTestAccuracy,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -129,6 +147,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GettersSettersWithFeatureValidati
             .endpointId         = kTestEndpointId,
             .featureFlags       = allFeatures,
             .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+            .accuracyStruct     = kTestAccuracy,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -178,6 +197,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GettersSettersWithFeatureValidati
             .endpointId         = kTestEndpointId,
             .featureFlags       = noFeatures,
             .optionalAttributes = static_cast<ElectricalEnergyMeasurement::OptionalAttributes>(0),
+            .accuracyStruct     = kTestAccuracy,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -209,6 +229,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, FeatureAttributeTest)
             .endpointId         = kTestEndpointId,
             .featureFlags       = allFeatures,
             .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+            .accuracyStruct     = kTestAccuracy,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -261,6 +282,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, ReadAttributeWithClusterTesterTes
         .endpointId         = kTestEndpointId,
         .featureFlags       = allFeatures,
         .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+        .accuracyStruct     = kTestAccuracy,
     });
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -316,6 +338,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, SnapshotsSetValuesAndGenerateEven
         .endpointId         = kTestEndpointId,
         .featureFlags       = allFeatures,
         .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+        .accuracyStruct     = kTestAccuracy,
     });
 
     EXPECT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -41,6 +41,21 @@ static chip::app::CircularEventBuffer gCircularEventBuffer[3];
 
 constexpr EndpointId kTestEndpointId = 1;
 
+const Structs::MeasurementAccuracyRangeStruct::Type kTestAccuracyRanges[] = {
+    { .rangeMin   = 0,
+      .rangeMax   = 1'000'000'000'000'000, // 1 million Mwh
+      .percentMax = MakeOptional(static_cast<chip::Percent100ths>(500)),
+      .percentMin = MakeOptional(static_cast<chip::Percent100ths>(50)) }
+};
+
+const Structs::MeasurementAccuracyStruct::Type kTestAccuracy = {
+    .measurementType  = MeasurementTypeEnum::kElectricalEnergy,
+    .measured         = true,
+    .minMeasuredValue = 0,
+    .maxMeasuredValue = 1'000'000'000'000'000,
+    .accuracyRanges   = DataModel::List<const Structs::MeasurementAccuracyRangeStruct::Type>(kTestAccuracyRanges)
+};
+
 struct TestElectricalEnergyMeasurementClusterBackwardsCompatibility : public ::testing::Test
 {
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
@@ -95,7 +110,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestAttrAcc
     EXPECT_FALSE(minimalAttrAccess.HasFeature(Feature::kExportedEnergy));
     EXPECT_FALSE(minimalAttrAccess.HasFeature(Feature::kCumulativeEnergy));
     EXPECT_FALSE(minimalAttrAccess.HasFeature(Feature::kPeriodicEnergy));
-    minimalAttrAccess.Shutdown(ClusterShutdownType::kClusterShutdown);
+    minimalAttrAccess.Shutdown();
 
     // Test optional attribute checking methods
     EXPECT_TRUE(attrAccess.SupportsOptAttr(OptionalAttributes::kOptionalAttributeCumulativeEnergyReset));
@@ -104,10 +119,10 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestAttrAcc
     ElectricalEnergyMeasurementAttrAccess noOptAttrAccess(features, noOptionalAttrs, kTestEndpointId + 2);
     EXPECT_EQ(noOptAttrAccess.Init(), CHIP_NO_ERROR);
     EXPECT_FALSE(noOptAttrAccess.SupportsOptAttr(OptionalAttributes::kOptionalAttributeCumulativeEnergyReset));
-    noOptAttrAccess.Shutdown(ClusterShutdownType::kClusterShutdown);
+    noOptAttrAccess.Shutdown();
 
     // Test shutdown
-    attrAccess.Shutdown(ClusterShutdownType::kClusterShutdown);
+    attrAccess.Shutdown();
 
     // Verify cluster is unregistered from the registry
     EXPECT_EQ(FindElectricalEnergyMeasurementClusterOnEndpoint(kTestEndpointId), nullptr);
@@ -130,23 +145,44 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
     // Initialize the cluster with test context for event logging
     EXPECT_EQ(cluster->Startup(mContext.Get()), CHIP_NO_ERROR);
 
-    // Test SetMeasurementAccuracy
+    // Test SetMeasurementAccuracy and verify accuracyRanges survives source data destruction
     {
+        Structs::MeasurementAccuracyRangeStruct::Type testMeasurementAccuracyRanges[] = {
+            { .rangeMin   = 0,
+              .rangeMax   = 1'000'000'000'000'000, // 1 million Mwh
+              .percentMax = MakeOptional(static_cast<chip::Percent100ths>(500)),
+              .percentMin = MakeOptional(static_cast<chip::Percent100ths>(50)) }
+        };
+
         Structs::MeasurementAccuracyStruct::Type accuracy;
         accuracy.measurementType  = MeasurementTypeEnum::kApparentEnergy;
         accuracy.measured         = true;
         accuracy.minMeasuredValue = 0;
         accuracy.maxMeasuredValue = 1000000;
-        accuracy.accuracyRanges   = DataModel::List<Structs::MeasurementAccuracyRangeStruct::Type>();
+        accuracy.accuracyRanges   = DataModel::List<const Structs::MeasurementAccuracyRangeStruct::Type>(
+            testMeasurementAccuracyRanges, MATTER_ARRAY_SIZE(testMeasurementAccuracyRanges));
 
         EXPECT_EQ(SetMeasurementAccuracy(kTestEndpointId, accuracy), CHIP_NO_ERROR);
 
-        // Verify the value was set
-        Structs::MeasurementAccuracyStruct::Type readAccuracy;
-        cluster->GetMeasurementAccuracy(readAccuracy);
-        EXPECT_EQ(readAccuracy.measurementType, MeasurementTypeEnum::kApparentEnergy);
-        EXPECT_TRUE(readAccuracy.measured);
+        // Overwrite source data; if the cluster only holds a Span, reads will return these values instead
+        testMeasurementAccuracyRanges[0].rangeMin   = 999;
+        testMeasurementAccuracyRanges[0].rangeMax   = 999;
+        testMeasurementAccuracyRanges[0].percentMax = MakeOptional(static_cast<chip::Percent100ths>(999));
+        testMeasurementAccuracyRanges[0].percentMin = MakeOptional(static_cast<chip::Percent100ths>(999));
     }
+
+    // Verify the that the MeasurementAccuracyStruct is preserved past the scope of the previous test
+    Structs::MeasurementAccuracyStruct::Type readAccuracy;
+    cluster->GetMeasurementAccuracy(readAccuracy);
+    EXPECT_EQ(readAccuracy.measurementType, MeasurementTypeEnum::kApparentEnergy);
+    EXPECT_TRUE(readAccuracy.measured);
+    EXPECT_EQ(readAccuracy.minMeasuredValue, 0);
+    EXPECT_EQ(readAccuracy.maxMeasuredValue, 1000000);
+    EXPECT_EQ(readAccuracy.accuracyRanges.size(), 1u);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].rangeMin, 0);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].rangeMax, 1'000'000'000'000'000);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMax.Value(), 500);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMin.Value(), 50);
 
     // Test SetCumulativeReset
     {
@@ -272,7 +308,36 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
     }
 
     // Cleanup
-    attrAccess.Shutdown(ClusterShutdownType::kClusterShutdown);
+    attrAccess.Shutdown();
+}
+
+TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestConstructorWithAccuracy)
+{
+    BitMask<Feature> features(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
+    BitMask<OptionalAttributes> noOptionalAttrs;
+
+    ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
+        .endpointId         = kTestEndpointId + 10,
+        .featureFlags       = features,
+        .optionalAttributes = noOptionalAttrs,
+        .accuracyStruct     = kTestAccuracy,
+    });
+
+    Structs::MeasurementAccuracyStruct::Type readAccuracy;
+    cluster.GetMeasurementAccuracy(readAccuracy);
+
+    EXPECT_EQ(readAccuracy.measurementType, MeasurementTypeEnum::kElectricalEnergy);
+    EXPECT_TRUE(readAccuracy.measured);
+    EXPECT_EQ(readAccuracy.minMeasuredValue, 0);
+    EXPECT_EQ(readAccuracy.maxMeasuredValue, 1'000'000'000'000'000);
+    ASSERT_EQ(readAccuracy.accuracyRanges.size(), 1u);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].rangeMin, 0);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].rangeMax, 1'000'000'000'000'000);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMax.Value(), 500);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMin.Value(), 50);
+
+    // Verify zero-copy: the ranges Span should point directly at the static data
+    EXPECT_EQ(readAccuracy.accuracyRanges.data(), kTestAccuracyRanges);
 }
 
 } // namespace

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -171,7 +171,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
         testMeasurementAccuracyRanges[0].percentMin = MakeOptional(static_cast<chip::Percent100ths>(999));
     }
 
-    // Verify the that the MeasurementAccuracyStruct is preserved past the scope of the previous test
+    // Verify that the MeasurementAccuracyStruct is preserved past the scope of the previous test
     Structs::MeasurementAccuracyStruct::Type readAccuracy;
     cluster->GetMeasurementAccuracy(readAccuracy);
     EXPECT_EQ(readAccuracy.measurementType, MeasurementTypeEnum::kApparentEnergy);

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -208,7 +208,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
         EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMax.Value(), 500);
         EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMin.Value(), 50);
     }
-    
+
     // Test SetCumulativeReset
     {
         Structs::CumulativeEnergyResetStruct::Type resetData;

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -184,6 +184,31 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
     EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMax.Value(), 500);
     EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMin.Value(), 50);
 
+    // Test SetMeasurementAccuracy and verify empty accuracyRanges doesn't modify the existing accuracyRanges
+    {
+        Structs::MeasurementAccuracyStruct::Type accuracy;
+        accuracy.measurementType  = MeasurementTypeEnum::kApparentEnergy;
+        accuracy.measured         = true;
+        accuracy.minMeasuredValue = 0;
+        accuracy.maxMeasuredValue = 1000000;
+
+        EXPECT_EQ(SetMeasurementAccuracy(kTestEndpointId, accuracy), CHIP_NO_ERROR);
+
+        // Verify the value was set
+        Structs::MeasurementAccuracyStruct::Type readAccuracy;
+        cluster->GetMeasurementAccuracy(readAccuracy);
+        // Verify that the MeasurementAccuracyStruct is not erased by the empty accuracyRanges
+        EXPECT_EQ(readAccuracy.measurementType, MeasurementTypeEnum::kApparentEnergy);
+        EXPECT_TRUE(readAccuracy.measured);
+        EXPECT_EQ(readAccuracy.minMeasuredValue, 0);
+        EXPECT_EQ(readAccuracy.maxMeasuredValue, 1000000);
+        EXPECT_EQ(readAccuracy.accuracyRanges.size(), 1u);
+        EXPECT_EQ(readAccuracy.accuracyRanges[0].rangeMin, 0);
+        EXPECT_EQ(readAccuracy.accuracyRanges[0].rangeMax, 1'000'000'000'000'000);
+        EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMax.Value(), 500);
+        EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMin.Value(), 50);
+    }
+    
     // Test SetCumulativeReset
     {
         Structs::CumulativeEnergyResetStruct::Type resetData;


### PR DESCRIPTION
#### Summary
This PR attempts to clarify the data ownership of the accuracy range in the EEM cluster by implementing a Read Only buffer in the cluster object.

Now, providing the accuracy range through the config in the constructor results in a reference to the data array being passed, requiring the data lifetime to be longer than the cluster's.

Using the SetAccuracy method will result in allocating the memory in the cluser.

#### Related issues

https://github.com/project-chip/connectedhomeip/pull/43169 (Although already closed).

#### Testing

Built and ran EVSE, instrumented TestElectricalEnergyMeasurementClusterBackwardsCompatibility to further test the possible usage of the cluster.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
