### PR TITLE
[Energy] EEM Cluster Refactor

### DIFF
--- a/examples/energy-management/device-energy-management/include/DEMConfig.h
+++ b/examples/energy-management/device-energy-management/include/DEMConfig.h
@@ -20,5 +20,16 @@
 #include <DeviceEnergyManagementDelegateImpl.h>
 #include <lib/core/DataModelTypes.h>
 
+namespace chip {
+namespace app {
+namespace Clusters {
+class ElectricalSensorManager;
+} // namespace Clusters
+} // namespace app
+} // namespace chip
+
 // The DEM Delegate is used for the TestEventTriggers
 chip::app::Clusters::DeviceEnergyManagement::DeviceEnergyManagementDelegate * GetDEMDelegate();
+
+// Global accessor for the ElectricalSensorManager (defined in each app's Main.cpp)
+chip::app::Clusters::ElectricalSensorManager * GetESManager();

--- a/examples/energy-management/device-energy-management/include/DEMManufacturerDelegate.h
+++ b/examples/energy-management/device-energy-management/include/DEMManufacturerDelegate.h
@@ -80,45 +80,6 @@ public:
     {
         return CHIP_NO_ERROR;
     }
-
-    /**
-     * @brief   Allows a client application to send in power readings into the system
-     *
-     * @param[in]  aEndpointId       - Endpoint to send to EPM Cluster
-     * @param[in]  aActivePower_mW   - ActivePower measured in milli-watts
-     * @param[in]  aVoltage_mV       - Voltage measured in milli-volts
-     * @param[in]  aActiveCurrent_mA - ActiveCurrent measured in milli-amps
-     */
-    virtual CHIP_ERROR SendPowerReading(EndpointId aEndpointId, int64_t aActivePower_mW, int64_t aVoltage_mV, int64_t aCurrent_mA)
-    {
-        return CHIP_NO_ERROR;
-    }
-    /**
-     * @brief   Allows a client application to send cumulative energy readings into the system
-     *
-     *          This is a helper function to add timestamps to the readings
-     *
-     * @param[in]  aCumulativeEnergyImported -total energy imported in milli-watthours
-     * @param[in]  aCumulativeEnergyExported -total energy exported in milli-watthours
-     */
-    virtual CHIP_ERROR SendCumulativeEnergyReading(EndpointId aEndpointId, int64_t aCumulativeEnergyImported,
-                                                   int64_t aCumulativeEnergyExported)
-    {
-        return CHIP_NO_ERROR;
-    }
-    /**
-     * @brief   Allows a client application to send periodic energy readings into the system
-     *
-     *          This is a helper function to add timestamps to the readings
-     *
-     * @param[in]  aPeriodicEnergyImported - energy imported in milli-watthours in last period
-     * @param[in]  aPeriodicEnergyExported - energy exported in milli-watthours in last period
-     */
-    virtual CHIP_ERROR SendPeriodicEnergyReading(EndpointId aEndpointId, int64_t aCumulativeEnergyImported,
-                                                 int64_t aCumulativeEnergyExported)
-    {
-        return CHIP_NO_ERROR;
-    }
 };
 
 } // namespace DeviceEnergyManagement

