### PR TITLE
[Camera] Fix TC_WEBRTC_1_6 failure on not finding any WebRTC session to close

### DIFF
--- a/src/python_testing/TC_WEBRTC_1_6.py
+++ b/src/python_testing/TC_WEBRTC_1_6.py
@@ -226,11 +226,11 @@ class TC_WEBRTC_1_6(MatterBaseTest, WebRTCTestHelper):
                 payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
             )
         except InteractionModelError as e:
-            # Since on closing the browser popup, the PC state changes to Disonnected/Closed.
+            # Since on closing the browser popup, the PC state changes to Disconnected/Closed.
             # Some implementations can remove session from CurrentSessions on connection state
             # switching to Disconnected/Closed. Hence ignore NotFound status response.
-            if (e.status == Status.NotFound):
-                pass
+            if (e.status != Status.NotFound):
+                raise
 
         if dut_has_vdo_feature:
             self.step(10)

--- a/src/python_testing/TC_WEBRTC_1_6.py
+++ b/src/python_testing/TC_WEBRTC_1_6.py
@@ -23,6 +23,7 @@ from test_plan_support import commission_if_required
 from matter.ChipDeviceCtrl import TransportPayloadCapability
 from matter.clusters import CameraAvStreamManagement, Objects, WebRTCTransportProvider
 from matter.clusters.Types import NullValue
+from matter.interaction_model import InteractionModelError, Status
 from matter.testing.decorators import has_feature, run_if_endpoint_matches
 from matter.testing.matter_testing import MatterBaseTest
 from matter.testing.runner import TestStep, default_matter_test_main
@@ -216,13 +217,20 @@ class TC_WEBRTC_1_6(MatterBaseTest, WebRTCTestHelper):
             self.user_verify_two_way_talk("Verify if two way talk back is working")
 
         self.step(9)
-        await self.send_single_cmd(
-            cmd=WebRTCTransportProvider.Commands.EndSession(
-                webRTCSessionID=session_id, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup
-            ),
-            endpoint=endpoint,
-            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
-        )
+        try:
+            await self.send_single_cmd(
+                cmd=WebRTCTransportProvider.Commands.EndSession(
+                    webRTCSessionID=session_id, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup
+                ),
+                endpoint=endpoint,
+                payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+            )
+        except InteractionModelError as e:
+            # Since on closing the browser popup, the PC state changes to Disonnected/Closed.
+            # Some implementations can remove session from CurrentSessions on connection state
+            # switching to Disconnected/Closed. Hence ignore NotFound status response.
+            if (e.status == Status.NotFound):
+                pass
 
         if dut_has_vdo_feature:
             self.step(10)


### PR DESCRIPTION
### Summary
Issue: The test case fails with camera-app as EndSession is invoked at step 9.

Since the peer connection gets closed on closing the browser popup, some implementations can remove the session from CurrentSessions attribute on peer connection state switching to Closed/Disconnected. Hence TC_WEBRTC_1_6.py needs to be updated to ignore any NOT_FOUND status response for EndSession command at step 9.

Fixes: https://github.com/project-chip/certification-tool/issues/905

### Testing
Verified locally with Test Harness.