### PR TITLE
Adjust the minFrameRate configuration to be 15 fps for stream allocation in the test scripts and camera-app.

### DIFF
--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -54,7 +54,8 @@ static constexpr uint16_t kMaxResolutionHeight       = 1080; // 1080p resolution
 static constexpr uint16_t kSnapshotStreamFrameRate   = 30;
 static constexpr uint16_t kMaxVideoFrameRate         = 120;
 static constexpr uint16_t k60fpsVideoFrameRate       = 60;
-static constexpr uint16_t kMinVideoFrameRate         = 30;
+static constexpr uint16_t k30fpsVideoFrameRate       = 30;
+static constexpr uint16_t kMinVideoFrameRate         = 15;
 static constexpr uint32_t kMinBitRateBps             = 10000;   // 10 kbps
 static constexpr uint32_t kMaxBitRateBps             = 2000000; // 2 mbps
 static constexpr uint32_t kKeyFrameIntervalMsec      = 4000;    // 4 sec; recommendation from Spec
@@ -365,7 +366,7 @@ private:
     uint8_t mZoom = chip::app::Clusters::CameraAvSettingsUserLevelManagement::kDefaultZoom;
     // Use a standard 1080p aspect ratio
     chip::app::Clusters::Globals::Structs::ViewportStruct::Type mViewport = { 0, 0, 1920, 1080 };
-    uint16_t mCurrentVideoFrameRate                                       = kMinVideoFrameRate;
+    uint16_t mCurrentVideoFrameRate                                       = k30fpsVideoFrameRate;
     bool mHDREnabled                                                      = false;
     bool mSpeakerMuted                                                    = false;
     bool mMicrophoneMuted                                                 = false;

