### PR TITLE
[DRAFT] [Silabs] [Refactor] BLE Skeleton code

### DIFF
--- a/src/platform/silabs/SiWx/BUILD.gn
+++ b/src/platform/silabs/SiWx/BUILD.gn
@@ -90,6 +90,8 @@ static_library("SiWx") {
     "${chip_root}/src/app/common:ids",
     "${chip_root}/src/platform/logging:headers",
     "${sl_provision_root}:headers",
+    "${silabs_platform_dir}/ble:ble",
+    "${silabs_platform_dir}/ble/SiWx:ble-siwx",
   ]
 
   if (chip_enable_multi_ota_requestor) {

--- a/src/platform/silabs/SiWx/BUILD.gn
+++ b/src/platform/silabs/SiWx/BUILD.gn
@@ -89,9 +89,9 @@ static_library("SiWx") {
   deps = [
     "${chip_root}/src/app/common:ids",
     "${chip_root}/src/platform/logging:headers",
-    "${sl_provision_root}:headers",
     "${silabs_platform_dir}/ble:ble",
     "${silabs_platform_dir}/ble/SiWx:ble-siwx",
+    "${sl_provision_root}:headers",
   ]
 
   if (chip_enable_multi_ota_requestor) {

--- a/src/platform/silabs/ble/BUILD.gn
+++ b/src/platform/silabs/ble/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/third_party/silabs/efr32_sdk.gni")
+
+# Shared BLE channel interface and types (headers only).
+# Platform implementations: ble/efr32 (BleChannelMatterEfr32), ble/SiWx (BleChannelMatterSiWx).
+source_set("ble") {
+  public_deps = [ "${chip_root}/src/platform:platform_base" ]
+  include_dirs = [ "${silabs_platform_dir}/ble" ]
+}

--- a/src/platform/silabs/ble/BleChannel.h
+++ b/src/platform/silabs/ble/BleChannel.h
@@ -1,0 +1,87 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Abstract interface for a BLE channel (Matter BLE or side channel).
+ *      BLEManagerImpl holds a Matter channel and an optional side channel;
+ *      all platform BLE operations are delegated to the channel.
+ *      No native stack headers in this interface.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "BlePlatformTypes.h"
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ * Abstract base for any BLE channel (Matter BLE or side channel).
+ * Platform implementations: BleChannelMatterEfr32, BleChannelMatterSiWx (Matter);
+ * BleSideChannelEfr32, BleSideChannelSiWx (side channel).
+ */
+class BleChannel
+{
+public:
+    virtual ~BleChannel() = default;
+
+    // ----- Initialization -----
+    virtual CHIP_ERROR Init()                                             = 0;
+    virtual CHIP_ERROR Shutdown()                                        = 0;
+
+    // ----- Advertising -----
+    virtual CHIP_ERROR StartAdvertising(const BleAdvertisingParams & params) = 0;
+    virtual CHIP_ERROR StopAdvertising()                                 = 0;
+    virtual CHIP_ERROR SetAdvertisingData(const uint8_t * data, size_t length) = 0;
+
+    // ----- Connection -----
+    virtual CHIP_ERROR CloseConnection(BleConnectionHandle conId)         = 0;
+    virtual CHIP_ERROR UpdateConnectionParams(BleConnectionHandle conId,
+                                              const BleConnectionParams & params) = 0;
+
+    // ----- GATT -----
+    virtual CHIP_ERROR SendIndication(BleConnectionHandle conId, uint16_t charHandle,
+                                     const uint8_t * data, size_t length) = 0;
+    virtual uint16_t GetMTU(BleConnectionHandle conId) const             = 0;
+
+    // ----- Event handling -----
+    /** Callback invoked when channel parses an event and produces a BleEvent (e.g. for Matter BLE). */
+    virtual void SetEventCallback(BleEventCallback callback, void * context) = 0;
+    /** Returns true if this channel handles the given platform event id. */
+    virtual bool CanHandleEvent(uint32_t eventId) const                  = 0;
+    /** Single entry point: parse platform event, optionally build BleEvent and invoke callback. */
+    virtual void ParseEvent(void * platformEvent)                        = 0;
+
+    // ----- Address / identity -----
+    virtual CHIP_ERROR GetAddress(uint8_t * addr, size_t * length)        = 0;
+    virtual CHIP_ERROR SetDeviceName(const char * name)                   = 0;
+
+    // ----- Indication timer -----
+    virtual CHIP_ERROR StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs,
+                                            void (*callback)(void *), void * context) = 0;
+    virtual CHIP_ERROR CancelIndicationTimer(BleConnectionHandle conId)  = 0;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/ble/BleChannel.h
+++ b/src/platform/silabs/ble/BleChannel.h
@@ -46,40 +46,38 @@ public:
     virtual ~BleChannel() = default;
 
     // ----- Initialization -----
-    virtual CHIP_ERROR Init()                                             = 0;
-    virtual CHIP_ERROR Shutdown()                                        = 0;
+    virtual CHIP_ERROR Init()     = 0;
+    virtual CHIP_ERROR Shutdown() = 0;
 
     // ----- Advertising -----
-    virtual CHIP_ERROR StartAdvertising(const BleAdvertisingParams & params) = 0;
-    virtual CHIP_ERROR StopAdvertising()                                 = 0;
+    virtual CHIP_ERROR StartAdvertising(const BleAdvertisingParams & params)   = 0;
+    virtual CHIP_ERROR StopAdvertising()                                       = 0;
     virtual CHIP_ERROR SetAdvertisingData(const uint8_t * data, size_t length) = 0;
 
     // ----- Connection -----
-    virtual CHIP_ERROR CloseConnection(BleConnectionHandle conId)         = 0;
-    virtual CHIP_ERROR UpdateConnectionParams(BleConnectionHandle conId,
-                                              const BleConnectionParams & params) = 0;
+    virtual CHIP_ERROR CloseConnection(BleConnectionHandle conId)                                            = 0;
+    virtual CHIP_ERROR UpdateConnectionParams(BleConnectionHandle conId, const BleConnectionParams & params) = 0;
 
     // ----- GATT -----
-    virtual CHIP_ERROR SendIndication(BleConnectionHandle conId, uint16_t charHandle,
-                                     const uint8_t * data, size_t length) = 0;
-    virtual uint16_t GetMTU(BleConnectionHandle conId) const             = 0;
+    virtual CHIP_ERROR SendIndication(BleConnectionHandle conId, uint16_t charHandle, const uint8_t * data, size_t length) = 0;
+    virtual uint16_t GetMTU(BleConnectionHandle conId) const                                                               = 0;
 
     // ----- Event handling -----
     /** Callback invoked when channel parses an event and produces a BleEvent (e.g. for Matter BLE). */
     virtual void SetEventCallback(BleEventCallback callback, void * context) = 0;
     /** Returns true if this channel handles the given platform event id. */
-    virtual bool CanHandleEvent(uint32_t eventId) const                  = 0;
+    virtual bool CanHandleEvent(uint32_t eventId) const = 0;
     /** Single entry point: parse platform event, optionally build BleEvent and invoke callback. */
-    virtual void ParseEvent(void * platformEvent)                        = 0;
+    virtual void ParseEvent(void * platformEvent) = 0;
 
     // ----- Address / identity -----
-    virtual CHIP_ERROR GetAddress(uint8_t * addr, size_t * length)        = 0;
-    virtual CHIP_ERROR SetDeviceName(const char * name)                   = 0;
+    virtual CHIP_ERROR GetAddress(uint8_t * addr, size_t * length) = 0;
+    virtual CHIP_ERROR SetDeviceName(const char * name)            = 0;
 
     // ----- Indication timer -----
-    virtual CHIP_ERROR StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs,
-                                            void (*callback)(void *), void * context) = 0;
-    virtual CHIP_ERROR CancelIndicationTimer(BleConnectionHandle conId)  = 0;
+    virtual CHIP_ERROR StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs, void (*callback)(void *),
+                                            void * context)             = 0;
+    virtual CHIP_ERROR CancelIndicationTimer(BleConnectionHandle conId) = 0;
 };
 
 } // namespace Internal