--- a/examples/energy-management/electrical-sensor/BUILD.gn
+++ b/examples/energy-management/electrical-sensor/BUILD.gn
@@ -21,7 +21,9 @@ config("config") {
 
 static_library("electrical-sensor") {
   sources = [
+    "${chip_root}/examples/energy-management/electrical-sensor/src/ElectricalEnergyMeasurementDelegateImpl.cpp",
     "${chip_root}/examples/energy-management/electrical-sensor/src/ElectricalPowerMeasurementDelegateImpl.cpp",
+    "${chip_root}/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp",
     "${chip_root}/examples/energy-management/electrical-sensor/src/PowerTopologyDelegateImpl.cpp",
   ]
 

--- a/examples/energy-management/electrical-sensor/include/ElectricalEnergyMeasurementDelegateImpl.h
+++ b/examples/energy-management/electrical-sensor/include/ElectricalEnergyMeasurementDelegateImpl.h
@@ -1,0 +1,55 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h>
+#include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ElectricalEnergyMeasurement {
+
+class ElectricalEnergyMeasurementDelegate : public Delegate
+{
+public:
+    ~ElectricalEnergyMeasurementDelegate() = default;
+
+    // Delegate interface -- pulled by the cluster on its reporting timer
+    DataModel::Nullable<int64_t> GetCumulativeEnergyImported() override;
+    DataModel::Nullable<int64_t> GetCumulativeEnergyExported() override;
+    DataModel::Nullable<int64_t> GetPeriodicEnergyImported() override;
+    DataModel::Nullable<int64_t> GetPeriodicEnergyExported() override;
+
+    // Application API to push raw counter values
+    void SetCumulativeEnergyImported(int64_t value) { mCumulativeImported = value; }
+    void SetCumulativeEnergyExported(int64_t value) { mCumulativeExported = value; }
+    void SetPeriodicEnergyImported(int64_t value) { mPeriodicImported = value; }
+    void SetPeriodicEnergyExported(int64_t value) { mPeriodicExported = value; }
+
+private:
+    int64_t mCumulativeImported = 0;
+    int64_t mCumulativeExported = 0;
+    int64_t mPeriodicImported   = 0;
+    int64_t mPeriodicExported   = 0;
+};
+
+} // namespace ElectricalEnergyMeasurement
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/energy-management/electrical-sensor/include/ElectricalPowerMeasurementDelegateImpl.h
+++ b/examples/energy-management/electrical-sensor/include/ElectricalPowerMeasurementDelegateImpl.h
@@ -26,7 +26,7 @@ namespace app {
 namespace Clusters {
 namespace ElectricalPowerMeasurement {
 
-class ElectricalPowerMeasurementDelegate : public ElectricalPowerMeasurement::Delegate
+class ElectricalPowerMeasurementDelegate : public Delegate
 {
 public:
     ~ElectricalPowerMeasurementDelegate() = default;

--- a/examples/energy-management/electrical-sensor/include/ElectricalSensorManager.h
+++ b/examples/energy-management/electrical-sensor/include/ElectricalSensorManager.h
@@ -1,0 +1,103 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <ElectricalEnergyMeasurementDelegateImpl.h>
+#include <ElectricalPowerMeasurementDelegateImpl.h>
+#include <PowerTopologyDelegateImpl.h>
+#include <app/server-cluster/ServerClusterInterfaceRegistry.h>
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/TimerDelegate.h>
+#include <platform/DefaultTimerDelegate.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+
+/** @brief Manages the Electrical Power Measurement (EPM), Electrical Energy Measurement (EEM), and
+ *  Power Topology (PT) clusters for energy-management example apps.
+ *  Holds all three delegates and their cluster instances.
+ */
+class ElectricalSensorManager
+{
+public:
+    ElectricalSensorManager()                                            = default;
+    ~ElectricalSensorManager()                                           = default;
+    ElectricalSensorManager(const ElectricalSensorManager &)             = delete;
+    ElectricalSensorManager & operator=(const ElectricalSensorManager &) = delete;
+
+    // --- Configuration structs for the clusters to simplify initialization ---
+    struct EpmConfig
+    {
+        BitMask<ElectricalPowerMeasurement::Feature> features;
+        BitMask<ElectricalPowerMeasurement::OptionalAttributes> optionalAttributes;
+    };
+
+    struct EemConfig
+    {
+        BitMask<ElectricalEnergyMeasurement::Feature> features;
+        ElectricalEnergyMeasurement::ElectricalEnergyMeasurementCluster::OptionalAttributesSet optionalAttributes;
+        const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyStruct::Type & accuracyStruct;
+    };
+
+    struct PtConfig
+    {
+        BitMask<PowerTopology::Feature> features;
+    };
+
+    CHIP_ERROR Init(EndpointId endpointId, const EpmConfig & epmConfig, const EemConfig & eemConfig, const PtConfig & ptConfig);
+    void Shutdown();
+
+    // --- Setters forwarded to the EEM delegate ---
+    void SetCumulativeEnergyImported(int64_t value) { mEEMDelegate.SetCumulativeEnergyImported(value); }
+    void SetCumulativeEnergyExported(int64_t value) { mEEMDelegate.SetCumulativeEnergyExported(value); }
+    void SetPeriodicEnergyImported(int64_t value) { mEEMDelegate.SetPeriodicEnergyImported(value); }
+    void SetPeriodicEnergyExported(int64_t value) { mEEMDelegate.SetPeriodicEnergyExported(value); }
+
+    // --- Power reading API (updates EPM delegate) ---
+    CHIP_ERROR SendPowerReading(int64_t aActivePower_mW, int64_t aVoltage_mV, int64_t aActiveCurrent_mA);
+
+    // --- Cluster / delegate accessors ---
+    ElectricalEnergyMeasurement::ElectricalEnergyMeasurementDelegate * GetEEMDelegate() { return &mEEMDelegate; }
+    ElectricalEnergyMeasurement::ElectricalEnergyMeasurementCluster * GetEEMCluster();
+    ElectricalPowerMeasurement::ElectricalPowerMeasurementDelegate * GetEPMDelegate() { return mEPMDelegate.get(); }
+    ElectricalPowerMeasurement::ElectricalPowerMeasurementInstance * GetEPMInstance() { return mEPMInstance.get(); }
+    PowerTopology::PowerTopologyDelegate * GetPTDelegate() { return mPTDelegate.get(); }
+    PowerTopology::PowerTopologyInstance * GetPTInstance() { return mPTInstance.get(); }
+
+private:
+    // TODO: Have a getter on the Server's TimerDelegate to use here instead of the DefaultTimerDelegate
+    DefaultTimerDelegate mTimerDelegate;
+    ElectricalEnergyMeasurement::ElectricalEnergyMeasurementDelegate mEEMDelegate;
+
+    // EPM
+    std::unique_ptr<ElectricalPowerMeasurement::ElectricalPowerMeasurementDelegate> mEPMDelegate;
+    std::unique_ptr<ElectricalPowerMeasurement::ElectricalPowerMeasurementInstance> mEPMInstance;
+
+    // EEM (direct cluster registration, no CodegenIntegration)
+    std::unique_ptr<RegisteredServerCluster<ElectricalEnergyMeasurement::ElectricalEnergyMeasurementCluster>> mEEMCluster;
+
+    // Power Topology
+    std::unique_ptr<PowerTopology::PowerTopologyDelegate> mPTDelegate;
+    std::unique_ptr<PowerTopology::PowerTopologyInstance> mPTInstance;
+};
+
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/energy-management/electrical-sensor/include/ElectricalSensorManager.h
+++ b/examples/energy-management/electrical-sensor/include/ElectricalSensorManager.h
@@ -69,6 +69,7 @@ public:
     void SetCumulativeEnergyExported(int64_t value) { mEEMDelegate.SetCumulativeEnergyExported(value); }
     void SetPeriodicEnergyImported(int64_t value) { mEEMDelegate.SetPeriodicEnergyImported(value); }
     void SetPeriodicEnergyExported(int64_t value) { mEEMDelegate.SetPeriodicEnergyExported(value); }
+    void GenerateEEMReport();
 
     // --- Power reading API (updates EPM delegate) ---
     CHIP_ERROR SendPowerReading(int64_t aActivePower_mW, int64_t aVoltage_mV, int64_t aActiveCurrent_mA);

--- a/examples/energy-management/electrical-sensor/include/PowerTopologyDelegateImpl.h
+++ b/examples/energy-management/electrical-sensor/include/PowerTopologyDelegateImpl.h
@@ -70,7 +70,7 @@ private:
  * @return CHIP_NO_ERROR if the PowerTopology cluster is initialized successfully, otherwise an error code
  */
 CHIP_ERROR PowerTopologyInit(chip::EndpointId endpointId, std::unique_ptr<PowerTopologyDelegate> & aDelegate,
-                             std::unique_ptr<PowerTopologyInstance> & aInstance);
+                             std::unique_ptr<PowerTopologyInstance> & aInstance, Feature aFeature);
 
 CHIP_ERROR PowerTopologyShutdown(std::unique_ptr<PowerTopologyInstance> & aInstance,
                                  std::unique_ptr<PowerTopologyDelegate> & aDelegate);

--- a/examples/energy-management/electrical-sensor/include/PowerTopologyDelegateImpl.h
+++ b/examples/energy-management/electrical-sensor/include/PowerTopologyDelegateImpl.h
@@ -39,7 +39,7 @@ public:
 class PowerTopologyInstance : public Instance
 {
 public:
-    PowerTopologyInstance(EndpointId aEndpointId, PowerTopologyDelegate & aDelegate, Feature aFeature) :
+    PowerTopologyInstance(EndpointId aEndpointId, PowerTopologyDelegate & aDelegate, BitMask<Feature> aFeature) :
         PowerTopology::Instance(aEndpointId, aDelegate, aFeature)
     {
         mDelegate = &aDelegate;
@@ -70,7 +70,7 @@ private:
  * @return CHIP_NO_ERROR if the PowerTopology cluster is initialized successfully, otherwise an error code
  */
 CHIP_ERROR PowerTopologyInit(chip::EndpointId endpointId, std::unique_ptr<PowerTopologyDelegate> & aDelegate,
-                             std::unique_ptr<PowerTopologyInstance> & aInstance, Feature aFeature);
+                             std::unique_ptr<PowerTopologyInstance> & aInstance, BitMask<Feature> aFeature);
 
 CHIP_ERROR PowerTopologyShutdown(std::unique_ptr<PowerTopologyInstance> & aInstance,
                                  std::unique_ptr<PowerTopologyDelegate> & aDelegate);

--- a/examples/energy-management/electrical-sensor/src/ElectricalEnergyMeasurementDelegateImpl.cpp
+++ b/examples/energy-management/electrical-sensor/src/ElectricalEnergyMeasurementDelegateImpl.cpp
@@ -1,0 +1,51 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <ElectricalEnergyMeasurementDelegateImpl.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ElectricalEnergyMeasurement {
+
+using namespace chip::app::DataModel;
+
+Nullable<int64_t> ElectricalEnergyMeasurementDelegate::GetCumulativeEnergyImported()
+{
+    return MakeNullable(mCumulativeImported);
+}
+
+Nullable<int64_t> ElectricalEnergyMeasurementDelegate::GetCumulativeEnergyExported()
+{
+    return MakeNullable(mCumulativeExported);
+}
+
+Nullable<int64_t> ElectricalEnergyMeasurementDelegate::GetPeriodicEnergyImported()
+{
+    return MakeNullable(mPeriodicImported);
+}
+
+Nullable<int64_t> ElectricalEnergyMeasurementDelegate::GetPeriodicEnergyExported()
+{
+    return MakeNullable(mPeriodicExported);
+}
+
+} // namespace ElectricalEnergyMeasurement
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
+++ b/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
@@ -91,6 +91,14 @@ ElectricalEnergyMeasurementCluster * ElectricalSensorManager::GetEEMCluster()
     return nullptr;
 }
 
+void ElectricalSensorManager::GenerateEEMReport()
+{
+    if (mEEMCluster)
+    {
+        mEEMCluster->Cluster().GenerateReport();
+    }
+}
+
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
+++ b/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
@@ -1,0 +1,96 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <ElectricalSensorManager.h>
+
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+
+using namespace ElectricalPowerMeasurement;
+using namespace ElectricalEnergyMeasurement;
+
+CHIP_ERROR ElectricalSensorManager::Init(EndpointId endpointId, const EpmConfig & epmConfig, const EemConfig & eemConfig,
+                                         const PtConfig & ptConfig)
+{
+    // --- Initialize EPM ---
+    ReturnErrorOnFailure(
+        ElectricalPowerMeasurementInit(endpointId, mEPMDelegate, mEPMInstance, epmConfig.features, epmConfig.optionalAttributes));
+
+    // --- Initialize EEM ---
+    ElectricalEnergyMeasurementCluster::Config clusterConfig{
+        .endpointId         = endpointId,
+        .featureFlags       = eemConfig.features,
+        .optionalAttributes = eemConfig.optionalAttributes,
+        .accuracyStruct     = eemConfig.accuracyStruct,
+        .delegate           = mEEMDelegate,
+        .timerDelegate      = mTimerDelegate,
+    };
+
+    mEEMCluster = std::make_unique<RegisteredServerCluster<ElectricalEnergyMeasurementCluster>>(clusterConfig);
+    VerifyOrReturnError(mEEMCluster != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    ReturnErrorOnFailure(CodegenDataModelProvider::Instance().Registry().Register(mEEMCluster->Registration()));
+
+    // --- Initialize Power Topology ---
+    ReturnErrorOnFailure(PowerTopology::PowerTopologyInit(endpointId, mPTDelegate, mPTInstance, ptConfig.features));
+
+    return CHIP_NO_ERROR;
+}
+
+void ElectricalSensorManager::Shutdown()
+{
+    // Shutdown in reverse init order
+    TEMPORARY_RETURN_IGNORED PowerTopology::PowerTopologyShutdown(mPTInstance, mPTDelegate);
+
+    if (mEEMCluster)
+    {
+        CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&mEEMCluster->Cluster());
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(AppServer, "EEM: Failed to unregister cluster: %" CHIP_ERROR_FORMAT, err.Format());
+        }
+        mEEMCluster.reset();
+    }
+
+    TEMPORARY_RETURN_IGNORED ElectricalPowerMeasurementShutdown(mEPMInstance, mEPMDelegate);
+}
+
+CHIP_ERROR ElectricalSensorManager::SendPowerReading(int64_t aActivePower_mW, int64_t aVoltage_mV, int64_t aActiveCurrent_mA)
+{
+    VerifyOrReturnError(mEPMDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    TEMPORARY_RETURN_IGNORED mEPMDelegate->SetActivePower(DataModel::MakeNullable(aActivePower_mW));
+    TEMPORARY_RETURN_IGNORED mEPMDelegate->SetVoltage(DataModel::MakeNullable(aVoltage_mV));
+    TEMPORARY_RETURN_IGNORED mEPMDelegate->SetActiveCurrent(DataModel::MakeNullable(aActiveCurrent_mA));
+    return CHIP_NO_ERROR;
+}
+
+ElectricalEnergyMeasurementCluster * ElectricalSensorManager::GetEEMCluster()
+{
+    if (mEEMCluster)
+    {
+        return &mEEMCluster->Cluster();
+    }
+    return nullptr;
+}
+
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
+++ b/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
@@ -27,11 +27,22 @@ namespace Clusters {
 using namespace ElectricalPowerMeasurement;
 using namespace ElectricalEnergyMeasurement;
 
+namespace {
+/// Common pattern of:
+///   - if error (i.e. NOT CHIP_NO_ERROR), then call shutdown and return error
+#define SuccessOrShutdown(err_expr)                                                                       \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        if (CHIP_ERROR __err = err_expr; __err != CHIP_NO_ERROR) { Shutdown(); return __err; } \
+    } while (0)
+
+} // namespace
+
 CHIP_ERROR ElectricalSensorManager::Init(EndpointId endpointId, const EpmConfig & epmConfig, const EemConfig & eemConfig,
                                          const PtConfig & ptConfig)
 {
     // --- Initialize EPM ---
-    ReturnErrorOnFailure(
+    SuccessOrShutdown(
         ElectricalPowerMeasurementInit(endpointId, mEPMDelegate, mEPMInstance, epmConfig.features, epmConfig.optionalAttributes));
 
     // --- Initialize EEM ---
@@ -47,10 +58,10 @@ CHIP_ERROR ElectricalSensorManager::Init(EndpointId endpointId, const EpmConfig 
     mEEMCluster = std::make_unique<RegisteredServerCluster<ElectricalEnergyMeasurementCluster>>(clusterConfig);
     VerifyOrReturnError(mEEMCluster != nullptr, CHIP_ERROR_NO_MEMORY);
 
-    ReturnErrorOnFailure(CodegenDataModelProvider::Instance().Registry().Register(mEEMCluster->Registration()));
+    SuccessOrShutdown(CodegenDataModelProvider::Instance().Registry().Register(mEEMCluster->Registration()));
 
     // --- Initialize Power Topology ---
-    ReturnErrorOnFailure(PowerTopology::PowerTopologyInit(endpointId, mPTDelegate, mPTInstance, ptConfig.features));
+    SuccessOrShutdown(PowerTopology::PowerTopologyInit(endpointId, mPTDelegate, mPTInstance, ptConfig.features));
 
     return CHIP_NO_ERROR;
 }

--- a/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
+++ b/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
@@ -85,15 +85,16 @@ void ElectricalSensorManager::Shutdown()
         mEEMCluster.reset();
     }
 
-    TEMPORARY_RETURN_IGNORED ElectricalPowerMeasurementShutdown(mEPMInstance, mEPMDelegate);
+    RETURN_SAFELY_IGNORED ElectricalPowerMeasurementShutdown(mEPMInstance, mEPMDelegate);
 }
 
 CHIP_ERROR ElectricalSensorManager::SendPowerReading(int64_t aActivePower_mW, int64_t aVoltage_mV, int64_t aActiveCurrent_mA)
 {
     VerifyOrReturnError(mEPMDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    TEMPORARY_RETURN_IGNORED mEPMDelegate->SetActivePower(DataModel::MakeNullable(aActivePower_mW));
-    TEMPORARY_RETURN_IGNORED mEPMDelegate->SetVoltage(DataModel::MakeNullable(aVoltage_mV));
-    TEMPORARY_RETURN_IGNORED mEPMDelegate->SetActiveCurrent(DataModel::MakeNullable(aActiveCurrent_mA));
+    // All three setters below only return CHIP_NO_ERROR so we can safely ignore the return value
+    RETURN_SAFELY_IGNORED mEPMDelegate->SetActivePower(DataModel::MakeNullable(aActivePower_mW));
+    RETURN_SAFELY_IGNORED mEPMDelegate->SetVoltage(DataModel::MakeNullable(aVoltage_mV));
+    RETURN_SAFELY_IGNORED mEPMDelegate->SetActiveCurrent(DataModel::MakeNullable(aActiveCurrent_mA));
     return CHIP_NO_ERROR;
 }
 
@@ -110,7 +111,7 @@ void ElectricalSensorManager::GenerateEEMReport()
 {
     if (mEEMCluster)
     {
-        mEEMCluster->Cluster().GenerateReport();
+        mEEMCluster->Cluster().GenerateSnapshots();
     }
 }
 

--- a/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
+++ b/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
@@ -30,10 +30,14 @@ using namespace ElectricalEnergyMeasurement;
 namespace {
 /// Common pattern of:
 ///   - if error (i.e. NOT CHIP_NO_ERROR), then call shutdown and return error
-#define SuccessOrShutdown(err_expr)                                                                       \
+#define SuccessOrShutdown(err_expr)                                                                                                \
     do                                                                                                                             \
     {                                                                                                                              \
-        if (CHIP_ERROR __err = err_expr; __err != CHIP_NO_ERROR) { Shutdown(); return __err; } \
+        if (CHIP_ERROR __err = err_expr; __err != CHIP_NO_ERROR)                                                                   \
+        {                                                                                                                          \
+            Shutdown();                                                                                                            \
+            return __err;                                                                                                          \
+        }                                                                                                                          \
     } while (0)
 
 } // namespace

--- a/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
+++ b/examples/energy-management/electrical-sensor/src/ElectricalSensorManager.cpp
@@ -19,28 +19,12 @@
 
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
-
 namespace chip {
 namespace app {
 namespace Clusters {
 
 using namespace ElectricalPowerMeasurement;
 using namespace ElectricalEnergyMeasurement;
-
-namespace {
-/// Common pattern of:
-///   - if error (i.e. NOT CHIP_NO_ERROR), then call shutdown and return error
-#define SuccessOrShutdown(err_expr)                                                                                                \
-    do                                                                                                                             \
-    {                                                                                                                              \
-        if (CHIP_ERROR __err = err_expr; __err != CHIP_NO_ERROR)                                                                   \
-        {                                                                                                                          \
-            Shutdown();                                                                                                            \
-            return __err;                                                                                                          \
-        }                                                                                                                          \
-    } while (0)
-
-} // namespace
 
 CHIP_ERROR ElectricalSensorManager::Init(EndpointId endpointId, const EpmConfig & epmConfig, const EemConfig & eemConfig,
                                          const PtConfig & ptConfig)

--- a/examples/energy-management/electrical-sensor/src/PowerTopologyDelegateImpl.cpp
+++ b/examples/energy-management/electrical-sensor/src/PowerTopologyDelegateImpl.cpp
@@ -51,7 +51,7 @@ void PowerTopologyInstance::Shutdown()
  * Then call the Instance->Init() to register the attribute and command handlers
  */
 CHIP_ERROR PowerTopologyInit(chip::EndpointId endpointId, std::unique_ptr<PowerTopologyDelegate> & aDelegate,
-                             std::unique_ptr<PowerTopologyInstance> & aInstance)
+                             std::unique_ptr<PowerTopologyInstance> & aInstance, Feature aFeature)
 {
     CHIP_ERROR err;
 
@@ -68,8 +68,7 @@ CHIP_ERROR PowerTopologyInit(chip::EndpointId endpointId, std::unique_ptr<PowerT
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    aInstance = std::make_unique<PowerTopologyInstance>(
-        EndpointId(endpointId), *aDelegate, BitMask<PowerTopology::Feature, uint32_t>(PowerTopology::Feature::kNodeTopology));
+    aInstance = std::make_unique<PowerTopologyInstance>(EndpointId(endpointId), *aDelegate, aFeature);
 
     if (!aInstance)
     {

--- a/examples/energy-management/electrical-sensor/src/PowerTopologyDelegateImpl.cpp
+++ b/examples/energy-management/electrical-sensor/src/PowerTopologyDelegateImpl.cpp
@@ -51,7 +51,7 @@ void PowerTopologyInstance::Shutdown()
  * Then call the Instance->Init() to register the attribute and command handlers
  */
 CHIP_ERROR PowerTopologyInit(chip::EndpointId endpointId, std::unique_ptr<PowerTopologyDelegate> & aDelegate,
-                             std::unique_ptr<PowerTopologyInstance> & aInstance, Feature aFeature)
+                             std::unique_ptr<PowerTopologyInstance> & aInstance, BitMask<Feature> aFeature)
 {
     CHIP_ERROR err;
 

--- a/examples/energy-management/energy-management-triggers/FakeReadings.cpp
+++ b/examples/energy-management/energy-management-triggers/FakeReadings.cpp
@@ -166,6 +166,7 @@ void FakeReadings::FakeReadingsUpdate()
         esManager->SetPeriodicEnergyExported(mPeriodicEnergyExported);
         esManager->SetCumulativeEnergyImported(mTotalEnergyImported);
         esManager->SetCumulativeEnergyExported(mTotalEnergyExported);
+        esManager->GenerateEEMReport();
     }
 
     // start/restart the timer

--- a/examples/energy-management/energy-management-triggers/FakeReadings.cpp
+++ b/examples/energy-management/energy-management-triggers/FakeReadings.cpp
@@ -17,7 +17,7 @@
  */
 
 #include <DEMConfig.h>
-#include <DEMManufacturerDelegate.h>
+#include <ElectricalSensorManager.h>
 #include <app/clusters/device-energy-management-server/DeviceEnergyManagementTestEventTriggerHandler.h>
 #include <app/clusters/electrical-energy-measurement-server/EnergyReportingTestEventTriggerHandler.h>
 #include <app/clusters/power-source-server/power-source-server.h>
@@ -138,7 +138,11 @@ void FakeReadings::FakeReadingsUpdate()
     int64_t current = (static_cast<int64_t>(rand()) % (2 * mCurrentRandomness_mA)) - mCurrentRandomness_mA;
     current += mCurrent_mA; // add in the base current
 
-    TEMPORARY_RETURN_IGNORED GetDEMDelegate()->GetDEMManufacturerDelegate()->SendPowerReading(mEndpointId, power, voltage, current);
+    ElectricalSensorManager * esManager = GetESManager();
+    if (esManager != nullptr)
+    {
+        TEMPORARY_RETURN_IGNORED esManager->SendPowerReading(power, voltage, current);
+    }
 
     // update the energy meter - we'll assume that the power has been constant during the previous interval
     if (mPower_mW > 0)
@@ -156,11 +160,13 @@ void FakeReadings::FakeReadingsUpdate()
         mTotalEnergyExported += mPeriodicEnergyExported;
     }
 
-    TEMPORARY_RETURN_IGNORED GetDEMDelegate()->GetDEMManufacturerDelegate()->SendPeriodicEnergyReading(
-        mEndpointId, mPeriodicEnergyImported, mPeriodicEnergyExported);
-
-    TEMPORARY_RETURN_IGNORED GetDEMDelegate()->GetDEMManufacturerDelegate()->SendCumulativeEnergyReading(
-        mEndpointId, mTotalEnergyImported, mTotalEnergyExported);
+    if (esManager != nullptr)
+    {
+        esManager->SetPeriodicEnergyImported(mPeriodicEnergyImported);
+        esManager->SetPeriodicEnergyExported(mPeriodicEnergyExported);
+        esManager->SetCumulativeEnergyImported(mTotalEnergyImported);
+        esManager->SetCumulativeEnergyExported(mTotalEnergyExported);
+    }
 
     // start/restart the timer
     TEMPORARY_RETURN_IGNORED DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(mInterval_s), FakeReadingsTimerExpiry,

--- a/examples/evse-app/evse-common/include/EVSEManufacturerImpl.h
+++ b/examples/evse-app/evse-common/include/EVSEManufacturerImpl.h
@@ -20,9 +20,8 @@
 
 #include <DEMManufacturerDelegate.h>
 #include <DeviceEnergyManagementManager.h>
-#include <ElectricalPowerMeasurementDelegateImpl.h>
+#include <ElectricalSensorManager.h>
 #include <EnergyEvseManager.h>
-#include <PowerTopologyDelegateImpl.h>
 
 using chip::Protocols::InteractionModel::Status;
 namespace chip {
@@ -37,13 +36,11 @@ namespace EnergyEvse {
 class EVSEManufacturer : public DEMManufacturerDelegate
 {
 public:
-    EVSEManufacturer(EnergyEvseManager * aEvseInstance,
-                     ElectricalPowerMeasurement::ElectricalPowerMeasurementInstance * aEPMInstance,
-                     PowerTopology::PowerTopologyInstance * aPTInstance, DeviceEnergyManagementManager * aDEMInstance)
+    EVSEManufacturer(EnergyEvseManager * aEvseInstance, ElectricalSensorManager * aESManager,
+                     DeviceEnergyManagementManager * aDEMInstance)
     {
         mEvseInstance = aEvseInstance;
-        mEPMInstance  = aEPMInstance;
-        mPTInstance   = aPTInstance;
+        mESManager    = aESManager;
         mDEMInstance  = aDEMInstance;
     }
 
@@ -51,7 +48,7 @@ public:
 
     EnergyEvseManager * GetEvseInstance() { return mEvseInstance; }
 
-    ElectricalPowerMeasurement::ElectricalPowerMeasurementInstance * GetEPMInstance() { return mEPMInstance; }
+    ElectricalSensorManager * GetESManager() { return mESManager; }
 
     EnergyEvseDelegate * GetEvseDelegate()
     {
@@ -64,18 +61,18 @@ public:
 
     ElectricalPowerMeasurement::ElectricalPowerMeasurementDelegate * GetEPMDelegate()
     {
-        if (mEPMInstance)
+        if (mESManager)
         {
-            return mEPMInstance->GetDelegate();
+            return mESManager->GetEPMDelegate();
         }
         return nullptr;
     }
 
     PowerTopology::PowerTopologyDelegate * GetPTDelegate()
     {
-        if (mPTInstance)
+        if (mESManager)
         {
-            return mPTInstance->GetDelegate();
+            return mESManager->GetPTDelegate();
         }
         return nullptr;
     }
@@ -154,38 +151,6 @@ public:
      */
     CHIP_ERROR InitializePowerSourceCluster(chip::EndpointId endpointId);
 
-    /**
-     * @brief   Allows a client application to send in power readings into the system
-     *
-     * @param[in]  aEndpointId       - Endpoint to send to EPM Cluster
-     * @param[in]  aActivePower_mW   - ActivePower measured in milli-watts
-     * @param[in]  aVoltage_mV       - Voltage measured in milli-volts
-     * @param[in]  aActiveCurrent_mA - ActiveCurrent measured in milli-amps
-     */
-    CHIP_ERROR SendPowerReading(EndpointId aEndpointId, int64_t aActivePower_mW, int64_t aVoltage_mV, int64_t aCurrent_mA) override;
-
-    /**
-     * @brief   Allows a client application to send cumulative energy readings into the system
-     *
-     *          This is a helper function to add timestamps to the readings
-     *
-     * @param[in]  aCumulativeEnergyImported -total energy imported in milli-watthours
-     * @param[in]  aCumulativeEnergyExported -total energy exported in milli-watthours
-     */
-    CHIP_ERROR SendCumulativeEnergyReading(EndpointId aEndpointId, int64_t aCumulativeEnergyImported,
-                                           int64_t aCumulativeEnergyExported) override;
-
-    /**
-     * @brief   Allows a client application to send periodic energy readings into the system
-     *
-     *          This is a helper function to add timestamps to the readings
-     *
-     * @param[in]  aPeriodicEnergyImported - energy imported in milli-watthours in last period
-     * @param[in]  aPeriodicEnergyExported - energy exported in milli-watthours in last period
-     */
-    CHIP_ERROR SendPeriodicEnergyReading(EndpointId aEndpointId, int64_t aCumulativeEnergyImported,
-                                         int64_t aCumulativeEnergyExported) override;
-
     /**  Fake Meter data generation - used for testing EPM/EEM clusters */
     /**
      * @brief   Starts a fake load/generator to periodically callback the power and energy
@@ -231,8 +196,7 @@ public:
 
 private:
     EnergyEvseManager * mEvseInstance;
-    ElectricalPowerMeasurement::ElectricalPowerMeasurementInstance * mEPMInstance;
-    PowerTopology::PowerTopologyInstance * mPTInstance;
+    ElectricalSensorManager * mESManager;
     DeviceEnergyManagementManager * mDEMInstance;
 
     int64_t mLastChargingEnergyMeter    = 0;

--- a/examples/evse-app/evse-common/src/EVSEManufacturerImpl.cpp
+++ b/examples/evse-app/evse-common/src/EVSEManufacturerImpl.cpp
@@ -19,6 +19,7 @@
 #include <DEMManufacturerDelegate.h>
 #include <DeviceEnergyManagementDelegateImpl.h>
 #include <EVSEManufacturerImpl.h>
+#include <ElectricalSensorManager.h>
 #include <EnergyEvseDelegateImpl.h>
 #include <EnergyEvseManager.h>
 #include <EnergyTimeUtils.h>
@@ -26,7 +27,6 @@
 #include <FakeReadings.h>
 #include <app/clusters/device-energy-management-server/DeviceEnergyManagementTestEventTriggerHandler.h>
 #include <app/clusters/electrical-energy-measurement-server/EnergyReportingTestEventTriggerHandler.h>
-#include <app/clusters/electrical-energy-measurement-server/electrical-energy-measurement-server.h>
 #include <app/clusters/energy-evse-server/EnergyEvseTestEventTriggerHandler.h>
 #include <app/clusters/power-source-server/power-source-server.h>
 #include <app/server/Server.h>
@@ -467,178 +467,6 @@ CHIP_ERROR EVSEManufacturer::InitializePowerSourceCluster(chip::EndpointId endpo
     // Note per API - we do not need to maintain the span after the SetEndpointList has been called
     // since it takes a copy (see power-source-server/CodegenIntegration.cpp)
     return PowerSourceServer::Instance().SetEndpointList(endpointId, endpointList);
-}
-
-/**
- * @brief   Allows a client application to send in power readings into the system
- *
- * @param[in]  aEndpointId       - Endpoint to send to EPM Cluster
- * @param[in]  aActivePower_mW   - ActivePower measured in milli-watts
- * @param[in]  aVoltage_mV       - Voltage measured in milli-volts
- * @param[in]  aActiveCurrent_mA - ActiveCurrent measured in milli-amps
- */
-CHIP_ERROR EVSEManufacturer::SendPowerReading(EndpointId aEndpointId, int64_t aActivePower_mW, int64_t aVoltage_mV,
-                                              int64_t aActiveCurrent_mA)
-{
-    EVSEManufacturer * mn = GetEvseManufacturer();
-    VerifyOrReturnError(mn != nullptr, CHIP_ERROR_UNINITIALIZED);
-
-    ElectricalPowerMeasurementDelegate * dg = mn->GetEPMDelegate();
-    VerifyOrReturnError(dg != nullptr, CHIP_ERROR_UNINITIALIZED);
-
-    TEMPORARY_RETURN_IGNORED dg->SetActivePower(MakeNullable(aActivePower_mW));
-    TEMPORARY_RETURN_IGNORED dg->SetVoltage(MakeNullable(aVoltage_mV));
-    TEMPORARY_RETURN_IGNORED dg->SetActiveCurrent(MakeNullable(aActiveCurrent_mA));
-
-    return CHIP_NO_ERROR;
-}
-
-using namespace chip::app::Clusters::ElectricalEnergyMeasurement::Structs;
-
-/**
- * @brief   Allows a client application to send cumulative energy readings into the system
- *
- *          This is a helper function to add timestamps to the readings
- *
- * @param[in]  aCumulativeEnergyImported -total energy imported in milli-watthours
- * @param[in]  aCumulativeEnergyExported -total energy exported in milli-watthours
- */
-CHIP_ERROR EVSEManufacturer::SendCumulativeEnergyReading(EndpointId aEndpointId, int64_t aCumulativeEnergyImported,
-                                                         int64_t aCumulativeEnergyExported)
-{
-    const MeasurementData * data = MeasurementDataForEndpoint(aEndpointId);
-    VerifyOrReturnError(data != nullptr, CHIP_ERROR_UNINITIALIZED);
-
-    EnergyMeasurementStruct::Type energyImported;
-    EnergyMeasurementStruct::Type energyExported;
-
-    /** IMPORT */
-    // Copy last endTimestamp into new startTimestamp if it exists
-    energyImported.startTimestamp.ClearValue();
-    energyImported.startSystime.ClearValue();
-    if (data->cumulativeImported.HasValue())
-    {
-        energyImported.startTimestamp = data->cumulativeImported.Value().endTimestamp;
-        energyImported.startSystime   = data->cumulativeImported.Value().endSystime;
-    }
-
-    energyImported.energy = aCumulativeEnergyImported;
-
-    /** EXPORT */
-    // Copy last endTimestamp into new startTimestamp if it exists
-    energyExported.startTimestamp.ClearValue();
-    energyExported.startSystime.ClearValue();
-    if (data->cumulativeExported.HasValue())
-    {
-        energyExported.startTimestamp = data->cumulativeExported.Value().endTimestamp;
-        energyExported.startSystime   = data->cumulativeExported.Value().endSystime;
-    }
-
-    energyExported.energy = aCumulativeEnergyExported;
-
-    // Get current timestamp
-    uint32_t currentTimestamp;
-    CHIP_ERROR err = System::Clock::GetClock_MatterEpochS(currentTimestamp);
-    if (err == CHIP_NO_ERROR)
-    {
-        // use EpochTS
-        energyImported.endTimestamp.SetValue(currentTimestamp);
-        energyExported.endTimestamp.SetValue(currentTimestamp);
-    }
-    else
-    {
-        ChipLogError(AppServer, "GetClock_MatterEpochS returned error getting timestamp %" CHIP_ERROR_FORMAT, err.Format());
-
-        // use systemTime as a fallback
-        System::Clock::Milliseconds64 system_time_ms =
-            std::chrono::duration_cast<System::Clock::Milliseconds64>(chip::Server::GetInstance().TimeSinceInit());
-        uint64_t nowMS = static_cast<uint64_t>(system_time_ms.count());
-
-        energyImported.endSystime.SetValue(nowMS);
-        energyExported.endSystime.SetValue(nowMS);
-    }
-
-    // call the SDK to update attributes and generate an event
-    if (!NotifyCumulativeEnergyMeasured(aEndpointId, MakeOptional(energyImported), MakeOptional(energyExported)))
-    {
-        ChipLogError(AppServer, "Failed to notify Cumulative Energy reading.");
-        return CHIP_ERROR_INTERNAL;
-    }
-
-    return CHIP_NO_ERROR;
-}
-
-/**
- * @brief   Allows a client application to send periodic energy readings into the system
- *
- *          This is a helper function to add timestamps to the readings
- *
- * @param[in]  aPeriodicEnergyImported - energy imported in milli-watthours in last period
- * @param[in]  aPeriodicEnergyExported - energy exported in milli-watthours in last period
- */
-CHIP_ERROR EVSEManufacturer::SendPeriodicEnergyReading(EndpointId aEndpointId, int64_t aPeriodicEnergyImported,
-                                                       int64_t aPeriodicEnergyExported)
-{
-    const MeasurementData * data = MeasurementDataForEndpoint(aEndpointId);
-    VerifyOrReturnError(data != nullptr, CHIP_ERROR_UNINITIALIZED);
-
-    EnergyMeasurementStruct::Type energyImported;
-    EnergyMeasurementStruct::Type energyExported;
-
-    /** IMPORT */
-    // Copy last endTimestamp into new startTimestamp if it exists
-    energyImported.startTimestamp.ClearValue();
-    energyImported.startSystime.ClearValue();
-    if (data->periodicImported.HasValue())
-    {
-        energyImported.startTimestamp = data->periodicImported.Value().endTimestamp;
-        energyImported.startSystime   = data->periodicImported.Value().endSystime;
-    }
-
-    energyImported.energy = aPeriodicEnergyImported;
-
-    /** EXPORT */
-    // Copy last endTimestamp into new startTimestamp if it exists
-    energyExported.startTimestamp.ClearValue();
-    energyExported.startSystime.ClearValue();
-    if (data->periodicExported.HasValue())
-    {
-        energyExported.startTimestamp = data->periodicExported.Value().endTimestamp;
-        energyExported.startSystime   = data->periodicExported.Value().endSystime;
-    }
-
-    energyExported.energy = aPeriodicEnergyExported;
-
-    // Get current timestamp
-    uint32_t currentTimestamp;
-    CHIP_ERROR err = System::Clock::GetClock_MatterEpochS(currentTimestamp);
-    if (err == CHIP_NO_ERROR)
-    {
-        // use EpochTS
-        energyImported.endTimestamp.SetValue(currentTimestamp);
-        energyExported.endTimestamp.SetValue(currentTimestamp);
-    }
-    else
-    {
-        ChipLogError(AppServer, "GetClock_MatterEpochS returned error getting timestamp");
-
-        // use systemTime as a fallback
-        System::Clock::Milliseconds64 system_time_ms =
-            std::chrono::duration_cast<System::Clock::Milliseconds64>(chip::Server::GetInstance().TimeSinceInit());
-        uint64_t nowMS = static_cast<uint64_t>(system_time_ms.count());
-
-        energyImported.endSystime.SetValue(nowMS);
-        energyExported.endSystime.SetValue(nowMS);
-    }
-
-    // call the SDK to update attributes and generate an event
-    if (!NotifyPeriodicEnergyMeasured(aEndpointId, MakeOptional(energyImported), MakeOptional(energyExported)))
-    {
-        ChipLogError(AppServer, "Failed to notify Cumulative Energy reading.");
-        return CHIP_ERROR_INTERNAL;
-    }
-
-    return CHIP_NO_ERROR;
 }
 
 void EVSEManufacturer::UpdateEVFakeReadings(const Amperage_mA maximumChargeCurrent)

--- a/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
@@ -21,11 +21,9 @@
 #include <DeviceEnergyManagementDelegateImpl.h>
 #include <DeviceEnergyManagementManager.h>
 #include <EVSEManufacturerImpl.h>
-#include <ElectricalPowerMeasurementDelegateImpl.h>
+#include <ElectricalSensorManager.h>
 #include <EnergyEvseManager.h>
 #include <EnergyManagementAppCmdLineOptions.h>
-#include <PowerTopologyDelegateImpl.h>
-#include <app/clusters/electrical-energy-measurement-server/electrical-energy-measurement-server.h>
 #include <device-energy-management-modes.h>
 #include <energy-evse-modes.h>
 
@@ -44,7 +42,6 @@ using namespace chip::app::Clusters::DeviceEnergyManagement;
 using namespace chip::app::Clusters::ElectricalPowerMeasurement;
 using namespace chip::app::Clusters::ElectricalEnergyMeasurement;
 using namespace chip::app::Clusters::EnergyEvse;
-using namespace chip::app::Clusters::PowerTopology;
 
 namespace {
 
@@ -67,11 +64,7 @@ const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyStruct::Type kMea
 // Common cluster instances
 std::unique_ptr<DeviceEnergyManagementDelegate> gDEMDelegate;
 std::unique_ptr<DeviceEnergyManagementManager> gDEMInstance;
-std::unique_ptr<ElectricalPowerMeasurementDelegate> gEPMDelegate;
-std::unique_ptr<ElectricalPowerMeasurementInstance> gEPMInstance;
-std::unique_ptr<PowerTopologyDelegate> gPTDelegate;
-std::unique_ptr<PowerTopologyInstance> gPTInstance;
-std::unique_ptr<ElectricalEnergyMeasurementAttrAccess> gEEMAttrAccess;
+std::unique_ptr<ElectricalSensorManager> gESManager;
 bool gCommonClustersInitialized = false;
 
 // EVSE-specific instances
@@ -187,8 +180,7 @@ CHIP_ERROR EVSEManufacturerInit(chip::EndpointId powerSourceEndpointId)
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    gEvseManufacturer =
-        std::make_unique<EVSEManufacturer>(gEvseInstance.get(), gEPMInstance.get(), gPTInstance.get(), gDEMInstance.get());
+    gEvseManufacturer = std::make_unique<EVSEManufacturer>(gEvseInstance.get(), gESManager.get(), gDEMInstance.get());
     if (!gEvseManufacturer)
     {
         ChipLogError(AppServer, "Failed to allocate memory for EvseManufacturer");
@@ -224,15 +216,17 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
     {
         chip::BitMask<DeviceEnergyManagement::Feature> featureMap = GetFeatureMapFromCmdLine();
         TEMPORARY_RETURN_IGNORED DeviceEnergyManagementInit(endpointId, gDEMDelegate, gDEMInstance, featureMap);
-        // These features and optional attributes are used to make the app pass certification
-        // We recommend implementers of the app to modify these to fit their needs
-        TEMPORARY_RETURN_IGNORED ElectricalPowerMeasurementInit(
-            endpointId, gEPMDelegate, gEPMInstance,
-            BitMask<ElectricalPowerMeasurement::Feature, uint32_t>(
+
+        // Initialize ElectricalSensorManager (owns both EPM and EEM)
+        gESManager = std::make_unique<ElectricalSensorManager>();
+        VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        ElectricalSensorManager::EpmConfig epmConfig{
+            .features = BitMask<ElectricalPowerMeasurement::Feature, uint32_t>(
                 ElectricalPowerMeasurement::Feature::kDirectCurrent, ElectricalPowerMeasurement::Feature::kAlternatingCurrent,
                 ElectricalPowerMeasurement::Feature::kPolyphasePower, ElectricalPowerMeasurement::Feature::kHarmonics,
                 ElectricalPowerMeasurement::Feature::kPowerQuality),
-            BitMask<ElectricalPowerMeasurement::OptionalAttributes, uint32_t>(
+            .optionalAttributes = BitMask<ElectricalPowerMeasurement::OptionalAttributes, uint32_t>(
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeRanges,
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeVoltage,
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeActiveCurrent,
@@ -245,49 +239,52 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeRMSPower,
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeFrequency,
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributePowerFactor,
-                ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeNeutralCurrent));
-        TEMPORARY_RETURN_IGNORED PowerTopologyInit(endpointId, gPTDelegate, gPTInstance);
+                ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeNeutralCurrent),
+        };
+
+        ElectricalSensorManager::EemConfig eemConfig{
+            .features = BitMask<ElectricalEnergyMeasurement::Feature, uint32_t>(
+                ElectricalEnergyMeasurement::Feature::kImportedEnergy, ElectricalEnergyMeasurement::Feature::kExportedEnergy,
+                ElectricalEnergyMeasurement::Feature::kCumulativeEnergy, ElectricalEnergyMeasurement::Feature::kPeriodicEnergy),
+            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet().Set<ElectricalEnergyMeasurement::Attributes::CumulativeEnergyReset::Id>(),
+            .accuracyStruct = kMeasurementAccuracy,
+        };
+
+        ElectricalSensorManager::PtConfig ptConfig{
+            .features = BitMask<PowerTopology::Feature, uint32_t>(PowerTopology::Feature::kNodeTopology),
+        };
+
+        TEMPORARY_RETURN_IGNORED gESManager->Init(endpointId, epmConfig, eemConfig, ptConfig);
+
+        // Set CumulativeEnergyReset struct on the EEM cluster
+        ElectricalEnergyMeasurement::Structs::CumulativeEnergyResetStruct::Type resetStruct = {
+            .importedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
+            .exportedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
+            .importedResetSystime   = MakeOptional(MakeNullable(static_cast<uint64_t>(0))),
+            .exportedResetSystime   = MakeOptional(MakeNullable(static_cast<uint64_t>(0))),
+        };
+        if (auto * eemCluster = gESManager->GetEEMCluster())
+        {
+            TEMPORARY_RETURN_IGNORED eemCluster->SetCumulativeEnergyReset(MakeOptional(resetStruct));
+        }
     }
     VerifyOrReturnError(gDEMDelegate && gDEMInstance, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(gEPMDelegate && gEPMInstance, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(gPTDelegate && gPTInstance, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(gEEMAttrAccess, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
     gCommonClustersInitialized = true;
     return CHIP_NO_ERROR;
 }
 
 } // namespace
 
-void emberAfElectricalEnergyMeasurementClusterInitCallback(chip::EndpointId endpointId)
-{
-    VerifyOrDie(!gEEMAttrAccess);
-
-    gEEMAttrAccess = std::make_unique<ElectricalEnergyMeasurementAttrAccess>(
-        BitMask<ElectricalEnergyMeasurement::Feature, uint32_t>(
-            ElectricalEnergyMeasurement::Feature::kImportedEnergy, ElectricalEnergyMeasurement::Feature::kExportedEnergy,
-            ElectricalEnergyMeasurement::Feature::kCumulativeEnergy, ElectricalEnergyMeasurement::Feature::kPeriodicEnergy),
-        BitMask<ElectricalEnergyMeasurement::OptionalAttributes, uint32_t>(
-            ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset));
-
-    ElectricalEnergyMeasurement::Structs::CumulativeEnergyResetStruct::Type resetStruct = {
-        .importedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
-        .exportedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
-        .importedResetSystime   = MakeOptional(MakeNullable(static_cast<uint64_t>(0))),
-        .exportedResetSystime   = MakeOptional(MakeNullable(static_cast<uint64_t>(0))),
-    };
-
-    if (gEEMAttrAccess)
-    {
-        TEMPORARY_RETURN_IGNORED gEEMAttrAccess->Init();
-        TEMPORARY_RETURN_IGNORED SetMeasurementAccuracy(endpointId, kMeasurementAccuracy);
-        TEMPORARY_RETURN_IGNORED SetCumulativeReset(endpointId, MakeOptional(resetStruct));
-    }
-}
-
 DeviceEnergyManagement::DeviceEnergyManagementDelegate * GetDEMDelegate()
 {
     VerifyOrDieWithMsg(gDEMDelegate.get() != nullptr, AppServer, "DEM Delegate is null");
     return gDEMDelegate.get();
+}
+
+ElectricalSensorManager * GetESManager()
+{
+    return gESManager.get();
 }
 
 EVSEManufacturer * EnergyEvse::GetEvseManufacturer()
@@ -309,8 +306,11 @@ void EvseApplicationShutdown()
 
     /* Shutdown in reverse order that they were created */
     TEMPORARY_RETURN_IGNORED EVSEManufacturerShutdown();
-    TEMPORARY_RETURN_IGNORED PowerTopologyShutdown(gPTInstance, gPTDelegate);
-    TEMPORARY_RETURN_IGNORED ElectricalPowerMeasurementShutdown(gEPMInstance, gEPMDelegate);
+    if (gESManager)
+    {
+        gESManager->Shutdown();
+        gESManager.reset();
+    }
     TEMPORARY_RETURN_IGNORED EnergyEvseShutdown();
     DeviceEnergyManagementShutdown(gDEMInstance, gDEMDelegate);
 

--- a/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
@@ -246,7 +246,8 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
             .features = BitMask<ElectricalEnergyMeasurement::Feature, uint32_t>(
                 ElectricalEnergyMeasurement::Feature::kImportedEnergy, ElectricalEnergyMeasurement::Feature::kExportedEnergy,
                 ElectricalEnergyMeasurement::Feature::kCumulativeEnergy, ElectricalEnergyMeasurement::Feature::kPeriodicEnergy),
-            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet().Set<ElectricalEnergyMeasurement::Attributes::CumulativeEnergyReset::Id>(),
+            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet()
+                                      .Set<ElectricalEnergyMeasurement::Attributes::CumulativeEnergyReset::Id>(),
             .accuracyStruct = kMeasurementAccuracy,
         };
 

--- a/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
@@ -271,7 +271,7 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
             RETURN_SAFELY_IGNORED eemCluster->SetCumulativeEnergyReset(MakeOptional(resetStruct));
         }
     }
-    
+
     VerifyOrReturnError(gDEMDelegate && gDEMInstance, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
     gCommonClustersInitialized = true;

--- a/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
@@ -215,11 +215,11 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
     if (!gCommonClustersInitialized)
     {
         chip::BitMask<DeviceEnergyManagement::Feature> featureMap = GetFeatureMapFromCmdLine();
-        TEMPORARY_RETURN_IGNORED DeviceEnergyManagementInit(endpointId, gDEMDelegate, gDEMInstance, featureMap);
+        ReturnErrorOnFailure(DeviceEnergyManagementInit(endpointId, gDEMDelegate, gDEMInstance, featureMap));
 
         // Initialize ElectricalSensorManager (owns both EPM and EEM)
         gESManager = std::make_unique<ElectricalSensorManager>();
-        VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_NO_MEMORY);
+        VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
         ElectricalSensorManager::EpmConfig epmConfig{
             .features = BitMask<ElectricalPowerMeasurement::Feature, uint32_t>(
@@ -255,7 +255,7 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
             .features = BitMask<PowerTopology::Feature, uint32_t>(PowerTopology::Feature::kNodeTopology),
         };
 
-        TEMPORARY_RETURN_IGNORED gESManager->Init(endpointId, epmConfig, eemConfig, ptConfig);
+        ReturnErrorOnFailure(gESManager->Init(endpointId, epmConfig, eemConfig, ptConfig));
 
         // Set CumulativeEnergyReset struct on the EEM cluster
         ElectricalEnergyMeasurement::Structs::CumulativeEnergyResetStruct::Type resetStruct = {
@@ -266,9 +266,12 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
         };
         if (auto * eemCluster = gESManager->GetEEMCluster())
         {
-            TEMPORARY_RETURN_IGNORED eemCluster->SetCumulativeEnergyReset(MakeOptional(resetStruct));
+            // We can ignore the error here as the only reason for error is if the feature is not supported
+            // and the feature is enabled
+            RETURN_SAFELY_IGNORED eemCluster->SetCumulativeEnergyReset(MakeOptional(resetStruct));
         }
     }
+    
     VerifyOrReturnError(gDEMDelegate && gDEMInstance, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
     gCommonClustersInitialized = true;

--- a/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
+++ b/examples/evse-app/evse-common/src/EnergyEvseMain.cpp
@@ -268,7 +268,8 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
         {
             // We can ignore the error here as the only reason for error is if the feature is not supported
             // and the feature is enabled
-            RETURN_SAFELY_IGNORED eemCluster->SetCumulativeEnergyReset(MakeOptional(resetStruct));
+            RETURN_SAFELY_IGNORED eemCluster->SetCumulativeEnergyReset(
+                DataModel::Nullable<ElectricalEnergyMeasurement::Structs::CumulativeEnergyResetStruct::Type>(resetStruct));
         }
     }
 

--- a/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
+++ b/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
@@ -233,7 +233,8 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
             .features = BitMask<ElectricalEnergyMeasurement::Feature, uint32_t>(
                 ElectricalEnergyMeasurement::Feature::kImportedEnergy, ElectricalEnergyMeasurement::Feature::kExportedEnergy,
                 ElectricalEnergyMeasurement::Feature::kCumulativeEnergy, ElectricalEnergyMeasurement::Feature::kPeriodicEnergy),
-            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet().Set<ElectricalEnergyMeasurement::Attributes::CumulativeEnergyReset::Id>(),
+            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet()
+                                      .Set<ElectricalEnergyMeasurement::Attributes::CumulativeEnergyReset::Id>(),
             .accuracyStruct = kMeasurementAccuracy,
         };
 

--- a/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
+++ b/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
@@ -23,13 +23,11 @@
 
 #include <DeviceEnergyManagementDelegateImpl.h>
 #include <DeviceEnergyManagementManager.h>
-#include <ElectricalPowerMeasurementDelegateImpl.h>
+#include <ElectricalSensorManager.h>
 #include <EnergyManagementAppCmdLineOptions.h>
-#include <PowerTopologyDelegateImpl.h>
 #include <WaterHeaterInstance.h>
 #include <WaterHeaterMain.h>
 #include <WaterHeaterManufacturer.h>
-#include <app/clusters/electrical-energy-measurement-server/electrical-energy-measurement-server.h>
 #include <device-energy-management-modes.h>
 #include <water-heater-mode.h>
 
@@ -46,7 +44,6 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::DeviceEnergyManagement;
 using namespace chip::app::Clusters::ElectricalPowerMeasurement;
 using namespace chip::app::Clusters::ElectricalEnergyMeasurement;
-using namespace chip::app::Clusters::PowerTopology;
 using namespace chip::app::Clusters::WaterHeaterManagement;
 
 namespace {
@@ -70,11 +67,7 @@ const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyStruct::Type kMea
 // Common cluster instances
 std::unique_ptr<DeviceEnergyManagementDelegate> gDEMDelegate;
 std::unique_ptr<DeviceEnergyManagementManager> gDEMInstance;
-std::unique_ptr<ElectricalPowerMeasurementDelegate> gEPMDelegate;
-std::unique_ptr<ElectricalPowerMeasurementInstance> gEPMInstance;
-std::unique_ptr<PowerTopologyDelegate> gPTDelegate;
-std::unique_ptr<PowerTopologyInstance> gPTInstance;
-std::unique_ptr<ElectricalEnergyMeasurementAttrAccess> gEEMAttrAccess;
+std::unique_ptr<ElectricalSensorManager> gESManager;
 bool gCommonClustersInitialized = false;
 
 // Water Heater specific instances
@@ -210,15 +203,17 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
     if (!gCommonClustersInitialized)
     {
         TEMPORARY_RETURN_IGNORED DeviceEnergyManagementInit(endpointId, gDEMDelegate, gDEMInstance, GetFeatureMapFromCmdLine());
-        // These features and optional attributes are used to make the app pass certification
-        // We recommend implementers of the app to modify these to fit their needs
-        TEMPORARY_RETURN_IGNORED ElectricalPowerMeasurementInit(
-            endpointId, gEPMDelegate, gEPMInstance,
-            BitMask<ElectricalPowerMeasurement::Feature, uint32_t>(
+
+        // Initialize ElectricalSensorManager (owns both EPM and EEM)
+        gESManager = std::make_unique<ElectricalSensorManager>();
+        VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        ElectricalSensorManager::EpmConfig epmConfig{
+            .features = BitMask<ElectricalPowerMeasurement::Feature, uint32_t>(
                 ElectricalPowerMeasurement::Feature::kDirectCurrent, ElectricalPowerMeasurement::Feature::kAlternatingCurrent,
                 ElectricalPowerMeasurement::Feature::kPolyphasePower, ElectricalPowerMeasurement::Feature::kHarmonics,
                 ElectricalPowerMeasurement::Feature::kPowerQuality),
-            BitMask<ElectricalPowerMeasurement::OptionalAttributes, uint32_t>(
+            .optionalAttributes = BitMask<ElectricalPowerMeasurement::OptionalAttributes, uint32_t>(
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeRanges,
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeVoltage,
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeActiveCurrent,
@@ -231,13 +226,37 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeRMSPower,
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeFrequency,
                 ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributePowerFactor,
-                ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeNeutralCurrent));
-        TEMPORARY_RETURN_IGNORED PowerTopologyInit(endpointId, gPTDelegate, gPTInstance);
+                ElectricalPowerMeasurement::OptionalAttributes::kOptionalAttributeNeutralCurrent),
+        };
+
+        ElectricalSensorManager::EemConfig eemConfig{
+            .features = BitMask<ElectricalEnergyMeasurement::Feature, uint32_t>(
+                ElectricalEnergyMeasurement::Feature::kImportedEnergy, ElectricalEnergyMeasurement::Feature::kExportedEnergy,
+                ElectricalEnergyMeasurement::Feature::kCumulativeEnergy, ElectricalEnergyMeasurement::Feature::kPeriodicEnergy),
+            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet().Set<ElectricalEnergyMeasurement::Attributes::CumulativeEnergyReset::Id>(),
+            .accuracyStruct = kMeasurementAccuracy,
+        };
+
+        ElectricalSensorManager::PtConfig ptConfig{
+            .features = BitMask<PowerTopology::Feature, uint32_t>(PowerTopology::Feature::kNodeTopology),
+        };
+
+        TEMPORARY_RETURN_IGNORED gESManager->Init(endpointId, epmConfig, eemConfig, ptConfig);
+
+        // Set CumulativeEnergyReset struct on the EEM cluster
+        ElectricalEnergyMeasurement::Structs::CumulativeEnergyResetStruct::Type resetStruct = {
+            .importedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
+            .exportedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
+            .importedResetSystime   = MakeOptional(MakeNullable(static_cast<uint64_t>(0))),
+            .exportedResetSystime   = MakeOptional(MakeNullable(static_cast<uint64_t>(0))),
+        };
+        if (auto * eemCluster = gESManager->GetEEMCluster())
+        {
+            TEMPORARY_RETURN_IGNORED eemCluster->SetCumulativeEnergyReset(MakeOptional(resetStruct));
+        }
     }
     VerifyOrReturnError(gDEMDelegate && gDEMInstance, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(gEPMDelegate && gEPMInstance, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(gPTDelegate && gPTInstance, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(gEEMAttrAccess, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
     gCommonClustersInitialized = true;
     return CHIP_NO_ERROR;
 }
@@ -250,35 +269,14 @@ DeviceEnergyManagement::DeviceEnergyManagementDelegate * GetDEMDelegate()
     return gDEMDelegate.get();
 }
 
+ElectricalSensorManager * GetESManager()
+{
+    return gESManager.get();
+}
+
 WaterHeaterManufacturer * WaterHeaterManagement::GetWaterHeaterManufacturer()
 {
     return gWaterHeaterManufacturer.get();
-}
-
-void emberAfElectricalEnergyMeasurementClusterInitCallback(chip::EndpointId endpointId)
-{
-    VerifyOrDie(!gEEMAttrAccess);
-
-    gEEMAttrAccess = std::make_unique<ElectricalEnergyMeasurementAttrAccess>(
-        BitMask<ElectricalEnergyMeasurement::Feature, uint32_t>(
-            ElectricalEnergyMeasurement::Feature::kImportedEnergy, ElectricalEnergyMeasurement::Feature::kExportedEnergy,
-            ElectricalEnergyMeasurement::Feature::kCumulativeEnergy, ElectricalEnergyMeasurement::Feature::kPeriodicEnergy),
-        BitMask<ElectricalEnergyMeasurement::OptionalAttributes, uint32_t>(
-            ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset));
-
-    ElectricalEnergyMeasurement::Structs::CumulativeEnergyResetStruct::Type resetStruct = {
-        .importedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
-        .exportedResetTimestamp = MakeOptional(MakeNullable(static_cast<uint32_t>(0))),
-        .importedResetSystime   = MakeOptional(MakeNullable(static_cast<uint64_t>(0))),
-        .exportedResetSystime   = MakeOptional(MakeNullable(static_cast<uint64_t>(0))),
-    };
-
-    if (gEEMAttrAccess)
-    {
-        TEMPORARY_RETURN_IGNORED gEEMAttrAccess->Init();
-        TEMPORARY_RETURN_IGNORED SetMeasurementAccuracy(endpointId, kMeasurementAccuracy);
-        TEMPORARY_RETURN_IGNORED SetCumulativeReset(endpointId, MakeOptional(resetStruct));
-    }
 }
 
 void WaterHeaterApplicationInit()
@@ -306,9 +304,12 @@ void WaterHeaterApplicationShutdown()
     ChipLogDetail(AppServer, "Water Heater App: WaterHeaterShutdown()");
 
     /* Shutdown in reverse order that they were created */
-    TEMPORARY_RETURN_IGNORED PowerTopologyShutdown(gPTInstance, gPTDelegate);                /* Free the PowerTopology */
-    TEMPORARY_RETURN_IGNORED ElectricalPowerMeasurementShutdown(gEPMInstance, gEPMDelegate); /* Free the Energy Meter */
-    DeviceEnergyManagementShutdown(gDEMInstance, gDEMDelegate);                              /* Free the DEM */
+    if (gESManager)
+    {
+        gESManager->Shutdown();
+        gESManager.reset();
+    }
+    DeviceEnergyManagementShutdown(gDEMInstance, gDEMDelegate);
 
     // Shutdown Water Heater specific clusters
     TEMPORARY_RETURN_IGNORED WaterHeaterManufacturerShutdown();

--- a/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
+++ b/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
@@ -202,11 +202,11 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
 {
     if (!gCommonClustersInitialized)
     {
-        TEMPORARY_RETURN_IGNORED DeviceEnergyManagementInit(endpointId, gDEMDelegate, gDEMInstance, GetFeatureMapFromCmdLine());
-
+        ReturnErrorOnFailure(DeviceEnergyManagementInit(endpointId, gDEMDelegate, gDEMInstance, GetFeatureMapFromCmdLine()));
+        
         // Initialize ElectricalSensorManager (owns both EPM and EEM)
         gESManager = std::make_unique<ElectricalSensorManager>();
-        VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_NO_MEMORY);
+        VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
         ElectricalSensorManager::EpmConfig epmConfig{
             .features = BitMask<ElectricalPowerMeasurement::Feature, uint32_t>(
@@ -242,7 +242,7 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
             .features = BitMask<PowerTopology::Feature, uint32_t>(PowerTopology::Feature::kNodeTopology),
         };
 
-        TEMPORARY_RETURN_IGNORED gESManager->Init(endpointId, epmConfig, eemConfig, ptConfig);
+        ReturnErrorOnFailure(gESManager->Init(endpointId, epmConfig, eemConfig, ptConfig));
 
         // Set CumulativeEnergyReset struct on the EEM cluster
         ElectricalEnergyMeasurement::Structs::CumulativeEnergyResetStruct::Type resetStruct = {
@@ -253,9 +253,12 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
         };
         if (auto * eemCluster = gESManager->GetEEMCluster())
         {
-            TEMPORARY_RETURN_IGNORED eemCluster->SetCumulativeEnergyReset(MakeOptional(resetStruct));
+            // We can ignore the error here as the only reason for error is if the feature is not supported
+            // and the feature is enabled
+            RETURN_SAFELY_IGNORED eemCluster->SetCumulativeEnergyReset(MakeOptional(resetStruct));
         }
     }
+
     VerifyOrReturnError(gDEMDelegate && gDEMInstance, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
     gCommonClustersInitialized = true;

--- a/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
+++ b/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
@@ -203,7 +203,7 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
     if (!gCommonClustersInitialized)
     {
         ReturnErrorOnFailure(DeviceEnergyManagementInit(endpointId, gDEMDelegate, gDEMInstance, GetFeatureMapFromCmdLine()));
-        
+
         // Initialize ElectricalSensorManager (owns both EPM and EEM)
         gESManager = std::make_unique<ElectricalSensorManager>();
         VerifyOrReturnError(gESManager != nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
+++ b/examples/water-heater-app/water-heater-common/src/WaterHeaterMain.cpp
@@ -255,7 +255,7 @@ CHIP_ERROR EnergyManagementCommonClustersInit(chip::EndpointId endpointId)
         {
             // We can ignore the error here as the only reason for error is if the feature is not supported
             // and the feature is enabled
-            RETURN_SAFELY_IGNORED eemCluster->SetCumulativeEnergyReset(MakeOptional(resetStruct));
+            RETURN_SAFELY_IGNORED eemCluster->SetCumulativeEnergyReset(MakeNullable(resetStruct));
         }
     }
 

--- a/src/app/clusters/electrical-energy-measurement-server/BUILD.gn
+++ b/src/app/clusters/electrical-energy-measurement-server/BUILD.gn
@@ -18,6 +18,7 @@ source_set("electrical-energy-measurement-server") {
   sources = [
     "ElectricalEnergyMeasurementCluster.cpp",
     "ElectricalEnergyMeasurementCluster.h",
+    "ElectricalEnergyMeasurementDelegate.h",
     "EnergyReportingTestEventTriggerHandler.h",
   ]
 

--- a/src/app/clusters/electrical-energy-measurement-server/BUILD.gn
+++ b/src/app/clusters/electrical-energy-measurement-server/BUILD.gn
@@ -23,6 +23,7 @@ source_set("electrical-energy-measurement-server") {
   ]
 
   public_deps = [
+    "${chip_root}/src/app/cluster-building-blocks",
     "${chip_root}/src/app/data-model-provider",
     "${chip_root}/src/app/server",
     "${chip_root}/src/app/server-cluster",

--- a/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2025 Project CHIP Authors
+ *    Copyright (c) 2026 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,12 +21,14 @@
 #include <protocols/interaction_model/StatusCode.h>
 
 #include <app/EventLogging.h>
+#include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h>
 #include <app/reporting/reporting.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <data-model-providers/codegen/CodegenProcessingConfig.h>
 #include <lib/support/CodeUtils.h>
+#include <platform/DefaultTimerDelegate.h>
 
 #include <lib/support/logging/CHIPLogging.h>
 #include <zap-generated/gen_config.h>
@@ -74,6 +76,20 @@ inline void UnregisterLegacyEEM(SingleLinkedListNode<ElectricalEnergyMeasurement
 
 // Default empty accuracy used at construction time; real values are set later via SetMeasurementAccuracy.
 const MeasurementAccuracyStruct::Type kDefaultAccuracy = {};
+
+// No-op delegate for legacy CodegenIntegration path (readings are pushed via snapshot methods)
+class NoOpEEMDelegate : public ElectricalEnergyMeasurement::Delegate
+{
+public:
+    DataModel::Nullable<int64_t> GetCumulativeEnergyImported() override { return DataModel::NullNullable; }
+    DataModel::Nullable<int64_t> GetCumulativeEnergyExported() override { return DataModel::NullNullable; }
+    DataModel::Nullable<int64_t> GetPeriodicEnergyImported() override { return DataModel::NullNullable; }
+    DataModel::Nullable<int64_t> GetPeriodicEnergyExported() override { return DataModel::NullNullable; }
+};
+
+NoOpEEMDelegate gNoOpDelegate;
+DefaultTimerDelegate gDefaultTimerDelegate;
+
 } // namespace
 
 namespace chip {
@@ -83,12 +99,17 @@ namespace ElectricalEnergyMeasurement {
 
 ElectricalEnergyMeasurementAttrAccess::ElectricalEnergyMeasurementAttrAccess(BitMask<Feature> aFeature,
                                                                              BitMask<OptionalAttributes> aOptionalAttrs,
-                                                                             EndpointId endpointId) :
+                                                                             EndpointId endpointId, Delegate & delegate,
+                                                                             TimerDelegate & timerDelegate) :
     mCluster(ElectricalEnergyMeasurementCluster::Config{
-        .endpointId         = endpointId,
-        .featureFlags       = aFeature,
-        .optionalAttributes = aOptionalAttrs,
-        .accuracyStruct     = kDefaultAccuracy,
+        .endpointId   = endpointId,
+        .featureFlags = aFeature,
+        .optionalAttributes =
+            ElectricalEnergyMeasurementCluster::OptionalAttributesSet().Set<Attributes::CumulativeEnergyReset::Id>(
+                aOptionalAttrs.Has(OptionalAttributes::kOptionalAttributeCumulativeEnergyReset)),
+        .accuracyStruct = kDefaultAccuracy,
+        .delegate       = delegate,
+        .timerDelegate  = timerDelegate,
     })
 {
     mClusterListNode.mValue = &mCluster.Cluster();

--- a/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.cpp
@@ -99,6 +99,12 @@ namespace ElectricalEnergyMeasurement {
 
 ElectricalEnergyMeasurementAttrAccess::ElectricalEnergyMeasurementAttrAccess(BitMask<Feature> aFeature,
                                                                              BitMask<OptionalAttributes> aOptionalAttrs,
+                                                                             EndpointId endpointId) :
+    ElectricalEnergyMeasurementAttrAccess(aFeature, aOptionalAttrs, endpointId, gNoOpDelegate, gDefaultTimerDelegate)
+{}
+
+ElectricalEnergyMeasurementAttrAccess::ElectricalEnergyMeasurementAttrAccess(BitMask<Feature> aFeature,
+                                                                             BitMask<OptionalAttributes> aOptionalAttrs,
                                                                              EndpointId endpointId, Delegate & delegate,
                                                                              TimerDelegate & timerDelegate) :
     mCluster(ElectricalEnergyMeasurementCluster::Config{

--- a/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.cpp
@@ -121,14 +121,6 @@ ElectricalEnergyMeasurementAttrAccess::ElectricalEnergyMeasurementAttrAccess(Bit
     mClusterListNode.mValue = &mCluster.Cluster();
 }
 
-const ElectricalEnergyMeasurement::MeasurementData * MeasurementDataForEndpoint(EndpointId endpointId)
-{
-    ElectricalEnergyMeasurementCluster * cluster = FindElectricalEnergyMeasurementClusterOnEndpoint(endpointId);
-    VerifyOrReturnValue(cluster != nullptr, nullptr);
-
-    return cluster->GetMeasurementData();
-}
-
 CHIP_ERROR SetMeasurementAccuracy(EndpointId endpointId, const MeasurementAccuracyStruct::Type & accuracy)
 {
     ElectricalEnergyMeasurementCluster * cluster = FindElectricalEnergyMeasurementClusterOnEndpoint(endpointId);
@@ -136,15 +128,17 @@ CHIP_ERROR SetMeasurementAccuracy(EndpointId endpointId, const MeasurementAccura
     return cluster->SetMeasurementAccuracy(accuracy);
 }
 
-CHIP_ERROR SetCumulativeReset(EndpointId endpointId, const Optional<CumulativeEnergyResetStruct::Type> & cumulativeReset)
+CHIP_ERROR SetCumulativeReset(EndpointId endpointId,
+                              const DataModel::Nullable<Structs::CumulativeEnergyResetStruct::Type> & cumulativeReset)
 {
     ElectricalEnergyMeasurementCluster * cluster = FindElectricalEnergyMeasurementClusterOnEndpoint(endpointId);
     VerifyOrReturnError(cluster != nullptr, CHIP_ERROR_NOT_FOUND);
     return cluster->SetCumulativeEnergyReset(cumulativeReset);
 }
 
-bool NotifyCumulativeEnergyMeasured(EndpointId endpointId, const Optional<EnergyMeasurementStruct::Type> & energyImported,
-                                    const Optional<EnergyMeasurementStruct::Type> & energyExported)
+bool NotifyCumulativeEnergyMeasured(EndpointId endpointId,
+                                    const DataModel::Nullable<EnergyMeasurementStruct::Type> & energyImported,
+                                    const DataModel::Nullable<EnergyMeasurementStruct::Type> & energyExported)
 {
     ElectricalEnergyMeasurementCluster * cluster = FindElectricalEnergyMeasurementClusterOnEndpoint(endpointId);
 
@@ -155,8 +149,8 @@ bool NotifyCumulativeEnergyMeasured(EndpointId endpointId, const Optional<Energy
     return true;
 }
 
-bool NotifyPeriodicEnergyMeasured(EndpointId endpointId, const Optional<EnergyMeasurementStruct::Type> & energyImported,
-                                  const Optional<EnergyMeasurementStruct::Type> & energyExported)
+bool NotifyPeriodicEnergyMeasured(EndpointId endpointId, const DataModel::Nullable<EnergyMeasurementStruct::Type> & energyImported,
+                                  const DataModel::Nullable<EnergyMeasurementStruct::Type> & energyExported)
 {
     ElectricalEnergyMeasurementCluster * cluster = FindElectricalEnergyMeasurementClusterOnEndpoint(endpointId);
 

--- a/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.h
+++ b/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2025 Project CHIP Authors
+ *    Copyright (c) 2026 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,10 @@
  */
 #pragma once
 #include "ElectricalEnergyMeasurementCluster.h"
+#include "ElectricalEnergyMeasurementDelegate.h"
 
 #include <lib/core/Optional.h>
+#include <lib/support/TimerDelegate.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/server-cluster/ServerClusterInterfaceRegistry.h>
@@ -31,11 +33,16 @@ namespace ElectricalEnergyMeasurement {
 
 constexpr EndpointId kDefaultEndpointId = 1;
 
+enum class OptionalAttributes : uint32_t
+{
+    kOptionalAttributeCumulativeEnergyReset = 0x1,
+};
+
 class ElectricalEnergyMeasurementAttrAccess
 {
 public:
     ElectricalEnergyMeasurementAttrAccess(BitMask<Feature> aFeature, BitMask<OptionalAttributes> aOptionalAttrs,
-                                          EndpointId endpointId = kDefaultEndpointId);
+                                          EndpointId endpointId, Delegate & delegate, TimerDelegate & timerDelegate);
 
     ~ElectricalEnergyMeasurementAttrAccess() {}
 

--- a/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.h
+++ b/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2026 Project CHIP Authors
+ *    Copyright (c) 2025-2026 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,10 @@
  *    limitations under the License.
  */
 #pragma once
-#include "ElectricalEnergyMeasurementCluster.h"
-#include "ElectricalEnergyMeasurementDelegate.h"
+#include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h>
+#include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h>
 
-#include <lib/core/Optional.h>
+#include <app/data-model/Nullable.h>
 #include <lib/support/TimerDelegate.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
@@ -60,17 +60,18 @@ private:
     RegisteredServerCluster<ElectricalEnergyMeasurementCluster> mCluster;
 };
 
-bool NotifyCumulativeEnergyMeasured(EndpointId endpointId, const Optional<Structs::EnergyMeasurementStruct::Type> & energyImported,
-                                    const Optional<Structs::EnergyMeasurementStruct::Type> & energyExported);
+bool NotifyCumulativeEnergyMeasured(EndpointId endpointId,
+                                    const DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> & energyImported,
+                                    const DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> & energyExported);
 
-bool NotifyPeriodicEnergyMeasured(EndpointId endpointId, const Optional<Structs::EnergyMeasurementStruct::Type> & energyImported,
-                                  const Optional<Structs::EnergyMeasurementStruct::Type> & energyExported);
+bool NotifyPeriodicEnergyMeasured(EndpointId endpointId,
+                                  const DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> & energyImported,
+                                  const DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> & energyExported);
 
 CHIP_ERROR SetMeasurementAccuracy(EndpointId endpointId, const Structs::MeasurementAccuracyStruct::Type & accuracy);
 
-CHIP_ERROR SetCumulativeReset(EndpointId endpointId, const Optional<Structs::CumulativeEnergyResetStruct::Type> & cumulativeReset);
-
-const ElectricalEnergyMeasurement::MeasurementData * MeasurementDataForEndpoint(EndpointId endpointId);
+CHIP_ERROR SetCumulativeReset(EndpointId endpointId,
+                              const DataModel::Nullable<Structs::CumulativeEnergyResetStruct::Type> & cumulativeReset);
 
 ElectricalEnergyMeasurementCluster * FindElectricalEnergyMeasurementClusterOnEndpoint(chip::EndpointId endpoint);
 

--- a/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.h
+++ b/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.h
@@ -42,6 +42,9 @@ class ElectricalEnergyMeasurementAttrAccess
 {
 public:
     ElectricalEnergyMeasurementAttrAccess(BitMask<Feature> aFeature, BitMask<OptionalAttributes> aOptionalAttrs,
+                                          EndpointId endpointId = kDefaultEndpointId);
+
+    ElectricalEnergyMeasurementAttrAccess(BitMask<Feature> aFeature, BitMask<OptionalAttributes> aOptionalAttrs,
                                           EndpointId endpointId, Delegate & delegate, TimerDelegate & timerDelegate);
 
     ~ElectricalEnergyMeasurementAttrAccess() {}

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -96,9 +96,8 @@ ElectricalEnergyMeasurementCluster::ElectricalEnergyMeasurementCluster(const Con
             config.featureFlags.HasAll(Feature::kPeriodicEnergy, Feature::kImportedEnergy));
         attrs.Set<Attributes::PeriodicEnergyExported::Id>(
             config.featureFlags.HasAll(Feature::kPeriodicEnergy, Feature::kExportedEnergy));
-        attrs.Set<Attributes::CumulativeEnergyReset::Id>(
-            config.optionalAttributes.IsSet(Attributes::CumulativeEnergyReset::Id) &&
-            config.featureFlags.Has(Feature::kCumulativeEnergy));
+        attrs.Set<Attributes::CumulativeEnergyReset::Id>(config.optionalAttributes.IsSet(Attributes::CumulativeEnergyReset::Id) &&
+                                                          config.featureFlags.Has(Feature::kCumulativeEnergy));
         return attrs;
     }()),
     mDelegate(config.delegate), mTimerDelegate(config.timerDelegate), mReportInterval(config.reportInterval)

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -97,7 +97,7 @@ ElectricalEnergyMeasurementCluster::ElectricalEnergyMeasurementCluster(const Con
         attrs.Set<Attributes::PeriodicEnergyExported::Id>(
             config.featureFlags.HasAll(Feature::kPeriodicEnergy, Feature::kExportedEnergy));
         attrs.Set<Attributes::CumulativeEnergyReset::Id>(config.optionalAttributes.IsSet(Attributes::CumulativeEnergyReset::Id) &&
-                                                          config.featureFlags.Has(Feature::kCumulativeEnergy));
+                                                         config.featureFlags.Has(Feature::kCumulativeEnergy));
         return attrs;
     }()),
     mDelegate(config.delegate), mTimerDelegate(config.timerDelegate), mReportInterval(config.reportInterval)

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2026 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,16 +30,17 @@
 #include <clusters/ElectricalEnergyMeasurement/Metadata.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <system/SystemClock.h>
 
 using chip::Protocols::InteractionModel::Status;
 
 namespace chip {
 namespace app {
 namespace Clusters {
+namespace ElectricalEnergyMeasurement {
 
-using namespace ElectricalEnergyMeasurement::Attributes;
-using namespace ElectricalEnergyMeasurement::Structs;
-using namespace ElectricalEnergyMeasurement;
+using namespace Attributes;
+using namespace Structs;
 
 namespace {
 
@@ -83,6 +84,181 @@ bool ValueChanged(const Optional<CumulativeEnergyResetStruct::Type> & previous,
 
 } // anonymous namespace
 
+ElectricalEnergyMeasurementCluster::ElectricalEnergyMeasurementCluster(const Config & config) :
+    DefaultServerCluster({ config.endpointId, ElectricalEnergyMeasurement::Id }), mFeatureFlags(config.featureFlags),
+    mEnabledOptionalAttributes([&]() {
+        OptionalAttributesSet attrs;
+        attrs.Set<Attributes::CumulativeEnergyImported::Id>(
+            config.featureFlags.HasAll(Feature::kCumulativeEnergy, Feature::kImportedEnergy));
+        attrs.Set<Attributes::CumulativeEnergyExported::Id>(
+            config.featureFlags.HasAll(Feature::kCumulativeEnergy, Feature::kExportedEnergy));
+        attrs.Set<Attributes::PeriodicEnergyImported::Id>(
+            config.featureFlags.HasAll(Feature::kPeriodicEnergy, Feature::kImportedEnergy));
+        attrs.Set<Attributes::PeriodicEnergyExported::Id>(
+            config.featureFlags.HasAll(Feature::kPeriodicEnergy, Feature::kExportedEnergy));
+        attrs.Set<Attributes::CumulativeEnergyReset::Id>(
+            config.optionalAttributes.IsSet(Attributes::CumulativeEnergyReset::Id) &&
+            config.featureFlags.Has(Feature::kCumulativeEnergy));
+        return attrs;
+    }()),
+    mDelegate(config.delegate), mTimerDelegate(config.timerDelegate), mReportInterval(config.reportInterval)
+{
+    mMeasurementData.measurementAccuracy.measurementType  = config.accuracyStruct.measurementType;
+    mMeasurementData.measurementAccuracy.measured         = config.accuracyStruct.measured;
+    mMeasurementData.measurementAccuracy.minMeasuredValue = config.accuracyStruct.minMeasuredValue;
+    mMeasurementData.measurementAccuracy.maxMeasuredValue = config.accuracyStruct.maxMeasuredValue;
+
+    using RangeType = MeasurementAccuracyRangeStruct::Type;
+    ReadOnlyBufferBuilder<RangeType> rangesBuilder;
+    VerifyOrDie(rangesBuilder.ReferenceExisting(config.accuracyStruct.accuracyRanges) == CHIP_NO_ERROR);
+    mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer();
+    mMeasurementData.measurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
+}
+
+CHIP_ERROR ElectricalEnergyMeasurementCluster::Startup(ServerClusterContext & context)
+{
+    ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
+    StartReportTimer();
+    return CHIP_NO_ERROR;
+}
+
+void ElectricalEnergyMeasurementCluster::Shutdown(ClusterShutdownType shutdownType)
+{
+    CancelReportTimer();
+    DefaultServerCluster::Shutdown(shutdownType);
+}
+
+void ElectricalEnergyMeasurementCluster::StartReportTimer()
+{
+    CancelReportTimer();
+    ReturnAndLogOnFailure(mTimerDelegate.StartTimer(&mReportTimer, mReportInterval), AppServer,
+                          "EEM: Failed to start report timer");
+}
+
+void ElectricalEnergyMeasurementCluster::CancelReportTimer()
+{
+    if (mTimerDelegate.IsTimerActive(&mReportTimer))
+    {
+        mTimerDelegate.CancelTimer(&mReportTimer);
+    }
+}
+
+void ElectricalEnergyMeasurementCluster::ReportTimer::TimerFired()
+{
+    mCluster.DoGenerateReport();
+    mCluster.StartReportTimer();
+}
+
+Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct>
+ElectricalEnergyMeasurementCluster::BuildMeasurement(DataModel::Nullable<int64_t> energy,
+                                                     const Optional<EnergyMeasurementStruct> & previous)
+{
+    if (energy.IsNull())
+    {
+        return Optional<EnergyMeasurementStruct>();
+    }
+
+    EnergyMeasurementStruct measurement;
+    measurement.energy = energy.Value();
+
+    // Carry forward previous endTimestamp/endSystime as new start
+    measurement.startTimestamp.ClearValue();
+    measurement.startSystime.ClearValue();
+    if (previous.HasValue())
+    {
+        measurement.startTimestamp = previous.Value().endTimestamp;
+        measurement.startSystime   = previous.Value().endSystime;
+    }
+
+    uint32_t epochTimestamp;
+    CHIP_ERROR err = System::Clock::GetClock_MatterEpochS(epochTimestamp);
+    if (err == CHIP_NO_ERROR)
+    {
+        measurement.endTimestamp.SetValue(epochTimestamp);
+    }
+    else
+    {
+        System::Clock::Milliseconds64 sysTimeMs = System::SystemClock().GetMonotonicMilliseconds64();
+        measurement.endSystime.SetValue(static_cast<uint64_t>(sysTimeMs.count()));
+    }
+
+    return MakeOptional(measurement);
+}
+
+void ElectricalEnergyMeasurementCluster::GenerateReport()
+{
+    // Enforce min 1s between reports
+    System::Clock::Timestamp now = mTimerDelegate.GetCurrentMonotonicTimestamp();
+    if (mLastReportTime != System::Clock::kZero && (now - mLastReportTime) < kMinReportInterval)
+    {
+        return;
+    }
+
+    DoGenerateReport();
+    StartReportTimer();
+}
+
+void ElectricalEnergyMeasurementCluster::DoGenerateReport()
+{
+    mLastReportTime = mTimerDelegate.GetCurrentMonotonicTimestamp();
+
+    // Generate cumulative energy report if feature is enabled
+    if (mFeatureFlags.Has(Feature::kCumulativeEnergy))
+    {
+        Events::CumulativeEnergyMeasured::Type event;
+        bool hasData = false;
+
+        if (mFeatureFlags.Has(Feature::kImportedEnergy))
+        {
+            auto measurement = BuildMeasurement(mDelegate.GetCumulativeEnergyImported(), mMeasurementData.cumulativeImported);
+            TEMPORARY_RETURN_IGNORED SetCumulativeEnergyImported(measurement);
+            event.energyImported = measurement;
+            hasData              = true;
+        }
+
+        if (mFeatureFlags.Has(Feature::kExportedEnergy))
+        {
+            auto measurement = BuildMeasurement(mDelegate.GetCumulativeEnergyExported(), mMeasurementData.cumulativeExported);
+            TEMPORARY_RETURN_IGNORED SetCumulativeEnergyExported(measurement);
+            event.energyExported = measurement;
+            hasData              = true;
+        }
+
+        if (hasData && mContext != nullptr)
+        {
+            mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
+        }
+    }
+
+    // Generate periodic energy report if feature is enabled
+    if (mFeatureFlags.Has(Feature::kPeriodicEnergy))
+    {
+        Events::PeriodicEnergyMeasured::Type event;
+        bool hasData = false;
+
+        if (mFeatureFlags.Has(Feature::kImportedEnergy))
+        {
+            auto measurement = BuildMeasurement(mDelegate.GetPeriodicEnergyImported(), mMeasurementData.periodicImported);
+            TEMPORARY_RETURN_IGNORED SetPeriodicEnergyImported(measurement);
+            event.energyImported = measurement;
+            hasData              = true;
+        }
+
+        if (mFeatureFlags.Has(Feature::kExportedEnergy))
+        {
+            auto measurement = BuildMeasurement(mDelegate.GetPeriodicEnergyExported(), mMeasurementData.periodicExported);
+            TEMPORARY_RETURN_IGNORED SetPeriodicEnergyExported(measurement);
+            event.energyExported = measurement;
+            hasData              = true;
+        }
+
+        if (hasData && mContext != nullptr)
+        {
+            mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
+        }
+    }
+}
+
 void ElectricalEnergyMeasurementCluster::GetMeasurementAccuracy(MeasurementAccuracyStruct & outValue) const
 {
     outValue = mMeasurementData.measurementAccuracy;
@@ -98,29 +274,6 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::GetCumulativeEnergyImported(Optio
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
     outValue = mMeasurementData.cumulativeImported;
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR ElectricalEnergyMeasurementCluster::SetMeasurementAccuracy(const MeasurementAccuracyStruct & value)
-{
-    if (ValueChanged(mMeasurementData.measurementAccuracy, value))
-    {
-        mMeasurementData.measurementAccuracy.measurementType  = value.measurementType;
-        mMeasurementData.measurementAccuracy.measured         = value.measured;
-        mMeasurementData.measurementAccuracy.minMeasuredValue = value.minMeasuredValue;
-        mMeasurementData.measurementAccuracy.maxMeasuredValue = value.maxMeasuredValue;
-        NotifyAttributeChanged(Accuracy::Id);
-    }
-
-    // Always update ranges if they are present since ValueChanged intentionally skips comparing them
-    if (!value.accuracyRanges.empty())
-    {
-        ReadOnlyBufferBuilder<MeasurementAccuracyRangeStruct::Type> rangesBuilder;
-        ReturnErrorOnFailure(rangesBuilder.AppendElements(value.accuracyRanges));
-        mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer();
-        mMeasurementData.measurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
-    }
-
     return CHIP_NO_ERROR;
 }
 
@@ -174,10 +327,32 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::GetCumulativeEnergyReset(Optional
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ElectricalEnergyMeasurementCluster::SetMeasurementAccuracy(const MeasurementAccuracyStruct & value)
+{
+    if (ValueChanged(mMeasurementData.measurementAccuracy, value))
+    {
+        mMeasurementData.measurementAccuracy.measurementType  = value.measurementType;
+        mMeasurementData.measurementAccuracy.measured         = value.measured;
+        mMeasurementData.measurementAccuracy.minMeasuredValue = value.minMeasuredValue;
+        mMeasurementData.measurementAccuracy.maxMeasuredValue = value.maxMeasuredValue;
+        NotifyAttributeChanged(Accuracy::Id);
+    }
+
+    // Always update ranges if they are present since ValueChanged intentionally skips comparing them
+    if (!value.accuracyRanges.empty())
+    {
+        ReadOnlyBufferBuilder<MeasurementAccuracyRangeStruct::Type> rangesBuilder;
+        ReturnErrorOnFailure(rangesBuilder.AppendElements(value.accuracyRanges));
+        mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer();
+        mMeasurementData.measurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyImported(const Optional<EnergyMeasurementStruct> & value)
 {
-    if (!mFeatureFlags.HasAll(ElectricalEnergyMeasurement::Feature::kCumulativeEnergy,
-                              ElectricalEnergyMeasurement::Feature::kImportedEnergy))
+    if (!mFeatureFlags.HasAll(Feature::kCumulativeEnergy, Feature::kImportedEnergy))
     {
         ChipLogError(
             Zcl, "Electrical Energy Measurement: CumulativeEnergyImported requires kCumulativeEnergy and kImportedEnergy features");
@@ -374,6 +549,7 @@ void ElectricalEnergyMeasurementCluster::PeriodicEnergySnapshot(const Optional<E
     mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
 }
 
+} // namespace ElectricalEnergyMeasurement
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -216,17 +216,23 @@ void ElectricalEnergyMeasurementCluster::DoGenerateReport()
         if (mFeatureFlags.Has(Feature::kImportedEnergy))
         {
             auto measurement = BuildMeasurement(mDelegate.GetCumulativeEnergyImported(), mMeasurementData.cumulativeImported);
-            TEMPORARY_RETURN_IGNORED SetCumulativeEnergyImported(measurement);
-            event.energyImported = measurement;
-            hasData              = hasData || measurement.HasValue();
+            if (measurement.HasValue())
+            {
+                TEMPORARY_RETURN_IGNORED SetCumulativeEnergyImported(measurement);
+                event.energyImported = measurement;
+                hasData              = true;
+            }
         }
 
         if (mFeatureFlags.Has(Feature::kExportedEnergy))
         {
             auto measurement = BuildMeasurement(mDelegate.GetCumulativeEnergyExported(), mMeasurementData.cumulativeExported);
-            TEMPORARY_RETURN_IGNORED SetCumulativeEnergyExported(measurement);
-            event.energyExported = measurement;
-            hasData              = hasData || measurement.HasValue();
+            if (measurement.HasValue())
+            {
+                TEMPORARY_RETURN_IGNORED SetCumulativeEnergyExported(measurement);
+                event.energyExported = measurement;
+                hasData              = true;
+            }
         }
 
         if (hasData && mContext != nullptr)
@@ -244,17 +250,23 @@ void ElectricalEnergyMeasurementCluster::DoGenerateReport()
         if (mFeatureFlags.Has(Feature::kImportedEnergy))
         {
             auto measurement = BuildMeasurement(mDelegate.GetPeriodicEnergyImported(), mMeasurementData.periodicImported);
-            TEMPORARY_RETURN_IGNORED SetPeriodicEnergyImported(measurement);
-            event.energyImported = measurement;
-            hasData              = hasData || measurement.HasValue();
+            if (measurement.HasValue())
+            {
+                TEMPORARY_RETURN_IGNORED SetPeriodicEnergyImported(measurement);
+                event.energyImported = measurement;
+                hasData              = true;
+            }
         }
 
         if (mFeatureFlags.Has(Feature::kExportedEnergy))
         {
             auto measurement = BuildMeasurement(mDelegate.GetPeriodicEnergyExported(), mMeasurementData.periodicExported);
-            TEMPORARY_RETURN_IGNORED SetPeriodicEnergyExported(measurement);
-            event.energyExported = measurement;
-            hasData              = hasData || measurement.HasValue();
+            if (measurement.HasValue())
+            {
+                TEMPORARY_RETURN_IGNORED SetPeriodicEnergyExported(measurement);
+                event.energyExported = measurement;
+                hasData              = true;
+            }
         }
 
         if (hasData && mContext != nullptr)

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -139,18 +139,6 @@ ElectricalEnergyMeasurementCluster::ElectricalEnergyMeasurementCluster(const Con
     mMeasurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::Startup(ServerClusterContext & context)
-{
-    ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
-
-    if (mFeatureFlags.HasAny(Feature::kCumulativeEnergy, Feature::kPeriodicEnergy))
-    {
-        StartReportDelayTimer();
-    }
-
-    return CHIP_NO_ERROR;
-}
-
 void ElectricalEnergyMeasurementCluster::Shutdown(ClusterShutdownType shutdownType)
 {
     CancelReportDelayTimer();
@@ -250,11 +238,6 @@ void ElectricalEnergyMeasurementCluster::GenerateSnapshots()
             exported = BuildMeasurement(mDelegate.GetPeriodicEnergyExported(), mPeriodicExported, false);
         }
         PeriodicEnergySnapshot(imported, exported);
-    }
-
-    if (mFeatureFlags.HasAny(Feature::kCumulativeEnergy, Feature::kPeriodicEnergy))
-    {
-        StartReportDelayTimer();
     }
 }
 

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -112,7 +112,6 @@ ElectricalEnergyMeasurementCluster::ElectricalEnergyMeasurementCluster(const Con
         mReportInterval = kMaxReportInterval;
     }
 
-
     mMeasurementData.measurementAccuracy.measurementType  = config.accuracyStruct.measurementType;
     mMeasurementData.measurementAccuracy.measured         = config.accuracyStruct.measured;
     mMeasurementData.measurementAccuracy.minMeasuredValue = config.accuracyStruct.minMeasuredValue;
@@ -219,7 +218,7 @@ void ElectricalEnergyMeasurementCluster::DoGenerateReport()
             auto measurement = BuildMeasurement(mDelegate.GetCumulativeEnergyImported(), mMeasurementData.cumulativeImported);
             TEMPORARY_RETURN_IGNORED SetCumulativeEnergyImported(measurement);
             event.energyImported = measurement;
-            hasData = hasData || measurement.HasValue();
+            hasData              = hasData || measurement.HasValue();
         }
 
         if (mFeatureFlags.Has(Feature::kExportedEnergy))
@@ -227,7 +226,7 @@ void ElectricalEnergyMeasurementCluster::DoGenerateReport()
             auto measurement = BuildMeasurement(mDelegate.GetCumulativeEnergyExported(), mMeasurementData.cumulativeExported);
             TEMPORARY_RETURN_IGNORED SetCumulativeEnergyExported(measurement);
             event.energyExported = measurement;
-            hasData = hasData || measurement.HasValue();
+            hasData              = hasData || measurement.HasValue();
         }
 
         if (hasData && mContext != nullptr)
@@ -247,7 +246,7 @@ void ElectricalEnergyMeasurementCluster::DoGenerateReport()
             auto measurement = BuildMeasurement(mDelegate.GetPeriodicEnergyImported(), mMeasurementData.periodicImported);
             TEMPORARY_RETURN_IGNORED SetPeriodicEnergyImported(measurement);
             event.energyImported = measurement;
-            hasData = hasData || measurement.HasValue();
+            hasData              = hasData || measurement.HasValue();
         }
 
         if (mFeatureFlags.Has(Feature::kExportedEnergy))

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -102,6 +102,17 @@ ElectricalEnergyMeasurementCluster::ElectricalEnergyMeasurementCluster(const Con
     }()),
     mDelegate(config.delegate), mTimerDelegate(config.timerDelegate), mReportInterval(config.reportInterval)
 {
+    // The report interval must be between kMinReportInterval and kMaxReportInterval, we cap it here.
+    if (mReportInterval < kMinReportInterval)
+    {
+        mReportInterval = kMinReportInterval;
+    }
+    else if (mReportInterval > kMaxReportInterval)
+    {
+        mReportInterval = kMaxReportInterval;
+    }
+
+
     mMeasurementData.measurementAccuracy.measurementType  = config.accuracyStruct.measurementType;
     mMeasurementData.measurementAccuracy.measured         = config.accuracyStruct.measured;
     mMeasurementData.measurementAccuracy.minMeasuredValue = config.accuracyStruct.minMeasuredValue;
@@ -117,7 +128,12 @@ ElectricalEnergyMeasurementCluster::ElectricalEnergyMeasurementCluster(const Con
 CHIP_ERROR ElectricalEnergyMeasurementCluster::Startup(ServerClusterContext & context)
 {
     ReturnErrorOnFailure(DefaultServerCluster::Startup(context));
-    StartReportTimer();
+
+    if (mFeatureFlags.HasAny(Feature::kCumulativeEnergy, Feature::kPeriodicEnergy))
+    {
+        StartReportTimer();
+    }
+
     return CHIP_NO_ERROR;
 }
 
@@ -212,7 +228,7 @@ void ElectricalEnergyMeasurementCluster::DoGenerateReport()
             auto measurement = BuildMeasurement(mDelegate.GetCumulativeEnergyImported(), mMeasurementData.cumulativeImported);
             TEMPORARY_RETURN_IGNORED SetCumulativeEnergyImported(measurement);
             event.energyImported = measurement;
-            hasData              = true;
+            hasData = hasData || measurement.HasValue();
         }
 
         if (mFeatureFlags.Has(Feature::kExportedEnergy))
@@ -220,7 +236,7 @@ void ElectricalEnergyMeasurementCluster::DoGenerateReport()
             auto measurement = BuildMeasurement(mDelegate.GetCumulativeEnergyExported(), mMeasurementData.cumulativeExported);
             TEMPORARY_RETURN_IGNORED SetCumulativeEnergyExported(measurement);
             event.energyExported = measurement;
-            hasData              = true;
+            hasData = hasData || measurement.HasValue();
         }
 
         if (hasData && mContext != nullptr)
@@ -240,7 +256,7 @@ void ElectricalEnergyMeasurementCluster::DoGenerateReport()
             auto measurement = BuildMeasurement(mDelegate.GetPeriodicEnergyImported(), mMeasurementData.periodicImported);
             TEMPORARY_RETURN_IGNORED SetPeriodicEnergyImported(measurement);
             event.energyImported = measurement;
-            hasData              = true;
+            hasData = hasData || measurement.HasValue();
         }
 
         if (mFeatureFlags.Has(Feature::kExportedEnergy))
@@ -248,7 +264,7 @@ void ElectricalEnergyMeasurementCluster::DoGenerateReport()
             auto measurement = BuildMeasurement(mDelegate.GetPeriodicEnergyExported(), mMeasurementData.periodicExported);
             TEMPORARY_RETURN_IGNORED SetPeriodicEnergyExported(measurement);
             event.energyExported = measurement;
-            hasData              = true;
+            hasData              = hasData || measurement.HasValue();
         }
 
         if (hasData && mContext != nullptr)

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -185,17 +185,8 @@ ElectricalEnergyMeasurementCluster::BuildMeasurement(DataModel::Nullable<int64_t
         measurement.startSystime   = previous.Value().endSystime;
     }
 
-    uint32_t epochTimestamp;
-    CHIP_ERROR err = System::Clock::GetClock_MatterEpochS(epochTimestamp);
-    if (err == CHIP_NO_ERROR)
-    {
-        measurement.endTimestamp.SetValue(epochTimestamp);
-    }
-    else
-    {
-        System::Clock::Milliseconds64 sysTimeMs = System::SystemClock().GetMonotonicMilliseconds64();
-        measurement.endSystime.SetValue(static_cast<uint64_t>(sysTimeMs.count()));
-    }
+    System::Clock::Milliseconds64 sysTimeMs = mTimerDelegate.GetCurrentMonotonicTimestamp();
+    measurement.endSystime.SetValue(static_cast<uint64_t>(sysTimeMs.count()));
 
     return MakeOptional(measurement);
 }
@@ -367,13 +358,6 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetMeasurementAccuracy(const Meas
 
 CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyImported(const Optional<EnergyMeasurementStruct> & value)
 {
-    if (!mFeatureFlags.HasAll(Feature::kCumulativeEnergy, Feature::kImportedEnergy))
-    {
-        ChipLogError(
-            Zcl, "Electrical Energy Measurement: CumulativeEnergyImported requires kCumulativeEnergy and kImportedEnergy features");
-        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-    }
-
     if (ValueChanged(mMeasurementData.cumulativeImported, value))
     {
         mMeasurementData.cumulativeImported = value;
@@ -384,14 +368,6 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyImported(const
 
 CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyExported(const Optional<EnergyMeasurementStruct> & value)
 {
-    if (!mFeatureFlags.HasAll(ElectricalEnergyMeasurement::Feature::kCumulativeEnergy,
-                              ElectricalEnergyMeasurement::Feature::kExportedEnergy))
-    {
-        ChipLogError(
-            Zcl, "Electrical Energy Measurement: CumulativeEnergyExported requires kCumulativeEnergy and kExportedEnergy features");
-        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-    }
-
     if (ValueChanged(mMeasurementData.cumulativeExported, value))
     {
         mMeasurementData.cumulativeExported = value;

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -59,27 +59,52 @@ bool ValueChanged(const EnergyMeasurementStruct::Type & previous, const EnergyMe
         (previous.reactiveEnergy != newValue.reactiveEnergy);
 }
 
-bool ValueChanged(const Optional<EnergyMeasurementStruct::Type> & previous,
-                  const Optional<EnergyMeasurementStruct::Type> & newValue)
+bool ValueChanged(const DataModel::Nullable<EnergyMeasurementStruct::Type> & previous,
+                  const DataModel::Nullable<EnergyMeasurementStruct::Type> & newValue)
 {
-    if (previous.HasValue() != newValue.HasValue())
+    if (previous.IsNull() != newValue.IsNull())
         return true;
-    if (!previous.HasValue())
+    if (previous.IsNull())
         return false;
     return ValueChanged(previous.Value(), newValue.Value());
 }
 
-bool ValueChanged(const Optional<CumulativeEnergyResetStruct::Type> & previous,
-                  const Optional<CumulativeEnergyResetStruct::Type> & newValue)
+bool ValueChanged(const DataModel::Nullable<CumulativeEnergyResetStruct::Type> & previous,
+                  const DataModel::Nullable<CumulativeEnergyResetStruct::Type> & newValue)
 {
-    if (previous.HasValue() != newValue.HasValue())
+    if (previous.IsNull() != newValue.IsNull())
         return true;
-    if (!previous.HasValue())
+    if (previous.IsNull())
         return false;
     return (previous.Value().importedResetTimestamp != newValue.Value().importedResetTimestamp) ||
         (previous.Value().exportedResetTimestamp != newValue.Value().exportedResetTimestamp) ||
         (previous.Value().importedResetSystime != newValue.Value().importedResetSystime) ||
         (previous.Value().exportedResetSystime != newValue.Value().exportedResetSystime);
+}
+
+/** Rate-limit subscription reporting per attribute: notify when endSystime advanced by at least kMinReportInterval
+ *  (monotonic ms), or when null / missing timestamps / non-monotonic endSystime. */
+bool ShouldNotifyEnergyMeasurementAttribute(const DataModel::Nullable<EnergyMeasurementStruct::Type> & previous,
+                                            const DataModel::Nullable<EnergyMeasurementStruct::Type> & newValue)
+{
+    if (newValue.IsNull())
+    {
+        return true;
+    }
+    if (previous.IsNull() || !previous.Value().endSystime.HasValue())
+    {
+        return true;
+    }
+    if (!newValue.Value().endSystime.HasValue())
+    {
+        return true;
+    }
+
+    const uint64_t minIntervalMs = static_cast<uint64_t>(
+        std::chrono::duration_cast<System::Clock::Milliseconds64>(ElectricalEnergyMeasurementCluster::kMinReportInterval).count());
+    const uint64_t prevEnd = previous.Value().endSystime.Value();
+    const uint64_t newEnd  = newValue.Value().endSystime.Value();
+    return (newEnd < prevEnd) || (newEnd - prevEnd >= minIntervalMs);
 }
 
 } // anonymous namespace
@@ -112,16 +137,16 @@ ElectricalEnergyMeasurementCluster::ElectricalEnergyMeasurementCluster(const Con
         mReportInterval = kMaxReportInterval;
     }
 
-    mMeasurementData.measurementAccuracy.measurementType  = config.accuracyStruct.measurementType;
-    mMeasurementData.measurementAccuracy.measured         = config.accuracyStruct.measured;
-    mMeasurementData.measurementAccuracy.minMeasuredValue = config.accuracyStruct.minMeasuredValue;
-    mMeasurementData.measurementAccuracy.maxMeasuredValue = config.accuracyStruct.maxMeasuredValue;
+    mMeasurementAccuracy.measurementType  = config.accuracyStruct.measurementType;
+    mMeasurementAccuracy.measured         = config.accuracyStruct.measured;
+    mMeasurementAccuracy.minMeasuredValue = config.accuracyStruct.minMeasuredValue;
+    mMeasurementAccuracy.maxMeasuredValue = config.accuracyStruct.maxMeasuredValue;
 
     using RangeType = MeasurementAccuracyRangeStruct::Type;
     ReadOnlyBufferBuilder<RangeType> rangesBuilder;
     VerifyOrDie(rangesBuilder.ReferenceExisting(config.accuracyStruct.accuracyRanges) == CHIP_NO_ERROR);
-    mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer();
-    mMeasurementData.measurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
+    mAccuracyRangesStorage              = rangesBuilder.TakeBuffer();
+    mMeasurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
 }
 
 CHIP_ERROR ElectricalEnergyMeasurementCluster::Startup(ServerClusterContext & context)
@@ -130,7 +155,7 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::Startup(ServerClusterContext & co
 
     if (mFeatureFlags.HasAny(Feature::kCumulativeEnergy, Feature::kPeriodicEnergy))
     {
-        StartReportTimer();
+        StartSnapshotTimer();
     }
 
     return CHIP_NO_ERROR;
@@ -138,150 +163,125 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::Startup(ServerClusterContext & co
 
 void ElectricalEnergyMeasurementCluster::Shutdown(ClusterShutdownType shutdownType)
 {
-    CancelReportTimer();
+    CancelSnapshotTimer();
     DefaultServerCluster::Shutdown(shutdownType);
 }
 
-void ElectricalEnergyMeasurementCluster::StartReportTimer()
+void ElectricalEnergyMeasurementCluster::StartSnapshotTimer()
 {
-    CancelReportTimer();
-    ReturnAndLogOnFailure(mTimerDelegate.StartTimer(&mReportTimer, mReportInterval), AppServer,
+    CancelSnapshotTimer();
+    ReturnAndLogOnFailure(mTimerDelegate.StartTimer(&mSnapshotTimer, mReportInterval), AppServer,
                           "EEM: Failed to start report timer");
 }
 
-void ElectricalEnergyMeasurementCluster::CancelReportTimer()
+void ElectricalEnergyMeasurementCluster::CancelSnapshotTimer()
 {
-    if (mTimerDelegate.IsTimerActive(&mReportTimer))
+    if (mTimerDelegate.IsTimerActive(&mSnapshotTimer))
     {
-        mTimerDelegate.CancelTimer(&mReportTimer);
+        mTimerDelegate.CancelTimer(&mSnapshotTimer);
     }
 }
 
-void ElectricalEnergyMeasurementCluster::ReportTimer::TimerFired()
+void ElectricalEnergyMeasurementCluster::SnapshotTimer::TimerFired()
 {
-    mCluster.DoGenerateReport();
-    mCluster.StartReportTimer();
+    mCluster.DoGenerateSnapshots();
+    mCluster.mLastReportTime = mCluster.mTimerDelegate.GetCurrentMonotonicTimestamp();
+    mCluster.StartSnapshotTimer();
 }
 
-Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct>
+DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct>
 ElectricalEnergyMeasurementCluster::BuildMeasurement(DataModel::Nullable<int64_t> energy,
-                                                     const Optional<EnergyMeasurementStruct> & previous)
+                                                     const DataModel::Nullable<EnergyMeasurementStruct> & previous,
+                                                     bool isCumulative)
 {
     if (energy.IsNull())
     {
-        return Optional<EnergyMeasurementStruct>();
+        return DataModel::NullNullable;
     }
 
     EnergyMeasurementStruct measurement;
     measurement.energy = energy.Value();
 
-    // Carry forward previous endTimestamp/endSystime as new start
-    measurement.startTimestamp.ClearValue();
-    measurement.startSystime.ClearValue();
-    if (previous.HasValue())
+    if (!isCumulative)
     {
-        measurement.startTimestamp = previous.Value().endTimestamp;
-        measurement.startSystime   = previous.Value().endSystime;
+        if (!previous.IsNull())
+        {
+            measurement.startTimestamp = previous.Value().endTimestamp;
+            measurement.startSystime   = previous.Value().endSystime;
+        }
     }
 
-    System::Clock::Milliseconds64 sysTimeMs = mTimerDelegate.GetCurrentMonotonicTimestamp();
-    measurement.endSystime.SetValue(static_cast<uint64_t>(sysTimeMs.count()));
+    // Get current timestamp
+    uint32_t currentTimestamp;
+    CHIP_ERROR err = System::Clock::GetClock_MatterEpochS(currentTimestamp);
+    if (err == CHIP_NO_ERROR)
+    {
+        measurement.endTimestamp.SetValue(currentTimestamp);
+    }
+    else
+    {
+        System::Clock::Milliseconds64 sysTimeMs = mTimerDelegate.GetCurrentMonotonicTimestamp();
+        measurement.endSystime.SetValue(static_cast<uint64_t>(sysTimeMs.count()));
+    }
 
-    return MakeOptional(measurement);
+    return DataModel::MakeNullable(measurement);
 }
 
-void ElectricalEnergyMeasurementCluster::GenerateReport()
+void ElectricalEnergyMeasurementCluster::GenerateSnapshots()
 {
-    // Enforce min 1s between reports
+    // Enforce min 1s between events
     System::Clock::Timestamp now = mTimerDelegate.GetCurrentMonotonicTimestamp();
     if (mLastReportTime != System::Clock::kZero && (now - mLastReportTime) < kMinReportInterval)
     {
         return;
     }
 
-    DoGenerateReport();
-    StartReportTimer();
+    DoGenerateSnapshots();
+    StartSnapshotTimer();
 }
 
-void ElectricalEnergyMeasurementCluster::DoGenerateReport()
+void ElectricalEnergyMeasurementCluster::DoGenerateSnapshots()
 {
-    mLastReportTime = mTimerDelegate.GetCurrentMonotonicTimestamp();
-
-    // Generate cumulative energy report if feature is enabled
     if (mFeatureFlags.Has(Feature::kCumulativeEnergy))
     {
-        Events::CumulativeEnergyMeasured::Type event;
-        bool hasData = false;
+        Nullable<EnergyMeasurementStruct> imported = DataModel::NullNullable;
+        Nullable<EnergyMeasurementStruct> exported = DataModel::NullNullable;
 
         if (mFeatureFlags.Has(Feature::kImportedEnergy))
         {
-            auto measurement = BuildMeasurement(mDelegate.GetCumulativeEnergyImported(), mMeasurementData.cumulativeImported);
-            if (measurement.HasValue())
-            {
-                TEMPORARY_RETURN_IGNORED SetCumulativeEnergyImported(measurement);
-                event.energyImported = measurement;
-                hasData              = true;
-            }
+            imported = BuildMeasurement(mDelegate.GetCumulativeEnergyImported(), mCumulativeImported, true);
         }
-
         if (mFeatureFlags.Has(Feature::kExportedEnergy))
         {
-            auto measurement = BuildMeasurement(mDelegate.GetCumulativeEnergyExported(), mMeasurementData.cumulativeExported);
-            if (measurement.HasValue())
-            {
-                TEMPORARY_RETURN_IGNORED SetCumulativeEnergyExported(measurement);
-                event.energyExported = measurement;
-                hasData              = true;
-            }
+            exported = BuildMeasurement(mDelegate.GetCumulativeEnergyExported(), mCumulativeExported, true);
         }
-
-        if (hasData && mContext != nullptr)
-        {
-            mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
-        }
+        CumulativeEnergySnapshot(imported, exported);
     }
 
-    // Generate periodic energy report if feature is enabled
     if (mFeatureFlags.Has(Feature::kPeriodicEnergy))
     {
-        Events::PeriodicEnergyMeasured::Type event;
-        bool hasData = false;
+        Nullable<EnergyMeasurementStruct> imported = DataModel::NullNullable;
+        Nullable<EnergyMeasurementStruct> exported = DataModel::NullNullable;
 
         if (mFeatureFlags.Has(Feature::kImportedEnergy))
         {
-            auto measurement = BuildMeasurement(mDelegate.GetPeriodicEnergyImported(), mMeasurementData.periodicImported);
-            if (measurement.HasValue())
-            {
-                TEMPORARY_RETURN_IGNORED SetPeriodicEnergyImported(measurement);
-                event.energyImported = measurement;
-                hasData              = true;
-            }
+            imported = BuildMeasurement(mDelegate.GetPeriodicEnergyImported(), mPeriodicImported, false);
         }
-
         if (mFeatureFlags.Has(Feature::kExportedEnergy))
         {
-            auto measurement = BuildMeasurement(mDelegate.GetPeriodicEnergyExported(), mMeasurementData.periodicExported);
-            if (measurement.HasValue())
-            {
-                TEMPORARY_RETURN_IGNORED SetPeriodicEnergyExported(measurement);
-                event.energyExported = measurement;
-                hasData              = true;
-            }
+            exported = BuildMeasurement(mDelegate.GetPeriodicEnergyExported(), mPeriodicExported, false);
         }
-
-        if (hasData && mContext != nullptr)
-        {
-            mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
-        }
+        PeriodicEnergySnapshot(imported, exported);
     }
 }
 
 void ElectricalEnergyMeasurementCluster::GetMeasurementAccuracy(MeasurementAccuracyStruct & outValue) const
 {
-    outValue = mMeasurementData.measurementAccuracy;
+    outValue = mMeasurementAccuracy;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::GetCumulativeEnergyImported(Optional<EnergyMeasurementStruct> & outValue) const
+CHIP_ERROR
+ElectricalEnergyMeasurementCluster::GetCumulativeEnergyImported(DataModel::Nullable<EnergyMeasurementStruct> & outValue) const
 {
     if (!mFeatureFlags.HasAll(ElectricalEnergyMeasurement::Feature::kCumulativeEnergy,
                               ElectricalEnergyMeasurement::Feature::kImportedEnergy))
@@ -290,11 +290,12 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::GetCumulativeEnergyImported(Optio
             Zcl, "Electrical Energy Measurement: CumulativeEnergyImported requires kCumulativeEnergy and kImportedEnergy features");
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    outValue = mMeasurementData.cumulativeImported;
+    outValue = mCumulativeImported;
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::GetCumulativeEnergyExported(Optional<EnergyMeasurementStruct> & outValue) const
+CHIP_ERROR
+ElectricalEnergyMeasurementCluster::GetCumulativeEnergyExported(Nullable<EnergyMeasurementStruct> & outValue) const
 {
     if (!mFeatureFlags.HasAll(ElectricalEnergyMeasurement::Feature::kCumulativeEnergy,
                               ElectricalEnergyMeasurement::Feature::kExportedEnergy))
@@ -303,11 +304,11 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::GetCumulativeEnergyExported(Optio
             Zcl, "Electrical Energy Measurement: CumulativeEnergyExported requires kCumulativeEnergy and kExportedEnergy features");
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    outValue = mMeasurementData.cumulativeExported;
+    outValue = mCumulativeExported;
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::GetPeriodicEnergyImported(Optional<EnergyMeasurementStruct> & outValue) const
+CHIP_ERROR ElectricalEnergyMeasurementCluster::GetPeriodicEnergyImported(Nullable<EnergyMeasurementStruct> & outValue) const
 {
     if (!mFeatureFlags.HasAll(ElectricalEnergyMeasurement::Feature::kPeriodicEnergy,
                               ElectricalEnergyMeasurement::Feature::kImportedEnergy))
@@ -316,11 +317,11 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::GetPeriodicEnergyImported(Optiona
                      "Electrical Energy Measurement: PeriodicEnergyImported requires kPeriodicEnergy and kImportedEnergy features");
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    outValue = mMeasurementData.periodicImported;
+    outValue = mPeriodicImported;
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::GetPeriodicEnergyExported(Optional<EnergyMeasurementStruct> & outValue) const
+CHIP_ERROR ElectricalEnergyMeasurementCluster::GetPeriodicEnergyExported(Nullable<EnergyMeasurementStruct> & outValue) const
 {
     if (!mFeatureFlags.HasAll(ElectricalEnergyMeasurement::Feature::kPeriodicEnergy,
                               ElectricalEnergyMeasurement::Feature::kExportedEnergy))
@@ -329,29 +330,29 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::GetPeriodicEnergyExported(Optiona
                      "Electrical Energy Measurement: PeriodicEnergyExported requires kPeriodicEnergy and kExportedEnergy features");
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    outValue = mMeasurementData.periodicExported;
+    outValue = mPeriodicExported;
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::GetCumulativeEnergyReset(Optional<CumulativeEnergyResetStruct> & outValue) const
+CHIP_ERROR ElectricalEnergyMeasurementCluster::GetCumulativeEnergyReset(Nullable<CumulativeEnergyResetStruct> & outValue) const
 {
     if (!mEnabledOptionalAttributes.IsSet(CumulativeEnergyReset::Id))
     {
         ChipLogError(Zcl, "Electrical Energy Measurement: CumulativeEnergyReset requires kCumulativeEnergy feature");
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    outValue = mMeasurementData.cumulativeReset;
+    outValue = mCumulativeReset;
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ElectricalEnergyMeasurementCluster::SetMeasurementAccuracy(const MeasurementAccuracyStruct & value)
 {
-    if (ValueChanged(mMeasurementData.measurementAccuracy, value))
+    if (ValueChanged(mMeasurementAccuracy, value))
     {
-        mMeasurementData.measurementAccuracy.measurementType  = value.measurementType;
-        mMeasurementData.measurementAccuracy.measured         = value.measured;
-        mMeasurementData.measurementAccuracy.minMeasuredValue = value.minMeasuredValue;
-        mMeasurementData.measurementAccuracy.maxMeasuredValue = value.maxMeasuredValue;
+        mMeasurementAccuracy.measurementType  = value.measurementType;
+        mMeasurementAccuracy.measured         = value.measured;
+        mMeasurementAccuracy.minMeasuredValue = value.minMeasuredValue;
+        mMeasurementAccuracy.maxMeasuredValue = value.maxMeasuredValue;
         NotifyAttributeChanged(Accuracy::Id);
     }
 
@@ -360,34 +361,42 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetMeasurementAccuracy(const Meas
     {
         ReadOnlyBufferBuilder<MeasurementAccuracyRangeStruct::Type> rangesBuilder;
         ReturnErrorOnFailure(rangesBuilder.AppendElements(value.accuracyRanges));
-        mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer();
-        mMeasurementData.measurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
+        mAccuracyRangesStorage              = rangesBuilder.TakeBuffer();
+        mMeasurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
     }
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyImported(const Optional<EnergyMeasurementStruct> & value)
+CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyImported(const Nullable<EnergyMeasurementStruct> & value)
 {
-    if (ValueChanged(mMeasurementData.cumulativeImported, value))
+    if (ValueChanged(mCumulativeImported, value))
     {
-        mMeasurementData.cumulativeImported = value;
-        NotifyAttributeChanged(CumulativeEnergyImported::Id);
+        const bool notify   = ShouldNotifyEnergyMeasurementAttribute(mCumulativeImported, value);
+        mCumulativeImported = value;
+        if (notify)
+        {
+            NotifyAttributeChanged(CumulativeEnergyImported::Id);
+        }
     }
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyExported(const Optional<EnergyMeasurementStruct> & value)
+CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyExported(const Nullable<EnergyMeasurementStruct> & value)
 {
-    if (ValueChanged(mMeasurementData.cumulativeExported, value))
+    if (ValueChanged(mCumulativeExported, value))
     {
-        mMeasurementData.cumulativeExported = value;
-        NotifyAttributeChanged(CumulativeEnergyExported::Id);
+        const bool notify   = ShouldNotifyEnergyMeasurementAttribute(mCumulativeExported, value);
+        mCumulativeExported = value;
+        if (notify)
+        {
+            NotifyAttributeChanged(CumulativeEnergyExported::Id);
+        }
     }
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::SetPeriodicEnergyImported(const Optional<EnergyMeasurementStruct> & value)
+CHIP_ERROR ElectricalEnergyMeasurementCluster::SetPeriodicEnergyImported(const Nullable<EnergyMeasurementStruct> & value)
 {
     if (!mFeatureFlags.HasAll(ElectricalEnergyMeasurement::Feature::kPeriodicEnergy,
                               ElectricalEnergyMeasurement::Feature::kImportedEnergy))
@@ -396,15 +405,19 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetPeriodicEnergyImported(const O
                      "Electrical Energy Measurement: PeriodicEnergyImported requires kPeriodicEnergy and kImportedEnergy features");
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    if (ValueChanged(mMeasurementData.periodicImported, value))
+    if (ValueChanged(mPeriodicImported, value))
     {
-        mMeasurementData.periodicImported = value;
-        NotifyAttributeChanged(PeriodicEnergyImported::Id);
+        const bool notify = ShouldNotifyEnergyMeasurementAttribute(mPeriodicImported, value);
+        mPeriodicImported = value;
+        if (notify)
+        {
+            NotifyAttributeChanged(PeriodicEnergyImported::Id);
+        }
     }
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::SetPeriodicEnergyExported(const Optional<EnergyMeasurementStruct> & value)
+CHIP_ERROR ElectricalEnergyMeasurementCluster::SetPeriodicEnergyExported(const Nullable<EnergyMeasurementStruct> & value)
 {
     if (!mFeatureFlags.HasAll(ElectricalEnergyMeasurement::Feature::kPeriodicEnergy,
                               ElectricalEnergyMeasurement::Feature::kExportedEnergy))
@@ -414,24 +427,28 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetPeriodicEnergyExported(const O
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
 
-    if (ValueChanged(mMeasurementData.periodicExported, value))
+    if (ValueChanged(mPeriodicExported, value))
     {
-        mMeasurementData.periodicExported = value;
-        NotifyAttributeChanged(PeriodicEnergyExported::Id);
+        const bool notify = ShouldNotifyEnergyMeasurementAttribute(mPeriodicExported, value);
+        mPeriodicExported = value;
+        if (notify)
+        {
+            NotifyAttributeChanged(PeriodicEnergyExported::Id);
+        }
     }
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyReset(const Optional<CumulativeEnergyResetStruct> & value)
+CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyReset(const Nullable<CumulativeEnergyResetStruct> & value)
 {
     if (!mEnabledOptionalAttributes.IsSet(CumulativeEnergyReset::Id))
     {
         ChipLogError(Zcl, "Electrical Energy Measurement: CumulativeEnergyReset requires kCumulativeEnergy feature");
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    if (ValueChanged(mMeasurementData.cumulativeReset, value))
+    if (ValueChanged(mCumulativeReset, value))
     {
-        mMeasurementData.cumulativeReset = value;
+        mCumulativeReset = value;
         NotifyAttributeChanged(CumulativeEnergyReset::Id);
     }
     return CHIP_NO_ERROR;
@@ -449,42 +466,42 @@ DataModel::ActionReturnStatus ElectricalEnergyMeasurementCluster::ReadAttribute(
         return encoder.Encode(kRevision);
 
     case Accuracy::Id:
-        return encoder.Encode(mMeasurementData.measurementAccuracy);
+        return encoder.Encode(mMeasurementAccuracy);
 
     case CumulativeEnergyImported::Id:
-        if (!mMeasurementData.cumulativeImported.HasValue())
+        if (mCumulativeImported.IsNull())
         {
             return encoder.EncodeNull();
         }
-        return encoder.Encode(mMeasurementData.cumulativeImported.Value());
+        return encoder.Encode(mCumulativeImported.Value());
 
     case CumulativeEnergyExported::Id:
-        if (!mMeasurementData.cumulativeExported.HasValue())
+        if (mCumulativeExported.IsNull())
         {
             return encoder.EncodeNull();
         }
-        return encoder.Encode(mMeasurementData.cumulativeExported.Value());
+        return encoder.Encode(mCumulativeExported.Value());
 
     case PeriodicEnergyImported::Id:
-        if (!mMeasurementData.periodicImported.HasValue())
+        if (mPeriodicImported.IsNull())
         {
             return encoder.EncodeNull();
         }
-        return encoder.Encode(mMeasurementData.periodicImported.Value());
+        return encoder.Encode(mPeriodicImported.Value());
 
     case PeriodicEnergyExported::Id:
-        if (!mMeasurementData.periodicExported.HasValue())
+        if (mPeriodicExported.IsNull())
         {
             return encoder.EncodeNull();
         }
-        return encoder.Encode(mMeasurementData.periodicExported.Value());
+        return encoder.Encode(mPeriodicExported.Value());
 
     case CumulativeEnergyReset::Id:
-        if (!mMeasurementData.cumulativeReset.HasValue())
+        if (mCumulativeReset.IsNull())
         {
             return encoder.EncodeNull();
         }
-        return encoder.Encode(mMeasurementData.cumulativeReset.Value());
+        return encoder.Encode(mCumulativeReset.Value());
 
     default:
         return Protocols::InteractionModel::Status::UnsupportedAttribute;
@@ -507,48 +524,56 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::Attributes(const ConcreteClusterP
     return listBuilder.Append(Span(kMandatoryMetadata), Span(optionalAttributes), mEnabledOptionalAttributes);
 }
 
-void ElectricalEnergyMeasurementCluster::CumulativeEnergySnapshot(const Optional<EnergyMeasurementStruct> & energyImported,
-                                                                  const Optional<EnergyMeasurementStruct> & energyExported)
+void ElectricalEnergyMeasurementCluster::CumulativeEnergySnapshot(const Nullable<EnergyMeasurementStruct> & energyImported,
+                                                                  const Nullable<EnergyMeasurementStruct> & energyExported)
 {
     VerifyOrReturn(Features().Has(Feature::kCumulativeEnergy));
     Events::CumulativeEnergyMeasured::Type event;
+    bool hasData = false;
 
-    if (Features().Has(Feature::kImportedEnergy))
+    if (Features().Has(Feature::kImportedEnergy) && !energyImported.IsNull())
     {
-        TEMPORARY_RETURN_IGNORED SetCumulativeEnergyImported(energyImported);
-        event.energyImported = energyImported;
+        RETURN_SAFELY_IGNORED SetCumulativeEnergyImported(energyImported);
+        event.energyImported.SetValue(energyImported.Value());
+        hasData = true;
     }
 
-    if (Features().Has(Feature::kExportedEnergy))
+    if (Features().Has(Feature::kExportedEnergy) && !energyExported.IsNull())
     {
-        TEMPORARY_RETURN_IGNORED SetCumulativeEnergyExported(energyExported);
-        event.energyExported = energyExported;
+        RETURN_SAFELY_IGNORED SetCumulativeEnergyExported(energyExported);
+        event.energyExported.SetValue(energyExported.Value());
+        hasData = true;
     }
 
-    VerifyOrReturn(mContext != nullptr);
+    VerifyOrReturn(hasData && mContext != nullptr);
     mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
+    mLastReportTime = mTimerDelegate.GetCurrentMonotonicTimestamp();
 }
 
-void ElectricalEnergyMeasurementCluster::PeriodicEnergySnapshot(const Optional<EnergyMeasurementStruct> & energyImported,
-                                                                const Optional<EnergyMeasurementStruct> & energyExported)
+void ElectricalEnergyMeasurementCluster::PeriodicEnergySnapshot(const Nullable<EnergyMeasurementStruct> & energyImported,
+                                                                const Nullable<EnergyMeasurementStruct> & energyExported)
 {
     VerifyOrReturn(Features().Has(Feature::kPeriodicEnergy));
     Events::PeriodicEnergyMeasured::Type event;
+    bool hasData = false;
 
-    if (Features().Has(Feature::kImportedEnergy))
+    if (Features().Has(Feature::kImportedEnergy) && !energyImported.IsNull())
     {
-        TEMPORARY_RETURN_IGNORED SetPeriodicEnergyImported(energyImported);
-        event.energyImported = energyImported;
+        RETURN_SAFELY_IGNORED SetPeriodicEnergyImported(energyImported);
+        event.energyImported.SetValue(energyImported.Value());
+        hasData = true;
     }
 
-    if (Features().Has(Feature::kExportedEnergy))
+    if (Features().Has(Feature::kExportedEnergy) && !energyExported.IsNull())
     {
-        TEMPORARY_RETURN_IGNORED SetPeriodicEnergyExported(energyExported);
-        event.energyExported = energyExported;
+        RETURN_SAFELY_IGNORED SetPeriodicEnergyExported(energyExported);
+        event.energyExported.SetValue(energyExported.Value());
+        hasData = true;
     }
 
-    VerifyOrReturn(mContext != nullptr);
+    VerifyOrReturn(hasData && mContext != nullptr);
     mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
+    mLastReportTime = mTimerDelegate.GetCurrentMonotonicTimestamp();
 }
 
 } // namespace ElectricalEnergyMeasurement

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -125,18 +125,8 @@ ElectricalEnergyMeasurementCluster::ElectricalEnergyMeasurementCluster(const Con
                                                          config.featureFlags.Has(Feature::kCumulativeEnergy));
         return attrs;
     }()),
-    mDelegate(config.delegate), mTimerDelegate(config.timerDelegate), mReportInterval(config.reportInterval)
+    mDelegate(config.delegate), mTimerDelegate(config.timerDelegate)
 {
-    // The report interval must be between kMinReportInterval and kMaxReportInterval, we cap it here.
-    if (mReportInterval < kMinReportInterval)
-    {
-        mReportInterval = kMinReportInterval;
-    }
-    else if (mReportInterval > kMaxReportInterval)
-    {
-        mReportInterval = kMaxReportInterval;
-    }
-
     mMeasurementAccuracy.measurementType  = config.accuracyStruct.measurementType;
     mMeasurementAccuracy.measured         = config.accuracyStruct.measured;
     mMeasurementAccuracy.minMeasuredValue = config.accuracyStruct.minMeasuredValue;
@@ -155,7 +145,7 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::Startup(ServerClusterContext & co
 
     if (mFeatureFlags.HasAny(Feature::kCumulativeEnergy, Feature::kPeriodicEnergy))
     {
-        StartSnapshotTimer();
+        StartReportDelayTimer();
     }
 
     return CHIP_NO_ERROR;
@@ -163,30 +153,33 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::Startup(ServerClusterContext & co
 
 void ElectricalEnergyMeasurementCluster::Shutdown(ClusterShutdownType shutdownType)
 {
-    CancelSnapshotTimer();
+    CancelReportDelayTimer();
     DefaultServerCluster::Shutdown(shutdownType);
 }
 
-void ElectricalEnergyMeasurementCluster::StartSnapshotTimer()
+void ElectricalEnergyMeasurementCluster::StartReportDelayTimer()
 {
-    CancelSnapshotTimer();
-    ReturnAndLogOnFailure(mTimerDelegate.StartTimer(&mSnapshotTimer, mReportInterval), AppServer,
+    // If we already have a timer active, we let it run its course
+    if (mTimerDelegate.IsTimerActive(&mReportDelayTimer))
+    {
+        return;
+    }
+    // If we delay the report, we start a new timer to ensure we eventually report within the max delay interval.
+    ReturnAndLogOnFailure(mTimerDelegate.StartTimer(&mReportDelayTimer, kMaxReportDelayInterval), AppServer,
                           "EEM: Failed to start report timer");
 }
 
-void ElectricalEnergyMeasurementCluster::CancelSnapshotTimer()
+void ElectricalEnergyMeasurementCluster::CancelReportDelayTimer()
 {
-    if (mTimerDelegate.IsTimerActive(&mSnapshotTimer))
+    if (mTimerDelegate.IsTimerActive(&mReportDelayTimer))
     {
-        mTimerDelegate.CancelTimer(&mSnapshotTimer);
+        mTimerDelegate.CancelTimer(&mReportDelayTimer);
     }
 }
 
-void ElectricalEnergyMeasurementCluster::SnapshotTimer::TimerFired()
+void ElectricalEnergyMeasurementCluster::ReportDelayTimer::TimerFired()
 {
-    mCluster.DoGenerateSnapshots();
-    mCluster.mLastReportTime = mCluster.mTimerDelegate.GetCurrentMonotonicTimestamp();
-    mCluster.StartSnapshotTimer();
+    mCluster.GenerateSnapshots();
 }
 
 DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct>
@@ -211,36 +204,21 @@ ElectricalEnergyMeasurementCluster::BuildMeasurement(DataModel::Nullable<int64_t
         }
     }
 
-    // Get current timestamp
-    uint32_t currentTimestamp;
-    CHIP_ERROR err = System::Clock::GetClock_MatterEpochS(currentTimestamp);
+    // Matter epoch timestamp when available; monotonic endSystime is always set so ShouldNotifyEnergyMeasurementAttribute can
+    // enforce kMinReportInterval even when real-time clock is available.
+    uint32_t currentTimestamp = 0;
+    CHIP_ERROR err            = System::Clock::GetClock_MatterEpochS(currentTimestamp);
     if (err == CHIP_NO_ERROR)
     {
         measurement.endTimestamp.SetValue(currentTimestamp);
     }
-    else
-    {
-        System::Clock::Milliseconds64 sysTimeMs = mTimerDelegate.GetCurrentMonotonicTimestamp();
-        measurement.endSystime.SetValue(static_cast<uint64_t>(sysTimeMs.count()));
-    }
+    System::Clock::Milliseconds64 sysTimeMs = mTimerDelegate.GetCurrentMonotonicTimestamp();
+    measurement.endSystime.SetValue(static_cast<uint64_t>(sysTimeMs.count()));
 
     return DataModel::MakeNullable(measurement);
 }
 
 void ElectricalEnergyMeasurementCluster::GenerateSnapshots()
-{
-    // Enforce min 1s between events
-    System::Clock::Timestamp now = mTimerDelegate.GetCurrentMonotonicTimestamp();
-    if (mLastReportTime != System::Clock::kZero && (now - mLastReportTime) < kMinReportInterval)
-    {
-        return;
-    }
-
-    DoGenerateSnapshots();
-    StartSnapshotTimer();
-}
-
-void ElectricalEnergyMeasurementCluster::DoGenerateSnapshots()
 {
     if (mFeatureFlags.Has(Feature::kCumulativeEnergy))
     {
@@ -272,6 +250,11 @@ void ElectricalEnergyMeasurementCluster::DoGenerateSnapshots()
             exported = BuildMeasurement(mDelegate.GetPeriodicEnergyExported(), mPeriodicExported, false);
         }
         PeriodicEnergySnapshot(imported, exported);
+    }
+
+    if (mFeatureFlags.HasAny(Feature::kCumulativeEnergy, Feature::kPeriodicEnergy))
+    {
+        StartReportDelayTimer();
     }
 }
 
@@ -377,6 +360,13 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyImported(const
         if (notify)
         {
             NotifyAttributeChanged(CumulativeEnergyImported::Id);
+            mAttributeDirtyState.Clear(AttributeIgnoredDirtyState::CumulativeEnergyImported);
+        }
+        else
+        {
+            mAttributeDirtyState.Set(AttributeIgnoredDirtyState::CumulativeEnergyImported);
+            // If we delay the report, we start a new timer to ensure we eventually report within the max delay interval.
+            StartReportDelayTimer();
         }
     }
     return CHIP_NO_ERROR;
@@ -391,6 +381,13 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyExported(const
         if (notify)
         {
             NotifyAttributeChanged(CumulativeEnergyExported::Id);
+            mAttributeDirtyState.Clear(AttributeIgnoredDirtyState::CumulativeEnergyExported);
+        }
+        else
+        {
+            mAttributeDirtyState.Set(AttributeIgnoredDirtyState::CumulativeEnergyExported);
+            // If we delay the report, we start a new timer to ensure we eventually report within the max delay interval.
+            StartReportDelayTimer();
         }
     }
     return CHIP_NO_ERROR;
@@ -412,6 +409,13 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetPeriodicEnergyImported(const N
         if (notify)
         {
             NotifyAttributeChanged(PeriodicEnergyImported::Id);
+            mAttributeDirtyState.Clear(AttributeIgnoredDirtyState::PeriodicEnergyImported);
+        }
+        else
+        {
+            mAttributeDirtyState.Set(AttributeIgnoredDirtyState::PeriodicEnergyImported);
+            // If we delay the report, we start a new timer to ensure we eventually report within the max delay interval.
+            StartReportDelayTimer();
         }
     }
     return CHIP_NO_ERROR;
@@ -434,6 +438,13 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetPeriodicEnergyExported(const N
         if (notify)
         {
             NotifyAttributeChanged(PeriodicEnergyExported::Id);
+            mAttributeDirtyState.Clear(AttributeIgnoredDirtyState::PeriodicEnergyExported);
+        }
+        else
+        {
+            mAttributeDirtyState.Set(AttributeIgnoredDirtyState::PeriodicEnergyExported);
+            // If we delay the report, we start a new timer to ensure we eventually report within the max delay interval.
+            StartReportDelayTimer();
         }
     }
     return CHIP_NO_ERROR;
@@ -534,20 +545,25 @@ void ElectricalEnergyMeasurementCluster::CumulativeEnergySnapshot(const Nullable
     if (Features().Has(Feature::kImportedEnergy) && !energyImported.IsNull())
     {
         RETURN_SAFELY_IGNORED SetCumulativeEnergyImported(energyImported);
-        event.energyImported.SetValue(energyImported.Value());
-        hasData = true;
+        if (!mAttributeDirtyState.Has(AttributeIgnoredDirtyState::CumulativeEnergyImported))
+        {
+            event.energyImported.SetValue(energyImported.Value());
+            hasData = true;
+        }
     }
 
     if (Features().Has(Feature::kExportedEnergy) && !energyExported.IsNull())
     {
         RETURN_SAFELY_IGNORED SetCumulativeEnergyExported(energyExported);
-        event.energyExported.SetValue(energyExported.Value());
-        hasData = true;
+        if (!mAttributeDirtyState.Has(AttributeIgnoredDirtyState::CumulativeEnergyExported))
+        {
+            event.energyExported.SetValue(energyExported.Value());
+            hasData = true;
+        }
     }
 
     VerifyOrReturn(hasData && mContext != nullptr);
     mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
-    mLastReportTime = mTimerDelegate.GetCurrentMonotonicTimestamp();
 }
 
 void ElectricalEnergyMeasurementCluster::PeriodicEnergySnapshot(const Nullable<EnergyMeasurementStruct> & energyImported,
@@ -560,20 +576,25 @@ void ElectricalEnergyMeasurementCluster::PeriodicEnergySnapshot(const Nullable<E
     if (Features().Has(Feature::kImportedEnergy) && !energyImported.IsNull())
     {
         RETURN_SAFELY_IGNORED SetPeriodicEnergyImported(energyImported);
-        event.energyImported.SetValue(energyImported.Value());
-        hasData = true;
+        if (!mAttributeDirtyState.Has(AttributeIgnoredDirtyState::PeriodicEnergyImported))
+        {
+            event.energyImported.SetValue(energyImported.Value());
+            hasData = true;
+        }
     }
 
     if (Features().Has(Feature::kExportedEnergy) && !energyExported.IsNull())
     {
         RETURN_SAFELY_IGNORED SetPeriodicEnergyExported(energyExported);
-        event.energyExported.SetValue(energyExported.Value());
-        hasData = true;
+        if (!mAttributeDirtyState.Has(AttributeIgnoredDirtyState::PeriodicEnergyExported))
+        {
+            event.energyExported.SetValue(energyExported.Value());
+            hasData = true;
+        }
     }
 
     VerifyOrReturn(hasData && mContext != nullptr);
     mContext->interactionContext.eventsGenerator.GenerateEvent(event, mPath.mEndpointId);
-    mLastReportTime = mTimerDelegate.GetCurrentMonotonicTimestamp();
 }
 
 } // namespace ElectricalEnergyMeasurement

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -15,7 +15,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "app/cluster-building-blocks/QuieterReporting.h"
 #include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h>
 
 #include <protocols/interaction_model/StatusCode.h>

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
@@ -15,6 +15,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include "app/cluster-building-blocks/QuieterReporting.h"
 #include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h>
 
 #include <protocols/interaction_model/StatusCode.h>
@@ -82,31 +83,6 @@ bool ValueChanged(const DataModel::Nullable<CumulativeEnergyResetStruct::Type> &
         (previous.Value().exportedResetSystime != newValue.Value().exportedResetSystime);
 }
 
-/** Rate-limit subscription reporting per attribute: notify when endSystime advanced by at least kMinReportInterval
- *  (monotonic ms), or when null / missing timestamps / non-monotonic endSystime. */
-bool ShouldNotifyEnergyMeasurementAttribute(const DataModel::Nullable<EnergyMeasurementStruct::Type> & previous,
-                                            const DataModel::Nullable<EnergyMeasurementStruct::Type> & newValue)
-{
-    if (newValue.IsNull())
-    {
-        return true;
-    }
-    if (previous.IsNull() || !previous.Value().endSystime.HasValue())
-    {
-        return true;
-    }
-    if (!newValue.Value().endSystime.HasValue())
-    {
-        return true;
-    }
-
-    const uint64_t minIntervalMs = static_cast<uint64_t>(
-        std::chrono::duration_cast<System::Clock::Milliseconds64>(ElectricalEnergyMeasurementCluster::kMinReportInterval).count());
-    const uint64_t prevEnd = previous.Value().endSystime.Value();
-    const uint64_t newEnd  = newValue.Value().endSystime.Value();
-    return (newEnd < prevEnd) || (newEnd - prevEnd >= minIntervalMs);
-}
-
 } // anonymous namespace
 
 ElectricalEnergyMeasurementCluster::ElectricalEnergyMeasurementCluster(const Config & config) :
@@ -141,33 +117,7 @@ ElectricalEnergyMeasurementCluster::ElectricalEnergyMeasurementCluster(const Con
 
 void ElectricalEnergyMeasurementCluster::Shutdown(ClusterShutdownType shutdownType)
 {
-    CancelReportDelayTimer();
     DefaultServerCluster::Shutdown(shutdownType);
-}
-
-void ElectricalEnergyMeasurementCluster::StartReportDelayTimer()
-{
-    // If we already have a timer active, we let it run its course
-    if (mTimerDelegate.IsTimerActive(&mReportDelayTimer))
-    {
-        return;
-    }
-    // If we delay the report, we start a new timer to ensure we eventually report within the max delay interval.
-    ReturnAndLogOnFailure(mTimerDelegate.StartTimer(&mReportDelayTimer, kMaxReportDelayInterval), AppServer,
-                          "EEM: Failed to start report timer");
-}
-
-void ElectricalEnergyMeasurementCluster::CancelReportDelayTimer()
-{
-    if (mTimerDelegate.IsTimerActive(&mReportDelayTimer))
-    {
-        mTimerDelegate.CancelTimer(&mReportDelayTimer);
-    }
-}
-
-void ElectricalEnergyMeasurementCluster::ReportDelayTimer::TimerFired()
-{
-    mCluster.GenerateSnapshots();
 }
 
 DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct>
@@ -215,11 +165,11 @@ void ElectricalEnergyMeasurementCluster::GenerateSnapshots()
 
         if (mFeatureFlags.Has(Feature::kImportedEnergy))
         {
-            imported = BuildMeasurement(mDelegate.GetCumulativeEnergyImported(), mCumulativeImported, true);
+            imported = BuildMeasurement(mDelegate.GetCumulativeEnergyImported(), mCumulativeImported.value(), true);
         }
         if (mFeatureFlags.Has(Feature::kExportedEnergy))
         {
-            exported = BuildMeasurement(mDelegate.GetCumulativeEnergyExported(), mCumulativeExported, true);
+            exported = BuildMeasurement(mDelegate.GetCumulativeEnergyExported(), mCumulativeExported.value(), true);
         }
         CumulativeEnergySnapshot(imported, exported);
     }
@@ -231,11 +181,11 @@ void ElectricalEnergyMeasurementCluster::GenerateSnapshots()
 
         if (mFeatureFlags.Has(Feature::kImportedEnergy))
         {
-            imported = BuildMeasurement(mDelegate.GetPeriodicEnergyImported(), mPeriodicImported, false);
+            imported = BuildMeasurement(mDelegate.GetPeriodicEnergyImported(), mPeriodicImported.value(), false);
         }
         if (mFeatureFlags.Has(Feature::kExportedEnergy))
         {
-            exported = BuildMeasurement(mDelegate.GetPeriodicEnergyExported(), mPeriodicExported, false);
+            exported = BuildMeasurement(mDelegate.GetPeriodicEnergyExported(), mPeriodicExported.value(), false);
         }
         PeriodicEnergySnapshot(imported, exported);
     }
@@ -256,7 +206,7 @@ ElectricalEnergyMeasurementCluster::GetCumulativeEnergyImported(DataModel::Nulla
             Zcl, "Electrical Energy Measurement: CumulativeEnergyImported requires kCumulativeEnergy and kImportedEnergy features");
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    outValue = mCumulativeImported;
+    outValue = mCumulativeImported.value();
     return CHIP_NO_ERROR;
 }
 
@@ -270,7 +220,7 @@ ElectricalEnergyMeasurementCluster::GetCumulativeEnergyExported(Nullable<EnergyM
             Zcl, "Electrical Energy Measurement: CumulativeEnergyExported requires kCumulativeEnergy and kExportedEnergy features");
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    outValue = mCumulativeExported;
+    outValue = mCumulativeExported.value();
     return CHIP_NO_ERROR;
 }
 
@@ -283,7 +233,7 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::GetPeriodicEnergyImported(Nullabl
                      "Electrical Energy Measurement: PeriodicEnergyImported requires kPeriodicEnergy and kImportedEnergy features");
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    outValue = mPeriodicImported;
+    outValue = mPeriodicImported.value();
     return CHIP_NO_ERROR;
 }
 
@@ -296,7 +246,7 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::GetPeriodicEnergyExported(Nullabl
                      "Electrical Energy Measurement: PeriodicEnergyExported requires kPeriodicEnergy and kExportedEnergy features");
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     }
-    outValue = mPeriodicExported;
+    outValue = mPeriodicExported.value();
     return CHIP_NO_ERROR;
 }
 
@@ -334,103 +284,75 @@ CHIP_ERROR ElectricalEnergyMeasurementCluster::SetMeasurementAccuracy(const Meas
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyImported(const Nullable<EnergyMeasurementStruct> & value)
+AttributeDirtyState ElectricalEnergyMeasurementCluster::SetCumulativeEnergyImported(const Nullable<EnergyMeasurementStruct> & value)
 {
-    if (ValueChanged(mCumulativeImported, value))
+    AttributeDirtyState dirtyState = AttributeDirtyState::kNoReportNeeded;
+    if (ValueChanged(mCumulativeImported.value(), value))
     {
-        const bool notify   = ShouldNotifyEnergyMeasurementAttribute(mCumulativeImported, value);
-        mCumulativeImported = value;
-        if (notify)
+        dirtyState = mCumulativeImported.SetValue(value, mTimerDelegate.GetCurrentMonotonicTimestamp());
+        if (dirtyState == AttributeDirtyState::kMustReport)
         {
             NotifyAttributeChanged(CumulativeEnergyImported::Id);
-            mAttributeDirtyState.Clear(AttributeIgnoredDirtyState::CumulativeEnergyImported);
-        }
-        else
-        {
-            mAttributeDirtyState.Set(AttributeIgnoredDirtyState::CumulativeEnergyImported);
-            // If we delay the report, we start a new timer to ensure we eventually report within the max delay interval.
-            StartReportDelayTimer();
         }
     }
-    return CHIP_NO_ERROR;
+    return dirtyState;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyExported(const Nullable<EnergyMeasurementStruct> & value)
+AttributeDirtyState ElectricalEnergyMeasurementCluster::SetCumulativeEnergyExported(const Nullable<EnergyMeasurementStruct> & value)
 {
-    if (ValueChanged(mCumulativeExported, value))
+    AttributeDirtyState dirtyState = AttributeDirtyState::kNoReportNeeded;
+    if (ValueChanged(mCumulativeExported.value(), value))
     {
-        const bool notify   = ShouldNotifyEnergyMeasurementAttribute(mCumulativeExported, value);
-        mCumulativeExported = value;
-        if (notify)
+        dirtyState = mCumulativeExported.SetValue(value, mTimerDelegate.GetCurrentMonotonicTimestamp());
+        if (dirtyState == AttributeDirtyState::kMustReport)
         {
             NotifyAttributeChanged(CumulativeEnergyExported::Id);
-            mAttributeDirtyState.Clear(AttributeIgnoredDirtyState::CumulativeEnergyExported);
-        }
-        else
-        {
-            mAttributeDirtyState.Set(AttributeIgnoredDirtyState::CumulativeEnergyExported);
-            // If we delay the report, we start a new timer to ensure we eventually report within the max delay interval.
-            StartReportDelayTimer();
         }
     }
-    return CHIP_NO_ERROR;
+    return dirtyState;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::SetPeriodicEnergyImported(const Nullable<EnergyMeasurementStruct> & value)
+AttributeDirtyState ElectricalEnergyMeasurementCluster::SetPeriodicEnergyImported(const Nullable<EnergyMeasurementStruct> & value)
 {
+    AttributeDirtyState dirtyState = AttributeDirtyState::kNoReportNeeded;
     if (!mFeatureFlags.HasAll(ElectricalEnergyMeasurement::Feature::kPeriodicEnergy,
                               ElectricalEnergyMeasurement::Feature::kImportedEnergy))
     {
         ChipLogError(Zcl,
                      "Electrical Energy Measurement: PeriodicEnergyImported requires kPeriodicEnergy and kImportedEnergy features");
-        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+        return AttributeDirtyState::kNoReportNeeded;
     }
-    if (ValueChanged(mPeriodicImported, value))
+    if (ValueChanged(mPeriodicImported.value(), value))
     {
-        const bool notify = ShouldNotifyEnergyMeasurementAttribute(mPeriodicImported, value);
-        mPeriodicImported = value;
-        if (notify)
+        dirtyState = mPeriodicImported.SetValue(value, mTimerDelegate.GetCurrentMonotonicTimestamp());
+        if (dirtyState == AttributeDirtyState::kMustReport)
         {
             NotifyAttributeChanged(PeriodicEnergyImported::Id);
-            mAttributeDirtyState.Clear(AttributeIgnoredDirtyState::PeriodicEnergyImported);
-        }
-        else
-        {
-            mAttributeDirtyState.Set(AttributeIgnoredDirtyState::PeriodicEnergyImported);
-            // If we delay the report, we start a new timer to ensure we eventually report within the max delay interval.
-            StartReportDelayTimer();
         }
     }
-    return CHIP_NO_ERROR;
+    return dirtyState;
 }
 
-CHIP_ERROR ElectricalEnergyMeasurementCluster::SetPeriodicEnergyExported(const Nullable<EnergyMeasurementStruct> & value)
+AttributeDirtyState ElectricalEnergyMeasurementCluster::SetPeriodicEnergyExported(const Nullable<EnergyMeasurementStruct> & value)
 {
+    AttributeDirtyState dirtyState = AttributeDirtyState::kNoReportNeeded;
     if (!mFeatureFlags.HasAll(ElectricalEnergyMeasurement::Feature::kPeriodicEnergy,
                               ElectricalEnergyMeasurement::Feature::kExportedEnergy))
     {
         ChipLogError(Zcl,
                      "Electrical Energy Measurement: PeriodicEnergyExported requires kPeriodicEnergy and kExportedEnergy features");
-        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+        return AttributeDirtyState::kNoReportNeeded;
     }
 
-    if (ValueChanged(mPeriodicExported, value))
+    if (ValueChanged(mPeriodicExported.value(), value))
     {
-        const bool notify = ShouldNotifyEnergyMeasurementAttribute(mPeriodicExported, value);
-        mPeriodicExported = value;
-        if (notify)
+        dirtyState = mPeriodicExported.SetValue(value, mTimerDelegate.GetCurrentMonotonicTimestamp());
+        if (dirtyState == AttributeDirtyState::kMustReport)
         {
             NotifyAttributeChanged(PeriodicEnergyExported::Id);
-            mAttributeDirtyState.Clear(AttributeIgnoredDirtyState::PeriodicEnergyExported);
-        }
-        else
-        {
-            mAttributeDirtyState.Set(AttributeIgnoredDirtyState::PeriodicEnergyExported);
-            // If we delay the report, we start a new timer to ensure we eventually report within the max delay interval.
-            StartReportDelayTimer();
         }
     }
-    return CHIP_NO_ERROR;
+    return dirtyState;
 }
 
 CHIP_ERROR ElectricalEnergyMeasurementCluster::SetCumulativeEnergyReset(const Nullable<CumulativeEnergyResetStruct> & value)
@@ -463,32 +385,32 @@ DataModel::ActionReturnStatus ElectricalEnergyMeasurementCluster::ReadAttribute(
         return encoder.Encode(mMeasurementAccuracy);
 
     case CumulativeEnergyImported::Id:
-        if (mCumulativeImported.IsNull())
+        if (mCumulativeImported.value().IsNull())
         {
             return encoder.EncodeNull();
         }
-        return encoder.Encode(mCumulativeImported.Value());
+        return encoder.Encode(mCumulativeImported.value().Value());
 
     case CumulativeEnergyExported::Id:
-        if (mCumulativeExported.IsNull())
+        if (mCumulativeExported.value().IsNull())
         {
             return encoder.EncodeNull();
         }
-        return encoder.Encode(mCumulativeExported.Value());
+        return encoder.Encode(mCumulativeExported.value().Value());
 
     case PeriodicEnergyImported::Id:
-        if (mPeriodicImported.IsNull())
+        if (mPeriodicImported.value().IsNull())
         {
             return encoder.EncodeNull();
         }
-        return encoder.Encode(mPeriodicImported.Value());
+        return encoder.Encode(mPeriodicImported.value().Value());
 
     case PeriodicEnergyExported::Id:
-        if (mPeriodicExported.IsNull())
+        if (mPeriodicExported.value().IsNull())
         {
             return encoder.EncodeNull();
         }
-        return encoder.Encode(mPeriodicExported.Value());
+        return encoder.Encode(mPeriodicExported.value().Value());
 
     case CumulativeEnergyReset::Id:
         if (mCumulativeReset.IsNull())
@@ -527,8 +449,7 @@ void ElectricalEnergyMeasurementCluster::CumulativeEnergySnapshot(const Nullable
 
     if (Features().Has(Feature::kImportedEnergy) && !energyImported.IsNull())
     {
-        RETURN_SAFELY_IGNORED SetCumulativeEnergyImported(energyImported);
-        if (!mAttributeDirtyState.Has(AttributeIgnoredDirtyState::CumulativeEnergyImported))
+        if (SetCumulativeEnergyImported(energyImported) == AttributeDirtyState::kMustReport)
         {
             event.energyImported.SetValue(energyImported.Value());
             hasData = true;
@@ -537,8 +458,7 @@ void ElectricalEnergyMeasurementCluster::CumulativeEnergySnapshot(const Nullable
 
     if (Features().Has(Feature::kExportedEnergy) && !energyExported.IsNull())
     {
-        RETURN_SAFELY_IGNORED SetCumulativeEnergyExported(energyExported);
-        if (!mAttributeDirtyState.Has(AttributeIgnoredDirtyState::CumulativeEnergyExported))
+        if (SetCumulativeEnergyExported(energyExported) == AttributeDirtyState::kMustReport)
         {
             event.energyExported.SetValue(energyExported.Value());
             hasData = true;
@@ -558,8 +478,7 @@ void ElectricalEnergyMeasurementCluster::PeriodicEnergySnapshot(const Nullable<E
 
     if (Features().Has(Feature::kImportedEnergy) && !energyImported.IsNull())
     {
-        RETURN_SAFELY_IGNORED SetPeriodicEnergyImported(energyImported);
-        if (!mAttributeDirtyState.Has(AttributeIgnoredDirtyState::PeriodicEnergyImported))
+        if (SetPeriodicEnergyImported(energyImported) == AttributeDirtyState::kMustReport)
         {
             event.energyImported.SetValue(energyImported.Value());
             hasData = true;
@@ -568,8 +487,7 @@ void ElectricalEnergyMeasurementCluster::PeriodicEnergySnapshot(const Nullable<E
 
     if (Features().Has(Feature::kExportedEnergy) && !energyExported.IsNull())
     {
-        RETURN_SAFELY_IGNORED SetPeriodicEnergyExported(energyExported);
-        if (!mAttributeDirtyState.Has(AttributeIgnoredDirtyState::PeriodicEnergyExported))
+        if (SetPeriodicEnergyExported(energyExported) == AttributeDirtyState::kMustReport)
         {
             event.energyExported.SetValue(energyExported.Value());
             hasData = true;

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2025 Project CHIP Authors
+ *    Copyright (c) 2026 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/OptionalAttributeSet.h>
 #include <clusters/ElectricalEnergyMeasurement/AttributeIds.h>
@@ -24,17 +25,14 @@
 #include <clusters/ElectricalEnergyMeasurement/Structs.h>
 #include <lib/core/Optional.h>
 #include <lib/support/ReadOnlyBuffer.h>
+#include <lib/support/TimerDelegate.h>
 
 namespace chip {
 namespace app {
 namespace Clusters {
 namespace ElectricalEnergyMeasurement {
 
-enum class OptionalAttributes : uint32_t
-{
-    kOptionalAttributeCumulativeEnergyReset = 0x1,
-};
-// Data structure to hold measurement data for backwards compatibility
+/** @brief Data structure to hold measurement data for backwards compatibility */
 struct MeasurementData
 {
     Structs::MeasurementAccuracyStruct::Type measurementAccuracy;
@@ -44,74 +42,56 @@ struct MeasurementData
     Optional<Structs::EnergyMeasurementStruct::Type> periodicExported;
     Optional<Structs::CumulativeEnergyResetStruct::Type> cumulativeReset;
 };
-}; // namespace ElectricalEnergyMeasurement
 
 class ElectricalEnergyMeasurementCluster : public DefaultServerCluster
 {
 public:
-    // Type aliases for shorter struct type names
-    using MeasurementAccuracyStruct   = ElectricalEnergyMeasurement::Structs::MeasurementAccuracyStruct::Type;
-    using EnergyMeasurementStruct     = ElectricalEnergyMeasurement::Structs::EnergyMeasurementStruct::Type;
-    using CumulativeEnergyResetStruct = ElectricalEnergyMeasurement::Structs::CumulativeEnergyResetStruct::Type;
+    using MeasurementAccuracyStruct   = Structs::MeasurementAccuracyStruct::Type;
+    using EnergyMeasurementStruct     = Structs::EnergyMeasurementStruct::Type;
+    using CumulativeEnergyResetStruct = Structs::CumulativeEnergyResetStruct::Type;
 
-    using OptionalAttributesSet = OptionalAttributeSet<                        //
-        ElectricalEnergyMeasurement::Attributes::CumulativeEnergyImported::Id, //
-        ElectricalEnergyMeasurement::Attributes::CumulativeEnergyExported::Id, //
-        ElectricalEnergyMeasurement::Attributes::PeriodicEnergyImported::Id,   //
-        ElectricalEnergyMeasurement::Attributes::PeriodicEnergyExported::Id,   //
-        ElectricalEnergyMeasurement::Attributes::CumulativeEnergyReset::Id     //
+    using OptionalAttributesSet = OptionalAttributeSet< //
+        Attributes::CumulativeEnergyImported::Id,       //
+        Attributes::CumulativeEnergyExported::Id,       //
+        Attributes::PeriodicEnergyImported::Id,         //
+        Attributes::PeriodicEnergyExported::Id,         //
+        Attributes::CumulativeEnergyReset::Id           //
         >;
+
+    static constexpr System::Clock::Timeout kMaxReportInterval = System::Clock::Seconds32(60);
+    static constexpr System::Clock::Timeout kMinReportInterval = System::Clock::Seconds32(1);
 
     struct Config
     {
         EndpointId endpointId;
-        BitMask<ElectricalEnergyMeasurement::Feature> featureFlags;
-        BitMask<ElectricalEnergyMeasurement::OptionalAttributes> optionalAttributes;
-        const ElectricalEnergyMeasurement::Structs::MeasurementAccuracyStruct::Type & accuracyStruct;
+        BitMask<Feature> featureFlags;
+        OptionalAttributesSet optionalAttributes;
+        const Structs::MeasurementAccuracyStruct::Type & accuracyStruct;
+        Delegate & delegate;
+        TimerDelegate & timerDelegate;
+        System::Clock::Timeout reportInterval = kMaxReportInterval;
     };
 
-    /// @brief Constructor for ElectricalEnergyMeasurementCluster.
-    /// @param config The configuration for the cluster.
-    /// @note The accuracyStruct must outlive the cluster to avoid dangling pointers.
-    ElectricalEnergyMeasurementCluster(const Config & config) :
-        DefaultServerCluster({ config.endpointId, ElectricalEnergyMeasurement::Id }), mFeatureFlags(config.featureFlags),
-        mEnabledOptionalAttributes([&]() {
-            OptionalAttributesSet attrs;
-            attrs.Set<ElectricalEnergyMeasurement::Attributes::CumulativeEnergyImported::Id>(config.featureFlags.HasAll(
-                ElectricalEnergyMeasurement::Feature::kCumulativeEnergy, ElectricalEnergyMeasurement::Feature::kImportedEnergy));
-            attrs.Set<ElectricalEnergyMeasurement::Attributes::CumulativeEnergyExported::Id>((config.featureFlags.HasAll(
-                ElectricalEnergyMeasurement::Feature::kCumulativeEnergy, ElectricalEnergyMeasurement::Feature::kExportedEnergy)));
-            attrs.Set<ElectricalEnergyMeasurement::Attributes::PeriodicEnergyImported::Id>(config.featureFlags.HasAll(
-                ElectricalEnergyMeasurement::Feature::kPeriodicEnergy, ElectricalEnergyMeasurement::Feature::kImportedEnergy));
-            attrs.Set<ElectricalEnergyMeasurement::Attributes::PeriodicEnergyExported::Id>(config.featureFlags.HasAll(
-                ElectricalEnergyMeasurement::Feature::kPeriodicEnergy, ElectricalEnergyMeasurement::Feature::kExportedEnergy));
-            attrs.Set<ElectricalEnergyMeasurement::Attributes::CumulativeEnergyReset::Id>(
-                config.optionalAttributes.Has(
-                    ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset) &&
-                config.featureFlags.Has(ElectricalEnergyMeasurement::Feature::kCumulativeEnergy));
-            return attrs;
-        }())
-    {
-        mMeasurementData.measurementAccuracy.measurementType  = config.accuracyStruct.measurementType;
-        mMeasurementData.measurementAccuracy.measured         = config.accuracyStruct.measured;
-        mMeasurementData.measurementAccuracy.minMeasuredValue = config.accuracyStruct.minMeasuredValue;
-        mMeasurementData.measurementAccuracy.maxMeasuredValue = config.accuracyStruct.maxMeasuredValue;
+    /** @brief Constructor for ElectricalEnergyMeasurementCluster.
+     *
+     * @param config The configuration for the cluster. The only optional attribute is Cumulative Energy Reset,
+     *  the other attributes will be enabled based on the feature flags. Cumulative Energy Reset is only enabled
+     *  if the feature flag for Cumulative Energy is enabled AND the optional attribute is set in the config.
+     *
+     * @note The accuracyStruct must outlive the cluster to avoid dangling pointers.
+     */
+    ElectricalEnergyMeasurementCluster(const Config & config);
 
-        // ReferenceExisting: caller's accuracyRanges data must outlive the cluster
-        using RangeType = ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type;
-        ReadOnlyBufferBuilder<RangeType> rangesBuilder;
-        VerifyOrDie(rangesBuilder.ReferenceExisting(config.accuracyStruct.accuracyRanges) == CHIP_NO_ERROR);
-        mAccuracyRangesStorage                              = rangesBuilder.TakeBuffer();
-        mMeasurementData.measurementAccuracy.accuracyRanges = mAccuracyRangesStorage;
-    }
+    CHIP_ERROR Startup(ServerClusterContext & context) override;
+    void Shutdown(ClusterShutdownType shutdownType) override;
 
     const OptionalAttributesSet & OptionalAttributes() const { return mEnabledOptionalAttributes; }
-    const BitFlags<ElectricalEnergyMeasurement::Feature> & Features() const { return mFeatureFlags; }
+    const BitFlags<Feature> & Features() const { return mFeatureFlags; }
 
-    // Direct access to measurement data - for backwards compatibility
-    const ElectricalEnergyMeasurement::MeasurementData * GetMeasurementData() const { return &mMeasurementData; }
+    /** @brief Direct access to measurement data - for backwards compatibility */
+    const MeasurementData * GetMeasurementData() const { return &mMeasurementData; }
 
-    // Getters - return copies with error checking
+    /** @brief Getters */
     void GetMeasurementAccuracy(MeasurementAccuracyStruct & outValue) const;
     CHIP_ERROR GetCumulativeEnergyImported(Optional<EnergyMeasurementStruct> & outValue) const;
     CHIP_ERROR GetCumulativeEnergyExported(Optional<EnergyMeasurementStruct> & outValue) const;
@@ -119,10 +99,12 @@ public:
     CHIP_ERROR GetPeriodicEnergyExported(Optional<EnergyMeasurementStruct> & outValue) const;
     CHIP_ERROR GetCumulativeEnergyReset(Optional<CumulativeEnergyResetStruct> & outValue) const;
 
-    /// @brief Sets the measurement accuracy.
-    /// @param value The new measurement accuracy value.
-    /// @return CHIP_ERROR_NO_MEMORY if the deep copy of accuracyRanges fails to allocate.
-    /// @note Use the constructor with Config::accuracyStruct for zero-copy reference to long-lived (e.g. flash) data.
+    /** @brief Sets the measurement accuracy.
+     *
+     * @return CHIP_ERROR_NO_MEMORY if the deep copy of accuracyRanges fails to allocate.
+     *
+     * @note Use the constructor with Config::accuracyStruct for zero-copy reference to long-lived (e.g. flash) data.
+     */
     CHIP_ERROR SetMeasurementAccuracy(const MeasurementAccuracyStruct & value);
     CHIP_ERROR SetCumulativeEnergyReset(const Optional<CumulativeEnergyResetStruct> & value);
 
@@ -130,28 +112,61 @@ public:
                                                 AttributeValueEncoder & encoder) override;
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
+    /** @brief Handle to Force an immediate report:
+     *  pulls readings from the delegate, updates attributes, generates events, and resets the periodic timer.
+     *
+     * @note Enforces the min 1s reporting rule, if a report was generated less than 1s ago, this will do nothing.
+     */
+    void GenerateReport();
+
+    /** @brief Legacy snapshot methods -- kept for backwards compatibility with CodegenIntegration */
     void CumulativeEnergySnapshot(const Optional<EnergyMeasurementStruct> & energyImported,
                                   const Optional<EnergyMeasurementStruct> & energyExported);
-
     void PeriodicEnergySnapshot(const Optional<EnergyMeasurementStruct> & energyImported,
                                 const Optional<EnergyMeasurementStruct> & energyExported);
 
 private:
-    // These setters are private since it is intended that the app updates those attributes through CumulativeEnergySnapshot and
-    // PeriodicEnergySnapshot.
     CHIP_ERROR SetCumulativeEnergyImported(const Optional<EnergyMeasurementStruct> & value);
     CHIP_ERROR SetCumulativeEnergyExported(const Optional<EnergyMeasurementStruct> & value);
     CHIP_ERROR SetPeriodicEnergyImported(const Optional<EnergyMeasurementStruct> & value);
     CHIP_ERROR SetPeriodicEnergyExported(const Optional<EnergyMeasurementStruct> & value);
 
-    const BitFlags<ElectricalEnergyMeasurement::Feature> mFeatureFlags;
-    const OptionalAttributesSet mEnabledOptionalAttributes;
-    ElectricalEnergyMeasurement::MeasurementData mMeasurementData;
+    /** @brief Builds an EnergyMeasurementStruct with timestamps, carrying forward the previous endTimestamp as the new startTimestamp. */
+    Optional<EnergyMeasurementStruct> BuildMeasurement(DataModel::Nullable<int64_t> energy,
+                                                       const Optional<EnergyMeasurementStruct> & previous);
 
-    // Owns the accuracyRanges backing store; either references long-lived data (ReferenceExisting) or an allocated copy.
-    ReadOnlyBuffer<ElectricalEnergyMeasurement::Structs::MeasurementAccuracyRangeStruct::Type> mAccuracyRangesStorage;
+    /** @brief Core report logic shared by GenerateReport() and the timer callback */
+    void DoGenerateReport();
+
+    void StartReportTimer();
+    void CancelReportTimer();
+
+    class ReportTimer : public TimerContext
+    {
+    public:
+        ReportTimer(ElectricalEnergyMeasurementCluster & cluster) : mCluster(cluster) {}
+        void TimerFired() override;
+
+    private:
+        ElectricalEnergyMeasurementCluster & mCluster;
+    };
+
+    const BitFlags<Feature> mFeatureFlags;
+    const OptionalAttributesSet mEnabledOptionalAttributes;
+    MeasurementData mMeasurementData;
+
+    /** @brief Owns the accuracyRanges backing store; either references long-lived data (ReferenceExisting) when passing in 
+     * Config::accuracyStruct or an allocated copy when using the SetMeasurementAccuracy() method */
+    ReadOnlyBuffer<Structs::MeasurementAccuracyRangeStruct::Type> mAccuracyRangesStorage;
+
+    Delegate & mDelegate;
+    TimerDelegate & mTimerDelegate;
+    System::Clock::Timeout mReportInterval;
+    System::Clock::Timestamp mLastReportTime{ System::Clock::kZero };
+    ReportTimer mReportTimer{ *this };
 };
 
+} // namespace ElectricalEnergyMeasurement
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
@@ -131,7 +131,8 @@ private:
     CHIP_ERROR SetPeriodicEnergyImported(const Optional<EnergyMeasurementStruct> & value);
     CHIP_ERROR SetPeriodicEnergyExported(const Optional<EnergyMeasurementStruct> & value);
 
-    /** @brief Builds an EnergyMeasurementStruct with timestamps, carrying forward the previous endTimestamp as the new startTimestamp. */
+    /** @brief Builds an EnergyMeasurementStruct with timestamps, carrying forward the previous endTimestamp as the new
+     * startTimestamp. */
     Optional<EnergyMeasurementStruct> BuildMeasurement(DataModel::Nullable<int64_t> energy,
                                                        const Optional<EnergyMeasurementStruct> & previous);
 

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
@@ -156,7 +156,7 @@ private:
     const OptionalAttributesSet mEnabledOptionalAttributes;
     MeasurementData mMeasurementData;
 
-    /** @brief Owns the accuracyRanges backing store; either references long-lived data (ReferenceExisting) when passing in 
+    /** @brief Owns the accuracyRanges backing store; either references long-lived data (ReferenceExisting) when passing in
      * Config::accuracyStruct or an allocated copy when using the SetMeasurementAccuracy() method */
     ReadOnlyBuffer<Structs::MeasurementAccuracyRangeStruct::Type> mAccuracyRangesStorage;
 

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2026 Project CHIP Authors
+ *    Copyright (c) 2025-2026 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h>
+#include <app/data-model/Nullable.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/OptionalAttributeSet.h>
 #include <clusters/ElectricalEnergyMeasurement/AttributeIds.h>
@@ -32,23 +33,14 @@ namespace app {
 namespace Clusters {
 namespace ElectricalEnergyMeasurement {
 
-/** @brief Data structure to hold measurement data for backwards compatibility */
-struct MeasurementData
-{
-    Structs::MeasurementAccuracyStruct::Type measurementAccuracy;
-    Optional<Structs::EnergyMeasurementStruct::Type> cumulativeImported;
-    Optional<Structs::EnergyMeasurementStruct::Type> cumulativeExported;
-    Optional<Structs::EnergyMeasurementStruct::Type> periodicImported;
-    Optional<Structs::EnergyMeasurementStruct::Type> periodicExported;
-    Optional<Structs::CumulativeEnergyResetStruct::Type> cumulativeReset;
-};
-
 class ElectricalEnergyMeasurementCluster : public DefaultServerCluster
 {
 public:
     using MeasurementAccuracyStruct   = Structs::MeasurementAccuracyStruct::Type;
     using EnergyMeasurementStruct     = Structs::EnergyMeasurementStruct::Type;
     using CumulativeEnergyResetStruct = Structs::CumulativeEnergyResetStruct::Type;
+    template <typename T>
+    using Nullable = DataModel::Nullable<T>;
 
     using OptionalAttributesSet = OptionalAttributeSet< //
         Attributes::CumulativeEnergyImported::Id,       //
@@ -88,16 +80,13 @@ public:
     const OptionalAttributesSet & OptionalAttributes() const { return mEnabledOptionalAttributes; }
     const BitFlags<Feature> & Features() const { return mFeatureFlags; }
 
-    /** @brief Direct access to measurement data - for backwards compatibility */
-    const MeasurementData * GetMeasurementData() const { return &mMeasurementData; }
-
     /** @brief Getters */
     void GetMeasurementAccuracy(MeasurementAccuracyStruct & outValue) const;
-    CHIP_ERROR GetCumulativeEnergyImported(Optional<EnergyMeasurementStruct> & outValue) const;
-    CHIP_ERROR GetCumulativeEnergyExported(Optional<EnergyMeasurementStruct> & outValue) const;
-    CHIP_ERROR GetPeriodicEnergyImported(Optional<EnergyMeasurementStruct> & outValue) const;
-    CHIP_ERROR GetPeriodicEnergyExported(Optional<EnergyMeasurementStruct> & outValue) const;
-    CHIP_ERROR GetCumulativeEnergyReset(Optional<CumulativeEnergyResetStruct> & outValue) const;
+    CHIP_ERROR GetCumulativeEnergyImported(Nullable<EnergyMeasurementStruct> & outValue) const;
+    CHIP_ERROR GetCumulativeEnergyExported(Nullable<EnergyMeasurementStruct> & outValue) const;
+    CHIP_ERROR GetPeriodicEnergyImported(Nullable<EnergyMeasurementStruct> & outValue) const;
+    CHIP_ERROR GetPeriodicEnergyExported(Nullable<EnergyMeasurementStruct> & outValue) const;
+    CHIP_ERROR GetCumulativeEnergyReset(Nullable<CumulativeEnergyResetStruct> & outValue) const;
 
     /** @brief Sets the measurement accuracy.
      *
@@ -106,46 +95,55 @@ public:
      * @note Use the constructor with Config::accuracyStruct for zero-copy reference to long-lived (e.g. flash) data.
      */
     CHIP_ERROR SetMeasurementAccuracy(const MeasurementAccuracyStruct & value);
-    CHIP_ERROR SetCumulativeEnergyReset(const Optional<CumulativeEnergyResetStruct> & value);
+    CHIP_ERROR SetCumulativeEnergyReset(const Nullable<CumulativeEnergyResetStruct> & value);
 
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                 AttributeValueEncoder & encoder) override;
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
     /** @brief Handle to Force an immediate report:
-     *  pulls readings from the delegate, updates attributes, generates events, and resets the periodic timer.
+     *  pulls readings from the delegate, updates attributes, generates events, and resets the snapshot timer.
      *
-     * @note Enforces the min 1s reporting rule, if a report was generated less than 1s ago, this will do nothing.
+     * @note Enforces the min 1s reporting rule, if a report was generated less than 1s ago, this will do nothing and the
+     * snapshot timer will ensure the next snapshot is generated withing 60 seconds of ignoring the attribute changes.
      */
-    void GenerateReport();
+    void GenerateSnapshots();
 
     /** @brief Legacy snapshot methods -- kept for backwards compatibility with CodegenIntegration */
-    void CumulativeEnergySnapshot(const Optional<EnergyMeasurementStruct> & energyImported,
-                                  const Optional<EnergyMeasurementStruct> & energyExported);
-    void PeriodicEnergySnapshot(const Optional<EnergyMeasurementStruct> & energyImported,
-                                const Optional<EnergyMeasurementStruct> & energyExported);
+    void CumulativeEnergySnapshot(const Nullable<EnergyMeasurementStruct> & energyImported,
+                                  const Nullable<EnergyMeasurementStruct> & energyExported);
+    void PeriodicEnergySnapshot(const Nullable<EnergyMeasurementStruct> & energyImported,
+                                const Nullable<EnergyMeasurementStruct> & energyExported);
 
 private:
-    CHIP_ERROR SetCumulativeEnergyImported(const Optional<EnergyMeasurementStruct> & value);
-    CHIP_ERROR SetCumulativeEnergyExported(const Optional<EnergyMeasurementStruct> & value);
-    CHIP_ERROR SetPeriodicEnergyImported(const Optional<EnergyMeasurementStruct> & value);
-    CHIP_ERROR SetPeriodicEnergyExported(const Optional<EnergyMeasurementStruct> & value);
+    CHIP_ERROR SetCumulativeEnergyImported(const Nullable<EnergyMeasurementStruct> & value);
+    CHIP_ERROR SetCumulativeEnergyExported(const Nullable<EnergyMeasurementStruct> & value);
+    CHIP_ERROR SetPeriodicEnergyImported(const Nullable<EnergyMeasurementStruct> & value);
+    CHIP_ERROR SetPeriodicEnergyExported(const Nullable<EnergyMeasurementStruct> & value);
 
-    /** @brief Builds an EnergyMeasurementStruct with timestamps, carrying forward the previous endTimestamp as the new
-     * startTimestamp. */
-    Optional<EnergyMeasurementStruct> BuildMeasurement(DataModel::Nullable<int64_t> energy,
-                                                       const Optional<EnergyMeasurementStruct> & previous);
+    // Attributes
+    Structs::MeasurementAccuracyStruct::Type mMeasurementAccuracy;
+    Nullable<Structs::EnergyMeasurementStruct::Type> mCumulativeImported;
+    Nullable<Structs::EnergyMeasurementStruct::Type> mCumulativeExported;
+    Nullable<Structs::EnergyMeasurementStruct::Type> mPeriodicImported;
+    Nullable<Structs::EnergyMeasurementStruct::Type> mPeriodicExported;
+    Nullable<Structs::CumulativeEnergyResetStruct::Type> mCumulativeReset;
 
-    /** @brief Core report logic shared by GenerateReport() and the timer callback */
-    void DoGenerateReport();
+    /** @brief Builds an EnergyMeasurementStruct with timestamps. For periodic (isCumulative == false), copies previous
+     *  endTimestamp/endSystime into start*. For cumulative (isCumulative == true), start fields stay unset (spec). */
+    DataModel::Nullable<EnergyMeasurementStruct>
+    BuildMeasurement(Nullable<int64_t> energy, const Nullable<EnergyMeasurementStruct> & previous, bool isCumulative);
 
-    void StartReportTimer();
-    void CancelReportTimer();
+    /** @brief Core snapshot logic shared by GenerateSnapshots() and the timer callback */
+    void DoGenerateSnapshots();
 
-    class ReportTimer : public TimerContext
+    void StartSnapshotTimer();
+    void CancelSnapshotTimer();
+
+    class SnapshotTimer : public TimerContext
     {
     public:
-        ReportTimer(ElectricalEnergyMeasurementCluster & cluster) : mCluster(cluster) {}
+        SnapshotTimer(ElectricalEnergyMeasurementCluster & cluster) : mCluster(cluster) {}
         void TimerFired() override;
 
     private:
@@ -154,7 +152,6 @@ private:
 
     const BitFlags<Feature> mFeatureFlags;
     const OptionalAttributesSet mEnabledOptionalAttributes;
-    MeasurementData mMeasurementData;
 
     /** @brief Owns the accuracyRanges backing store; either references long-lived data (ReferenceExisting) when passing in
      * Config::accuracyStruct or an allocated copy when using the SetMeasurementAccuracy() method */
@@ -164,7 +161,7 @@ private:
     TimerDelegate & mTimerDelegate;
     System::Clock::Timeout mReportInterval;
     System::Clock::Timestamp mLastReportTime{ System::Clock::kZero };
-    ReportTimer mReportTimer{ *this };
+    SnapshotTimer mSnapshotTimer{ *this };
 };
 
 } // namespace ElectricalEnergyMeasurement

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
@@ -52,8 +52,8 @@ public:
 
     static constexpr System::Clock::Timeout kMaxReportDelayInterval = System::Clock::Seconds32(60);
     /// Alias for the maximum delay between timer-driven snapshot attempts (same as kMaxReportDelayInterval).
-    static constexpr System::Clock::Timeout kMaxReportInterval      = kMaxReportDelayInterval;
-    static constexpr System::Clock::Timeout kMinReportInterval      = System::Clock::Seconds32(1);
+    static constexpr System::Clock::Timeout kMaxReportInterval = kMaxReportDelayInterval;
+    static constexpr System::Clock::Timeout kMinReportInterval = System::Clock::Seconds32(1);
 
     struct Config
     {
@@ -116,13 +116,13 @@ public:
                                 const Nullable<EnergyMeasurementStruct> & energyExported);
 
 private:
-enum class AttributeIgnoredDirtyState : uint32_t
-{
-    CumulativeEnergyImported = 0x1,
-    CumulativeEnergyExported = 0x2,
-    PeriodicEnergyImported = 0x4,
-    PeriodicEnergyExported = 0x8,
-};
+    enum class AttributeIgnoredDirtyState : uint32_t
+    {
+        CumulativeEnergyImported = 0x1,
+        CumulativeEnergyExported = 0x2,
+        PeriodicEnergyImported   = 0x4,
+        PeriodicEnergyExported   = 0x8,
+    };
 
     CHIP_ERROR SetCumulativeEnergyImported(const Nullable<EnergyMeasurementStruct> & value);
     CHIP_ERROR SetCumulativeEnergyExported(const Nullable<EnergyMeasurementStruct> & value);

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
@@ -75,7 +75,6 @@ public:
      */
     ElectricalEnergyMeasurementCluster(const Config & config);
 
-    CHIP_ERROR Startup(ServerClusterContext & context) override;
     void Shutdown(ClusterShutdownType shutdownType) override;
 
     const OptionalAttributesSet & OptionalAttributes() const { return mEnabledOptionalAttributes; }

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
@@ -101,11 +101,11 @@ public:
                                                 AttributeValueEncoder & encoder) override;
     CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
-    /** @brief Handle to Force an immediate report:
-     *  pulls readings from the delegate, updates attributes, generates events, and resets the snapshot timer.
+    /** @brief Handle to request an immediate snapshot/report:
+     *  pulls readings from the delegate, updates attributes, and generates events.
      *
-     * @note Enforces the min 1s reporting rule, if a report was generated less than 1s ago, this will do nothing and the
-     * snapshot timer will ensure the next snapshot is generated within 60 seconds of ignoring the attribute changes.
+     * @note Enforces the minimum reporting interval: if a report was generated less than kMinReportInterval ago, this will
+     *       do nothing, and any subsequent reports will be produced according to the existing reporting/timer mechanisms.
      */
     void GenerateSnapshots();
 

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
@@ -50,8 +50,10 @@ public:
         Attributes::CumulativeEnergyReset::Id           //
         >;
 
-    static constexpr System::Clock::Timeout kMaxReportInterval = System::Clock::Seconds32(60);
-    static constexpr System::Clock::Timeout kMinReportInterval = System::Clock::Seconds32(1);
+    static constexpr System::Clock::Timeout kMaxReportDelayInterval = System::Clock::Seconds32(60);
+    /// Alias for the maximum delay between timer-driven snapshot attempts (same as kMaxReportDelayInterval).
+    static constexpr System::Clock::Timeout kMaxReportInterval      = kMaxReportDelayInterval;
+    static constexpr System::Clock::Timeout kMinReportInterval      = System::Clock::Seconds32(1);
 
     struct Config
     {
@@ -61,7 +63,6 @@ public:
         const Structs::MeasurementAccuracyStruct::Type & accuracyStruct;
         Delegate & delegate;
         TimerDelegate & timerDelegate;
-        System::Clock::Timeout reportInterval = kMaxReportInterval;
     };
 
     /** @brief Constructor for ElectricalEnergyMeasurementCluster.
@@ -105,7 +106,7 @@ public:
      *  pulls readings from the delegate, updates attributes, generates events, and resets the snapshot timer.
      *
      * @note Enforces the min 1s reporting rule, if a report was generated less than 1s ago, this will do nothing and the
-     * snapshot timer will ensure the next snapshot is generated withing 60 seconds of ignoring the attribute changes.
+     * snapshot timer will ensure the next snapshot is generated within 60 seconds of ignoring the attribute changes.
      */
     void GenerateSnapshots();
 
@@ -116,6 +117,14 @@ public:
                                 const Nullable<EnergyMeasurementStruct> & energyExported);
 
 private:
+enum class AttributeIgnoredDirtyState : uint32_t
+{
+    CumulativeEnergyImported = 0x1,
+    CumulativeEnergyExported = 0x2,
+    PeriodicEnergyImported = 0x4,
+    PeriodicEnergyExported = 0x8,
+};
+
     CHIP_ERROR SetCumulativeEnergyImported(const Nullable<EnergyMeasurementStruct> & value);
     CHIP_ERROR SetCumulativeEnergyExported(const Nullable<EnergyMeasurementStruct> & value);
     CHIP_ERROR SetPeriodicEnergyImported(const Nullable<EnergyMeasurementStruct> & value);
@@ -134,16 +143,13 @@ private:
     DataModel::Nullable<EnergyMeasurementStruct>
     BuildMeasurement(Nullable<int64_t> energy, const Nullable<EnergyMeasurementStruct> & previous, bool isCumulative);
 
-    /** @brief Core snapshot logic shared by GenerateSnapshots() and the timer callback */
-    void DoGenerateSnapshots();
+    void StartReportDelayTimer();
+    void CancelReportDelayTimer();
 
-    void StartSnapshotTimer();
-    void CancelSnapshotTimer();
-
-    class SnapshotTimer : public TimerContext
+    class ReportDelayTimer : public TimerContext
     {
     public:
-        SnapshotTimer(ElectricalEnergyMeasurementCluster & cluster) : mCluster(cluster) {}
+        ReportDelayTimer(ElectricalEnergyMeasurementCluster & cluster) : mCluster(cluster) {}
         void TimerFired() override;
 
     private:
@@ -159,9 +165,9 @@ private:
 
     Delegate & mDelegate;
     TimerDelegate & mTimerDelegate;
-    System::Clock::Timeout mReportInterval;
-    System::Clock::Timestamp mLastReportTime{ System::Clock::kZero };
-    SnapshotTimer mSnapshotTimer{ *this };
+
+    BitFlags<AttributeIgnoredDirtyState> mAttributeDirtyState;
+    ReportDelayTimer mReportDelayTimer{ *this };
 };
 
 } // namespace ElectricalEnergyMeasurement

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
@@ -52,7 +52,7 @@ public:
         >;
 
     //
-    // Per Spec, a server cannot report morte frequently than every 1 second:
+    // Per Spec, a server cannot report more frequently than every 1 second:
     // 6.X. [Cumulative/Periodic]Energy[Imported/Exported] Attribute:
     // The server SHALL NOT mark this attribute ready for report if the last time this was done was more recently than 1 second ago.
     //
@@ -156,7 +156,7 @@ public:
      *  pulls readings from the delegate, updates attributes, and generates events.
      *
      * @note Enforces the minimum reporting interval: if a report was generated less than kMinReportInterval ago, this will
-     *       do nothing, and any subsequent reports will be produced according to the existing reporting/timer mechanisms.
+     *        update the cluster values without generating a report.
      */
     void GenerateSnapshots();
 
@@ -167,14 +167,6 @@ public:
                                 const Nullable<EnergyMeasurementStruct> & energyExported);
 
 private:
-    enum class AttributeIgnoredDirtyState : uint32_t
-    {
-        CumulativeEnergyImported = 0x1,
-        CumulativeEnergyExported = 0x2,
-        PeriodicEnergyImported   = 0x4,
-        PeriodicEnergyExported   = 0x8,
-    };
-
     AttributeDirtyState SetCumulativeEnergyImported(const Nullable<EnergyMeasurementStruct> & value);
     AttributeDirtyState SetCumulativeEnergyExported(const Nullable<EnergyMeasurementStruct> & value);
     AttributeDirtyState SetPeriodicEnergyImported(const Nullable<EnergyMeasurementStruct> & value);

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <app/cluster-building-blocks/QuieterReporting.h>
 #include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h>
 #include <app/data-model/Nullable.h>
 #include <app/server-cluster/DefaultServerCluster.h>
@@ -50,11 +51,61 @@ public:
         Attributes::CumulativeEnergyReset::Id           //
         >;
 
-    static constexpr System::Clock::Timeout kMaxReportDelayInterval = System::Clock::Seconds32(60);
-    /// Alias for the maximum delay between timer-driven snapshot attempts (same as kMaxReportDelayInterval).
-    static constexpr System::Clock::Timeout kMaxReportInterval = kMaxReportDelayInterval;
+    //
+    // Per Spec, a server cannot report morte frequently than every 1 second:
+    // 6.X. [Cumulative/Periodic]Energy[Imported/Exported] Attribute:
+    // The server SHALL NOT mark this attribute ready for report if the last time this was done was more recently than 1 second ago.
+    //
     static constexpr System::Clock::Timeout kMinReportInterval = System::Clock::Seconds32(1);
 
+    /**
+     * Quieter reporting wrapper for Nullable<EnergyMeasurementStruct>.
+     *
+     * QuieterReportingAttribute<T> only accepts arithmetic T. This wrapper provides
+     * the same semantics for the EnergyMeasurementStruct and updates the dirty state based on
+     * the struct's `energy` field via an internal QuieterReportingAttribute<int64_t>.
+     *
+     */
+    class QuieterReportingEnergyAttribute
+    {
+    public:
+        using StructType = Structs::EnergyMeasurementStruct::Type;
+        template <typename T>
+        using Nullable = DataModel::Nullable<T>;
+
+        QuieterReportingEnergyAttribute() = default;
+
+        explicit QuieterReportingEnergyAttribute(const Nullable<StructType> & initialValue) :
+            mValue(initialValue), mEnergyTracker(EnergyKey(initialValue))
+        {}
+
+        const Nullable<StructType> & value() const { return mValue; }
+
+        /**
+         * Update the held struct and compute reporting state based on the energy field.
+         *
+         * @param newValue new struct value (or null) to store
+         * @param now      monotonic timestamp at the time of the call
+         * @return AttributeDirtyState::kMustReport if a report is required, otherwise kNoReportNeeded.
+         */
+        AttributeDirtyState SetValue(const Nullable<StructType> & newValue, System::Clock::Milliseconds64 now)
+        {
+
+            auto predicate            = mEnergyTracker.GetPredicateForSufficientTimeSinceLastDirty(kMinReportInterval);
+            AttributeDirtyState state = mEnergyTracker.SetValue(EnergyKey(newValue), now, predicate);
+            mValue                    = newValue;
+            return state;
+        }
+
+    private:
+        static Nullable<int64_t> EnergyKey(const Nullable<StructType> & v)
+        {
+            return v.IsNull() ? Nullable<int64_t>() : DataModel::MakeNullable(v.Value().energy);
+        }
+
+        Nullable<StructType> mValue;
+        QuieterReportingAttribute<int64_t> mEnergyTracker;
+    };
     struct Config
     {
         EndpointId endpointId;
@@ -124,36 +175,23 @@ private:
         PeriodicEnergyExported   = 0x8,
     };
 
-    CHIP_ERROR SetCumulativeEnergyImported(const Nullable<EnergyMeasurementStruct> & value);
-    CHIP_ERROR SetCumulativeEnergyExported(const Nullable<EnergyMeasurementStruct> & value);
-    CHIP_ERROR SetPeriodicEnergyImported(const Nullable<EnergyMeasurementStruct> & value);
-    CHIP_ERROR SetPeriodicEnergyExported(const Nullable<EnergyMeasurementStruct> & value);
+    AttributeDirtyState SetCumulativeEnergyImported(const Nullable<EnergyMeasurementStruct> & value);
+    AttributeDirtyState SetCumulativeEnergyExported(const Nullable<EnergyMeasurementStruct> & value);
+    AttributeDirtyState SetPeriodicEnergyImported(const Nullable<EnergyMeasurementStruct> & value);
+    AttributeDirtyState SetPeriodicEnergyExported(const Nullable<EnergyMeasurementStruct> & value);
 
     // Attributes
     Structs::MeasurementAccuracyStruct::Type mMeasurementAccuracy;
-    Nullable<Structs::EnergyMeasurementStruct::Type> mCumulativeImported;
-    Nullable<Structs::EnergyMeasurementStruct::Type> mCumulativeExported;
-    Nullable<Structs::EnergyMeasurementStruct::Type> mPeriodicImported;
-    Nullable<Structs::EnergyMeasurementStruct::Type> mPeriodicExported;
+    QuieterReportingEnergyAttribute mCumulativeImported;
+    QuieterReportingEnergyAttribute mCumulativeExported;
+    QuieterReportingEnergyAttribute mPeriodicImported;
+    QuieterReportingEnergyAttribute mPeriodicExported;
     Nullable<Structs::CumulativeEnergyResetStruct::Type> mCumulativeReset;
 
     /** @brief Builds an EnergyMeasurementStruct with timestamps. For periodic (isCumulative == false), copies previous
      *  endTimestamp/endSystime into start*. For cumulative (isCumulative == true), start fields stay unset (spec). */
     DataModel::Nullable<EnergyMeasurementStruct>
     BuildMeasurement(Nullable<int64_t> energy, const Nullable<EnergyMeasurementStruct> & previous, bool isCumulative);
-
-    void StartReportDelayTimer();
-    void CancelReportDelayTimer();
-
-    class ReportDelayTimer : public TimerContext
-    {
-    public:
-        ReportDelayTimer(ElectricalEnergyMeasurementCluster & cluster) : mCluster(cluster) {}
-        void TimerFired() override;
-
-    private:
-        ElectricalEnergyMeasurementCluster & mCluster;
-    };
 
     const BitFlags<Feature> mFeatureFlags;
     const OptionalAttributesSet mEnabledOptionalAttributes;
@@ -164,9 +202,6 @@ private:
 
     Delegate & mDelegate;
     TimerDelegate & mTimerDelegate;
-
-    BitFlags<AttributeIgnoredDirtyState> mAttributeDirtyState;
-    ReportDelayTimer mReportDelayTimer{ *this };
 };
 
 } // namespace ElectricalEnergyMeasurement

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h
@@ -1,0 +1,48 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/data-model/Nullable.h>
+#include <lib/core/DataModelTypes.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ElectricalEnergyMeasurement {
+
+/// Abstract interface for the EEM cluster to pull energy readings from hardware.
+///
+/// The cluster calls these methods on its reporting timer (or on a manual GenerateReport() call).
+/// Implementations should return Nullable null when the value cannot currently be determined.
+/// The cluster only calls getters matching its enabled features.
+/// All values are in milli-watt-hours (mWh).
+class Delegate
+{
+public:
+    virtual ~Delegate() = default;
+
+    virtual DataModel::Nullable<int64_t> GetCumulativeEnergyImported() = 0;
+    virtual DataModel::Nullable<int64_t> GetCumulativeEnergyExported() = 0;
+    virtual DataModel::Nullable<int64_t> GetPeriodicEnergyImported()   = 0;
+    virtual DataModel::Nullable<int64_t> GetPeriodicEnergyExported()   = 0;
+};
+
+} // namespace ElectricalEnergyMeasurement
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h
@@ -28,7 +28,13 @@ namespace ElectricalEnergyMeasurement {
 /// Abstract interface for the EEM cluster to pull energy readings from hardware.
 ///
 /// The cluster calls these methods on its reporting timer (or on a manual GenerateSnapshots() call).
-/// Implementations should return Nullable null when the value cannot currently be determined.
+/// Implementations should return a non-null value when a new reading is available, and Nullable null when
+/// the value cannot currently be determined or when there is no new reading to report.
+///
+/// Current cluster behavior: a null reading is treated as "no update". The cluster preserves the previously
+/// stored attribute value and does not emit an attribute change or event for that reading; null does not
+/// clear the attribute. Delegate implementations should be written with this behavior in mind.
+///
 /// The cluster only calls getters matching its enabled features.
 /// All values are in milli-watt-hours (mWh).
 class Delegate

--- a/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h
+++ b/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementDelegate.h
@@ -27,7 +27,7 @@ namespace ElectricalEnergyMeasurement {
 
 /// Abstract interface for the EEM cluster to pull energy readings from hardware.
 ///
-/// The cluster calls these methods on its reporting timer (or on a manual GenerateReport() call).
+/// The cluster calls these methods on its reporting timer (or on a manual GenerateSnapshots() call).
 /// Implementations should return Nullable null when the value cannot currently be determined.
 /// The cluster only calls getters matching its enabled features.
 /// All values are in milli-watt-hours (mWh).

--- a/src/app/clusters/electrical-energy-measurement-server/tests/BUILD.gn
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/BUILD.gn
@@ -32,6 +32,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/app/data-model-provider/tests:encode-decode",
     "${chip_root}/src/app/server-cluster/testing",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/lib/support:timer-delegate-mock",
   ]
 }
 
@@ -58,5 +59,7 @@ chip_test_suite("tests-backwards-compatibility") {
     "${chip_root}/src/app/server-cluster/testing",
     "${chip_root}/src/data-model-providers/codegen/tests:mock_model",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/lib/support:timer-delegate-mock",
+    "${chip_root}/src/platform",
   ]
 }

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2025 Project CHIP Authors
+ *    Copyright (c) 2026 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
  */
 
 #include <app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.h>
+#include <lib/support/TimerDelegateMock.h>
 #include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
@@ -54,13 +55,59 @@ const Structs::MeasurementAccuracyStruct::Type kTestAccuracy = {
     .accuracyRanges   = DataModel::List<const Structs::MeasurementAccuracyRangeStruct::Type>(kTestAccuracyRanges)
 };
 
+class MockEEMDelegate : public ElectricalEnergyMeasurement::Delegate
+{
+public:
+    DataModel::Nullable<int64_t> GetCumulativeEnergyImported() override { return DataModel::MakeNullable(mCumulativeImported); }
+    DataModel::Nullable<int64_t> GetCumulativeEnergyExported() override { return DataModel::MakeNullable(mCumulativeExported); }
+    DataModel::Nullable<int64_t> GetPeriodicEnergyImported() override { return DataModel::MakeNullable(mPeriodicImported); }
+    DataModel::Nullable<int64_t> GetPeriodicEnergyExported() override { return DataModel::MakeNullable(mPeriodicExported); }
+
+    int64_t mCumulativeImported = 0;
+    int64_t mCumulativeExported = 0;
+    int64_t mPeriodicImported   = 0;
+    int64_t mPeriodicExported   = 0;
+};
+
 struct TestElectricalEnergyMeasurementCluster : public ::testing::Test
 {
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
 
     void SetUp() override {}
+
+    MockEEMDelegate mDelegate;
+    TimerDelegateMock mTimerDelegate;
 };
+
+TEST_F(TestElectricalEnergyMeasurementCluster, TestConstructorWithAccuracy)
+{
+    BitMask<Feature> features(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
+    ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
+        .endpointId         = kTestEndpointId + 10,
+        .featureFlags       = features,
+        .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet(),
+        .accuracyStruct     = kTestAccuracy,
+        .delegate           = mDelegate,
+        .timerDelegate      = mTimerDelegate,
+    });
+
+    Structs::MeasurementAccuracyStruct::Type readAccuracy;
+    cluster.GetMeasurementAccuracy(readAccuracy);
+
+    EXPECT_EQ(readAccuracy.measurementType, MeasurementTypeEnum::kElectricalEnergy);
+    EXPECT_TRUE(readAccuracy.measured);
+    EXPECT_EQ(readAccuracy.minMeasuredValue, 0);
+    EXPECT_EQ(readAccuracy.maxMeasuredValue, 1'000'000'000'000'000);
+    ASSERT_EQ(readAccuracy.accuracyRanges.size(), 1u);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].rangeMin, 0);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].rangeMax, 1'000'000'000'000'000);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMax.Value(), 500);
+    EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMin.Value(), 50);
+
+    // Verify zero-copy: the ranges Span should point directly at the static data
+    EXPECT_EQ(readAccuracy.accuracyRanges.data(), kTestAccuracyRanges);
+}
 
 TEST_F(TestElectricalEnergyMeasurementCluster, AttributeListTest)
 {
@@ -73,8 +120,10 @@ TEST_F(TestElectricalEnergyMeasurementCluster, AttributeListTest)
         ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
             .endpointId         = kTestEndpointId,
             .featureFlags       = noFeatures,
-            .optionalAttributes = static_cast<ElectricalEnergyMeasurement::OptionalAttributes>(0),
+            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet(),
             .accuracyStruct     = kTestAccuracy,
+            .delegate           = mDelegate,
+            .timerDelegate      = mTimerDelegate,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -89,12 +138,13 @@ TEST_F(TestElectricalEnergyMeasurementCluster, AttributeListTest)
         BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
                                      Feature::kPeriodicEnergy);
 
-        // Optional attributes are automatically set based on feature flags in Config constructor
         ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
             .endpointId         = kTestEndpointId,
             .featureFlags       = allFeatures,
-            .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet().Set<CumulativeEnergyReset::Id>(),
             .accuracyStruct     = kTestAccuracy,
+            .delegate           = mDelegate,
+            .timerDelegate      = mTimerDelegate,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -114,20 +164,19 @@ TEST_F(TestElectricalEnergyMeasurementCluster, AttributeListTest)
 
     // Test 3: CumulativeEnergyReset requires kCumulativeEnergy feature
     {
-        // Even if we request the optional CumulativeEnergyReset attribute,
-        // it should not be enabled without kCumulativeEnergy feature
         BitMask<Feature> noFeatures;
 
         ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
             .endpointId         = kTestEndpointId,
             .featureFlags       = noFeatures,
-            .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet().Set<CumulativeEnergyReset::Id>(),
             .accuracyStruct     = kTestAccuracy,
+            .delegate           = mDelegate,
+            .timerDelegate      = mTimerDelegate,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
-        // Verify CumulativeEnergyReset is NOT present because kCumulativeEnergy feature is not enabled
         EXPECT_TRUE(IsAttributesListEqualTo(cluster, { Attributes::Accuracy::kMetadataEntry }));
 
         cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -146,8 +195,10 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GettersSettersWithFeatureValidati
         ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
             .endpointId         = kTestEndpointId,
             .featureFlags       = allFeatures,
-            .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet().Set<CumulativeEnergyReset::Id>(),
             .accuracyStruct     = kTestAccuracy,
+            .delegate           = mDelegate,
+            .timerDelegate      = mTimerDelegate,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
@@ -196,13 +247,14 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GettersSettersWithFeatureValidati
         ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
             .endpointId         = kTestEndpointId,
             .featureFlags       = noFeatures,
-            .optionalAttributes = static_cast<ElectricalEnergyMeasurement::OptionalAttributes>(0),
+            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet(),
             .accuracyStruct     = kTestAccuracy,
+            .delegate           = mDelegate,
+            .timerDelegate      = mTimerDelegate,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
-        // Try to get values - should fail with feature error
         Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
         EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
         EXPECT_EQ(cluster.GetCumulativeEnergyExported(readValue), CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
@@ -228,39 +280,36 @@ TEST_F(TestElectricalEnergyMeasurementCluster, FeatureAttributeTest)
         ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
             .endpointId         = kTestEndpointId,
             .featureFlags       = allFeatures,
-            .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet().Set<CumulativeEnergyReset::Id>(),
             .accuracyStruct     = kTestAccuracy,
+            .delegate           = mDelegate,
+            .timerDelegate      = mTimerDelegate,
         });
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
         ClusterTester tester(cluster);
 
-        // Test CumulativeEnergyImported (requires kCumulativeEnergy + kImportedEnergy)
         {
             DataModel::Nullable<Structs::EnergyMeasurementStruct::DecodableType> value;
             EXPECT_TRUE(tester.ReadAttribute(CumulativeEnergyImported::Id, value).IsSuccess());
         }
 
-        // Test CumulativeEnergyExported (requires kCumulativeEnergy + kExportedEnergy)
         {
             DataModel::Nullable<Structs::EnergyMeasurementStruct::DecodableType> value;
             EXPECT_TRUE(tester.ReadAttribute(CumulativeEnergyExported::Id, value).IsSuccess());
         }
 
-        // Test PeriodicEnergyImported (requires kPeriodicEnergy + kImportedEnergy)
         {
             DataModel::Nullable<Structs::EnergyMeasurementStruct::DecodableType> value;
             EXPECT_TRUE(tester.ReadAttribute(PeriodicEnergyImported::Id, value).IsSuccess());
         }
 
-        // Test PeriodicEnergyExported (requires kPeriodicEnergy + kExportedEnergy)
         {
             DataModel::Nullable<Structs::EnergyMeasurementStruct::DecodableType> value;
             EXPECT_TRUE(tester.ReadAttribute(PeriodicEnergyExported::Id, value).IsSuccess());
         }
 
-        // Test CumulativeEnergyReset (requires kCumulativeEnergy)
         {
             DataModel::Nullable<Structs::CumulativeEnergyResetStruct::DecodableType> value;
             EXPECT_TRUE(tester.ReadAttribute(CumulativeEnergyReset::Id, value).IsSuccess());
@@ -274,20 +323,20 @@ TEST_F(TestElectricalEnergyMeasurementCluster, ReadAttributeWithClusterTesterTes
 {
     TestServerClusterContext context;
 
-    // Create a cluster with all features enabled
     BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
                                  Feature::kPeriodicEnergy);
 
     ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
         .endpointId         = kTestEndpointId,
         .featureFlags       = allFeatures,
-        .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+        .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet().Set<CumulativeEnergyReset::Id>(),
         .accuracyStruct     = kTestAccuracy,
+        .delegate           = mDelegate,
+        .timerDelegate      = mTimerDelegate,
     });
 
     EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
-    // Create ClusterTester for simplified attribute reading
     ClusterTester tester(cluster);
 
     Structs::MeasurementAccuracyStruct::DecodableType accuracy;
@@ -330,36 +379,35 @@ TEST_F(TestElectricalEnergyMeasurementCluster, SnapshotsSetValuesAndGenerateEven
 {
     TestServerClusterContext testContext;
 
-    // Create a cluster with all features enabled
     BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
                                  Feature::kPeriodicEnergy);
 
     ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
         .endpointId         = kTestEndpointId,
         .featureFlags       = allFeatures,
-        .optionalAttributes = ElectricalEnergyMeasurement::OptionalAttributes::kOptionalAttributeCumulativeEnergyReset,
+        .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet().Set<CumulativeEnergyReset::Id>(),
         .accuracyStruct     = kTestAccuracy,
+        .delegate           = mDelegate,
+        .timerDelegate      = mTimerDelegate,
     });
 
     EXPECT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
 
     auto & logOnlyEvents = testContext.EventsGenerator();
 
-    // Prepare energy measurement data
     ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct energyImported;
-    energyImported.energy = 10000; // 10 Wh
+    energyImported.energy = 10000;
 
     ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct energyExported;
-    energyExported.energy = 5000; // 5 Wh
+    energyExported.energy = 5000;
 
     Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> optionalImported(energyImported);
     Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> optionalExported(energyExported);
 
-    // Test cumulative energy snapshot - should set values and generate event
+    // Test cumulative energy snapshot
     {
         cluster.CumulativeEnergySnapshot(optionalImported, optionalExported);
 
-        // Verify that values were set
         Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
         EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
         ASSERT_TRUE(readValue.HasValue());
@@ -369,14 +417,13 @@ TEST_F(TestElectricalEnergyMeasurementCluster, SnapshotsSetValuesAndGenerateEven
         ASSERT_TRUE(readValue.HasValue());
         EXPECT_EQ(readValue.Value().energy, 5000);
 
-        // Get the event from the queue
         auto event = logOnlyEvents.GetNextEvent();
 
-        using CumulativeEventType = chip::app::Clusters::ElectricalEnergyMeasurement::Events::CumulativeEnergyMeasured::Type;
+        using CumulativeEventType = Events::CumulativeEnergyMeasured::Type;
         ASSERT_TRUE(event.has_value());
         EXPECT_EQ((*event).eventOptions.mPath,
                   ConcreteEventPath(kTestEndpointId, CumulativeEventType::GetClusterId(), CumulativeEventType::GetEventId()));
-        chip::app::Clusters::ElectricalEnergyMeasurement::Events::CumulativeEnergyMeasured::DecodableType decodedEvent;
+        Events::CumulativeEnergyMeasured::DecodableType decodedEvent;
 
         ASSERT_EQ((*event).GetEventData(decodedEvent), CHIP_NO_ERROR);
 
@@ -387,11 +434,10 @@ TEST_F(TestElectricalEnergyMeasurementCluster, SnapshotsSetValuesAndGenerateEven
         EXPECT_EQ(decodedEvent.energyExported.Value().energy, 5000);
     }
 
-    // Test periodic energy snapshot - should set values and generate event
+    // Test periodic energy snapshot
     {
         cluster.PeriodicEnergySnapshot(optionalImported, optionalExported);
 
-        // Verify that values were set
         Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
         EXPECT_EQ(cluster.GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
         ASSERT_TRUE(readValue.HasValue());
@@ -401,14 +447,13 @@ TEST_F(TestElectricalEnergyMeasurementCluster, SnapshotsSetValuesAndGenerateEven
         ASSERT_TRUE(readValue.HasValue());
         EXPECT_EQ(readValue.Value().energy, 5000);
 
-        // Get the event from the queue
         auto event = logOnlyEvents.GetNextEvent();
 
-        using PeriodicEventType = chip::app::Clusters::ElectricalEnergyMeasurement::Events::PeriodicEnergyMeasured::Type;
+        using PeriodicEventType = Events::PeriodicEnergyMeasured::Type;
         ASSERT_TRUE(event.has_value());
         EXPECT_EQ((*event).eventOptions.mPath,
                   ConcreteEventPath(kTestEndpointId, PeriodicEventType::GetClusterId(), PeriodicEventType::GetEventId()));
-        chip::app::Clusters::ElectricalEnergyMeasurement::Events::PeriodicEnergyMeasured::DecodableType decodedEvent;
+        Events::PeriodicEnergyMeasured::DecodableType decodedEvent;
 
         ASSERT_EQ((*event).GetEventData(decodedEvent), CHIP_NO_ERROR);
 
@@ -418,6 +463,162 @@ TEST_F(TestElectricalEnergyMeasurementCluster, SnapshotsSetValuesAndGenerateEven
         ASSERT_TRUE(decodedEvent.energyExported.HasValue());
         EXPECT_EQ(decodedEvent.energyExported.Value().energy, 5000);
     }
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportPullsDelegateAndGeneratesEvents)
+{
+    TestServerClusterContext testContext;
+
+    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
+                                 Feature::kPeriodicEnergy);
+
+    ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
+        .endpointId         = kTestEndpointId,
+        .featureFlags       = allFeatures,
+        .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet(),
+        .accuracyStruct     = kTestAccuracy,
+        .delegate           = mDelegate,
+        .timerDelegate      = mTimerDelegate,
+    });
+
+    EXPECT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+    auto & logOnlyEvents = testContext.EventsGenerator();
+
+    // Set delegate values
+    mDelegate.mCumulativeImported = 42000;
+    mDelegate.mCumulativeExported = 10000;
+    mDelegate.mPeriodicImported   = 500;
+    mDelegate.mPeriodicExported   = 200;
+
+    // Advance clock past min report interval so GenerateReport works
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
+
+    cluster.GenerateReport();
+
+    // Verify cumulative event
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+        Events::CumulativeEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 42000);
+        ASSERT_TRUE(decoded.energyExported.HasValue());
+        EXPECT_EQ(decoded.energyExported.Value().energy, 10000);
+    }
+
+    // Verify periodic event
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+        Events::PeriodicEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 500);
+        ASSERT_TRUE(decoded.energyExported.HasValue());
+        EXPECT_EQ(decoded.energyExported.Value().energy, 200);
+    }
+
+    // Verify internal measurement data was updated
+    Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
+    EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
+    ASSERT_TRUE(readValue.HasValue());
+    EXPECT_EQ(readValue.Value().energy, 42000);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportRespectsMinInterval)
+{
+    TestServerClusterContext testContext;
+
+    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
+
+    ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
+        .endpointId         = kTestEndpointId,
+        .featureFlags       = allFeatures,
+        .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet(),
+        .accuracyStruct     = kTestAccuracy,
+        .delegate           = mDelegate,
+        .timerDelegate      = mTimerDelegate,
+    });
+
+    EXPECT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+    auto & logOnlyEvents = testContext.EventsGenerator();
+
+    mDelegate.mCumulativeImported = 100;
+
+    // Advance the clock to avoid having the last report = 0, impossible in practice but would happen in tests without this.
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
+
+    // First report should work (clock at 0, no previous report)
+    cluster.GenerateReport();
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+    }
+
+    // Second call 1 ms after first report -- should be silently dropped (min 1s)
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
+    mDelegate.mCumulativeImported = 200;
+    cluster.GenerateReport();
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        EXPECT_FALSE(event.has_value());
+    }
+
+    // Advance past min interval
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
+    cluster.GenerateReport();
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+        Events::CumulativeEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 200);
+    }
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalEnergyMeasurementCluster, TimerFiresAndGeneratesReport)
+{
+    TestServerClusterContext testContext;
+
+    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
+
+    ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
+        .endpointId         = kTestEndpointId,
+        .featureFlags       = allFeatures,
+        .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet(),
+        .accuracyStruct     = kTestAccuracy,
+        .delegate           = mDelegate,
+        .timerDelegate      = mTimerDelegate,
+    });
+
+    EXPECT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+    auto & logOnlyEvents = testContext.EventsGenerator();
+
+    mDelegate.mCumulativeImported = 99999;
+
+    // Advance clock by the report interval (default 60s) -- should trigger TimerFired
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
+
+    auto event = logOnlyEvents.GetNextEvent();
+    ASSERT_TRUE(event.has_value());
+
+    Events::CumulativeEnergyMeasured::DecodableType decoded;
+    ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+    ASSERT_TRUE(decoded.energyImported.HasValue());
+    EXPECT_EQ(decoded.energyImported.Value().energy, 99999);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -641,7 +641,6 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateReport)
     EXPECT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
     auto & logOnlyEvents = testContext.EventsGenerator();
 
-
     {
         // Test when the delegate has no data, all values are null
         mDelegate.mCumulativeImported.SetNull();
@@ -649,8 +648,8 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateReport)
         mDelegate.mPeriodicImported.SetNull();
         mDelegate.mPeriodicExported.SetNull();
 
-        DataModel::Nullable<int64_t>  testImported = mDelegate.GetCumulativeEnergyImported();
-        DataModel::Nullable<int64_t>  testExported = mDelegate.GetCumulativeEnergyExported();
+        DataModel::Nullable<int64_t> testImported = mDelegate.GetCumulativeEnergyImported();
+        DataModel::Nullable<int64_t> testExported = mDelegate.GetCumulativeEnergyExported();
         EXPECT_TRUE(testImported.IsNull());
         EXPECT_TRUE(testExported.IsNull());
 

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -659,15 +659,28 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TimerFiresAndGeneratesReport)
 
     auto & logOnlyEvents = testContext.EventsGenerator();
 
+    // Establish stored values with a first report.
+    mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(1));
+    mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(1));
+    mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(1));
+    mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(1));
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
+    cluster.GenerateSnapshots();
+    ASSERT_TRUE(logOnlyEvents.GetNextEvent().has_value());
+    ASSERT_TRUE(logOnlyEvents.GetNextEvent().has_value());
+
+    // Rate-limited update within 1 s -- starts the delay timer.
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
     mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(99999));
     mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(88888));
     mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(7777));
     mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(6666));
+    cluster.GenerateSnapshots();
+    EXPECT_FALSE(logOnlyEvents.GetNextEvent().has_value());
 
-    // Advance clock by the report interval (default 60s) -- should trigger TimerFired → GenerateSnapshots
-    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
+    // Advance past the max-delay timer -- should fire and produce a full report.
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportDelayInterval);
 
-    // CumulativeEnergyMeasured event with both imported and exported
     {
         auto event = logOnlyEvents.GetNextEvent();
         ASSERT_TRUE(event.has_value());
@@ -679,7 +692,6 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TimerFiresAndGeneratesReport)
         EXPECT_EQ(decoded.energyExported.Value().energy, 88888);
     }
 
-    // PeriodicEnergyMeasured event with both imported and exported
     {
         auto event = logOnlyEvents.GetNextEvent();
         ASSERT_TRUE(event.has_value());
@@ -691,7 +703,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TimerFiresAndGeneratesReport)
         EXPECT_EQ(decoded.energyExported.Value().energy, 6666);
     }
 
-    // All 4 attributes must be readable with the correct values
+    // All 4 attributes must be readable with the correct values.
     {
         DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
         EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -537,7 +537,8 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateSnapshotsRespectsMinInter
 {
     TestServerClusterContext testContext;
 
-    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
+    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
+                                 Feature::kPeriodicEnergy);
 
     ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
         .endpointId         = kTestEndpointId,
@@ -553,36 +554,86 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateSnapshotsRespectsMinInter
     auto & logOnlyEvents = testContext.EventsGenerator();
 
     mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(100));
+    mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(50));
+    mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(10));
+    mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(5));
 
-    // Advance the clock to avoid having the last report = 0, impossible in practice but would happen in tests without this.
     mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
 
-    // First report should work (clock at 0, no previous report)
+    // First report -- all 4 attributes should notify, both events should fire.
     cluster.GenerateSnapshots();
     {
-        auto event = logOnlyEvents.GetNextEvent();
-        ASSERT_TRUE(event.has_value());
+        auto cumulativeEvent = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(cumulativeEvent.has_value());
+        Events::CumulativeEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ(cumulativeEvent->GetEventData(decoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 100);
+        ASSERT_TRUE(decoded.energyExported.HasValue());
+        EXPECT_EQ(decoded.energyExported.Value().energy, 50);
+
+        auto periodicEvent = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(periodicEvent.has_value());
+        Events::PeriodicEnergyMeasured::DecodableType periodicDecoded;
+        ASSERT_EQ(periodicEvent->GetEventData(periodicDecoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(periodicDecoded.energyImported.HasValue());
+        EXPECT_EQ(periodicDecoded.energyImported.Value().energy, 10);
+        ASSERT_TRUE(periodicDecoded.energyExported.HasValue());
+        EXPECT_EQ(periodicDecoded.energyExported.Value().energy, 5);
     }
 
-    // Second call 1 ms after first report -- should be silently dropped (min 1s)
+    // +1 ms: inside min interval -- all 4 attributes should be gated, no events.
     mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
     mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(200));
+    mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(150));
+    mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(20));
+    mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(15));
     cluster.GenerateSnapshots();
     {
-        auto event = logOnlyEvents.GetNextEvent();
-        EXPECT_FALSE(event.has_value());
+        EXPECT_FALSE(logOnlyEvents.GetNextEvent().has_value());
     }
 
-    // Advance past min interval
+    // Attribute values are still updated internally even when gated.
+    {
+        DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
+        EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 200);
+
+        EXPECT_EQ(cluster.GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 150);
+
+        EXPECT_EQ(cluster.GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 20);
+
+        EXPECT_EQ(cluster.GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 15);
+    }
+
+    // Advance past min interval -- all 4 should notify, both events should fire with latest values.
     mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
     cluster.GenerateSnapshots();
     {
-        auto event = logOnlyEvents.GetNextEvent();
-        ASSERT_TRUE(event.has_value());
+        auto cumulativeEvent = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(cumulativeEvent.has_value());
         Events::CumulativeEnergyMeasured::DecodableType decoded;
-        ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+        ASSERT_EQ(cumulativeEvent->GetEventData(decoded), CHIP_NO_ERROR);
         ASSERT_TRUE(decoded.energyImported.HasValue());
         EXPECT_EQ(decoded.energyImported.Value().energy, 200);
+        ASSERT_TRUE(decoded.energyExported.HasValue());
+        EXPECT_EQ(decoded.energyExported.Value().energy, 150);
+
+        auto periodicEvent = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(periodicEvent.has_value());
+        Events::PeriodicEnergyMeasured::DecodableType periodicDecoded;
+        ASSERT_EQ(periodicEvent->GetEventData(periodicDecoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(periodicDecoded.energyImported.HasValue());
+        EXPECT_EQ(periodicDecoded.energyImported.Value().energy, 20);
+        ASSERT_TRUE(periodicDecoded.energyExported.HasValue());
+        EXPECT_EQ(periodicDecoded.energyExported.Value().energy, 15);
     }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -592,7 +643,8 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TimerFiresAndGeneratesReport)
 {
     TestServerClusterContext testContext;
 
-    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
+    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
+                                 Feature::kPeriodicEnergy);
 
     ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
         .endpointId         = kTestEndpointId,
@@ -608,17 +660,56 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TimerFiresAndGeneratesReport)
     auto & logOnlyEvents = testContext.EventsGenerator();
 
     mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(99999));
+    mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(88888));
+    mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(7777));
+    mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(6666));
 
-    // Advance clock by the report interval (default 60s) -- should trigger TimerFired
+    // Advance clock by the report interval (default 60s) -- should trigger TimerFired → GenerateSnapshots
     mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
 
-    auto event = logOnlyEvents.GetNextEvent();
-    ASSERT_TRUE(event.has_value());
+    // CumulativeEnergyMeasured event with both imported and exported
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+        Events::CumulativeEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ(event->GetEventData(decoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 99999);
+        ASSERT_TRUE(decoded.energyExported.HasValue());
+        EXPECT_EQ(decoded.energyExported.Value().energy, 88888);
+    }
 
-    Events::CumulativeEnergyMeasured::DecodableType decoded;
-    ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
-    ASSERT_TRUE(decoded.energyImported.HasValue());
-    EXPECT_EQ(decoded.energyImported.Value().energy, 99999);
+    // PeriodicEnergyMeasured event with both imported and exported
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+        Events::PeriodicEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ(event->GetEventData(decoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 7777);
+        ASSERT_TRUE(decoded.energyExported.HasValue());
+        EXPECT_EQ(decoded.energyExported.Value().energy, 6666);
+    }
+
+    // All 4 attributes must be readable with the correct values
+    {
+        DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
+        EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 99999);
+
+        EXPECT_EQ(cluster.GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 88888);
+
+        EXPECT_EQ(cluster.GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 7777);
+
+        EXPECT_EQ(cluster.GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 6666);
+    }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
@@ -680,7 +771,8 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
             EXPECT_FALSE(decoded.energyImported.Value().startTimestamp.HasValue());
             EXPECT_FALSE(decoded.energyImported.Value().startSystime.HasValue());
             ASSERT_TRUE(decoded.energyImported.Value().endTimestamp.HasValue());
-            EXPECT_FALSE(decoded.energyImported.Value().endSystime.HasValue());
+            ASSERT_TRUE(decoded.energyImported.Value().endSystime.HasValue());
+            EXPECT_EQ(decoded.energyImported.Value().endSystime.Value(), 0u);
         }
 
         // Second cumulative reading: still no start* (cumulative BuildMeasurement omits carry-over).
@@ -696,6 +788,9 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
             EXPECT_EQ(decoded.energyImported.Value().energy, 200);
             EXPECT_FALSE(decoded.energyImported.Value().startTimestamp.HasValue());
             EXPECT_FALSE(decoded.energyImported.Value().startSystime.HasValue());
+            ASSERT_TRUE(decoded.energyImported.Value().endSystime.HasValue());
+            EXPECT_EQ(decoded.energyImported.Value().endSystime.Value(),
+                      static_cast<uint64_t>(mTimerDelegate.GetCurrentMonotonicTimestamp().count()));
         }
     }
 
@@ -749,6 +844,101 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
 
         periodicCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
     }
+}
+
+TEST_F(TestElectricalEnergyMeasurementCluster, RateLimitedUpdateFlushesOnMaxDelayTimer)
+{
+    TestServerClusterContext testContext;
+
+    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
+                                 Feature::kPeriodicEnergy);
+
+    ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
+        .endpointId         = kTestEndpointId,
+        .featureFlags       = allFeatures,
+        .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet(),
+        .accuracyStruct     = kTestAccuracy,
+        .delegate           = mDelegate,
+        .timerDelegate      = mTimerDelegate,
+    });
+
+    EXPECT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+    auto & logOnlyEvents = testContext.EventsGenerator();
+
+    // Seed all 4 attributes with initial values and get a clean first report.
+    mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(100));
+    mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(50));
+    mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(10));
+    mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(5));
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
+    cluster.GenerateSnapshots();
+    {
+        // Drain the two initial events (cumulative + periodic).
+        ASSERT_TRUE(logOnlyEvents.GetNextEvent().has_value());
+        ASSERT_TRUE(logOnlyEvents.GetNextEvent().has_value());
+    }
+
+    // Update all 4 delegate values inside the min interval -- all should be rate-limited.
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
+    mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(200));
+    mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(150));
+    mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(20));
+    mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(15));
+    cluster.GenerateSnapshots();
+    EXPECT_FALSE(logOnlyEvents.GetNextEvent().has_value());
+
+    // Fire the max-delay timer -- all 4 dirty attributes should flush, both events should be generated.
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportDelayInterval);
+
+    // CumulativeEnergyMeasured event
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value()) << "Max-delay timer did not produce CumulativeEnergyMeasured event";
+        Events::CumulativeEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ(event->GetEventData(decoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 200);
+        ASSERT_TRUE(decoded.energyExported.HasValue());
+        EXPECT_EQ(decoded.energyExported.Value().energy, 150);
+    }
+
+    // PeriodicEnergyMeasured event
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value()) << "Max-delay timer did not produce PeriodicEnergyMeasured event";
+        Events::PeriodicEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ(event->GetEventData(decoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 20);
+        ASSERT_TRUE(decoded.energyExported.HasValue());
+        EXPECT_EQ(decoded.energyExported.Value().energy, 15);
+    }
+
+    // All 4 attributes should be readable with the latest values.
+    {
+        DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
+        EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 200);
+
+        EXPECT_EQ(cluster.GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 150);
+
+        EXPECT_EQ(cluster.GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 20);
+
+        EXPECT_EQ(cluster.GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
+        ASSERT_FALSE(readValue.IsNull());
+        EXPECT_EQ(readValue.Value().energy, 15);
+    }
+
+    // No stale events left over.
+    EXPECT_FALSE(logOnlyEvents.GetNextEvent().has_value());
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
 } // namespace

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -207,35 +207,35 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GettersSettersWithFeatureValidati
         ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct energyData;
         energyData.energy = 1000;
 
