### PR TITLE
Add 1.5.1 and 1.6 to PICS Generator

### DIFF
--- a/src/tools/PICS-generator/PICSGenerator.py
+++ b/src/tools/PICS-generator/PICSGenerator.py
@@ -441,6 +441,10 @@ class DeviceMappingTest(MatterBaseTest):
                 xml_clusters, problems = build_xml_clusters(PrebuiltDataModelDirectory.k1_4_2)
             elif specVersion == 0x1050000:
                 xml_clusters, problems = build_xml_clusters(PrebuiltDataModelDirectory.k1_5)
+            elif specVersion == 0x1050100:
+                xml_clusters, problems = build_xml_clusters(PrebuiltDataModelDirectory.k1_5_1)
+            elif specVersion == 0x1060000:
+                xml_clusters, problems = build_xml_clusters(PrebuiltDataModelDirectory.k1_6)
             else:
                 console.print("FAILURE: Specification version reported by device not supported")
                 return


### PR DESCRIPTION
#### Summary

This PR adds auto detection of 1.5.1 and 1.6 to the PICS Generator

#### Testing

Validated to generate for devices claiming 1.5.1 and 1.6 in basic information

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
