### PR TITLE
Fixing delegate crash if a delegate does not implement metrics

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -97,7 +97,9 @@ void MTRDeviceControllerDelegateBridge::OnStatusUpdate(chip::Controller::DeviceP
         // to mark end of commissioning request.
         // Since OnPairingComplete(failure_code) might not be invoked in all cases, use this opportunity to inform of failed commissioning
         // and default the error to timeout since that is best guess in this layer.
-        if (status == chip::Controller::DevicePairingDelegate::Status::SecurePairingFailed && [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
+        if (status == chip::Controller::DevicePairingDelegate::Status::SecurePairingFailed
+            && strongDelegate != static_cast<id<MTRDeviceControllerDelegate>>(strongController)
+            && [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
             OnCommissioningComplete(mDeviceNodeId, CHIP_ERROR_TIMEOUT);
         }
     }


### PR DESCRIPTION
#### Summary

2026-02-25 11:53:31.405397+0800 0x9129     Default     0x0                  1103   0    CHIPServiceRequestHandlerExtension: (CoreFoundation) *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[MTRDeviceController_Concrete controller:commissioningComplete:nodeID:metrics:]: unrecognized selector sent to instance 0x10408d0f0'


#### Testing

Reproduced manually

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