-        Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> optionalEnergyData(energyData);
+        DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> nullableEnergyData(energyData);
 
-        cluster.CumulativeEnergySnapshot(optionalEnergyData, optionalEnergyData);
-        cluster.PeriodicEnergySnapshot(optionalEnergyData, optionalEnergyData);
+        cluster.CumulativeEnergySnapshot(nullableEnergyData, nullableEnergyData);
+        cluster.PeriodicEnergySnapshot(nullableEnergyData, nullableEnergyData);
 
         ElectricalEnergyMeasurementCluster::CumulativeEnergyResetStruct resetData;
-        Optional<ElectricalEnergyMeasurementCluster::CumulativeEnergyResetStruct> optionalResetData(resetData);
-        EXPECT_EQ(cluster.SetCumulativeEnergyReset(optionalResetData), CHIP_NO_ERROR);
+        DataModel::Nullable<ElectricalEnergyMeasurementCluster::CumulativeEnergyResetStruct> nullableResetData(resetData);
+        EXPECT_EQ(cluster.SetCumulativeEnergyReset(nullableResetData), CHIP_NO_ERROR);
 
         // Read back via getters and verify values
-        Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
+        DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
 
         EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
-        EXPECT_TRUE(readValue.HasValue());
+        EXPECT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 1000);
 
         EXPECT_EQ(cluster.GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
-        EXPECT_TRUE(readValue.HasValue());
+        EXPECT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 1000);
 
         EXPECT_EQ(cluster.GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
-        EXPECT_TRUE(readValue.HasValue());
+        EXPECT_FALSE(readValue.IsNull());
 
         EXPECT_EQ(cluster.GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
-        EXPECT_TRUE(readValue.HasValue());
+        EXPECT_FALSE(readValue.IsNull());
 
-        Optional<ElectricalEnergyMeasurementCluster::CumulativeEnergyResetStruct> readResetValue;
+        DataModel::Nullable<ElectricalEnergyMeasurementCluster::CumulativeEnergyResetStruct> readResetValue;
         EXPECT_EQ(cluster.GetCumulativeEnergyReset(readResetValue), CHIP_NO_ERROR);
-        EXPECT_TRUE(readResetValue.HasValue());
+        EXPECT_FALSE(readResetValue.IsNull());
 
         cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
     }
@@ -255,13 +255,13 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GettersSettersWithFeatureValidati
 
         EXPECT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
 
-        Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
+        DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
         EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
         EXPECT_EQ(cluster.GetCumulativeEnergyExported(readValue), CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
         EXPECT_EQ(cluster.GetPeriodicEnergyImported(readValue), CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
         EXPECT_EQ(cluster.GetPeriodicEnergyExported(readValue), CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-        Optional<ElectricalEnergyMeasurementCluster::CumulativeEnergyResetStruct> readResetValue;
+        DataModel::Nullable<ElectricalEnergyMeasurementCluster::CumulativeEnergyResetStruct> readResetValue;
         EXPECT_EQ(cluster.GetCumulativeEnergyReset(readResetValue), CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
         cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -344,10 +344,10 @@ TEST_F(TestElectricalEnergyMeasurementCluster, ReadAttributeWithClusterTesterTes
 
     ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct energyData;
     energyData.energy = 5000;
-    Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> optionalEnergyData(energyData);
+    DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> nullableEnergyData(energyData);
 
-    cluster.CumulativeEnergySnapshot(optionalEnergyData, optionalEnergyData);
-    cluster.PeriodicEnergySnapshot(optionalEnergyData, optionalEnergyData);
+    cluster.CumulativeEnergySnapshot(nullableEnergyData, nullableEnergyData);
+    cluster.PeriodicEnergySnapshot(nullableEnergyData, nullableEnergyData);
 
     DataModel::Nullable<Structs::EnergyMeasurementStruct::DecodableType> cumulativeImported;
     ASSERT_EQ(tester.ReadAttribute(CumulativeEnergyImported::Id, cumulativeImported), CHIP_NO_ERROR);
@@ -401,20 +401,20 @@ TEST_F(TestElectricalEnergyMeasurementCluster, SnapshotsSetValuesAndGenerateEven
     ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct energyExported;
     energyExported.energy = 5000;
 
-    Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> optionalImported(energyImported);
-    Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> optionalExported(energyExported);
+    DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> nullableImported(energyImported);
+    DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> nullableExported(energyExported);
 
     // Test cumulative energy snapshot
     {
-        cluster.CumulativeEnergySnapshot(optionalImported, optionalExported);
+        cluster.CumulativeEnergySnapshot(nullableImported, nullableExported);
 
-        Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
+        DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
         EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue());
+        ASSERT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 10000);
 
         EXPECT_EQ(cluster.GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue());
+        ASSERT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 5000);
 
         auto event = logOnlyEvents.GetNextEvent();
@@ -436,15 +436,15 @@ TEST_F(TestElectricalEnergyMeasurementCluster, SnapshotsSetValuesAndGenerateEven
 
     // Test periodic energy snapshot
     {
-        cluster.PeriodicEnergySnapshot(optionalImported, optionalExported);
+        cluster.PeriodicEnergySnapshot(nullableImported, nullableExported);
 
-        Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
+        DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
         EXPECT_EQ(cluster.GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue());
+        ASSERT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 10000);
 
         EXPECT_EQ(cluster.GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue());
+        ASSERT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 5000);
 
         auto event = logOnlyEvents.GetNextEvent();
@@ -467,7 +467,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, SnapshotsSetValuesAndGenerateEven
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
-TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportPullsDelegateAndGeneratesEvents)
+TEST_F(TestElectricalEnergyMeasurementCluster, GenerateSnapshotsPullsDelegateAndGeneratesEvents)
 {
     TestServerClusterContext testContext;
 
@@ -493,10 +493,10 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportPullsDelegateAndGen
     mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(500));
     mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(200));
 
-    // Advance clock past min report interval so GenerateReport works
+    // Advance clock past min report interval so GenerateSnapshots works
     mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
 
-    cluster.GenerateReport();
+    cluster.GenerateSnapshots();
 
     // Verify cumulative event
     {
@@ -525,15 +525,15 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportPullsDelegateAndGen
     }
 
     // Verify internal measurement data was updated
-    Optional<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
+    DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
     EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
-    ASSERT_TRUE(readValue.HasValue());
+    ASSERT_FALSE(readValue.IsNull());
     EXPECT_EQ(readValue.Value().energy, 42000);
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
-TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportRespectsMinInterval)
+TEST_F(TestElectricalEnergyMeasurementCluster, GenerateSnapshotsRespectsMinInterval)
 {
     TestServerClusterContext testContext;
 
@@ -558,7 +558,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportRespectsMinInterval
     mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
 
     // First report should work (clock at 0, no previous report)
-    cluster.GenerateReport();
+    cluster.GenerateSnapshots();
     {
         auto event = logOnlyEvents.GetNextEvent();
         ASSERT_TRUE(event.has_value());
@@ -567,7 +567,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportRespectsMinInterval
     // Second call 1 ms after first report -- should be silently dropped (min 1s)
     mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
     mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(200));
-    cluster.GenerateReport();
+    cluster.GenerateSnapshots();
     {
         auto event = logOnlyEvents.GetNextEvent();
         EXPECT_FALSE(event.has_value());
@@ -575,7 +575,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportRespectsMinInterval
 
     // Advance past min interval
     mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
-    cluster.GenerateReport();
+    cluster.GenerateSnapshots();
     {
         auto event = logOnlyEvents.GetNextEvent();
         ASSERT_TRUE(event.has_value());
@@ -623,7 +623,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TimerFiresAndGeneratesReport)
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }
 
-TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateReport)
+TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
 {
     TestServerClusterContext testContext;
 
@@ -658,7 +658,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateReport)
         EXPECT_TRUE(testImported.IsNull());
         EXPECT_TRUE(testExported.IsNull());
 
-        cluster.GenerateReport();
+        cluster.GenerateSnapshots();
         {
             auto event = logOnlyEvents.GetNextEvent();
             EXPECT_FALSE(event.has_value());
@@ -666,11 +666,10 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateReport)
 
         mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(100));
         mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(50));
