### PR TITLE
Update Bridged Device Basic Info to latest spec logic

### DIFF
--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -76,16 +76,35 @@ Status Device::OnNodeLabelChanged(const std::string & newNodeLabel)
 
 app::ServerClusterRegistration &
 Device::CreateBridgedDeviceInfo(chip::EndpointId endpointId,
-                                chip::app::Clusters::BridgedDeviceBasicInformationCluster::RequiredData && required,
-                                chip::app::Clusters::BridgedDeviceBasicInformationCluster::FixedData && fixed)
+                                chip::app::Clusters::BridgedDeviceBasicInformationCluster::MutableData && mutableData,
+                                chip::app::Clusters::BridgedDeviceBasicInformationCluster::FixedData && fixedData)
 {
     VerifyOrDie(!mBridgedDevice.IsConstructed());
 
     static chip::app::DefaultTimerDelegate timerDelegate;
 
-    mBridgedDevice.Create(endpointId, std::move(required), std::move(fixed),
+    // Ensure configuration version is set.
+    // If we were passed a version in mutableData (e.g. from restore), keep it.
+    // Otherwise default to 1 and use our delegate.
+    if (!mutableData.configurationVersion.has_value())
+    {
+        mutableData.configurationVersion.emplace(app::Clusters::BridgedDeviceBasicInformationCluster::Versioning{
+            .version = 1,
+            .delegate = gEmberVersionUpdate,
+        });
+    }
+    else
+    {
+         // If it WAS set (e.g. by caller), we still need to ensure the delegate is set is valid.
+         // Since 'delegate' is a reference, we cannot rebind it. We must reconstruct the Versioning object.
+         mutableData.configurationVersion.emplace(app::Clusters::BridgedDeviceBasicInformationCluster::Versioning{
+            .version = mutableData.configurationVersion->version,
+            .delegate = gEmberVersionUpdate,
+         });
+    }
+
+    mBridgedDevice.Create(endpointId, std::move(mutableData), std::move(fixedData),
                           app::Clusters::BridgedDeviceBasicInformationCluster::Context{
-                              .parentVersionConfiguration = gEmberVersionUpdate,
                               .delegate                   = *this,
                               .timerDelegate              = timerDelegate,
                           });
@@ -164,7 +183,7 @@ void Device::GenerateUniqueId()
 uint32_t Device::GetConfigurationVersion()
 {
     VerifyOrReturnValue(mBridgedDevice.IsConstructed(), 1);
-    return mBridgedDevice.Cluster().GetConfigurationVersion();
+    return mBridgedDevice.Cluster().GetConfigurationVersion().value_or(1);
 }
 
 void Device::IncreaseConfigurationVersion()
@@ -172,7 +191,7 @@ void Device::IncreaseConfigurationVersion()
     VerifyOrReturn(mBridgedDevice.IsConstructed());
     LogErrorOnFailure(mBridgedDevice.Cluster().IncreaseConfigurationVersion());
     ChipLogProgress(DeviceLayer, "Device[%s]: New Configuration Version=\"%d\"", mName,
-                    mBridgedDevice.Cluster().GetConfigurationVersion());
+                    mBridgedDevice.Cluster().GetConfigurationVersion().value_or(0));
 }
 
 DeviceOnOff::DeviceOnOff(const char * szDeviceName, std::string szLocation) : Device(szDeviceName, szLocation)

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -86,22 +86,12 @@ Device::CreateBridgedDeviceInfo(chip::EndpointId endpointId,
     // Ensure configuration version is set.
     // If we were passed a version in mutableData (e.g. from restore), keep it.
     // Otherwise default to 1 and use our delegate.
-    if (!mutableData.configurationVersion.has_value())
-    {
-        mutableData.configurationVersion.emplace(app::Clusters::BridgedDeviceBasicInformationCluster::Versioning{
-            .version  = 1,
-            .delegate = gEmberVersionUpdate,
-        });
-    }
-    else
-    {
-        // If it WAS set (e.g. by caller), we still need to ensure the delegate is set is valid.
-        // Since 'delegate' is a reference, we cannot rebind it. We must reconstruct the Versioning object.
-        mutableData.configurationVersion.emplace(app::Clusters::BridgedDeviceBasicInformationCluster::Versioning{
-            .version  = mutableData.configurationVersion->version,
-            .delegate = gEmberVersionUpdate,
-        });
-    }
+    uint32_t version = mutableData.configurationVersion.has_value() ? mutableData.configurationVersion->version : 1;
+
+mutableData.configurationVersion.emplace(app::Clusters::BridgedDeviceBasicInformationCluster::Versioning{
+    .version = version,
+    .delegate = gEmberVersionUpdate,
+});
 
     mBridgedDevice.Create(endpointId, std::move(mutableData), std::move(fixedData),
                           app::Clusters::BridgedDeviceBasicInformationCluster::Context{

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -88,10 +88,10 @@ Device::CreateBridgedDeviceInfo(chip::EndpointId endpointId,
     // Otherwise default to 1 and use our delegate.
     uint32_t version = mutableData.configurationVersion.has_value() ? mutableData.configurationVersion->version : 1;
 
-mutableData.configurationVersion.emplace(app::Clusters::BridgedDeviceBasicInformationCluster::Versioning{
-    .version = version,
-    .delegate = gEmberVersionUpdate,
-});
+    mutableData.configurationVersion.emplace(app::Clusters::BridgedDeviceBasicInformationCluster::Versioning{
+        .version  = version,
+        .delegate = gEmberVersionUpdate,
+    });
 
     mBridgedDevice.Create(endpointId, std::move(mutableData), std::move(fixedData),
                           app::Clusters::BridgedDeviceBasicInformationCluster::Context{

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -89,24 +89,24 @@ Device::CreateBridgedDeviceInfo(chip::EndpointId endpointId,
     if (!mutableData.configurationVersion.has_value())
     {
         mutableData.configurationVersion.emplace(app::Clusters::BridgedDeviceBasicInformationCluster::Versioning{
-            .version = 1,
+            .version  = 1,
             .delegate = gEmberVersionUpdate,
         });
     }
     else
     {
-         // If it WAS set (e.g. by caller), we still need to ensure the delegate is set is valid.
-         // Since 'delegate' is a reference, we cannot rebind it. We must reconstruct the Versioning object.
-         mutableData.configurationVersion.emplace(app::Clusters::BridgedDeviceBasicInformationCluster::Versioning{
-            .version = mutableData.configurationVersion->version,
+        // If it WAS set (e.g. by caller), we still need to ensure the delegate is set is valid.
+        // Since 'delegate' is a reference, we cannot rebind it. We must reconstruct the Versioning object.
+        mutableData.configurationVersion.emplace(app::Clusters::BridgedDeviceBasicInformationCluster::Versioning{
+            .version  = mutableData.configurationVersion->version,
             .delegate = gEmberVersionUpdate,
-         });
+        });
     }
 
     mBridgedDevice.Create(endpointId, std::move(mutableData), std::move(fixedData),
                           app::Clusters::BridgedDeviceBasicInformationCluster::Context{
-                              .delegate                   = *this,
-                              .timerDelegate              = timerDelegate,
+                              .delegate      = *this,
+                              .timerDelegate = timerDelegate,
                           });
     return mBridgedDevice.Registration();
 }

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -66,8 +66,8 @@ public:
 
     chip::app::ServerClusterRegistration &
     CreateBridgedDeviceInfo(chip::EndpointId endpointId,
-                            chip::app::Clusters::BridgedDeviceBasicInformationCluster::RequiredData && required,
-                            chip::app::Clusters::BridgedDeviceBasicInformationCluster::FixedData && fixed
+                            chip::app::Clusters::BridgedDeviceBasicInformationCluster::MutableData && mutableData,
+                            chip::app::Clusters::BridgedDeviceBasicInformationCluster::FixedData && fixedData
 
     );
 

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -294,11 +294,11 @@ int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const E
                     LogErrorOnFailure(CodegenDataModelProvider::Instance().Registry().Register(
                         dev->CreateBridgedDeviceInfo(gCurrentEndpointId,
                                                      {
-                                                         .reachable            = true,
-                                                         .nodeLabel            = dev->GetName(),
+                                                         .reachable = true,
+                                                         .nodeLabel = dev->GetName(),
                                                      },
                                                      {
-                                                         .uniqueId             = dev->GetUniqueId(),
+                                                         .uniqueId = dev->GetUniqueId(),
                                                      })));
 
                     return index;

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -294,12 +294,12 @@ int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const E
                     LogErrorOnFailure(CodegenDataModelProvider::Instance().Registry().Register(
                         dev->CreateBridgedDeviceInfo(gCurrentEndpointId,
                                                      {
-                                                         .uniqueId             = dev->GetUniqueId(),
                                                          .reachable            = true,
                                                          .nodeLabel            = dev->GetName(),
-                                                         .configurationVersion = dev->GetConfigurationVersion(),
                                                      },
-                                                     {})));
+                                                     {
+                                                         .uniqueId             = dev->GetUniqueId(),
+                                                     })));
 
                     return index;
                 }

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
@@ -72,7 +72,7 @@ CharSpan ToSpan(const std::optional<std::string> & s)
     return ToSpan(*s);
 }
 
-bool operator==(const LocationDescriptorStructType & a, const LocationDescriptorStructType & b)
+bool IsLocationEqual(const LocationDescriptorStructType & a, const LocationDescriptorStructType & b)
 {
     return a.locationName.data_equal(b.locationName) && (a.floorNumber == b.floorNumber) && (a.areaType == b.areaType);
 }
@@ -91,7 +91,7 @@ Globals::Structs::LocationDescriptorStruct::Type BridgedDeviceBasicInformationCl
 bool BridgedDeviceBasicInformationCluster::OwnedDeviceLocation::operator==(
     const Globals::Structs::LocationDescriptorStruct::Type & other) const
 {
-    return ToView() == other;
+    return IsLocationEqual(ToView(), other);
 }
 
 BridgedDeviceBasicInformationCluster::OwnedDeviceLocation &
@@ -219,7 +219,7 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetDeviceLoc
     {
         if (!location.IsNull())
         {
-            if (mMutableData.deviceLocation->Value().ToView() == location.Value())
+            if (IsLocationEqual(mMutableData.deviceLocation->Value().ToView(), location.Value()))
             {
                 return Status::Success; // No change
             }

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
@@ -16,6 +16,7 @@
  */
 #include <app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h>
 
+#include <app/data-model/Encode.h>
 #include <app/persistence/AttributePersistence.h>
 #include <app/persistence/String.h>
 #include <app/server-cluster/AttributeListBuilder.h>
@@ -23,17 +24,35 @@
 #include <clusters/BridgedDeviceBasicInformation/Commands.h>
 #include <clusters/BridgedDeviceBasicInformation/Events.h>
 #include <clusters/BridgedDeviceBasicInformation/Metadata.h>
+#include <lib/core/TLV.h>
 #include <lib/support/BitFlags.h>
 #include <lib/support/Span.h>
 
 #include <algorithm>
+#include <optional>
 
 using namespace chip::app::Clusters::BridgedDeviceBasicInformation;
 using chip::Protocols::InteractionModel::Status;
 
+using LocationDescriptorStructType = chip::app::Clusters::Globals::Structs::LocationDescriptorStruct::Type;
+
 namespace chip::app::Clusters {
 
 namespace {
+
+// DeviceLocation is a structure containing:
+//    - locationName: string (up to 128 bytes)
+//    - floorNumber: int16 (2 bytes)
+//    - areaType: enum (1 byte)
+// TLV Encoding Size Estimation:
+//   - Outer anonymous container: Tag (1) + Length (1) = 2 bytes
+//   - Structure container: Tag (2) + Length (1) = 3 bytes
+//   - locationName: Context Tag (2) + Length (2) + Value (128) = 132 bytes
+//   - floorNumber: Context Tag (2) + Value (2) = 4 bytes
+//   - areaType: Context Tag (2) + Value (1) = 3 bytes
+// Total estimated max size: 2 + 3 + 132 + 4 + 3 = 144 bytes.
+// Using 160 bytes to provide a small buffer.
+constexpr size_t kMaxLocationDescriptorTLVEncodingSize = 160;
 
 static constexpr uint32_t kMinKeepActiveTimeoutMs = 30 * 1000;
 static constexpr uint32_t kMaxKeepActiveTimeoutMs = 3600 * 1000;
@@ -53,7 +72,59 @@ CharSpan ToSpan(const std::optional<std::string> & s)
     return ToSpan(*s);
 }
 
+bool operator==(const LocationDescriptorStructType & a, const LocationDescriptorStructType & b)
+{
+    return a.locationName.data_equal(b.locationName) && (a.floorNumber == b.floorNumber) && (a.areaType == b.areaType);
+}
+
+bool operator==(const std::optional<BridgedDeviceBasicInformationCluster::OwnedDeviceLocation> & a,
+                const DataModel::Nullable<LocationDescriptorStructType> & b)
+{
+    return (a.has_value() == !b.IsNull()) && (!a.has_value() || (a->ToView() == b.Value()));
+}
+
 } // namespace
+
+Globals::Structs::LocationDescriptorStruct::Type BridgedDeviceBasicInformationCluster::OwnedDeviceLocation::ToView() const
+{
+    return {
+        .locationName = { locationName.data(), locationName.size() },
+        .floorNumber  = floorNumber.has_value() ? DataModel::MakeNullable(*floorNumber) : DataModel::Nullable<int16_t>(),
+        .areaType     = areaType.has_value() ? DataModel::MakeNullable(*areaType) : DataModel::Nullable<Globals::AreaTypeTag>(),
+    };
+}
+
+bool BridgedDeviceBasicInformationCluster::OwnedDeviceLocation::operator==(
+    const Globals::Structs::LocationDescriptorStruct::Type & other) const
+{
+    return ToView() == other;
+}
+
+BridgedDeviceBasicInformationCluster::OwnedDeviceLocation &
+BridgedDeviceBasicInformationCluster::OwnedDeviceLocation::operator=(const Globals::Structs::LocationDescriptorStruct::Type & value)
+{
+    locationName = std::string{ value.locationName.data(), value.locationName.size() };
+
+    if (value.floorNumber.IsNull())
+    {
+        floorNumber.reset();
+    }
+    else
+    {
+        floorNumber = value.floorNumber.Value();
+    }
+
+    if (value.areaType.IsNull())
+    {
+        areaType.reset();
+    }
+    else
+    {
+        areaType = value.areaType.Value();
+    }
+
+    return *this;
+}
 
 DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetNodeLabel(CharSpan nodeLabel)
 {
@@ -98,6 +169,70 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetNodeLabel
     return Status::Success;
 }
 
+CHIP_ERROR BridgedDeviceBasicInformationCluster::PersistDeviceLocation()
+{
+    VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    AttributePersistence persistence(mContext->attributeStorage);
+
+    uint8_t buffer[kMaxLocationDescriptorTLVEncodingSize];
+    MutableByteSpan span(buffer);
+    return persistence.StoreTLV({ mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id },
+                                GetDeviceLocation(), span);
+}
+
+DataModel::ActionReturnStatus
+BridgedDeviceBasicInformationCluster::SetDeviceLocationInternal(const DataModel::Nullable<LocationDescriptorStructType> & location,
+                                                                PersistenceMode mode)
+{
+    if (!location.IsNull())
+    {
+        // Validation: At least one field must be non-null/empty
+        VerifyOrReturnError(!location.Value().locationName.empty() || !location.Value().floorNumber.IsNull() ||
+                                !location.Value().areaType.IsNull(),
+                            Status::ConstraintError);
+
+        // constraint on location name
+        VerifyOrReturnError(location.Value().locationName.size() <= 128, Status::ConstraintError);
+    }
+
+    if (mRequiredData.deviceLocation == location)
+    {
+        return Status::Success; // No change
+    }
+
+    std::optional<OwnedDeviceLocation> oldValue = mRequiredData.deviceLocation;
+
+    if (location.IsNull())
+    {
+        mRequiredData.deviceLocation.reset();
+    }
+    else
+    {
+        mRequiredData.deviceLocation = location.Value();
+    }
+
+    if (mode == PersistenceMode::kPersist)
+    {
+        CHIP_ERROR err = PersistDeviceLocation();
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Zcl, "Failed to persist DeviceLocation: %" CHIP_ERROR_FORMAT, err.Format());
+            // Revert the change
+            mRequiredData.deviceLocation = oldValue;
+            return Status::Failure;
+        }
+    }
+
+    NotifyAttributeChanged(Attributes::DeviceLocation::Id);
+    return Status::Success;
+}
+
+DataModel::ActionReturnStatus
+BridgedDeviceBasicInformationCluster::SetDeviceLocation(const DataModel::Nullable<LocationDescriptorStructType> & location)
+{
+    return SetDeviceLocationInternal(location, PersistenceMode::kPersist);
+}
+
 CHIP_ERROR BridgedDeviceBasicInformationCluster::Startup(ServerClusterContext & context)
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
@@ -105,24 +240,50 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::Startup(ServerClusterContext & 
     AttributePersistence persistence(context.attributeStorage);
     Storage::String<Attributes::NodeLabel::TypeInfo::MaxLength()> storedLabel;
 
+    // LoadString already handles logging in case of load errors
+    // We do not want to re-persist what we just loaded from NVM, hence kDoNotPersist
+    // Failure here is unlikely and most applications cannot recover from it, so we ignore the status
     if (persistence.LoadString({ mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::NodeLabel::Id }, storedLabel))
     {
-        // LoadString already handles logging in case of load errors.
-        // We do not want to re-persist what we just loaded from NVM, hence kDoNotPersist.
-        // Failure here is unlikely and most applications cannot recover from it, so we ignore the status.
+        // Safe to ignore result: SetNodeLabelInternal is called with kDoNotPersist, so it will not fail due to persistence errors.
+        // Other failures (like constraint errors) are not expected here as the value comes from storage.
         RETURN_SAFELY_IGNORED SetNodeLabelInternal(storedLabel.Content(), PersistenceMode::kDoNotPersist);
     }
     else
     {
-        // missing label, we keep whatever is already in the cluster (e.g. set at startup)
+        // missing label, we keep whatever is already in the cluster (e.g. set at start up);
         Storage::String<Attributes::NodeLabel::TypeInfo::MaxLength()> initialLabel;
         initialLabel.SetContent(ToSpan(mRequiredData.nodeLabel));
 
         // Ignore errors on purpose: not stored, but already an initial value from the app, so
         // same value is likely to be provided again. Failure to store here should not cause the cluster
-        // to stop initializing.
+        // to stop initializing
         RETURN_SAFELY_IGNORED persistence.StoreString(
             { mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::NodeLabel::Id }, initialLabel);
+    }
+
+    // Load DeviceLocation
+    // Note: We reuse the buffer logic here.
+    // The loaded value (DataModel::Nullable<LocationDescriptorStructType>) will contain Spans pointing into `buffer`.
+    // However, `SetDeviceLocationInternal` (via `OwnedDeviceLocation`) makes a deep copy of the data (std::string),
+    // so it is safe for the buffer to go out of scope after this block.
+    //
+    // We use a buffer size determined by kMaxLocationDescriptorTLVEncodingSize.
+    uint8_t buffer[kMaxLocationDescriptorTLVEncodingSize];
+    MutableByteSpan span(buffer);
+    DataModel::Nullable<LocationDescriptorStructType> loaded;
+
+    if (persistence.LoadTLV({ mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id }, loaded,
+                            span) == CHIP_NO_ERROR)
+    {
+        // Best effort: SetDeviceLocationInternal is called with kDoNotPersist, so it will not fail due to persistence errors.
+        // Other failures (like constraint errors) are not expected here as the value comes from storage.
+        LogErrorOnFailure(SetDeviceLocationInternal(loaded, PersistenceMode::kDoNotPersist).GetUnderlyingError());
+    }
+    else
+    {
+        // Best effort: Failure to store here should not cause the cluster to stop initializing
+        LogErrorOnFailure(PersistDeviceLocation());
     }
 
     return CHIP_NO_ERROR;
@@ -189,6 +350,8 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::ReadAttribut
             mFixedData.productAppearance.value_or(BridgedDeviceBasicInformation::Structs::ProductAppearanceStruct::Type{}));
     case ConfigurationVersion::Id:
         return encoder.Encode(mRequiredData.configurationVersion);
+    case DeviceLocation::Id:
+        return encoder.Encode(GetDeviceLocation());
     default:
         return Status::UnsupportedAttribute;
     }
