### PR TITLE
[Silabs] Add Changes to fix issue with using  EFR32 BLE instead siwx BLE

### DIFF
--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -126,8 +126,14 @@ CHIP_ERROR BLEManagerImpl::_Init()
     // SW timer for BLE timeouts and interval change.
     sbleAdvTimeoutTimer = osTimerNew(BleAdvTimeoutHandler, osTimerOnce, NULL, NULL);
 
+    // Preserve kSiLabsBLEStackInitialize so a boot event that set it before _Init() (e.g. from HandleBootEvent) is not lost.
+    bool hadBleStackInit = mFlags.Has(Flags::kSiLabsBLEStackInitialize);
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
+    if (hadBleStackInit)
+    {
+        mFlags.Set(Flags::kSiLabsBLEStackInitialize);
+    }
 
     // Check that an address was not already configured at boot.
     // This covers the init-shutdown-init case to comply with the BLE address change at boot only requirement

--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -130,10 +130,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     bool hadBleStackInit = mFlags.Has(Flags::kSiLabsBLEStackInitialize);
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
-    if (hadBleStackInit)
-    {
-        mFlags.Set(Flags::kSiLabsBLEStackInitialize);
-    }
+    mFlags.Set(Flags::kSiLabsBLEStackInitialize, hadBleStackInit);
 
     // Check that an address was not already configured at boot.
     // This covers the init-shutdown-init case to comply with the BLE address change at boot only requirement

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -143,7 +143,7 @@ const sl_wifi_device_configuration_t config = {
                                                 | SL_SI91X_TCP_IP_FEAT_DHCPV6_CLIENT | SL_SI91X_TCP_IP_FEAT_IPV6
 #endif
                                                 | SL_SI91X_TCP_IP_FEAT_ICMP | SL_SI91X_TCP_IP_FEAT_EXTENSION_VALID),
-                     .custom_feature_bit_map = (SL_SI91X_CUSTOM_FEAT_EXTENTION_VALID | RSI_CUSTOM_FEATURE_BIT_MAP),
+                     .custom_feature_bit_map     = (SL_SI91X_CUSTOM_FEAT_EXTENTION_VALID | RSI_CUSTOM_FEATURE_BIT_MAP),
                      .ext_custom_feature_bit_map = (RSI_EXT_CUSTOM_FEATURE_BIT_MAP
 #if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                                                     | (SL_SI91X_EXT_FEAT_BT_CUSTOM_FEAT_ENABLE)

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -143,7 +143,7 @@ const sl_wifi_device_configuration_t config = {
                                                 | SL_SI91X_TCP_IP_FEAT_DHCPV6_CLIENT | SL_SI91X_TCP_IP_FEAT_IPV6
 #endif
                                                 | SL_SI91X_TCP_IP_FEAT_ICMP | SL_SI91X_TCP_IP_FEAT_EXTENSION_VALID),
-                     .custom_feature_bit_map     = (SL_SI91X_CUSTOM_FEAT_EXTENTION_VALID | RSI_CUSTOM_FEATURE_BIT_MAP),
+                     .custom_feature_bit_map = (SL_SI91X_CUSTOM_FEAT_EXTENTION_VALID | RSI_CUSTOM_FEATURE_BIT_MAP),
 #if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                      .ext_custom_feature_bit_map = (RSI_EXT_CUSTOM_FEATURE_BIT_MAP | (SL_SI91X_EXT_FEAT_BT_CUSTOM_FEAT_ENABLE)
 #else
@@ -201,8 +201,8 @@ const sl_wifi_device_configuration_t config = {
 #endif
                                                  ),
 #else
-                     .ble_feature_bit_map    = 0,
-                     .ble_ext_feature_bit_map = 0,
+                     .ble_feature_bit_map        = 0,
+                     .ble_ext_feature_bit_map    = 0,
 #endif
                      .config_feature_bit_map = (SL_SI91X_FEAT_SLEEP_GPIO_SEL_BITMAP | RSI_CONFIG_FEATURE_BITMAP) }
 };

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -144,10 +144,9 @@ const sl_wifi_device_configuration_t config = {
 #endif
                                                 | SL_SI91X_TCP_IP_FEAT_ICMP | SL_SI91X_TCP_IP_FEAT_EXTENSION_VALID),
                      .custom_feature_bit_map = (SL_SI91X_CUSTOM_FEAT_EXTENTION_VALID | RSI_CUSTOM_FEATURE_BIT_MAP),
