### PR TITLE
[Silabs] Updated deprecated APIs to their recommended alternatives

### DIFF
--- a/src/platform/silabs/SiWx/SiWxPlatformInterface.h
+++ b/src/platform/silabs/SiWx/SiWxPlatformInterface.h
@@ -54,7 +54,7 @@ void gpio_uulp_pin_interrupt_callback(uint32_t pin_intr)
         // BTN_0 is pressed
         // NOTE: the GPIO is masked since the interrupt is invoked before scheduler is started, thus this is required to hand over
         // control to scheduler, the PIN is unmasked in the power manager flow before going to sleep
-        status = sl_si91x_gpio_driver_mask_uulp_npss_interrupt(BIT(pin_intr));
+        status = sl_si91x_gpio_driver_mask_set_uulp_npss_interrupt(pin_intr);
         VerifyOrReturn(status == SL_STATUS_OK, ChipLogError(DeviceLayer, "failed to mask interrupt: %ld", status));
     }
 }

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -512,9 +512,9 @@ sl_status_t SetWifiConfigurations()
         join_feature_bitmap |= SL_SI91X_JOIN_FEAT_QUICK_JOIN;
     }
 
-    status = sl_si91x_set_join_configuration(SL_WIFI_CLIENT_INTERFACE, join_feature_bitmap);
+    status = sl_wifi_set_join_configuration(SL_WIFI_CLIENT_INTERFACE, join_feature_bitmap);
     VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "sl_si91x_set_join_configuration failed: 0x%lx", status));
+                        ChipLogError(DeviceLayer, "sl_wifi_set_join_configuration failed: 0x%lx", status));
 
     status = sl_net_set_profile(SL_NET_WIFI_CLIENT_INTERFACE, SL_NET_DEFAULT_WIFI_CLIENT_PROFILE_ID, &profile);
     VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "sl_net_set_profile failed: 0x%lx", status));
@@ -528,14 +528,14 @@ sl_status_t SetWifiConfigurations()
  *
  * @param configuration Matter Power Save Configuration
  *
- * @return sl_si91x_performance_profile_t SiWx Power Save Configuration; Default value is High Performance
+ * @return sl_wifi_system_performance_profile_t SiWx Power Save Configuration; Default value is High Performance
  *                                        kHighPerformance: HIGH_PERFORMANCE
  *                                        kConnectedSleep: ASSOCIATED_POWER_SAVE
  *                                        kDeepSleep: DEEP_SLEEP_WITH_RAM_RETENTION
  */
-sl_si91x_performance_profile_t ConvertPowerSaveConfiguration(PowerSaveInterface::PowerSaveConfiguration configuration)
+sl_wifi_system_performance_profile_t ConvertPowerSaveConfiguration(PowerSaveInterface::PowerSaveConfiguration configuration)
 {
-    sl_si91x_performance_profile_t profile = HIGH_PERFORMANCE;
+    sl_wifi_system_performance_profile_t profile = HIGH_PERFORMANCE;
 
     switch (configuration)
     {


### PR DESCRIPTION
#### Summary
This PR updates deprecated APIs to their recommended alternatives across platform and shell components to resolve deprecation warnings. The changes replace deprecated Silicon Labs WiFi SDK and GPIO driver functions with their current equivalents.

Key Changes:
- Replaced deprecated `sl_si91x_set_join_configuration` with `sl_wifi_set_join_configuration` in WiFi interface
- Updated `sl_si91x_performance_profile_t` type to `sl_wifi_system_performance_profile_t`
- Replaced `sl_si91x_gpio_driver_mask_uulp_npss_interrupt` with `sl_si91x_gpio_driver_mask_set_uulp_npss_interrupt`

#### Related issues
N/A

#### Testing
- Tested local builds on Light and Lock app (both WiFi and Thread)
- Confirmed that no deprecation warnings appear in the build logs after the update.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)