### PR TITLE
[Docs] Update docs about delegate based attribute updated callbacks.

### DIFF
--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -329,10 +329,10 @@ attribute's value changes.
     [Delegate/Driver Pattern for Validation](#delegate-driver-pattern-for-validation),
     each mutable attribute should have a corresponding
     `On<AttributeName>Changed` callback in the delegate interface. These are
-    _pre-write_ hooks—invoked after spec-level validation and the no-op guard,
+    _pre-write_ hooks invoked after spec-level validation and the no-op guard,
     but _before_ the value is committed. The callback must always receive the
     **proposed new value**, not the current (stale) value. Returning `true`
-    accepts the change; returning `false` vetoes it—the cluster must then fail
+    accepts the change; returning `false` vetoes it the cluster must then fail
     the operation with `Protocols::InteractionModel::Status::Failure` (for APIs
     returning `Status`) or `CHIP_ERROR_INCORRECT_STATE` (for APIs returning
     `CHIP_ERROR`). Default implementations should return `true` so applications

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -332,7 +332,7 @@ attribute's value changes.
     _pre-write_ hooks invoked after spec-level validation and the no-op guard,
     but _before_ the value is committed. The callback must always receive the
     **proposed new value**, not the current (stale) value. Returning `true`
-    accepts the change; returning `false` vetoes it the cluster must then fail
+    accepts the change; returning `false` vetoes it. The cluster must then fail
     the operation with `Protocols::InteractionModel::Status::Failure` (for APIs
     returning `Status`) or `CHIP_ERROR_INCORRECT_STATE` (for APIs returning
     `CHIP_ERROR`). Default implementations should return `true` so applications

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -325,19 +325,18 @@ attribute's value changes.
         VerifyOrReturnValue(mValue != newValue, ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
         ```
 
-
--   **Per-Attribute Change Callbacks:** As a concrete realization of the
+*   **Per-Attribute Change Callbacks:** As a concrete realization of the
     [Delegate/Driver Pattern for Validation](#delegate-driver-pattern-for-validation),
-    each mutable attribute should have a corresponding `On<AttributeName>Changed`
-    callback in the delegate interface. These are _pre-write_ hooks—invoked
-    after spec-level validation and the no-op guard, but _before_ the value is
-    committed. The callback must always receive the **proposed new value**, not
-    the current (stale) value. Returning `true` accepts the change; returning
-    `false` vetoes it—the cluster must then fail the operation with
-    `Protocols::InteractionModel::Status::Failure` (for APIs returning `Status`)
-    or `CHIP_ERROR_INCORRECT_STATE` (for APIs returning `CHIP_ERROR`).
-    Default implementations should return `true` so applications only override
-    the callbacks they need.
+    each mutable attribute should have a corresponding
+    `On<AttributeName>Changed` callback in the delegate interface. These are
+    _pre-write_ hooks—invoked after spec-level validation and the no-op guard,
+    but _before_ the value is committed. The callback must always receive the
+    **proposed new value**, not the current (stale) value. Returning `true`
+    accepts the change; returning `false` vetoes it—the cluster must then fail
+    the operation with `Protocols::InteractionModel::Status::Failure` (for APIs
+    returning `Status`) or `CHIP_ERROR_INCORRECT_STATE` (for APIs returning
+    `CHIP_ERROR`). Default implementations should return `true` so applications
+    only override the callbacks they need.
 
     **Example:** The
     [Boolean State Configuration delegate](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h)

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -325,17 +325,47 @@ attribute's value changes.
         VerifyOrReturnValue(mValue != newValue, ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
         ```
 
--   **OnClusterAttributeChanged Pattern:** Each cluster should implement a
-    centralized helper method (e.g., `OnClusterAttributeChanged(AttributeId)`)
-    that combines both network and application notifications.
-    -   Call `NotifyAttributeChanged()` to notify network subscribers.
-    -   Call delegate callbacks to notify the application layer of the _actual_
-        change.
-    -   Invoke this method only when a value has truly changed.
-    -   **Example:** See
-        [Boolean State Configuration](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.h)
-        which declares `OnClusterAttributeChanged(AttributeId)` as a private
-        helper.
+
+-   **Per-Attribute Change Callbacks:** As a concrete realization of the
+    [Delegate/Driver Pattern for Validation](#delegate-driver-pattern-for-validation),
+    each mutable attribute should have a corresponding `On<AttributeName>Changed`
+    callback in the delegate interface. These are _pre-write_ hooks—invoked
+    after spec-level validation and the no-op guard, but _before_ the value is
+    committed. The callback must always receive the **proposed new value**, not
+    the current (stale) value. Returning `true` accepts the change; returning
+    `false` vetoes it—the cluster must then fail the operation with
+    `Protocols::InteractionModel::Status::Failure` (for APIs returning `Status`)
+    or `CHIP_ERROR_INCORRECT_STATE` (for APIs returning `CHIP_ERROR`).
+    Default implementations should return `true` so applications only override
+    the callbacks they need.
+
+    **Example:** The
+    [Boolean State Configuration delegate](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-delegate.h)
+    declares:
+
+    ```cpp
+    virtual bool OnCurrentSensitivityLevelChanged(uint8_t newValue) { return true; }
+    virtual bool OnAlarmsActiveChanged(chip::BitMask<AlarmModeBitmap> newValue) { return true; }
+    virtual bool OnAlarmsSuppressedChanged(chip::BitMask<AlarmModeBitmap> newValue) { return true; }
+    virtual bool OnAlarmsEnabledChanged(chip::BitMask<AlarmModeBitmap> newValue) { return true; }
+    virtual bool OnSensorFaultChanged(chip::BitMask<SensorFaultBitmap> newValue) { return true; }
+    ```
+
+    And the cluster invokes them in the standard order—validate, guard no-op,
+    call delegate, then commit and notify:
+
+    ```cpp
+    VerifyOrReturnError(level < mSupportedSensitivityLevels, CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    VerifyOrReturnError(mCurrentSensitivityLevel != level, CHIP_NO_ERROR);
+
+    if (mDelegate != nullptr)
+    {
+        VerifyOrReturnError(mDelegate->OnCurrentSensitivityLevelChanged(level), CHIP_ERROR_INCORRECT_STATE);
+    }
+
+    mCurrentSensitivityLevel = level;
+    NotifyAttributeChanged(CurrentSensitivityLevel::Id);
+    ```
 
 #### Persistent Storage
 

--- a/docs/guides/writing_clusters.md
+++ b/docs/guides/writing_clusters.md
@@ -325,7 +325,7 @@ attribute's value changes.
         VerifyOrReturnValue(mValue != newValue, ActionReturnStatus::FixedStatus::kWriteSuccessNoOp);
         ```
 
-*   **Per-Attribute Change Callbacks:** As a concrete realization of the
+-   **Per-Attribute Change Callbacks:** As a concrete realization of the
     [Delegate/Driver Pattern for Validation](#delegate-driver-pattern-for-validation),
     each mutable attribute should have a corresponding
     `On<AttributeName>Changed` callback in the delegate interface. These are


### PR DESCRIPTION
#### Summary

- As per discussion in https://github.com/project-chip/connectedhomeip/pull/42964, we should have pre-attribute change callback for each mutable attribute.
- PR adds the guideline while implementing the interface, when the cluster is migrated.

#### Related issues

NA

#### Testing

NA, docs update.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
