### PR TITLE
Fix mypy-validation workflow broken by 065cd60

### DIFF
--- a/.github/workflows/mypy-validation.yml
+++ b/.github/workflows/mypy-validation.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Build Python environment
         run: |
           scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv'
+          out/venv/bin/pip install mypy
 
       - name: Run mypy validation (ChipDeviceCtrl.py)
         shell: bash

--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -1634,7 +1634,7 @@ class ChipDeviceControllerBase():
             sessionActiveThreshold=sessionParametersStruct.SessionActiveThreshold if sessionParametersStruct.SessionActiveThreshold != 0 else None,
             dataModelRevision=sessionParametersStruct.DataModelRevision if sessionParametersStruct.DataModelRevision != 0 else None,
             interactionModelRevision=sessionParametersStruct.InteractionModelRevision if sessionParametersStruct.InteractionModelRevision != 0 else None,
-            specficiationVersion=sessionParametersStruct.SpecificationVersion if sessionParametersStruct.SpecificationVersion != 0 else None,
+            specificationVersion=sessionParametersStruct.SpecificationVersion if sessionParametersStruct.SpecificationVersion != 0 else None,
             maxPathsPerInvoke=sessionParametersStruct.MaxPathsPerInvoke)
 
     async def TestOnlySendBatchCommands(self, nodeId: int, commands: typing.List[ClusterCommand.InvokeRequestInfo],

--- a/src/controller/python/matter/interaction_model/delegate.py
+++ b/src/controller/python/matter/interaction_model/delegate.py
@@ -123,7 +123,7 @@ class SessionParameters:
     sessionActiveThreshold: Optional[int]
     dataModelRevision: Optional[int]
     interactionModelRevision: Optional[int]
-    specficiationVersion: Optional[int]
+    specificationVersion: Optional[int]
     maxPathsPerInvoke: int
 
 


### PR DESCRIPTION
#### Summary

Since 065cd60 commit the mypy-validation is broken.
Adding `mypy` installation directly in the workflow, since it is only required for validation (it is not a direct dependency for any of our packets).

#### Testing

CI will verify (fixed typo in `src/controller/python/matter/ChipDeviceCtrl.py` to trigger mypy workflow):
https://github.com/project-chip/connectedhomeip/actions/runs/22852780268/job/66285194600?pr=43523