### PR TITLE
[ClusterTester] Add support for testing both list-writing patterns in `WriteAttribute` 

### DIFF
--- a/docs/cluster_and_device_type_dev/cluster_tester.md
+++ b/docs/cluster_and_device_type_dev/cluster_tester.md
@@ -110,30 +110,51 @@ class TestGroupKeyManagementCluster : public ::testing::Test
 
 ```
 
-### Writing Attributes (Lists & Structs)
+### Writing Attributes (Structs)
 
-The tester handles complex types like Lists and Structs automatically.
+The tester handles complex types like Structs automatically, with the exception
+of lists.
 
 ```cpp
-TEST_F(TestGroupKeyManagementCluster, TestWriteGroupKeyMapAttribute)
+TEST_F(TestCameraAVStreamManagementCluster, TestReadWriteViewport)
 {
-    // Create a vector of Structs
-    std::vector<GroupKeyManagement::Structs::GroupKeyMapStruct::Type> keys;
+    ...
 
-    GroupKeyManagement::Structs::GroupKeyMapStruct::Type key;
-    key.groupId = 0x1234;
-    key.groupKeySetID = 1;
-    key.fabricIndex = kTestFabricIndex;
-    keys.push_back(key);
+    // Write a valid new value
+    Attributes::Viewport::TypeInfo::Type newViewport = { 0, 0, 1280, 720 };
+    EXPECT_EQ(mClusterTester.WriteAttribute(Attributes::Viewport::Id, newViewport), CHIP_NO_ERROR);
 
-    // Wrap in DataModel::List
-    auto listToWrite = app::DataModel::List<const GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(keys.data(), keys.size());
+}
+```
 
-    // Write the attribute
-    // The tester automatically handles EncodeForWrite for fabric-scoped attributes
-    CHIP_ERROR err = tester.WriteAttribute(GroupKeyManagement::Attributes::GroupKeyMap::Id, listToWrite).GetUnderlyingError();
+### Writing List Attributes
 
-    ASSERT_EQ(err, CHIP_NO_ERROR);
+- There are (Mainly) two patterns used to write list attributes, and cluster
+  servers are expected to support both of them.
+- Therefore an overload of WriteAttribute specifically for lists was created,
+  which includes a parameter `ListWritingPattern`.
+- It is recommended to always use both patterns when testing list attributes, an
+  example would be through a range-for loop as in the example below
+
+```cpp
+TEST_F(TestUserLabelCluster, WriteValidLabelListTest)
+{
+    // Repeating the testcase twice, once for each List Writing Pattern
+    for (ListWritingPattern listWritingPattern : { ListWritingPattern::ReplaceAll, ListWritingPattern::ClearAllThenAppendItems })
+    {
+        ClusterTester tester(userLabel);
+        Structs::LabelStruct::Type labels[] = {
+            { .label = "room"_span, .value = "bedroom 2"_span },
+            { .label = "orientation"_span, .value = "North"_span },
+        };
+
+        // Wrap in DataModel::List
+        auto listToWrite = DataModel::List(labels)
+
+        // Write the attribute
+        // The tester automatically handles EncodeForWrite for fabric-scoped attributes
+        ASSERT_EQ(tester.WriteAttribute(LabelList::Id, listToWrite, listWritingPattern), CHIP_NO_ERROR);
+    }
 }
 
 ```
@@ -177,33 +198,33 @@ behaviors that simplify testing.
 When using `ReadAttribute`, `ClusterTester` automatically manages the underlying
 TLV data for you.
 
--   **Views & Lists**: If you read a type that contains views (like `CharSpan`,
-    `ByteSpan`, or `DecodableList`), the tester buffers the TLV data internally.
--   **Lifetime Safety**: This data remains valid for the lifetime of the
-    `ClusterTester` instance, allowing you to safely iterate over lists or
-    inspect spans without worrying about the buffer being freed immediately
-    after the read call.
+- **Views & Lists**: If you read a type that contains views (like `CharSpan`,
+  `ByteSpan`, or `DecodableList`), the tester buffers the TLV data internally.
+- **Lifetime Safety**: This data remains valid for the lifetime of the
+  `ClusterTester` instance, allowing you to safely iterate over lists or inspect
+  spans without worrying about the buffer being freed immediately after the read
+  call.
 
 ### Fabric Scoping (Writes)
 
 `WriteAttribute` abstracts away the complexity of fabric-sensitive writes.
 
--   **Auto-Encoding**: It uses C++ introspection to detect if a struct is
-    fabric-scoped. If so, it automatically uses `EncodeForWrite`; otherwise, it
-    uses standard `Encode`.
--   **Subject Descriptor**: It automatically applies the Access Control subject
-    descriptor corresponding to the fabric index set via `SetFabricIndex()`.
+- **Auto-Encoding**: It uses C++ introspection to detect if a struct is
+  fabric-scoped. If so, it automatically uses `EncodeForWrite`; otherwise, it
+  uses standard `Encode`.
+- **Subject Descriptor**: It automatically applies the Access Control subject
+  descriptor corresponding to the fabric index set via `SetFabricIndex()`.
 
 ### Command Results (Invoke)
 
 The `Invoke` wrapper simplifies the distinction between Status responses and
 Data responses.
 
--   **Unified Result**: It returns an `InvokeResult` that acts as a single
-    container for both success/failure status and the decoded response payload
-    (if the command returns data).
--   **Synchronous execution**: The helper is designed for unit tests where
-    command execution is expected to be synchronous.
+- **Unified Result**: It returns an `InvokeResult` that acts as a single
+  container for both success/failure status and the decoded response payload (if
+  the command returns data).
+- **Synchronous execution**: The helper is designed for unit tests where command
+  execution is expected to be synchronous.
 
 ### Testing Side Effects (Events & Reporting)
 

--- a/docs/cluster_and_device_type_dev/cluster_tester.md
+++ b/docs/cluster_and_device_type_dev/cluster_tester.md
@@ -129,12 +129,13 @@ TEST_F(TestCameraAVStreamManagementCluster, TestReadWriteViewport)
 
 ### Writing List Attributes
 
--   There are (Mainly) two patterns used to write list attributes, and cluster
-    servers are expected to support both of them.
--   Therefore an overload of WriteAttribute specifically for lists was created,
-    which includes a parameter `ListWritingPattern`.
--   It is recommended to always use both patterns when testing list attributes,
-    an example would be through a range-for loop as in the example below
+- There are (Mainly) two patterns used to write list attributes, and cluster
+  servers usually support both of them.
+- For that reason, ClusterTester provides a `WriteAttribute` overload for lists
+  that takes a `ListWritingPattern`
+- Tests for list attributes should exercise both patterns to ensure future
+  proofing. One way of doing that could be be through a range-for loop as in the
+  example below.
 
 ```cpp
 TEST_F(TestUserLabelCluster, WriteValidLabelListTest)
