### PR TITLE
[Tests] Improve test summary

### DIFF
--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -61,7 +61,7 @@ class TestResult:
     iteration: int
     status: TestStatus
     duration_seconds: float
-    exception: BaseException | str | None
+    exception: BaseException | str | None = None
 
     @property
     def name_decorated(self) -> str:

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import contextlib
+import datetime
+import enum
+import json
+import logging
+import os
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+class TestStatus(enum.StrEnum):
+    """Status of test execution."""
+
+    PASSED = enum.auto()
+    FAILED = enum.auto()
+    DRY_RUN = enum.auto()
+    CANCELLED = enum.auto()
+
+    @property
+    def symbol(self) -> str:
+        match self:
+            case TestStatus.PASSED | TestStatus.DRY_RUN:
+                return "✓"
+            case TestStatus.FAILED:
+                return "✗"
+            case TestStatus.CANCELLED:
+                return "!"
+            case unknown:
+                raise ValueError(f"Unknown test status: {unknown}")
+
+    def decorate_name(self, name: str) -> str:
+        return f"{self.symbol} {name}"
+
+
+@dataclass
+class TestResult:
+    """Summary of execution of a single test."""
+
+    name: str
+    iteration: int
+    status: TestStatus
+    duration_seconds: float
+    exception: BaseException | None
+
+    @property
+    def name_decorated(self) -> str:
+        return TestStatus(self.status).decorate_name(self.name)
+
+    @classmethod
+    def run_test(cls, name: str, iteration: int, dry_run: bool, test_func: Callable[[], None]) -> TestResult:
+        """Run a test and generate execution summary.
+
+        Mind that it catches any exception and saves it in the result. It's up to the caller to reraise the exception.
+        """
+        log.info("Would run test: '%s'" if dry_run else "%s - Starting test", name)
+
+        result = TestResult(name, iteration, TestStatus.FAILED, duration_seconds=0, exception=None)
+        test_start = test_end = time.monotonic()
+        try:
+            test_func()
+            test_end = time.monotonic()
+            result.status = TestStatus.DRY_RUN if dry_run else TestStatus.PASSED
+        except BaseException as e:
+            test_end = time.monotonic()
+            result.status = TestStatus.CANCELLED if isinstance(e, KeyboardInterrupt) else TestStatus.FAILED
+            result.exception = e
+
+            if os.path.exists('thread.pcap'):
+                os.system("echo 'base64 -d - >thread.pcap <<EOF' && base64 thread.pcap && echo EOF")
+        finally:
+            result.duration_seconds = test_end - test_start
+
+            symbol = result.status.symbol
+            match result.status:
+                case TestStatus.PASSED:
+                    log.info("%s %s - Completed in %0.2f seconds", symbol, name, result.duration_seconds)
+                case TestStatus.CANCELLED:
+                    log.warning("%s %s - Cancelled after %0.2f seconds", symbol, name, result.duration_seconds)
+                case TestStatus.FAILED:
+                    log.error("%s %s - Failed in %0.2f seconds", symbol, name, result.duration_seconds, exc_info=result.exception)
+
+            return result
+
+
+@dataclass
+class RunStats:
+    """Statistics of test runs, aggregated across iterations."""
+    total_runs: int = field(default=0, init=False)
+    passed: int = field(default=0, init=False)
+    failed: int = field(default=0, init=False)
+    cancelled: int = field(default=0, init=False)
+    mean_duration: float = field(default=0.0, init=False)
+    exception_first: BaseException | str | None = field(default=None, init=False)
+
+    @property
+    def pass_rate(self) -> float:
+        return self.passed / self.total_runs if self.total_runs > 0 else 0.0
+
+    @property
+    def fail_rate(self) -> float:
+        return self.failed / self.total_runs if self.total_runs > 0 else 0.0
+
+    @property
+    def status_msg(self) -> str:
+        if self.cancelled:
+            return f"{TestStatus.CANCELLED.symbol} Cancelled"
+        if self.failed:
+            exc = self.exception_first if isinstance(self.exception_first, str) else repr(self.exception_first)
+            return f"{TestStatus.FAILED.symbol} {exc}"
+        return TestStatus.PASSED.symbol
+
+    def record(self, result: TestResult) -> None:
+        """Record a test result."""
+        # Increment counters depending on the result status.
+        self.total_runs += 1
+        match result.status:
+            case TestStatus.PASSED:
+                self.passed += 1
+            case TestStatus.FAILED:
+                self.failed += 1
+            case TestStatus.CANCELLED:
+                self.cancelled += 1
+
+        # Calculate cumulative average.
+        self.mean_duration += (result.duration_seconds - self.mean_duration) / self.total_runs
+
+        # Save the exception if it's the first one.
+        if result.exception is not None and self.exception_first is None:
+            self.exception_first = result.exception
+
+
+@dataclass
+class RunSummary(RunStats):
+    """Summary of a test run, including results of all iterations and aggregated statistics (both global and per-test)."""
+    iterations: int
+    run_timestamp: datetime.datetime | str = field(default_factory=lambda: datetime.datetime.now(datetime.timezone.utc))
+    results: list[TestResult] = field(default_factory=list, init=False)
+    test_stats: dict[str, RunStats] = field(default_factory=dict, init=False)
+
+    def record(self, result: TestResult) -> None:
+        """Record a test result."""
+        self.results.append(result)
+
+        # Increment global counters.
+        super().record(result)
+
+        # Increment per-test statistics.
+        if result.name not in self.test_stats:
+            self.test_stats[result.name] = RunStats()
+        self.test_stats[result.name].record(result)
+
+    def write_json(self, path: Path) -> None:
+        """Write the test run summary to a JSON file."""
+        def encoder(obj: Any):
+            """JSON encoder for non-serializable objects."""
+            if isinstance(obj, datetime.datetime):
+                return obj.isoformat()
+            return repr(obj)
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(self), indent=2, default=encoder))
+        log.info("Test run summary written to %s", path)
+
+    @classmethod
+    def from_json(cls, path: Path) -> RunSummary:
+        """Read the test run summary from a JSON file."""
+        raw = json.loads(path.read_text())
+        ret = RunSummary(iterations=raw.get("iterations", 1))
+
+        # Recover a timestamp.
+        timestamp = raw.get("run_timestamp", "unknown")
+        with contextlib.suppress(KeyError, ValueError):
+            timestamp = datetime.datetime.fromisoformat(timestamp)
+        ret.run_timestamp = timestamp
+
+        # We use only contents of "results" to reconstruct the summary, as all the statistics can be recalculated from the results.
+        for result in raw.get("results", []):
+            try:
+                ret.record(TestResult(**result))
+            except Exception as e:
+                log.warning("Skipping result record %r due to an exception while parsing JSON file %s: %r", result, path, e)
+        return ret
+
+    @staticmethod
+    def _print_table(rows: Iterable[tuple[str, ...]], title: str = "", headers_fmt: tuple[tuple[str, str], ...] | None = None,
+                     top_btm_rule: str | None = None, mid_rule: str | None = "-", col_sep: str = "  ", content_padding: int = 2,
+                     rule_padding: int = 2, last_col_max_width: int | None = None, no_content_msg: str | None = None) -> None:
+        """Print a table to the console.
+
+        Arguments:
+            rows -- iterable of rows to print, where each row is a tuple of cell values (as strings).
+
+        Keyword Arguments:
+            title -- optional table title surrounded by top_btm_rules.
+            headers_fmt -- optional tuple of header title and format pairs.
+            top_btm_rule -- optional top and bottom rule character or an explicit string.
+            mid_rule -- optional between header and content rule character or an explicit string.
+            col_sep -- column separator.
+            content_padding -- number of spaces before and after row content on the outer border of the table.
+            rule_padding -- number of spaces before and after rules on the outer border of the table.
+            last_col_max_width -- optional constraint for the last column. It doesn't truncate the data, but only sets format.
+            no_content_msg -- optional message to show if there are no rows. Raise ValueError if not present and there are no rows.
+        """
+        # Filter out empty rows, and check if there are any rows defined.
+        content_padding_str = " " * content_padding
+        if not (rows := tuple(row for row in rows if any(cell for cell in row))):
+            if no_content_msg is not None:
+                print()
+                print(f"{content_padding_str}{no_content_msg}")
+                return
+            raise ValueError("There should be at least one row in the table")
+
+        # If headers are not defined, prepare default alignment. Otherwise, unpack to headers and formats tuples.
+        headers, fmt = zip(*((("", "<") for _ in rows[0]) if headers_fmt is None else headers_fmt))
+
+        # Check if number of columns is consistent for all rows.
+        all_rows = (headers,) + rows
+        if len({len(row) for row in all_rows}) != 1:
+            raise ValueError("All rows must have the same number of columns")
+
+        # Calculate widths of columns, the table and rules.
+        col_widths = [max(len(row[i]) for row in all_rows) for i in range(len(rows[0]))]
+        if last_col_max_width is not None:
+            col_widths[-1] = min(col_widths[-1], last_col_max_width)
+        total_width = 2 * content_padding + max(len(title), sum(col_widths) + len(col_sep)*(len(col_widths) - 1))
+        rule_width = total_width - 2 * rule_padding
+
+        # Prepare formatting strings.
+        rule_pad_str = " " * rule_padding
+        top_btm_rule_str = f"{rule_pad_str}{top_btm_rule*rule_width}" if top_btm_rule and len(top_btm_rule) == 1 else top_btm_rule
+        mid_rule_str = f"{rule_pad_str}{mid_rule*rule_width}" if mid_rule and len(mid_rule) == 1 else mid_rule
+        row_format = content_padding_str + col_sep.join(f"{{:{fmt}{width}}}" for fmt, width in zip(fmt, col_widths))
+
+        # Print the table.
+        print()
+        if top_btm_rule_str:
+            print(top_btm_rule_str)
+        if title:
+            print(f"{content_padding_str}{title}")
+            if top_btm_rule_str:
+                print(top_btm_rule_str)
+        if headers_fmt:
+            print(row_format.format(*headers))
+            if mid_rule_str:
+                print(mid_rule_str)
+        for row in rows:
+            print(row_format.format(*row))
+        if top_btm_rule_str:
+            print(top_btm_rule_str)
+
+    def print_summary(self, show_failed: bool = True, show_flaky: bool = True, top_slowest: int = 20,
+                      show_all: bool = True) -> None:
+        """Print summary of test run.
+
+        Keyword Arguments:
+            show_failed -- separately list failed tests.
+            show_flaky -- if running multiple iterations, list tests with the highest failure rate across iterations.
+            top_slowest -- list the slowest tests. If 0 don't list any, if negative list all tests.
+            show_all -- list stats for all tests across all iterations, including mean duration and status message (passed, failed
+                        with exception, or cancelled).
+        """
+        self._print_table(title="TEST RUN SUMMARY", top_btm_rule="=", col_sep=" : ", rule_padding=0,
+                          rows=(("Run timestamp", str(self.run_timestamp)),
+                                ("Iterations", str(self.iterations)),
+                                ("Total runs", str(self.total_runs)),
+                                ("Passed", str(self.passed)),
+                                ("Failed", str(self.failed)),
+                                ("Cancelled", str(self.cancelled)),
+                                (("Pass rate", f"{100 * self.pass_rate:.1f}%") if self.total_runs else ())))
+
+        if show_failed:
+            failed_results = tuple(r for r in self.results if r.status == TestStatus.FAILED)
+            self._print_table(title=f"FAILED TESTS ({len(failed_results)}):",
+                              no_content_msg="No failures recorded",
+                              headers_fmt=(("Test name", "<"), ("Iter", ">"), ("Duration", ">")),
+                              rows=((r.name_decorated, str(r.iteration), f"{r.duration_seconds:.2f}s")
+                              for r in sorted(failed_results, key=lambda x: x.name)))
+
+        if show_flaky and self.iterations > 1:
+            flaky = tuple((name, stats) for name, stats in self.test_stats.items() if stats.failed > 0)
+            self._print_table(title=f"FAILURE RATE BY TEST (across {self.iterations} iterations)",
+                              no_content_msg="No flaky results",
+                              headers_fmt=(("Test name", "<"), ("Failuers", ">"), ("Rate", ">")),
+                              rows=((name, f"{stats.failed}/{stats.total_runs:<2}", f"{100 * stats.fail_rate:.1f}%")
+                              for name, stats in sorted(flaky, key=lambda item: -item[1].failed)))
+
+        if top_slowest:
+            slowest = sorted((r for r in self.results if r.status not in (TestStatus.DRY_RUN, TestStatus.CANCELLED)),
+                             key=lambda x: -x.duration_seconds)[:top_slowest]
+            self._print_table(title=f"SLOWEST {top_slowest if top_slowest > 0 else 'ALL'} TEST RUNS:",
+                              headers_fmt=(("Test name", "<"), ("Status", "<"), ("Iter", ">"), ("Duration", ">")),
+                              rows=((r.name_decorated, r.status, str(r.iteration), f"{r.duration_seconds:.2f}s")
+                              for r in slowest))
+
+        if show_all:
+            self._print_table(title="STATS OF ALL TESTS:", no_content_msg="No tests to show", last_col_max_width=20,
+                              headers_fmt=(("Test name", "<"), ("Passed", ">"), ("Mean time", ">"), ("Status", "<")),
+                              rows=((name, f"{stats.passed}/{stats.total_runs}", f"{stats.mean_duration:.2f}s", stats.status_msg)
+                                    for name, stats in self.test_stats.items()))
+
+        # Final vertical padding.
+        print()

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -98,7 +98,7 @@ class TestResult:
                     print(base64.b64encode(pcap_path.read_bytes()).decode("ascii"))
                     print("EOF")
         finally:
-            result.duration_seconds = round(test_end - test_start, 3)
+            result.duration_seconds = test_end - test_start
 
             symbol = result.status.symbol
             match result.status:
@@ -154,7 +154,7 @@ class RunStats:
                 self.cancelled += 1
 
         # Calculate cumulative average.
-        self.mean_duration += round((result.duration_seconds - self.mean_duration) / self.total_runs, 3)
+        self.mean_duration += (result.duration_seconds - self.mean_duration) / self.total_runs
 
         # Save the exception if it's the first one.
         if result.exception is not None and self.exception_first is None:
@@ -183,14 +183,23 @@ class RunSummary(RunStats):
 
     def write_json(self, path: Path) -> None:
         """Write the test run summary to a JSON file."""
-        def encoder(obj: Any):
-            """JSON encoder for non-serializable objects."""
+        def encode(obj: Any) -> Any:
+            """JSON encoder for non-serializable objects.
+
+            We cannot use json.dumps(default) for all cases, as it doesn't touch floats.
+            """
+            if isinstance(obj, dict):
+                return {key: encode(value) for key, value in obj.items()}
+            if isinstance(obj, Iterable) and not isinstance(obj, (str, bytes)):
+                return [encode(item) for item in obj]
             if isinstance(obj, datetime.datetime):
                 return obj.isoformat()