@@ -203,6 +366,11 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::WriteAttribu
         CharSpan newNodeLabel;
         ReturnErrorOnFailure(aDecoder.Decode(newNodeLabel));
         return SetNodeLabel(newNodeLabel);
+    }
+    case Attributes::DeviceLocation::Id: {
+        DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> newLocation;
+        ReturnErrorOnFailure(aDecoder.Decode(newLocation));
+        return SetDeviceLocation(newLocation);
     }
     case Attributes::ConfigurationVersion::Id:
         return Status::UnsupportedWrite; // Not writable via Matter
@@ -235,6 +403,7 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::Attributes(const ConcreteCluste
         { true, UniqueID::kMetadataEntry }, // mandatory for new revisions
         { mFixedData.productAppearance.has_value(), ProductAppearance::kMetadataEntry },
         { true, ConfigurationVersion::kMetadataEntry }, // Always present
+        { true, DeviceLocation::kMetadataEntry },       // Always present (Provisionally Mandatory)
     };
 
     AttributeListBuilder listBuilder(builder);

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
@@ -77,12 +77,6 @@ bool operator==(const LocationDescriptorStructType & a, const LocationDescriptor
     return a.locationName.data_equal(b.locationName) && (a.floorNumber == b.floorNumber) && (a.areaType == b.areaType);
 }
 
-bool operator==(const std::optional<BridgedDeviceBasicInformationCluster::OwnedDeviceLocation> & a,
-                const DataModel::Nullable<LocationDescriptorStructType> & b)
-{
-    return (a.has_value() == !b.IsNull()) && (!a.has_value() || (a->ToView() == b.Value()));
-}
-
 } // namespace
 
 Globals::Structs::LocationDescriptorStruct::Type BridgedDeviceBasicInformationCluster::OwnedDeviceLocation::ToView() const
@@ -174,16 +168,25 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::PersistDeviceLocation()
     VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
     AttributePersistence persistence(mContext->attributeStorage);
 
+    // When persisting, we persist the Nullable<LocationDescriptorStructType> directly.
+    // We reconstruct it from our internal state.
+    auto locationToStore = GetDeviceLocation();
+
+    // Only persist if attribute exists on the cluster.
+    VerifyOrReturnError(locationToStore.has_value(), CHIP_NO_ERROR);
+
     uint8_t buffer[kMaxLocationDescriptorTLVEncodingSize];
     MutableByteSpan span(buffer);
     return persistence.StoreTLV({ mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id },
-                                GetDeviceLocation(), span);
+                                *locationToStore, span);
 }
 
