### PR TITLE
Add missing include required for std::find

### DIFF
--- a/src/app/tests/TestClosureDimensionCluster.cpp
+++ b/src/app/tests/TestClosureDimensionCluster.cpp
@@ -15,6 +15,12 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#include <algorithm>
+#include <vector>
+
+#include <pw_unit_test/framework.h>
+
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/clusters/closure-dimension-server/closure-dimension-cluster-logic.h>
 #include <app/clusters/closure-dimension-server/closure-dimension-cluster-objects.h>
@@ -23,10 +29,8 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/UnitTestUtils.h>
 #include <platform/CHIPDeviceLayer.h>
-#include <pw_unit_test/framework.h>
 #include <system/SystemClock.h>
 #include <system/SystemTimer.h>
-#include <vector>
 
 using namespace chip::app::Clusters::ClosureDimension;
 


### PR DESCRIPTION
#### Summary

The `std::find` function is defined in the `<algorithm>` header file. Without including it, compilation fails on Tizen 10.0 with GCC 14.2:

```
INFO    ../../src/test_driver/tizen/third_party/connectedhomeip/src/app/tests/TestClosureDimensionCluster.cpp:110:21: error: no matching function for call to ‘find(std::vector<unsigned int>::iterator, std::vector<unsigned int>::iterator, chip::AttributeId&)’
INFO      110 |     return std::find(changes.begin(), changes.end(), id) != changes.end();
INFO          |            ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

#### Testing

Verified locally that adding `<algorithm>` header file fixes the problem.