--- a/src/platform/silabs/ble/BlePlatformTypes.h
+++ b/src/platform/silabs/ble/BlePlatformTypes.h
@@ -61,12 +61,12 @@ enum class BleEventType : uint32_t
  */
 struct BleEvent
 {
-    BleEventType type = BleEventType::kUnknown;
-    BleConnectionHandle connection  = nullptr;
-    void * data                     = nullptr;
-    size_t dataLength               = 0;
+    BleEventType type              = BleEventType::kUnknown;
+    BleConnectionHandle connection = nullptr;
+    void * data                    = nullptr;
+    size_t dataLength              = 0;
     uint16_t attributeHandle       = 0;
-    uint32_t timerId                = 0;
+    uint32_t timerId               = 0;
 };
 
 /**
@@ -74,10 +74,10 @@ struct BleEvent
  */
 struct BleAdvertisingParams
 {
-    uint16_t minInterval  = 0;
-    uint16_t maxInterval  = 0;
-    bool connectable      = true;
-    uint8_t * customData  = nullptr;
+    uint16_t minInterval    = 0;
+    uint16_t maxInterval    = 0;
+    bool connectable        = true;
+    uint8_t * customData    = nullptr;
     size_t customDataLength = 0;
 };
 

--- a/src/platform/silabs/ble/BlePlatformTypes.h
+++ b/src/platform/silabs/ble/BlePlatformTypes.h
@@ -1,0 +1,103 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Platform-agnostic BLE types used by BleChannel and BLEManagerImpl.
+ *      Shared across Matter BLE and side channel implementations.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ * Connection handle type for BLE operations. Platform code casts to/from
+ * BLE_CONNECTION_OBJECT where required by the Matter BleLayer.
+ */
+using BleConnectionHandle = void *;
+
+/**
+ * BLE event types delivered from platform stack to channel (ParseEvent)
+ * and then to BLEManagerImpl via callback (OnMatterBleEvent).
+ */
+enum class BleEventType : uint32_t
+{
+    kConnectionOpened,
+    kConnectionClosed,
+    kConnectionParameters,
+    kMtuExchanged,
+    kGattWrite,
+    kGattRead,
+    kIndicationConfirmation,
+    kSoftTimerExpired,
+    kBoot,
+    kUnknown
+};
+
+/**
+ * Unified BLE event passed from channel to BLEManagerImpl.
+ */
+struct BleEvent
+{
+    BleEventType type = BleEventType::kUnknown;
+    BleConnectionHandle connection  = nullptr;
+    void * data                     = nullptr;
+    size_t dataLength               = 0;
+    uint16_t attributeHandle       = 0;
+    uint32_t timerId                = 0;
+};
+
+/**
+ * Advertising parameters for StartAdvertising.
+ */
+struct BleAdvertisingParams
+{
+    uint16_t minInterval  = 0;
+    uint16_t maxInterval  = 0;
+    bool connectable      = true;
+    uint8_t * customData  = nullptr;
+    size_t customDataLength = 0;
+};
+
+/**
+ * Connection parameters for UpdateConnectionParams.
+ */
+struct BleConnectionParams
+{
+    uint16_t minInterval = 0;
+    uint16_t maxInterval = 0;
+    uint16_t latency     = 0;
+    uint16_t timeout     = 0;
+};
+
+/**
+ * Event callback type: channel calls this when it has parsed a platform event
+ * and produced a BleEvent (e.g. for Matter BLE).
+ */
+using BleEventCallback = void (*)(const BleEvent & event, void * context);
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/ble/BleSideChannel.h
+++ b/src/platform/silabs/ble/BleSideChannel.h
@@ -54,14 +54,14 @@ public:
     virtual CHIP_ERROR ConfigureAdvertising(const BleSideChannelAdvConfig & config) = 0;
 
     // ----- GATT server (side channel) -----