@@ -149,7 +150,7 @@ TEST_F(TestUserLabelCluster, WriteValidLabelListTest)
         };
 
         // Wrap in DataModel::List
-        auto listToWrite = DataModel::List(labels)
+        auto listToWrite = DataModel::List(labels);
 
         // Write the attribute
         // The tester automatically handles EncodeForWrite for fabric-scoped attributes
@@ -198,33 +199,33 @@ behaviors that simplify testing.
 When using `ReadAttribute`, `ClusterTester` automatically manages the underlying
 TLV data for you.
 
--   **Views & Lists**: If you read a type that contains views (like `CharSpan`,
-    `ByteSpan`, or `DecodableList`), the tester buffers the TLV data internally.
--   **Lifetime Safety**: This data remains valid for the lifetime of the
-    `ClusterTester` instance, allowing you to safely iterate over lists or
-    inspect spans without worrying about the buffer being freed immediately
-    after the read call.
+- **Views & Lists**: If you read a type that contains views (like `CharSpan`,
+  `ByteSpan`, or `DecodableList`), the tester buffers the TLV data internally.
+- **Lifetime Safety**: This data remains valid for the lifetime of the
+  `ClusterTester` instance, allowing you to safely iterate over lists or inspect
+  spans without worrying about the buffer being freed immediately after the read
+  call.
 
 ### Fabric Scoping (Writes)
 
 `WriteAttribute` abstracts away the complexity of fabric-sensitive writes.
 
--   **Auto-Encoding**: It uses C++ introspection to detect if a struct is
-    fabric-scoped. If so, it automatically uses `EncodeForWrite`; otherwise, it
-    uses standard `Encode`.
--   **Subject Descriptor**: It automatically applies the Access Control subject
-    descriptor corresponding to the fabric index set via `SetFabricIndex()`.
+- **Auto-Encoding**: It uses C++ introspection to detect if a struct is
+  fabric-scoped. If so, it automatically uses `EncodeForWrite`; otherwise, it
+  uses standard `Encode`.
+- **Subject Descriptor**: It automatically applies the Access Control subject
+  descriptor corresponding to the fabric index set via `SetFabricIndex()`.
 
 ### Command Results (Invoke)
 
 The `Invoke` wrapper simplifies the distinction between Status responses and
 Data responses.
 
--   **Unified Result**: It returns an `InvokeResult` that acts as a single
-    container for both success/failure status and the decoded response payload
-    (if the command returns data).
--   **Synchronous execution**: The helper is designed for unit tests where
-    command execution is expected to be synchronous.
+- **Unified Result**: It returns an `InvokeResult` that acts as a single
+  container for both success/failure status and the decoded response payload (if
+  the command returns data).
+- **Synchronous execution**: The helper is designed for unit tests where command
+  execution is expected to be synchronous.
 
 ### Testing Side Effects (Events & Reporting)
 

--- a/docs/cluster_and_device_type_dev/cluster_tester.md
+++ b/docs/cluster_and_device_type_dev/cluster_tester.md
@@ -134,8 +134,8 @@ TEST_F(TestCameraAVStreamManagementCluster, TestReadWriteViewport)
 -   For that reason, ClusterTester provides a `WriteAttribute` overload for
     lists that takes a `ListWritingPattern`
 -   Tests for list attributes should exercise both patterns to ensure future
