### PR TITLE
[Telink] CNET-4-12 fix on non-concurrent mode

### DIFF
--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -279,3 +279,10 @@ endif
 config TFLM_FEATURE
 	bool "Enable the TFLM micro speech feature"
 	default n
+
+config CHIP_TELINK_OPENTHREAD_NETWORK_SWITCH_PATH
+	bool "Keep Thread enabled when switching between commissioned datasets"
+	help
+		Keep Thread enabled while switching between commissioned
+		datasets to reduce detached window during fail-safe rollback/connect.
+	default y

--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -279,10 +279,3 @@ endif
 config TFLM_FEATURE
 	bool "Enable the TFLM micro speech feature"
 	default n
-
-config CHIP_OPENTHREAD_NETWORK_SWITCH_PATH
-	bool "Keep Thread enabled when switching between commissioned datasets"
-	help
-		Keep Thread enabled while switching between commissioned
-		datasets to reduce detached window during fail-safe rollback/connect.
-	default y

--- a/config/telink/chip-module/Kconfig
+++ b/config/telink/chip-module/Kconfig
@@ -280,7 +280,7 @@ config TFLM_FEATURE
 	bool "Enable the TFLM micro speech feature"
 	default n
 
-config CHIP_TELINK_OPENTHREAD_NETWORK_SWITCH_PATH
+config CHIP_OPENTHREAD_NETWORK_SWITCH_PATH
 	bool "Keep Thread enabled when switching between commissioned datasets"
 	help
 		Keep Thread enabled while switching between commissioned

--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -364,6 +364,9 @@ config OPENTHREAD_IP6_MAX_EXT_MCAST_ADDRS
     default 2 if PM
     default 8
 
+config CHIP_OPENTHREAD_NETWORK_SWITCH_PATH
+    default y
+
 endif # NET_L2_OPENTHREAD
 
 config NET_TX_STACK_SIZE

--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -170,6 +170,13 @@ config CHIP_FACTORY_RESET_ERASE_NVS
 	  configuration is supposed to be cleared on a factory reset, including
 	  device-specific entries.
 
