### PR TITLE
[CI] do not run coverage build for dependabot PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -523,7 +523,7 @@ jobs:
         env:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
             
-        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
+        if: github.actor != 'restyled-io[bot]' && github.actor != 'dependabot[bot]' && inputs.run-codeql != true
         # Use namespace to get more disk space and slightly better performance (Compile and unit tests
         # are CPU bound)
         #


### PR DESCRIPTION
#### Summary

- It's useless to run linux coverage build for dependabot PRs, and it eats up CI time

#### Testing

- Workflow will test it