### PR TITLE
[Groupcast]Add feature constraint check on JoinGroup command with mCastAddrPolic…

### DIFF
--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -238,8 +238,6 @@ void GroupcastCluster::GroupcastTestingTimer::TimerFired()
     mCluster.mTestingState = Groupcast::GroupcastTestingEnum::kDisableTesting;
 }
 
-// Methods moved from GroupcastLogic
-
 CHIP_ERROR GroupcastCluster::ReadMembership(const chip::Access::SubjectDescriptor * subject, EndpointId endpoint,
                                             AttributeValueEncoder & aEncoder)
 {
@@ -355,6 +353,11 @@ Status GroupcastCluster::JoinGroup(FabricIndex fabric_index, const Groupcast::Co
 
     // ReplaceEndpoints can only be present if kListener feature is supported
     VerifyOrReturnError(!data.replaceEndpoints.HasValue() || mFeatures.Has(Groupcast::Feature::kListener), Status::ConstraintError);
+
+    VerifyOrReturnError(!data.mcastAddrPolicy.HasValue() ||
+                            (Groupcast::MulticastAddrPolicyEnum::kIanaAddr == data.mcastAddrPolicy.Value()) ||
+                            mFeatures.Has(Groupcast::Feature::kPerGroup),
+                        Status::ConstraintError);
 
     // Check endpoints
     size_t endpoint_count = 0;

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -354,10 +354,10 @@ Status GroupcastCluster::JoinGroup(FabricIndex fabric_index, const Groupcast::Co
     // ReplaceEndpoints can only be present if kListener feature is supported
     VerifyOrReturnError(!data.replaceEndpoints.HasValue() || mFeatures.Has(Groupcast::Feature::kListener), Status::ConstraintError);
 
-    VerifyOrReturnError(!data.mcastAddrPolicy.HasValue() ||
-                            (Groupcast::MulticastAddrPolicyEnum::kIanaAddr == data.mcastAddrPolicy.Value()) ||
-                            mFeatures.Has(Groupcast::Feature::kPerGroup),
-                        Status::ConstraintError);
+    if (data.mcastAddrPolicy.HasValue() && data.mcastAddrPolicy.Value() == Groupcast::MulticastAddrPolicyEnum::kPerGroup)
+    {
+        VerifyOrReturnError(mFeatures.Has(Groupcast::Feature::kPerGroup), Status::ConstraintError);
+    }
 
     // Check endpoints
     size_t endpoint_count = 0;

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -159,7 +159,7 @@ struct TestGroupcastCluster : public ::testing::Test
     app::Clusters::GroupcastCluster mSender{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate },
                                              BitFlags<Feature>{ Feature::kSender } };
     app::Clusters::GroupcastCluster mListener{ { mFabricHelper.GetFabricTable(), mProvider, mMockTimerDelegate },
-                                               BitFlags<Feature>{ Feature::kListener } };
+                                               BitFlags<Feature>{ Feature::kListener, Feature::kPerGroup } };
 };
 
 TEST_F(TestGroupcastCluster, TestAttributes)
@@ -764,6 +764,24 @@ TEST_F(TestGroupcastCluster, TestJoinGroupCommand)
         ASSERT_TRUE(result.status.has_value());
         EXPECT_EQ(result.status.value().GetStatusCode().GetStatus(), // NOLINT(bugprone-unchecked-optional-access)
                   Protocols::InteractionModel::Status::Success);
+
+        // Join group: McastAddrPolicy kPerGroup without kPerGroup feature set
+        data.groupID         = 2;
+        data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kPerGroup);
+        result               = tester.Invoke(Commands::JoinGroup::Id, data);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::ConstraintError));
+
+        // Join group: McastAddrPolicy kIanaAddr without kPerGroup feature
+        data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
+        data.key.ClearValue();
+        result = tester.Invoke(Commands::JoinGroup::Id, data);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
+
+        // Join group: McastAddrPolicy absent without kPerGroup feature
+        data.groupID = 3;
+        data.mcastAddrPolicy.ClearValue();
+        result = tester.Invoke(Commands::JoinGroup::Id, data);
+        EXPECT_EQ(result.GetStatusCode(), ClusterStatusCode(Status::Success));
 
         // Join group: Non-empty endpoints
         data.groupID   = 3;


### PR DESCRIPTION
…y=kPerGroup.

#### Summary
The Join Group command succeed with mcastAddrPolicy set to PerGroup even when the PerGroupAddress feature is not set.
This issue was caught with TC_GC_2.2.py at step 13 on a app with Groupcast but without the PerGroupAddress feature set.

Fix: Add a check in the JoinGroup command handling verifyin the received mcastAddrPolicy field and correspondance with the cluster featuremap value.

- Add unit test to Validate this contraint check and expected outcome (positive/negative testing) 
- Add the `Feature::kPerGroup` to the mListener groupcast cluster instance in the unit test so the existing test still pass as before as some did JoinGroup with  McastAddrPolicy=kPerGroup.


#### Related issues
fixes #43495

#### Testing
Unit test TestGroupcastCluster.cpp
TC_GC_2.2.py against a all-cluster-app built without  the PGA feature set.