-        mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(10));
-        mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(5));
+        mDelegate.mPeriodicImported.SetNull();
+        mDelegate.mPeriodicExported.SetNull();
 
-        cluster.GenerateReport();
-        uint64_t firstEndSystime = 0;
+        cluster.GenerateSnapshots();
         {
             auto event = logOnlyEvents.GetNextEvent();
             ASSERT_TRUE(event.has_value());
@@ -680,15 +679,14 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateReport)
             EXPECT_EQ(decoded.energyImported.Value().energy, 100);
             EXPECT_FALSE(decoded.energyImported.Value().startTimestamp.HasValue());
             EXPECT_FALSE(decoded.energyImported.Value().startSystime.HasValue());
-            EXPECT_FALSE(decoded.energyImported.Value().endTimestamp.HasValue());
-            ASSERT_TRUE(decoded.energyImported.Value().endSystime.HasValue());
-            firstEndSystime = decoded.energyImported.Value().endSystime.Value();
+            ASSERT_TRUE(decoded.energyImported.Value().endTimestamp.HasValue());
+            EXPECT_FALSE(decoded.energyImported.Value().endSystime.HasValue());
         }
 
-        // Test path where previous.HasValue() is true
+        // Second cumulative reading: still no start* (cumulative BuildMeasurement omits carry-over).
         mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(200));
         mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
