### PR TITLE
[Tizen] Move context removal methods to private scope

### DIFF
--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -89,7 +89,7 @@ void OnRegister(dnssd_error_e result, dnssd_service_h service, void * data)
         ChipLogError(DeviceLayer, "DNSsd %s: Error: %s", __func__, get_error_message(result));
         rCtx->mCallback(rCtx->mCbContext, nullptr, nullptr, MATTER_PLATFORM_ERROR(result));
         // After this point, the context might be no longer valid
-        rCtx->mInstance.RemoveContext(rCtx);
+        rCtx->RemoveFromOwner();
         return;
     }
 
@@ -115,9 +115,8 @@ gboolean OnBrowseTimeout(void * userData)
     auto * bCtx = reinterpret_cast<chip::Dnssd::BrowseContext *>(userData);
 
     bCtx->mCallback(bCtx->mCbContext, bCtx->mServices.data(), bCtx->mServices.size(), true, CHIP_NO_ERROR);
-
     // After this point the context might be no longer valid
-    bCtx->mInstance.RemoveContext(bCtx);
+    bCtx->RemoveFromOwner();
 
     // This is a one-shot timer
     return G_SOURCE_REMOVE;
@@ -210,7 +209,7 @@ exit:
     {
         bCtx->mCallback(bCtx->mCbContext, nullptr, 0, true, MATTER_PLATFORM_ERROR(ret));
         // After this point the context might be no longer valid
-        bCtx->mInstance.RemoveContext(bCtx);
+        bCtx->RemoveFromOwner();
     }
 }
 
@@ -342,9 +341,8 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * userData)
 
     err = chip::DeviceLayer::SystemLayer().ScheduleLambda([rCtx] {
         ChipLogProgress(DeviceLayer, "DNSsd Handle resolve task on schedule lambda");
-
         rCtx->Finalize(CHIP_NO_ERROR);
-        rCtx->mInstance.RemoveContext(rCtx);
+        rCtx->RemoveFromOwner();
     });
     VerifyOrExit(err == CHIP_NO_ERROR,
                  ChipLogError(DeviceLayer, "Failed to schedule resolve task: %" CHIP_ERROR_FORMAT, err.Format()));
@@ -353,7 +351,7 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * userData)
 
 exit:
     rCtx->Finalize(ret != DNSSD_ERROR_NONE ? MATTER_PLATFORM_ERROR(ret) : err);
-    rCtx->mInstance.RemoveContext(rCtx);
+    rCtx->RemoveFromOwner();
 }
 
 CHIP_ERROR ResolveAsync(chip::Dnssd::ResolveContext * rCtx)
@@ -423,6 +421,11 @@ RegisterContext::~RegisterContext()
     }
 }
 
+void RegisterContext::RemoveFromOwner()
+{
+    mInstance.RemoveRegisterContext(this);
+}
+
 BrowseContext::BrowseContext(DnssdTizen & instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
                              DnssdBrowseCallback callback, void * context) :
     mInstance(instance),
@@ -438,6 +441,11 @@ BrowseContext::~BrowseContext()
         g_source_destroy(mTimeoutSource);
         g_source_unref(mTimeoutSource);
     }
+}
+
+void BrowseContext::RemoveFromOwner()
+{
+    mInstance.RemoveBrowseContext(this);
 }
 
 ResolveContext::ResolveContext(DnssdTizen & instance, const char * name, const char * type, uint32_t interfaceId,
@@ -463,6 +471,11 @@ void ResolveContext::Finalize(CHIP_ERROR error)
     chip::Inet::IPAddress ipAddr = mResult.mAddress.value();
 
     mCallback(mCbContext, &mResult, chip::Span<chip::Inet::IPAddress>(&ipAddr, 1), CHIP_NO_ERROR);
+}
+
+void ResolveContext::RemoveFromOwner()
+{
+    mInstance.RemoveResolveContext(this);
 }
 
 CHIP_ERROR DnssdTizen::Init(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)