-DataModel::ActionReturnStatus
-BridgedDeviceBasicInformationCluster::SetDeviceLocationInternal(const DataModel::Nullable<LocationDescriptorStructType> & location,
-                                                                PersistenceMode mode)
+DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetDeviceLocationInternal(
+    const DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> & location, PersistenceMode mode)
 {
+    // Cluster must support this attribute
+    VerifyOrReturnError(mRequiredData.deviceLocation.has_value(), Status::UnsupportedAttribute);
+
     if (!location.IsNull())
     {
         // Validation: At least one field must be non-null/empty
@@ -195,26 +198,39 @@ BridgedDeviceBasicInformationCluster::SetDeviceLocationInternal(const DataModel:
         VerifyOrReturnError(location.Value().locationName.size() <= 128, Status::ConstraintError);
     }
 
-    if (mRequiredData.deviceLocation == location)
+    // Check for equality
+    if (mRequiredData.deviceLocation->IsNull())
     {
-        return Status::Success; // No change
-    }
-
-    std::optional<OwnedDeviceLocation> oldValue = mRequiredData.deviceLocation;
-
-    if (location.IsNull())
-    {
-        mRequiredData.deviceLocation.reset();
+        if (location.IsNull())
+        {
+            return Status::Success; // No change
+        }
     }
     else
     {
-        mRequiredData.deviceLocation = location.Value();
+        if (!location.IsNull())
+        {
+            if (mRequiredData.deviceLocation->Value().ToView() == location.Value())
+            {
+                return Status::Success; // No change
+            }
+        }
+    }
+
+    auto oldValue = mRequiredData.deviceLocation;
+
+    if (location.IsNull())
+    {
+        mRequiredData.deviceLocation->SetNull();
+    }
+    else
+    {
+        mRequiredData.deviceLocation->SetNonNull(location.Value());
     }
 
     if (mode == PersistenceMode::kPersist)
     {
-        CHIP_ERROR err = PersistDeviceLocation();
-        if (err != CHIP_NO_ERROR)
+        if (auto err = PersistDeviceLocation(); err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "Failed to persist DeviceLocation: %" CHIP_ERROR_FORMAT, err.Format());
             // Revert the change
@@ -227,8 +243,8 @@ BridgedDeviceBasicInformationCluster::SetDeviceLocationInternal(const DataModel:
     return Status::Success;
 }
 
-DataModel::ActionReturnStatus
-BridgedDeviceBasicInformationCluster::SetDeviceLocation(const DataModel::Nullable<LocationDescriptorStructType> & location)
+DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetDeviceLocation(
+    const DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> & location)
 {
     return SetDeviceLocationInternal(location, PersistenceMode::kPersist);
 }
@@ -273,17 +289,25 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::Startup(ServerClusterContext & 
     MutableByteSpan span(buffer);
     DataModel::Nullable<LocationDescriptorStructType> loaded;
 
-    if (persistence.LoadTLV({ mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id }, loaded,
-                            span) == CHIP_NO_ERROR)
+    if (mRequiredData.deviceLocation.has_value())
     {
-        // Best effort: SetDeviceLocationInternal is called with kDoNotPersist, so it will not fail due to persistence errors.
-        // Other failures (like constraint errors) are not expected here as the value comes from storage.
-        LogErrorOnFailure(SetDeviceLocationInternal(loaded, PersistenceMode::kDoNotPersist).GetUnderlyingError());
-    }
-    else
-    {
-        // Best effort: Failure to store here should not cause the cluster to stop initializing
-        LogErrorOnFailure(PersistDeviceLocation());
+        CHIP_ERROR err = persistence.LoadTLV(
+            { mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id }, loaded, span);
+        if (err == CHIP_NO_ERROR)
+        {
+            // Best effort: SetDeviceLocationInternal is called with kDoNotPersist, so it will not fail due to persistence errors.
+            // Other failures (like constraint errors) are not expected here as the value comes from storage.
+            LogErrorOnFailure(SetDeviceLocationInternal(loaded, PersistenceMode::kDoNotPersist).GetUnderlyingError());
+        }
+        else if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+        {
+            // Nothing in storage, keep the initial value (from mRequiredData).
+            // This is a best-effort attempt to keep persisted data in sync with startup value
+            // and what is read through `ReadAttribute`.
+            //
+            // Failure to store here should not cause the cluster to stop initializing.
+            LogErrorOnFailure(PersistDeviceLocation());
+        }
     }
 
     return CHIP_NO_ERROR;
@@ -351,7 +375,11 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::ReadAttribut
     case ConfigurationVersion::Id:
         return encoder.Encode(mRequiredData.configurationVersion);
     case DeviceLocation::Id:
-        return encoder.Encode(GetDeviceLocation());
+        if (auto location = GetDeviceLocation(); location.has_value())
+        {
+            return encoder.Encode(*location);
+        }
+        return Status::UnsupportedAttribute;
     default:
         return Status::UnsupportedAttribute;
     }
@@ -402,8 +430,8 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::Attributes(const ConcreteCluste
         { mFixedData.serialNumber.has_value(), SerialNumber::kMetadataEntry },
         { true, UniqueID::kMetadataEntry }, // mandatory for new revisions
         { mFixedData.productAppearance.has_value(), ProductAppearance::kMetadataEntry },
-        { true, ConfigurationVersion::kMetadataEntry }, // Always present
-        { true, DeviceLocation::kMetadataEntry },       // Always present (Provisionally Mandatory)
+        { true, ConfigurationVersion::kMetadataEntry },                               // Always present
+        { mRequiredData.deviceLocation.has_value(), DeviceLocation::kMetadataEntry }, // Always present (Provisionally Mandatory)
     };
 
     AttributeListBuilder listBuilder(builder);

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
@@ -99,7 +99,16 @@ bool BridgedDeviceBasicInformationCluster::OwnedDeviceLocation::operator==(
 BridgedDeviceBasicInformationCluster::OwnedDeviceLocation &
 BridgedDeviceBasicInformationCluster::OwnedDeviceLocation::operator=(const Globals::Structs::LocationDescriptorStruct::Type & value)
 {
-    locationName = std::string{ value.locationName.data(), value.locationName.size() };
+    // Special handling since empty char-span will return nullptr for data() and
+    // std::string does not like that
+    if (value.locationName.empty())
+    {
+        locationName.clear();
+    }
+    else
+    {
+        locationName = std::string{ value.locationName.data(), value.locationName.size() };
+    }
 
     if (value.floorNumber.IsNull())
     {

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
@@ -439,7 +439,8 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::Attributes(const ConcreteCluste
         { true, UniqueID::kMetadataEntry }, // mandatory for new revisions
         { mFixedData.productAppearance.has_value(), ProductAppearance::kMetadataEntry },
         { mMutableData.configurationVersion.has_value(), ConfigurationVersion::kMetadataEntry },
-        { mMutableData.deviceLocation.has_value(), DeviceLocation::kMetadataEntry }, // Present when supported (Provisionally Mandatory)
+        { mMutableData.deviceLocation.has_value(),
+          DeviceLocation::kMetadataEntry }, // Present when supported (Provisionally Mandatory)
     };
 
     AttributeListBuilder listBuilder(builder);

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
@@ -439,7 +439,7 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::Attributes(const ConcreteCluste
         { true, UniqueID::kMetadataEntry }, // mandatory for new revisions
         { mFixedData.productAppearance.has_value(), ProductAppearance::kMetadataEntry },
         { mMutableData.configurationVersion.has_value(), ConfigurationVersion::kMetadataEntry },
-        { mMutableData.deviceLocation.has_value(), DeviceLocation::kMetadataEntry }, // Always present (Provisionally Mandatory)
+        { mMutableData.deviceLocation.has_value(), DeviceLocation::kMetadataEntry }, // Present when supported (Provisionally Mandatory)
     };
 
     AttributeListBuilder listBuilder(builder);

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
@@ -46,14 +46,12 @@ namespace {
 //    - locationName: string (up to 128 bytes)
 //    - floorNumber: int16 (2 bytes)
 //    - areaType: enum (1 byte)
-// TLV Encoding Size Estimation:
-//   - Outer anonymous container: Tag (1) + Length (1) = 2 bytes
-//   - Structure container: Tag (2) + Length (1) = 3 bytes
-//   - locationName: Context Tag (2) + Length (2) + Value (128) = 132 bytes
-//   - floorNumber: Context Tag (2) + Value (2) = 4 bytes
-//   - areaType: Context Tag (2) + Value (1) = 3 bytes
-// Total estimated max size: 2 + 3 + 132 + 4 + 3 = 144 bytes.
-// Using 160 bytes to provide a small buffer.
+//
+// The TLV encoding size for this structure depends on tag and length
+// encoding details, which can vary. The constant below is a conservative
+// upper bound chosen to comfortably hold a LocationDescriptorStruct with a
+// locationName of up to 128 bytes plus associated metadata and TLV
+// overhead, with additional headroom for future changes.
 constexpr size_t kMaxLocationDescriptorTLVEncodingSize = 160;
 
 static constexpr uint32_t kMinKeepActiveTimeoutMs = 30 * 1000;

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
@@ -184,10 +184,7 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::PersistDeviceLocation()
     // Only persist if attribute exists on the cluster.
     VerifyOrReturnError(locationToStore.has_value(), CHIP_NO_ERROR);
 
-    uint8_t buffer[kMaxLocationDescriptorTLVEncodingSize];
-    MutableByteSpan span(buffer);
-    return persistence.StoreTLV({ mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id },
-                                *locationToStore, span);
+    return persistence.StoreTLV<kMaxLocationDescriptorTLVEncodingSize>({ mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id }, *locationToStore);
 }
 
 DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetDeviceLocationInternal(

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
@@ -14,6 +14,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include "lib/core/CHIPError.h"
+#include "lib/support/CodeUtils.h"
 #include <app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h>
 
 #include <app/data-model/Encode.h>
@@ -132,7 +134,7 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetNodeLabel
     // std::string may not like a nullptr .data() when the charspan is empty.
     const std::string newValue = nodeLabel.empty() ? std::string() : std::string{ nodeLabel.data(), nodeLabel.size() };
 
-    if (mRequiredData.nodeLabel == newValue)
+    if (mMutableData.nodeLabel == newValue)
     {
         return DataModel::ActionReturnStatus::FixedStatus::kWriteSuccessNoOp;
     }
@@ -157,7 +159,7 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetNodeLabel
         }
     }
 
-    mRequiredData.nodeLabel = newValue;
+    mMutableData.nodeLabel = newValue;
     NotifyAttributeChanged(Attributes::NodeLabel::Id);
 
     return Status::Success;
@@ -185,7 +187,7 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetDeviceLoc
     const DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> & location, PersistenceMode mode)
 {
     // Cluster must support this attribute
-    VerifyOrReturnError(mRequiredData.deviceLocation.has_value(), Status::UnsupportedAttribute);
+    VerifyOrReturnError(mMutableData.deviceLocation.has_value(), Status::UnsupportedAttribute);
 
     if (!location.IsNull())
     {
@@ -199,7 +201,7 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetDeviceLoc
     }
 
     // Check for equality
-    if (mRequiredData.deviceLocation->IsNull())
+    if (mMutableData.deviceLocation->IsNull())
     {
         if (location.IsNull())
         {
@@ -210,22 +212,22 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetDeviceLoc
     {
         if (!location.IsNull())
         {
-            if (mRequiredData.deviceLocation->Value().ToView() == location.Value())
+            if (mMutableData.deviceLocation->Value().ToView() == location.Value())
             {
                 return Status::Success; // No change
             }
         }
     }
 
-    auto oldValue = mRequiredData.deviceLocation;
+    auto oldValue = mMutableData.deviceLocation;
 
     if (location.IsNull())
     {
-        mRequiredData.deviceLocation->SetNull();
+        mMutableData.deviceLocation->SetNull();
     }
     else
     {
-        mRequiredData.deviceLocation->SetNonNull(location.Value());
+        mMutableData.deviceLocation->SetNonNull(location.Value());
     }
 
     if (mode == PersistenceMode::kPersist)
@@ -234,7 +236,7 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetDeviceLoc
         {
             ChipLogError(Zcl, "Failed to persist DeviceLocation: %" CHIP_ERROR_FORMAT, err.Format());
             // Revert the change
-            mRequiredData.deviceLocation = oldValue;
+            mMutableData.deviceLocation = oldValue;
             return Status::Failure;
         }
     }
@@ -269,7 +271,7 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::Startup(ServerClusterContext & 
     {
         // missing label, we keep whatever is already in the cluster (e.g. set at start up);
         Storage::String<Attributes::NodeLabel::TypeInfo::MaxLength()> initialLabel;
-        initialLabel.SetContent(ToSpan(mRequiredData.nodeLabel));
+        initialLabel.SetContent(ToSpan(mMutableData.nodeLabel));
 
         // Ignore errors on purpose: not stored, but already an initial value from the app, so
         // same value is likely to be provided again. Failure to store here should not cause the cluster
@@ -289,7 +291,7 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::Startup(ServerClusterContext & 
     MutableByteSpan span(buffer);
     DataModel::Nullable<LocationDescriptorStructType> loaded;
 
-    if (mRequiredData.deviceLocation.has_value())
+    if (mMutableData.deviceLocation.has_value())
     {
         CHIP_ERROR err = persistence.LoadTLV(
             { mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id }, loaded, span);
@@ -301,7 +303,7 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::Startup(ServerClusterContext & 
         }
         else if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
         {
-            // Nothing in storage, keep the initial value (from mRequiredData).
+            // Nothing in storage, keep the initial value (from mMutableData).
             // This is a best-effort attempt to keep persisted data in sync with startup value
             // and what is read through `ReadAttribute`.
             //
@@ -315,9 +317,10 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::Startup(ServerClusterContext & 
 
 CHIP_ERROR BridgedDeviceBasicInformationCluster::IncreaseConfigurationVersion()
 {
-    ReturnErrorOnFailure(mClusterContext.parentVersionConfiguration.IncreaseConfigurationVersion());
+    VerifyOrReturnError(mMutableData.configurationVersion.has_value(), CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute));
 
-    mRequiredData.configurationVersion++;
+    ReturnErrorOnFailure(mMutableData.configurationVersion->delegate.IncreaseConfigurationVersion());
+    mMutableData.configurationVersion->version++;
     NotifyAttributeChanged(Attributes::ConfigurationVersion::Id);
 
     return CHIP_NO_ERROR;
@@ -346,7 +349,7 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::ReadAttribut
     case ProductID::Id:
         return encoder.Encode(mFixedData.productId.value_or(0));
     case NodeLabel::Id:
-        return encoder.Encode(ToSpan(mRequiredData.nodeLabel));
+        return encoder.Encode(ToSpan(mMutableData.nodeLabel));
     case HardwareVersion::Id:
         return encoder.Encode(mFixedData.hardwareVersion.value_or(0));
     case HardwareVersionString::Id:
@@ -366,14 +369,14 @@ DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::ReadAttribut
     case SerialNumber::Id:
         return encoder.Encode(ToSpan(mFixedData.serialNumber));
     case Reachable::Id:
-        return encoder.Encode(mRequiredData.reachable);
+        return encoder.Encode(mMutableData.reachable);
     case UniqueID::Id:
-        return encoder.Encode(ToSpan(mRequiredData.uniqueId));
+        return encoder.Encode(ToSpan(mFixedData.uniqueId));
     case ProductAppearance::Id:
         return encoder.Encode(
             mFixedData.productAppearance.value_or(BridgedDeviceBasicInformation::Structs::ProductAppearanceStruct::Type{}));
     case ConfigurationVersion::Id:
-        return encoder.Encode(mRequiredData.configurationVersion);
+        return encoder.Encode(mMutableData.configurationVersion.has_value() ? mMutableData.configurationVersion->version : 1);
     case DeviceLocation::Id:
         if (auto location = GetDeviceLocation(); location.has_value())
         {
@@ -430,8 +433,8 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::Attributes(const ConcreteCluste
         { mFixedData.serialNumber.has_value(), SerialNumber::kMetadataEntry },
         { true, UniqueID::kMetadataEntry }, // mandatory for new revisions
         { mFixedData.productAppearance.has_value(), ProductAppearance::kMetadataEntry },
-        { true, ConfigurationVersion::kMetadataEntry },                               // Always present
-        { mRequiredData.deviceLocation.has_value(), DeviceLocation::kMetadataEntry }, // Always present (Provisionally Mandatory)
+        { mMutableData.configurationVersion.has_value(), ConfigurationVersion::kMetadataEntry },
+        { mMutableData.deviceLocation.has_value(), DeviceLocation::kMetadataEntry }, // Always present (Provisionally Mandatory)
     };
 
     AttributeListBuilder listBuilder(builder);
@@ -515,9 +518,9 @@ void BridgedDeviceBasicInformationCluster::GenerateLeaveEvent()
 
 void BridgedDeviceBasicInformationCluster::SetReachable(bool reachable)
 {
-    VerifyOrReturn(mRequiredData.reachable != reachable);
+    VerifyOrReturn(mMutableData.reachable != reachable);
 
-    mRequiredData.reachable = reachable;
+    mMutableData.reachable = reachable;
     NotifyAttributeChanged(Attributes::Reachable::Id);
 
     VerifyOrReturn(mContext != nullptr);

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
@@ -184,7 +184,8 @@ CHIP_ERROR BridgedDeviceBasicInformationCluster::PersistDeviceLocation()
     // Only persist if attribute exists on the cluster.
     VerifyOrReturnError(locationToStore.has_value(), CHIP_NO_ERROR);
 
-    return persistence.StoreTLV<kMaxLocationDescriptorTLVEncodingSize>({ mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id }, *locationToStore);
+    return persistence.StoreTLV<kMaxLocationDescriptorTLVEncodingSize>(
+        { mPath.mEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id }, *locationToStore);
 }
 
 DataModel::ActionReturnStatus BridgedDeviceBasicInformationCluster::SetDeviceLocationInternal(

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
@@ -138,7 +138,8 @@ public:
     std::optional<DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type>> GetDeviceLocation() const
     {
         VerifyOrReturnValue(mMutableData.deviceLocation.has_value(), std::nullopt);
-        VerifyOrReturnValue(!mMutableData.deviceLocation->IsNull(), DataModel::Nullable<LocationDescriptorStructType>(DataModel::NullNullable));
+        VerifyOrReturnValue(!mMutableData.deviceLocation->IsNull(),
+                            DataModel::Nullable<LocationDescriptorStructType>(DataModel::NullNullable));
 
         return DataModel::MakeNullable(mMutableData.deviceLocation->Value().ToView());
     }

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
@@ -22,6 +22,7 @@
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/BridgedDeviceBasicInformation/ClusterId.h>
 #include <clusters/BridgedDeviceBasicInformation/Structs.h>
+#include <clusters/shared/Structs.h>
 #include <lib/support/TimerDelegate.h>
 
 #include <optional>
@@ -39,12 +40,31 @@ namespace chip::app::Clusters {
 ///   - Node-wide startup/shutdown events are provided by the Node's Basic Information cluster.
 ///   - Per-endpoint (bridged device) lifecycle is detectable via the Descriptor cluster.
 ///   - They are marked as Optional (O) in the Bridged Device Basic Information specification.
-///
-/// Note: DeviceLocation attribute (0x0017) is not supported as it is not in the standard Bridged Device Basic Information Cluster
-/// XML.
 class BridgedDeviceBasicInformationCluster : public DefaultServerCluster, public TimerContext
 {
 public:
+    // A device location, however without using Span (i.e. using actual strings and owning the storage)
+    struct OwnedDeviceLocation
+    {
+        std::string locationName;
+        std::optional<int16_t> floorNumber;
+        std::optional<Globals::AreaTypeTag> areaType;
+
+        OwnedDeviceLocation() = default;
+        OwnedDeviceLocation(const Globals::Structs::LocationDescriptorStruct::Type & other) { *this = other; }
+
+        // Return a view of this value as a LocationDescriptorStruct. The locationName
+        // will point into "this" so the lifetime of this MUST exceed the usage of the returned value.
+        Globals::Structs::LocationDescriptorStruct::Type ToView() const;
+
+        // compare with a non-owned version
+        bool operator==(const Globals::Structs::LocationDescriptorStruct::Type & other) const;
+        bool operator!=(const Globals::Structs::LocationDescriptorStruct::Type & other) const { return !(*this == other); }
+
+        // set the current value from a non-owned version
+        OwnedDeviceLocation & operator=(const Globals::Structs::LocationDescriptorStruct::Type & value);
+    };
+
     struct Context
     {
         // NOTE: These delegate references are used throughout the cluster's lifetime.
@@ -85,6 +105,7 @@ public:
         bool reachable = false; // initial value for reachable
         std::string nodeLabel;
         uint32_t configurationVersion = 1;
+        std::optional<OwnedDeviceLocation> deviceLocation;
     };
 
     BridgedDeviceBasicInformationCluster(EndpointId endpointId, RequiredData && required, FixedData && fixedData,
@@ -104,6 +125,14 @@ public:
     DataModel::ActionReturnStatus SetNodeLabel(CharSpan nodeLabel);
 
     uint32_t GetConfigurationVersion() const { return mRequiredData.configurationVersion; }
+
+    DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> GetDeviceLocation() const
+    {
+        VerifyOrReturnValue(mRequiredData.deviceLocation.has_value(), DataModel::NullNullable);
+        return DataModel::MakeNullable(mRequiredData.deviceLocation->ToView());
+    }
+    DataModel::ActionReturnStatus
+    SetDeviceLocation(const DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> & location);
 
     /// Increases the configuration version and ALSO increases the device
     /// configuration version. Specifically handles the spec requirement of:
@@ -159,6 +188,21 @@ private:
     /// @param mode Whether to persist the new value to NVM.
     /// @return Status code indicating the result of the operation.
     DataModel::ActionReturnStatus SetNodeLabelInternal(CharSpan nodeLabel, PersistenceMode mode);
+
+    /// Updates the DeviceLocation attribute value with optional persistence.
+    ///
+    /// This internal helper validates the new value via the delegate, persists it to NVM if requested,
+    /// and then updates the in-memory state and notifies subscribers.
+    ///
+    /// @param location The new device location to set.
+    /// @param mode Whether to persist the new value to NVM.
+    /// @return Status code indicating the result of the operation.
+    DataModel::ActionReturnStatus
+    SetDeviceLocationInternal(const DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> & location,
+                              PersistenceMode mode);
+
+    /// Store the current DeviceLocation to persistent storage
+    CHIP_ERROR PersistDeviceLocation();
 
     // TimerContext
     void TimerFired() override;

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
@@ -131,10 +131,7 @@ public:
 
     std::optional<uint32_t> GetConfigurationVersion() const
     {
-        if (!mMutableData.configurationVersion.has_value())
-        {
-            return std::nullopt;
-        }
+        VerifyOrReturnValue(mMutableData.configurationVersion.has_value(), std::nullopt);
         return mMutableData.configurationVersion->version;
     }
 

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
@@ -69,10 +69,15 @@ public:
     {
         // NOTE: These delegate references are used throughout the cluster's lifetime.
         // Their lifetimes MUST be greater than or equal to the lifetime of this cluster instance.
-        ConfigurationVersionDelegate & parentVersionConfiguration;
         BridgedDeviceBasicInformationDelegate & delegate;
         TimerDelegate & timerDelegate;
         BridgedDeviceIcdDelegate * icdDelegate = nullptr; // if nullptr, ICD support feature is disabled
+    };
+
+    struct Versioning
+    {
+        uint32_t version;
+        ConfigurationVersionDelegate & delegate;
     };
 
     /// Most attributes in the bridged device basic information cluster are fixed
@@ -82,6 +87,8 @@ public:
     /// Attribute will be exposed if the optional values have a value.
     struct FixedData
     {
+        std::string uniqueId; // Mandatory, fixed once set
+
         std::optional<std::string> vendorName;
         std::optional<VendorId> vendorId;
         std::optional<std::string> productName;
@@ -98,51 +105,56 @@ public:
         std::optional<BridgedDeviceBasicInformation::Structs::ProductAppearanceStruct::Type> productAppearance;
     };
 
-    /// Mandatory data for every bridged device
-    struct RequiredData
+    /// Mutable data for bridged device
+    struct MutableData
     {
-        std::string uniqueId;   // Fixed once set
         bool reachable = false; // initial value for reachable
         std::string nodeLabel;
-        uint32_t configurationVersion = 1;
         std::optional<DataModel::Nullable<OwnedDeviceLocation>> deviceLocation;
+        std::optional<Versioning> configurationVersion;
     };
 
-    BridgedDeviceBasicInformationCluster(EndpointId endpointId, RequiredData && required, FixedData && fixedData,
+    BridgedDeviceBasicInformationCluster(EndpointId endpointId, MutableData && mutableData, FixedData && fixedData,
                                          Context && context) :
         DefaultServerCluster({ endpointId, BridgedDeviceBasicInformation::Id }),
-        mRequiredData(std::move(required)), mFixedData(std::move(fixedData)), mClusterContext(std::move(context))
-
+        mMutableData(std::move(mutableData)), mFixedData(std::move(fixedData)), mClusterContext(std::move(context))
     {}
 
-    bool GetReachable() const { return mRequiredData.reachable; }
+    bool GetReachable() const { return mMutableData.reachable; }
     void SetReachable(bool reachable);
 
-    const std::string & GetUniqueId() const { return mRequiredData.uniqueId; }
+    const std::string & GetUniqueId() const { return mFixedData.uniqueId; }
     const FixedData & GetFixedData() const { return mFixedData; }
 
-    const std::string & GetNodeLabel() const { return mRequiredData.nodeLabel; }
+    const std::string & GetNodeLabel() const { return mMutableData.nodeLabel; }
     DataModel::ActionReturnStatus SetNodeLabel(CharSpan nodeLabel);
 
-    uint32_t GetConfigurationVersion() const { return mRequiredData.configurationVersion; }
+    std::optional<uint32_t> GetConfigurationVersion() const
+    {
+        if (!mMutableData.configurationVersion.has_value())
+        {
+            return std::nullopt;
+        }
+        return mMutableData.configurationVersion->version;
+    }
 
     std::optional<DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type>> GetDeviceLocation() const
     {
-        if (!mRequiredData.deviceLocation.has_value())
+        if (!mMutableData.deviceLocation.has_value())
         {
             return std::nullopt;
         }
 
-        if (mRequiredData.deviceLocation->IsNull())
+        if (mMutableData.deviceLocation->IsNull())
         {
             return DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type>(DataModel::NullNullable);
         }
 
-        return DataModel::MakeNullable(mRequiredData.deviceLocation->Value().ToView());
+        return DataModel::MakeNullable(mMutableData.deviceLocation->Value().ToView());
     }
 
     /// Device location can only be set if the cluster supports device location
-    /// (i.e. the RequiredData has a location that is not std::nullopt)
+    /// (i.e. the MutableData has a location that is not std::nullopt)
     DataModel::ActionReturnStatus
     SetDeviceLocation(const DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> & location);
 
@@ -222,7 +234,7 @@ private:
     void StartPendingActiveTimer(System::Clock::Milliseconds32 timeoutMs);
     void CancelPendingActiveTimer();
 
-    RequiredData mRequiredData;
+    MutableData mMutableData;
     const FixedData mFixedData;
     const Context mClusterContext;
 

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
@@ -139,7 +139,7 @@ public:
     {
         VerifyOrReturnValue(mMutableData.deviceLocation.has_value(), std::nullopt);
         VerifyOrReturnValue(!mMutableData.deviceLocation->IsNull(),
-                            DataModel::Nullable<LocationDescriptorStructType>(DataModel::NullNullable));
+                            DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type>(DataModel::NullNullable));
 
         return DataModel::MakeNullable(mMutableData.deviceLocation->Value().ToView());
     }

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
@@ -105,7 +105,7 @@ public:
         bool reachable = false; // initial value for reachable
         std::string nodeLabel;
         uint32_t configurationVersion = 1;
-        std::optional<OwnedDeviceLocation> deviceLocation;
+        std::optional<DataModel::Nullable<OwnedDeviceLocation>> deviceLocation;
     };
 
     BridgedDeviceBasicInformationCluster(EndpointId endpointId, RequiredData && required, FixedData && fixedData,
@@ -126,11 +126,23 @@ public:
 
     uint32_t GetConfigurationVersion() const { return mRequiredData.configurationVersion; }
 
-    DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> GetDeviceLocation() const
+    std::optional<DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type>> GetDeviceLocation() const
     {
-        VerifyOrReturnValue(mRequiredData.deviceLocation.has_value(), DataModel::NullNullable);
-        return DataModel::MakeNullable(mRequiredData.deviceLocation->ToView());
+        if (!mRequiredData.deviceLocation.has_value())
+        {
+            return std::nullopt;
+        }
+
+        if (mRequiredData.deviceLocation->IsNull())
+        {
+            return DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type>(DataModel::NullNullable);
+        }
+
+        return DataModel::MakeNullable(mRequiredData.deviceLocation->Value().ToView());
     }
+
+    /// Device location can only be set if the cluster supports device location
+    /// (i.e. the RequiredData has a location that is not std::nullopt)
     DataModel::ActionReturnStatus
     SetDeviceLocation(const DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> & location);
 

--- a/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
+++ b/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h
@@ -140,15 +140,8 @@ public:
 
     std::optional<DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type>> GetDeviceLocation() const
     {
-        if (!mMutableData.deviceLocation.has_value())
-        {
-            return std::nullopt;
-        }
-
-        if (mMutableData.deviceLocation->IsNull())
-        {
-            return DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type>(DataModel::NullNullable);
-        }
+        VerifyOrReturnValue(mMutableData.deviceLocation.has_value(), std::nullopt);
+        VerifyOrReturnValue(!mMutableData.deviceLocation->IsNull(), DataModel::Nullable<LocationDescriptorStructType>(DataModel::NullNullable));
 
         return DataModel::MakeNullable(mMutableData.deviceLocation->Value().ToView());
     }

--- a/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
@@ -227,40 +227,42 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestEmptyAttributes)
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId  = "foo-bar",
                                                      .reachable = true,
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "foo-bar",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_TRUE(IsAttributesListEqualTo(cluster,
                                         {
                                             Attributes::UniqueID::kMetadataEntry,
                                             Attributes::Reachable::kMetadataEntry,
                                             Attributes::NodeLabel::kMetadataEntry,
-                                            Attributes::ConfigurationVersion::kMetadataEntry,
                                         }));
 }
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestPartialAttributes)
 {
+    BridgedDeviceBasicInformationCluster::Versioning versioning = {
+        .version  = 200u,
+        .delegate = mMockVersionConfiguration,
+    };
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId             = "foo-bar",
-                                                     .reachable            = true,
-                                                     .nodeLabel            = "mylabel",
-                                                     .configurationVersion = 200u,
+                                                     .reachable = true,
+                                                     .nodeLabel = "mylabel",
+                                                     .configurationVersion = versioning,
                                                  },
                                                  {
+                                                     .uniqueId   = "foo-bar",
                                                      .partNumber = "010203",
                                                  },
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_TRUE(IsAttributesListEqualTo(cluster,
                                         {
@@ -274,15 +276,19 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestPartialAttributes)
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestAllAttributes)
 {
+    BridgedDeviceBasicInformationCluster::Versioning versioning = {
+        .version  = 123u,
+        .delegate = mMockVersionConfiguration,
+    };
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId             = "foo-bar",
                                                      .reachable            = true,
                                                      .nodeLabel            = "Remote",
-                                                     .configurationVersion = 123u,
                                                      .deviceLocation       = NullOptional,
+                                                     .configurationVersion = versioning,
                                                  },
                                                  {
+                                                     .uniqueId              = "foo-bar",
                                                      .vendorName            = "ACME",
                                                      .vendorId              = VendorId::Common,
                                                      .productName           = "Bridge",
@@ -303,9 +309,8 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestAllAttributes)
                                                          },
                                                  },
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_TRUE(IsAttributesListEqualTo(cluster,
                                         {
@@ -333,15 +338,19 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestAllAttributes)
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestAttributeReads)
 {
+    BridgedDeviceBasicInformationCluster::Versioning versioning = {
+        .version  = 5u,
+        .delegate = mMockVersionConfiguration,
+    };
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId             = "test-unique-id",
                                                      .reachable            = true,
                                                      .nodeLabel            = "TestLabel",
-                                                     .configurationVersion = 5u,
                                                      .deviceLocation       = NullOptional,
+                                                     .configurationVersion = versioning,
                                                  },
                                                  {
+                                                     .uniqueId              = "test-unique-id",
                                                      .vendorName            = "TestVendor",
                                                      .vendorId              = VendorId::TestVendor1,
                                                      .productName           = "TestProduct",
@@ -362,9 +371,8 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestAttributeReads)
                                                          },
                                                  },
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     ClusterTester tester(cluster);
 
@@ -419,15 +427,14 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestKeepActiveCommand)
 {
     TestBridgedDeviceIcdDelegate icdDelegate;
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
+                                                 {},
                                                  {
                                                      .uniqueId = "icd-dev",
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
-                                                     .icdDelegate                = &icdDelegate,
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
+                                                     .icdDelegate   = &icdDelegate,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
     ClusterTester tester(cluster);
@@ -467,13 +474,14 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestNotifyDeviceActiveWithoutRe
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
+                                                     .reachable = true,
+                                                 },
+                                                 {
                                                      .uniqueId = "no-icd",
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
 
@@ -489,14 +497,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestShutdownCancelsTimer)
     TestBridgedDeviceIcdDelegate icdDelegate;
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
+                                                     .reachable = true,
+                                                 },
+                                                 {
                                                      .uniqueId = "icd-dev",
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
-                                                     .icdDelegate                = &icdDelegate,
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
+                                                     .icdDelegate   = &icdDelegate,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
     ClusterTester tester(cluster);
@@ -519,14 +528,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestKeepActiveTimerNoRegression
     TestBridgedDeviceIcdDelegate icdDelegate;
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
+                                                     .reachable = true,
+                                                 },
+                                                 {
                                                      .uniqueId = "icd-dev",
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
-                                                     .icdDelegate                = &icdDelegate,
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
+                                                     .icdDelegate   = &icdDelegate,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
     ClusterTester tester(cluster);
@@ -565,14 +575,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestKeepActiveCommandMultipleRe
     TestBridgedDeviceIcdDelegate icdDelegate;
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
+                                                     .reachable = true,
+                                                 },
+                                                 {
                                                      .uniqueId = "icd-dev",
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
-                                                     .icdDelegate                = &icdDelegate,
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
+                                                     .icdDelegate   = &icdDelegate,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
     ClusterTester tester(cluster);
@@ -630,14 +641,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestKeepActiveCommandTimeoutDom
     TestBridgedDeviceIcdDelegate icdDelegate;
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
+                                                     .reachable = true,
+                                                 },
+                                                 {
                                                      .uniqueId = "icd-dev",
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
-                                                     .icdDelegate                = &icdDelegate,
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
+                                                     .icdDelegate   = &icdDelegate,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
     ClusterTester tester(cluster);
@@ -662,14 +674,14 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestReachableChangedEvent)
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId  = "event-dev",
                                                      .reachable = false,
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "event-dev",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
 
@@ -689,13 +701,14 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestLeaveEvent)
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
+                                                     .reachable = true,
+                                                 },
+                                                 {
                                                      .uniqueId = "event-dev",
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
 
@@ -714,13 +727,14 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestFeatureMap)
     {
         BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                      {
+                                                         .reachable = true,
+                                                     },
+                                                     {
                                                          .uniqueId = "no-icd",
                                                      },
-                                                     {},
                                                      {
-                                                         .parentVersionConfiguration = mMockVersionConfiguration,
-                                                         .delegate                   = mDelegate,
-                                                         .timerDelegate              = mMockTimer,
+                                                         .delegate      = mDelegate,
+                                                         .timerDelegate = mMockTimer,
                                                      });
         EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
         ClusterTester tester(cluster);
@@ -734,14 +748,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestFeatureMap)
         TestBridgedDeviceIcdDelegate icdDelegate;
         BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                      {
+                                                         .reachable = true,
+                                                     },
+                                                     {
                                                          .uniqueId = "icd",
                                                      },
-                                                     {},
                                                      {
-                                                         .parentVersionConfiguration = mMockVersionConfiguration,
-                                                         .delegate                   = mDelegate,
-                                                         .timerDelegate              = mMockTimer,
-                                                         .icdDelegate                = &icdDelegate,
+                                                         .delegate      = mDelegate,
+                                                         .timerDelegate = mMockTimer,
+                                                         .icdDelegate   = &icdDelegate,
                                                      });
         EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
         ClusterTester tester(cluster);
@@ -753,16 +768,21 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestFeatureMap)
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestSetNodeLabel)
 {
+    BridgedDeviceBasicInformationCluster::Versioning versioning = {
+        .version  = 1u,
+        .delegate = mMockVersionConfiguration,
+    };
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId             = "test-label",
-                                                     .configurationVersion = 1u,
+                                                     .reachable            = true,
+                                                     .configurationVersion = versioning,
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "test-label",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
     ClusterTester tester(cluster);
@@ -799,14 +819,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestSetNodeLabelEmpty)
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId  = "label-test",
+                                                     .reachable = true,
                                                      .nodeLabel = "Initial",
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "label-test",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
 
     // Test setting to empty
@@ -814,18 +835,44 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestSetNodeLabelEmpty)
     EXPECT_EQ(cluster.GetNodeLabel(), "");
 }
 
-TEST_F(TestBridgedDeviceBasicInformationCluster, TestSetConfigurationVersion)
+TEST_F(TestBridgedDeviceBasicInformationCluster, TestConfigurationVersionMissing)
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId             = "test-cfg-ver",
-                                                     .configurationVersion = 1u,
+                                                     .reachable = true,
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "missing-config",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
+                                                 });
+    EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
+    ClusterTester tester(cluster);
+
+    // IncreaseConfigurationVersion should fail with UnsupportedAttribute when
+    // no configuration version is supported by the device.
+    EXPECT_EQ(cluster.IncreaseConfigurationVersion(), CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute));
+}
+
+TEST_F(TestBridgedDeviceBasicInformationCluster, TestSetConfigurationVersion)
+{
+    BridgedDeviceBasicInformationCluster::Versioning versioning = {
+        .version  = 1u,
+        .delegate = mMockVersionConfiguration,
+    };
+    BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
+                                                 {
+                                                     .reachable            = true,
+                                                     .configurationVersion = versioning,
+                                                 },
+                                                 {
+                                                     .uniqueId = "test-cfg-ver",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
     ClusterTester tester(cluster);
@@ -846,13 +893,14 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestAcceptedCommands)
     {
         BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                      {
+                                                         .reachable = true,
+                                                     },
+                                                     {
                                                          .uniqueId = "no-icd",
                                                      },
-                                                     {},
                                                      {
-                                                         .parentVersionConfiguration = mMockVersionConfiguration,
-                                                         .delegate                   = mDelegate,
-                                                         .timerDelegate              = mMockTimer,
+                                                         .delegate      = mDelegate,
+                                                         .timerDelegate = mMockTimer,
                                                      });
 
         ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> builder;
@@ -865,14 +913,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestAcceptedCommands)
         TestBridgedDeviceIcdDelegate icdDelegate;
         BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                      {
+                                                         .reachable = true,
+                                                     },
+                                                     {
                                                          .uniqueId = "icd",
                                                      },
