### PR TITLE
[Python Tests] Summarize execute python test failures and timings to help identify flaky tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1163,7 +1163,20 @@ jobs:
             - name: Run Tests ${{matrix.filter}}
               if: ${{matrix.filter != ''}}
               run: |
-                  scripts/run_in_python_env.sh out/venv 'src/python_testing/execute_python_tests.py --env-file /tmp/test_env.yaml --search-directory src/python_testing --regex "${{matrix.filter}}"'
+                  scripts/run_in_python_env.sh out/venv 'src/python_testing/execute_python_tests.py run --env-file /tmp/test_env.yaml --search-directory src/python_testing --regex "${{matrix.filter}}" --summary-file test-summaries/python-tests.json'
+            - name: Print python test summary
+              if: ${{ matrix.filter != '' && always() }}
+              run: |
+                  [ -f test-summaries/python-tests.json ] && \
+                    scripts/run_in_python_env.sh out/venv \
+                      'src/python_testing/execute_python_tests.py summarize --summary-file test-summaries/python-tests.json' || true
+            - name: Upload python test summary
+              uses: actions/upload-artifact@v7
+              if: ${{ matrix.filter != '' && always() }}
+              with:
+                  name: test-summaries-python-${{ matrix.filter }}
+                  path: test-summaries/python-tests.json
+                  retention-days: 30
 
             - name: Execute Jupyter Notebooks
               if: ${{matrix.filter == ''}}

--- a/src/python_testing/execute_python_tests.py
+++ b/src/python_testing/execute_python_tests.py
@@ -26,7 +26,6 @@ import re
 import subprocess
 import sys
 import time
-from collections import Counter
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 

--- a/src/python_testing/execute_python_tests.py
+++ b/src/python_testing/execute_python_tests.py
@@ -16,13 +16,19 @@
 #    limitations under the License.
 #
 
+import datetime
 import fnmatch
 import glob as g
+import json
 import logging
 import os
 import re
 import subprocess
 import sys
+import time
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
 
 import click
 import coloredlogs
@@ -30,7 +36,35 @@ import yaml
 
 log = logging.getLogger(__name__)
 
-# Function to load --app argument environment variables from a file
+
+@dataclass
+class TestResult:
+    name: str
+    status: str          # "passed" | "failed" | "dry_run"
+    duration_seconds: float
+
+
+@dataclass
+class RunSummary:
+    run_timestamp: datetime.datetime
+    total_runs: int = 0
+    passed: int = 0
+    failed: int = 0
+    results: list[TestResult] = field(default_factory=list)
+
+    def record(self, name: str, status: str, duration: float) -> None:
+        self.results.append(TestResult(name=name, status=status, duration_seconds=round(duration, 3)))
+        if status == "passed":
+            self.passed += 1
+        elif status == "failed":
+            self.failed += 1
+
+    def write_json(self, path: Path) -> None:
+        data = asdict(self)
+        data["run_timestamp"] = self.run_timestamp.isoformat()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, indent=2))
+        log.info("Test run summary written to %s", path)
 
 
 def load_env_from_yaml(file_path):
@@ -51,7 +85,12 @@ def load_env_from_yaml(file_path):
             os.environ[key] = value
 
 