-        cluster.GenerateReport();
+        cluster.GenerateSnapshots();
         {
             auto event = logOnlyEvents.GetNextEvent();
             ASSERT_TRUE(event.has_value());
@@ -696,12 +694,61 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateReport)
             ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
             ASSERT_TRUE(decoded.energyImported.HasValue());
             EXPECT_EQ(decoded.energyImported.Value().energy, 200);
-            ASSERT_TRUE(decoded.energyImported.Value().startSystime.HasValue());
-            EXPECT_EQ(decoded.energyImported.Value().startSystime.Value(), firstEndSystime);
+            EXPECT_FALSE(decoded.energyImported.Value().startTimestamp.HasValue());
+            EXPECT_FALSE(decoded.energyImported.Value().startSystime.HasValue());
         }
     }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+
+    // Carry-over of endTimestamp -> startTimestamp is periodic-only; exercise with periodic cluster.
+    {
+        BitMask<Feature> periodicFeatures(Feature::kImportedEnergy, Feature::kPeriodicEnergy);
+        ElectricalEnergyMeasurementCluster periodicCluster(ElectricalEnergyMeasurementCluster::Config{
+            .endpointId         = static_cast<EndpointId>(kTestEndpointId + 1),
+            .featureFlags       = periodicFeatures,
+            .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet(),
+            .accuracyStruct     = kTestAccuracy,
+            .delegate           = mDelegate,
+            .timerDelegate      = mTimerDelegate,
+        });
+        EXPECT_EQ(periodicCluster.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+        mDelegate.mCumulativeImported.SetNull();
+        mDelegate.mCumulativeExported.SetNull();
+        mDelegate.mPeriodicImported = DataModel::MakeNullable(static_cast<int64_t>(10));
+        mDelegate.mPeriodicExported.SetNull();
+
+        periodicCluster.GenerateSnapshots();
+        uint32_t firstPeriodicEndTimestamp = 0;
+        {
+            auto event = logOnlyEvents.GetNextEvent();
+            ASSERT_TRUE(event.has_value());
+            Events::PeriodicEnergyMeasured::DecodableType decoded;
+            ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+            ASSERT_TRUE(decoded.energyImported.HasValue());
+            EXPECT_EQ(decoded.energyImported.Value().energy, 10);
+            EXPECT_FALSE(decoded.energyImported.Value().startTimestamp.HasValue());
+            ASSERT_TRUE(decoded.energyImported.Value().endTimestamp.HasValue());
+            firstPeriodicEndTimestamp = decoded.energyImported.Value().endTimestamp.Value();
+        }
+
+        mDelegate.mPeriodicImported = DataModel::MakeNullable(static_cast<int64_t>(20));
+        mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
+        periodicCluster.GenerateSnapshots();
+        {
+            auto event = logOnlyEvents.GetNextEvent();
+            ASSERT_TRUE(event.has_value());
+            Events::PeriodicEnergyMeasured::DecodableType decoded;
+            ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+            ASSERT_TRUE(decoded.energyImported.HasValue());
+            EXPECT_EQ(decoded.energyImported.Value().energy, 20);
+            ASSERT_TRUE(decoded.energyImported.Value().startTimestamp.HasValue());
+            EXPECT_EQ(decoded.energyImported.Value().startTimestamp.Value(), firstPeriodicEndTimestamp);
+        }
+
+        periodicCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+    }
 }
 
 } // namespace

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -641,7 +641,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateReport)
     EXPECT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
     auto & logOnlyEvents = testContext.EventsGenerator();
 