-    proofing. One way of doing that could be be through a range-for loop as in
-    the example below.
+    proofing. One way of doing that could be through a range-for loop as in the
+    example below.
 
 ```cpp
 TEST_F(TestUserLabelCluster, WriteValidLabelListTest)

--- a/docs/cluster_and_device_type_dev/cluster_tester.md
+++ b/docs/cluster_and_device_type_dev/cluster_tester.md
@@ -129,13 +129,13 @@ TEST_F(TestCameraAVStreamManagementCluster, TestReadWriteViewport)
 
 ### Writing List Attributes
 
-- There are (Mainly) two patterns used to write list attributes, and cluster
-  servers usually support both of them.
-- For that reason, ClusterTester provides a `WriteAttribute` overload for lists
-  that takes a `ListWritingPattern`
-- Tests for list attributes should exercise both patterns to ensure future
-  proofing. One way of doing that could be be through a range-for loop as in the
-  example below.
+-   There are (Mainly) two patterns used to write list attributes, and cluster
+    servers usually support both of them.
+-   For that reason, ClusterTester provides a `WriteAttribute` overload for
+    lists that takes a `ListWritingPattern`
+-   Tests for list attributes should exercise both patterns to ensure future
+    proofing. One way of doing that could be be through a range-for loop as in
+    the example below.
 
 ```cpp
 TEST_F(TestUserLabelCluster, WriteValidLabelListTest)
@@ -199,33 +199,33 @@ behaviors that simplify testing.
 When using `ReadAttribute`, `ClusterTester` automatically manages the underlying
 TLV data for you.
 
-- **Views & Lists**: If you read a type that contains views (like `CharSpan`,
-  `ByteSpan`, or `DecodableList`), the tester buffers the TLV data internally.
-- **Lifetime Safety**: This data remains valid for the lifetime of the
-  `ClusterTester` instance, allowing you to safely iterate over lists or inspect
-  spans without worrying about the buffer being freed immediately after the read
-  call.
+-   **Views & Lists**: If you read a type that contains views (like `CharSpan`,
+    `ByteSpan`, or `DecodableList`), the tester buffers the TLV data internally.
+-   **Lifetime Safety**: This data remains valid for the lifetime of the
+    `ClusterTester` instance, allowing you to safely iterate over lists or
+    inspect spans without worrying about the buffer being freed immediately
+    after the read call.
 
 ### Fabric Scoping (Writes)
 
 `WriteAttribute` abstracts away the complexity of fabric-sensitive writes.
 
-- **Auto-Encoding**: It uses C++ introspection to detect if a struct is
-  fabric-scoped. If so, it automatically uses `EncodeForWrite`; otherwise, it
-  uses standard `Encode`.
-- **Subject Descriptor**: It automatically applies the Access Control subject
-  descriptor corresponding to the fabric index set via `SetFabricIndex()`.
+-   **Auto-Encoding**: It uses C++ introspection to detect if a struct is
+    fabric-scoped. If so, it automatically uses `EncodeForWrite`; otherwise, it
+    uses standard `Encode`.
+-   **Subject Descriptor**: It automatically applies the Access Control subject
+    descriptor corresponding to the fabric index set via `SetFabricIndex()`.
 
 ### Command Results (Invoke)
 
 The `Invoke` wrapper simplifies the distinction between Status responses and
 Data responses.
 
-- **Unified Result**: It returns an `InvokeResult` that acts as a single
-  container for both success/failure status and the decoded response payload (if
-  the command returns data).
-- **Synchronous execution**: The helper is designed for unit tests where command
-  execution is expected to be synchronous.
+-   **Unified Result**: It returns an `InvokeResult` that acts as a single
+    container for both success/failure status and the decoded response payload
+    (if the command returns data).
+-   **Synchronous execution**: The helper is designed for unit tests where
+    command execution is expected to be synchronous.
 
 ### Testing Side Effects (Events & Reporting)
 

--- a/docs/cluster_and_device_type_dev/cluster_tester.md
+++ b/docs/cluster_and_device_type_dev/cluster_tester.md
@@ -129,12 +129,12 @@ TEST_F(TestCameraAVStreamManagementCluster, TestReadWriteViewport)
 
 ### Writing List Attributes
 
