### PR TITLE
[Restyler] add copy_files to allow new restyler to be faster locally

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -37,6 +37,12 @@ comments: false
 # Request review on the Restyle PR
 request_review: none
 
+copy_files:
+    - .prettierrc.json
+    - .clang-format
+    - .editorconfig
+    - pyproject.toml
+
 # Patterns to exclude from all Restylers
 exclude:
     - ".github/workflows/**/*" # https://github.com/restyled-io/restyler/issues/73

--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -59,6 +59,15 @@ restyle-paths() {
 
 ensure_restyle_installed() {
     if command -v restyle >/dev/null 2>&1; then
+        local version
+        version=$(restyle --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' || echo "0.0.0.0")
+        if [[ "$(printf '%s\n' "0.8.1.0" "$version" | sort -V | head -n1)" != "0.8.1.0" ]]; then
+            echo "[restyle-diff.sh] WARNING: restyle version $version is older than the version 0.8.1.0 which is faster and most stable"
+            echo "[restyle-diff.sh] Please UPGRADE to a newer restyle CLI by running"
+            echo "[restyle-diff.sh] 1. rm -f \"\$(command -v restyle)\""
+            echo "[restyle-diff.sh] 2. re-run this script without using sudo (it will automatically download latest restyle-CLI version)."
+            exit 1
+        fi
         return 0
     fi
 

--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -57,11 +57,24 @@ restyle-paths() {
 
 }
 
+version_lt() {
+    local v1="$1" v2="$2"
+    local num1 num2 i=0
+    while :; do
+        num1="${v1%%.*}" v1="${v1#"$num1"}" v1="${v1#.}"
+        num2="${v2%%.*}" v2="${v2#"$num2"}" v2="${v2#.}"
+        num1=${num1:-0} num2=${num2:-0}
+        if [ "$num1" -lt "$num2" ] 2>/dev/null; then return 0; fi
+        if [ "$num1" -gt "$num2" ] 2>/dev/null; then return 1; fi
+        if [ -z "$v1" ] && [ -z "$v2" ]; then return 1; fi
+    done
+}
+
 ensure_restyle_installed() {
     if command -v restyle >/dev/null 2>&1; then
         local version
         version=$(restyle --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' || echo "0.0.0.0")
-        if [[ "$(printf '%s\n' "0.8.1.0" "$version" | sort -V | head -n1)" != "0.8.1.0" ]]; then
+        if version_lt "$version" "0.8.1.0"; then
             echo "[restyle-diff.sh] WARNING: restyle version $version is older than the version 0.8.1.0 which is faster and most stable"
             echo "[restyle-diff.sh] Please UPGRADE to a newer restyle CLI by running"
             echo "[restyle-diff.sh] 1. rm -f \"\$(command -v restyle)\""


### PR DESCRIPTION
#### Summary

- As of Restyler v 0.8.1.0, we have a new parameter `copy_files` that allows us to only copy the files we need, for a faster local restyler experience
- Configured copy_files to copy configuration files AND files to be restyled, and not the whole repo as was the case before 
- this was released following discussions due to restyler becoming too slow locally: https://github.com/restyled-io/restyler/issues/314#issuecomment-3974460742 

#### Testing

- Tested locally on my machine