-    virtual void HandleReadRequest(void * platformEvent, const uint8_t * data, size_t length)   = 0;
-    virtual void HandleWriteRequest(void * platformEvent, uint8_t * data, size_t length)       = 0;
-    virtual void HandleCCCDWriteRequest(void * platformEvent, bool & isNewSubscription)        = 0;
-    virtual void UpdateMtu(void * platformEvent)                                               = 0;
+    virtual void HandleReadRequest(void * platformEvent, const uint8_t * data, size_t length) = 0;
+    virtual void HandleWriteRequest(void * platformEvent, uint8_t * data, size_t length)      = 0;
+    virtual void HandleCCCDWriteRequest(void * platformEvent, bool & isNewSubscription)       = 0;
+    virtual void UpdateMtu(void * platformEvent)                                              = 0;
 
     // ----- Connection state (side channel) -----
-    virtual CHIP_ERROR AddConnection(BleConnectionHandle conId, uint16_t mtu)                  = 0;
-    virtual CHIP_ERROR RemoveConnection(BleConnectionHandle conId)                             = 0;
+    virtual CHIP_ERROR AddConnection(BleConnectionHandle conId, uint16_t mtu) = 0;
+    virtual CHIP_ERROR RemoveConnection(BleConnectionHandle conId)            = 0;
 };
 
 } // namespace Internal

