### PR TITLE
[Fake platform] Ensure that we only build TestPlatform when building unit tests

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -173,7 +173,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
       deps += [ "${chip_root}/src/app/server" ]
     }
 
-    if (chip_build_tests) {
+    if (chip_build_tests && chip_device_platform != "fake") {
       deps += [
         "//examples:example_tests",
         "//src:tests",
@@ -185,6 +185,10 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
       if (current_os == "android" && current_toolchain == default_toolchain) {
         deps += [ "${chip_root}/build/chip/java/tests:java_build_test" ]
       }
+    }
+
+    if (chip_link_tests && chip_device_platform == "fake") {
+      deps += [ "//:fake_platform_tests" ]
     }
 
     if (chip_with_lwip) {
@@ -258,9 +262,8 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
   }
 
   group("check") {
-    if (chip_link_tests) {
+    if (chip_link_tests && chip_device_platform != "fake") {
       deps = [
-        "//:fake_platform_tests",
         "//examples/chef:chef.tests",
         "//scripts/build:build_examples.tests",
         "//scripts/py_matter_idl:matter-idl.tests",
@@ -275,6 +278,8 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
       if (current_os == "linux" || current_os == "mac") {
         deps += [ "${chip_root}/scripts/tools/zap:tests" ]
       }
+    } else if (chip_link_tests && chip_device_platform == "fake") {
+      deps = [ "//:fake_platform_tests" ]
     }
   }
 } else {

--- a/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
+++ b/src/app/clusters/administrator-commissioning-server/tests/BUILD.gn
@@ -19,9 +19,9 @@ import("${chip_root}/build/chip/chip_test_suite.gni")
 
 chip_test_suite("tests") {
   output_name = "libTestAdministratorCommissioningCluster"
-  if (!chip_fake_platform) {
-    test_sources = [ "TestAdministratorCommissioningCluster.cpp" ]
-  }
+
+  test_sources = [ "TestAdministratorCommissioningCluster.cpp" ]
+
   cflags = [ "-Wconversion" ]
 
   public_deps = [

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -272,6 +272,7 @@ chip_test_suite("tests") {
     "TestEventOverflow.cpp",
     "TestEventPathParams.cpp",
     "TestFabricScopedEventLogging.cpp",
+    "TestFailSafeContext.cpp",
     "TestInteractionModelEngine.cpp",
     "TestMessageDef.cpp",
     "TestNumericAttributeTraits.cpp",
@@ -286,6 +287,7 @@ chip_test_suite("tests") {
     "TestStatusIB.cpp",
     "TestStatusResponseMessage.cpp",
     "TestTestEventTriggerDelegate.cpp",
+    "TestThreadBorderRouterManagementCluster.cpp",
     "TestTimeSyncDataProvider.cpp",
     "TestTimedHandler.cpp",
     "TestWriteInteraction.cpp",
@@ -300,6 +302,7 @@ chip_test_suite("tests") {
     ":ecosystem-information-test-srcs",
     ":operational-state-test-srcs",
     ":ota-requestor-test-srcs",
+    ":thread-border-router-management-test-srcs",
     ":thread-network-directory-test-srcs",
     ":time-sync-data-provider-test-srcs",
     "${chip_root}/src/app",
@@ -347,14 +350,6 @@ chip_test_suite("tests") {
       "${chip_root}/src/messaging/tests/echo:common",
     ]
   }
-  if (!chip_fake_platform) {
-    test_sources += [ "TestThreadBorderRouterManagementCluster.cpp" ]
-    public_deps += [ ":thread-border-router-management-test-srcs" ]
-  }
-
-  if (!chip_fake_platform) {
-    test_sources += [ "TestFailSafeContext.cpp" ]
-  }
 
   # DefaultICDClientStorage assumes that raw AES key is used by the application
   if (chip_crypto != "psa") {
@@ -373,10 +368,10 @@ chip_test_suite("tests") {
     test_sources += [ "TestClusterStateCache.cpp" ]
   }
 
-  # On NRF, Open IoT SDK and fake platforms we do not have a realtime clock available,
+  # On NRF platform we do not have a realtime clock available,
   # so TestEventLogging.cpp would be testing the same thing as TestEventLoggingNoUTCTime,
   # but it's not set up to deal with the timestamps being that low.
-  if (chip_device_platform != "nrfconnect" && chip_device_platform != "fake") {
+  if (chip_device_platform != "nrfconnect") {
     test_sources += [ "TestEventLogging.cpp" ]
   }
 }

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -37,6 +37,7 @@ chip_test_suite("tests") {
       "TestEventNumberCaching.cpp",
       "TestReadChunking.cpp",
       "TestServerCommandDispatch.cpp",
+      "TestWriteChunking.cpp",
     ]
 
     # Not supported on efr32.

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -39,14 +39,6 @@ chip_test_suite("tests") {
       "TestServerCommandDispatch.cpp",
     ]
 
-    # At some instances, this Test end ups allocating more than 32 Timers, and since the fake platform doesn`t use the heap, the maximum number of allowed timers is 32.
-    # So we get failures because we can't allocate any more timers, in the log it looks like:
-    # SendMessage() to UDP:[::1]:5541 failed: b
-    # deactivating since the Fake platform is mostly done to test Platform APIs
-    if (chip_device_platform != "fake") {
-      test_sources += [ "TestWriteChunking.cpp" ]
-    }
-
     # Not supported on efr32.
     if (chip_device_platform != "efr32") {
       test_sources += [

--- a/src/controller/tests/data_model/BUILD.gn
+++ b/src/controller/tests/data_model/BUILD.gn
@@ -29,7 +29,7 @@ chip_test_suite("data_model") {
   ]
 
   test_sources = []
-  if (chip_device_platform != "esp32" && chip_device_platform != "fake") {
+  if (chip_device_platform != "esp32") {
     test_sources += [
       "TestCommands.cpp",
       "TestWrite.cpp",

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -23,7 +23,7 @@ declare_args() {
   chip_enable_dnssd_tests = chip_device_platform == "darwin"
 }
 
-if (chip_device_platform != "none" && chip_device_platform != "fake") {
+if (chip_device_platform != "none") {
   import("${chip_root}/build/chip/chip_test_suite.gni")
 
   chip_test_suite("tests") {

--- a/src/system/tests/BUILD.gn
+++ b/src/system/tests/BUILD.gn
@@ -31,10 +31,6 @@ chip_test_suite("tests") {
     "TestTimeSource.cpp",
   ]
 
-  if (chip_device_platform != "fake") {
-    test_sources += [ "TestSystemScheduleWork.cpp" ]
-  }
-
   # SystemPacketBuffer on nrfconnect uses LwIP buffers, which ignore the
   #  requested allocation size and always allocate at max-size.  So our test,
   #  which tries to size-limit the buffers, does not work correctly there.

--- a/src/system/tests/BUILD.gn
+++ b/src/system/tests/BUILD.gn
@@ -27,6 +27,7 @@ chip_test_suite("tests") {
     "TestSystemErrorStr.cpp",
     "TestSystemPacketBuffer.cpp",
     "TestSystemScheduleLambda.cpp",
+    "TestSystemScheduleWork.cpp",
     "TestSystemTimer.cpp",
     "TestTimeSource.cpp",
   ]


### PR DESCRIPTION
#### Summary

- Fake Platform was originally designed just for testing DNS-SD, namely `TestPlatform.cpp`. However, for long we have been building and running most available unit tests on the fake-platform. This eats up CI time and sometimes we have compatibility issues and time wasted to try to get Tests to work for the fake-platform. 

- Ensure that only `TestPlatform.cpp` is built and run when specifying linux-fake as the platform

#### Testing
- This is covered in CI in a seperate step.
- Tested locally using
```
scripts/build/build_examples.py --target linux-fake-tests build
```

