### PR TITLE
Add the support for generated commands method in groupcast cluster

### DIFF
--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -156,12 +156,10 @@ CHIP_ERROR GroupcastCluster::AcceptedCommands(const ConcreteClusterPath & path,
     return builder.ReferenceExisting(kAcceptedCommands);
 }
 
-CHIP_ERROR GroupcastCluster::GeneratedCommands(const ConcreteClusterPath & path,
-                                               ReadOnlyBufferBuilder<CommandId> & builder)
+CHIP_ERROR GroupcastCluster::GeneratedCommands(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<CommandId> & builder)
 {
     return builder.ReferenceExisting(kGeneratedCommands);
 }
-
 
 Status GroupcastCluster::GroupcastTesting(FabricIndex fabricIndex, Groupcast::Commands::GroupcastTesting::DecodableType data)
 {

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -25,6 +25,11 @@ constexpr DataModel::AcceptedCommandEntry kAcceptedCommands[] = {
     Groupcast::Commands::UpdateGroupKey::kMetadataEntry,   Groupcast::Commands::ConfigureAuxiliaryACL::kMetadataEntry,
     Groupcast::Commands::GroupcastTesting::kMetadataEntry,
 };
+
+constexpr CommandId kGeneratedCommands[] = {
+    Groupcast::Commands::LeaveGroupResponse::Id,
+};
+
 } // namespace
 
 GroupcastCluster::GroupcastCluster(GroupcastContext && context) : GroupcastCluster(std::move(context), {}) {}
@@ -150,6 +155,13 @@ CHIP_ERROR GroupcastCluster::AcceptedCommands(const ConcreteClusterPath & path,
 {
     return builder.ReferenceExisting(kAcceptedCommands);
 }
+
+CHIP_ERROR GroupcastCluster::GeneratedCommands(const ConcreteClusterPath & path,
+                                               ReadOnlyBufferBuilder<CommandId> & builder)
+{
+    return builder.ReferenceExisting(kGeneratedCommands);
+}
+
 
 Status GroupcastCluster::GroupcastTesting(FabricIndex fabricIndex, Groupcast::Commands::GroupcastTesting::DecodableType data)
 {

--- a/src/app/clusters/groupcast/GroupcastCluster.h
+++ b/src/app/clusters/groupcast/GroupcastCluster.h
@@ -64,9 +64,7 @@ public:
     CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path,
                                 ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder) override;
 
-    CHIP_ERROR GeneratedCommands(const ConcreteClusterPath & path,
-                                 ReadOnlyBufferBuilder<CommandId> & builder) override;
-
+    CHIP_ERROR GeneratedCommands(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<CommandId> & builder) override;
 
     Protocols::InteractionModel::Status GroupcastTesting(FabricIndex fabricIndex,
                                                          Groupcast::Commands::GroupcastTesting::DecodableType data);

--- a/src/app/clusters/groupcast/GroupcastCluster.h
+++ b/src/app/clusters/groupcast/GroupcastCluster.h
@@ -64,6 +64,10 @@ public:
     CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path,
                                 ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder) override;
 
+    CHIP_ERROR GeneratedCommands(const ConcreteClusterPath & path,
+                                 ReadOnlyBufferBuilder<CommandId> & builder) override;
+
+
     Protocols::InteractionModel::Status GroupcastTesting(FabricIndex fabricIndex,
                                                          Groupcast::Commands::GroupcastTesting::DecodableType data);
 


### PR DESCRIPTION
#### Problem
- The generated commands list returns empty when read through chip-tool in case of groupcast cluster.

#### Change Overview
- Added the support for generated commands method in groupcast cluster.


#### Testing
- Verified reading the generated command list before and after the change.