--- a/src/platform/silabs/ble/BleSideChannel.h
+++ b/src/platform/silabs/ble/BleSideChannel.h
@@ -1,0 +1,69 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Abstract base for side channel implementations (e.g. provisioning CLI).
+ *      Extends BleChannel with side-channel-specific API (GATT read/write/CCCD, etc.).
+ */
+
+#pragma once
+
+#include "BleChannel.h"
+#include "BlePlatformTypes.h"
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ * Configuration for side-channel advertising (platform-specific payload).
+ * Platform may define a concrete type; this struct is a placeholder for the skeleton.
+ */
+struct BleSideChannelAdvConfig
+{
+    void * opaque = nullptr;
+};
+
+/**
+ * Abstract base for side channel. Implements BleChannel and adds
+ * HandleReadRequest, HandleWriteRequest, HandleCCCDWriteRequest, UpdateMtu,
+ * AddConnection, RemoveConnection, ConfigureAdvertising.
+ */
+class BleSideChannel : public BleChannel
+{
+public:
+    ~BleSideChannel() override = default;
+
+    // ----- Side-channel advertising -----
+    virtual CHIP_ERROR ConfigureAdvertising(const BleSideChannelAdvConfig & config) = 0;
+
+    // ----- GATT server (side channel) -----
+    virtual void HandleReadRequest(void * platformEvent, const uint8_t * data, size_t length)   = 0;
+    virtual void HandleWriteRequest(void * platformEvent, uint8_t * data, size_t length)       = 0;
+    virtual void HandleCCCDWriteRequest(void * platformEvent, bool & isNewSubscription)        = 0;
+    virtual void UpdateMtu(void * platformEvent)                                               = 0;
+
+    // ----- Connection state (side channel) -----
+    virtual CHIP_ERROR AddConnection(BleConnectionHandle conId, uint16_t mtu)                  = 0;
+    virtual CHIP_ERROR RemoveConnection(BleConnectionHandle conId)                             = 0;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/ble/SiWx/BUILD.gn
+++ b/src/platform/silabs/ble/SiWx/BUILD.gn
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/third_party/silabs/efr32_sdk.gni")
+
+# Matter BLE channel implementation for SiWx917 (skeleton; full impl in Phase 3).
+source_set("ble-siwx") {
+  sources = [
+    "${silabs_platform_dir}/ble/SiWx/BleChannelMatterSiWx.cpp",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/platform:platform_base",
+    "${silabs_platform_dir}/ble:ble",
+  ]
+
+  include_dirs = [
+    "${silabs_platform_dir}/ble",
+    "${silabs_platform_dir}/ble/SiWx",
+  ]
+}

--- a/src/platform/silabs/ble/SiWx/BUILD.gn
+++ b/src/platform/silabs/ble/SiWx/BUILD.gn
@@ -17,9 +17,7 @@ import("${chip_root}/third_party/silabs/efr32_sdk.gni")
 
 # Matter BLE channel implementation for SiWx917 (skeleton; full impl in Phase 3).
 source_set("ble-siwx") {
-  sources = [
-    "${silabs_platform_dir}/ble/SiWx/BleChannelMatterSiWx.cpp",
-  ]
+  sources = [ "${silabs_platform_dir}/ble/SiWx/BleChannelMatterSiWx.cpp" ]
 
   public_deps = [
     "${chip_root}/src/platform:platform_base",

--- a/src/platform/silabs/ble/SiWx/BleChannelMatterSiWx.cpp
+++ b/src/platform/silabs/ble/SiWx/BleChannelMatterSiWx.cpp
@@ -1,0 +1,109 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Matter BLE channel implementation for SiWx917.
+ */
+
+#include "BleChannelMatterSiWx.h"
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+CHIP_ERROR BleChannelMatterSiWx::Init()
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR BleChannelMatterSiWx::Shutdown()
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR BleChannelMatterSiWx::StartAdvertising(const BleAdvertisingParams & params)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterSiWx::StopAdvertising()
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterSiWx::SetAdvertisingData(const uint8_t * data, size_t length)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterSiWx::CloseConnection(BleConnectionHandle conId)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterSiWx::UpdateConnectionParams(BleConnectionHandle conId,
+                                                        const BleConnectionParams & params)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterSiWx::SendIndication(BleConnectionHandle conId, uint16_t charHandle,
+                                                const uint8_t * data, size_t length)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+uint16_t BleChannelMatterSiWx::GetMTU(BleConnectionHandle conId) const
+{
+    return 0;
+}
+
+void BleChannelMatterSiWx::SetEventCallback(BleEventCallback callback, void * context) {}
+
+bool BleChannelMatterSiWx::CanHandleEvent(uint32_t eventId) const
+{
+    return false;
+}
+
+void BleChannelMatterSiWx::ParseEvent(void * platformEvent) {}
+
+CHIP_ERROR BleChannelMatterSiWx::GetAddress(uint8_t * addr, size_t * length)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterSiWx::SetDeviceName(const char * name)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterSiWx::StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs,
+                                                      void (*callback)(void *), void * context)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterSiWx::CancelIndicationTimer(BleConnectionHandle conId)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/ble/SiWx/BleChannelMatterSiWx.cpp
+++ b/src/platform/silabs/ble/SiWx/BleChannelMatterSiWx.cpp
@@ -57,14 +57,12 @@ CHIP_ERROR BleChannelMatterSiWx::CloseConnection(BleConnectionHandle conId)
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-CHIP_ERROR BleChannelMatterSiWx::UpdateConnectionParams(BleConnectionHandle conId,
-                                                        const BleConnectionParams & params)
+CHIP_ERROR BleChannelMatterSiWx::UpdateConnectionParams(BleConnectionHandle conId, const BleConnectionParams & params)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-CHIP_ERROR BleChannelMatterSiWx::SendIndication(BleConnectionHandle conId, uint16_t charHandle,
-                                                const uint8_t * data, size_t length)
+CHIP_ERROR BleChannelMatterSiWx::SendIndication(BleConnectionHandle conId, uint16_t charHandle, const uint8_t * data, size_t length)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
@@ -93,8 +91,8 @@ CHIP_ERROR BleChannelMatterSiWx::SetDeviceName(const char * name)
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-CHIP_ERROR BleChannelMatterSiWx::StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs,
-                                                      void (*callback)(void *), void * context)
+CHIP_ERROR BleChannelMatterSiWx::StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs, void (*callback)(void *),
+                                                      void * context)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/silabs/ble/SiWx/BleChannelMatterSiWx.h
+++ b/src/platform/silabs/ble/SiWx/BleChannelMatterSiWx.h
@@ -43,11 +43,9 @@ public:
     CHIP_ERROR SetAdvertisingData(const uint8_t * data, size_t length) override;
 
     CHIP_ERROR CloseConnection(BleConnectionHandle conId) override;
