### PR TITLE
ESP32: handle return value in lighting-app

### DIFF
--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -211,11 +211,16 @@ extern "C" void app_main()
 
     SetDeviceAttestationCredentialsProvider(get_dac_provider());
 
-    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+    error = chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+    if (error != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "PlatformMgr().ScheduleWork() failed, error:%" CHIP_ERROR_FORMAT, error.Format());
+        return;
+    }
 
     error = GetAppTask().StartAppTask();
     if (error != CHIP_NO_ERROR)
     {
-        ESP_LOGE(TAG, "GetAppTask().StartAppTask() failed : %s", ErrorStr(error));
+        ESP_LOGE(TAG, "GetAppTask().StartAppTask() failed error:%" CHIP_ERROR_FORMAT, error.Format());
     }
 }

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -221,6 +221,6 @@ extern "C" void app_main()
     error = GetAppTask().StartAppTask();
     if (error != CHIP_NO_ERROR)
     {
-        ESP_LOGE(TAG, "GetAppTask().StartAppTask() failed error:%" CHIP_ERROR_FORMAT, error.Format());
+        ESP_LOGE(TAG, "GetAppTask().StartAppTask() failed, error:%" CHIP_ERROR_FORMAT, error.Format());
     }
 }


### PR DESCRIPTION
#### Summary

While working with lighting-app/esp32, came across this nodiscard warning

```
../main/main.cpp:214:50: warning: ignoring returned value of type 'CHIP_ERROR' {aka 'chip::ChipError'}, declared with attribute 'nodiscard' [-Wunused-result]
  214 |     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

- Handing the return value from API `chip::DeviceLayer::PlatformMgr().ScheduleWork()`

#### Testing

- re-built the app and warning disappeared!