+config CHIP_OPENTHREAD_NETWORK_SWITCH_PATH
+	bool "Keep Thread enabled when switching between commissioned datasets"
+	default n
+	help
+		Keep Thread enabled while switching between commissioned
+		datasets to reduce detached window during fail-safe rollback/connect.
+
 module = MATTER
 module-str = Matter
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -648,14 +648,15 @@ NetworkCommissioningCluster::HandleConnectNetwork(CommandHandler & handler, cons
 
     mpWirelessDriver->ConnectNetwork(req.networkID, this);
 #else
+    mConnectNetworkResponseSentEarly = false;
     // In Non-concurrent mode postpone the final execution of ConnectNetwork until the operational
     // network has been fully brought up and kOperationalNetworkStarted is delivered.
-    // mConnectingNetworkIDLen and mConnectingNetworkID contain the received SSID.
-    //
+
     // For PASE/BLE requests, reply before tearing down the commissioning transport.
     // For CASE requests, keep the command open and reply from OnResult after attach finishes.
     if (IsConnectNetworkRequestOverPASE(handler))
     {
+        mConnectNetworkResponseSentEarly = true;
         SendNonConcurrentConnectNetworkResponse();
     }
     else
@@ -827,7 +828,7 @@ void NetworkCommissioningCluster::DisconnectLingeringConnection()
 void NetworkCommissioningCluster::OnResult(Status commissioningError, CharSpan debugText, int32_t interfaceStatus)
 {
     auto commandHandleRef = std::move(mAsyncCommandHandle);
-
+    auto commandHandle    = commandHandleRef.Get();
     // In Non-concurrent mode the commandHandle will be null here, the ConnectNetworkResponse
     // has already been sent and the BLE will have been stopped, however the other functionality
     // is still required
@@ -862,14 +863,23 @@ void NetworkCommissioningCluster::OnResult(Status commissioningError, CharSpan d
     SetLastNetworkId(ByteSpan{ mConnectingNetworkID, mConnectingNetworkIDLen });
     SetLastNetworkingStatusValue(MakeNullable(commissioningError));
 
+    bool shouldSendConnectNetworkResponse = true;
 #if (CONFIG_NETWORK_LAYER_BLE || CHIP_DEVICE_CONFIG_ENABLE_THREAD_MESHCOP) && !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
-    ChipLogProgress(NetworkProvisioning, "Non-concurrent mode, ConnectNetworkResponse will NOT be sent");
-    // Do not send the ConnectNetworkResponse if in non-concurrent mode
-    // TODO(#30576) raised to modify CommandHandler to notify it if no response required
-    // -----> Is this required here: commandHandle->FinishCommand();
-#else
+    if (mConnectNetworkResponseSentEarly)
+    {
+        ChipLogProgress(NetworkProvisioning, "Non-concurrent mode, ConnectNetworkResponse was already sent");
+        shouldSendConnectNetworkResponse = false;
+    }
+#endif
+
+    if (shouldSendConnectNetworkResponse && commandHandle != nullptr)
+    {
     commandHandle->AddResponse(mAsyncCommandPath, response);
-#endif // CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+    }
+
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+    mConnectNetworkResponseSentEarly = false;
+#endif
 
     if (commissioningError == Status::kSuccess)
     {
@@ -968,6 +978,10 @@ void NetworkCommissioningCluster::OnCommissioningComplete()
 void NetworkCommissioningCluster::OnFailSafeTimerExpired()
 {
     VerifyOrReturn(mpWirelessDriver != nullptr);
+
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+    mConnectNetworkResponseSentEarly = false;
+#endif
 
     ChipLogDetail(Zcl, "Failsafe timeout, tell platform driver to revert network credentials.");
     TEMPORARY_RETURN_IGNORED mpWirelessDriver->RevertConfiguration();

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -29,7 +29,6 @@
 #include <app/reporting/reporting.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <app/server-cluster/DefaultServerCluster.h>
-#include <app/server/Server.h>
 #include <clusters/NetworkCommissioning/AttributeIds.h>
 #include <clusters/NetworkCommissioning/CommandIds.h>
 #include <clusters/NetworkCommissioning/Commands.h>
@@ -653,13 +652,14 @@ NetworkCommissioningCluster::HandleConnectNetwork(CommandHandler & handler, cons
     mpWirelessDriver->ConnectNetwork(req.networkID, this);
 #else
     mConnectNetworkResponseSentEarly = false;
-    // In Non-concurrent mode postpone the final execution of ConnectNetwork until the operational
-    // network has been fully brought up and kOperationalNetworkStarted is delivered.
-
-    // For PASE/BLE requests, reply before tearing down the commissioning transport.
-    // For CASE requests, keep the command open and reply from OnResult after attach finishes.
+    // In non-concurrent mode there are two execution paths:
+    // 1) PASE/BLE: send ConnectNetworkResponse early before tearing down the commissioning
+    //    transport; actual connect is started later from OnPlatformEventHandler.
+    // 2) CASE: start connect immediately here and send ConnectNetworkResponse from OnResult
+    //    after attach finishes.
     if (IsConnectNetworkRequestOverPASE(handler))
     {
+        // PASE path must respond before commissioning transport is torn down.
         mConnectNetworkResponseSentEarly = true;
         SendNonConcurrentConnectNetworkResponse();
     }

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -27,9 +27,9 @@
 #include <app/clusters/network-commissioning/WifiScanResponse.h>
 #include <app/data-model/Nullable.h>
 #include <app/reporting/reporting.h>
-#include <app/server/Server.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <app/server-cluster/DefaultServerCluster.h>
+#include <app/server/Server.h>
 #include <clusters/NetworkCommissioning/AttributeIds.h>
 #include <clusters/NetworkCommissioning/CommandIds.h>
 #include <clusters/NetworkCommissioning/Commands.h>
@@ -50,8 +50,8 @@
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 #include <protocols/interaction_model/StatusCode.h>
-#include <transport/SecureSession.h>
 #include <tracing/macros.h>
+#include <transport/SecureSession.h>
 
 namespace chip {
 namespace app {
@@ -64,12 +64,16 @@ using namespace chip::app::Clusters::NetworkCommissioning;
 
 namespace {
 
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+
 bool IsConnectNetworkRequestOverPASE(CommandHandler & handler)
 {
     Messaging::ExchangeContext * exchangeCtx = handler.GetExchangeContext();
     return exchangeCtx && exchangeCtx->HasSessionHandle() && exchangeCtx->GetSessionHandle()->IsSecureSession() &&
         exchangeCtx->GetSessionHandle()->AsSecureSession()->GetSecureSessionType() == Transport::SecureSession::Type::kPASE;
 }
+
+#endif // CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
 
 // Note: CHIP_CONFIG_NETWORK_COMMISSIONING_DEBUG_TEXT_BUFFER_SIZE can be 0, this disables debug text
 using DebugTextStorage = std::array<char, CHIP_CONFIG_NETWORK_COMMISSIONING_DEBUG_TEXT_BUFFER_SIZE>;
@@ -833,7 +837,6 @@ void NetworkCommissioningCluster::OnResult(Status commissioningError, CharSpan d
     // has already been sent and the BLE will have been stopped, however the other functionality
     // is still required
 #if CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
-    auto commandHandle = commandHandleRef.Get();
     if (commandHandle == nullptr)
     {
         // When the platform shut down, interaction model engine will invalidate all commandHandle to avoid dangling references.
@@ -874,7 +877,7 @@ void NetworkCommissioningCluster::OnResult(Status commissioningError, CharSpan d
 
     if (shouldSendConnectNetworkResponse && commandHandle != nullptr)
     {
-    commandHandle->AddResponse(mAsyncCommandPath, response);
+        commandHandle->AddResponse(mAsyncCommandPath, response);
     }
 
 #if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -27,6 +27,7 @@
 #include <app/clusters/network-commissioning/WifiScanResponse.h>
 #include <app/data-model/Nullable.h>
 #include <app/reporting/reporting.h>
+#include <app/server/Server.h>
 #include <app/server-cluster/AttributeListBuilder.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <clusters/NetworkCommissioning/AttributeIds.h>
@@ -39,6 +40,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/AutoRelease.h>
+#include <lib/support/BytesToHex.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/SortUtils.h>
@@ -48,6 +50,7 @@
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 #include <protocols/interaction_model/StatusCode.h>
+#include <transport/SecureSession.h>
 #include <tracing/macros.h>
 
 namespace chip {
@@ -60,6 +63,13 @@ using namespace DeviceLayer::NetworkCommissioning;
 using namespace chip::app::Clusters::NetworkCommissioning;
 
 namespace {
+
+bool IsConnectNetworkRequestOverPASE(CommandHandler & handler)
+{
+    Messaging::ExchangeContext * exchangeCtx = handler.GetExchangeContext();
+    return exchangeCtx && exchangeCtx->HasSessionHandle() && exchangeCtx->GetSessionHandle()->IsSecureSession() &&
+        exchangeCtx->GetSessionHandle()->AsSecureSession()->GetSecureSessionType() == Transport::SecureSession::Type::kPASE;
+}
 
 // Note: CHIP_CONFIG_NETWORK_COMMISSIONING_DEBUG_TEXT_BUFFER_SIZE can be 0, this disables debug text
 using DebugTextStorage = std::array<char, CHIP_CONFIG_NETWORK_COMMISSIONING_DEBUG_TEXT_BUFFER_SIZE>;
@@ -640,9 +650,18 @@ NetworkCommissioningCluster::HandleConnectNetwork(CommandHandler & handler, cons
 #else
     // In Non-concurrent mode postpone the final execution of ConnectNetwork until the operational
     // network has been fully brought up and kOperationalNetworkStarted is delivered.
-    // mConnectingNetworkIDLen and mConnectingNetworkID contain the received SSID
-    // As per spec, send the ConnectNetworkResponse(Success) prior to releasing the commissioning channel
-    SendNonConcurrentConnectNetworkResponse();
+    // mConnectingNetworkIDLen and mConnectingNetworkID contain the received SSID.
+    //
+    // For PASE/BLE requests, reply before tearing down the commissioning transport.
+    // For CASE requests, keep the command open and reply from OnResult after attach finishes.
+    if (IsConnectNetworkRequestOverPASE(handler))
+    {
+        SendNonConcurrentConnectNetworkResponse();
+    }
+    else
+    {
+        HandleNonConcurrentConnectNetwork();
+    }
 #endif
     return std::nullopt;
 }
@@ -650,8 +669,26 @@ NetworkCommissioningCluster::HandleConnectNetwork(CommandHandler & handler, cons
 std::optional<ActionReturnStatus> NetworkCommissioningCluster::HandleNonConcurrentConnectNetwork()
 {
     ByteSpan nonConcurrentNetworkID = ByteSpan(mConnectingNetworkID, mConnectingNetworkIDLen);
-    ChipLogProgress(NetworkProvisioning, "Non-concurrent mode, Connect to Network SSID=%s",
-                    NullTerminated(mConnectingNetworkID, mConnectingNetworkIDLen).c_str());
+    if (mFeatureFlags.Has(Feature::kThreadNetworkInterface))
+    {
+        constexpr size_t kThreadNetworkIdHexMax = (2 * kMaxNetworkIDLen) + 1;
+        char threadNetworkIdHex[kThreadNetworkIdHexMax];
+        if (Encoding::BytesToUppercaseHexString(nonConcurrentNetworkID.data(), nonConcurrentNetworkID.size(), threadNetworkIdHex,
+                                                sizeof(threadNetworkIdHex)) == CHIP_NO_ERROR)
+        {
+            ChipLogProgress(NetworkProvisioning, "Non-concurrent mode, Connect to Thread Network ID=%s", threadNetworkIdHex);
+        }
+        else
+        {
+            ChipLogProgress(NetworkProvisioning, "Non-concurrent mode, Connect to Thread Network ID (len=%u)",
+                            static_cast<unsigned>(nonConcurrentNetworkID.size()));
+        }
+    }
+    else
+    {
+        ChipLogProgress(NetworkProvisioning, "Non-concurrent mode, Connect to Wi-Fi SSID=%s",
+                        NullTerminated(mConnectingNetworkID, mConnectingNetworkIDLen).c_str());
+    }
     mpWirelessDriver->ConnectNetwork(nonConcurrentNetworkID, this);
     return std::nullopt;
 }

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
@@ -241,6 +241,9 @@ private:
     Optional<uint64_t> mCurrentOperationBreadcrumb;
     bool mScanningWasDirected = false;
 #if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+    // Tracks whether ConnectNetworkResponse was already sent from HandleConnectNetwork()
+    // on the PASE/BLE path. OnResult() uses this to avoid sending a duplicate response
+    // after the attach callback, and the flag is reset at command start / fail-safe expiry.
     bool mConnectNetworkResponseSentEarly = false;
 #endif
     Context mClusterContext;

--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.h
@@ -240,6 +240,9 @@ private:
     uint8_t mLastNetworkIDLen = 0;
     Optional<uint64_t> mCurrentOperationBreadcrumb;
     bool mScanningWasDirected = false;
+#if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+    bool mConnectNetworkResponseSentEarly = false;
+#endif
     Context mClusterContext;
 
     void SetLastNetworkingStatusValue(NetworkCommissioning::Attributes::LastNetworkingStatus::TypeInfo::Type networkingStatusValue);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -391,6 +391,17 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_AttachToThreadN
 
     // Reset the previously set callback since it will never be called in case incorrect dataset was supplied.
     mpConnectCallback = nullptr;
+
+#if CONFIG_CHIP_TELINK_OPENTHREAD_NETWORK_SWITCH_PATH
+if (callback == nullptr && dataset.IsCommissioned() && current_dataset.IsCommissioned() &&
+        !dataset.AsByteSpan().data_equal(current_dataset.AsByteSpan()) && Impl()->IsThreadEnabled())
+    {
+        ReturnErrorOnFailure(Impl()->SetThreadProvision(dataset.AsByteSpan()));
+        mpConnectCallback = callback;
+        return CHIP_NO_ERROR;
+    }
+#endif
+
     ReturnErrorOnFailure(Impl()->SetThreadEnabled(false));
     ReturnErrorOnFailure(Impl()->SetThreadProvision(dataset.AsByteSpan()));
 

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -397,7 +397,6 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_AttachToThreadN
         !dataset.AsByteSpan().data_equal(current_dataset.AsByteSpan()) && Impl()->IsThreadEnabled())
     {
         ReturnErrorOnFailure(Impl()->SetThreadProvision(dataset.AsByteSpan()));
-        mpConnectCallback = callback;
         return CHIP_NO_ERROR;
     }
 #endif

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -392,8 +392,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_AttachToThreadN
     // Reset the previously set callback since it will never be called in case incorrect dataset was supplied.
     mpConnectCallback = nullptr;
 
-#if CONFIG_CHIP_TELINK_OPENTHREAD_NETWORK_SWITCH_PATH
-if (callback == nullptr && dataset.IsCommissioned() && current_dataset.IsCommissioned() &&
+#if defined(CONFIG_CHIP_OPENTHREAD_NETWORK_SWITCH_PATH) && CONFIG_CHIP_OPENTHREAD_NETWORK_SWITCH_PATH
+    if (callback == nullptr && dataset.IsCommissioned() && current_dataset.IsCommissioned() &&
         !dataset.AsByteSpan().data_equal(current_dataset.AsByteSpan()) && Impl()->IsThreadEnabled())
     {
         ReturnErrorOnFailure(Impl()->SetThreadProvision(dataset.AsByteSpan()));


### PR DESCRIPTION
#### Summary

Since https://github.com/project-chip/connectedhomeip/pull/41702 has been introduced we've migrated our platform to using non-concurrent. But CNET-4.12 has been failing on step 8 and later after little fix on our platform side it got stuck on 12th, as well as Nordic does, for comparison.

NetworkCommissioningCluster.cpp handles ble-thread transition fine but as far as I understand there's no thread-thread path, as we need it in this test case.
And I've investigated response was missing for that "being in 1st thread network attach to 2nd network" step so `networkcommissioning connect-network` command would finish properly and DUT could attach indeed. It did sent response in step 7 but actually in never communicated on 2nd network in further steps.

#### Changes overview

`ConnectNetwork` response is now transport-aware (PASE vs CASE) in `NetworkCommissioningCluster.cpp`. Previously non-concurrent flow assumed response was already sent and could skip sending in cases where it was actually still required.
Now:
- If request comes over PASE(BLE), response is sent early (before tearing down commissioning transport).
- If request comes over CASE(Thread in this case), response is sent later from `OnResult()` after attach completes.

This way it avoids “missing response / timeout” behavior when the command is issued over CASE.


Added explicit state tracking for early response in `NetworkCommissioningCluster` with new flag `mConnectNetworkResponseSentEarly`. So it prevents double responses and ensures exactly one valid `ConnectNetworkResponse` is emitted.


Added Telink-only fast dataset switch path in OpenThread attach. When enabled, and only for thread-to-thread switch with no callback path(not as for ble-thread), code updates dataset without full Thread disable/enable cycle.
This way it reduces detached window during rollback/switch, improving chances to keep command/session flow stable in non-concurrent mode.

Improved connect logging for Thread, Thread path now logs Extended PAN ID (hex) instead of SSID-style text.
So Thread network ID diagnostics become accurate and easier to correlate with datasets.

#### Related issues
https://github.com/project-chip/connectedhomeip/issues/40370
https://github.com/project-chip/connectedhomeip/pull/40629
https://github.com/project-chip/matter-test-scripts/issues/583

Hi @emessina-max , I just wanted to reach you out to inform I'd like to apply changes amongst those you did earlier in https://github.com/project-chip/connectedhomeip/pull/41702.
Maybe you could give some advice on what I'm trying to do here (if you have time of course)?

#### Testing

- Builds verified by GitHub CI
- Tested with TH on B92 on `src/python_testing/TC_CNET_4_12.py` having two OTBR (RPI based) with separate networks, as test prerequisites demand