-    
+
     {
         // Test when the delegate has no data, all values are null
         mDelegate.mCumulativeImported.SetNull();

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -58,15 +58,15 @@ const Structs::MeasurementAccuracyStruct::Type kTestAccuracy = {
 class MockEEMDelegate : public ElectricalEnergyMeasurement::Delegate
 {
 public:
-    DataModel::Nullable<int64_t> GetCumulativeEnergyImported() override { return DataModel::MakeNullable(mCumulativeImported); }
-    DataModel::Nullable<int64_t> GetCumulativeEnergyExported() override { return DataModel::MakeNullable(mCumulativeExported); }
-    DataModel::Nullable<int64_t> GetPeriodicEnergyImported() override { return DataModel::MakeNullable(mPeriodicImported); }
-    DataModel::Nullable<int64_t> GetPeriodicEnergyExported() override { return DataModel::MakeNullable(mPeriodicExported); }
+    DataModel::Nullable<int64_t> GetCumulativeEnergyImported() override { return mCumulativeImported; }
+    DataModel::Nullable<int64_t> GetCumulativeEnergyExported() override { return mCumulativeExported; }
+    DataModel::Nullable<int64_t> GetPeriodicEnergyImported() override { return mPeriodicImported; }
+    DataModel::Nullable<int64_t> GetPeriodicEnergyExported() override { return mPeriodicExported; }
 
-    int64_t mCumulativeImported = 0;
-    int64_t mCumulativeExported = 0;
-    int64_t mPeriodicImported   = 0;
-    int64_t mPeriodicExported   = 0;
+    DataModel::Nullable<int64_t> mCumulativeImported;
+    DataModel::Nullable<int64_t> mCumulativeExported;
+    DataModel::Nullable<int64_t> mPeriodicImported;
+    DataModel::Nullable<int64_t> mPeriodicExported;
 };
 
 struct TestElectricalEnergyMeasurementCluster : public ::testing::Test
@@ -488,10 +488,10 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportPullsDelegateAndGen
     auto & logOnlyEvents = testContext.EventsGenerator();
 
     // Set delegate values
-    mDelegate.mCumulativeImported = 42000;
-    mDelegate.mCumulativeExported = 10000;
-    mDelegate.mPeriodicImported   = 500;
-    mDelegate.mPeriodicExported   = 200;
+    mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(42000));
+    mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(10000));
+    mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(500));
+    mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(200));
 
     // Advance clock past min report interval so GenerateReport works
     mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