@@ -571,7 +584,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     { // Notify caller about error
         callback(context, nullptr, nullptr, err);
-        RemoveContext(serviceCtx);
+        RemoveRegisterContext(serviceCtx);
     }
     return err;
 }
@@ -603,7 +616,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     { // Notify caller about error
         callback(context, nullptr, 0, true, err);
-        RemoveContext(browseCtx);
+        RemoveBrowseContext(browseCtx);
     }
     return err;
 }
@@ -625,7 +638,7 @@ CHIP_ERROR DnssdTizen::Resolve(const DnssdService & browseResult, chip::Inet::In
 
 exit:
     if (err != CHIP_NO_ERROR)
-        RemoveContext(resolveCtx);
+        RemoveResolveContext(resolveCtx);
     return err;
 }
 
@@ -665,7 +678,7 @@ ResolveContext * DnssdTizen::CreateResolveContext(const char * name, const char 
     return ctxPtr;
 }
 
-void DnssdTizen::RemoveContext(RegisterContext * context)
+void DnssdTizen::RemoveRegisterContext(RegisterContext * context)
 {
     std::lock_guard<std::mutex> lock(mMutex);
     auto it = std::find_if(mRegisterContexts.begin(), mRegisterContexts.end(),
@@ -676,7 +689,7 @@ void DnssdTizen::RemoveContext(RegisterContext * context)
     }
 }
 
-void DnssdTizen::RemoveContext(BrowseContext * context)
+void DnssdTizen::RemoveBrowseContext(BrowseContext * context)
 {
     std::lock_guard<std::mutex> lock(mMutex);
     auto it =
@@ -687,7 +700,7 @@ void DnssdTizen::RemoveContext(BrowseContext * context)
     }
 }
 
-void DnssdTizen::RemoveContext(ResolveContext * context)
+void DnssdTizen::RemoveResolveContext(ResolveContext * context)
 {
     std::lock_guard<std::mutex> lock(mMutex);
     auto it = std::find_if(mResolveContexts.begin(), mResolveContexts.end(),

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -56,6 +56,8 @@ struct RegisterContext
     RegisterContext(DnssdTizen & instance, const char * type, const DnssdService & service, DnssdPublishCallback callback,
                     void * context);
     ~RegisterContext();
+
+    void RemoveFromOwner();
 };
 
 struct BrowseContext
@@ -78,6 +80,8 @@ struct BrowseContext
     BrowseContext(DnssdTizen & instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
                   DnssdBrowseCallback callback, void * context);
     ~BrowseContext();
+
+    void RemoveFromOwner();
 };
 
 struct ResolveContext
@@ -103,6 +107,7 @@ struct ResolveContext
     ~ResolveContext() = default;
 
     void Finalize(CHIP_ERROR error);
+    void RemoveFromOwner();
 };
 
 class DnssdTizen
@@ -123,14 +128,13 @@ public:
     CHIP_ERROR Resolve(const DnssdService & browseResult, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
                        void * context);
 
-    // TODO (a.bokowy): Make these methods private
-    void RemoveContext(RegisterContext * context);
-    void RemoveContext(BrowseContext * context);
-    void RemoveContext(ResolveContext * context);
-
     static DnssdTizen & GetInstance() { return sInstance; }
 
 private:
+    friend struct RegisterContext;
+    friend struct BrowseContext;
+    friend struct ResolveContext;
+
     DnssdTizen() = default;
     static DnssdTizen sInstance;
 
@@ -140,6 +144,10 @@ private:
                                         DnssdBrowseCallback callback, void * context);
     ResolveContext * CreateResolveContext(const char * name, const char * type, uint32_t interfaceId, DnssdResolveCallback callback,
                                           void * context);
+
+    void RemoveRegisterContext(RegisterContext * context);
+    void RemoveBrowseContext(BrowseContext * context);
+    void RemoveResolveContext(ResolveContext * context);
 
     std::mutex mMutex;
     std::set<std::unique_ptr<RegisterContext>> mRegisterContexts;


### PR DESCRIPTION
#### Summary

This commit is a followup for #43386

#### Testing

CI will verify potential build breaks.