-- There are (Mainly) two patterns used to write list attributes, and cluster
-  servers are expected to support both of them.
-- Therefore an overload of WriteAttribute specifically for lists was created,
-  which includes a parameter `ListWritingPattern`.
-- It is recommended to always use both patterns when testing list attributes, an
-  example would be through a range-for loop as in the example below
+-   There are (Mainly) two patterns used to write list attributes, and cluster
+    servers are expected to support both of them.
+-   Therefore an overload of WriteAttribute specifically for lists was created,
+    which includes a parameter `ListWritingPattern`.
+-   It is recommended to always use both patterns when testing list attributes,
+    an example would be through a range-for loop as in the example below
 
 ```cpp
 TEST_F(TestUserLabelCluster, WriteValidLabelListTest)
@@ -198,33 +198,33 @@ behaviors that simplify testing.
 When using `ReadAttribute`, `ClusterTester` automatically manages the underlying
 TLV data for you.
 
-- **Views & Lists**: If you read a type that contains views (like `CharSpan`,
-  `ByteSpan`, or `DecodableList`), the tester buffers the TLV data internally.
-- **Lifetime Safety**: This data remains valid for the lifetime of the
-  `ClusterTester` instance, allowing you to safely iterate over lists or inspect
-  spans without worrying about the buffer being freed immediately after the read
-  call.
+-   **Views & Lists**: If you read a type that contains views (like `CharSpan`,
+    `ByteSpan`, or `DecodableList`), the tester buffers the TLV data internally.
+-   **Lifetime Safety**: This data remains valid for the lifetime of the
+    `ClusterTester` instance, allowing you to safely iterate over lists or
+    inspect spans without worrying about the buffer being freed immediately
+    after the read call.
 
 ### Fabric Scoping (Writes)
 
 `WriteAttribute` abstracts away the complexity of fabric-sensitive writes.
 
-- **Auto-Encoding**: It uses C++ introspection to detect if a struct is
-  fabric-scoped. If so, it automatically uses `EncodeForWrite`; otherwise, it
-  uses standard `Encode`.
-- **Subject Descriptor**: It automatically applies the Access Control subject
-  descriptor corresponding to the fabric index set via `SetFabricIndex()`.
+-   **Auto-Encoding**: It uses C++ introspection to detect if a struct is
+    fabric-scoped. If so, it automatically uses `EncodeForWrite`; otherwise, it
+    uses standard `Encode`.
+-   **Subject Descriptor**: It automatically applies the Access Control subject
+    descriptor corresponding to the fabric index set via `SetFabricIndex()`.
 
 ### Command Results (Invoke)
 
 The `Invoke` wrapper simplifies the distinction between Status responses and
 Data responses.
 
-- **Unified Result**: It returns an `InvokeResult` that acts as a single
-  container for both success/failure status and the decoded response payload (if
-  the command returns data).
-- **Synchronous execution**: The helper is designed for unit tests where command
-  execution is expected to be synchronous.
+-   **Unified Result**: It returns an `InvokeResult` that acts as a single
+    container for both success/failure status and the decoded response payload
+    (if the command returns data).
+-   **Synchronous execution**: The helper is designed for unit tests where
+    command execution is expected to be synchronous.
 
 ### Testing Side Effects (Events & Reporting)
 

--- a/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
@@ -109,12 +109,13 @@ struct TestGroupKeyManagementCluster : public ::testing::Test
     // Writes a list of group keys to the GroupKeyMap attribute for a given fabric.
     // Used to set up test scenarios with pre-existing keys.
     void PrepopulateGroupKeyMap(const std::vector<GroupKeyManagement::Structs::GroupKeyMapStruct::Type> & keys,
-                                FabricIndex fabricIndex)
+                                FabricIndex fabricIndex, ListWritingPattern listWritingPattern)
     {
         auto listToWrite =
             app::DataModel::List<const GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(keys.data(), keys.size());
 
-        CHIP_ERROR err = tester.WriteAttribute(GroupKeyManagement::Attributes::GroupKeyMap::Id, listToWrite).GetUnderlyingError();
+        CHIP_ERROR err = tester.WriteAttribute(GroupKeyManagement::Attributes::GroupKeyMap::Id, listToWrite, listWritingPattern)
+                             .GetUnderlyingError();
         ASSERT_EQ(err, CHIP_NO_ERROR);
     }
 
@@ -180,38 +181,49 @@ TEST_F(TestGroupKeyManagementCluster, AttributesTest)
 // Cluster should accept writing multiple group keys with the same KeySetID but different Group IDs
 TEST_F(TestGroupKeyManagementCluster, TestWriteGroupKeyMapAttributeSameKeySetDifferentGroup)
 {
-    auto keys = TestHelpers::CreateGroupKeyMapList(2, kTestFabricIndex, kTestGroupId, kTestKeySetId, 1, 0);
-    PrepopulateGroupKeyMap(keys, kTestFabricIndex);
-    VerifyGroupKeysMatch(kTestFabricIndex, keys);
+    for (ListWritingPattern listWritingPattern : { ListWritingPattern::ReplaceAll, ListWritingPattern::ClearAllThenAppendItems })
+    {
+        auto keys = TestHelpers::CreateGroupKeyMapList(2, kTestFabricIndex, kTestGroupId, kTestKeySetId, 1, 0);
+        PrepopulateGroupKeyMap(keys, kTestFabricIndex, listWritingPattern);
+        VerifyGroupKeysMatch(kTestFabricIndex, keys);
+    }
 }
 
 // Cluster should reject a write containing duplicate keys for the same group/keyset combination.
 TEST_F(TestGroupKeyManagementCluster, TestWriteGroupKeyMapAttributeDuplicateKey)
 {
-    //  Intentionally creates two identical entries (duplicate group/keyset combination).
-    // by setting increments  to 0 (groupIdIncrement = 0, keySetIdIncrement = 0)
-    auto keys = TestHelpers::CreateGroupKeyMapList(2, kTestFabricIndex, kTestGroupId, kTestKeySetId, 0, 0);
+    for (ListWritingPattern listWritingPattern : { ListWritingPattern::ReplaceAll, ListWritingPattern::ClearAllThenAppendItems })
+    {
+        //  Intentionally creates two identical entries (duplicate group/keyset combination).
+        // by setting increments  to 0 (groupIdIncrement = 0, keySetIdIncrement = 0)
+        auto keys = TestHelpers::CreateGroupKeyMapList(2, kTestFabricIndex, kTestGroupId, kTestKeySetId, 0, 0);
 
-    auto listToWrite = app::DataModel::List<const GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(keys.data(), keys.size());
+        auto listToWrite =
+            app::DataModel::List<const GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(keys.data(), keys.size());
 
-    CHIP_ERROR err = tester.WriteAttribute(GroupKeyManagement::Attributes::GroupKeyMap::Id, listToWrite).GetUnderlyingError();
+        CHIP_ERROR err = tester.WriteAttribute(GroupKeyManagement::Attributes::GroupKeyMap::Id, listToWrite, listWritingPattern)
+                             .GetUnderlyingError();
 
-    ASSERT_EQ(err, CHIP_ERROR_DUPLICATE_KEY_ID);
+        ASSERT_EQ(err, CHIP_ERROR_DUPLICATE_KEY_ID);
 
-    // Explicitly check that the write stops at the first duplicate entry,
-    // but the valid entries processed *before* the error (i.e., keys[0]) are persisted.
-    std::vector<GroupKeyManagement::Structs::GroupKeyMapStruct::Type> expectedKeys;
-    expectedKeys.push_back(keys[0]);
+        // Explicitly check that the write stops at the first duplicate entry,
+        // but the valid entries processed *before* the error (i.e., keys[0]) are persisted.
+        std::vector<GroupKeyManagement::Structs::GroupKeyMapStruct::Type> expectedKeys;
+        expectedKeys.push_back(keys[0]);
 
-    VerifyGroupKeysMatch(kTestFabricIndex, expectedKeys);
+        VerifyGroupKeysMatch(kTestFabricIndex, expectedKeys);
+    }
 }
 
 TEST_F(TestGroupKeyManagementCluster, TestWriteGroupKeyMapAttribute)
 {
-    auto keys = TestHelpers::CreateGroupKeyMapList(2, kTestFabricIndex);
+    for (ListWritingPattern listWritingPattern : { ListWritingPattern::ReplaceAll, ListWritingPattern::ClearAllThenAppendItems })
+    {
+        auto keys = TestHelpers::CreateGroupKeyMapList(2, kTestFabricIndex);
 
-    PrepopulateGroupKeyMap(keys, kTestFabricIndex);
-    VerifyGroupKeysMatch(kTestFabricIndex, keys);
+        PrepopulateGroupKeyMap(keys, kTestFabricIndex, listWritingPattern);
+        VerifyGroupKeysMatch(kTestFabricIndex, keys);
+    }
 }
 
 const chip::EndpointId kTestEndpoint1 = 10;

--- a/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
+++ b/src/app/clusters/group-key-mgmt-server/tests/TestGroupKeyManagementCluster.cpp
@@ -109,7 +109,7 @@ struct TestGroupKeyManagementCluster : public ::testing::Test
     // Writes a list of group keys to the GroupKeyMap attribute for a given fabric.
     // Used to set up test scenarios with pre-existing keys.
     void PrepopulateGroupKeyMap(const std::vector<GroupKeyManagement::Structs::GroupKeyMapStruct::Type> & keys,
-                                FabricIndex fabricIndex, ListWritingPattern listWritingPattern)
+                                ListWritingPattern listWritingPattern)
     {
         auto listToWrite =
             app::DataModel::List<const GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(keys.data(), keys.size());
@@ -184,7 +184,7 @@ TEST_F(TestGroupKeyManagementCluster, TestWriteGroupKeyMapAttributeSameKeySetDif
     for (ListWritingPattern listWritingPattern : { ListWritingPattern::ReplaceAll, ListWritingPattern::ClearAllThenAppendItems })
     {
         auto keys = TestHelpers::CreateGroupKeyMapList(2, kTestFabricIndex, kTestGroupId, kTestKeySetId, 1, 0);
-        PrepopulateGroupKeyMap(keys, kTestFabricIndex, listWritingPattern);
+        PrepopulateGroupKeyMap(keys, listWritingPattern);
         VerifyGroupKeysMatch(kTestFabricIndex, keys);
     }
 }
@@ -221,7 +221,7 @@ TEST_F(TestGroupKeyManagementCluster, TestWriteGroupKeyMapAttribute)
     {
         auto keys = TestHelpers::CreateGroupKeyMapList(2, kTestFabricIndex);
 
-        PrepopulateGroupKeyMap(keys, kTestFabricIndex, listWritingPattern);
+        PrepopulateGroupKeyMap(keys, listWritingPattern);
         VerifyGroupKeysMatch(kTestFabricIndex, keys);
     }
 }

--- a/src/app/clusters/user-label-server/tests/TestUserLabelCluster.cpp
+++ b/src/app/clusters/user-label-server/tests/TestUserLabelCluster.cpp
@@ -115,53 +115,71 @@ TEST_F(TestUserLabelCluster, ReadAttributeTest)
 
 TEST_F(TestUserLabelCluster, WriteValidLabelListTest)
 {
-    ClusterTester tester(userLabel);
-    Structs::LabelStruct::Type labels[] = {
-        { .label = "room"_span, .value = "bedroom 2"_span },
-        { .label = "orientation"_span, .value = "North"_span },
-    };
-    ASSERT_EQ(tester.WriteAttribute(LabelList::Id, DataModel::List(labels)), CHIP_NO_ERROR);
+    for (ListWritingPattern listWritingPattern : { ListWritingPattern::ReplaceAll, ListWritingPattern::ClearAllThenAppendItems })
+    {
+        ClusterTester tester(userLabel);
+        Structs::LabelStruct::Type labels[] = {
+            { .label = "room"_span, .value = "bedroom 2"_span },
+            { .label = "orientation"_span, .value = "North"_span },
+        };
+        ASSERT_EQ(tester.WriteAttribute(LabelList::Id, DataModel::List(labels), listWritingPattern), CHIP_NO_ERROR);
+    }
 }
 
 TEST_F(TestUserLabelCluster, WriteLabelWithLabelTooLongTest)
 {
-    ClusterTester tester(userLabel);
-    constexpr auto tooLongLabel = "this_label_is_way_too_long"_span;
-    static_assert(tooLongLabel.size() > UserLabelCluster::kMaxLabelSize);
-    Structs::LabelStruct::Type labels[] = {
-        { .label = tooLongLabel, .value = "value"_span },
-    };
-    ASSERT_EQ(tester.WriteAttribute(LabelList::Id, DataModel::List(labels)), CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    for (ListWritingPattern listWritingPattern : { ListWritingPattern::ReplaceAll, ListWritingPattern::ClearAllThenAppendItems })
+    {
+        ClusterTester tester(userLabel);
+        constexpr auto tooLongLabel = "this_label_is_way_too_long"_span;
+        static_assert(tooLongLabel.size() > UserLabelCluster::kMaxLabelSize);
+        Structs::LabelStruct::Type labels[] = {
+            { .label = tooLongLabel, .value = "value"_span },
+        };
+        ASSERT_EQ(tester.WriteAttribute(LabelList::Id, DataModel::List(labels), listWritingPattern),
+                  CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    }
 }
 
 TEST_F(TestUserLabelCluster, WriteLabelWithValueTooLongTest)
 {
-    ClusterTester tester(userLabel);
-    constexpr auto tooLongValue = "this_value_is_way_too_long"_span;
-    static_assert(tooLongValue.size() > UserLabelCluster::kMaxValueSize);
-    Structs::LabelStruct::Type labels[] = {
-        { .label = "room"_span, .value = tooLongValue },
-    };
-    ASSERT_EQ(tester.WriteAttribute(LabelList::Id, DataModel::List(labels)), CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    for (ListWritingPattern listWritingPattern : { ListWritingPattern::ReplaceAll, ListWritingPattern::ClearAllThenAppendItems })
+    {
+        ClusterTester tester(userLabel);
+        constexpr auto tooLongValue = "this_value_is_way_too_long"_span;
+        static_assert(tooLongValue.size() > UserLabelCluster::kMaxValueSize);
+        Structs::LabelStruct::Type labels[] = {
+            { .label = "room"_span, .value = tooLongValue },
+        };
+        ASSERT_EQ(tester.WriteAttribute(LabelList::Id, DataModel::List(labels), listWritingPattern),
+                  CHIP_IM_GLOBAL_STATUS(ConstraintError));
+    }
 }
 
 TEST_F(TestUserLabelCluster, WriteEmptyLabelsTest)
 {
-    ClusterTester tester(userLabel);
-    Structs::LabelStruct::Type labels[] = {
-        { .label = ""_span, .value = ""_span }, // empty label and value are allowed per spec
-    };
-    ASSERT_EQ(tester.WriteAttribute(LabelList::Id, DataModel::List(labels)), CHIP_NO_ERROR);
+    for (ListWritingPattern listWritingPattern : { ListWritingPattern::ReplaceAll, ListWritingPattern::ClearAllThenAppendItems })
+    {
+        ClusterTester tester(userLabel);
+        Structs::LabelStruct::Type labels[] = {
+            { .label = ""_span, .value = ""_span }, // empty label and value are allowed per spec
+        };
+        ASSERT_EQ(tester.WriteAttribute(LabelList::Id, DataModel::List(labels), listWritingPattern), CHIP_NO_ERROR);
+    }
 }
 
 TEST_F(TestUserLabelCluster, WriteMaxSizeLabelListTest)
 {
-    ClusterTester tester(userLabel);
-    std::array<Structs::LabelStruct::Type, chip::DeviceLayer::kMaxUserLabelListLength> labels;
-    for (size_t i = 0; i < labels.size(); i++)
+    for (ListWritingPattern listWritingPattern : { ListWritingPattern::ReplaceAll, ListWritingPattern::ClearAllThenAppendItems })
     {
-        labels[i].label = "label"_span;
-        labels[i].value = "value"_span;
+        ClusterTester tester(userLabel);
+        std::array<Structs::LabelStruct::Type, chip::DeviceLayer::kMaxUserLabelListLength> labels;
+        for (size_t i = 0; i < labels.size(); i++)
+        {
+            labels[i].label = "label"_span;
+            labels[i].value = "value"_span;
+        }
+        ASSERT_EQ(tester.WriteAttribute(LabelList::Id, DataModel::List(labels.data(), labels.size()), listWritingPattern),
+                  CHIP_NO_ERROR);
     }
-    ASSERT_EQ(tester.WriteAttribute(LabelList::Id, DataModel::List(labels.data(), labels.size())), CHIP_NO_ERROR);
 }

--- a/src/app/data-model-provider/tests/WriteTesting.h
+++ b/src/app/data-model-provider/tests/WriteTesting.h
@@ -86,6 +86,12 @@ public:
         return *this;
     }
 
+    WriteOperation & SetListOperation(app::ConcreteDataAttributePath::ListOperation listOp)
+    {
+        mRequest.path.mListOp = listOp;
+        return *this;
+    }
+
     const app::DataModel::WriteAttributeRequest & GetRequest() const { return mRequest; }
 
     // Helper to encode a value, using EncodeForWrite for fabric-scoped types

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -83,6 +83,22 @@ namespace Testing {
 //     ASSERT_GT(it.GetValue().label.size(), 0u);
 // }
 //
+
+template <typename>
+inline constexpr bool kIsList = false;
+
+template <typename T>
+inline constexpr bool kIsList<app::DataModel::List<T>> = true;
+
+// All Cluster Servers are expected to support both of the below list writing patterns.
+enum class ListWritingPattern
+{
+    ReplaceAll, // Write the list by encoding the entire list in a single TLV Array, which will replace the entire list on the
+                // cluster side.
+    ClearAllThenAppendItems, // Write the list by first sending a write with an empty list (TLV Array) to clear the entire list on
+                             // the cluster side, then writing list items individually one by one (Appending Items).
+};
+
 class ClusterTester
 {
 public:
@@ -143,9 +159,12 @@ public:
     // Use `app::Clusters::<ClusterName>::Attributes::<AttributeName>::TypeInfo::Type` for the `value` parameter to be spec
     // compliant (see the comment of the class for usage example).
     // Will construct the attribute path using the first path returned by `GetPaths()` on the cluster.
+    // WARNING: This method should NOT be used for writing list attributes, use the overload below that takes a ListWritingPattern
+    // parameter instead.
+
     // @returns `CHIP_ERROR_INCORRECT_STATE` if `GetPaths()` doesn't return a list with one path.
     // @returns `CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute)` if the attribute is not present in AttributeList.
-    template <typename T>
+    template <typename T, std::enable_if_t<!kIsList<T>, int> = 0>
     app::DataModel::ActionReturnStatus WriteAttribute(AttributeId attr, const T & value)
     {
         const auto & paths = mCluster.GetPaths();
@@ -163,33 +182,62 @@ public:
         const Access::SubjectDescriptor subjectDescriptor = mHandler.GetSubjectDescriptor();
         writeOp.SetSubjectDescriptor(subjectDescriptor);
 
-        uint8_t buffer[1024];
-        TLV::TLVWriter writer;
-        writer.Init(buffer);
+        auto decoder = writeOp.DecoderFor(value);
 
-        // - DataModel::Encode(integral, enum, etc.) for simple types.
-        // - DataModel::Encode(List<X>) for lists (which iterates and calls Encode on elements).
-        // - DataModel::Encode(Struct) for non-fabric-scoped structs.
-        // - Note: For attribute writes, DataModel::EncodeForWrite is usually preferred for fabric-scoped types,
-        //         but the generic DataModel::Encode often works as a top-level function.
-        //         If you use EncodeForWrite, you ensure fabric-scoped list items are handled correctly:
+        return mCluster.WriteAttribute(writeOp.GetRequest(), decoder).GetUnderlyingError();
+    }
 
-        if constexpr (app::DataModel::IsFabricScoped<T>::value)
+    // This WriteAttribute overload is for writing list attributes, and allows specifying the pattern used for mutating/writing the
+    // list on the cluster side (i.e. Replacing the list in its entirety vs Clearing the list in its entirety then appending/writing
+    // list items individually).
+    // Cluster servers support both patterns of writing lists, Therefore we should always test list attributes using both
+    // patterns.
+    template <typename T>
+    app::DataModel::ActionReturnStatus WriteAttribute(AttributeId attr, const app::DataModel::List<T> & listValue,
+                                                      ListWritingPattern listWritingPattern)
+    {
+        const auto & paths = mCluster.GetPaths();
+
+        VerifyOrReturnError(paths.size() == 1u, CHIP_ERROR_INCORRECT_STATE);
+
+        // Verify that the attribute is present in AttributeList before attempting to write it.
+        // This ensures tests match real-world behavior where the Interaction Model checks AttributeList first.
+        VerifyOrReturnError(IsAttributeInAttributeList(attr), Protocols::InteractionModel::Status::UnsupportedAttribute);
+
+        app::ConcreteAttributePath path(paths[0].mEndpointId, paths[0].mClusterId, attr);
+        chip::Testing::WriteOperation writeOp(path);
+
+        // Create a stable object on the stack
+        const Access::SubjectDescriptor subjectDescriptor = mHandler.GetSubjectDescriptor();
+        writeOp.SetSubjectDescriptor(subjectDescriptor);
+
+        switch (listWritingPattern)
         {
-            ReturnErrorOnFailure(chip::app::DataModel::EncodeForWrite(writer, TLV::AnonymousTag(), value));
+        case ListWritingPattern::ReplaceAll: {
+
+            // For ReplaceAll, we need to write the entire list in one go
+            writeOp.SetListOperation(app::ConcreteDataAttributePath::ListOperation::ReplaceAll);
+            auto decoder = writeOp.DecoderFor(listValue);
+            return mCluster.WriteAttribute(writeOp.GetRequest(), decoder).GetUnderlyingError();
         }
-        else
-        {
-            ReturnErrorOnFailure(chip::app::DataModel::Encode(writer, TLV::AnonymousTag(), value));
+
+        case ListWritingPattern::ClearAllThenAppendItems: {
+
+            // We first write an empty list to clear the existing list using ReplaceAll List Operation
+            writeOp.SetListOperation(app::ConcreteDataAttributePath::ListOperation::ReplaceAll);
+            auto decoderEmptyReplaceAll = writeOp.DecoderFor(app::DataModel::List<uint8_t>());
+            ReturnErrorOnFailure(mCluster.WriteAttribute(writeOp.GetRequest(), decoderEmptyReplaceAll).GetUnderlyingError());
+
+            // We now write each list item individually with AppendItem list operation.
+            writeOp.SetListOperation(app::ConcreteDataAttributePath::ListOperation::AppendItem);
+            for (ListIndex i = 0; i < listValue.size(); i++)
+            {
+                auto decoder = writeOp.DecoderFor(listValue[i]);
+                ReturnErrorOnFailure(mCluster.WriteAttribute(writeOp.GetRequest(), decoder).GetUnderlyingError());
+            }
+            return Protocols::InteractionModel::Status::Success;
         }
-
-        TLV::TLVReader reader;
-        reader.Init(buffer, writer.GetLengthWritten());
-        ReturnErrorOnFailure(reader.Next());
-
-        app::AttributeValueDecoder decoder(reader, *writeOp.GetRequest().subjectDescriptor);
-
-        return mCluster.WriteAttribute(writeOp.GetRequest(), decoder);
+        }
     }
 
     // Result structure for Invoke operations, containing both status and decoded response.

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -225,15 +225,17 @@ public:
 
             // We first write an empty list to clear the existing list using ReplaceAll List Operation
             writeOp.SetListOperation(app::ConcreteDataAttributePath::ListOperation::ReplaceAll);
-            auto decoderEmptyReplaceAll = writeOp.DecoderFor(app::DataModel::List<uint8_t>());
-            ReturnErrorOnFailure(mCluster.WriteAttribute(writeOp.GetRequest(), decoderEmptyReplaceAll).GetUnderlyingError());
+            auto decoder = writeOp.DecoderFor(app::DataModel::List<uint8_t>());
+            auto status  = mCluster.WriteAttribute(writeOp.GetRequest(), decoder);
+            VerifyOrReturnValue(status.IsSuccess(), status);
 
             // We now write each list item individually with AppendItem list operation.
             writeOp.SetListOperation(app::ConcreteDataAttributePath::ListOperation::AppendItem);
-            for (ListIndex i = 0; i < listValue.size(); i++)
+            for (const auto & listItem : listValue)
             {
-                auto decoder = writeOp.DecoderFor(listValue[i]);
-                ReturnErrorOnFailure(mCluster.WriteAttribute(writeOp.GetRequest(), decoder).GetUnderlyingError());
+                auto decoderAppend = writeOp.DecoderFor(listItem);
+                auto statusAppend  = mCluster.WriteAttribute(writeOp.GetRequest(), decoderAppend);
+                VerifyOrReturnValue(statusAppend.IsSuccess(), statusAppend);
             }
             return Protocols::InteractionModel::Status::Success;
         }

--- a/src/app/server-cluster/testing/ClusterTester.h
+++ b/src/app/server-cluster/testing/ClusterTester.h
@@ -184,13 +184,13 @@ public:
 
         auto decoder = writeOp.DecoderFor(value);
 
-        return mCluster.WriteAttribute(writeOp.GetRequest(), decoder).GetUnderlyingError();
+        return mCluster.WriteAttribute(writeOp.GetRequest(), decoder);
     }
 
     // This WriteAttribute overload is for writing list attributes, and allows specifying the pattern used for mutating/writing the
     // list on the cluster side (i.e. Replacing the list in its entirety vs Clearing the list in its entirety then appending/writing
     // list items individually).
-    // Cluster servers support both patterns of writing lists, Therefore we should always test list attributes using both
+    // Cluster servers usually support both patterns of writing lists, Therefore we should always test list attributes using both
     // patterns.
     template <typename T>
     app::DataModel::ActionReturnStatus WriteAttribute(AttributeId attr, const app::DataModel::List<T> & listValue,
@@ -218,7 +218,7 @@ public:
             // For ReplaceAll, we need to write the entire list in one go
             writeOp.SetListOperation(app::ConcreteDataAttributePath::ListOperation::ReplaceAll);
             auto decoder = writeOp.DecoderFor(listValue);
-            return mCluster.WriteAttribute(writeOp.GetRequest(), decoder).GetUnderlyingError();
+            return mCluster.WriteAttribute(writeOp.GetRequest(), decoder);
         }
 
         case ListWritingPattern::ClearAllThenAppendItems: {
@@ -237,6 +237,9 @@ public:
             }
             return Protocols::InteractionModel::Status::Success;
         }
+        default:
+            ChipLogError(Test, "Unhandled ListWritingPattern");
+            return CHIP_ERROR_INVALID_ARGUMENT;
         }
     }
 


### PR DESCRIPTION
#### Problem

- the current way of writing List Attributes in `ClusterTester.h` does NOT use the default List-writing Pattern that our `WriteClient.h` uses, i.e.
  - for nearly all clusters (Except Access Control), the `WriteClient.h` first sends an empty ReplaceAll list to clear the list Attribute on the cluster server; Then Appends each time individually --> this pattern was not possible using `ClusterTester`
  - While for ACL Cluster alone, we write all the list in one go, using a `ListOperation::ReplaceAll`; The Current  `ClusterTester` uses this list-writing pattern for **ALL** clusters.

#### Solution

- Create an overload of `WriteAttribute` that takes in a `ListWritingPattern` parameter.
- encourage and convert all unit tests of list attributes to use BOTH list-writing patterns; since all cluster-servers already support both patterns, and for future-proofing (in case we ever change the list-writing pattern for any cluster) .

#### Testing

- modified unit tests that write to list attributes to use both patterns, all changes are covered by these unit test modifications