-    CHIP_ERROR UpdateConnectionParams(BleConnectionHandle conId,
-                                     const BleConnectionParams & params) override;
+    CHIP_ERROR UpdateConnectionParams(BleConnectionHandle conId, const BleConnectionParams & params) override;
 
-    CHIP_ERROR SendIndication(BleConnectionHandle conId, uint16_t charHandle,
-                              const uint8_t * data, size_t length) override;
+    CHIP_ERROR SendIndication(BleConnectionHandle conId, uint16_t charHandle, const uint8_t * data, size_t length) override;
     uint16_t GetMTU(BleConnectionHandle conId) const override;
 
     void SetEventCallback(BleEventCallback callback, void * context) override;
@@ -57,8 +55,8 @@ public:
     CHIP_ERROR GetAddress(uint8_t * addr, size_t * length) override;
     CHIP_ERROR SetDeviceName(const char * name) override;
 
-    CHIP_ERROR StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs,
-                                    void (*callback)(void *), void * context) override;
+    CHIP_ERROR StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs, void (*callback)(void *),
+                                    void * context) override;
     CHIP_ERROR CancelIndicationTimer(BleConnectionHandle conId) override;
 };
 

--- a/src/platform/silabs/ble/SiWx/BleChannelMatterSiWx.h
+++ b/src/platform/silabs/ble/SiWx/BleChannelMatterSiWx.h
@@ -1,0 +1,67 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Matter BLE channel implementation for SiWx917.
+ */
+
+#pragma once
+
+#include "BleChannel.h"
+#include "BlePlatformTypes.h"
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+class BleChannelMatterSiWx : public BleChannel
+{
+public:
+    BleChannelMatterSiWx()           = default;
+    ~BleChannelMatterSiWx() override = default;
+
+    CHIP_ERROR Init() override;
+    CHIP_ERROR Shutdown() override;
+
+    CHIP_ERROR StartAdvertising(const BleAdvertisingParams & params) override;
+    CHIP_ERROR StopAdvertising() override;
+    CHIP_ERROR SetAdvertisingData(const uint8_t * data, size_t length) override;
+
+    CHIP_ERROR CloseConnection(BleConnectionHandle conId) override;
+    CHIP_ERROR UpdateConnectionParams(BleConnectionHandle conId,
+                                     const BleConnectionParams & params) override;
+
+    CHIP_ERROR SendIndication(BleConnectionHandle conId, uint16_t charHandle,
+                              const uint8_t * data, size_t length) override;
+    uint16_t GetMTU(BleConnectionHandle conId) const override;
+
+    void SetEventCallback(BleEventCallback callback, void * context) override;
+    bool CanHandleEvent(uint32_t eventId) const override;
+    void ParseEvent(void * platformEvent) override;
+
+    CHIP_ERROR GetAddress(uint8_t * addr, size_t * length) override;
+    CHIP_ERROR SetDeviceName(const char * name) override;
+
+    CHIP_ERROR StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs,
+                                    void (*callback)(void *), void * context) override;
+    CHIP_ERROR CancelIndicationTimer(BleConnectionHandle conId) override;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/ble/efr32/BUILD.gn
+++ b/src/platform/silabs/ble/efr32/BUILD.gn
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/third_party/silabs/efr32_sdk.gni")
+
+# Matter BLE channel implementation for EFR32 (skeleton; full impl in Phase 2).
+source_set("ble-efr32") {
+  sources = [
+    "${silabs_platform_dir}/ble/efr32/BleChannelMatterEfr32.cpp",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/platform:platform_base",
+    "${silabs_platform_dir}/ble:ble",
+  ]
+
+  include_dirs = [
+    "${silabs_platform_dir}/ble",
+    "${silabs_platform_dir}/ble/efr32",
+  ]
+}

