### PR TITLE
Thread: enable Thread commissioner only on commissioner build

### DIFF
--- a/src/controller/flags.gni
+++ b/src/controller/flags.gni
@@ -23,10 +23,13 @@ declare_args() {
 
   # Build controller with webrtc python bindings
   chip_support_webrtc_python_bindings = false
+}
 
-  # Disable Thread MeshCoP if cross-compiling by default.
+declare_args() {
+  # Disable Thread MeshCoP if cross-compiling because of missing libevent.
   chip_support_thread_meshcop =
       matter_enable_recommended && chip_device_platform == "linux" &&
       !chip_system_config_use_openthread_inet_endpoints &&
-      current_cpu == host_cpu && current_os == host_os
+      current_cpu == host_cpu && current_os == host_os &&
+      chip_support_commissioning_in_controller
 }

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -140,11 +140,9 @@ declare_args() {
   chip_device_config_enable_wifipaf =
       chip_enable_wifi && chip_device_platform == "linux"
 
-  # Disable Thread MeshCoP if cross-compiling by default.
   chip_device_config_enable_thread_meshcop =
       chip_device_platform == "linux" &&
-      chip_system_config_use_openthread_inet_endpoints &&
-      current_cpu == host_cpu && current_os == host_os
+      chip_system_config_use_openthread_inet_endpoints
 }
 
 declare_args() {


### PR DESCRIPTION
#### Summary

This commit cleans the Matter commissioning over Thread support flags by only enabling `chip_support_thread_meshcop` on commissioners.

* `chip_support_thread_meshcop`: controls whether the commissioner supports commissioning over Thread MeshCoP.
* `chip_device_config_enable_thread_meshcop`: controls whether the device supports commissioning over Thread MeshCoP.

#### Related issues

The current flags may enable `chip_support_thread_meshcop` on non-commissioner builds.

#### Testing

This is going to be tested by existing tests.