-@click.command()
+@click.group()
+def main():
+    pass
+
+
+@main.command('run', help='Execute the Python certification tests.')
 @click.option(
     "--search-directory",
     type=str,
@@ -67,7 +106,7 @@ def load_env_from_yaml(file_path):
 @click.option(
     "--keep-going",
     is_flag=True,
-    help="Run ALL the test, report a final status of what passed/failed.",
+    help="Run ALL the tests, report a final status of what passed/failed.",
 )
 @click.option(
     "--dry-run",
@@ -84,21 +123,23 @@ def load_env_from_yaml(file_path):
     multiple=True,
     help="Regex the tests to pick. Use `!` to negate the expression. Expressions FILTERS out non-matching (i.e. you can use it to restrict more and more, but not to add)",
 )
-def main(search_directory, env_file, keep_going, dry_run: bool, glob: list[str], regex: list[str]):
-    # Determine the root directory of the CHIP project
+@click.option(
+    "--summary-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="If provided, write a JSON test-run summary to this file at the end of the run.",
+)
+def cmd_run(search_directory, env_file, keep_going, dry_run: bool, glob: list[str], regex: list[str], summary_file: Path | None):
     chip_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
-    # Load environment variables from the specified file
     load_env_from_yaml(env_file)
 
-    # Define the base command to run tests
     base_command = os.path.join(chip_root, "scripts/tests/run_python_test.py")
 
     with open(os.path.join(chip_root, "src/python_testing/test_metadata.yaml")) as f:
         metadata = yaml.full_load(f)
     excluded_patterns = {item["name"] for item in metadata["not_automated"]}
 
-    # Get all .py files in the directory
     all_python_files = g.glob(os.path.join(search_directory, "*.py"))
 
     for pattern in glob:
@@ -117,30 +158,101 @@ def main(search_directory, env_file, keep_going, dry_run: bool, glob: list[str],
             def match(p): return r.search(p) is not None
         all_python_files = [path for path in all_python_files if match(path)]
 
-    # Filter out the files matching the excluded patterns
     python_files = [file for file in all_python_files if os.path.basename(file) not in excluded_patterns]
 
-    # Run each script with the base command
+    run_summary = RunSummary(run_timestamp=datetime.datetime.now(datetime.timezone.utc))
+
     failed_scripts = []
-    for script in python_files:
-        try:
-            full_command = f"{base_command} --load-from-env {env_file} --script {script}"
-            if dry_run:
-                print(f"DRY-RUN(skip): {full_command}", flush=True)  # Flush print to stdout immediately
-            else:
-                print(f"Running command: {full_command}", flush=True)  # Flush print to stdout immediately
-                subprocess.run(full_command, shell=True, check=True)
-        except Exception:
-            if keep_going:
-                failed_scripts.append(script)
-            else:
-                raise
+    try:
+        for script in python_files:
+            test_start = time.monotonic()
+            try:
+                full_command = f"{base_command} --load-from-env {env_file} --script {script}"
+                if dry_run:
+                    print(f"DRY-RUN(skip): {full_command}", flush=True)
+                    run_summary.record(os.path.basename(script), "dry_run", time.monotonic() - test_start)
+                else:
+                    print(f"Running command: {full_command}", flush=True)
+                    subprocess.run(full_command, shell=True, check=True)
+                    run_summary.record(os.path.basename(script), "passed", time.monotonic() - test_start)
+            except Exception:
+                run_summary.record(os.path.basename(script), "failed", time.monotonic() - test_start)
+                if keep_going:
+                    failed_scripts.append(script)
+                else:
+                    raise
+    finally:
+        run_summary.total_runs = len(run_summary.results)
+        if summary_file is not None:
+            run_summary.write_json(summary_file)
 
     if failed_scripts:
         log.error("FAILURES detected:")
         for s in failed_scripts:
             log.error("   - %s", s)
         sys.exit(1)
+
+
+@main.command('summarize', help='Pretty-print a JSON summary file produced by the "run" command.')
+@click.option(
+    '--summary-file',
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help='Path to the JSON summary file to display.',
+)
+@click.option(
+    '--top-slowest',
+    default=20,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help='Number of slowest tests to include in the timing table.',
+)
+def cmd_summarize(summary_file: Path, top_slowest: int) -> None:
+    raw = json.loads(summary_file.read_text())
+    results: list[dict] = raw.get("results", [])
+
+    passed = raw.get("passed", 0)
+    failed = raw.get("failed", 0)
+    total = raw.get("total_runs", len(results))
+    ts = raw.get("run_timestamp", "unknown")
+
+    sep = "=" * 72
+
+    print(sep)
+    print("  PYTHON TEST RUN SUMMARY")
+    print(sep)
+    print(f"  Run timestamp : {ts}")
+    print(f"  Total runs    : {total}")
+    print(f"  Passed        : {passed}")
+    print(f"  Failed        : {failed}")
+    if total:
+        print(f"  Pass rate     : {100 * passed / total:.1f}%")
+    print(sep)
+
+    failed_results = [r for r in results if r["status"] == "failed"]
+    if failed_results:
+        print(f"\n  FAILED TESTS ({len(failed_results)}):")
+        print(f"  {'Test name':<60} {'Duration':>10}")
+        print("  " + "-" * 72)
+        for r in sorted(failed_results, key=lambda x: x["name"]):
+            print(f"  {'✗  ' + r['name']:<60} {r['duration_seconds']:>9.2f}s")
+    else:
+        print("\n  No failures recorded.")
+
+    slowest = sorted(
+        [r for r in results if r["status"] != "dry_run"],
+        key=lambda x: -x["duration_seconds"]
+    )[:top_slowest]
+
+    if slowest:
+        print(f"\n  SLOWEST {top_slowest} TEST RUNS:")
+        print(f"  {'Test name':<60} {'Status':<8}  {'Duration':>10}")
+        print("  " + "-" * 82)
+        for r in slowest:
+            mark = "✓" if r["status"] == "passed" else "✗"
+            print(f"  {mark + '  ' + r['name']:<60} {r['status']:<8}  {r['duration_seconds']:>9.2f}s")
+
+    print(sep)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Summary
**Changes being made:**
**execute_python_tests.py:**
- Applied the same treatment to the Python certification test runner . Converted it to a click group with a run subcommand (existing behaviour plus timing tracking and --summary-file) and a summarize subcommand that prints the same style of report. Timings are tracked around each test subprocess call and the JSON is written in a finally block so it is always produced even if a test fails and --keep-going is off.

**tests.yaml:**

- Wired --summary-file into every existing Python certification test shards in the REPL test job. Added two always-run steps after the tests in each job: one that prints the summary to the CI logs so it is visible even when the run fails, and one that uploads the JSON files as artifacts for 30 days, laying the groundwork for historical tracking later.

**Notes:** Similar to YAML summarize test results done in PR [43488](https://github.com/project-chip/connectedhomeip/pull/43488) just this is for python3 tests run with execute_python_tests test runner

#### Testing

Example test command to create json results file for ACL tests:
```
src/python_testing/execute_python_tests.py run --env-file local_test_env.yaml --search-directory src/python_testing --keep-going --summary-file test-summaries/python-tests.json --regex ".*ACL.*"
```
Then once results json file created in test-summaries folder, run this command to generate the prettified results:
```
src/python_testing/execute_python_tests.py summarize --summary-file test-summaries/python-tests.json
```