### PR TITLE
[Darwin] add implementations for Darwin cluster extensions

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRAttributeSpecifiedCheck_Private-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeSpecifiedCheck_Private-src.zapt
@@ -32,6 +32,31 @@ static BOOL AttributeIsSpecifiedIn{{asUpperCamelCase name preserveAcronyms=true}
 {{/if}}
 {{/zcl_clusters}}
 
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+{{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
+static BOOL PrivateAttributeIsSpecifiedIn{{asUpperCamelCase name preserveAcronyms=true}}Cluster(AttributeId aAttributeId)
+{
+    using namespace Clusters::{{asUpperCamelCase name}};
+    switch (aAttributeId) {
+        {{#zcl_attributes_server}}
+        {{#if manufacturerCode}}
+        {{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+        case Attributes::{{asUpperCamelCase name}}::Id: {
+            return YES;
+        }
+        {{/if}}
+        {{/if}}
+        {{/zcl_attributes_server}}
+        default: {
+            return NO;
+        }
+    }
+}
+{{/if}}
+{{/if}}
+{{/zcl_clusters}}
+
 BOOL MTRPrivateAttributeIsSpecified(ClusterId aClusterId, AttributeId aAttributeId)
 {
     switch (aClusterId)
@@ -41,6 +66,15 @@ BOOL MTRPrivateAttributeIsSpecified(ClusterId aClusterId, AttributeId aAttribute
         {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
         case Clusters::{{asUpperCamelCase name}}::Id: {
             return AttributeIsSpecifiedIn{{asUpperCamelCase name preserveAcronyms=true}}Cluster(aAttributeId);
+        }
+        {{/if}}
+        {{/if}}
+        {{/zcl_clusters}}
+        {{#zcl_clusters}}
+        {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+        {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
+        case Clusters::{{asUpperCamelCase name}}::Id: {
+            return PrivateAttributeIsSpecifiedIn{{asUpperCamelCase name preserveAcronyms=true}}Cluster(aAttributeId);
         }
         {{/if}}
         {{/if}}

--- a/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder_Private-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder_Private-src.zapt
@@ -87,6 +87,45 @@ static id _Nullable DecodeAttributeValueFor{{asUpperCamelCase name preserveAcron
 {{/if}}
 {{/zcl_clusters}}
 
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+{{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
+static id _Nullable DecodePrivateAttributeValueFor{{asUpperCamelCase name preserveAcronyms=true}}Cluster(AttributeId aAttributeId, TLV::TLVReader & aReader, CHIP_ERROR * aError)
+{
+    using namespace Clusters::{{asUpperCamelCase name}};
+    switch (aAttributeId) {
+        {{#zcl_attributes_server removeKeys='isOptional'}}
+        {{#if clusterRef}}
+        {{#if manufacturerCode}}
+        {{#if (isSupported (asUpperCamelCase ../name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+        case Attributes::{{asUpperCamelCase name}}::Id: {
+            using TypeInfo = Attributes::{{asUpperCamelCase name}}::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nil;
+            }
+            {{asObjectiveCType type parent.name}} value;
+            {{>decode_value target="value" source="cppValue" cluster=parent.name errorCode="*aError = err; return nil;" depth=0}}
+            return value;
+        }
+        {{/if}}
+        {{/if}}
+        {{/if}}
+        {{/zcl_attributes_server}}
+        default: {
+            break;
+        }
+    }
+
+    *aError = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB;
+    return nil;
+}
+{{/if}}
+{{/if}}
+{{/zcl_clusters}}
+
 id _Nullable MTRPrivateDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader & aReader, CHIP_ERROR * aError)
 {
     if (IsGlobalAttribute(aPath.mAttributeId)) {
@@ -99,6 +138,15 @@ id _Nullable MTRPrivateDecodeAttributeValue(const ConcreteAttributePath & aPath,
         {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
         case Clusters::{{asUpperCamelCase name}}::Id: {
             return DecodeAttributeValueFor{{asUpperCamelCase name preserveAcronyms=true}}Cluster(aPath.mAttributeId, aReader, aError);
+        }
+        {{/if}}
+        {{/if}}
+        {{/zcl_clusters}}
+        {{#zcl_clusters}}
+        {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+        {{#if (isSupported (asUpperCamelCase name preserveAcronyms=true))}}
+        case Clusters::{{asUpperCamelCase name}}::Id: {
+            return DecodePrivateAttributeValueFor{{asUpperCamelCase name preserveAcronyms=true}}Cluster(aPath.mAttributeId, aReader, aError);
         }
         {{/if}}
         {{/if}}

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Private-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Private-src.zapt
@@ -29,4 +29,35 @@
 {{/if}}
 {{/zcl_clusters}}
 
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+@implementation MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} (PrivateExtensions)
+
+{{#zcl_commands}}
+{{#if manufacturerCode}}
+{{#if (is_str_equal source 'client')}}
+{{#*inline "commandImpl"}}
+{{#if (isSupported cluster command=command)}}
+{{#*inline "paramsType"}}MTR{{cluster}}Cluster{{command}}Params{{/inline}}
+{{> base_clusters_command_impl cluster=cluster}}
+{{/if}}
+{{/inline}}
+{{> commandImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
+                command=(asUpperCamelCase name preserveAcronyms=true)}}
+{{/if}}
+{{/if}}
+{{/zcl_commands}}
+
+{{#zcl_attributes_server removeKeys='isOptional'}}
+{{#if manufacturerCode}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
+{{> base_clusters_attribute_impl}}
+{{/if}}
+{{/if}}
+{{/zcl_attributes_server}}
+
+@end
+{{/if}}
+{{/zcl_clusters}}
+
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/src/darwin/Framework/CHIP/templates/MTRClusters_Private-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_Private-src.zapt
@@ -59,4 +59,65 @@
 {{/if}}
 {{/zcl_clusters}}
 
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+@implementation MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} (PrivateExtensions)
+
+{{#zcl_commands}}
+{{#if manufacturerCode}}
+{{#*inline "commandImpl"}}
+{{#if (isSupported cluster command=command)}}
+{{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{cluster}}Cluster{{asUpperCamelCase responseName preserveAcronyms=true}}{{else}}CommandSuccess{{/if}}{{/inline}}
+{{#*inline "paramsType"}}MTR{{cluster}}Cluster{{command}}Params{{/inline}}
+{{> clusters_command_impl cluster=cluster}}
+{{/if}}
+{{/inline}}
+{{#if (is_str_equal source 'client')}}
+{{> commandImpl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
+                command=(asUpperCamelCase name preserveAcronyms=true)}}
+{{/if}}
+{{/if}}
+{{/zcl_commands}}
+
+{{#zcl_attributes_server}}
+{{#if manufacturerCode}}
+{{#if (and
+        (or clusterRef
+            (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true)))
+        (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true)))}}
+{{#*inline "cluster"}}{{asUpperCamelCase parent.name preserveAcronyms=true}}{{/inline}}
+{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
+- (NSDictionary<NSString *, id> * _Nullable)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params {
+    return [self.device readAttributeWithEndpointID:self.endpointID clusterID:@(MTRClusterIDType{{>cluster}}ID) attributeID:@(MTRPrivateAttributeIDTypeCluster{{>cluster}}{{>attribute}}ID) params:params];
+}
+
+{{#if (or isWritableAttribute
+      (isInConfigList (concat (asUpperCamelCase parent.name) "::" label) "DarwinForceWritable"))}}
+{{#*inline "callbackName"}}DefaultSuccess{{/inline}}
+- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs
+{
+  [self write{{>attribute}}WithValue:dataValueDictionary expectedValueInterval:expectedValueIntervalMs params:nil];
+}
+- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params
+{
+    NSNumber *timedWriteTimeout = params.timedWriteTimeout;
+    {{#if mustUseTimedWrite}}
+    if (!timedWriteTimeout) {
+        timedWriteTimeout = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
+    }
+    {{/if}}
+
+    [self.device writeAttributeWithEndpointID:self.endpointID clusterID:@(MTRClusterIDType{{>cluster}}ID) attributeID:@(MTRPrivateAttributeIDTypeCluster{{>cluster}}{{>attribute}}ID) value:dataValueDictionary expectedValueInterval:expectedValueIntervalMs timedWriteTimeout:timedWriteTimeout];
+}
+
+{{/if}}
+
+{{/if}}
+{{/if}}
+{{/zcl_attributes_server}}
+
+@end
+{{/if}}
+{{/zcl_clusters}}
+
 // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc_Private-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc_Private-src.zapt
@@ -73,4 +73,64 @@ static void LogAndConvertDecodingError(CHIP_ERROR err, NSError * __autoreleasing
 {{/if}}
 {{/zcl_clusters}}
 
+{{#zcl_clusters}}
+{{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
+{{#zcl_commands}}
+{{#if manufacturerCode}}
+{{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true) isForCommandPayload=true)}}
+
+@implementation MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Params
+{{> command_params_init_impl}}
+
+{{> command_params_copy_impl cluster=(asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true)}}
+
+{{> command_params_description_impl}}
+
+{{#if (isStrEqual source "server")}}
+- (nullable instancetype)initWithResponseValue:(NSDictionary<NSString *, id> *)responseValue
+                                         error:(NSError * __autoreleasing *)error
+{
+  if (!(self = [super init])) {
+    return nil;
+  }
+
+  using DecodableType = chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType;
+  chip::System::PacketBufferHandle buffer = [MTRBaseDevice _responseDataForCommand:responseValue
+                                                                         clusterID:DecodableType::GetClusterId()
+                                                                         commandID:DecodableType::GetCommandId()
+                                                                             error:error];
+  if (buffer.IsNull()) {
+    return nil;
+  }
+
+  chip::TLV::TLVReader reader;
+  reader.Init(buffer->Start(), buffer->DataLength());
+
+  CHIP_ERROR err = reader.Next(chip::TLV::AnonymousTag());
+  if (err == CHIP_NO_ERROR) {
+    DecodableType decodedStruct;
+    err = chip::app::DataModel::Decode(reader, decodedStruct);
+    if (err == CHIP_NO_ERROR) {
+      err = [self _setFieldsFromDecodableStruct:decodedStruct];
+      if (err == CHIP_NO_ERROR) {
+        return self;
+      }
+    }
+  }
+
+  LogAndConvertDecodingError(err, error);
+  return nil;
+}
+{{/if}}
+
+@end
+
+{{/if}}
+{{> command_params_internal_methods cluster=(asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true) categoryName="PrivateMethods"}}
+
+{{/if}}
+{{/zcl_commands}}
+{{/if}}
+{{/zcl_clusters}}
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc_Private-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc_Private-src.zapt
@@ -66,9 +66,9 @@ static void LogAndConvertDecodingError(CHIP_ERROR err, NSError * __autoreleasing
 
 @end
 
-{{/if}}
 {{> command_params_internal_methods cluster=(asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true) categoryName="PrivateMethods"}}
 
+{{/if}}
 {{/zcl_commands}}
 {{/if}}
 {{/zcl_clusters}}
@@ -125,9 +125,9 @@ static void LogAndConvertDecodingError(CHIP_ERROR err, NSError * __autoreleasing
 
 @end
 
-{{/if}}
 {{> command_params_internal_methods cluster=(asUpperCamelCase parent.name preserveAcronyms=true) command=(asUpperCamelCase name preserveAcronyms=true) categoryName="PrivateMethods"}}
 
+{{/if}}
 {{/if}}
 {{/zcl_commands}}
 {{/if}}


### PR DESCRIPTION

#### Summary
Before changes, headers were correctly generated, but not matching implementations.  Add matching implementations for codegen.

#### Testing

- [x] `./scripts/tools/zap_regen_all.py --type all`; check for no changes.  (no darwin-specific cluster extensions are specified in config.)

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
