### PR TITLE
[Darwin] Fix private cluster extension header conditions; `switch` types

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRClusterNames_Private-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterNames_Private-src.zapt
@@ -40,7 +40,8 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType)clusterID) {
+    if ((clusterID & 0xFFFF0000) != 0) {
+        switch ((MTRPrivateClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
@@ -84,6 +85,13 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {{/if}}
 {{/if}}
 {{/zcl_clusters}}
+
+        default:
+           result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
+           break;
+        }
+    } else {
+        switch ((MTRClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
@@ -130,6 +138,7 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
            result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
            break;
         }
+    }
 
     return result;
 }
@@ -140,7 +149,8 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {{~#*inline "commandIDOutput"}}
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType)clusterID) {
+    if ((clusterID & 0xFFFF0000) != 0) {
+        switch ((MTRPrivateClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
@@ -174,6 +184,13 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
 {{/if}}
 {{/if}}
 {{/zcl_clusters}}
+
+        default:
+           result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
+           break;
+        }
+    } else {
+        switch ((MTRClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
@@ -213,6 +230,7 @@ NSString * MTRPrivateAttributeNameForID(MTRClusterIDType clusterID, MTRAttribute
            result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
            break;
         }
+    }
 
     return result;
 {{/inline}}
@@ -233,7 +251,8 @@ NSString * MTRPrivateEventNameForID(MTRClusterIDType clusterID, MTREventIDType e
 {
     NSString * result = nil;
 
-    switch ((MTRPrivateClusterIDType)clusterID) {
+    if ((clusterID & 0xFFFF0000) != 0) {
+        switch ((MTRPrivateClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinPrivateClusters")}}
@@ -274,6 +293,13 @@ NSString * MTRPrivateEventNameForID(MTRClusterIDType clusterID, MTREventIDType e
 {{/if}}
 {{/if}}
 {{/zcl_clusters}}
+
+        default:
+           result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
+           break;
+        }
+    } else {
+        switch ((MTRClusterIDType)clusterID) {
 
 {{#zcl_clusters}}
 {{#if (isInConfigList (asUpperCamelCase name preserveAcronyms=true) "DarwinClustersWithPrivateExtensions")}}
@@ -317,6 +343,7 @@ NSString * MTRPrivateEventNameForID(MTRClusterIDType clusterID, MTREventIDType e
            result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
            break;
         }
+    }
 
     return result;
 }

--- a/src/darwin/Framework/CHIP/templates/MTRClusters_Private.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_Private.zapt
@@ -58,9 +58,35 @@ MTR_PROVISIONALLY_AVAILABLE
  */
 @interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} (PrivateExtensions)
 
-{{> commandDeclarations manufacturerCodeOnly=true}}
+{{#zcl_commands}}
+{{#if (is_str_equal source 'client')}}
+{{#if manufacturerCode}}
+{{#*inline "commandDecl"}}
+{{#if (isSupported cluster command=command)}}
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{cluster}}Cluster{{command}}Params * {{#unless commandHasRequiredField}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion;
+{{/if}}
+{{/inline}}
+{{> commandDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true)
+                command=(asUpperCamelCase name preserveAcronyms=true)}}
+{{/if}}
+{{/if}}
+{{/zcl_commands}}
 
-{{> attributeDeclarations manufacturerCodeOnly=true}}
+{{#zcl_attributes_server}}
+{{#if manufacturerCode}}
+{{#if (and (or clusterRef
+               (isSupported "" globalAttribute=(asUpperCamelCase label preserveAcronyms=true)))
+           (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true)))}}
+{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
+- (NSDictionary<NSString *, id> * _Nullable)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params;
+{{#if (or isWritableAttribute
+      (isInConfigList (concat (asUpperCamelCase parent.name) "::" label) "DarwinForceWritable"))}}
+- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
+- (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs params:(MTRWriteParams * _Nullable)params;
+{{/if}}
+{{/if}}
+{{/if}}
+{{/zcl_attributes_server}}
 
 @end
 {{/if}}


### PR DESCRIPTION
#### Summary

Template `manufacturerCodeOnly` param didn't work inside `zcl_attributes_server` scope.  Unwind partial.
Introspection `switch` statements didn't correctly handle public cluster extension IDs.

#### Testing

`scripts/tools/zap/generate.py -t src/darwin/Framework/CHIP/templates/templates.json`
- Private cluster extension introspections should be in the public cluster extension part of introspection `switch` statements
- Private cluster introspections should be in the private cluster extension part of introspection `switch` statements
- Public methods of public clusters with private cluster extensions should not be generated to private headers - public headers only.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