-                                                     {},
                                                      {
-                                                         .parentVersionConfiguration = mMockVersionConfiguration,
-                                                         .delegate                   = mDelegate,
-                                                         .timerDelegate              = mMockTimer,
-                                                         .icdDelegate                = &icdDelegate,
+                                                         .delegate      = mDelegate,
+                                                         .timerDelegate = mMockTimer,
+                                                         .icdDelegate   = &icdDelegate,
                                                      });
 
         ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> builder;
@@ -885,14 +934,14 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestReachableChangedSuppression
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId  = "reachable-test",
                                                      .reachable = true,
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "reachable-test",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
 
@@ -907,16 +956,21 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestReachableChangedSuppression
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestWriteNodeLabel)
 {
+    BridgedDeviceBasicInformationCluster::Versioning versioning = {
+        .version  = 1u,
+        .delegate = mMockVersionConfiguration,
+    };
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId             = "test-unique-id",
-                                                     .configurationVersion = 1u,
+                                                     .reachable            = true,
+                                                     .configurationVersion = versioning,
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "test-unique-id",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
     ClusterTester tester(cluster);
@@ -940,16 +994,21 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestWriteNodeLabel)
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestWriteConfigurationVersion)
 {
+    BridgedDeviceBasicInformationCluster::Versioning versioning = {
+        .version  = 1u,
+        .delegate = mMockVersionConfiguration,
+    };
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId             = "test-unique-id",
-                                                     .configurationVersion = 1u,
+                                                     .reachable            = true,
+                                                     .configurationVersion = versioning,
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "test-unique-id",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
     ClusterTester tester(cluster);
@@ -962,14 +1021,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestSetNodeLabelDelegateError)
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId  = "test-label",
+                                                     .reachable = true,
                                                      .nodeLabel = "Initial",
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "test-label",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
 
