### PR TITLE
[Zephyr][config] Add Missing PSA Kconfig to Enable ECDSA for Matter Commissioning

### DIFF
--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -84,6 +84,7 @@ config CHIP_CRYPTO_PSA
 	imply PSA_WANT_ALG_ECDH
 	imply PSA_WANT_ALG_HKDF
 	imply PSA_WANT_ALG_HMAC
+	imply PSA_WANT_ALG_ECDSA
 
 config CHIP_FACTORY_RESET_ERASE_SETTINGS
 	bool "Erase NVS flash pages on factory reset"


### PR DESCRIPTION

#### Summary

This PR adds the missing PSA Kconfig option required to enable ECDSA support for Matter commissioning.
Although ECDSA is already implicitly enabled for the NXP RW612 board through another configuration path, it was not explicitly selected for Matter, which can lead to cases where ECDSA is not enabled when expected. This change ensures that ECDSA is correctly enabled and avoids build inconsistencies.

#### Testing

Tested by building NXP Zephyr Thermostat example for the RW612 board and doing a Matter-over-thread and Matter-over-Wifi commissioning
- Matter-WiFi build: "west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr/ -p always"
- Matter-Thread build:  "west build -d build_zephyr -b frdm_rw612 examples/thermostat/nxp/zephyr/ -DEXTRA_CONF_FILE=prj_thread_ftd.conf -p always"