@@ -552,7 +552,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportRespectsMinInterval
 
     auto & logOnlyEvents = testContext.EventsGenerator();
 
-    mDelegate.mCumulativeImported = 100;
+    mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(100));
 
     // Advance the clock to avoid having the last report = 0, impossible in practice but would happen in tests without this.
     mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
@@ -566,7 +566,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateReportRespectsMinInterval
 
     // Second call 1 ms after first report -- should be silently dropped (min 1s)
     mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
-    mDelegate.mCumulativeImported = 200;
+    mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(200));
     cluster.GenerateReport();
     {
         auto event = logOnlyEvents.GetNextEvent();
@@ -607,7 +607,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TimerFiresAndGeneratesReport)
 
     auto & logOnlyEvents = testContext.EventsGenerator();
 
-    mDelegate.mCumulativeImported = 99999;
+    mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(99999));
 
     // Advance clock by the report interval (default 60s) -- should trigger TimerFired
     mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
@@ -619,6 +619,88 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TimerFiresAndGeneratesReport)
     ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
     ASSERT_TRUE(decoded.energyImported.HasValue());
     EXPECT_EQ(decoded.energyImported.Value().energy, 99999);
+
+    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateReport)
+{
+    TestServerClusterContext testContext;
+
+    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
+
+    ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
+        .endpointId         = kTestEndpointId,
+        .featureFlags       = allFeatures,
+        .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet(),
+        .accuracyStruct     = kTestAccuracy,
+        .delegate           = mDelegate,
+        .timerDelegate      = mTimerDelegate,
+    });
+
+    EXPECT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
+    auto & logOnlyEvents = testContext.EventsGenerator();
+
+    
+    {
+        // Test when the delegate has no data, all values are null
+        mDelegate.mCumulativeImported.SetNull();
+        mDelegate.mCumulativeExported.SetNull();
+        mDelegate.mPeriodicImported.SetNull();
+        mDelegate.mPeriodicExported.SetNull();
+
+        DataModel::Nullable<int64_t>  testImported = mDelegate.GetCumulativeEnergyImported();
+        DataModel::Nullable<int64_t>  testExported = mDelegate.GetCumulativeEnergyExported();
+        EXPECT_TRUE(testImported.IsNull());
+        EXPECT_TRUE(testExported.IsNull());
+
+        testImported = mDelegate.GetPeriodicEnergyImported();
+        testExported = mDelegate.GetPeriodicEnergyExported();
+        EXPECT_TRUE(testImported.IsNull());
+        EXPECT_TRUE(testExported.IsNull());
+
+        cluster.GenerateReport();
+        {
+            auto event = logOnlyEvents.GetNextEvent();
+            EXPECT_FALSE(event.has_value());
+        }
+
+        mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(100));
+        mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(50));
+        mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(10));
+        mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(5));
+
+        cluster.GenerateReport();
+        uint64_t firstEndSystime = 0;
+        {
+            auto event = logOnlyEvents.GetNextEvent();
+            ASSERT_TRUE(event.has_value());
+            Events::CumulativeEnergyMeasured::DecodableType decoded;
+            ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+            ASSERT_TRUE(decoded.energyImported.HasValue());
+            EXPECT_EQ(decoded.energyImported.Value().energy, 100);
+            EXPECT_FALSE(decoded.energyImported.Value().startTimestamp.HasValue());
+            EXPECT_FALSE(decoded.energyImported.Value().startSystime.HasValue());
+            EXPECT_FALSE(decoded.energyImported.Value().endTimestamp.HasValue());
+            ASSERT_TRUE(decoded.energyImported.Value().endSystime.HasValue());
+            firstEndSystime = decoded.energyImported.Value().endSystime.Value();
+        }
+
+        // Test path where previous.HasValue() is true
+        mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(200));
+        mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
+        cluster.GenerateReport();
+        {
+            auto event = logOnlyEvents.GetNextEvent();
+            ASSERT_TRUE(event.has_value());
+            Events::CumulativeEnergyMeasured::DecodableType decoded;
+            ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+            ASSERT_TRUE(decoded.energyImported.HasValue());
+            EXPECT_EQ(decoded.energyImported.Value().energy, 200);
+            ASSERT_TRUE(decoded.energyImported.Value().startSystime.HasValue());
+            EXPECT_EQ(decoded.energyImported.Value().startSystime.Value(), firstEndSystime);
+        }
+    }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
 }

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -696,7 +696,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
             EXPECT_FALSE(decoded.energyImported.Value().startTimestamp.HasValue());
             EXPECT_FALSE(decoded.energyImported.Value().startSystime.HasValue());
             uint32_t currentTimestamp;
-            if(System::Clock::GetClock_MatterEpochS(currentTimestamp) == CHIP_NO_ERROR)
+            if (System::Clock::GetClock_MatterEpochS(currentTimestamp) == CHIP_NO_ERROR)
             {
                 ASSERT_TRUE(decoded.energyImported.Value().endTimestamp.HasValue());
             }
@@ -759,7 +759,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
             EXPECT_EQ(decoded.energyImported.Value().energy, 10);
             EXPECT_FALSE(decoded.energyImported.Value().startTimestamp.HasValue());
 
-            if(System::Clock::GetClock_MatterEpochS(currentTimestamp) == CHIP_NO_ERROR)
+            if (System::Clock::GetClock_MatterEpochS(currentTimestamp) == CHIP_NO_ERROR)
             {
                 ASSERT_TRUE(decoded.energyImported.Value().endTimestamp.HasValue());
                 firstPeriodicEndTimestamp = decoded.energyImported.Value().endTimestamp.Value();
@@ -780,7 +780,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
             ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
             ASSERT_TRUE(decoded.energyImported.HasValue());
             EXPECT_EQ(decoded.energyImported.Value().energy, 20);
-            if(System::Clock::GetClock_MatterEpochS(currentTimestamp) == CHIP_NO_ERROR)
+            if (System::Clock::GetClock_MatterEpochS(currentTimestamp) == CHIP_NO_ERROR)
             {
                 ASSERT_TRUE(decoded.energyImported.Value().startTimestamp.HasValue());
                 EXPECT_EQ(decoded.energyImported.Value().startTimestamp.Value(), firstPeriodicEndTimestamp);

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -749,6 +749,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
 
         periodicCluster.GenerateSnapshots();
         uint32_t firstPeriodicEndTimestamp = 0;
+        uint32_t currentTimestamp;
         {
             auto event = logOnlyEvents.GetNextEvent();
             ASSERT_TRUE(event.has_value());
@@ -757,8 +758,16 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
             ASSERT_TRUE(decoded.energyImported.HasValue());
             EXPECT_EQ(decoded.energyImported.Value().energy, 10);
             EXPECT_FALSE(decoded.energyImported.Value().startTimestamp.HasValue());
-            ASSERT_TRUE(decoded.energyImported.Value().endTimestamp.HasValue());
-            firstPeriodicEndTimestamp = decoded.energyImported.Value().endTimestamp.Value();
+            
+            if(System::Clock::GetClock_MatterEpochS(currentTimestamp) == CHIP_NO_ERROR)
+            {
+                ASSERT_TRUE(decoded.energyImported.Value().endTimestamp.HasValue());
+                firstPeriodicEndTimestamp = decoded.energyImported.Value().endTimestamp.Value();
+            }
+            else
+            {
+                EXPECT_FALSE(decoded.energyImported.Value().endTimestamp.HasValue());
+            }
         }
 
         mDelegate.mPeriodicImported = DataModel::MakeNullable(static_cast<int64_t>(20));
@@ -771,8 +780,11 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
             ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
             ASSERT_TRUE(decoded.energyImported.HasValue());
             EXPECT_EQ(decoded.energyImported.Value().energy, 20);
-            ASSERT_TRUE(decoded.energyImported.Value().startTimestamp.HasValue());
-            EXPECT_EQ(decoded.energyImported.Value().startTimestamp.Value(), firstPeriodicEndTimestamp);
+            if(System::Clock::GetClock_MatterEpochS(currentTimestamp) == CHIP_NO_ERROR)
+            {
+                ASSERT_TRUE(decoded.energyImported.Value().startTimestamp.HasValue());
+                EXPECT_EQ(decoded.energyImported.Value().startTimestamp.Value(), firstPeriodicEndTimestamp);
+            }
         }
 
         periodicCluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -821,7 +833,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, RateLimitedUpdateFlushesOnMaxDela
     cluster.GenerateSnapshots();
     EXPECT_FALSE(logOnlyEvents.GetNextEvent().has_value());
 
-    // Wait for the min-delay and generate report, all 4 dirty attributes shoult be in the next event.
+    // Wait for the min-delay and generate report, all 4 dirty attributes should be in the next event.
     mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
     cluster.GenerateSnapshots();
 

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -758,7 +758,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
             ASSERT_TRUE(decoded.energyImported.HasValue());
             EXPECT_EQ(decoded.energyImported.Value().energy, 10);
             EXPECT_FALSE(decoded.energyImported.Value().startTimestamp.HasValue());
-            
+
             if(System::Clock::GetClock_MatterEpochS(currentTimestamp) == CHIP_NO_ERROR)
             {
                 ASSERT_TRUE(decoded.energyImported.Value().endTimestamp.HasValue());

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -695,7 +695,15 @@ TEST_F(TestElectricalEnergyMeasurementCluster, TestGenerateSnapshots)
             EXPECT_EQ(decoded.energyImported.Value().energy, 100);
             EXPECT_FALSE(decoded.energyImported.Value().startTimestamp.HasValue());
             EXPECT_FALSE(decoded.energyImported.Value().startSystime.HasValue());
-            ASSERT_TRUE(decoded.energyImported.Value().endTimestamp.HasValue());
+            uint32_t currentTimestamp;
+            if(System::Clock::GetClock_MatterEpochS(currentTimestamp) == CHIP_NO_ERROR)
+            {
+                ASSERT_TRUE(decoded.energyImported.Value().endTimestamp.HasValue());
+            }
+            else
+            {
+                EXPECT_FALSE(decoded.energyImported.Value().endTimestamp.HasValue());
+            }
             ASSERT_TRUE(decoded.energyImported.Value().endSystime.HasValue());
             EXPECT_EQ(decoded.energyImported.Value().endSystime.Value(), 0u);
         }

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementCluster.cpp
@@ -560,7 +560,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateSnapshotsRespectsMinInter
 
     mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
 
-    // First report -- all 4 attributes should notify, both events should fire.
+    // First report, all 4 attributes should notify, both events should fire.
     cluster.GenerateSnapshots();
     {
         auto cumulativeEvent = logOnlyEvents.GetNextEvent();
@@ -582,7 +582,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateSnapshotsRespectsMinInter
         EXPECT_EQ(periodicDecoded.energyExported.Value().energy, 5);
     }
 
-    // +1 ms: inside min interval -- all 4 attributes should be gated, no events.
+    // +1 ms: inside min interval, all 4 attributes should be gated, no events.
     mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
     mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(200));
     mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(150));
@@ -613,7 +613,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateSnapshotsRespectsMinInter
         EXPECT_EQ(readValue.Value().energy, 15);
     }
 