@@ -985,14 +1045,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestNodeLabelPersistence)
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId  = "test-persistence",
+                                                     .reachable = true,
                                                      .nodeLabel = "Initial",
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "test-persistence",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
 
@@ -1039,14 +1100,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestStartupPersistence)
 
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId  = "test-startup",
+                                                     .reachable = true,
                                                      .nodeLabel = "ConstructorLabel",
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "test-startup",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
 
     // Startup should load from persistence
@@ -1070,14 +1132,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationWriteRead)
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId       = "test-devicelocation",
+                                                     .reachable      = true,
                                                      .deviceLocation = NullOptional, // mark attribute supported
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "test-devicelocation",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
     ClusterTester tester(cluster);
@@ -1123,14 +1186,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationValidation)
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId       = "test-devicelocation",
+                                                     .reachable      = true,
                                                      .deviceLocation = NullOptional, // mark attribute supported
                                                  },
-                                                 {},
                                                  {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
+                                                     .uniqueId = "test-devicelocation",
+                                                 },
+                                                 {
+                                                     .delegate      = mDelegate,
+                                                     .timerDelegate = mMockTimer,
                                                  });
     EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
     ClusterTester tester(cluster);
@@ -1174,14 +1238,15 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationPersistence)
     {
         BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                      {
-                                                         .uniqueId       = "test-devicelocation",
+                                                         .reachable      = true,
                                                          .deviceLocation = NullOptional, // mark attribute supported
                                                      },
-                                                     {},
                                                      {
-                                                         .parentVersionConfiguration = mMockVersionConfiguration,
-                                                         .delegate                   = mDelegate,
-                                                         .timerDelegate              = mMockTimer,
+                                                         .uniqueId = "test-devicelocation",
+                                                     },
+                                                     {
+                                                         .delegate      = mDelegate,
+                                                         .timerDelegate = mMockTimer,
                                                      });
         EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
         ClusterTester tester(cluster);
@@ -1190,26 +1255,28 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationPersistence)
         ASSERT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, testLocation), CHIP_NO_ERROR);
     }
 
-    // Re-initialize cluster, it should load from persistence
-    BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
-                                                 {
-                                                     .uniqueId       = "test-devicelocation",
-                                                     .deviceLocation = NullOptional, // mark attribute supported
-                                                 },
-                                                 {},
-                                                 {
-                                                     .parentVersionConfiguration = mMockVersionConfiguration,
-                                                     .delegate                   = mDelegate,
-                                                     .timerDelegate              = mMockTimer,
-                                                 });
-    EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
-    ClusterTester tester(cluster);
-
-    // Read back and check
-    DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> readLocationNullable;
-    ASSERT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
-    ASSERT_FALSE(readLocationNullable.IsNull());
-    EXPECT_TRUE(LocationDescriptorStructEquals(readLocationNullable.Value(), testLocation));
+    // New cluster instance
+    {
+        BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
+                                                     {
+                                                         .reachable      = true,
+                                                         .deviceLocation = NullOptional, // mark attribute supported
+                                                     },
+                                                     {
+                                                         .uniqueId = "test-devicelocation",
+                                                     },
+                                                     {
+                                                         .delegate      = mDelegate,
+                                                         .timerDelegate = mMockTimer,
+                                                         // No parent version config needed for this test as we don't check version behavior here
+                                                     });
+        EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
+        ClusterTester tester(cluster);
+        DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> readLocationNullable;
+        ASSERT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+        ASSERT_FALSE(readLocationNullable.IsNull());
+        EXPECT_TRUE(LocationDescriptorStructEquals(readLocationNullable.Value(), testLocation));
+    }
 }
 
 } // namespace

--- a/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
@@ -1279,3 +1279,19 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationPersistence)
 }
 
 } // namespace
+
+TEST_F(TestBridgedDeviceBasicInformationCluster, TestOwnedDeviceLocationAssignmentWithEmptySpan)
+{
+    BridgedDeviceBasicInformationCluster::OwnedDeviceLocation ownedLocation;
+    Globals::Structs::LocationDescriptorStruct::Type locationStruct;
+
+    // Default constructed CharSpan has nullptr data and 0 size
+    locationStruct.locationName = CharSpan();
+    locationStruct.floorNumber.SetNull();
+    locationStruct.areaType.SetNull();
+
+    // This should NOT crash (it was causing UB/crash because of std::string(nullptr, 0))
+    ownedLocation = locationStruct;
+
+    EXPECT_TRUE(ownedLocation.locationName.empty());
+}

--- a/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
@@ -34,7 +34,10 @@
 #include <clusters/BridgedDeviceBasicInformation/Enums.h>
 #include <clusters/BridgedDeviceBasicInformation/Events.h>
 #include <clusters/BridgedDeviceBasicInformation/Metadata.h>
+#include <clusters/shared/Enums.h>
+#include <clusters/shared/Structs.h>
 #include <lib/core/CHIPError.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/BitFlags.h>
@@ -238,6 +241,7 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestEmptyAttributes)
                                             Attributes::Reachable::kMetadataEntry,
                                             Attributes::NodeLabel::kMetadataEntry,
                                             Attributes::ConfigurationVersion::kMetadataEntry,
+                                            Attributes::DeviceLocation::kMetadataEntry,
                                         }));
 }
 
@@ -265,6 +269,7 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestPartialAttributes)
                                             Attributes::NodeLabel::kMetadataEntry,
                                             Attributes::PartNumber::kMetadataEntry,
                                             Attributes::ConfigurationVersion::kMetadataEntry,
+                                            Attributes::DeviceLocation::kMetadataEntry,
                                         }));
 }
 
@@ -317,6 +322,7 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestAllAttributes)
                                             Attributes::UniqueID::kMetadataEntry,
                                             Attributes::ProductAppearance::kMetadataEntry,
                                             Attributes::ConfigurationVersion::kMetadataEntry,
+                                            Attributes::DeviceLocation::kMetadataEntry,
                                         }));
 }
 
@@ -363,37 +369,37 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestAttributeReads)
     bool boolVal;
 
     EXPECT_EQ(tester.ReadAttribute(Attributes::UniqueID::Id, charSpanVal), CHIP_NO_ERROR);
-    EXPECT_TRUE(charSpanVal.data_equal(CharSpan::fromCharString("test-unique-id")));
+    EXPECT_TRUE(charSpanVal.data_equal("test-unique-id"_span));
     EXPECT_EQ(tester.ReadAttribute(Attributes::Reachable::Id, boolVal), CHIP_NO_ERROR);
     EXPECT_TRUE(boolVal);
     EXPECT_EQ(tester.ReadAttribute(Attributes::VendorName::Id, charSpanVal), CHIP_NO_ERROR);
-    EXPECT_TRUE(charSpanVal.data_equal(CharSpan::fromCharString("TestVendor")));
+    EXPECT_TRUE(charSpanVal.data_equal("TestVendor"_span));
     EXPECT_EQ(tester.ReadAttribute(Attributes::VendorID::Id, vendorIdVal), CHIP_NO_ERROR);
     EXPECT_EQ(vendorIdVal, VendorId::TestVendor1);
     EXPECT_EQ(tester.ReadAttribute(Attributes::ProductName::Id, charSpanVal), CHIP_NO_ERROR);
-    EXPECT_TRUE(charSpanVal.data_equal(CharSpan::fromCharString("TestProduct")));
+    EXPECT_TRUE(charSpanVal.data_equal("TestProduct"_span));
     EXPECT_EQ(tester.ReadAttribute(Attributes::ProductID::Id, u16Val), CHIP_NO_ERROR);
     EXPECT_EQ(u16Val, 0xABCD);
     EXPECT_EQ(tester.ReadAttribute(Attributes::NodeLabel::Id, charSpanVal), CHIP_NO_ERROR);
-    EXPECT_TRUE(charSpanVal.data_equal(CharSpan::fromCharString("TestLabel")));
+    EXPECT_TRUE(charSpanVal.data_equal("TestLabel"_span));
     EXPECT_EQ(tester.ReadAttribute(Attributes::HardwareVersion::Id, u16Val), CHIP_NO_ERROR);
     EXPECT_EQ(u16Val, 1u);
     EXPECT_EQ(tester.ReadAttribute(Attributes::HardwareVersionString::Id, charSpanVal), CHIP_NO_ERROR);
-    EXPECT_TRUE(charSpanVal.data_equal(CharSpan::fromCharString("v1.0")));
+    EXPECT_TRUE(charSpanVal.data_equal("v1.0"_span));
     EXPECT_EQ(tester.ReadAttribute(Attributes::SoftwareVersion::Id, u32Val), CHIP_NO_ERROR);
     EXPECT_EQ(u32Val, 2u);
     EXPECT_EQ(tester.ReadAttribute(Attributes::SoftwareVersionString::Id, charSpanVal), CHIP_NO_ERROR);
-    EXPECT_TRUE(charSpanVal.data_equal(CharSpan::fromCharString("v2.0")));
+    EXPECT_TRUE(charSpanVal.data_equal("v2.0"_span));
     EXPECT_EQ(tester.ReadAttribute(Attributes::ManufacturingDate::Id, charSpanVal), CHIP_NO_ERROR);
-    EXPECT_TRUE(charSpanVal.data_equal(CharSpan::fromCharString("20240101")));
+    EXPECT_TRUE(charSpanVal.data_equal("20240101"_span));
     EXPECT_EQ(tester.ReadAttribute(Attributes::PartNumber::Id, charSpanVal), CHIP_NO_ERROR);
-    EXPECT_TRUE(charSpanVal.data_equal(CharSpan::fromCharString("PN123")));
+    EXPECT_TRUE(charSpanVal.data_equal("PN123"_span));
     EXPECT_EQ(tester.ReadAttribute(Attributes::ProductURL::Id, charSpanVal), CHIP_NO_ERROR);
-    EXPECT_TRUE(charSpanVal.data_equal(CharSpan::fromCharString("http://test.com")));
+    EXPECT_TRUE(charSpanVal.data_equal("http://test.com"_span));
     EXPECT_EQ(tester.ReadAttribute(Attributes::ProductLabel::Id, charSpanVal), CHIP_NO_ERROR);