-            return repr(obj)
+            if isinstance(obj, float):
+                return round(obj, 3)  # Round floats to 3 decimal places for better readability.
+            return obj
 
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(asdict(self), indent=2, default=encoder))
+        path.write_text(json.dumps(encode(asdict(self)), indent=2, default=repr))
         log.info("Test run summary written to %s", path)
 
     @classmethod

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -93,7 +93,7 @@ class TestResult:
             if os.path.exists('thread.pcap'):
                 os.system("echo 'base64 -d - >thread.pcap <<EOF' && base64 thread.pcap && echo EOF")
         finally:
-            result.duration_seconds = test_end - test_start
+            result.duration_seconds = round(test_end - test_start, 3)
 
             symbol = result.status.symbol
             match result.status:
@@ -149,7 +149,7 @@ class RunStats:
                 self.cancelled += 1
 
         # Calculate cumulative average.
-        self.mean_duration += (result.duration_seconds - self.mean_duration) / self.total_runs
+        self.mean_duration += round((result.duration_seconds - self.mean_duration) / self.total_runs, 3)
 
         # Save the exception if it's the first one.
         if result.exception is not None and self.exception_first is None:

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -196,7 +196,7 @@ class RunSummary(RunStats):
 
         # Recover a timestamp.
         timestamp = raw.get("run_timestamp", "unknown")
