### PR TITLE
Move Wi-Fi AP Introspection and Observation Methods from Interface Header to Implementation Source

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -324,11 +324,6 @@ private:
 };
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
-inline ConnectivityManager::WiFiAPMode ConnectivityManagerImpl::_GetWiFiAPMode()
-{
-    return mWiFiAPMode;
-}
-
 inline bool ConnectivityManagerImpl::_IsWiFiAPActive()
 {
     return mWiFiAPState == kWiFiAPState_Active;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -324,11 +324,6 @@ private:
 };
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
-inline bool ConnectivityManagerImpl::_IsWiFiAPActive()
-{
-    return mWiFiAPState == kWiFiAPState_Active;
-}
-
 inline bool ConnectivityManagerImpl::_IsWiFiAPApplicationControlled()
 {
     return mWiFiAPMode == kWiFiAPMode_ApplicationControlled;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -324,11 +324,6 @@ private:
 };
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
-inline bool ConnectivityManagerImpl::_IsWiFiAPApplicationControlled()
-{
-    return mWiFiAPMode == kWiFiAPMode_ApplicationControlled;
-}
-
 inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout()
 {
     return mWiFiAPIdleTimeout;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -323,13 +323,5 @@ private:
     NetworkStatusChangeCallback * mpStatusChangeCallback;
 };
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout()
-{
-    return mWiFiAPIdleTimeout;
-}
-
-#endif
-
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -172,6 +172,11 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision()
     }
 }
 
+bool ConnectivityManagerImpl::_IsWiFiAPActive()
+{
+    return mWiFiAPState == kWiFiAPState_Active;
+}
+
 ConnectivityManager::WiFiAPMode ConnectivityManagerImpl::_GetWiFiAPMode()
 {
     return mWiFiAPMode;

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -177,6 +177,11 @@ bool ConnectivityManagerImpl::_IsWiFiAPActive()
     return mWiFiAPState == kWiFiAPState_Active;
 }
 
+bool ConnectivityManagerImpl::_IsWiFiAPApplicationControlled()
+{
+    return mWiFiAPMode == kWiFiAPMode_ApplicationControlled;
+}
+
 ConnectivityManager::WiFiAPMode ConnectivityManagerImpl::_GetWiFiAPMode()
 {
     return mWiFiAPMode;

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -172,6 +172,11 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision()
     }
 }
 
+ConnectivityManager::WiFiAPMode ConnectivityManagerImpl::_GetWiFiAPMode()
+{
+    return mWiFiAPMode;
+}
+
 CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -182,6 +182,11 @@ bool ConnectivityManagerImpl::_IsWiFiAPApplicationControlled()
     return mWiFiAPMode == kWiFiAPMode_ApplicationControlled;
 }
 
+System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout()
+{
+    return mWiFiAPIdleTimeout;
+}
+
 ConnectivityManager::WiFiAPMode ConnectivityManagerImpl::_GetWiFiAPMode()
 {
     return mWiFiAPMode;


### PR DESCRIPTION
#### Summary

Per #42516, this relocates what is ultimately wpa_supplicant-specific introspection and observation method implementation from the soon to be generic and abstract `ConnectivityManagerImpl` header to the wpa_supplicant-specific implementation source.

#### Related issues

#42516

#### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.2 Apple "Home" app with a Connectivity Manager implementation using this infrastructure.