### PR TITLE
Leverage 'Internal::WiFiSSIDFixedBuffer' for the SSID of Interest

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <lib/support/FixedBuffer.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/GenericConnectivityManagerImpl.h>
 #include <platform/internal/GenericConnectivityManagerImpl_UDP.h>
@@ -284,8 +285,7 @@ private:
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    uint8_t sInterestedSSID[Internal::kMaxWiFiSSIDLength];
-    uint8_t sInterestedSSIDLen;
+    Internal::WiFiSSIDFixedBuffer mInterestedSSID;
 #endif
     NetworkCommissioning::WiFiDriver::ScanCallback * mpScanCallback;
     NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementWpaSupplicant.cpp
@@ -1270,14 +1270,13 @@ CHIP_ERROR ConnectivityManagerImpl::StartWiFiScan(ByteSpan ssid, WiFiDriver::Sca
     VerifyOrReturnError(mWpaSupplicant.iface, CHIP_ERROR_INCORRECT_STATE);
     // There is another ongoing scan request, reject the new one.
     VerifyOrReturnError(mpScanCallback == nullptr, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(ssid.size() <= sizeof(sInterestedSSID), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(ssid.size() <= mInterestedSSID.capacity(), CHIP_ERROR_INVALID_ARGUMENT);
 
     GAutoPtr<GError> err;
     GVariant * args = nullptr;
     GVariantBuilder builder;
 
-    memcpy(sInterestedSSID, ssid.data(), ssid.size());
-    sInterestedSSIDLen = ssid.size();
+    mInterestedSSID = ssid;
 
     g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
     g_variant_builder_add(&builder, "{sv}", "Type", g_variant_new_string("active"));
@@ -1587,8 +1586,9 @@ void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(WpaSupplicant1Interface * 
         WiFiScanResponse network;
         if (_GetBssInfo(bssPath, network))
         {
-            if (sInterestedSSIDLen == 0 ||
-                (network.ssidLen == sInterestedSSIDLen && memcmp(network.ssid, sInterestedSSID, sInterestedSSIDLen) == 0))
+            if (mInterestedSSID.empty() ||
+                (network.ssidLen == mInterestedSSID.size() &&
+                 memcmp(network.ssid, mInterestedSSID.data(), mInterestedSSID.size()) == 0))
             {
                 networkScanned->push_back(network);
             }


### PR DESCRIPTION
#### Summary

Per #42516, this leverages the recently-introduced `Internal::WiFiSSIDFixedBuffer` template data type for handling the Wi-Fi scan SSID-of-interest data member.

#### Related issues

https://github.com/project-chip/connectedhomeip/issues/42516

#### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.2 Apple "Home" app with a Connectivity Manager implementation using this infrastructure.