-    // Advance past min interval -- all 4 should notify, both events should fire with latest values.
+    // Advance past min interval, all 4 should notify, both events should fire with latest values.
     mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
     cluster.GenerateSnapshots();
     {
@@ -634,93 +634,6 @@ TEST_F(TestElectricalEnergyMeasurementCluster, GenerateSnapshotsRespectsMinInter
         EXPECT_EQ(periodicDecoded.energyImported.Value().energy, 20);
         ASSERT_TRUE(periodicDecoded.energyExported.HasValue());
         EXPECT_EQ(periodicDecoded.energyExported.Value().energy, 15);
-    }
-
-    cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
-}
-
-TEST_F(TestElectricalEnergyMeasurementCluster, TimerFiresAndGeneratesReport)
-{
-    TestServerClusterContext testContext;
-
-    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
-                                 Feature::kPeriodicEnergy);
-
-    ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
-        .endpointId         = kTestEndpointId,
-        .featureFlags       = allFeatures,
-        .optionalAttributes = ElectricalEnergyMeasurementCluster::OptionalAttributesSet(),
-        .accuracyStruct     = kTestAccuracy,
-        .delegate           = mDelegate,
-        .timerDelegate      = mTimerDelegate,
-    });
-
-    EXPECT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
-
-    auto & logOnlyEvents = testContext.EventsGenerator();
-
-    // Establish stored values with a first report.
-    mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(1));
-    mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(1));
-    mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(1));
-    mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(1));
-    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
-    cluster.GenerateSnapshots();
-    ASSERT_TRUE(logOnlyEvents.GetNextEvent().has_value());
-    ASSERT_TRUE(logOnlyEvents.GetNextEvent().has_value());
-
-    // Rate-limited update within 1 s -- starts the delay timer.
-    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
-    mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(99999));
-    mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(88888));
-    mDelegate.mPeriodicImported   = DataModel::MakeNullable(static_cast<int64_t>(7777));
-    mDelegate.mPeriodicExported   = DataModel::MakeNullable(static_cast<int64_t>(6666));
-    cluster.GenerateSnapshots();
-    EXPECT_FALSE(logOnlyEvents.GetNextEvent().has_value());
-
-    // Advance past the max-delay timer -- should fire and produce a full report.
-    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportDelayInterval);
-
-    {
-        auto event = logOnlyEvents.GetNextEvent();
-        ASSERT_TRUE(event.has_value());
-        Events::CumulativeEnergyMeasured::DecodableType decoded;
-        ASSERT_EQ(event->GetEventData(decoded), CHIP_NO_ERROR);
-        ASSERT_TRUE(decoded.energyImported.HasValue());
-        EXPECT_EQ(decoded.energyImported.Value().energy, 99999);
-        ASSERT_TRUE(decoded.energyExported.HasValue());
-        EXPECT_EQ(decoded.energyExported.Value().energy, 88888);
-    }
-
-    {
-        auto event = logOnlyEvents.GetNextEvent();
-        ASSERT_TRUE(event.has_value());
-        Events::PeriodicEnergyMeasured::DecodableType decoded;
-        ASSERT_EQ(event->GetEventData(decoded), CHIP_NO_ERROR);
-        ASSERT_TRUE(decoded.energyImported.HasValue());
-        EXPECT_EQ(decoded.energyImported.Value().energy, 7777);
-        ASSERT_TRUE(decoded.energyExported.HasValue());
-        EXPECT_EQ(decoded.energyExported.Value().energy, 6666);
-    }
-
-    // All 4 attributes must be readable with the correct values.
-    {
-        DataModel::Nullable<ElectricalEnergyMeasurementCluster::EnergyMeasurementStruct> readValue;
-        EXPECT_EQ(cluster.GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_FALSE(readValue.IsNull());
-        EXPECT_EQ(readValue.Value().energy, 99999);
-
-        EXPECT_EQ(cluster.GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
-        ASSERT_FALSE(readValue.IsNull());
-        EXPECT_EQ(readValue.Value().energy, 88888);
-
-        EXPECT_EQ(cluster.GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_FALSE(readValue.IsNull());
-        EXPECT_EQ(readValue.Value().energy, 7777);
-
-        EXPECT_EQ(cluster.GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
-        ASSERT_FALSE(readValue.IsNull());
-        EXPECT_EQ(readValue.Value().energy, 6666);
     }
 
     cluster.Shutdown(ClusterShutdownType::kClusterShutdown);
@@ -891,7 +804,7 @@ TEST_F(TestElectricalEnergyMeasurementCluster, RateLimitedUpdateFlushesOnMaxDela
         ASSERT_TRUE(logOnlyEvents.GetNextEvent().has_value());
     }
 
-    // Update all 4 delegate values inside the min interval -- all should be rate-limited.
+    // Update all 4 delegate values inside the min interval, all should be rate-limited.
     mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
     mDelegate.mCumulativeImported = DataModel::MakeNullable(static_cast<int64_t>(200));
     mDelegate.mCumulativeExported = DataModel::MakeNullable(static_cast<int64_t>(150));
@@ -900,8 +813,9 @@ TEST_F(TestElectricalEnergyMeasurementCluster, RateLimitedUpdateFlushesOnMaxDela
     cluster.GenerateSnapshots();
     EXPECT_FALSE(logOnlyEvents.GetNextEvent().has_value());
 
-    // Fire the max-delay timer -- all 4 dirty attributes should flush, both events should be generated.
-    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportDelayInterval);
+    // Wait for the min-delay and generate report, all 4 dirty attributes shoult be in the next event.
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
+    cluster.GenerateSnapshots();
 
     // CumulativeEnergyMeasured event
     {

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -57,6 +57,15 @@ public:
     int64_t mPeriodicExported   = 0;
 };
 
+class NoOpEEMDelegateCompat : public ElectricalEnergyMeasurement::Delegate
+{
+public:
+    DataModel::Nullable<int64_t> GetCumulativeEnergyImported() override { return DataModel::NullNullable; }
+    DataModel::Nullable<int64_t> GetCumulativeEnergyExported() override { return DataModel::NullNullable; }
+    DataModel::Nullable<int64_t> GetPeriodicEnergyImported() override { return DataModel::NullNullable; }
+    DataModel::Nullable<int64_t> GetPeriodicEnergyExported() override { return DataModel::NullNullable; }
+};
+
 struct TestElectricalEnergyMeasurementClusterBackwardsCompatibility : public ::testing::Test
 {
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
@@ -80,6 +89,7 @@ struct TestElectricalEnergyMeasurementClusterBackwardsCompatibility : public ::t
     Testing::TestServerClusterContext mContext;
     chip::MonotonicallyIncreasingCounter<chip::EventNumber> mEventCounter;
     MockEEMDelegateCompat mDelegate;
+    NoOpEEMDelegateCompat mNoOpDelegate;
     chip::TimerDelegateMock mTimerDelegate;
 };
 
@@ -428,6 +438,106 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, GenerateRep
         ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
         ASSERT_TRUE(decoded.energyImported.HasValue());
         EXPECT_EQ(decoded.energyImported.Value().energy, 200);
+    }
+
+    attrAccess.Shutdown();
+}
+
+TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerDoesNotWipeSnapshotValuesWithNoOpDelegate)
+{
+    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
+                                 Feature::kPeriodicEnergy);
+    BitMask<OptionalAttributes> noOptionalAttrs;
+
+    ElectricalEnergyMeasurementAttrAccess attrAccess(allFeatures, noOptionalAttrs, kTestEndpointId, mNoOpDelegate, mTimerDelegate);
+    EXPECT_EQ(attrAccess.Init(), CHIP_NO_ERROR);
+
+    ElectricalEnergyMeasurementCluster * cluster = FindElectricalEnergyMeasurementClusterOnEndpoint(kTestEndpointId);
+    ASSERT_NE(cluster, nullptr);
+    EXPECT_EQ(cluster->Startup(mContext.Get()), CHIP_NO_ERROR);
+
+    // Push values through the legacy Snapshot methods (the CodegenIntegration path)
+    {
+        Structs::EnergyMeasurementStruct::Type energyData;
+        energyData.energy = 42000;
+        Optional<Structs::EnergyMeasurementStruct::Type> energyImported(energyData);
+
+        energyData.energy = 7000;
+        Optional<Structs::EnergyMeasurementStruct::Type> energyExported(energyData);
+
+        cluster->CumulativeEnergySnapshot(energyImported, energyExported);
+    }
+    {
+        Structs::EnergyMeasurementStruct::Type energyData;
+        energyData.energy = 1500;
+        Optional<Structs::EnergyMeasurementStruct::Type> energyImported(energyData);
+
+        energyData.energy = 500;
+        Optional<Structs::EnergyMeasurementStruct::Type> energyExported(energyData);
+
+        cluster->PeriodicEnergySnapshot(energyImported, energyExported);
+    }
+
+    // Verify values are set
+    {
+        Optional<Structs::EnergyMeasurementStruct::Type> readValue;
+        EXPECT_EQ(cluster->GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_TRUE(readValue.HasValue());
+        EXPECT_EQ(readValue.Value().energy, 42000);
+
+        EXPECT_EQ(cluster->GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
+        ASSERT_TRUE(readValue.HasValue());
+        EXPECT_EQ(readValue.Value().energy, 7000);
+
+        EXPECT_EQ(cluster->GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_TRUE(readValue.HasValue());
+        EXPECT_EQ(readValue.Value().energy, 1500);
+
+        EXPECT_EQ(cluster->GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
+        ASSERT_TRUE(readValue.HasValue());
+        EXPECT_EQ(readValue.Value().energy, 500);
+    }
+
+    // Fire the periodic timer -- NoOpDelegate returns NullNullable for all readings.
+    // The fix must ensure DoGenerateReport() does NOT overwrite the snapshot values.
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
+
+    // Cumulative values must survive the timer-based report
+    {
+        Optional<Structs::EnergyMeasurementStruct::Type> readValue;
+        EXPECT_EQ(cluster->GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_TRUE(readValue.HasValue()) << "Timer wiped CumulativeEnergyImported set via CumulativeEnergySnapshot";
+        EXPECT_EQ(readValue.Value().energy, 42000);
+
+        EXPECT_EQ(cluster->GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
+        ASSERT_TRUE(readValue.HasValue()) << "Timer wiped CumulativeEnergyExported set via CumulativeEnergySnapshot";
+        EXPECT_EQ(readValue.Value().energy, 7000);
+    }
+
+    // Periodic values must survive the timer-based report
+    {
+        Optional<Structs::EnergyMeasurementStruct::Type> readValue;
+        EXPECT_EQ(cluster->GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_TRUE(readValue.HasValue()) << "Timer wiped PeriodicEnergyImported set via PeriodicEnergySnapshot";
+        EXPECT_EQ(readValue.Value().energy, 1500);
+
+        EXPECT_EQ(cluster->GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
+        ASSERT_TRUE(readValue.HasValue()) << "Timer wiped PeriodicEnergyExported set via PeriodicEnergySnapshot";
+        EXPECT_EQ(readValue.Value().energy, 500);
+    }
+
+    // Fire the timer a second time to verify repeated timer cycles don't degrade values
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
+
+    {
+        Optional<Structs::EnergyMeasurementStruct::Type> readValue;
+        EXPECT_EQ(cluster->GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_TRUE(readValue.HasValue()) << "Second timer cycle wiped CumulativeEnergyImported";
+        EXPECT_EQ(readValue.Value().energy, 42000);
+
+        EXPECT_EQ(cluster->GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
+        ASSERT_TRUE(readValue.HasValue()) << "Second timer cycle wiped PeriodicEnergyImported";
+        EXPECT_EQ(readValue.Value().energy, 1500);
     }
 
     attrAccess.Shutdown();

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "app/data-model/Nullable.h"
-#include "pw_unit_test/framework.h"
 #include <app/EventManagement.h>
 #include <app/clusters/electrical-energy-measurement-server/CodegenIntegration.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
@@ -421,6 +420,49 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, GenerateSna
         ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
         ASSERT_TRUE(decoded.energyImported.HasValue());
         EXPECT_EQ(decoded.energyImported.Value().energy, 200);
+    }
+
+    attrAccess.Shutdown();
+}
+
+TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, RateLimitedUpdateFlushesOnMaxDelayTimer)
+{
+    BitMask<Feature> features(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
+    BitMask<OptionalAttributes> noOptionalAttrs;
+
+    ElectricalEnergyMeasurementAttrAccess attrAccess(features, noOptionalAttrs, kTestEndpointId, mDelegate, mTimerDelegate);
+    EXPECT_EQ(attrAccess.Init(), CHIP_NO_ERROR);
+
+    ElectricalEnergyMeasurementCluster * cluster = FindElectricalEnergyMeasurementClusterOnEndpoint(kTestEndpointId);
+    ASSERT_NE(cluster, nullptr);
+    EXPECT_EQ(cluster->Startup(mContext.Get()), CHIP_NO_ERROR);
+
+    auto & logOnlyEvents = mContext.EventsGenerator();
+
+    mDelegate.mCumulativeImported = 10;
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
+    cluster->GenerateSnapshots();
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+    }
+
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
+    mDelegate.mCumulativeImported = 20;
+    cluster->GenerateSnapshots();
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        EXPECT_FALSE(event.has_value());
+    }
+
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportDelayInterval);
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+        Events::CumulativeEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 20);
     }
 
     attrAccess.Shutdown();

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -346,13 +346,24 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerFiresA
 
     auto & logOnlyEvents = mContext.EventsGenerator();
 
+    // First report to establish stored values with endSystime.
+    mDelegate.mCumulativeImported = 1;
+    mDelegate.mPeriodicImported   = 1;
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
+    cluster->GenerateSnapshots();
+    ASSERT_TRUE(logOnlyEvents.GetNextEvent().has_value());
+    ASSERT_TRUE(logOnlyEvents.GetNextEvent().has_value());
+
+    // Rate-limited update within 1 s starts the delay timer.
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
     mDelegate.mCumulativeImported = 77000;
     mDelegate.mPeriodicImported   = 300;
+    cluster->GenerateSnapshots();
+    EXPECT_FALSE(logOnlyEvents.GetNextEvent().has_value());
 
-    // Advance clock by the default report interval (60s) -- should trigger timer-based report
-    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
+    // Advance past the max-delay timer -- fires and produces a report.
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportDelayInterval);
 
-    // Verify cumulative event was generated
     {
         auto event = logOnlyEvents.GetNextEvent();
         ASSERT_TRUE(event.has_value());
@@ -362,7 +373,6 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerFiresA
         EXPECT_EQ(decoded.energyImported.Value().energy, 77000);
     }
 
-    // Verify periodic event was generated
     {
         auto event = logOnlyEvents.GetNextEvent();
         ASSERT_TRUE(event.has_value());
@@ -468,7 +478,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, RateLimited
     attrAccess.Shutdown();
 }
 
-TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerDoesNotWipeSnapshotValuesWithNoOpDelegate)
+TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, GenerateSnapshotsDoesNotWipeValuesWithNoOpDelegate)
 {
     BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
                                  Feature::kPeriodicEnergy);
@@ -481,7 +491,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerDoesNo
     ASSERT_NE(cluster, nullptr);
     EXPECT_EQ(cluster->Startup(mContext.Get()), CHIP_NO_ERROR);
 
-    // Push values through the legacy Snapshot methods (the CodegenIntegration path)
+    // Push values through the legacy Snapshot methods (the CodegenIntegration path).
     {
         Structs::EnergyMeasurementStruct::Type energyData;
         energyData.energy = 42000;
@@ -503,7 +513,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerDoesNo
         cluster->PeriodicEnergySnapshot(energyImported, energyExported);
     }
 
-    // Verify values are set
+    // Verify values are set.
     {
         DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> readValue;
         EXPECT_EQ(cluster->GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
@@ -523,44 +533,44 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerDoesNo
         EXPECT_EQ(readValue.Value().energy, 500);
     }
 
-    // Fire the periodic timer -- NoOpDelegate returns NullNullable for all readings.
-    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
+    // GenerateSnapshots with a NoOpDelegate (returns NullNullable for all readings) must not wipe
+    // values previously set via the legacy Snapshot methods.
+    cluster->GenerateSnapshots();
 
-    // Cumulative values must survive the timer-based report
     {
         DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> readValue;
         EXPECT_EQ(cluster->GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_FALSE(readValue.IsNull()) << "Timer wiped CumulativeEnergyImported set via CumulativeEnergySnapshot";
+        ASSERT_FALSE(readValue.IsNull()) << "GenerateSnapshots wiped CumulativeEnergyImported set via CumulativeEnergySnapshot";
         EXPECT_EQ(readValue.Value().energy, 42000);
 
         EXPECT_EQ(cluster->GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
-        ASSERT_FALSE(readValue.IsNull()) << "Timer wiped CumulativeEnergyExported set via CumulativeEnergySnapshot";
+        ASSERT_FALSE(readValue.IsNull()) << "GenerateSnapshots wiped CumulativeEnergyExported set via CumulativeEnergySnapshot";
         EXPECT_EQ(readValue.Value().energy, 7000);
     }
 
-    // Periodic values must survive the timer-based report
     {
         DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> readValue;
         EXPECT_EQ(cluster->GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_FALSE(readValue.IsNull()) << "Timer wiped PeriodicEnergyImported set via PeriodicEnergySnapshot";
+        ASSERT_FALSE(readValue.IsNull()) << "GenerateSnapshots wiped PeriodicEnergyImported set via PeriodicEnergySnapshot";
         EXPECT_EQ(readValue.Value().energy, 1500);
 
         EXPECT_EQ(cluster->GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
-        ASSERT_FALSE(readValue.IsNull()) << "Timer wiped PeriodicEnergyExported set via PeriodicEnergySnapshot";
+        ASSERT_FALSE(readValue.IsNull()) << "GenerateSnapshots wiped PeriodicEnergyExported set via PeriodicEnergySnapshot";
         EXPECT_EQ(readValue.Value().energy, 500);
     }
 
-    // Fire the timer a second time to verify repeated timer cycles don't degrade values
-    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
+    // Second call to verify repeated GenerateSnapshots cycles don't degrade values.
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
+    cluster->GenerateSnapshots();
 
     {
         DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> readValue;
         EXPECT_EQ(cluster->GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_FALSE(readValue.IsNull()) << "Second timer cycle wiped CumulativeEnergyImported";
+        ASSERT_FALSE(readValue.IsNull()) << "Second GenerateSnapshots wiped CumulativeEnergyImported";
         EXPECT_EQ(readValue.Value().energy, 42000);
 
         EXPECT_EQ(cluster->GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_FALSE(readValue.IsNull()) << "Second timer cycle wiped PeriodicEnergyImported";
+        ASSERT_FALSE(readValue.IsNull()) << "Second GenerateSnapshots wiped PeriodicEnergyImported";
         EXPECT_EQ(readValue.Value().energy, 1500);
     }
 

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#include "app/data-model/Nullable.h"
+#include "pw_unit_test/framework.h"
 #include <app/EventManagement.h>
 #include <app/clusters/electrical-energy-measurement-server/CodegenIntegration.h>
 #include <app/server-cluster/testing/TestServerClusterContext.h>
@@ -224,14 +226,14 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
     // Test SetCumulativeReset
     {
         Structs::CumulativeEnergyResetStruct::Type resetData;
-        Optional<Structs::CumulativeEnergyResetStruct::Type> optionalReset(resetData);
+        DataModel::Nullable<Structs::CumulativeEnergyResetStruct::Type> optionalReset(resetData);
 
         EXPECT_EQ(SetCumulativeReset(kTestEndpointId, optionalReset), CHIP_NO_ERROR);
 
         // Verify the value was set
-        Optional<Structs::CumulativeEnergyResetStruct::Type> readReset;
+        DataModel::Nullable<Structs::CumulativeEnergyResetStruct::Type> readReset;
         EXPECT_EQ(cluster->GetCumulativeEnergyReset(readReset), CHIP_NO_ERROR);
-        EXPECT_TRUE(readReset.HasValue());
+        EXPECT_FALSE(readReset.IsNull());
     }
 
     // Test NotifyCumulativeEnergyMeasured
@@ -240,21 +242,21 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
 
         Structs::EnergyMeasurementStruct::Type energyData;
         energyData.energy = 5000;
-        Optional<Structs::EnergyMeasurementStruct::Type> energyImported(energyData);
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> energyImported(energyData);
 
         energyData.energy = 2000;
-        Optional<Structs::EnergyMeasurementStruct::Type> energyExported(energyData);
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> energyExported(energyData);
 
         EXPECT_TRUE(NotifyCumulativeEnergyMeasured(kTestEndpointId, energyImported, energyExported));
 
         // Verify the values were set
-        Optional<Structs::EnergyMeasurementStruct::Type> readValue;
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> readValue;
         EXPECT_EQ(cluster->GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
-        EXPECT_TRUE(readValue.HasValue());
+        EXPECT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 5000);
 
         EXPECT_EQ(cluster->GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
-        EXPECT_TRUE(readValue.HasValue());
+        EXPECT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 2000);
 
         // Verify event was generated
@@ -282,21 +284,21 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
 
         Structs::EnergyMeasurementStruct::Type energyData;
         energyData.energy = 1500;
-        Optional<Structs::EnergyMeasurementStruct::Type> energyImported(energyData);
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> energyImported(energyData);
 
         energyData.energy = 800;
-        Optional<Structs::EnergyMeasurementStruct::Type> energyExported(energyData);
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> energyExported(energyData);
 
         EXPECT_TRUE(NotifyPeriodicEnergyMeasured(kTestEndpointId, energyImported, energyExported));
 
         // Verify the values were set
-        Optional<Structs::EnergyMeasurementStruct::Type> readValue;
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> readValue;
         EXPECT_EQ(cluster->GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
-        EXPECT_TRUE(readValue.HasValue());
+        EXPECT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 1500);
 
         EXPECT_EQ(cluster->GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
-        EXPECT_TRUE(readValue.HasValue());
+        EXPECT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 800);
 
         // Verify event was generated
@@ -317,28 +319,9 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
         EXPECT_EQ(decodedEvent.energyExported.Value().energy, 800);
     }
 
-    // Test MeasurementDataForEndpoint
-    {
-        const MeasurementData * data = MeasurementDataForEndpoint(kTestEndpointId);
-        ASSERT_NE(data, nullptr);
-
-        // Verify data structure contains expected values from previous sets
-        EXPECT_EQ(data->measurementAccuracy.measurementType, MeasurementTypeEnum::kApparentEnergy);
-        EXPECT_TRUE(data->cumulativeImported.HasValue());
-        EXPECT_EQ(data->cumulativeImported.Value().energy, 5000);
-        EXPECT_TRUE(data->cumulativeExported.HasValue());
-        EXPECT_EQ(data->cumulativeExported.Value().energy, 2000);
-        EXPECT_TRUE(data->periodicImported.HasValue());
-        EXPECT_EQ(data->periodicImported.Value().energy, 1500);
-        EXPECT_TRUE(data->periodicExported.HasValue());
-        EXPECT_EQ(data->periodicExported.Value().energy, 800);
-        EXPECT_TRUE(data->cumulativeReset.HasValue());
-    }
-
     // Test with non-existent endpoint
     {
         EXPECT_EQ(FindElectricalEnergyMeasurementClusterOnEndpoint(999), nullptr);
-        EXPECT_EQ(MeasurementDataForEndpoint(999), nullptr);
         EXPECT_EQ(SetMeasurementAccuracy(999, {}), CHIP_ERROR_NOT_FOUND);
         EXPECT_EQ(SetCumulativeReset(999, {}), CHIP_ERROR_NOT_FOUND);
         EXPECT_FALSE(NotifyCumulativeEnergyMeasured(999, {}, {}));
@@ -393,7 +376,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerFiresA
     attrAccess.Shutdown();
 }
 
-TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, GenerateReportRespectsMinInterval)
+TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, GenerateSnapshotsRespectsMinInterval)
 {
     BitMask<Feature> features(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
     BitMask<OptionalAttributes> noOptionalAttrs;
@@ -413,7 +396,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, GenerateRep
     mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
 
     // First manual report should succeed
-    cluster->GenerateReport();
+    cluster->GenerateSnapshots();
     {
         auto event = logOnlyEvents.GetNextEvent();
         ASSERT_TRUE(event.has_value());
@@ -422,7 +405,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, GenerateRep
     // Immediately after (< 1s) -- should be silently dropped
     mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
     mDelegate.mCumulativeImported = 200;
-    cluster->GenerateReport();
+    cluster->GenerateSnapshots();
     {
         auto event = logOnlyEvents.GetNextEvent();
         EXPECT_FALSE(event.has_value());
@@ -430,7 +413,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, GenerateRep
 
     // Advance past min interval (1s) -- should succeed
     mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
-    cluster->GenerateReport();
+    cluster->GenerateSnapshots();
     {
         auto event = logOnlyEvents.GetNextEvent();
         ASSERT_TRUE(event.has_value());
@@ -460,69 +443,68 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerDoesNo
     {
         Structs::EnergyMeasurementStruct::Type energyData;
         energyData.energy = 42000;
-        Optional<Structs::EnergyMeasurementStruct::Type> energyImported(energyData);
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> energyImported(energyData);
 
         energyData.energy = 7000;
-        Optional<Structs::EnergyMeasurementStruct::Type> energyExported(energyData);
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> energyExported(energyData);
 
         cluster->CumulativeEnergySnapshot(energyImported, energyExported);
     }
     {
         Structs::EnergyMeasurementStruct::Type energyData;
         energyData.energy = 1500;
-        Optional<Structs::EnergyMeasurementStruct::Type> energyImported(energyData);
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> energyImported(energyData);
 
         energyData.energy = 500;
-        Optional<Structs::EnergyMeasurementStruct::Type> energyExported(energyData);
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> energyExported(energyData);
 
         cluster->PeriodicEnergySnapshot(energyImported, energyExported);
     }
 
     // Verify values are set
     {
-        Optional<Structs::EnergyMeasurementStruct::Type> readValue;
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> readValue;
         EXPECT_EQ(cluster->GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue());
+        ASSERT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 42000);
 
         EXPECT_EQ(cluster->GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue());
+        ASSERT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 7000);
 
         EXPECT_EQ(cluster->GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue());
+        ASSERT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 1500);
 
         EXPECT_EQ(cluster->GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue());
+        ASSERT_FALSE(readValue.IsNull());
         EXPECT_EQ(readValue.Value().energy, 500);
     }
 
     // Fire the periodic timer -- NoOpDelegate returns NullNullable for all readings.
-    // The fix must ensure DoGenerateReport() does NOT overwrite the snapshot values.
     mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
 
     // Cumulative values must survive the timer-based report
     {
-        Optional<Structs::EnergyMeasurementStruct::Type> readValue;
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> readValue;
         EXPECT_EQ(cluster->GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue()) << "Timer wiped CumulativeEnergyImported set via CumulativeEnergySnapshot";
+        ASSERT_FALSE(readValue.IsNull()) << "Timer wiped CumulativeEnergyImported set via CumulativeEnergySnapshot";
         EXPECT_EQ(readValue.Value().energy, 42000);
 
         EXPECT_EQ(cluster->GetCumulativeEnergyExported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue()) << "Timer wiped CumulativeEnergyExported set via CumulativeEnergySnapshot";
+        ASSERT_FALSE(readValue.IsNull()) << "Timer wiped CumulativeEnergyExported set via CumulativeEnergySnapshot";
         EXPECT_EQ(readValue.Value().energy, 7000);
     }
 
     // Periodic values must survive the timer-based report
     {
-        Optional<Structs::EnergyMeasurementStruct::Type> readValue;
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> readValue;
         EXPECT_EQ(cluster->GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue()) << "Timer wiped PeriodicEnergyImported set via PeriodicEnergySnapshot";
+        ASSERT_FALSE(readValue.IsNull()) << "Timer wiped PeriodicEnergyImported set via PeriodicEnergySnapshot";
         EXPECT_EQ(readValue.Value().energy, 1500);
 
         EXPECT_EQ(cluster->GetPeriodicEnergyExported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue()) << "Timer wiped PeriodicEnergyExported set via PeriodicEnergySnapshot";
+        ASSERT_FALSE(readValue.IsNull()) << "Timer wiped PeriodicEnergyExported set via PeriodicEnergySnapshot";
         EXPECT_EQ(readValue.Value().energy, 500);
     }
 
@@ -530,13 +512,13 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerDoesNo
     mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
 
     {
-        Optional<Structs::EnergyMeasurementStruct::Type> readValue;
+        DataModel::Nullable<Structs::EnergyMeasurementStruct::Type> readValue;
         EXPECT_EQ(cluster->GetCumulativeEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue()) << "Second timer cycle wiped CumulativeEnergyImported";
+        ASSERT_FALSE(readValue.IsNull()) << "Second timer cycle wiped CumulativeEnergyImported";
         EXPECT_EQ(readValue.Value().energy, 42000);
 
         EXPECT_EQ(cluster->GetPeriodicEnergyImported(readValue), CHIP_NO_ERROR);
-        ASSERT_TRUE(readValue.HasValue()) << "Second timer cycle wiped PeriodicEnergyImported";
+        ASSERT_FALSE(readValue.IsNull()) << "Second timer cycle wiped PeriodicEnergyImported";
         EXPECT_EQ(readValue.Value().energy, 1500);
     }
 

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -89,7 +89,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestAttrAcc
                               Feature::kPeriodicEnergy);
     BitMask<OptionalAttributes> optionalAttrs(OptionalAttributes::kOptionalAttributeCumulativeEnergyReset);
 
-    ElectricalEnergyMeasurementAttrAccess attrAccess(features, optionalAttrs, kTestEndpointId, mDelegate, mTimerDelegate);
+    ElectricalEnergyMeasurementAttrAccess attrAccess(features, optionalAttrs, kTestEndpointId);
 
     // Test initialization
     EXPECT_EQ(attrAccess.Init(), CHIP_NO_ERROR);
@@ -107,8 +107,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestAttrAcc
     // Test with a feature that's not enabled
     BitMask<Feature> minimalFeatures(Feature::kImportedEnergy);
     BitMask<OptionalAttributes> noOptionalAttrs;
-    ElectricalEnergyMeasurementAttrAccess minimalAttrAccess(minimalFeatures, noOptionalAttrs, kTestEndpointId + 1, mDelegate,
-                                                            mTimerDelegate);
+    ElectricalEnergyMeasurementAttrAccess minimalAttrAccess(minimalFeatures, noOptionalAttrs, kTestEndpointId + 1);
     EXPECT_EQ(minimalAttrAccess.Init(), CHIP_NO_ERROR);
     EXPECT_TRUE(minimalAttrAccess.HasFeature(Feature::kImportedEnergy));
     EXPECT_FALSE(minimalAttrAccess.HasFeature(Feature::kExportedEnergy));
@@ -120,8 +119,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestAttrAcc
     EXPECT_TRUE(attrAccess.SupportsOptAttr(OptionalAttributes::kOptionalAttributeCumulativeEnergyReset));
 
     // Test with no optional attributes
-    ElectricalEnergyMeasurementAttrAccess noOptAttrAccess(features, noOptionalAttrs, kTestEndpointId + 2, mDelegate,
-                                                          mTimerDelegate);
+    ElectricalEnergyMeasurementAttrAccess noOptAttrAccess(features, noOptionalAttrs, kTestEndpointId + 2);
     EXPECT_EQ(noOptAttrAccess.Init(), CHIP_NO_ERROR);
     EXPECT_FALSE(noOptAttrAccess.SupportsOptAttr(OptionalAttributes::kOptionalAttributeCumulativeEnergyReset));
     noOptAttrAccess.Shutdown();

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2025 Project CHIP Authors
+ *    Copyright (c) 2026 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include <clusters/ElectricalEnergyMeasurement/Events.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 #include <lib/support/CHIPCounter.h>
+#include <lib/support/TimerDelegateMock.h>
 #include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
@@ -42,19 +43,18 @@ static chip::app::CircularEventBuffer gCircularEventBuffer[3];
 
 constexpr EndpointId kTestEndpointId = 1;
 
-const Structs::MeasurementAccuracyRangeStruct::Type kTestAccuracyRanges[] = {
-    { .rangeMin   = 0,
-      .rangeMax   = 1'000'000'000'000'000, // 1 million Mwh
-      .percentMax = MakeOptional(static_cast<chip::Percent100ths>(500)),
-      .percentMin = MakeOptional(static_cast<chip::Percent100ths>(50)) }
-};
+class MockEEMDelegateCompat : public ElectricalEnergyMeasurement::Delegate
+{
+public:
+    DataModel::Nullable<int64_t> GetCumulativeEnergyImported() override { return DataModel::MakeNullable(mCumulativeImported); }
+    DataModel::Nullable<int64_t> GetCumulativeEnergyExported() override { return DataModel::MakeNullable(mCumulativeExported); }
+    DataModel::Nullable<int64_t> GetPeriodicEnergyImported() override { return DataModel::MakeNullable(mPeriodicImported); }
+    DataModel::Nullable<int64_t> GetPeriodicEnergyExported() override { return DataModel::MakeNullable(mPeriodicExported); }
 
-const Structs::MeasurementAccuracyStruct::Type kTestAccuracy = {
-    .measurementType  = MeasurementTypeEnum::kElectricalEnergy,
-    .measured         = true,
-    .minMeasuredValue = 0,
-    .maxMeasuredValue = 1'000'000'000'000'000,
-    .accuracyRanges   = DataModel::List<const Structs::MeasurementAccuracyRangeStruct::Type>(kTestAccuracyRanges)
+    int64_t mCumulativeImported = 0;
+    int64_t mCumulativeExported = 0;
+    int64_t mPeriodicImported   = 0;
+    int64_t mPeriodicExported   = 0;
 };
 
 struct TestElectricalEnergyMeasurementClusterBackwardsCompatibility : public ::testing::Test
@@ -79,6 +79,8 @@ struct TestElectricalEnergyMeasurementClusterBackwardsCompatibility : public ::t
 
     Testing::TestServerClusterContext mContext;
     chip::MonotonicallyIncreasingCounter<chip::EventNumber> mEventCounter;
+    MockEEMDelegateCompat mDelegate;
+    chip::TimerDelegateMock mTimerDelegate;
 };
 
 TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestAttrAccessLifecycle)
@@ -87,7 +89,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestAttrAcc
                               Feature::kPeriodicEnergy);
     BitMask<OptionalAttributes> optionalAttrs(OptionalAttributes::kOptionalAttributeCumulativeEnergyReset);
 
-    ElectricalEnergyMeasurementAttrAccess attrAccess(features, optionalAttrs, kTestEndpointId);
+    ElectricalEnergyMeasurementAttrAccess attrAccess(features, optionalAttrs, kTestEndpointId, mDelegate, mTimerDelegate);
 
     // Test initialization
     EXPECT_EQ(attrAccess.Init(), CHIP_NO_ERROR);
@@ -105,7 +107,8 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestAttrAcc
     // Test with a feature that's not enabled
     BitMask<Feature> minimalFeatures(Feature::kImportedEnergy);
     BitMask<OptionalAttributes> noOptionalAttrs;
-    ElectricalEnergyMeasurementAttrAccess minimalAttrAccess(minimalFeatures, noOptionalAttrs, kTestEndpointId + 1);
+    ElectricalEnergyMeasurementAttrAccess minimalAttrAccess(minimalFeatures, noOptionalAttrs, kTestEndpointId + 1, mDelegate,
+                                                            mTimerDelegate);
     EXPECT_EQ(minimalAttrAccess.Init(), CHIP_NO_ERROR);
     EXPECT_TRUE(minimalAttrAccess.HasFeature(Feature::kImportedEnergy));
     EXPECT_FALSE(minimalAttrAccess.HasFeature(Feature::kExportedEnergy));
@@ -117,7 +120,8 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestAttrAcc
     EXPECT_TRUE(attrAccess.SupportsOptAttr(OptionalAttributes::kOptionalAttributeCumulativeEnergyReset));
 
     // Test with no optional attributes
-    ElectricalEnergyMeasurementAttrAccess noOptAttrAccess(features, noOptionalAttrs, kTestEndpointId + 2);
+    ElectricalEnergyMeasurementAttrAccess noOptAttrAccess(features, noOptionalAttrs, kTestEndpointId + 2, mDelegate,
+                                                          mTimerDelegate);
     EXPECT_EQ(noOptAttrAccess.Init(), CHIP_NO_ERROR);
     EXPECT_FALSE(noOptAttrAccess.SupportsOptAttr(OptionalAttributes::kOptionalAttributeCumulativeEnergyReset));
     noOptAttrAccess.Shutdown();
@@ -136,7 +140,7 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
                                  Feature::kPeriodicEnergy);
     BitMask<OptionalAttributes> optionalAttrs(OptionalAttributes::kOptionalAttributeCumulativeEnergyReset);
 
-    ElectricalEnergyMeasurementAttrAccess attrAccess(allFeatures, optionalAttrs, kTestEndpointId);
+    ElectricalEnergyMeasurementAttrAccess attrAccess(allFeatures, optionalAttrs, kTestEndpointId, mDelegate, mTimerDelegate);
     EXPECT_EQ(attrAccess.Init(), CHIP_NO_ERROR);
 
     // Verify cluster can be found via FindElectricalEnergyMeasurementClusterOnEndpoint
@@ -337,33 +341,98 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
     attrAccess.Shutdown();
 }
 
-TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestConstructorWithAccuracy)
+TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerFiresAndGeneratesReport)
+{
+    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
+                                 Feature::kPeriodicEnergy);
+    BitMask<OptionalAttributes> noOptionalAttrs;
+
+    ElectricalEnergyMeasurementAttrAccess attrAccess(allFeatures, noOptionalAttrs, kTestEndpointId, mDelegate, mTimerDelegate);
+    EXPECT_EQ(attrAccess.Init(), CHIP_NO_ERROR);
+
+    ElectricalEnergyMeasurementCluster * cluster = FindElectricalEnergyMeasurementClusterOnEndpoint(kTestEndpointId);
+    ASSERT_NE(cluster, nullptr);
+    EXPECT_EQ(cluster->Startup(mContext.Get()), CHIP_NO_ERROR);
+
+    auto & logOnlyEvents = mContext.EventsGenerator();
+
+    mDelegate.mCumulativeImported = 77000;
+    mDelegate.mPeriodicImported   = 300;
+
+    // Advance clock by the default report interval (60s) -- should trigger timer-based report
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportInterval);
+
+    // Verify cumulative event was generated
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+        Events::CumulativeEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 77000);
+    }
+
+    // Verify periodic event was generated
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+        Events::PeriodicEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 300);
+    }
+
+    attrAccess.Shutdown();
+}
+
+TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, GenerateReportRespectsMinInterval)
 {
     BitMask<Feature> features(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
     BitMask<OptionalAttributes> noOptionalAttrs;
 
-    ElectricalEnergyMeasurementCluster cluster(ElectricalEnergyMeasurementCluster::Config{
-        .endpointId         = kTestEndpointId + 10,
-        .featureFlags       = features,
-        .optionalAttributes = noOptionalAttrs,
-        .accuracyStruct     = kTestAccuracy,
-    });
+    ElectricalEnergyMeasurementAttrAccess attrAccess(features, noOptionalAttrs, kTestEndpointId, mDelegate, mTimerDelegate);
+    EXPECT_EQ(attrAccess.Init(), CHIP_NO_ERROR);
 
-    Structs::MeasurementAccuracyStruct::Type readAccuracy;
-    cluster.GetMeasurementAccuracy(readAccuracy);
+    ElectricalEnergyMeasurementCluster * cluster = FindElectricalEnergyMeasurementClusterOnEndpoint(kTestEndpointId);
+    ASSERT_NE(cluster, nullptr);
+    EXPECT_EQ(cluster->Startup(mContext.Get()), CHIP_NO_ERROR);
 
-    EXPECT_EQ(readAccuracy.measurementType, MeasurementTypeEnum::kElectricalEnergy);
-    EXPECT_TRUE(readAccuracy.measured);
-    EXPECT_EQ(readAccuracy.minMeasuredValue, 0);
-    EXPECT_EQ(readAccuracy.maxMeasuredValue, 1'000'000'000'000'000);
-    ASSERT_EQ(readAccuracy.accuracyRanges.size(), 1u);
-    EXPECT_EQ(readAccuracy.accuracyRanges[0].rangeMin, 0);
-    EXPECT_EQ(readAccuracy.accuracyRanges[0].rangeMax, 1'000'000'000'000'000);
-    EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMax.Value(), 500);
-    EXPECT_EQ(readAccuracy.accuracyRanges[0].percentMin.Value(), 50);
+    auto & logOnlyEvents = mContext.EventsGenerator();
 
-    // Verify zero-copy: the ranges Span should point directly at the static data
-    EXPECT_EQ(readAccuracy.accuracyRanges.data(), kTestAccuracyRanges);
+    mDelegate.mCumulativeImported = 100;
+
+    // Advance clock so last-report time is non-zero
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
+
+    // First manual report should succeed
+    cluster->GenerateReport();
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+    }
+
+    // Immediately after (< 1s) -- should be silently dropped
+    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
+    mDelegate.mCumulativeImported = 200;
+    cluster->GenerateReport();
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        EXPECT_FALSE(event.has_value());
+    }
+
+    // Advance past min interval (1s) -- should succeed
+    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMinReportInterval);
+    cluster->GenerateReport();
+    {
+        auto event = logOnlyEvents.GetNextEvent();
+        ASSERT_TRUE(event.has_value());
+        Events::CumulativeEnergyMeasured::DecodableType decoded;
+        ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
+        ASSERT_TRUE(decoded.energyImported.HasValue());
+        EXPECT_EQ(decoded.energyImported.Value().energy, 200);
+    }
+
+    attrAccess.Shutdown();
 }
 
 } // namespace

--- a/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/tests/TestElectricalEnergyMeasurementClusterBackwardsCompatibility.cpp
@@ -331,60 +331,6 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TestCodegen
     attrAccess.Shutdown();
 }
 
-TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, TimerFiresAndGeneratesReport)
-{
-    BitMask<Feature> allFeatures(Feature::kImportedEnergy, Feature::kExportedEnergy, Feature::kCumulativeEnergy,
-                                 Feature::kPeriodicEnergy);
-    BitMask<OptionalAttributes> noOptionalAttrs;
-
-    ElectricalEnergyMeasurementAttrAccess attrAccess(allFeatures, noOptionalAttrs, kTestEndpointId, mDelegate, mTimerDelegate);
-    EXPECT_EQ(attrAccess.Init(), CHIP_NO_ERROR);
-
-    ElectricalEnergyMeasurementCluster * cluster = FindElectricalEnergyMeasurementClusterOnEndpoint(kTestEndpointId);
-    ASSERT_NE(cluster, nullptr);
-    EXPECT_EQ(cluster->Startup(mContext.Get()), CHIP_NO_ERROR);
-
-    auto & logOnlyEvents = mContext.EventsGenerator();
-
-    // First report to establish stored values with endSystime.
-    mDelegate.mCumulativeImported = 1;
-    mDelegate.mPeriodicImported   = 1;
-    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
-    cluster->GenerateSnapshots();
-    ASSERT_TRUE(logOnlyEvents.GetNextEvent().has_value());
-    ASSERT_TRUE(logOnlyEvents.GetNextEvent().has_value());
-
-    // Rate-limited update within 1 s starts the delay timer.
-    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
-    mDelegate.mCumulativeImported = 77000;
-    mDelegate.mPeriodicImported   = 300;
-    cluster->GenerateSnapshots();
-    EXPECT_FALSE(logOnlyEvents.GetNextEvent().has_value());
-
-    // Advance past the max-delay timer -- fires and produces a report.
-    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportDelayInterval);
-
-    {
-        auto event = logOnlyEvents.GetNextEvent();
-        ASSERT_TRUE(event.has_value());
-        Events::CumulativeEnergyMeasured::DecodableType decoded;
-        ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
-        ASSERT_TRUE(decoded.energyImported.HasValue());
-        EXPECT_EQ(decoded.energyImported.Value().energy, 77000);
-    }
-
-    {
-        auto event = logOnlyEvents.GetNextEvent();
-        ASSERT_TRUE(event.has_value());
-        Events::PeriodicEnergyMeasured::DecodableType decoded;
-        ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
-        ASSERT_TRUE(decoded.energyImported.HasValue());
-        EXPECT_EQ(decoded.energyImported.Value().energy, 300);
-    }
-
-    attrAccess.Shutdown();
-}
-
 TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, GenerateSnapshotsRespectsMinInterval)
 {
     BitMask<Feature> features(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
@@ -430,49 +376,6 @@ TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, GenerateSna
         ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
         ASSERT_TRUE(decoded.energyImported.HasValue());
         EXPECT_EQ(decoded.energyImported.Value().energy, 200);
-    }
-
-    attrAccess.Shutdown();
-}
-
-TEST_F(TestElectricalEnergyMeasurementClusterBackwardsCompatibility, RateLimitedUpdateFlushesOnMaxDelayTimer)
-{
-    BitMask<Feature> features(Feature::kImportedEnergy, Feature::kCumulativeEnergy);
-    BitMask<OptionalAttributes> noOptionalAttrs;
-
-    ElectricalEnergyMeasurementAttrAccess attrAccess(features, noOptionalAttrs, kTestEndpointId, mDelegate, mTimerDelegate);
-    EXPECT_EQ(attrAccess.Init(), CHIP_NO_ERROR);
-
-    ElectricalEnergyMeasurementCluster * cluster = FindElectricalEnergyMeasurementClusterOnEndpoint(kTestEndpointId);
-    ASSERT_NE(cluster, nullptr);
-    EXPECT_EQ(cluster->Startup(mContext.Get()), CHIP_NO_ERROR);
-
-    auto & logOnlyEvents = mContext.EventsGenerator();
-
-    mDelegate.mCumulativeImported = 10;
-    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(100));
-    cluster->GenerateSnapshots();
-    {
-        auto event = logOnlyEvents.GetNextEvent();
-        ASSERT_TRUE(event.has_value());
-    }
-
-    mTimerDelegate.AdvanceClock(System::Clock::Milliseconds64(1));
-    mDelegate.mCumulativeImported = 20;
-    cluster->GenerateSnapshots();
-    {
-        auto event = logOnlyEvents.GetNextEvent();
-        EXPECT_FALSE(event.has_value());
-    }
-
-    mTimerDelegate.AdvanceClock(ElectricalEnergyMeasurementCluster::kMaxReportDelayInterval);
-    {
-        auto event = logOnlyEvents.GetNextEvent();
-        ASSERT_TRUE(event.has_value());
-        Events::CumulativeEnergyMeasured::DecodableType decoded;
-        ASSERT_EQ((*event).GetEventData(decoded), CHIP_NO_ERROR);
-        ASSERT_TRUE(decoded.energyImported.HasValue());
-        EXPECT_EQ(decoded.energyImported.Value().energy, 20);
     }
 
     attrAccess.Shutdown();

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -499,7 +499,7 @@
  *    This is expected to be called from within a class that implements a Shutdown method.
  *    It checks for the specified error, which is expected to commonly be successful (CHIP_NO_ERROR),
  *    on failure, it calls the statements to be executed before shutdown if provided,
- *    executed before shutdown if provided, then calls the Shutdown method of the class en returns the error.
+ *    then calls the Shutdown method of the class and returns the error.
  *
  *  @param[in]  expr  A ChipError object to be evaluated against success (CHIP_NO_ERROR).
  *  @param[in]  ...     Statements to execute before shutdown. Optional.

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -493,6 +493,31 @@
 #endif // CHIP_CONFIG_ERROR_SOURCE
 
 /**
+ *  @def SuccessOrShutdown(expr, ...)
+ *
+ *  @brief
+ *    This is expected to be called from within a class that implements a Shutdown method.
+ *    It checks for the specified error, which is expected to commonly be successful (CHIP_NO_ERROR),
+ *    on failure, it calls the statements to be executed before shutdown if provided,
+ *    executed before shutdown if provided, then calls the Shutdown method of the class en returns the error.
+ *
+ *  @param[in]  expr  A ChipError object to be evaluated against success (CHIP_NO_ERROR).
+ *  @param[in]  ...     Statements to execute before shutdown. Optional.
+ *
+ */
+#define SuccessOrShutdown(expr, ...)                                                                                               \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        auto __err = (expr);                                                                                                       \
+        if (!::chip::ChipError::IsSuccess(__err))                                                                                  \
+        {                                                                                                                          \
+            __VA_ARGS__;                                                                                                           \
+            this->Shutdown();                                                                                                      \
+            return __err;                                                                                                          \
+        }                                                                                                                          \
+    } while (false)
+
+/**
  *  @def SuccessOrExit(error)
  *
  *  @brief


### PR DESCRIPTION
#### Summary

Refactoring the EEM cluster to be in line with the Cluster/Delegate structure we have adopted for the other electrical sensor devices.

Key Changes:
The Cluster now leverages QuieterReporting for attribute reports, enforcing reports delays of 1 second.
The cluster now has a Delegate that will fetch the appropriate values from the app side before generating those events.

Also refactored the energy-management files to have a dedicated Electrical Sensor Manager so DEM can be separated form ES.

The Electrical Sensor Manager directly uses the EEM cluster without CodegenIntegration, the other clusters will need to be converted as well before the energy management can be fully code driven.

NOTE: Keeping this as a draft PR until we rebase this on master once the EEM Accuracy PR lands.

#### Related issues

na

#### Testing

Unit test were added both for code driven backwards compatibility with code gen in the event that products want to keep using EEM the same way it was used before this refactor.

Manually tested event generation on EVSE app to confirm the refactor of ES Manager worked as expected.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