-    EXPECT_TRUE(charSpanVal.data_equal(CharSpan::fromCharString("Test Product Label")));
+    EXPECT_TRUE(charSpanVal.data_equal("Test Product Label"_span));
     EXPECT_EQ(tester.ReadAttribute(Attributes::SerialNumber::Id, charSpanVal), CHIP_NO_ERROR);
-    EXPECT_TRUE(charSpanVal.data_equal(CharSpan::fromCharString("SN789")));
+    EXPECT_TRUE(charSpanVal.data_equal("SN789"_span));
     EXPECT_EQ(tester.ReadAttribute(Attributes::ConfigurationVersion::Id, u32Val), CHIP_NO_ERROR);
     EXPECT_EQ(u32Val, 5u);
 
@@ -762,7 +768,7 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestSetNodeLabel)
 
     CharSpan nodeLabel;
     EXPECT_EQ(tester.ReadAttribute(Attributes::NodeLabel::Id, nodeLabel), CHIP_NO_ERROR);
-    EXPECT_TRUE(nodeLabel.data_equal(CharSpan::fromCharString("NewLabel")));
+    EXPECT_TRUE(nodeLabel.data_equal("NewLabel"_span));
 
     // Test no change
     mDelegate.mNodeLabelChangedCalled = false;
@@ -1046,6 +1052,154 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestStartupPersistence)
     // Delegate should have been called because stored value != constructor value
     EXPECT_TRUE(mDelegate.mNodeLabelChangedCalled);
     EXPECT_EQ(mDelegate.mLastNodeLabel, "StoredLabel");
+}
+
+bool LocationDescriptorStructEquals(const Globals::Structs::LocationDescriptorStruct::Type & a,
+                                    const Globals::Structs::LocationDescriptorStruct::Type & b)
+{
+    return a.locationName.data_equal(b.locationName) && (a.floorNumber == b.floorNumber) && (a.areaType == b.areaType);
+}
+
+TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationWriteRead)
+{
+    BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
+                                                 {
+                                                     .uniqueId = "test-devicelocation",
+                                                 },
+                                                 {},
+                                                 {
+                                                     .parentVersionConfiguration = mMockVersionConfiguration,
+                                                     .delegate                   = mDelegate,
+                                                     .timerDelegate              = mMockTimer,
+                                                 });
+    EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
+    ClusterTester tester(cluster);
+
+    // Check initial read (should be null)
+    DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> readLocationNullable;
+    EXPECT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+    EXPECT_TRUE(readLocationNullable.IsNull());
+
+    Globals::Structs::LocationDescriptorStruct::Type testLocation;
+    testLocation.locationName = "Living Room"_span;
+    testLocation.floorNumber.SetNonNull(1);
+    testLocation.areaType.SetNonNull(Globals::AreaTypeTag::kLivingRoom);
+
+    // Write the location
+    EXPECT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, testLocation), CHIP_NO_ERROR);
+
+    // Read it back
+    EXPECT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+    EXPECT_FALSE(readLocationNullable.IsNull());
+    EXPECT_TRUE(LocationDescriptorStructEquals(readLocationNullable.Value(), testLocation));
+
+    // Test clear (write valid location with null optionals)
+    Globals::Structs::LocationDescriptorStruct::Type clearLocation;
+    clearLocation.locationName = "Here"_span;
+    clearLocation.floorNumber.SetNull();
+    clearLocation.areaType.SetNull();
+    EXPECT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, clearLocation), CHIP_NO_ERROR);
+
+    EXPECT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+    EXPECT_FALSE(readLocationNullable.IsNull());
+    EXPECT_TRUE(LocationDescriptorStructEquals(readLocationNullable.Value(), clearLocation));
+
+    // Test writing null
+    DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> nullLocation;
+    nullLocation.SetNull();
+    EXPECT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, nullLocation), CHIP_NO_ERROR);
+    EXPECT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+    EXPECT_TRUE(readLocationNullable.IsNull());
+}
+
+TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationValidation)
+{
+    BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
+                                                 {
+                                                     .uniqueId = "test-devicelocation",
+                                                 },
+                                                 {},
+                                                 {
+                                                     .parentVersionConfiguration = mMockVersionConfiguration,
+                                                     .delegate                   = mDelegate,
+                                                     .timerDelegate              = mMockTimer,
+                                                 });
+    EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
+    ClusterTester tester(cluster);
+
+    Globals::Structs::LocationDescriptorStruct::Type invalidLocation;
+    invalidLocation.locationName = ""_span;
+    invalidLocation.floorNumber.SetNull();
+    invalidLocation.areaType.SetNull();
+
+    // Attempt to write invalid location
+    EXPECT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, invalidLocation), Status::ConstraintError);
+
+    // Check that the value is still null
+    DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> readLocationNullable;
+    EXPECT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+    EXPECT_TRUE(readLocationNullable.IsNull());
+}
+
+TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationPersistence)
+{
+    const ConcreteAttributePath path = { kTestEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id };
+
+    // Clear any previous persistence to ensure we start fresh
+    {
+        CHIP_ERROR err = mContext.StorageDelegate().SyncDeleteKeyValue(
+            DefaultStorageKeyAllocator::AttributeValue(kTestEndpointId, BridgedDeviceBasicInformation::Id,
+                                                       Attributes::DeviceLocation::Id)
+                .KeyName());
+        if (err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+        {
+            EXPECT_EQ(err, CHIP_NO_ERROR);
+        }
+    }
+
+    Globals::Structs::LocationDescriptorStruct::Type testLocation;
+    testLocation.locationName = "Kitchen"_span;
+    testLocation.floorNumber.SetNonNull(0);
+    testLocation.areaType.SetNull();
+
+    // Scope to ensure cluster is destroyed and re-created
+    {
+        BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
+                                                     {
+                                                         .uniqueId = "test-devicelocation",
+                                                     },
+                                                     {},
+                                                     {
+                                                         .parentVersionConfiguration = mMockVersionConfiguration,
+                                                         .delegate                   = mDelegate,
+                                                         .timerDelegate              = mMockTimer,
+                                                     });
+        EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
+        ClusterTester tester(cluster);
+
+        // Write the location
+        EXPECT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, testLocation), CHIP_NO_ERROR);
+    }
+
+    // Re-initialize cluster, it should load from persistence
+    BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
+                                                 {
+                                                     .uniqueId = "test-devicelocation",
+                                                 },
+                                                 {},
+                                                 {
+                                                     .parentVersionConfiguration = mMockVersionConfiguration,
+                                                     .delegate                   = mDelegate,
+                                                     .timerDelegate              = mMockTimer,
+                                                 });
+    EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
+    ClusterTester tester(cluster);
+
+    // Read back and check
+    DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> readLocationNullable;
+    EXPECT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+    ASSERT_FALSE(readLocationNullable.IsNull());
+    EXPECT_TRUE(LocationDescriptorStructEquals(readLocationNullable.Value(), testLocation));
 }
 
 } // namespace

--- a/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
@@ -1214,8 +1214,6 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationValidation)
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationPersistence)
 {
-    const ConcreteAttributePath path = { kTestEndpointId, BridgedDeviceBasicInformation::Id, Attributes::DeviceLocation::Id };
-
     // Clear any previous persistence to ensure we start fresh
     {
         CHIP_ERROR err = mContext.StorageDelegate().SyncDeleteKeyValue(

--- a/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
@@ -252,8 +252,8 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestPartialAttributes)
     };
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .reachable = true,
-                                                     .nodeLabel = "mylabel",
+                                                     .reachable            = true,
+                                                     .nodeLabel            = "mylabel",
                                                      .configurationVersion = versioning,
                                                  },
                                                  {
@@ -426,8 +426,7 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestAttributeReads)
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestKeepActiveCommand)
 {
     TestBridgedDeviceIcdDelegate icdDelegate;
-    BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
-                                                 {},
+    BridgedDeviceBasicInformationCluster cluster(kTestEndpointId, {},
                                                  {
                                                      .uniqueId = "icd-dev",
                                                  },
@@ -1257,19 +1256,19 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationPersistence)
 
     // New cluster instance
     {
-        BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
-                                                     {
-                                                         .reachable      = true,
-                                                         .deviceLocation = NullOptional, // mark attribute supported
-                                                     },
-                                                     {
-                                                         .uniqueId = "test-devicelocation",
-                                                     },
-                                                     {
-                                                         .delegate      = mDelegate,
-                                                         .timerDelegate = mMockTimer,
-                                                         // No parent version config needed for this test as we don't check version behavior here
-                                                     });
+        BridgedDeviceBasicInformationCluster cluster(
+            kTestEndpointId,
+            {
+                .reachable      = true,
+                .deviceLocation = NullOptional, // mark attribute supported
+            },
+            {
+                .uniqueId = "test-devicelocation",
+            },
+            {
+                .delegate = mDelegate, .timerDelegate = mMockTimer,
+                // No parent version config needed for this test as we don't check version behavior here
+            });
         EXPECT_EQ(cluster.Startup(mContext.Get()), CHIP_NO_ERROR);
         ClusterTester tester(cluster);
         DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> readLocationNullable;

--- a/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include "lib/core/Optional.h"
 #include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
@@ -134,7 +135,7 @@ public:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
-    virtual void RunUnitTests() override {}
+    void RunUnitTests() override {}
 
     uint32_t mConfigurationVersion = 10;
     uint32_t mStoreCalled          = 0;
@@ -241,7 +242,6 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestEmptyAttributes)
                                             Attributes::Reachable::kMetadataEntry,
                                             Attributes::NodeLabel::kMetadataEntry,
                                             Attributes::ConfigurationVersion::kMetadataEntry,
-                                            Attributes::DeviceLocation::kMetadataEntry,
                                         }));
 }
 
@@ -269,39 +269,44 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestPartialAttributes)
                                             Attributes::NodeLabel::kMetadataEntry,
                                             Attributes::PartNumber::kMetadataEntry,
                                             Attributes::ConfigurationVersion::kMetadataEntry,
-                                            Attributes::DeviceLocation::kMetadataEntry,
                                         }));
 }
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestAllAttributes)
 {
-    BridgedDeviceBasicInformationCluster cluster(
-        kTestEndpointId, { .uniqueId = "foo-bar", .reachable = true, .nodeLabel = "Remote", .configurationVersion = 123u },
-        {
-            .vendorName            = "ACME",
-            .vendorId              = VendorId::Common,
-            .productName           = "Bridge",
-            .productId             = 0x1234,
-            .hardwareVersion       = 0x1122,
-            .hardwareVersionString = "NewVersion-A",
-            .softwareVersion       = 0x11223344,
-            .softwareVersionString = "FancyBuild",
-            .manufacturingDate     = "010203",
-            .partNumber            = "A-B-C",
-            .productUrl            = "http://example.com",
-            .productLabel          = "New",
-            .serialNumber          = "SN123456",
-            .productAppearance =
-                Structs::ProductAppearanceStruct::Type{
-                    .finish       = ProductFinishEnum::kPolished,
-                    .primaryColor = ColorEnum::kFuchsia,
-                },
-        },
-        {
-            .parentVersionConfiguration = mMockVersionConfiguration,
-            .delegate                   = mDelegate,
-            .timerDelegate              = mMockTimer,
-        });
+    BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
+                                                 {
+                                                     .uniqueId             = "foo-bar",
+                                                     .reachable            = true,
+                                                     .nodeLabel            = "Remote",
+                                                     .configurationVersion = 123u,
+                                                     .deviceLocation       = NullOptional,
+                                                 },
+                                                 {
+                                                     .vendorName            = "ACME",
+                                                     .vendorId              = VendorId::Common,
+                                                     .productName           = "Bridge",
+                                                     .productId             = 0x1234,
+                                                     .hardwareVersion       = 0x1122,
+                                                     .hardwareVersionString = "NewVersion-A",
+                                                     .softwareVersion       = 0x11223344,
+                                                     .softwareVersionString = "FancyBuild",
+                                                     .manufacturingDate     = "010203",
+                                                     .partNumber            = "A-B-C",
+                                                     .productUrl            = "http://example.com",
+                                                     .productLabel          = "New",
+                                                     .serialNumber          = "SN123456",
+                                                     .productAppearance =
+                                                         Structs::ProductAppearanceStruct::Type{
+                                                             .finish       = ProductFinishEnum::kPolished,
+                                                             .primaryColor = ColorEnum::kFuchsia,
+                                                         },
+                                                 },
+                                                 {
+                                                     .parentVersionConfiguration = mMockVersionConfiguration,
+                                                     .delegate                   = mDelegate,
+                                                     .timerDelegate              = mMockTimer,
+                                                 });
     EXPECT_TRUE(IsAttributesListEqualTo(cluster,
                                         {
                                             Attributes::VendorName::kMetadataEntry,
@@ -334,6 +339,7 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestAttributeReads)
                                                      .reachable            = true,
                                                      .nodeLabel            = "TestLabel",
                                                      .configurationVersion = 5u,
+                                                     .deviceLocation       = NullOptional,
                                                  },
                                                  {
                                                      .vendorName            = "TestVendor",
@@ -1064,7 +1070,8 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationWriteRead)
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId = "test-devicelocation",
+                                                     .uniqueId       = "test-devicelocation",
+                                                     .deviceLocation = NullOptional, // mark attribute supported
                                                  },
                                                  {},
                                                  {
@@ -1077,7 +1084,7 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationWriteRead)
 
     // Check initial read (should be null)
     DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> readLocationNullable;
-    EXPECT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+    ASSERT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
     EXPECT_TRUE(readLocationNullable.IsNull());
 
     Globals::Structs::LocationDescriptorStruct::Type testLocation;
@@ -1089,7 +1096,7 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationWriteRead)
     EXPECT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, testLocation), CHIP_NO_ERROR);
 
     // Read it back
-    EXPECT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+    ASSERT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
     EXPECT_FALSE(readLocationNullable.IsNull());
     EXPECT_TRUE(LocationDescriptorStructEquals(readLocationNullable.Value(), testLocation));
 
@@ -1100,7 +1107,7 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationWriteRead)
     clearLocation.areaType.SetNull();
     EXPECT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, clearLocation), CHIP_NO_ERROR);
 
-    EXPECT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+    ASSERT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
     EXPECT_FALSE(readLocationNullable.IsNull());
     EXPECT_TRUE(LocationDescriptorStructEquals(readLocationNullable.Value(), clearLocation));
 
@@ -1116,7 +1123,8 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationValidation)
 {
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId = "test-devicelocation",
+                                                     .uniqueId       = "test-devicelocation",
+                                                     .deviceLocation = NullOptional, // mark attribute supported
                                                  },
                                                  {},
                                                  {
@@ -1133,11 +1141,11 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationValidation)
     invalidLocation.areaType.SetNull();
 
     // Attempt to write invalid location
-    EXPECT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, invalidLocation), Status::ConstraintError);
+    ASSERT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, invalidLocation), Status::ConstraintError);
 
     // Check that the value is still null
     DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> readLocationNullable;
-    EXPECT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+    ASSERT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
     EXPECT_TRUE(readLocationNullable.IsNull());
 }
 
