### PR TITLE
Added Connectivity Manager Implementation Basis and Delegate Objects

### DIFF
--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -128,6 +128,7 @@ static_library("Linux") {
     "ConnectivityManagerImpl.h",
     "ConnectivityManagerImpl_NetworkManagementBasis.cpp",
     "ConnectivityManagerImpl_NetworkManagementBasis.h",
+    "ConnectivityManagerImpl_NetworkManagementDelegate.h",
     "ConnectivityManagerImpl_NetworkManagementInterface.h",
     "ConnectivityManagerImpl_WiFiPafInterface.h",
     "ConnectivityUtils.cpp",

--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -126,6 +126,8 @@ static_library("Linux") {
     "ConfigurationManagerImpl.h",
     "ConnectivityManagerImpl.cpp",
     "ConnectivityManagerImpl.h",
+    "ConnectivityManagerImpl_NetworkManagementBasis.cpp",
+    "ConnectivityManagerImpl_NetworkManagementBasis.h",
     "ConnectivityManagerImpl_NetworkManagementInterface.h",
     "ConnectivityManagerImpl_WiFiPafInterface.h",
     "ConnectivityUtils.cpp",

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementBasis.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementBasis.cpp
@@ -1,0 +1,49 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "ConnectivityManagerImpl_NetworkManagementBasis.h"
+
+#include <lib/support/CodeUtils.h>
+
+#include "ConnectivityManagerImpl_NetworkManagementDelegate.h"
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+CHIP_ERROR NetworkManagementBasis::Init() noexcept
+{
+    mDelegate = nullptr;
+
+    return CHIP_NO_ERROR;
+}
+
+void NetworkManagementBasis::SetDelegate(NetworkManagementDelegate * inNetworkManagementDelegate) noexcept
+{
+    mDelegate = inNetworkManagementDelegate;
+}
+
+void NetworkManagementBasis::OnWiFiMediumAvailable(bool inAvailable) noexcept
+{
+    VerifyOrReturn(mDelegate != nullptr);
+
+    mDelegate->OnWiFiMediumAvailable(*this, inAvailable);
+}
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementBasis.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementBasis.h
@@ -1,0 +1,128 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+// Forward Declarations
+
+class NetworkManagementDelegate;
+
+/**
+ *  @brief
+ *    A lightweight base class providing delegate wiring for Linux
+ *    Connectivity Manager network management implementations.
+ *
+ *  This serves as a common base for concrete Linux Connectivity
+ *  Manager network management backends (for example, Connection
+ *  Manager- (also known as, connman) or wpa_supplicant-based
+ *  management).
+ *
+ *  The class provides:
+ *
+ *    * Storage and management of an optional network management
+ *      delegate.
+ *    * A protected action-delegation helper for reporting Wi-Fi
+ *      medium availability changes to the delegate.
+ *
+ *  This base does not define the full network management
+ *  control-plane API. Instead, it provides a small amount of shared
+ *  "glue" used to coordinate cross-cutting concerns between the
+ *  network management backend and the owning platform Connectivity
+ *  Manager implementation (which may also be coordinating the Wi-Fi
+ *  NAN USD / PAF commissioning transport).
+ *
+ *  @note
+ *    The delegate is not owned by this class. Callers must ensure the
+ *    delegate remains valid for as long as it is set.
+ *
+ *  @note
+ *    This type is intended to be used as a mix-in base alongside a
+ *    concrete network management interface implementation.
+ *
+ */
+class NetworkManagementBasis
+{
+public:
+    virtual ~NetworkManagementBasis() = default;
+
+    /**
+     *  @brief
+     *    Perform explicit class initialization.
+     *
+     *  Initializes internal state used by the base class, including
+     *  clearing any previously-set delegate.
+     *
+     *  Concrete derived classes should invoke this during their own
+     *  initialization (typically before establishing subscriptions or
+     *  starting external network management services).
+     *
+     */
+    CHIP_ERROR Init() noexcept;
+
+    /**
+     *  @brief
+     *    Set the delegate to receive coordination callbacks.
+     *
+     *  Sets (or clears) the network management delegate that will be
+     *  notified of relevant state changes observed by the network
+     *  management backend.
+     *
+     *  @note
+     *    The delegate is not owned by this object.
+     *
+     *  @param[in]  inNetworkManagementDelegate
+     *    A pointer to the delegate to set, or null to clear the
+     *    delegate.
+     *
+     *  @sa OnWiFiMediumAvailable
+     *
+     */
+    void SetDelegate(NetworkManagementDelegate * inNetworkManagementDelegate) noexcept;
+
+protected:
+    /**
+     *  @brief
+     *    Notify the delegate of Wi-Fi medium availability changes.
+     *
+     *  Derived classes should invoke this helper when the underlying
+     *  Wi-Fi control plane indicates that the Wi-Fi medium (radio /
+     *  interface resources) has become available or unavailable.
+     *
+     *  If a delegate is set, this forwards the notification to
+     *  NetworkManagementDelegate::OnWiFiMediumAvailable.
+     *
+     *  @param[in]  inAvailable
+     *    A Boolean indicating whether the Wi-Fi medium is available.
+     *
+     *  @sa SetDelegate
+     *
+     */
+    void OnWiFiMediumAvailable(bool inAvailable) noexcept;
+
+private:
+    NetworkManagementDelegate * mDelegate;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementDelegate.h
+++ b/src/platform/Linux/ConnectivityManagerImpl_NetworkManagementDelegate.h
@@ -1,0 +1,82 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+namespace chip {
+namespace DeviceLayer {
+
+namespace Internal {
+
+// Forward Declarations
+
+class NetworkManagementBasis;
+
+/**
+ *  @brief
+ *    A delegate interface for coordinating network-management-driven
+ *    Wi-Fi medium availability with other Connectivity Manager
+ *    implementation subsystems.
+ *
+ *  This delegate is used by a concrete network management basis
+ *  implementation to report changes in Wi-Fi medium availability to
+ *  an owning coordinator (typically the platform Connectivity Manager
+ *  implementation).
+ *
+ *  Wi-Fi medium availability reflects whether the underlying Wi-Fi
+ *  control plane / radio resources are usable for Wi-Fi operations
+ *  (for example, whether the Wi-Fi interface is present and powered,
+ *  and not blocked or otherwise unavailable).
+ *
+ *  The coordinator may use these notifications to:
+ *
+ *    * Update cached Connectivity Manager state.
+ *    * Drive Device Layer events and diagnostic attributes.
+ *    * Coordinate ownership or arbitration of Wi-Fi radio resources
+ *      between operational Wi-Fi usage (station / AP) and the
+ *      Wi-Fi Neighbor Awareness Networking (NAN) Unsynchronized Service
+ *      Discovery (USD) / Public Action Frame (PAF) commissioning
+ *      transport.
+ *
+ *  Concrete implementations should assume that notifications may be
+ *  delivered from an implementation-defined execution
+ *  context. Delegates should avoid blocking for extended periods.
+ *
+ */
+class NetworkManagementDelegate
+{
+public:
+    virtual ~NetworkManagementDelegate(void) = default;
+
+    /**
+     *  @brief
+     *    Indicate whether the Wi-Fi medium is available.
+     *
+     *  @param[in,out]  inOutNetworkManagement
+     *    A reference to the mutable network management entity making
+     *    the delegation.
+     *
+     *  @param[in]  inAvailable
+     *    A Boolean indicating whether the Wi-Fi medium is available.
+     *
+     */
+    virtual void OnWiFiMediumAvailable(NetworkManagementBasis & inOutNetworkManagement, bool inAvailable) = 0;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip


### PR DESCRIPTION
#### Summary

Per #42516 and [this overview](https://github.com/user-attachments/files/25854289/Matter.ConnectivityManager.Linux.Platform.Refactoring.html), this introduces two new pieces of infrastructure en route to enabling the end goal of more-pluggable Matter network management infrastructure for Linux.

1. Connectivity Manager Implementation Network Management Delegate
2. Connectivity Manager Implementation Network Management Basis Class

##### Connectivity Manager Implementation Network Management Delegate

This delegate is used by a concrete network management basis implementation to report changes in Wi-Fi medium availability to an owning coordinator (typically the platform Connectivity Manager implementation).
    
Wi-Fi medium availability reflects whether the underlying Wi-Fi control plane / radio resources are usable for Wi-Fi operations (for example, whether the Wi-Fi interface is present and powered, and not blocked or otherwise unavailable).
    
The coordinator may use these notifications to:
    
* Update cached Connectivity Manager state.
* Drive Device Layer events and diagnostic attributes.
* Coordinate ownership or arbitration of Wi-Fi radio resources between operational Wi-Fi usage (station / AP) and the Wi-Fi Neighbor Awareness Networking (NAN) Unsynchronized Service Discovery (USD) / Public Action Frame (PAF) commissioning transport.

##### Connectivity Manager Implementation Network Management Basis Class

A lightweight base class providing delegate wiring for Linux Connectivity Manager network management implementations.

This (will) serve(s) as a common base for concrete Linux Connectivity Manager network management backends (for example, Connection Manager- (also known as, connman) or wpa_supplicant-based management).

The class provides:
    
* Storage and management of an optional network management delegate.
* A protected action-delegation helper for reporting Wi-Fi medium availability changes to the delegate.
    
This base does not define the full network management control-plane API. Instead, it provides a small amount of shared "glue" used to coordinate cross-cutting concerns between the network management backend and the owning platform Connectivity Manager implementation (which may also be coordinating the Wi-Fi NAN USD / PAF commissioning transport).

#### Related issues

https://github.com/project-chip/connectedhomeip/issues/42516

#### Testing

An armvl-unknown-linux-gnu device has been successfully paired / commissioned using the iOS 26.2 Apple "Home" app with a Connectivity Manager implementation using this infrastructure.