### PR TITLE
Fix use-of-uninitialized error in TCP.h

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -65,11 +65,7 @@ CHIP_ERROR GetPeerAddress(Inet::TCPEndPoint & endPoint, PeerAddress & outAddr)
 
 } // namespace
 
-TCPBase::~TCPBase()
-{
-    // Call Close to free the listening socket and close all active connections.
-    Close();
-}
+TCPBase::~TCPBase() = default;
 
 void TCPBase::CloseActiveConnections()
 {

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -342,7 +342,13 @@ public:
         }
     }
 
-    ~TCP() override { mPendingPackets.ReleaseAll(); }
+    ~TCP() override
+    {
+        mPendingPackets.ReleaseAll();
+
+        // Call Close to free the listening socket and close all active connections.
+        Close();
+    }
 
 private:
     ActiveTCPConnectionState mConnectionsBuffer[kActiveConnectionsSize];


### PR DESCRIPTION
#### Summary

`mConnectionsBuffer` cannot be accessed by TCPBase during destruction since the derived class is destroyed first.
Move the `Close` call from TCPBase to TCP destructor to avoid such accesses.

#### Related issues

Fixes: #43489

#### Testing

Ran tests with memory sanitizer build.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
