### PR TITLE
Revert "Fix: Null mContext crash when commissioning after background/…

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingApp.mm
@@ -46,9 +46,6 @@
 // Client defiend data source used to initialize the MCCommissionableDataProvider and, if needed, update the MCCommissionableDataProvider post initialization. This is necessary for the Commissioner-Generated passcode commissioning feature.
 @property (nonatomic, strong) id<MCDataSource> dataSource;
 
-// Track whether this is the first start (cold boot) or subsequent start (warm boot)
-@property (atomic) BOOL hasStartedBefore;
-
 @end
 
 @implementation MCCastingApp
@@ -132,61 +129,32 @@
 
 - (void)startWithCompletionBlock:(void (^)(NSError *))completion
 {
-    ChipLogProgress(AppServer, "MCCastingApp.startWithCompletionBlock called (%s start)", self.hasStartedBefore ? "warm" : "cold");
-    self.hasStartedBefore = YES;
-
+    ChipLogProgress(AppServer, "MCCastingApp.startWithCompletionBlock called");
     VerifyOrReturn(_workQueue != nil && _clientQueue != nil, dispatch_async(self->_clientQueue, ^{
-        ChipLogError(AppServer, "MCCastingApp.startWithCompletionBlock failed: work queue or client queue is nil");
         completion([MCErrorUtils NSErrorFromChipError:CHIP_ERROR_INCORRECT_STATE]);
     }));
 
-    // Start event loop task FIRST (synchronously) to ensure proper state
-    __block CHIP_ERROR err = chip::DeviceLayer::PlatformMgrImpl().StartEventLoopTask();
-    if (err != CHIP_NO_ERROR) {
-        ChipLogError(AppServer, "MCCastingApp.startWithCompletionBlock StartEventLoopTask failed: %s", err.AsString());
+    dispatch_async(_workQueue, ^{
+        __block CHIP_ERROR err = matter::casting::core::CastingApp::GetInstance()->Start();
         dispatch_async(self->_clientQueue, ^{
             completion([MCErrorUtils NSErrorFromChipError:err]);
         });
-        // Early return to prevent double completion call
-        return;
-    }
-
-    // Only then start the casting app (on work queue)
-    dispatch_async(_workQueue, ^{
-        CHIP_ERROR startErr = matter::casting::core::CastingApp::GetInstance()->Start();
-        if (startErr != CHIP_NO_ERROR) {
-            ChipLogError(AppServer, "MCCastingApp.startWithCompletionBlock CastingApp::Start failed: %s", startErr.AsString());
-        }
-
-        dispatch_async(self->_clientQueue, ^{
-            completion([MCErrorUtils NSErrorFromChipError:startErr]);
-        });
     });
+    __block CHIP_ERROR err = chip::DeviceLayer::PlatformMgrImpl().StartEventLoopTask();
+    VerifyOrReturn(err == CHIP_NO_ERROR, dispatch_async(self->_clientQueue, ^{
+        completion([MCErrorUtils NSErrorFromChipError:err]);
+    }));
 }
 
 - (void)stopWithCompletionBlock:(void (^)(NSError *))completion
 {
     ChipLogProgress(AppServer, "MCCastingApp.stopWithCompletionBlock called");
     VerifyOrReturn(_workQueue != nil && _clientQueue != nil, dispatch_async(self->_clientQueue, ^{
-        ChipLogError(AppServer, "MCCastingApp.stopWithCompletionBlock failed: work queue or client queue is nil");
         completion([MCErrorUtils NSErrorFromChipError:CHIP_ERROR_INCORRECT_STATE]);
     }));
 
     dispatch_async(_workQueue, ^{
-        // Stop the casting app first
-        CHIP_ERROR err = matter::casting::core::CastingApp::GetInstance()->Stop();
-        if (err != CHIP_NO_ERROR) {
-            ChipLogError(AppServer, "MCCastingApp.stopWithCompletionBlock CastingApp::Stop failed: %s", err.AsString());
-        }
-
-        // Then stop the event loop task to transition WorkQueue to suspended state
-        CHIP_ERROR stopEventLoopErr = chip::DeviceLayer::PlatformMgrImpl().StopEventLoopTask();
-        if (stopEventLoopErr != CHIP_NO_ERROR) {
-            ChipLogError(AppServer, "MCCastingApp.stopWithCompletionBlock StopEventLoopTask failed: %s", stopEventLoopErr.AsString());
-            if (err == CHIP_NO_ERROR) {
-                err = stopEventLoopErr;
-            }
-        }
+        __block CHIP_ERROR err = matter::casting::core::CastingApp::GetInstance()->Stop();
 
         dispatch_async(self->_clientQueue, ^{
             completion([MCErrorUtils NSErrorFromChipError:err]);

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -24,13 +24,11 @@
 #include "support/ChipDeviceEventHandler.h"
 
 #include <DeviceInfoProviderImpl.h>
-#include <app/EventManagement.h>
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/bindings/BindingManager.h>
 #include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
-#include <data-model-providers/codegen/CodegenDataModelProvider.h>
 
 namespace {
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
@@ -125,13 +123,7 @@ CHIP_ERROR CastingApp::Start()
     // Start Matter server
     chip::ServerInitParams * serverInitParams = mAppParameters->GetServerInitParamsProvider()->Get();
     VerifyOrReturnError(serverInitParams != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-
-    CHIP_ERROR initError = chip::Server::GetInstance().Init(*serverInitParams);
-    if (initError != CHIP_NO_ERROR)
-    {
-        ChipLogError(Discovery, "CastingApp::Start() Server::Init failed: %s", initError.AsString());
-        return initError;
-    }
+    ReturnErrorOnFailure(chip::Server::GetInstance().Init(*serverInitParams));
 
     // Perform post server startup registrations
     ReturnErrorOnFailure(PostStartRegistrations());
@@ -150,7 +142,6 @@ CHIP_ERROR CastingApp::Start()
         CastingPlayer::GetTargetCastingPlayer()->VerifyOrEstablishConnection(connectionCallbacks);
     }
 
-    ChipLogProgress(Discovery, "CastingApp::Start() completed");
     return CHIP_NO_ERROR;
 }
 
@@ -197,21 +188,10 @@ CHIP_ERROR CastingApp::Stop()
     chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(nullptr);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
-    // Shutdown the Matter server to clean up active sessions
+    // Shutdown the Matter server
     chip::Server::GetInstance().Shutdown();
 
-    // Shutdown the CodegenDataModelProvider to reset mContext
-    CHIP_ERROR providerShutdownErr = chip::app::CodegenDataModelProvider::Instance().Shutdown();
-    if (providerShutdownErr != CHIP_NO_ERROR)
-    {
-        ChipLogError(Discovery, "CastingApp::Stop() CodegenDataModelProvider::Shutdown failed: %s", providerShutdownErr.AsString());
-    }
-
-    // Destroy EventManagement to reset its state
-    chip::app::EventManagement::DestroyEventManagement();
-
     mState = CASTING_APP_NOT_RUNNING; // CastingApp stopped successfully, set state to NOT_RUNNING
-    ChipLogProgress(Discovery, "CastingApp::Stop() completed");
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -240,19 +240,6 @@ void InteractionModelEngine::Shutdown()
 
     mReadHandlers.ReleaseAll();
 
-    // Shut down the data model provider to clear cluster mContext pointers.
-    // Required for proper Stop() → Start() lifecycle - ensures clusters are reinitialized.
-    if (mDataModelProvider != nullptr)
-    {
-        CHIP_ERROR err = mDataModelProvider->Shutdown();
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(InteractionModel,
-                         "InteractionModelEngine::Shutdown() Data model provider shutdown failed: %" CHIP_ERROR_FORMAT,
-                         err.Format());
-        }
-    }
-
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
     // Shut down any subscription clients that are still around.  They won't be
     // able to work after this point anyway, since we're about to drop our refs
@@ -1929,20 +1916,14 @@ DataModel::Provider * InteractionModelEngine::SetDataModelProvider(DataModel::Pr
     // Altering data model should not be done while IM is actively handling requests.
     VerifyOrDie(mReadHandlers.begin() == mReadHandlers.end());
 
-    // REMOVED: Early return when (model == mDataModelProvider) - breaks Stop() → Start()
-    // After Shutdown(), server clusters are uninitialized even though pointer is unchanged.
-    // Must call Startup() again to reinitialize cluster mContext pointers.
-
     if (model == mDataModelProvider)
     {
-        ChipLogDetail(DataManagement,
-                      "InteractionModelEngine::SetDataModelProvider() re-initializing same provider (Stop/Start cycle)");
+        // no-op, just return
+        return model;
     }
 
     DataModel::Provider * oldModel = mDataModelProvider;
-
-    // Only shutdown if changing to a different provider
-    if (oldModel != nullptr && oldModel != model)
+    if (oldModel != nullptr)
     {
         CHIP_ERROR err = oldModel->Shutdown();
         if (err != CHIP_NO_ERROR)

--- a/src/app/clusters/general-commissioning-server/GeneralCommissioningCluster.cpp
+++ b/src/app/clusters/general-commissioning-server/GeneralCommissioningCluster.cpp
@@ -526,23 +526,6 @@ GeneralCommissioningCluster::HandleCommissioningComplete(const DataModel::Invoke
     }
 #endif // CHIP_CONFIG_TERMS_AND_CONDITIONS_REQUIRED
 
-    // Check if mContext is valid before accessing it (can be null during app shutdown/restart)
-    if (mContext == nullptr)
-    {
-        ChipLogError(FailSafe, "GeneralCommissioning: mContext is NULL, cluster not initialized");
-        response.errorCode = CommissioningErrorEnum::kInvalidAuthentication;
-        handler->AddResponse(request.path, response);
-        return std::nullopt;
-    }
-
-    if (!mContext->interactionContext.actionContext.CurrentExchange())
-    {
-        ChipLogError(FailSafe, "GeneralCommissioning: Invalid exchange during commissioning complete");
-        response.errorCode = CommissioningErrorEnum::kInvalidAuthentication;
-        handler->AddResponse(request.path, response);
-        return std::nullopt;
-    }
-
     SessionHandle handle = mContext->interactionContext.actionContext.CurrentExchange()->GetSessionHandle();
 
     // Ensure it's a valid CASE session

--- a/src/app/server-cluster/DefaultServerCluster.cpp
+++ b/src/app/server-cluster/DefaultServerCluster.cpp
@@ -81,19 +81,7 @@ CHIP_ERROR DefaultServerCluster::Attributes(const ConcreteClusterPath & path, Re
 
 CHIP_ERROR DefaultServerCluster::Startup(ServerClusterContext & context)
 {
-    // Reset shutdown state to allow restart after shutdown
-    mIsShutdown = false;
-
-    // Make Startup() idempotent for Stop() → Start() lifecycle.
-    // Shutdown() does not fully clean up cluster objects - cluster objects persist across Stop() → Start().
-    // Only their state (mContext) is cleared.
-    // If already initialized, update context and return success (preserves mDataVersion).
-    if (mContext != nullptr)
-    {
-        ChipLogDetail(DataManagement, "DefaultServerCluster::Startup() already initialized, updating context (idempotent)");
-        mContext = &context;
-        return CHIP_NO_ERROR;
-    }
+    VerifyOrReturnError(mContext == nullptr, CHIP_ERROR_ALREADY_INITIALIZED);
 
     mContext = &context;
 
@@ -106,14 +94,7 @@ CHIP_ERROR DefaultServerCluster::Startup(ServerClusterContext & context)
 
 void DefaultServerCluster::Shutdown(ClusterShutdownType)
 {
-    // Make shutdown idempotent - safe to call multiple times
-    if (mIsShutdown)
-    {
-        return;
-    }
-
-    mContext    = nullptr;
-    mIsShutdown = true;
+    mContext = nullptr;
 }
 
 void DefaultServerCluster::NotifyAttributeChanged(AttributeId attributeId)

--- a/src/app/server-cluster/DefaultServerCluster.h
+++ b/src/app/server-cluster/DefaultServerCluster.h
@@ -106,8 +106,6 @@ public:
 protected:
     const ConcreteClusterPath mPath;
     ServerClusterContext * mContext = nullptr;
-    // Tracks if shutdown has been called to make it idempotent
-    bool mIsShutdown = false;
 
     bool IsStarted() const { return mContext != nullptr; }
 

--- a/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
+++ b/src/app/server-cluster/ServerClusterInterfaceRegistry.cpp
@@ -43,58 +43,21 @@ ServerClusterInterfaceRegistry::~ServerClusterInterfaceRegistry()
 
 CHIP_ERROR ServerClusterInterfaceRegistry::Register(ServerClusterRegistration & entry)
 {
+    // we have no strong way to check if entry is already registered somewhere else, so we use "next" as some
+    // form of double-check
+    VerifyOrReturnError(entry.next == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(entry.serverClusterInterface != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     Span<const ConcreteClusterPath> paths = entry.serverClusterInterface->GetPaths();
     VerifyOrReturnError(!paths.empty(), CHIP_ERROR_INVALID_ARGUMENT);
 
-    // Check early if this cluster is already registered (idempotent case)
-    // This prevents unnecessary validation work and ensures we don't modify the linked list structure
-    bool isAlreadyRegistered = false;
-    for (const ConcreteClusterPath & path : paths)
-    {
-        ServerClusterInterface * existing = Get(path);
-        if (existing == entry.serverClusterInterface)
-        {
-            isAlreadyRegistered = true;
-            break;
-        }
-    }
-
-    // Validate entry.next is nullptr (unless already registered)
-    // A non-null entry.next when not registered indicates the entry is
-    // already part of another list or improperly initialized
-    if (entry.next != nullptr && !isAlreadyRegistered)
-    {
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
-
-    // If already registered (idempotent case), return early
-    if (isAlreadyRegistered)
-    {
-#if CHIP_DETAIL_LOGGING
-        const ConcreteClusterPath path = entry.serverClusterInterface->GetPaths().front();
-        ChipLogDetail(DataManagement, "Cluster already registered for %u/" ChipLogFormatMEI ", skipping re-registration",
-                      path.mEndpointId, ChipLogValueMEI(path.mClusterId));
-#endif
-        return CHIP_NO_ERROR;
-    }
-
-    // Validate paths and check for duplicate registrations
-    // Note: Same cluster re-registering is OK (handled above), but a DIFFERENT
-    // cluster with the same endpoint/cluster ID is an error
-    // Duplicate checking makes this O(n^2) on total registered items. We preserve this to ensure
-    // cluster integrity during Stop/Start cycles, but this may be optimized in the future if needed.
     for (const ConcreteClusterPath & path : paths)
     {
         VerifyOrReturnError(path.HasValidIds(), CHIP_ERROR_INVALID_ARGUMENT);
 
-        // A different cluster is already registered for this path
-        ServerClusterInterface * existing = Get(path);
-        if (existing != nullptr)
-        {
-            return CHIP_ERROR_DUPLICATE_KEY_ID;
-        }
+        // Double-checking for duplicates makes the checks O(n^2) on the total number of registered
+        // items. We preserve this however we may want to make this optional at some point in time.
+        VerifyOrReturnError(Get(path) == nullptr, CHIP_ERROR_DUPLICATE_KEY_ID);
     }
 
     if (mContext.has_value())

--- a/src/app/server-cluster/ServerClusterInterfaceRegistry.h
+++ b/src/app/server-cluster/ServerClusterInterfaceRegistry.h
@@ -20,7 +20,6 @@
 #include <app/server-cluster/ServerClusterInterface.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
-#include <lib/support/logging/CHIPLogging.h>
 
 #include <cstdint>
 #include <new>
@@ -98,14 +97,7 @@ public:
     template <typename... Args>
     void Create(Args &&... args)
     {
-        // Handle idempotent Create() - if already constructed, this is a no-op.
-        // The cluster remains registered and functional. This supports the Stop() → Start() lifecycle
-        // where clusters are shutdown but remain constructed.
-        if (IsConstructed())
-        {
-            ChipLogDetail(DataManagement, "LazyRegisteredServerCluster::Create: Cluster already constructed, skipping re-creation");
-            return;
-        }
+        VerifyOrDie(!IsConstructed());
 
         new (mCluster) SERVER_CLUSTER(std::forward<Args>(args)...);
         new (mRegistration) ServerClusterRegistration(Cluster());

--- a/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
+++ b/src/app/server-cluster/tests/TestServerClusterInterfaceRegistry.cpp
@@ -335,9 +335,7 @@ TEST_F(TestServerClusterInterfaceRegistry, RegisterErrors)
 
     // Can't register a duplicate cluster
     EXPECT_EQ(registry.Register(registration1), CHIP_NO_ERROR);
-    // Idempotent: re-registering the same cluster object returns success
-    EXPECT_EQ(registry.Register(registration1), CHIP_NO_ERROR);
-    // Different cluster with same endpoint/cluster ID is still an error
+    EXPECT_EQ(registry.Register(registration1), CHIP_ERROR_DUPLICATE_KEY_ID);
     EXPECT_EQ(registry.Register(anotherRegistration1), CHIP_ERROR_DUPLICATE_KEY_ID);
 }
 
@@ -406,47 +404,4 @@ TEST_F(TestServerClusterInterfaceRegistry, StartupShutdownWithoutContext)
     EXPECT_EQ(cluster1.Cluster().GetShutdownCallCount(), 1u);
     EXPECT_EQ(cluster2.Cluster().GetShutdownCallCount(), 1u);
     EXPECT_EQ(cluster3.Cluster().GetShutdownCallCount(), 1u);
-}
-
-TEST_F(TestServerClusterInterfaceRegistry, WarmStartAfterShutdown)
-{
-    // This test validates app lifecycle management where apps need to:
-    // 1. Shutdown clusters when suspending/backgrounding (ClearContext)
-    // 2. Re-register and startup clusters when resuming/foregrounding
-    // The fix made Register() idempotent so re-registration succeeds without errors.
-    // This applies to any platform with app lifecycle (iOS, Android, tvOS, desktop, etc.)
-
-    RegisteredServerCluster<FakeServerClusterInterface> cluster1(kEp1, kCluster1);
-    RegisteredServerCluster<FakeServerClusterInterface> cluster2(kEp1, kCluster2);
-
-    ServerClusterInterfaceRegistry registry;
-    TestServerClusterContext context;
-
-    // COLD START: Initial registration and startup
-    EXPECT_EQ(registry.Register(cluster1.Registration()), CHIP_NO_ERROR);
-    EXPECT_EQ(registry.Register(cluster2.Registration()), CHIP_NO_ERROR);
-    EXPECT_EQ(registry.SetContext(ServerClusterContext{ context.Get() }), CHIP_NO_ERROR);
-
-    EXPECT_TRUE(cluster1.Cluster().HasContext());
-    EXPECT_TRUE(cluster2.Cluster().HasContext());
-
-    // BACKGROUND: Simulate app backgrounding - clear context (triggers Shutdown)
-    registry.ClearContext();
-    EXPECT_FALSE(cluster1.Cluster().HasContext());
-    EXPECT_FALSE(cluster2.Cluster().HasContext());
-
-    // WARM START: Re-register same clusters (should be idempotent - no errors)
-    EXPECT_EQ(registry.Register(cluster1.Registration()), CHIP_NO_ERROR);
-    EXPECT_EQ(registry.Register(cluster2.Registration()), CHIP_NO_ERROR);
-
-    // Set context again (triggers Startup)
-    EXPECT_EQ(registry.SetContext(ServerClusterContext{ context.Get() }), CHIP_NO_ERROR);
-
-    // Verify clusters are operational again
-    EXPECT_TRUE(cluster1.Cluster().HasContext());
-    EXPECT_TRUE(cluster2.Cluster().HasContext());
-
-    // Verify clusters are still accessible
-    EXPECT_EQ(registry.Get({ kEp1, kCluster1 }), &cluster1.Cluster());
-    EXPECT_EQ(registry.Get({ kEp1, kCluster2 }), &cluster2.Cluster());
 }

--- a/src/data-model-providers/codedriven/CodeDrivenDataModelProvider.cpp
+++ b/src/data-model-providers/codedriven/CodeDrivenDataModelProvider.cpp
@@ -58,11 +58,6 @@ CHIP_ERROR CodeDrivenDataModelProvider::Startup(DataModel::InteractionModelConte
 
         if (endpointRegistered)
         {
-            // IMPORTANT: Clusters persist across Stop() → Start() cycles. When Stop() is called,
-            // Shutdown() clears cluster state (mContext) but doesn't destroy the cluster objects.
-            // When Start() is called again, we reach here with clusters that may already be initialized.
-            // DefaultServerCluster::Startup() is now idempotent - it detects if already initialized
-            // and just updates the context pointer without re-randomizing mDataVersion.
             if (cluster->Startup(*mServerClusterContext) != CHIP_NO_ERROR)
             {
                 had_failure = true;
@@ -82,24 +77,20 @@ CHIP_ERROR CodeDrivenDataModelProvider::Shutdown()
 {
     bool had_failure = false;
 
-    // Call Shutdown() on all clusters to clear their state (sets mContext = nullptr).
-    // IMPORTANT: Do NOT unregister clusters from the registry. Cluster objects persist
-    // across Stop() → Start() cycles along with their LazyRegisteredServerCluster wrappers.
-    // Only their runtime state is cleared here. This allows Start() to re-initialize
-    // the same cluster objects without destroying/recreating them (preserves mDataVersion).
-    ChipLogDetail(DataManagement, "CodeDrivenDataModelProvider::Shutdown() clearing cluster state (clusters remain registered)");
-
-    for (auto * cluster : mServerClusterRegistry.AllServerClusterInstances())
-    {
-        cluster->Shutdown(ClusterShutdownType::kClusterShutdown);
-    }
-
-    // Remove all endpoints from mEndpointInterfaceRegistry - but don't remove clusters from mServerClusterRegistry
+    // Remove all endpoints. This will trigger Shutdown() on associated clusters.
     while (mEndpointInterfaceRegistry.begin() != mEndpointInterfaceRegistry.end())
     {
-        EndpointId endpointToRemove = mEndpointInterfaceRegistry.begin()->GetEndpointEntry().id;
-        // Unregister the endpoint but don't shutdown clusters (already done above)
-        if (mEndpointInterfaceRegistry.Unregister(endpointToRemove) != CHIP_NO_ERROR)
+        if (RemoveEndpoint(mEndpointInterfaceRegistry.begin()->GetEndpointEntry().id) != CHIP_NO_ERROR)
+        {
+            had_failure = true;
+        }
+    }
+
+    // Now we're safe to clean up the cluster registry.
+    while (mServerClusterRegistry.AllServerClusterInstances().begin() != mServerClusterRegistry.AllServerClusterInstances().end())
+    {
+        ServerClusterInterface * clusterToRemove = *mServerClusterRegistry.AllServerClusterInstances().begin();
+        if (mServerClusterRegistry.Unregister(clusterToRemove) != CHIP_NO_ERROR)
         {
             had_failure = true;
         }

--- a/src/data-model-providers/codedriven/tests/TestCodeDrivenDataModelProvider.cpp
+++ b/src/data-model-providers/codedriven/tests/TestCodeDrivenDataModelProvider.cpp
@@ -192,11 +192,7 @@ public:
 
     void Shutdown(ClusterShutdownType shutdownType) override
     {
-        // Respect idempotent shutdown - only count first shutdown
-        if (!mIsShutdown)
-        {
-            shutdownCallCount++;
-        }
+        shutdownCallCount++;
         DefaultServerCluster::Shutdown(shutdownType);
     }
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/tasks.py
@@ -201,17 +201,7 @@ class Subprocess(threading.Thread):
 
     def terminate(self):
         """Terminate the subprocess and wait for it to finish."""
-        import time
-
         self.p.terminate()
-
-        # WORKAROUND: Give kernel time to complete socket cleanup after SIGTERM.
-        # Rapid test succession can cause "Address already in use" errors when processes
-        # exit so quickly that the kernel hasn't finished releasing TCP ports (especially
-        # with optimized shutdown paths like idempotent cleanup patterns).
-        # This ensures the port is fully released before the next test starts.
-        time.sleep(2)
-
         self.join()
 
     def wait(self, timeout: Optional[float] = None) -> Optional[int]:


### PR DESCRIPTION
…foreground (#43127)"

This reverts commit ead81748828787a656ae05c7d980f908f09ea751.

#### Summary

When I originally reviewed #43127 I thought it was a change in TV-casting only, so I added a consensus review for media owners. However this seems to have changed internals of code driven logic which was unexpected. It also added an extra delay in tests for 2 seconds for every test, resulting in a noticeable blip in test timings.

<img width="2052" height="1166" alt="image" src="https://github.com/user-attachments/assets/de525582-68f5-429c-9de8-ff90a494ab03" />

I added some comments on the PR, however for now I propose a revert since the delta seems rather large and needs an actual review.

#### Testing

Revert only