--- a/src/python_testing/TC_AVSMTestBase.py
+++ b/src/python_testing/TC_AVSMTestBase.py
@@ -210,7 +210,7 @@ class AVSMTestBase:
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=streamUsage,
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(

--- a/src/python_testing/TC_AVSM_2_13.py
+++ b/src/python_testing/TC_AVSM_2_13.py
@@ -188,7 +188,7 @@ class TC_AVSM_2_13(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportResolution,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -222,7 +222,7 @@ class TC_AVSM_2_13(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportResolution,
                 maxResolution=cluster.Structs.VideoResolutionStruct(

--- a/src/python_testing/TC_AVSM_2_18.py
+++ b/src/python_testing/TC_AVSM_2_18.py
@@ -137,7 +137,7 @@ class TC_AVSM_2_18(MatterBaseTest, AVSMTestBase):
         min_resolution = min_viewport_resolution
         min_bit_rate = trade_off_point.minBitRate
         max_bit_rate = trade_off_point.minBitRate
-        min_frame_rate = 30
+        min_frame_rate = min(15, video_sensor_params.maxFPS)
         max_frame_rate = video_sensor_params.maxFPS
         key_frame_interval = 4000
 

--- a/src/python_testing/TC_AVSM_2_7.py
+++ b/src/python_testing/TC_AVSM_2_7.py
@@ -259,7 +259,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -293,7 +293,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -370,7 +370,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=outOfConstraintStreamUsage,
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -403,7 +403,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=notSupportedStreamUsage,
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -486,7 +486,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -513,7 +513,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -540,7 +540,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -567,7 +567,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=10,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -594,7 +594,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS + 10,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -636,8 +636,8 @@ class TC_AVSM_2_7(MatterBaseTest):
         )
         if len(aAllocatedVideoStreams) > 0:
             asserts.fail("Allocated video streams not cleared")
-        minFrameRateConfig = 30
-        maxFrameRateConfig = 40
+        minFrameRateConfig = min(15, aVideoSensorParams.maxFPS)
+        maxFrameRateConfig = aVideoSensorParams.maxFPS
         # Try and allocate up to maxConcurrentEncoders. If all these streams are
         # successfully allocated, the next one should hit a resource exhausted
         # error.

--- a/src/python_testing/TC_AVSM_2_7.py
+++ b/src/python_testing/TC_AVSM_2_7.py
@@ -636,8 +636,10 @@ class TC_AVSM_2_7(MatterBaseTest):
         )
         if len(aAllocatedVideoStreams) > 0:
             asserts.fail("Allocated video streams not cleared")
-        minFrameRateConfig = min(15, aVideoSensorParams.maxFPS)
-        maxFrameRateConfig = aVideoSensorParams.maxFPS
+
+        # start initial frame rate range low and gradually increase
+        minFrameRateConfig = 15
+        maxFrameRateConfig = 30
         # Try and allocate up to maxConcurrentEncoders. If all these streams are
         # successfully allocated, the next one should hit a resource exhausted
         # error.

--- a/src/python_testing/TC_AVSM_VideoStreamsPersistence.py
+++ b/src/python_testing/TC_AVSM_VideoStreamsPersistence.py
@@ -197,7 +197,7 @@ class TC_AVSM_VideoStreamsPersistence(MatterBaseTest):
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -289,7 +289,10 @@ class TC_AVSM_VideoStreamsPersistence(MatterBaseTest):
         asserts.assert_equal(aAllocatedVideoStreams[0].streamUsage, aStreamUsagePriorities[0], "Stream Usage does not match")
         asserts.assert_equal(aAllocatedVideoStreams[0].videoCodec,
                              aRateDistortionTradeOffPoints[0].codec, "Video codec does not match")
-        asserts.assert_equal(aAllocatedVideoStreams[0].minFrameRate, 30, "MinFrameRate does not match")
+        asserts.assert_equal(aAllocatedVideoStreams[0].minFrameRate,
+                             min(15, aVideoSensorParams.maxFPS),
+                             "MinFrameRate does not match")
+
         asserts.assert_equal(aAllocatedVideoStreams[0].maxFrameRate, aVideoSensorParams.maxFPS, "MaxFrameRate does not match")
         asserts.assert_equal(aAllocatedVideoStreams[0].minResolution, aMinViewportRes, "MinResolution does not match")
         asserts.assert_equal(aAllocatedVideoStreams[0].maxResolution.width,

--- a/src/python_testing/TC_AVSUMTestBase.py
+++ b/src/python_testing/TC_AVSUMTestBase.py
@@ -265,7 +265,7 @@ class AVSUMTestBase:
             response = await self.send_single_cmd(cmd=Clusters.CameraAvStreamManagement.Commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=Clusters.CameraAvStreamManagement.Structs.VideoResolutionStruct(width=aVideoSensorParams.sensorWidth,

--- a/src/python_testing/TC_PAVSTTestBase.py
+++ b/src/python_testing/TC_PAVSTTestBase.py
@@ -137,7 +137,7 @@ class PAVSTTestBase:
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewport,
                 maxResolution=cluster.Structs.VideoResolutionStruct(

--- a/src/python_testing/TC_WEBRTCPTestBase.py
+++ b/src/python_testing/TC_WEBRTCPTestBase.py
@@ -138,7 +138,7 @@ class WEBRTCPTestBase:
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=Globals.Enums.StreamUsageEnum.kLiveView,
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=min(15, aVideoSensorParams.maxFPS),
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewportRes,
                 maxResolution=cluster.Structs.VideoResolutionStruct(

--- a/src/python_testing/TC_WEBRTC_1_5.py
+++ b/src/python_testing/TC_WEBRTC_1_5.py
@@ -185,7 +185,7 @@ class TC_WEBRTC_1_5(MatterBaseTest):
                 cmd=CameraAvStreamManagement.Commands.VideoStreamAllocate(
                     streamUsage=aStreamUsagePriorities[0],
                     videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                    minFrameRate=30,
+                    minFrameRate=min(15, aVideoSensorParams.maxFPS),
                     maxFrameRate=aVideoSensorParams.maxFPS,
                     minResolution=aMinViewportRes,
                     maxResolution=CameraAvStreamManagement.Structs.VideoResolutionStruct(

--- a/src/python_testing/TC_WEBRTC_Utils.py
+++ b/src/python_testing/TC_WEBRTC_Utils.py
@@ -91,7 +91,7 @@ class WebRTCTestHelper:
                 cmd=CameraAvStreamManagement.Commands.VideoStreamAllocate(
                     streamUsage=aStreamUsagePriorities[0],
                     videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                    minFrameRate=30,
+                    minFrameRate=min(15, aVideoSensorParams.maxFPS),
                     maxFrameRate=aVideoSensorParams.maxFPS,
                     minResolution=aMinViewportRes,
                     maxResolution=CameraAvStreamManagement.Structs.VideoResolutionStruct(


### PR DESCRIPTION
#### Summary
Previously, it was set to 30 which can be high for some cameras. A value of 15fps is considered the baseline for video streaming min fps.

#### Testing
Executed all AVSM tests

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