-        with contextlib.suppress(KeyError, ValueError):
+        with contextlib.suppress(TypeError, ValueError):
             timestamp = datetime.datetime.fromisoformat(timestamp)
         ret.run_timestamp = timestamp
 

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -307,8 +307,13 @@ class RunSummary(RunStats):
 
         if top_slowest:
             slowest = sorted((r for r in self.results if r.status not in (TestStatus.DRY_RUN, TestStatus.CANCELLED)),
-                             key=lambda x: -x.duration_seconds)[:top_slowest]
-            self._print_table(title=f"SLOWEST {top_slowest if top_slowest > 0 else 'ALL'} TEST RUNS:",
+                             key=lambda x: -x.duration_seconds)
+
+            # Slice only the top slowest tests if the limit is set to a positive value. If it's negative, show all tests.
+            if top_slowest > 0:
+                slowest = slowest[:top_slowest]
+
+            self._print_table(title=f"SLOWEST {len(slowest)} TEST RUNS:",
                               headers_fmt=(("Test name", "<"), ("Status", "<"), ("Iter", ">"), ("Duration", ">")),
                               rows=((r.name_decorated, r.status, str(r.iteration), f"{r.duration_seconds:.2f}s")
                               for r in slowest))

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -87,11 +87,14 @@ class TestResult:
             result.status = TestStatus.DRY_RUN if dry_run else TestStatus.PASSED
         except BaseException as e:
             test_end = time.monotonic()
