### PR TITLE
[WebRTCP] Add missing validation of the content of currentSession

### DIFF
--- a/src/python_testing/TC_WEBRTCP_2_1.py
+++ b/src/python_testing/TC_WEBRTCP_2_1.py
@@ -193,6 +193,26 @@ class TC_WebRTCP_2_1(MatterBaseTest, WEBRTCPTestBase):
 
         asserts.assert_equal(len(current_sessions), 1, "Expected CurrentSessions to be 1")
 
+        session = current_sessions[0]
+
+        # ID is uint16 type and contains a valid value (0–65534)
+        asserts.assert_true(isinstance(session.id, int), "Session ID should be an integer (uint16)")
+        asserts.assert_true(0 <= session.id <= 65534, "Session ID should be in valid uint16 range (0–65534)")
+
+        # PeerNodeID is node-id type and contains a valid non-zero node-id value
+        asserts.assert_true(isinstance(session.peerNodeID, int), "PeerNodeID should be an integer (node-id)")
+        asserts.assert_greater(session.peerNodeID, 0, "PeerNodeID should be a valid non-zero node-id")
+
+        # PeerEndpointID is endpoint-no type and contains a valid endpoint value (0–65534)
+        asserts.assert_true(isinstance(session.peerEndpointID, int), "PeerEndpointID should be an integer (endpoint-no)")
+        asserts.assert_true(0 <= session.peerEndpointID <= 65534, "PeerEndpointID should be in valid endpoint range (0–65534)")
+
+        # StreamUsage is StreamUsageEnum type and contains a valid StreamUsageEnum value
+        asserts.assert_true(isinstance(session.streamUsage, Clusters.Globals.Enums.StreamUsageEnum),
+                            "StreamUsage should be a StreamUsageEnum type")
+        asserts.assert_not_equal(session.streamUsage, Clusters.Globals.Enums.StreamUsageEnum.kUnknownEnumValue,
+                                 "StreamUsage should be a valid known StreamUsageEnum value")
+
 
 if __name__ == "__main__":
     default_matter_test_main()


### PR DESCRIPTION
#### Summary

Add missing validation of the following fields of of currentSession

  - id: uint16 range, upper bound 65534 matches kMaxSessionId in the cluster server
  - peerNodeID: node-id is a non-zero 64-bit value per the Matter spec; > 0 covers the basic validity check
  - peerEndpointID: endpoint-no is 0–65534 (0xFFFF is kInvalidEndpointId)
  - streamUsage: kUnknownEnumValue is the sentinel in the generated Python enum for out-of-range values, so checking != kUnknownEnumValue confirms the DUT returned a known valid value


#### Related issues

N/A

#### Testing

Validate by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