--- a/src/platform/silabs/ble/efr32/BUILD.gn
+++ b/src/platform/silabs/ble/efr32/BUILD.gn
@@ -17,9 +17,7 @@ import("${chip_root}/third_party/silabs/efr32_sdk.gni")
 
 # Matter BLE channel implementation for EFR32 (skeleton; full impl in Phase 2).
 source_set("ble-efr32") {
-  sources = [
-    "${silabs_platform_dir}/ble/efr32/BleChannelMatterEfr32.cpp",
-  ]
+  sources = [ "${silabs_platform_dir}/ble/efr32/BleChannelMatterEfr32.cpp" ]
 
   public_deps = [
     "${chip_root}/src/platform:platform_base",

--- a/src/platform/silabs/ble/efr32/BleChannelMatterEfr32.cpp
+++ b/src/platform/silabs/ble/efr32/BleChannelMatterEfr32.cpp
@@ -1,0 +1,109 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Matter BLE channel implementation for EFR32.
+ */
+
+#include "BleChannelMatterEfr32.h"
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+CHIP_ERROR BleChannelMatterEfr32::Init()
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR BleChannelMatterEfr32::Shutdown()
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR BleChannelMatterEfr32::StartAdvertising(const BleAdvertisingParams & params)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterEfr32::StopAdvertising()
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterEfr32::SetAdvertisingData(const uint8_t * data, size_t length)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterEfr32::CloseConnection(BleConnectionHandle conId)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterEfr32::UpdateConnectionParams(BleConnectionHandle conId,
+                                                          const BleConnectionParams & params)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterEfr32::SendIndication(BleConnectionHandle conId, uint16_t charHandle,
+                                                 const uint8_t * data, size_t length)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+uint16_t BleChannelMatterEfr32::GetMTU(BleConnectionHandle conId) const
+{
+    return 0;
+}
+
+void BleChannelMatterEfr32::SetEventCallback(BleEventCallback callback, void * context) {}
+
+bool BleChannelMatterEfr32::CanHandleEvent(uint32_t eventId) const
+{
+    return false;
+}
+
+void BleChannelMatterEfr32::ParseEvent(void * platformEvent) {}
+
+CHIP_ERROR BleChannelMatterEfr32::GetAddress(uint8_t * addr, size_t * length)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterEfr32::SetDeviceName(const char * name)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterEfr32::StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs,
+                                                        void (*callback)(void *), void * context)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR BleChannelMatterEfr32::CancelIndicationTimer(BleConnectionHandle conId)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/ble/efr32/BleChannelMatterEfr32.cpp
+++ b/src/platform/silabs/ble/efr32/BleChannelMatterEfr32.cpp
@@ -57,14 +57,13 @@ CHIP_ERROR BleChannelMatterEfr32::CloseConnection(BleConnectionHandle conId)
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-CHIP_ERROR BleChannelMatterEfr32::UpdateConnectionParams(BleConnectionHandle conId,
-                                                          const BleConnectionParams & params)
+CHIP_ERROR BleChannelMatterEfr32::UpdateConnectionParams(BleConnectionHandle conId, const BleConnectionParams & params)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-CHIP_ERROR BleChannelMatterEfr32::SendIndication(BleConnectionHandle conId, uint16_t charHandle,
-                                                 const uint8_t * data, size_t length)
+CHIP_ERROR BleChannelMatterEfr32::SendIndication(BleConnectionHandle conId, uint16_t charHandle, const uint8_t * data,
+                                                 size_t length)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
@@ -93,8 +92,8 @@ CHIP_ERROR BleChannelMatterEfr32::SetDeviceName(const char * name)
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-CHIP_ERROR BleChannelMatterEfr32::StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs,
-                                                        void (*callback)(void *), void * context)
+CHIP_ERROR BleChannelMatterEfr32::StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs, void (*callback)(void *),
+                                                       void * context)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/silabs/ble/efr32/BleChannelMatterEfr32.h
+++ b/src/platform/silabs/ble/efr32/BleChannelMatterEfr32.h
@@ -32,7 +32,7 @@ namespace Internal {
 class BleChannelMatterEfr32 : public BleChannel
 {
 public:
-    BleChannelMatterEfr32()          = default;
+    BleChannelMatterEfr32()           = default;
     ~BleChannelMatterEfr32() override = default;
 
     CHIP_ERROR Init() override;
@@ -43,11 +43,9 @@ public:
     CHIP_ERROR SetAdvertisingData(const uint8_t * data, size_t length) override;
 
     CHIP_ERROR CloseConnection(BleConnectionHandle conId) override;
-    CHIP_ERROR UpdateConnectionParams(BleConnectionHandle conId,
-                                      const BleConnectionParams & params) override;
+    CHIP_ERROR UpdateConnectionParams(BleConnectionHandle conId, const BleConnectionParams & params) override;
 
-    CHIP_ERROR SendIndication(BleConnectionHandle conId, uint16_t charHandle,
-                              const uint8_t * data, size_t length) override;
+    CHIP_ERROR SendIndication(BleConnectionHandle conId, uint16_t charHandle, const uint8_t * data, size_t length) override;
     uint16_t GetMTU(BleConnectionHandle conId) const override;
 
     void SetEventCallback(BleEventCallback callback, void * context) override;
@@ -57,8 +55,8 @@ public:
     CHIP_ERROR GetAddress(uint8_t * addr, size_t * length) override;
     CHIP_ERROR SetDeviceName(const char * name) override;
 
-    CHIP_ERROR StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs,
-                                    void (*callback)(void *), void * context) override;
+    CHIP_ERROR StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs, void (*callback)(void *),
+                                    void * context) override;
     CHIP_ERROR CancelIndicationTimer(BleConnectionHandle conId) override;
 };
 

