### PR TITLE
[Docs] Don't recommend the logic separation

### DIFF
--- a/docs/cluster_and_device_type_dev/unit_testing_clusters.md
+++ b/docs/cluster_and_device_type_dev/unit_testing_clusters.md
@@ -151,7 +151,7 @@ high-level, strongly-typed wrappers for reading/writing attributes and invoking
 commands without manually handling TLV encoding or path construction.
 
 For detailed API usage and examples, please see the
-[ClusterTester Helper Class Guide](cluster_tester.md).
+[ClusterTester Helper Class Guide](https://project-chip.github.io/connectedhomeip-doc/cluster_and_device_type_dev/cluster_tester.html).
 
 ## Unit testing existing clusters
 

--- a/docs/cluster_and_device_type_dev/unit_testing_clusters.md
+++ b/docs/cluster_and_device_type_dev/unit_testing_clusters.md
@@ -151,7 +151,7 @@ high-level, strongly-typed wrappers for reading/writing attributes and invoking
 commands without manually handling TLV encoding or path construction.
 
 For detailed API usage and examples, please see the
-[ClusterTester Helper Class Guide](https://project-chip.github.io/connectedhomeip-doc/cluster_and_device_type_dev/cluster_tester.html).
+[ClusterTester Helper Class Guide](cluster_tester.md).
 
 ## Unit testing existing clusters
 

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -369,7 +369,8 @@ Unit tests should reside in `src/app/clusters/<cluster-name>/tests/`.
 Use the `chip::Testing::ClusterTester` utility to write your unit tests. This
 modern API removes the need to manually mock encoders, handlers, or raw TLV
 buffers. More on
-[ClusterTester Helper Class Guide](https://project-chip.github.io/connectedhomeip-doc/cluster_and_device_type_dev/cluster_tester.html).
+[ClusterTester Helper Class Guide](cluster_tester.md).
+
 
 -   **Test Setup:** Create a mock delegate to inject fake data into your cluster
     instance.

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -366,9 +366,11 @@ specification.
 
 Unit tests should reside in `src/app/clusters/<cluster-name>/tests/`.
 
--   Use the `chip::Testing::ClusterTester` utility to write your unit tests.
+Use the `chip::Testing::ClusterTester` utility to write your unit tests.
     This modern API removes the need to manually mock encoders, handlers, or raw
     TLV buffers.
+    More on [ClusterTester Helper Class Guide](https://project-chip.github.io/connectedhomeip-doc/cluster_and_device_type_dev/cluster_tester.html).
+
 -   **Test Setup:** Create a mock delegate to inject fake data into your cluster
     instance.
 -   **Menu Verification:** Ensure `Attributes()` and `AcceptedCommands()` return

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -368,9 +368,7 @@ Unit tests should reside in `src/app/clusters/<cluster-name>/tests/`.
 
 Use the `chip::Testing::ClusterTester` utility to write your unit tests. This
 modern API removes the need to manually mock encoders, handlers, or raw TLV
-buffers. More on
-[ClusterTester Helper Class Guide](cluster_tester.md).
-
+buffers. More on [ClusterTester Helper Class Guide](cluster_tester.md).
 
 -   **Test Setup:** Create a mock delegate to inject fake data into your cluster
     instance.

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -366,10 +366,10 @@ specification.
 
 Unit tests should reside in `src/app/clusters/<cluster-name>/tests/`.
 
-Use the `chip::Testing::ClusterTester` utility to write your unit tests.
-    This modern API removes the need to manually mock encoders, handlers, or raw
-    TLV buffers.
-    More on [ClusterTester Helper Class Guide](https://project-chip.github.io/connectedhomeip-doc/cluster_and_device_type_dev/cluster_tester.html).
+Use the `chip::Testing::ClusterTester` utility to write your unit tests. This
+modern API removes the need to manually mock encoders, handlers, or raw TLV
+buffers. More on
+[ClusterTester Helper Class Guide](https://project-chip.github.io/connectedhomeip-doc/cluster_and_device_type_dev/cluster_tester.html).
 
 -   **Test Setup:** Create a mock delegate to inject fake data into your cluster
     instance.

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -62,24 +62,36 @@ Names vary, however to be consistent with most of the existing code use:
 -   `cluster-name-server` for the cluster directory name
 -   `ClusterNameSnakeCluster.h/cpp` for the `ServerClusterInterface`
     implementation
--   `ClusterNameSnakeLogic.h/cpp` for the `Logic` implementation if applicable
 
-### Recommended Modular Layout
+### Recommended Implementation Pattern
 
-For better testability and maintainability, we recommend splitting the
-implementation into logical components. The
-[Software Diagnostics](https://github.com/project-chip/connectedhomeip/tree/master/src/app/clusters/software-diagnostics-server)
-cluster is a good example of this pattern.
+For optimal flash and RAM usage on resource-constrained devices, we strongly
+recommend a **combined implementation** pattern. You should avoid splitting the
+implementation into separate logic and translation layers, as this introduces
+unnecessary overhead.
 
--   **`ClusterLogic`:**
-    -   A type-safe class containing the core business logic of the cluster.
-    -   Manages all attribute storage.
-    -   Should be thoroughly unit-tested.
--   **`ClusterImplementation`:**
-    -   Implements the `ServerClusterInterface` (often by deriving from
-        `DefaultServerCluster`).
-    -   Acts as a translation layer between the data model (encoders/decoders)
-        and the `ClusterLogic`.
+-   **Combined Implementation (Recommended):**
+
+    -   The cluster's logic, data storage, and `ServerClusterInterface`
+        implementation are all contained within a single class (often by
+        deriving from `DefaultServerCluster`).
+    -   This minimizes boilerplate and virtual function translation layers,
+        resulting in a significantly smaller flash footprint.
+    -   **Example:** The
+        [Basic Information](https://github.com/project-chip/connectedhomeip/tree/master/src/app/clusters/basic-information)
+        cluster is a good example of a combined implementation.
+
+-   **Modular Implementation / `ClusterLogic` (Not Recommended):**
+
+    -   Historically, some clusters separated core business logic into a
+        type-safe `ClusterLogic` class, with a `ClusterImplementation` class
+        acting as a translation layer.
+    -   While this isolated the logic for testing, it adds noticeable flash and
+        RAM overhead and is **discouraged** for new clusters.
+    -   **Example:** The
+        [Administrator Commissioning](https://github.com/project-chip/connectedhomeip/tree/master/src/app/clusters/administrator-commissioning-server)
+        cluster demonstrates this legacy modular implementation.
+
 -   **`ClusterDriver` (or `Delegate`):**
     -   An optional interface providing callbacks to the application for cluster
         interactions. We recommend the term `Driver` to avoid confusion with the
@@ -128,43 +140,6 @@ writes or commands), use a delegate (or driver) interface that acts as a
 -   **Avoid Redundant Notifications:** Ensure that no-op operations (e.g.,
     writing the same value that is already present) are handled early and do not
     trigger delegate callbacks or change notifications.
-
-### Choosing the Right Implementation Pattern
-
-When implementing a cluster, you have two primary architectural choices: a
-**combined implementation** and a **modular implementation**. The best choice
-depends on the cluster's complexity and the constraints of the target device,
-particularly flash and RAM usage.
-
--   **Combined Implementation (Logic and Data in One Class):**
-
-    -   **Description:** In this pattern, the cluster's logic, data storage, and
-        `ServerClusterInterface` implementation are all contained within a
-        single class.
-    -   **Pros:** Simpler to write and can result in a smaller flash footprint,
-        making it ideal for simple clusters or resource-constrained devices.
-    -   **Cons:** Can be harder to test and maintain as the cluster's complexity
-        grows.
-    -   **Example:** The
-        [Basic Information](https://github.com/project-chip/connectedhomeip/tree/master/src/app/clusters/basic-information)
-        cluster is a good example of a combined implementation.
-
--   **Modular Implementation (Logic Separated from Data Model):**
-    -   **Description:** This pattern separates the core business logic into a
-        `ClusterLogic` class, while the `ClusterImplementation` class handles
-        the translation between the data model and the logic.
-    -   **Pros:** Promotes better testability, as the `ClusterLogic` can be
-        unit-tested in isolation. It is also more maintainable for complex
-        clusters.
-    -   **Cons:** May use slightly more flash and RAM due to the additional
-        class and virtual function calls.
-    -   **Example:** The
-        [Software Diagnostics](https://github.com/project-chip/connectedhomeip/tree/master/src/app/clusters/software-diagnostics-server)
-        cluster demonstrates a modular implementation.
-
-**Recommendation:** Start with a combined implementation for simpler clusters.
-If the cluster's logic is complex or if you need to maximize testability, choose
-the modular approach.
 
 ### BUILD file layout
 
@@ -389,11 +364,23 @@ specification.
 
 ### Unit Testing
 
--   Unit tests should reside in `src/app/clusters/<cluster-name>/tests/`.
--   At a minimum, `ClusterLogic` should be fully tested, including its behavior
-    with different feature configurations.
--   `ClusterImplementation` can also be unit-tested if its logic is complex.
-    Otherwise, integration tests should provide sufficient coverage.
+Unit tests should reside in `src/app/clusters/<cluster-name>/tests/`.
+
+-   Use the `chip::Testing::ClusterTester` utility to write your unit tests.
+    This modern API removes the need to manually mock encoders, handlers, or raw
+    TLV buffers.
+-   **Test Setup:** Create a mock delegate to inject fake data into your cluster
+    instance.
+-   **Menu Verification:** Ensure `Attributes()` and `AcceptedCommands()` return
+    the correct metadata, or `ClusterTester` will reject your reads/invocations.
+-   **Reads:** Test `ReadAttribute` via `tester.ReadAttribute()` and verify data
+    matches your mock.
+-   **Commands:** Test commands via `tester.Invoke()` and ensure specific
+    `Protocols::InteractionModel::Status` codes are returned accurately based on
+    delegate responses.
+-   **Reporting:** Verify reporting logic by reading `tester.GetDirtyList()` to
+    ensure state changes properly mark attributes as dirty, while No-Op writes
+    do not.
 
 ---
 
@@ -430,15 +417,14 @@ implementation.
 5. **Update `config-data.yaml`:** To enable these callbacks, add your cluster to
    the `CodeDrivenClusters` array in
    `src/app/common/templates/config-data.yaml`.
-6. **Update ZAP Configuration:** To prevent the Ember framework from allocating
-   memory for your cluster's attributes (which are now managed by your
-   `ClusterLogic`), you must:
-    - In `src/app/zap-templates/zcl/zcl.json` and
-      `zcl-with-test-extensions.json`, add all non-list attributes of your
-      cluster to `attributeAccessInterfaceAttributes`. This marks them as
-      externally handled.
-7. Once `config-data.yaml` and `zcl.json/zcl-with-test-extensions.json` are
-   updated, run the ZAP regeneration command, like
+6. **Update ZAP Configuration:** In `src/app/zap-templates/zcl/zcl.json` and
+   `zcl-with-test-extensions.json`, add your cluster to the lists, and configure
+   specific attributes to move from `RAM` to `Callback` if they shouldn't be
+   backed by Ember's storage. Remember to keep attributes that define default
+   values in `.matter` files in RAM.
+7. **Regenerate ZAP:** Once `config-data.yaml` and
+   `zcl.json/zcl-with-test-extensions.json` are updated, run the ZAP
+   regeneration command, like
 
     ```bash
     ./scripts/run_in_build_env.sh 'scripts/tools/zap_regen_all.py'

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -418,11 +418,12 @@ implementation.
 5. **Update `config-data.yaml`:** To enable these callbacks, add your cluster to
    the `CodeDrivenClusters` array in
    `src/app/common/templates/config-data.yaml`.
-6. **Update ZAP Configuration:** In `src/app/zap-templates/zcl/zcl.json` and
-   `zcl-with-test-extensions.json`, add your cluster to the lists, and configure
-   specific attributes to move from `RAM` to `Callback` if they shouldn't be
-   backed by Ember's storage. Remember to keep attributes that define default
-   values in `.matter` files in RAM.
+6. **Update ZAP Configuration:** To prevent the Ember framework from allocating
+   memory for your cluster's attributes, you must:
+    - In `src/app/zap-templates/zcl/zcl.json` and
+      `zcl-with-test-extensions.json`, add all non-list attributes of your
+      cluster to `attributeAccessInterfaceAttributes`. This marks them as
+      externally handled.
 7. **Regenerate ZAP:** Once `config-data.yaml` and
    `zcl.json/zcl-with-test-extensions.json` are updated, run the ZAP
    regeneration command, like


### PR DESCRIPTION
#### Summary
Don't recommend the logic separation for writing clusters as it sometimes results in flash overhead

#### Related issues

#### Testing
No tests needed
#### Readability checklist

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