-#if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
-                     .ext_custom_feature_bit_map = (RSI_EXT_CUSTOM_FEATURE_BIT_MAP | (SL_SI91X_EXT_FEAT_BT_CUSTOM_FEAT_ENABLE)
-#else
                      .ext_custom_feature_bit_map = (RSI_EXT_CUSTOM_FEATURE_BIT_MAP
+#if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
+                                                    | (SL_SI91X_EXT_FEAT_BT_CUSTOM_FEAT_ENABLE)
 #endif
 #if (defined A2DP_POWER_SAVE_ENABLE)
                                                     | SL_SI91X_EXT_FEAT_XTAL_CLK_ENABLE(2)

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -125,7 +125,11 @@ const sl_wifi_device_configuration_t config = {
         IGNORE_REGION,
 #endif
     .boot_config = { .oper_mode = SL_SI91X_CLIENT_MODE,
+#if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                      .coex_mode = SL_SI91X_WLAN_BLE_MODE,
+#else
+                     .coex_mode = 0, // WLAN-only when BLE disabled (e.g. BLE on EFR32 host)
+#endif
                      .feature_bit_map =
 #ifdef SLI_SI91X_MCU_INTERFACE
                          (SL_SI91X_FEAT_SECURITY_OPEN | SL_SI91X_FEAT_WPS_DISABLE),
@@ -140,22 +144,31 @@ const sl_wifi_device_configuration_t config = {
 #endif
                                                 | SL_SI91X_TCP_IP_FEAT_ICMP | SL_SI91X_TCP_IP_FEAT_EXTENSION_VALID),
                      .custom_feature_bit_map     = (SL_SI91X_CUSTOM_FEAT_EXTENTION_VALID | RSI_CUSTOM_FEATURE_BIT_MAP),
+#if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                      .ext_custom_feature_bit_map = (RSI_EXT_CUSTOM_FEATURE_BIT_MAP | (SL_SI91X_EXT_FEAT_BT_CUSTOM_FEAT_ENABLE)
+#else
+                     .ext_custom_feature_bit_map = (RSI_EXT_CUSTOM_FEATURE_BIT_MAP
+#endif
 #if (defined A2DP_POWER_SAVE_ENABLE)
                                                     | SL_SI91X_EXT_FEAT_XTAL_CLK_ENABLE(2)
-#endif
+#endif // A2DP_POWER_SAVE_ENABLE
                                                         ),
+#if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                      .bt_feature_bit_map = (RSI_BT_FEATURE_BITMAP
 #if (RSI_BT_GATT_ON_CLASSIC)
                                             | SL_SI91X_BT_ATT_OVER_CLASSIC_ACL /* to support att over classic acl link */
-#endif
+#endif                                                                         // RSI_BT_GATT_ON_CLASSIC
                                             ),
+#else
+                     .bt_feature_bit_map         = 0,
+#endif
 #ifdef RSI_PROCESS_MAX_RX_DATA
                      .ext_tcp_ip_feature_bit_map =
                          (RSI_EXT_TCPIP_FEATURE_BITMAP | SL_SI91X_CONFIG_FEAT_EXTENTION_VALID | SL_SI91X_EXT_TCP_MAX_RECV_LENGTH),
 #else
                      .ext_tcp_ip_feature_bit_map = (RSI_EXT_TCPIP_FEATURE_BITMAP | SL_SI91X_CONFIG_FEAT_EXTENTION_VALID),
 #endif
+#if defined(SLI_SI91X_ENABLE_BLE) && SLI_SI91X_ENABLE_BLE
                      //! ENABLE_BLE_PROTOCOL in bt_feature_bit_map
                      .ble_feature_bit_map =
                          ((SL_SI91X_BLE_MAX_NBR_PERIPHERALS(RSI_BLE_MAX_NBR_PERIPHERALS) |
@@ -187,6 +200,10 @@ const sl_wifi_device_configuration_t config = {
                                                  | SL_SI91X_BLE_GATT_INIT
 #endif
                                                  ),
+#else
+                     .ble_feature_bit_map    = 0,
+                     .ble_ext_feature_bit_map = 0,
+#endif
                      .config_feature_bit_map = (SL_SI91X_FEAT_SLEEP_GPIO_SEL_BITMAP | RSI_CONFIG_FEATURE_BITMAP) }
 };
 


### PR DESCRIPTION
#### Summary

This change makes the stack behave correctly when BLE runs on the EFR32 host instead of on the Si91x: the Si91x is configured as WLAN-only and BLE init state set before _Init() is no longer wiped in BLEManagerImpl.

Changes
1. src/platform/silabs/efr32/BLEManagerImpl.cpp
Problem: _Init() did mFlags.ClearAll() and then set defaults, so kSiLabsBLEStackInitialize was lost if something (e.g. HandleBootEvent) had already set it before _Init(). in 917 NCP , when we are using BLE on host, we see the HandleBootEvent is triggered before __Init().

Fix: Save kSiLabsBLEStackInitialize before clear, then restore it after re-applying the default flags so boot-order doesn’t break BLE stack initialization.

2. src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp

Problem: WiFi device config always used WLAN+BLE coexistence and BLE feature bitmaps, which is wrong when BLE is disabled on Si91x (BLE on EFR32 only).

Fix: Gate Si91x BLE-related fields on SLI_SI91X_ENABLE_BLE:
coex_mode: SL_SI91X_WLAN_BLE_MODE when BLE on Si91x is enabled; 0 when disabled (WLAN-only / BLE on EFR32).
ext_custom_feature_bit_map: Omit SL_SI91X_EXT_FEAT_BT_CUSTOM_FEAT_ENABLE when BLE is disabled.
bt_feature_bit_map / ble_feature_bit_map / ble_ext_feature_bit_map: Set to 0 when BLE is disabled so the 917 NCP isn’t configured for BLE it doesn’t use.


#### Related issues

N/A

#### Testing

Succesful Build  with 
1) sl_matter_enable_siwx_ble = false arg and completed ble commissioning using Efr32 BLE + si91x WLAN only
2)  sl_matter_enable_siwx_ble = true arg and completed ble commissioning using  si91x WLAN+BLE 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
