### PR TITLE
[nxp][cmake] Fix debug mode build errors

### DIFF
--- a/config/nxp/chip-cmake-freertos/CMakeLists.txt
+++ b/config/nxp/chip-cmake-freertos/CMakeLists.txt
@@ -98,6 +98,12 @@ elseif(CONFIG_CHIP_NVM_COMPONENT_NVMFWK)
     matter_add_gn_arg_string("nxp_nvm_component" "nvm_fwk")
 endif()
 
+# In debug mode build, warnings may appear which could break the build when
+# using a strict option like "treat all warnings as errors"
+if(CONFIG_DEBUG)
+    matter_add_gn_arg_bool("treat_warnings_as_errors" false)
+endif()
+
 if(CONFIG_CHIP_OTA_ENCRYPTION)
     matter_add_gn_arg_bool("chip_with_ota_encryption" CONFIG_CHIP_OTA_ENCRYPTION)
     matter_add_gn_arg_string("chip_with_ota_key" ${CONFIG_CHIP_OTA_ENCRYPTION_KEY})


### PR DESCRIPTION

#### Summary

Previous reshuffling of the makefiles has changed the build options for debug mode and has indirectly enabled the
"_treat_warnings_as_errors_" option. As the debug mode build still contains quite a number of build warnings, this option should stay disabled for the time being, at least until all the debug mode build warnings are fixed, in order not to block access to debug mode applications.

#### Testing

Now the Matter applications on the MCXW72 platform are successfully building in _debug mode_.