--- a/src/platform/silabs/ble/efr32/BleChannelMatterEfr32.h
+++ b/src/platform/silabs/ble/efr32/BleChannelMatterEfr32.h
@@ -1,0 +1,67 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Matter BLE channel implementation for EFR32.
+ */
+
+#pragma once
+
+#include "BleChannel.h"
+#include "BlePlatformTypes.h"
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+class BleChannelMatterEfr32 : public BleChannel
+{
+public:
+    BleChannelMatterEfr32()          = default;
+    ~BleChannelMatterEfr32() override = default;
+
+    CHIP_ERROR Init() override;
+    CHIP_ERROR Shutdown() override;
+
+    CHIP_ERROR StartAdvertising(const BleAdvertisingParams & params) override;
+    CHIP_ERROR StopAdvertising() override;
+    CHIP_ERROR SetAdvertisingData(const uint8_t * data, size_t length) override;
+
+    CHIP_ERROR CloseConnection(BleConnectionHandle conId) override;
+    CHIP_ERROR UpdateConnectionParams(BleConnectionHandle conId,
+                                      const BleConnectionParams & params) override;
+
+    CHIP_ERROR SendIndication(BleConnectionHandle conId, uint16_t charHandle,
+                              const uint8_t * data, size_t length) override;
+    uint16_t GetMTU(BleConnectionHandle conId) const override;
+
+    void SetEventCallback(BleEventCallback callback, void * context) override;
+    bool CanHandleEvent(uint32_t eventId) const override;
+    void ParseEvent(void * platformEvent) override;
+
+    CHIP_ERROR GetAddress(uint8_t * addr, size_t * length) override;
+    CHIP_ERROR SetDeviceName(const char * name) override;
+
+    CHIP_ERROR StartIndicationTimer(BleConnectionHandle conId, uint32_t timeoutMs,
+                                    void (*callback)(void *), void * context) override;
+    CHIP_ERROR CancelIndicationTimer(BleConnectionHandle conId) override;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -88,10 +88,17 @@ static_library("efr32") {
   } else {
     sources += [ "BLEManagerImpl.cpp" ]
   }
+
   deps = [
     "${chip_root}/src/app/common:ids",
     "${sl_provision_root}:headers",
+    "${silabs_platform_dir}/ble:ble",
   ]
+  if (sl_matter_enable_siwx_ble) {
+    deps += [ "${silabs_platform_dir}/ble/SiWx:ble-siwx" ]
+  } else {
+    deps += [ "${silabs_platform_dir}/ble/efr32:ble-efr32" ]
+  }
 
   # Add platform crypto implementation
   if (chip_crypto == "platform") {

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -91,8 +91,8 @@ static_library("efr32") {
 
   deps = [
     "${chip_root}/src/app/common:ids",
-    "${sl_provision_root}:headers",
     "${silabs_platform_dir}/ble:ble",
+    "${sl_provision_root}:headers",
   ]
   if (sl_matter_enable_siwx_ble) {
     deps += [ "${silabs_platform_dir}/ble/SiWx:ble-siwx" ]


### PR DESCRIPTION
#### Summary

This PR introduces the BLE channel abstraction and skeleton implementations so EFR32 and SiWx917 share a single API and both platforms build with the new structure. 

**Current logic**: 
There is a single BLEManagerImpl used for both EFR32 and SiWx917. The file is full of `#if SLI_SI91X_ENABLE_BLE / #else` branches: one path uses EFR32 APIs (sl_bt_msg_t, sl_bt_*, gatt_db.h), the other uses SiWx APIs (SilabsBleWrapper::BleEvent_t, rsi_ble_*, BLE task, queue). 
Init, event handling (e.g. HandleConnectEvent, HandleWriteEvent), and BLE operations are all duplicated inside this one class, which makes the code hard to read and maintain.

**What we’re doing**:
We’re moving the platform-specific BLE logic out of BLEManagerImpl and into separate channel classes. BLEManagerImpl stays a single, shared implementation but no longer contains EFR/SiWx conditionals for the stack. Instead it will hold a `BleChannel*` (e.g. BleChannelMatterEfr32 or BleChannelMatterSiWx), call a common API (e.g. channel->Init(), channel->ParseEvent(evt)), and get back a unified BleEvent via a callback. All sl_bt_* vs rsi_ble_* and event-type differences live inside the channel implementations, so we reduce the conditional logic in BLEManagerImpl and make adding or changing a platform a matter of implementing the channel interface instead of editing one big file.

Changes: 

- src/platform/silabs/ble/BlePlatformTypes.h
Platform-agnostic types: 
BleConnectionHandle, BleEventType, BleEvent, BleAdvertisingParams, BleConnectionParams, BleEventCallback. No stack-specific headers.

- src/platform/silabs/ble/BleChannel.h
Abstract BLE channel interface:
Init, Shutdown; StartAdvertising, StopAdvertising, SetAdvertisingData; CloseConnection, UpdateConnectionParams; SendIndication, GetMTU; SetEventCallback, CanHandleEvent, ParseEvent(void* platformEvent); GetAddress, SetDeviceName; StartIndicationTimer, CancelIndicationTimer.

- src/platform/silabs/ble/BleSideChannel.h
Abstract side-channel interface extending BleChannel:
ConfigureAdvertising(BleSideChannelAdvConfig), HandleReadRequest, HandleWriteRequest, HandleCCCDWriteRequest, UpdateMtu, AddConnection, RemoveConnection. For future provisioning/CLI side channel.

- src/platform/silabs/ble/efr32/BleChannelMatterEfr32.{h,cpp}
Matter BLE channel skeleton for EFR32: implements all BleChannel methods with stubs (e.g. CHIP_NO_ERROR for init, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE or no-op where appropriate). No sl_bt_* calls yet.

- src/platform/silabs/ble/SiWx/BleChannelMatterSiWx.{h,cpp}
Matter BLE channel skeleton for SiWx917: same as above for SiWx; no rsi_ble_* / SilabsBleWrapper usage yet.

- src/platform/silabs/ble/BUILD.gn
Defines shared ble target (headers/types only, include_dirs for ble).

- src/platform/silabs/ble/efr32/BUILD.gn
Defines ble-efr32 source set (compiles BleChannelMatterEfr32.cpp), depends on ble.

- src/platform/silabs/ble/SiWx/BUILD.gn
Defines ble-siwx source set (compiles BleChannelMatterSiWx.cpp), depends on ble.
 
The complete refactor would be done in the upcoming phases: 

- Phase 2: Implement BleChannelMatterEfr32 with real sl_bt_* logic and integrate with BLEManagerImpl (event path, init, delegation).
- Phase 3: Implement BleChannelMatterSiWx with BLE task and RSI/Silabs APIs and integrate with unified BLEManagerImpl.
- Phase 4: Side channel injection and routing.


#### Related issues

N/A

#### Testing

EFR32 and SiWx builds compile and link with the new skeleton.
No runtime BLE behavior change: BLEManagerImpl does not yet instantiate or use the new channels; that will be done in further phases.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
