### PR TITLE
[ICD] Fix ICD requirement not being set

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -617,16 +617,24 @@ void CommissioningWindowManager::ExpireFailSafeIfHeldByOpenPASESession()
 void CommissioningWindowManager::UpdateWindowStatus(CommissioningWindowStatusEnum aNewStatus)
 {
     CommissioningWindowStatusEnum oldClusterStatus = CommissioningWindowStatusForCluster();
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    // BugFix: The commissioning window can be open before the initialization of the ICD Manager.
+    // Trigger a request notification every time this function is called with an open status
+    // to ensure the ICDManager is in sync with the commissioning window status.
+    if (aNewStatus == CommissioningWindowStatusEnum::kEnhancedWindowOpen ||
+        aNewStatus == CommissioningWindowStatusEnum::kBasicWindowOpen)
+    {
+        app::ICDListener::KeepActiveFlags request = app::ICDListener::KeepActiveFlag::kCommissioningWindowOpen;
+        app::ICDNotifier::GetInstance().NotifyActiveRequestNotification(request);
+    }
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
     if (mWindowStatus != aNewStatus)
     {
         mWindowStatus = aNewStatus;
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
         app::ICDListener::KeepActiveFlags request = app::ICDListener::KeepActiveFlag::kCommissioningWindowOpen;
-        if (mWindowStatus != CommissioningWindowStatusEnum::kWindowNotOpen)
-        {
-            app::ICDNotifier::GetInstance().NotifyActiveRequestNotification(request);
-        }
-        else
+        if (mWindowStatus == CommissioningWindowStatusEnum::kWindowNotOpen)
         {
             app::ICDNotifier::GetInstance().NotifyActiveRequestWithdrawal(request);
         }


### PR DESCRIPTION
#### Summary

Fix requirement not being set as commissioning window is open before the initialization of the ICD Manager. As the updated status is called multiples times, simply removing the check for a new status solved the issue.

#### Related issues

None

#### Testing
Tested using a MG24 from silicon labs. Requirement is being set properly (confirmer with debug logs that were removed before opening this PR)