-            result.status = TestStatus.CANCELLED if isinstance(e, KeyboardInterrupt) else TestStatus.FAILED
             result.exception = e
 
-            if os.path.exists('thread.pcap'):
-                os.system("echo 'base64 -d - >thread.pcap <<EOF' && base64 thread.pcap && echo EOF")
+            if isinstance(e, KeyboardInterrupt):
+                result.status = TestStatus.CANCELLED
+            else:
+                result.status = TestStatus.FAILED
+                if os.path.exists('thread.pcap'):
+                    os.system("echo 'base64 -d - >thread.pcap <<EOF' && base64 thread.pcap && echo EOF")
         finally:
             result.duration_seconds = round(test_end - test_start, 3)
 

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -301,7 +301,7 @@ class RunSummary(RunStats):
             flaky = tuple((name, stats) for name, stats in self.test_stats.items() if stats.failed > 0)
             self._print_table(title=f"FAILURE RATE BY TEST (across {self.iterations} iterations)",
                               no_content_msg="No flaky results",
-                              headers_fmt=(("Test name", "<"), ("Failuers", ">"), ("Rate", ">")),
+                              headers_fmt=(("Test name", "<"), ("Failures", ">"), ("Rate", ">")),
                               rows=((name, f"{stats.failed}/{stats.total_runs:<2}", f"{100 * stats.fail_rate:.1f}%")
                               for name, stats in sorted(flaky, key=lambda item: -item[1].failed)))
 

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -79,7 +79,7 @@ class TestResult:
         """
         log.info("Would run test: '%s'" if dry_run else "%s - Starting test", name)
 
-        result = TestResult(name, iteration, TestStatus.FAILED, duration_seconds=0, exception=None)
+        result = cls(name, iteration, TestStatus.FAILED, duration_seconds=0, exception=None)
         test_start = test_end = time.monotonic()
         try:
             test_func()

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -14,12 +14,12 @@
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import datetime
 import enum
 import json
 import logging
-import os
 import time
 from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass, field
@@ -93,8 +93,10 @@ class TestResult:
                 result.status = TestStatus.CANCELLED
             else:
                 result.status = TestStatus.FAILED
-                if os.path.exists('thread.pcap'):
-                    os.system("echo 'base64 -d - >thread.pcap <<EOF' && base64 thread.pcap && echo EOF")
+                if (pcap_path := Path("thread.pcap")).exists():
+                    print("base64 -d - >thread.pcap <<EOF")
+                    print(base64.b64encode(pcap_path.read_bytes()).decode("ascii"))
+                    print("EOF")
         finally:
             result.duration_seconds = round(test_end - test_start, 3)
 

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -103,7 +103,8 @@ class TestResult:
                     log.warning("%s %s - Cancelled after %0.2f seconds", symbol, name, result.duration_seconds)
                 case TestStatus.FAILED:
                     assert isinstance(result.exception, BaseException), "Exception should be set for failed test results"
-                    log.error("%s %s - Failed in %0.2f seconds", symbol, name, result.duration_seconds, exc_info=result.exception)
+                    log.error("%s %s - Failed in %0.2f seconds", symbol, name, result.duration_seconds,
+                              exc_info=(type(result.exception), result.exception, result.exception.__traceback__))
 
             return result
 

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -140,7 +140,7 @@ class RunStats:
         # Increment counters depending on the result status.
         self.total_runs += 1
         match result.status:
-            case TestStatus.PASSED:
+            case TestStatus.PASSED | TestStatus.DRY_RUN:
                 self.passed += 1
             case TestStatus.FAILED:
                 self.failed += 1

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -319,7 +319,7 @@ class RunSummary(RunStats):
             if top_slowest > 0:
                 slowest = slowest[:top_slowest]
 
-            self._print_table(title=f"SLOWEST {len(slowest)} TEST RUNS:",
+            self._print_table(title=f"SLOWEST {len(slowest)} TEST RUNS:", no_content_msg="No tests to show for slowest list",
                               headers_fmt=(("Test name", "<"), ("Status", "<"), ("Iter", ">"), ("Duration", ">")),
                               rows=((r.name_decorated, r.status, str(r.iteration), f"{r.duration_seconds:.2f}s")
                               for r in slowest))

--- a/scripts/tests/chiptest/results.py
+++ b/scripts/tests/chiptest/results.py
@@ -61,11 +61,15 @@ class TestResult:
     iteration: int
     status: TestStatus
     duration_seconds: float
-    exception: BaseException | None
+    exception: BaseException | str | None
 
     @property
     def name_decorated(self) -> str:
         return TestStatus(self.status).decorate_name(self.name)
+
+    def __post_init__(self):
+        # Ensure that status is of type TestStatus, even if it's passed as a string (e.g. when loading from JSON).
+        self.status = TestStatus(self.status)
 
     @classmethod
     def run_test(cls, name: str, iteration: int, dry_run: bool, test_func: Callable[[], None]) -> TestResult:
@@ -98,6 +102,7 @@ class TestResult:
                 case TestStatus.CANCELLED:
                     log.warning("%s %s - Cancelled after %0.2f seconds", symbol, name, result.duration_seconds)
                 case TestStatus.FAILED:
+                    assert isinstance(result.exception, BaseException), "Exception should be set for failed test results"
                     log.error("%s %s - Failed in %0.2f seconds", symbol, name, result.duration_seconds, exc_info=result.exception)
 
             return result

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -14,17 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import enum
-import json
 import logging
 import os
 import random
 import sys
 import time
 import warnings
-from collections import Counter
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -33,6 +30,7 @@ import click
 import coloredlogs
 from chiptest.accessories import AppsRegister
 from chiptest.glob_matcher import GlobMatcher
+from chiptest.results import RunSummary, TestResult
 from chiptest.runner import Executor, SubprocessKind
 from chiptest.test_definition import TEST_THREAD_DATASET, SubprocessInfoRepo, TestDefinition, TestRunTime, TestTag
 from chipyaml.paths_finder import PathsFinder
@@ -69,47 +67,6 @@ class RunContext:
 
     # Deprecated options passed to `cmd_run`
     deprecated_chip_tool_path: Path | None = None
-
-
-class TestStatus(enum.Enum):
-    PASSED = "passed"
-    FAILED = "failed"
-    DRY_RUN = "dry_run"
-
-
-@dataclass
-class TestResult:
-    name: str
-    iteration: int
-    status: TestStatus
-    duration_seconds: float
-
-
-@dataclass
-class RunSummary:
-    run_timestamp: datetime.datetime
-    iterations: int
-    total_runs: int = 0
-    passed: int = 0
-    failed: int = 0
-    results: list[TestResult] = field(default_factory=list)
-
-    def record(self, name: str, iteration: int, status: TestStatus, duration: float) -> None:
-        self.results.append(TestResult(name=name, iteration=iteration, status=status, duration_seconds=round(duration, 3)))
-        if status == TestStatus.PASSED:
-            self.passed += 1
-        elif status == TestStatus.FAILED:
-            self.failed += 1
-
-    def write_json(self, path: Path) -> None:
-        data = asdict(self)
-        data["run_timestamp"] = self.run_timestamp.isoformat()
-        # Convert Enum to string for JSON serialization
-        for result in data["results"]:
-            result["status"] = result["status"].value
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(data, indent=2))
-        log.info("Test run summary written to %s", path)
 
 
 # TODO: When we update click to >= 8.2.0 we will be able to use the builtin `deprecated` argument for Option
@@ -546,28 +503,12 @@ def cmd_run(context: click.Context, dry_run: bool, iterations: int,
         raise click.BadOptionUsage("commissioning-method",
                                    f"Option --commissioning-method={commissioning_method} is available on Linux platform only")
 
+    run_summary = RunSummary(iterations)
     ble_controller_app = None
     ble_controller_tool = None
     thread_ba_host = None
     thread_ba_port = None
     to_terminate: list[Terminable] = []
-
-    run_summary = RunSummary(
-        run_timestamp=datetime.datetime.now(datetime.timezone.utc),
-        iterations=iterations,
-    )
-
-    def cleanup() -> None:
-        for item in reversed(to_terminate):
-            try:
-                log.info("Cleaning up %s", item.__class__.__name__)
-                item.terminate()
-            except Exception as e:
-                log.warning("Encountered exception during cleanup: %r", e)
-        to_terminate.clear()
-        if summary_file is not None:
-            run_summary.total_runs = len(run_summary.results)
-            run_summary.write_json(summary_file)
 
     try:
         if sys.platform == 'linux':
@@ -611,38 +552,25 @@ def cmd_run(context: click.Context, dry_run: bool, iterations: int,
         to_terminate.append(apps_register := AppsRegister())
         apps_register.init()
 
-        for i in range(iterations):
-            log.info("Starting iteration %d", i+1)
+        for i in range(1, iterations + 1):
+            log.info("Starting iteration %d", i)
             observed_failures = 0
             for test in context.obj.tests:
-                test_start = time.monotonic()
                 try:
-                    if dry_run:
-                        log.info("Would run test: '%s'", test.name)
-                    else:
-                        log.info("%-20s - Starting test", test.name)
-                    test.Run(
-                        runner, apps_register, subproc_info_repo, pics_file,
-                        test_timeout_seconds, dry_run,
-                        test_runtime=context.obj.runtime,
-                        ble_controller_app=ble_controller_app,
-                        ble_controller_tool=ble_controller_tool,
-                        op_network='Thread' if thread_required else 'WiFi',
-                        thread_ba_host=thread_ba_host,
-                        thread_ba_port=thread_ba_port,
-                    )
-                    test_end = time.monotonic()
-                    if dry_run:
-                        run_summary.record(test.name, i + 1, TestStatus.DRY_RUN, test_end - test_start)
-                    else:
-                        log.info("%-30s - Completed in %0.2f seconds", test.name, test_end - test_start)
-                        run_summary.record(test.name, i + 1, TestStatus.PASSED, test_end - test_start)
+                    run_summary.record(result := TestResult.run_test(
+                        test.name, i, dry_run, lambda: test.Run(
+                            runner, apps_register, subproc_info_repo, pics_file,
+                            test_timeout_seconds, dry_run,
+                            test_runtime=context.obj.runtime,
+                            ble_controller_app=ble_controller_app,
+                            ble_controller_tool=ble_controller_tool,
+                            op_network='Thread' if thread_required else 'WiFi',
+                            thread_ba_host=thread_ba_host,
+                            thread_ba_port=thread_ba_port,
+                        )))
+                    if result.exception is not None:
+                        raise result.exception
                 except Exception:
-                    if os.path.exists('thread.pcap'):
-                        os.system("echo 'base64 -d - >thread.pcap <<EOF' && base64 thread.pcap && echo EOF")
-                    test_end = time.monotonic()
-                    log.exception("%-30s - FAILED in %0.2f seconds", test.name, test_end - test_start)
-                    run_summary.record(test.name, i + 1, TestStatus.FAILED, test_end - test_start)
                     observed_failures += 1
                     if not keep_going:
                         sys.exit(2)
@@ -658,7 +586,16 @@ def cmd_run(context: click.Context, dry_run: bool, iterations: int,
         log.error("Caught exception during test execution: %s", e, exc_info=True)
         raise
     finally:
-        cleanup()
+        for item in reversed(to_terminate):
+            try:
+                log.info("Cleaning up %s", item.__class__.__name__)
+                item.terminate()
+            except Exception as e:
+                log.warning("Encountered exception during cleanup: %r", e)
+
+        run_summary.print_summary(show_failed=True, show_flaky=False, top_slowest=0, show_all=True)
+        if summary_file is not None:
+            run_summary.write_json(summary_file)
 
 
 @main.command(
@@ -667,78 +604,20 @@ def cmd_run(context: click.Context, dry_run: bool, iterations: int,
 @click.option(
     '--summary-file',
     required=True,
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    type=ExistingFilePath,
     help='Path to the JSON summary file to display.')
 @click.option(
     '--top-slowest',
     default=20,
     show_default=True,
-    type=click.IntRange(min=1),
-    help='Number of slowest tests to include in the timing table.')
-def cmd_summarize(summary_file: Path, top_slowest: int) -> None:
-    raw = json.loads(summary_file.read_text())
-    results: list[dict] = raw.get("results", [])
-
-    passed = raw.get("passed", 0)
-    failed = raw.get("failed", 0)
-    total = raw.get("total_runs", len(results))
-    iterations = raw.get("iterations", 1)
-    ts = raw.get("run_timestamp", "unknown")
-
-    sep = "=" * 72
-
-    print(sep)
-    print("  TEST RUN SUMMARY")
-    print(sep)
-    print(f"  Run timestamp : {ts}")
-    print(f"  Iterations    : {iterations}")
-    print(f"  Total runs    : {total}")
-    print(f"  Passed        : {passed}")
-    print(f"  Failed        : {failed}")
-    if total:
-        print(f"  Pass rate     : {100 * passed / total:.1f}%")
-    print(sep)
-
-    failed_results = [r for r in results if r["status"] == TestStatus.FAILED.value]
-    if failed_results:
-        print(f"\n  FAILED TESTS ({len(failed_results)}):")
-        print(f"  {'Test name':<50} {'Iter':>4}  {'Duration':>10}")
-        print("  " + "-" * 68)
-        for r in sorted(failed_results, key=lambda x: x["name"]):
-            print(f"  {'✗  ' + r['name']:<50} {r['iteration']:>4}  {r['duration_seconds']:>9.2f}s")
-    else:
-        print("\n  No failures recorded.")
-
-    if iterations > 1:
-        fail_counts: Counter = Counter()
-        run_counts: Counter = Counter()
-        for r in results:
-            run_counts[r["name"]] += 1
-            if r["status"] == TestStatus.FAILED.value:
-                fail_counts[r["name"]] += 1
-        flaky = [(name, fail_counts[name], run_counts[name]) for name in fail_counts if fail_counts[name] > 0]
-        if flaky:
-            print(f"\n  FAILURE RATE BY TEST (across {iterations} iterations):")
-            print(f"  {'Test name':<50} {'Failures':>8}  {'Rate':>8}")
-            print("  " + "-" * 70)
-            for name, fails, runs in sorted(flaky, key=lambda x: -x[1]):
-                rate = 100 * fails / runs
-                print(f"  {name:<50} {fails:>5}/{runs:<2}  {rate:>7.1f}%")
-
-    slowest = sorted(
-        [r for r in results if r["status"] != TestStatus.DRY_RUN.value],
-        key=lambda x: -x["duration_seconds"]
-    )[:top_slowest]
-
-    if slowest:
-        print(f"\n  SLOWEST {top_slowest} TEST RUNS:")
-        print(f"  {'Test name':<50} {'Status':<8} {'Iter':>4}  {'Duration':>10}")
-        print("  " + "-" * 76)
-        for r in slowest:
-            mark = "✓" if r["status"] == TestStatus.PASSED.value else "✗"
-            print(f"  {mark + '  ' + r['name']:<50} {r['status']:<8} {r['iteration']:>4}  {r['duration_seconds']:>9.2f}s")
-
-    print(sep)
+    type=click.IntRange(min=-1),
+    help='Number of slowest tests to include in the timing table. Disable with 0 and show all with -1.')
+@click.option(
+    '--show-all',
+    is_flag=True,
+    help='Show statistics of all tests for all iterations.')
+def cmd_summarize(summary_file: Path, top_slowest: int, show_all: bool) -> None:
+    RunSummary.from_json(summary_file).print_summary(top_slowest=top_slowest, show_all=show_all)
 
 
 # On Linux, allow an execution shell to be prepared


### PR DESCRIPTION
#### Summary

Improve the test summary stage in preparation for concurrent test execution.

- Move classes related to test results and summaries to a separate module.
- Explicitly create a test result while a test function is executing – this will make it easier in the future to handle results between concurrent workers and the result aggregator thread. This separation between creating `TestResult` and recording it in `RunSummary` might seem a bit forced for now, but it is crucial for future separation between pool-worker contexts, where the result will be sent back to the pool via a queue.
- Improve statistic creation, both global and per-test.
- Add `TestStatus.CANCELLED`, which is triggered on SIGINT. In the case of future concurrent test execution, it will be helpful to see which tests were executing on which runners when the cancel event arrived.
- Improve the readability of the summary printing logic.
- Print the run summary at the end of test execution.
- Calculate the average test execution time across all iterations.
- Move the `cleanup()` function in the test runner to the `finally` block. It was left over from #42261. Since it is executed only in `finally` it does not make sense to keep it separate from the execution context.
- Count iterations from 1 to prevent mistakes when showing them to the user. The iteration number is not used to index anything and is purely for user information.

#### Related issues

Part of the next batch of patches with the final goal of introducing concurrent test execution:

- https://github.com/project-chip/connectedhomeip/pull/43541
- https://github.com/project-chip/connectedhomeip/pull/43548

In the original concurrent test PoC I had a similar solution to test result aggregation, but since then upstream effort got merged (#43500). This PR builds on top of that while aligning the implementation to the concurrent test PoC.

In the follow up PR I'm planning to introduce a result processing thread.

#### Testing

Local tests with `run_test_suite.py`.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