@@ -1166,7 +1174,8 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationPersistence)
     {
         BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                      {
-                                                         .uniqueId = "test-devicelocation",
+                                                         .uniqueId       = "test-devicelocation",
+                                                         .deviceLocation = NullOptional, // mark attribute supported
                                                      },
                                                      {},
                                                      {
@@ -1178,13 +1187,14 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationPersistence)
         ClusterTester tester(cluster);
 
         // Write the location
-        EXPECT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, testLocation), CHIP_NO_ERROR);
+        ASSERT_EQ(tester.WriteAttribute(Attributes::DeviceLocation::Id, testLocation), CHIP_NO_ERROR);
     }
 
     // Re-initialize cluster, it should load from persistence
     BridgedDeviceBasicInformationCluster cluster(kTestEndpointId,
                                                  {
-                                                     .uniqueId = "test-devicelocation",
+                                                     .uniqueId       = "test-devicelocation",
+                                                     .deviceLocation = NullOptional, // mark attribute supported
                                                  },
                                                  {},
                                                  {
@@ -1197,7 +1207,7 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestDeviceLocationPersistence)
 
     // Read back and check
     DataModel::Nullable<Globals::Structs::LocationDescriptorStruct::Type> readLocationNullable;
-    EXPECT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
+    ASSERT_EQ(tester.ReadAttribute(Attributes::DeviceLocation::Id, readLocationNullable), CHIP_NO_ERROR);
     ASSERT_FALSE(readLocationNullable.IsNull());
     EXPECT_TRUE(LocationDescriptorStructEquals(readLocationNullable.Value(), testLocation));
 }

--- a/src/app/persistence/AttributePersistence.cpp
+++ b/src/app/persistence/AttributePersistence.cpp
@@ -103,13 +103,19 @@ CHIP_ERROR AttributePersistence::InternalLoadTLV(const ConcreteAttributePath & p
     TLV::TLVReader reader;
     reader.Init(buffer);
 
-    TLV::TLVType container;
     ReturnErrorOnFailure(reader.Next());
-    ReturnErrorOnFailure(reader.EnterContainer(container));
-    ReturnErrorOnFailure(reader.Next()); // Move to the element inside structure (Context Tag 1)
-    VerifyOrReturnError(reader.GetTag() == kTLVEncodingTag, CHIP_ERROR_INVALID_ARGUMENT);
-    ReturnErrorOnFailure(decoder(context, reader));
-    ReturnErrorOnFailure(reader.ExitContainer(container));
+    VerifyOrReturnError(reader.GetType() == TLV::kTLVType_Structure, CHIP_ERROR_WRONG_TLV_TYPE);
+
+    {
+        TLV::TLVType container;
+        ReturnErrorOnFailure(reader.EnterContainer(container));
+        ReturnErrorOnFailure(reader.Next()); // Move to the element inside structure (Context Tag 1)
+        VerifyOrReturnError(reader.GetTag() == kTLVEncodingTag, CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorOnFailure(decoder(context, reader));
+        ReturnErrorOnFailure(reader.VerifyEndOfContainer());
+        ReturnErrorOnFailure(reader.ExitContainer(container));
+    }
+    ReturnErrorOnFailure(reader.VerifyEndOfContainer());
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/persistence/AttributePersistence.cpp
+++ b/src/app/persistence/AttributePersistence.cpp
@@ -80,4 +80,38 @@ CHIP_ERROR AttributePersistence::StoreString(const ConcreteAttributePath & path,
     return mProvider.WriteValue(path, io.ContentWithPrefix());
 }
 
+CHIP_ERROR AttributePersistence::InternalStoreTLV(const ConcreteAttributePath & path, MutableByteSpan buffer, void * context,
+                                                  TLVEncoderCallback encoder)
+{
+    TLV::TLVWriter writer;
+    writer.Init(buffer);
+
+    TLV::TLVType container;
+    // We wrap the value in an Anonymous Structure to ensure a single valid top-level element.
+    ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container));
+    ReturnErrorOnFailure(encoder(context, writer));
+    ReturnErrorOnFailure(writer.EndContainer(container));
+
+    return mProvider.WriteValue(path, ByteSpan(buffer.data(), writer.GetLengthWritten()));
+}
+
+CHIP_ERROR AttributePersistence::InternalLoadTLV(const ConcreteAttributePath & path, MutableByteSpan buffer, void * context,
+                                                 TLVDecoderCallback decoder)
+{
+    ReturnErrorOnFailure(mProvider.ReadValue(path, buffer));
+
+    TLV::TLVReader reader;
+    reader.Init(buffer);
+
+    TLV::TLVType container;
+    ReturnErrorOnFailure(reader.Next());
+    ReturnErrorOnFailure(reader.EnterContainer(container));
+    ReturnErrorOnFailure(reader.Next()); // Move to the element inside structure (Context Tag 1)
+    VerifyOrReturnError(reader.GetTag() == kTLVEncodingTag, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorOnFailure(decoder(context, reader));
+    ReturnErrorOnFailure(reader.ExitContainer(container));
+
+    return CHIP_NO_ERROR;
+}
+
 } // namespace chip::app

--- a/src/app/persistence/AttributePersistence.cpp
+++ b/src/app/persistence/AttributePersistence.cpp
@@ -91,6 +91,7 @@ CHIP_ERROR AttributePersistence::InternalStoreTLV(const ConcreteAttributePath & 
     ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container));
     ReturnErrorOnFailure(encoder(context, writer));
     ReturnErrorOnFailure(writer.EndContainer(container));
+    ReturnErrorOnFailure(writer.Finalize());
 
     return mProvider.WriteValue(path, ByteSpan(buffer.data(), writer.GetLengthWritten()));
 }

--- a/src/app/persistence/AttributePersistence.cpp
+++ b/src/app/persistence/AttributePersistence.cpp
@@ -80,7 +80,7 @@ CHIP_ERROR AttributePersistence::StoreString(const ConcreteAttributePath & path,
     return mProvider.WriteValue(path, io.ContentWithPrefix());
 }
 
-CHIP_ERROR AttributePersistence::InternalStoreTLV(const ConcreteAttributePath & path, MutableByteSpan buffer, void * context,
+CHIP_ERROR AttributePersistence::InternalStoreTLV(const ConcreteAttributePath & path, MutableByteSpan buffer, const void * context,
                                                   TLVEncoderCallback encoder)
 {
     TLV::TLVWriter writer;

--- a/src/app/persistence/AttributePersistence.h
+++ b/src/app/persistence/AttributePersistence.h
@@ -176,7 +176,7 @@ public:
     template <typename T>
     CHIP_ERROR StoreTLV(const ConcreteAttributePath & path, const T & value, MutableByteSpan buffer)
     {
-        return InternalStoreTLV(path, buffer, const_cast<T *>(&value), [](void * context, TLV::TLVWriter & writer) -> CHIP_ERROR {
+        return InternalStoreTLV(path, buffer, &value, [](const void * context, TLV::TLVWriter & writer) -> CHIP_ERROR {
             return DataModel::Encode(writer, kTLVEncodingTag, *static_cast<const T *>(context));
         });
     }
@@ -233,10 +233,10 @@ private:
     bool InternalRawLoadNativeEndianValue(const ConcreteAttributePath & path, void * data, const void * valueOnLoadFailure,
                                           size_t size);
 
-    using TLVEncoderCallback = CHIP_ERROR (*)(void * context, TLV::TLVWriter & writer);
+    using TLVEncoderCallback = CHIP_ERROR (*)(const void * context, TLV::TLVWriter & writer);
     using TLVDecoderCallback = CHIP_ERROR (*)(void * context, TLV::TLVReader & reader);
 
-    CHIP_ERROR InternalStoreTLV(const ConcreteAttributePath & path, MutableByteSpan buffer, void * context,
+    CHIP_ERROR InternalStoreTLV(const ConcreteAttributePath & path, MutableByteSpan buffer, const void * context,
                                 TLVEncoderCallback encoder);
     CHIP_ERROR InternalLoadTLV(const ConcreteAttributePath & path, MutableByteSpan buffer, void * context,
                                TLVDecoderCallback decoder);

--- a/src/app/persistence/AttributePersistence.h
+++ b/src/app/persistence/AttributePersistence.h
@@ -18,8 +18,11 @@
 #include <app/AttributeValueDecoder.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
+#include <app/data-model/Decode.h>
+#include <app/data-model/Encode.h>
 #include <app/persistence/AttributePersistenceProvider.h>
 #include <app/persistence/String.h>
+#include <lib/core/TLV.h>
 
 #include <type_traits>
 
@@ -161,7 +164,57 @@ public:
     /// not use internal classes directly.
     CHIP_ERROR StoreString(const ConcreteAttributePath & path, const Storage::Internal::ShortString & value);
 
+    /// Validates that the value is different from the current one and writes to storage.
+    /// Uses the provided buffer for TLV encoding.
+    ///
+    /// The encoding format is:
+    ///   Structure (Anonymous Tag)
+    ///     <Value> (Context Tag 1)
+    ///   EndContainer
+    ///
+    /// This wrapper ensures valid top-level TLV elements and allows future extensibility.
+    template <typename T>
+    CHIP_ERROR StoreTLV(const ConcreteAttributePath & path, const T & value, MutableByteSpan buffer)
+    {
+        return InternalStoreTLV(path, buffer, const_cast<T *>(&value), [](void * context, TLV::TLVWriter & writer) -> CHIP_ERROR {
+            return DataModel::Encode(writer, kTLVEncodingTag, *static_cast<const T *>(context));
+        });
+    }
+
+    /// Stack-allocating overload for convenience.
+    template <size_t kMaxBufferSize, typename T>
+    CHIP_ERROR StoreTLV(const ConcreteAttributePath & path, const T & value)
+    {
+        uint8_t buffer[kMaxBufferSize];
+        return StoreTLV(path, value, MutableByteSpan(buffer));
+    }
+
+    /// Loads a TLV value from storage using the provided buffer.
+    ///
+    /// WARNING: If T contains views (e.g. Spans, DataModel::List), they will point into `buffer`.
+    /// The `buffer` MUST outlive the usage of `value`.
+    template <typename T>
+    CHIP_ERROR LoadTLV(const ConcreteAttributePath & path, T & value, MutableByteSpan buffer)
+    {
+        return InternalLoadTLV(path, buffer, &value, [](void * context, TLV::TLVReader & reader) -> CHIP_ERROR {
+            return DataModel::Decode(reader, *static_cast<T *>(context));
+        });
+    }
+
+    /// Stack-allocating overload for convenience.
+    template <size_t kMaxBufferSize, typename T>
+    CHIP_ERROR LoadTLV(const ConcreteAttributePath & path, T & value)
+    {
+        // NOTE: This overload assumes T does NOT contain views pointing to the buffer,
+        // because the buffer is destroyed when this function returns.
+        // Use the buffer-passing overload if T contains Views (like Span or List).
+        // Static assert is not available for "HasView", so we rely on documentation and careful usage.
+        uint8_t buffer[kMaxBufferSize];
+        return LoadTLV(path, value, MutableByteSpan(buffer));
+    }
+
 private:
+    static constexpr TLV::Tag kTLVEncodingTag = TLV::ContextTag(1);
     AttributePersistenceProvider & mProvider;
 
     /// Loads a raw value of size `size` into the memory pointed to by `data`.
@@ -171,6 +224,14 @@ private:
     /// reason for the load failure).
     bool InternalRawLoadNativeEndianValue(const ConcreteAttributePath & path, void * data, const void * valueOnLoadFailure,
                                           size_t size);
+
+    using TLVEncoderCallback = CHIP_ERROR (*)(void * context, TLV::TLVWriter & writer);
+    using TLVDecoderCallback = CHIP_ERROR (*)(void * context, TLV::TLVReader & reader);
+
+    CHIP_ERROR InternalStoreTLV(const ConcreteAttributePath & path, MutableByteSpan buffer, void * context,
+                                TLVEncoderCallback encoder);
+    CHIP_ERROR InternalLoadTLV(const ConcreteAttributePath & path, MutableByteSpan buffer, void * context,
+                               TLVDecoderCallback decoder);
 };
 
 } // namespace chip::app

--- a/src/app/persistence/AttributePersistence.h
+++ b/src/app/persistence/AttributePersistence.h
@@ -202,6 +202,14 @@ public:
     }
 
     /// Stack-allocating overload for convenience.
+    ///
+    /// @warning CRITICAL WARNING: Do NOT use this overload if T contains any data views
+    /// (e.g., CharSpan, ByteSpan, DataModel::List). The backing buffer for these views is allocated
+    /// on the stack and will be DESTROYED when this function returns, leading to DANGLING POINTERS
+    /// and undefined behavior.
+    ///
+    /// If T contains any view types, you MUST use the overload that accepts an external MutableByteSpan
+    /// to ensure the buffer outlives the usage of the decoded value.
     template <size_t kMaxBufferSize, typename T>
     CHIP_ERROR LoadTLV(const ConcreteAttributePath & path, T & value)
     {

--- a/src/app/persistence/AttributePersistence.h
+++ b/src/app/persistence/AttributePersistence.h
@@ -201,25 +201,6 @@ public:
         });
     }
 
-    /// Stack-allocating overload for convenience.
-    ///
-    /// @warning CRITICAL WARNING: Do NOT use this overload if T contains any data views
-    /// (e.g., CharSpan, ByteSpan, DataModel::List). The backing buffer for these views is allocated
-    /// on the stack and will be DESTROYED when this function returns, leading to DANGLING POINTERS
-    /// and undefined behavior.
-    ///
-    /// If T contains any view types, you MUST use the overload that accepts an external MutableByteSpan
-    /// to ensure the buffer outlives the usage of the decoded value.
-    template <size_t kMaxBufferSize, typename T>
-    CHIP_ERROR LoadTLV(const ConcreteAttributePath & path, T & value)
-    {
-        // NOTE: This overload assumes T does NOT contain views pointing to the buffer,
-        // because the buffer is destroyed when this function returns.
-        // Use the buffer-passing overload if T contains Views (like Span or List).
-        uint8_t buffer[kMaxBufferSize];
-        return LoadTLV(path, value, MutableByteSpan(buffer));
-    }
-
 private:
     static constexpr TLV::Tag kTLVEncodingTag = TLV::ContextTag(1);
     AttributePersistenceProvider & mProvider;

--- a/src/app/persistence/AttributePersistence.h
+++ b/src/app/persistence/AttributePersistence.h
@@ -164,7 +164,7 @@ public:
     /// not use internal classes directly.
     CHIP_ERROR StoreString(const ConcreteAttributePath & path, const Storage::Internal::ShortString & value);
 
-    /// Validates that the value is different from the current one and writes to storage.
+    /// Writes a TLV-encodable value (using DataModel::Encode) to the attribute storage.
     /// Uses the provided buffer for TLV encoding.
     ///
     /// The encoding format is:

--- a/src/app/persistence/AttributePersistence.h
+++ b/src/app/persistence/AttributePersistence.h
@@ -216,7 +216,6 @@ public:
         // NOTE: This overload assumes T does NOT contain views pointing to the buffer,
         // because the buffer is destroyed when this function returns.
         // Use the buffer-passing overload if T contains Views (like Span or List).
-        // Static assert is not available for "HasView", so we rely on documentation and careful usage.
         uint8_t buffer[kMaxBufferSize];
         return LoadTLV(path, value, MutableByteSpan(buffer));
     }

--- a/src/app/persistence/tests/TestAttributePersistence.cpp
+++ b/src/app/persistence/tests/TestAttributePersistence.cpp
@@ -983,4 +983,104 @@ TEST(TestAttributePersistence, TestStoreAndLoadTLV)
     }
 }
 
+TEST(TestAttributePersistence, TestAttributePersistenceTLVValidation)
+{
+    TestPersistentStorageDelegate storageDelegate;
+    DefaultAttributePersistenceProvider ramProvider;
+    ASSERT_EQ(ramProvider.Init(&storageDelegate), CHIP_NO_ERROR);
+
+    AttributePersistence persistence(ramProvider);
+    const ConcreteAttributePath path(1, 2, 3);
+
+    // Helper to write raw bytes to storage
+    auto writeRaw = [&](const ByteSpan & data) {
+        return storageDelegate.SyncSetKeyValue(
+            DefaultStorageKeyAllocator::AttributeValue(path.mEndpointId, path.mClusterId, path.mAttributeId).KeyName(), data.data(),
+            static_cast<uint16_t>(data.size()));
+    };
+
+    // 1. Not a structure (Just an integer)
+    {
+        uint8_t buffer[128];
+        TLV::TLVWriter writer;
+        writer.Init(buffer);
+        ASSERT_EQ(writer.Put(TLV::ContextTag(1), (uint32_t) 100), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Finalize(), CHIP_NO_ERROR);
+        ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
+
+        uint32_t value = 0;
+        // Should fail because it expects a Structure
+        EXPECT_EQ(persistence.LoadTLV<128>(path, value), CHIP_ERROR_WRONG_TLV_TYPE);
+    }
+
+    // 2. Empty Structure
+    {
+        uint8_t buffer[128];
+        TLV::TLVWriter writer;
+        writer.Init(buffer);
+        TLV::TLVType container;
+        ASSERT_EQ(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.EndContainer(container), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Finalize(), CHIP_NO_ERROR);
+        ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
+
+        uint32_t value = 0;
+        // Should fail because it expects an element inside
+        EXPECT_EQ(persistence.LoadTLV<128>(path, value), CHIP_END_OF_TLV);
+    }
+
+    // 3. Structure with Wrong Element Tag (Context Tag 2 instead of 1)
+    {
+        uint8_t buffer[128];
+        TLV::TLVWriter writer;
+        writer.Init(buffer);
+        TLV::TLVType container;
+        ASSERT_EQ(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Put(TLV::ContextTag(2), (uint32_t) 100), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.EndContainer(container), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Finalize(), CHIP_NO_ERROR);
+        ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
+
+        uint32_t value = 0;
+        // Should fail on tag check
+        EXPECT_EQ(persistence.LoadTLV<128>(path, value), CHIP_ERROR_INVALID_ARGUMENT);
+    }
+
+    // 4. Structure with Extra Element
+    {
+        uint8_t buffer[128];
+        TLV::TLVWriter writer;
+        writer.Init(buffer);
+        TLV::TLVType container;
+        ASSERT_EQ(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Put(TLV::ContextTag(1), (uint32_t) 100), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Put(TLV::ContextTag(2), (uint32_t) 200), CHIP_NO_ERROR); // Extra
+        ASSERT_EQ(writer.EndContainer(container), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Finalize(), CHIP_NO_ERROR);
+        ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
+
+        uint32_t value = 0;
+        // Should fail on VerifyEndOfContainer inside container
+        EXPECT_EQ(persistence.LoadTLV<128>(path, value), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    }
+
+    // 5. Trailing Data after Structure
+    {
+        uint8_t buffer[128];
+        TLV::TLVWriter writer;
+        writer.Init(buffer);
+        TLV::TLVType container;
+        ASSERT_EQ(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Put(TLV::ContextTag(1), (uint32_t) 100), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.EndContainer(container), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Put(TLV::ContextTag(2), (uint32_t) 200), CHIP_NO_ERROR); // Trailing
+        ASSERT_EQ(writer.Finalize(), CHIP_NO_ERROR);
+        ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
+
+        uint32_t value = 0;
+        // Should fail on VerifyEndOfContainer outside container
+        EXPECT_EQ(persistence.LoadTLV<128>(path, value), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    }
+}
+
 } // namespace

--- a/src/app/persistence/tests/TestAttributePersistence.cpp
+++ b/src/app/persistence/tests/TestAttributePersistence.cpp
@@ -1004,7 +1004,7 @@ TEST(TestAttributePersistence, TestAttributePersistenceTLVValidation)
         uint8_t buffer[128];
         TLV::TLVWriter writer;
         writer.Init(buffer);
-        ASSERT_EQ(writer.Put(TLV::ContextTag(1), (uint32_t) 100), CHIP_NO_ERROR);
+        ASSERT_EQ(writer.Put(TLV::AnonymousTag(), (uint32_t) 100), CHIP_NO_ERROR);
         ASSERT_EQ(writer.Finalize(), CHIP_NO_ERROR);
         ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
 
@@ -1073,7 +1073,7 @@ TEST(TestAttributePersistence, TestAttributePersistenceTLVValidation)
         ASSERT_EQ(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container), CHIP_NO_ERROR);
         ASSERT_EQ(writer.Put(TLV::ContextTag(1), (uint32_t) 100), CHIP_NO_ERROR);
         ASSERT_EQ(writer.EndContainer(container), CHIP_NO_ERROR);
-        ASSERT_EQ(writer.Put(TLV::ContextTag(2), (uint32_t) 200), CHIP_NO_ERROR); // Trailing
+        ASSERT_EQ(writer.Put(TLV::AnonymousTag(), (uint32_t) 200), CHIP_NO_ERROR); // Trailing
         ASSERT_EQ(writer.Finalize(), CHIP_NO_ERROR);
         ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
 

--- a/src/app/persistence/tests/TestAttributePersistence.cpp
+++ b/src/app/persistence/tests/TestAttributePersistence.cpp
@@ -968,13 +968,6 @@ TEST(TestAttributePersistence, TestStoreAndLoadTLV)
         EXPECT_EQ(persistence.StoreTLV<kBufferSize>(kPath, valueToStore2), CHIP_NO_ERROR);
     }
 
-    // Test LoadTLV with stack allocation (convenience overload)
-    {
-        TestTLVStruct loadedValue;
-        EXPECT_EQ(persistence.LoadTLV<kBufferSize>(kPath, loadedValue), CHIP_NO_ERROR);
-        EXPECT_EQ(loadedValue, valueToStore2);
-    }
-
     // Test StoreTLV with too small buffer
     {
         uint8_t buffer[4]; // Too small for TestTLVStruct
@@ -1009,8 +1002,9 @@ TEST(TestAttributePersistence, TestAttributePersistenceTLVValidation)
         ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
 
         uint32_t value = 0;
+        uint8_t readBuffer[128];
         // Should fail because it expects a Structure
-        EXPECT_EQ(persistence.LoadTLV<128>(path, value), CHIP_ERROR_WRONG_TLV_TYPE);
+        EXPECT_EQ(persistence.LoadTLV(path, value, MutableByteSpan(readBuffer)), CHIP_ERROR_WRONG_TLV_TYPE);
     }
 
     // 2. Empty Structure
@@ -1025,8 +1019,9 @@ TEST(TestAttributePersistence, TestAttributePersistenceTLVValidation)
         ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
 
         uint32_t value = 0;
+        uint8_t readBuffer[128];
         // Should fail because it expects an element inside
-        EXPECT_EQ(persistence.LoadTLV<128>(path, value), CHIP_END_OF_TLV);
+        EXPECT_EQ(persistence.LoadTLV(path, value, MutableByteSpan(readBuffer)), CHIP_END_OF_TLV);
     }
 
     // 3. Structure with Wrong Element Tag (Context Tag 2 instead of 1)
@@ -1042,8 +1037,9 @@ TEST(TestAttributePersistence, TestAttributePersistenceTLVValidation)
         ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
 
         uint32_t value = 0;
+        uint8_t readBuffer[128];
         // Should fail on tag check
-        EXPECT_EQ(persistence.LoadTLV<128>(path, value), CHIP_ERROR_INVALID_ARGUMENT);
+        EXPECT_EQ(persistence.LoadTLV(path, value, MutableByteSpan(readBuffer)), CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     // 4. Structure with Extra Element
@@ -1060,8 +1056,9 @@ TEST(TestAttributePersistence, TestAttributePersistenceTLVValidation)
         ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
 
         uint32_t value = 0;
+        uint8_t readBuffer[128];
         // Should fail on VerifyEndOfContainer inside container
-        EXPECT_EQ(persistence.LoadTLV<128>(path, value), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+        EXPECT_EQ(persistence.LoadTLV(path, value, MutableByteSpan(readBuffer)), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
     }
 
     // 5. Trailing Data after Structure
@@ -1078,8 +1075,9 @@ TEST(TestAttributePersistence, TestAttributePersistenceTLVValidation)
         ASSERT_EQ(writeRaw(ByteSpan(buffer, writer.GetLengthWritten())), CHIP_NO_ERROR);
 
         uint32_t value = 0;
+        uint8_t readBuffer[128];
         // Should fail on VerifyEndOfContainer outside container
-        EXPECT_EQ(persistence.LoadTLV<128>(path, value), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+        EXPECT_EQ(persistence.LoadTLV(path, value, MutableByteSpan(readBuffer)), CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
     }
 }
 

--- a/src/app/persistence/tests/TestAttributePersistence.cpp
+++ b/src/app/persistence/tests/TestAttributePersistence.cpp
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include "lib/core/TLVWriter.h"
 #include <pw_unit_test/framework.h>
 
 #include <app/AttributeValueDecoder.h>
@@ -886,4 +887,100 @@ TEST(TestAttributePersistence, TestWriteOnDifferentValueNullableEnum)
         ASSERT_EQ(loadedValue.Value(), CalendarTypeEnum::kCoptic);
     }
 }
+
+// A fake encodable TLV structure, for testing purposes only.
+struct TestTLVStruct
+{
+    uint32_t a = 0;
+    bool b     = false;
+
+    bool operator==(const TestTLVStruct & other) const { return a == other.a && b == other.b; }
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
+    {
+        TLV::TLVType outer;
+        ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(1), a));
+        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(2), b));
+        return writer.EndContainer(outer);
+    }
+
+    CHIP_ERROR Decode(TLV::TLVReader & reader)
+    {
+        TLV::TLVType outer;
+        ReturnErrorOnFailure(reader.EnterContainer(outer));
+
+        // Format of structure during Encode is known, so we force ordering.
+        ReturnErrorOnFailure(reader.Next());
+        VerifyOrReturnError(reader.GetTag() == TLV::ContextTag(1), CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorOnFailure(reader.Get(a));
+
+        ReturnErrorOnFailure(reader.Next());
+        VerifyOrReturnError(reader.GetTag() == TLV::ContextTag(2), CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorOnFailure(reader.Get(b));
+        VerifyOrReturnError(reader.Next() == CHIP_ERROR_END_OF_TLV, CHIP_ERROR_INVALID_ARGUMENT);
+
+        return reader.ExitContainer(outer);
+    }
+};
+
+TEST(TestAttributePersistence, TestStoreAndLoadTLV)
+{
+    TestPersistentStorageDelegate storageDelegate;
+    DefaultAttributePersistenceProvider ramProvider;
+    ASSERT_EQ(ramProvider.Init(&storageDelegate), CHIP_NO_ERROR);
+
+    AttributePersistence persistence(ramProvider);
+
+    const ConcreteAttributePath kPath(1, 2, 3);
+    const ConcreteAttributePath kOtherInvalidPath(1, 2, 4);
+    constexpr size_t kBufferSize = 128;
+
+    TestTLVStruct valueToStore{ .a = 12345, .b = true };
+    TestTLVStruct valueToStore2{ .a = 67890, .b = false };
+
+    // Test StoreTLV with external buffer
+    {
+        uint8_t buffer[kBufferSize];
+        MutableByteSpan span(buffer);
+        EXPECT_EQ(persistence.StoreTLV(kPath, valueToStore, span), CHIP_NO_ERROR);
+    }
+
+    // Test LoadTLV with external buffer
+    {
+        uint8_t buffer[kBufferSize];
+        MutableByteSpan span(buffer);
+        TestTLVStruct loadedValue;
+        EXPECT_EQ(persistence.LoadTLV(kPath, loadedValue, span), CHIP_NO_ERROR);
+        EXPECT_EQ(loadedValue, valueToStore);
+    }
+
+    // Test LoadTLV from wrong path
+    {
+        uint8_t buffer[kBufferSize];
+        MutableByteSpan span(buffer);
+        TestTLVStruct loadedValue;
+        EXPECT_NE(persistence.LoadTLV(kOtherInvalidPath, loadedValue, span), CHIP_NO_ERROR);
+    }
+
+    // Test StoreTLV with stack allocation (convenience overload)
+    {
+        EXPECT_EQ(persistence.StoreTLV<kBufferSize>(kPath, valueToStore2), CHIP_NO_ERROR);
+    }
+
+    // Test LoadTLV with stack allocation (convenience overload)
+    {
+        TestTLVStruct loadedValue;
+        EXPECT_EQ(persistence.LoadTLV<kBufferSize>(kPath, loadedValue), CHIP_NO_ERROR);
+        EXPECT_EQ(loadedValue, valueToStore2);
+    }
+
+    // Test StoreTLV with too small buffer
+    {
+        uint8_t buffer[4]; // Too small for TestTLVStruct
+        MutableByteSpan span(buffer);
+        EXPECT_EQ(persistence.StoreTLV(kPath, valueToStore, span), CHIP_ERROR_BUFFER_TOO_SMALL);
+    }
+}
+
 } // namespace


### PR DESCRIPTION
#### Summary

Bridge info needed:
  - DeviceLocation support
  - ConfigurationVersion should be an optional attribute

This had some sideffects in implementation, so I ended up with:

- Add DeviceLocation, that is optional nullable
  - add persistence of this as TLV
- Since we want TLV storage, I added TLV load/store to AttributePersistence, so we have some form of code reuse
- ConfigurationVersion that is optional
  - this let to some naming updates: we now use Fixed/Mutable data and I moved the tuple of ConfigurationVersion & Delegate into one single struct, to show they are to be used together (or not at all)
 
#### Testing

Many CI tests added

Manually ran bridge app and verified that data looks as expected:

<img width="1038" height="1030" alt="image" src="https://github.com/user-attachments/assets/ad99b006-cb71-4e11-9ebb-dfe5bde78569" />
