### PR TITLE
[BasicInformation] fetch data via a delegate

### DIFF
--- a/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
+++ b/examples/all-devices-app/all-devices-common/devices/root-node/RootNodeDevice.cpp
@@ -19,6 +19,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/InteractionModelEngine.h>
+#include <app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h>
 #include <app/clusters/groupcast/GroupcastCluster.h>
 #include <app/clusters/groupcast/GroupcastContext.h>
 #include <lib/support/CHIPMem.h>
@@ -48,14 +49,13 @@ CHIP_ERROR RootNodeDevice::Register(EndpointId endpointId, CodeDrivenDataModelPr
             .Set<BasicInformation::Attributes::LocalConfigDisabled::Id>()
             .Set<BasicInformation::Attributes::Reachable::Id>();
 
-    mBasicInformationCluster.Create(
-        optionalAttributeSet,
-        BasicInformationCluster::Context{
-            .deviceInstanceInfoProvider = mContext.deviceInstanceInfoProvider,
-            .configurationManager       = mContext.configurationManager,
-            .platformManager            = mContext.platformManager,
-            .subscriptionsPerFabric     = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric(),
-        });
+    static chip::app::Clusters::BasicInformation::DeviceLayerBasicInformationDelegate delegate({
+        .deviceInstanceInfoProvider = mContext.deviceInstanceInfoProvider,
+        .configurationManager       = mContext.configurationManager,
+        .platformManager            = mContext.platformManager,
+        .subscriptionsPerFabric     = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric(),
+    });
+    mBasicInformationCluster.Create(optionalAttributeSet, &delegate, mContext.platformManager);
 
     ReturnErrorOnFailure(provider.AddCluster(mBasicInformationCluster.Registration()));
     mGeneralCommissioningCluster.Create(

--- a/src/app/clusters/basic-information/BUILD.gn
+++ b/src/app/clusters/basic-information/BUILD.gn
@@ -18,6 +18,9 @@ source_set("basic-information") {
   sources = [
     "BasicInformationCluster.cpp",
     "BasicInformationCluster.h",
+    "BasicInformationDelegate.h",
+    "DeviceLayerBasicInformationDelegate.cpp",
+    "DeviceLayerBasicInformationDelegate.h",
   ]
   public_deps = [
     "${chip_root}/src/app:constants",

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -100,7 +100,7 @@ CHIP_ERROR ReadStringAttribute(BasicInformation::BasicInformationDelegate * dele
 }
 
 inline CHIP_ERROR ReadNumericAttribute(BasicInformation::BasicInformationDelegate * delegate, AttributeId attributeId,
-                                     AttributeValueEncoder & aEncoder)
+                                       AttributeValueEncoder & aEncoder)
 {
     uint32_t value = 0;
     ReturnErrorOnFailure(delegate->GetNumericAttribute(attributeId, value));
@@ -117,22 +117,7 @@ inline CHIP_ERROR ReadLocalConfigDisabled(BasicInformation::BasicInformationDele
 inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, BasicInformation::BasicInformationDelegate * delegate)
 {
     BasicInformation::Structs::CapabilityMinimaStruct::Type capabilityMinima;
-
-    // TODO: These values must be set from something based on the SDK impl, but there are no such constants today.
-    constexpr uint16_t kMinCaseSessionsPerFabricMandatedBySpec = 3;
-
-    auto capabilityMinimasFromDeviceInfo = delegate->GetSupportedCapabilityMinimaValues();
-
-    capabilityMinima.caseSessionsPerFabric  = kMinCaseSessionsPerFabricMandatedBySpec;
-    capabilityMinima.subscriptionsPerFabric = delegate->GetSubscriptionsPerFabric();
-    capabilityMinima.simultaneousInvocationsSupported =
-        chip::MakeOptional<uint16_t>(capabilityMinimasFromDeviceInfo.simultaneousInvocationsSupported);
-    capabilityMinima.simultaneousWritesSupported =
-        chip::MakeOptional<uint16_t>(capabilityMinimasFromDeviceInfo.simultaneousWritesSupported);
-    capabilityMinima.readPathsSupported = chip::MakeOptional<uint16_t>(capabilityMinimasFromDeviceInfo.readPathsSupported);
-    capabilityMinima.subscribePathsSupported =
-        chip::MakeOptional<uint16_t>(capabilityMinimasFromDeviceInfo.subscribePathsSupported);
-
+    ReturnErrorOnFailure(delegate->GetCapabilityMinima(capabilityMinima));
     return aEncoder.Encode(capabilityMinima);
 }
 

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -94,7 +94,9 @@ CHIP_ERROR ReadStringAttribute(BasicInformation::BasicInformationDelegate * dele
     char buffer[kMaxStringLength + 1];
     MutableCharSpan span(buffer, sizeof(buffer));
     ReturnErrorOnFailure(delegate->GetStringAttribute(attributeId, span));
-    return encoder.Encode(span);
+
+    // explicit char span creation to not synthesize a writer for Span<char> on top of Span<const char>
+    return encoder.Encode(CharSpan{buffer, span.size()});
 }
 
 inline CHIP_ERROR ReadVendorID(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -99,18 +99,12 @@ CHIP_ERROR ReadStringAttribute(BasicInformation::BasicInformationDelegate * dele
     return encoder.Encode(CharSpan{ buffer, span.size() });
 }
 
-inline CHIP_ERROR ReadVendorID(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadNumericAttribute(BasicInformation::BasicInformationDelegate * delegate, AttributeId attributeId,
+                                     AttributeValueEncoder & aEncoder)
 {
-    uint16_t vendorId = 0;
-    ReturnErrorOnFailure(delegate->GetVendorId(vendorId));
-    return aEncoder.Encode(vendorId);
-}
-
-inline CHIP_ERROR ReadProductID(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
-{
-    uint16_t productId = 0;
-    ReturnErrorOnFailure(delegate->GetProductId(productId));
-    return aEncoder.Encode(productId);
+    uint32_t value = 0;
+    ReturnErrorOnFailure(delegate->GetNumericAttribute(attributeId, value));
+    return aEncoder.Encode(value);
 }
 
 inline CHIP_ERROR ReadLocalConfigDisabled(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
@@ -118,20 +112,6 @@ inline CHIP_ERROR ReadLocalConfigDisabled(BasicInformation::BasicInformationDele
     bool localConfigDisabled = false;
     ReturnErrorOnFailure(delegate->GetLocalConfigDisabled(localConfigDisabled));
     return aEncoder.Encode(localConfigDisabled);
-}
-
-inline CHIP_ERROR ReadHardwareVersion(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
-{
-    uint16_t hardwareVersion = 0;
-    ReturnErrorOnFailure(delegate->GetHardwareVersion(hardwareVersion));
-    return aEncoder.Encode(hardwareVersion);
-}
-
-inline CHIP_ERROR ReadSoftwareVersion(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
-{
-    uint32_t softwareVersion = 0;
-    ReturnErrorOnFailure(delegate->GetSoftwareVersion(softwareVersion));
-    return aEncoder.Encode(softwareVersion);
 }
 
 inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, BasicInformation::BasicInformationDelegate * delegate)
@@ -156,36 +136,10 @@ inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, BasicIn
     return aEncoder.Encode(capabilityMinima);
 }
 
-inline CHIP_ERROR ReadConfigurationVersion(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
-{
-    uint32_t configurationVersion = 0;
-    ReturnErrorOnFailure(delegate->GetConfigurationVersion(configurationVersion));
-    return aEncoder.Encode(configurationVersion);
-}
-
 inline CHIP_ERROR ReadProductAppearance(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
-    ProductFinishEnum finish;
-    ReturnErrorOnFailure(delegate->GetProductFinish(&finish));
-
-    ColorEnum color;
-    CHIP_ERROR colorStatus = delegate->GetProductPrimaryColor(&color);
-    if (colorStatus != CHIP_NO_ERROR && colorStatus != CHIP_ERROR_NOT_IMPLEMENTED)
-    {
-        return colorStatus;
-    }
-
     Structs::ProductAppearanceStruct::Type productAppearance;
-    productAppearance.finish = finish;
-    if (colorStatus == CHIP_NO_ERROR)
-    {
-        productAppearance.primaryColor.SetNonNull(color);
-    }
-    else
-    {
-        productAppearance.primaryColor.SetNull();
-    }
-
+    ReturnErrorOnFailure(delegate->GetProductAppearance(productAppearance));
     return aEncoder.Encode(productAppearance);
 }
 
@@ -221,17 +175,17 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
     case VendorName::Id:
         return ReadStringAttribute(mDelegate, VendorName::Id, encoder);
     case VendorID::Id:
-        return ReadVendorID(mDelegate, encoder);
+        return ReadNumericAttribute(mDelegate, VendorID::Id, encoder);
     case ProductName::Id:
         return ReadStringAttribute(mDelegate, ProductName::Id, encoder);
     case ProductID::Id:
-        return ReadProductID(mDelegate, encoder);
+        return ReadNumericAttribute(mDelegate, ProductID::Id, encoder);
     case HardwareVersion::Id:
-        return ReadHardwareVersion(mDelegate, encoder);
+        return ReadNumericAttribute(mDelegate, HardwareVersion::Id, encoder);
     case HardwareVersionString::Id:
         return ReadStringAttribute(mDelegate, HardwareVersionString::Id, encoder);
     case SoftwareVersion::Id:
-        return ReadSoftwareVersion(mDelegate, encoder);
+        return ReadNumericAttribute(mDelegate, SoftwareVersion::Id, encoder);
     case SoftwareVersionString::Id:
         return ReadStringAttribute(mDelegate, SoftwareVersionString::Id, encoder);
     case ManufacturingDate::Id:
@@ -255,7 +209,7 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
     case MaxPathsPerInvoke::Id:
         return encoder.Encode<uint16_t>(CHIP_CONFIG_MAX_PATHS_PER_INVOKE);
     case ConfigurationVersion::Id:
-        return ReadConfigurationVersion(mDelegate, encoder);
+        return ReadNumericAttribute(mDelegate, ConfigurationVersion::Id, encoder);
     case Reachable::Id:
         // On some platforms `true` is defined as a unsigned int and that gets
         // a ambigous TLVWriter::Put error. Hence the specialization.
@@ -274,7 +228,7 @@ DataModel::ActionReturnStatus BasicInformationCluster::WriteAttribute(const Data
 CHIP_ERROR BasicInformationCluster::IncreaseConfigurationVersion()
 {
     uint32_t globalConfig = 0;
-    ReturnErrorOnFailure(mDelegate->GetConfigurationVersion(globalConfig));
+    ReturnErrorOnFailure(mDelegate->GetNumericAttribute(Attributes::ConfigurationVersion::Id, globalConfig));
     ReturnErrorOnFailure(mDelegate->StoreConfigurationVersion(globalConfig + 1));
     NotifyAttributeChanged(ConfigurationVersion::Id);
     return CHIP_NO_ERROR;

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -134,46 +134,6 @@ inline CHIP_ERROR ReadSoftwareVersion(BasicInformation::BasicInformationDelegate
     return aEncoder.Encode(softwareVersion);
 }
 
-inline CHIP_ERROR ReadManufacturingDate(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
-{
-    constexpr size_t kMaxLen        = BasicInformation::Attributes::ManufacturingDate::TypeInfo::MaxLength();
-    constexpr size_t kMaxDateLength = 8; // YYYYMMDD
-    static_assert(kMaxLen > kMaxDateLength, "kMaxLen must be greater than kMaxDateLength");
-    char manufacturingDateString[kMaxLen + 1] = { 0 };
-    uint16_t manufacturingYear;
-    uint8_t manufacturingMonth;
-    uint8_t manufacturingDayOfMonth;
-    size_t totalManufacturingDateLen = 0;
-    MutableCharSpan vendorSuffixSpan(manufacturingDateString + kMaxDateLength, kMaxLen - kMaxDateLength);
-    CHIP_ERROR status = delegate->GetManufacturingDate(manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
-
-    // TODO: Remove defaulting once proper runtime defaulting of unimplemented factory data is done
-    if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
-    {
-        manufacturingYear       = 2020;
-        manufacturingMonth      = 1;
-        manufacturingDayOfMonth = 1;
-        vendorSuffixSpan.reduce_size(0);
-        status = CHIP_NO_ERROR;
-    }
-    ReturnErrorOnFailure(status);
-
-    // Format is YYYYMMDD
-    snprintf(manufacturingDateString, sizeof(manufacturingDateString), "%04u%02u%02u", manufacturingYear, manufacturingMonth,
-             manufacturingDayOfMonth);
-
-    totalManufacturingDateLen = kMaxDateLength;
-    status                    = delegate->GetManufacturingDateSuffix(vendorSuffixSpan);
-    if (status == CHIP_NO_ERROR)
-    {
-        totalManufacturingDateLen += vendorSuffixSpan.size();
-    }
-
-    VerifyOrDie(totalManufacturingDateLen <= kMaxLen);
-
-    return aEncoder.Encode(CharSpan(manufacturingDateString, totalManufacturingDateLen));
-}
-
 inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, BasicInformation::BasicInformationDelegate * delegate)
 {
     BasicInformation::Structs::CapabilityMinimaStruct::Type capabilityMinima;
@@ -275,7 +235,7 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
     case SoftwareVersionString::Id:
         return ReadStringAttribute(mDelegate, SoftwareVersionString::Id, encoder);
     case ManufacturingDate::Id:
-        return ReadManufacturingDate(mDelegate, encoder);
+        return ReadStringAttribute(mDelegate, ManufacturingDate::Id, encoder);
     case PartNumber::Id:
         return ReadStringAttribute(mDelegate, PartNumber::Id, encoder);
     case ProductURL::Id:

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -137,11 +137,13 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
 {
     using namespace BasicInformation::Attributes;
 
-    switch (request.path.mAttributeId)
+    enum class AttributeReadType { kString, kNumeric, kOther };
+    AttributeReadType readType = AttributeReadType::kOther;
+    const AttributeId attributeId = request.path.mAttributeId;
+
+    switch (attributeId)
     {
     case FeatureMap::Id:
-        // Explicit specialization: TLVWriter.Put has specialization for various types
-        // but fails for `0u` with `unsigned int &` being ambigous.
         return encoder.Encode<uint32_t>(0);
     case ClusterRevision::Id:
         if (!mEnabledOptionalAttributes.IsSet(UniqueID::Id))
@@ -155,36 +157,6 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
         return ReadLocalConfigDisabled(mDelegate, encoder);
     case DataModelRevision::Id:
         return encoder.Encode(Revision::kDataModelRevision);
-    case Location::Id:
-        return ReadStringAttribute(mDelegate, Location::Id, encoder);
-    case VendorName::Id:
-        return ReadStringAttribute(mDelegate, VendorName::Id, encoder);
-    case VendorID::Id:
-        return ReadNumericAttribute(mDelegate, VendorID::Id, encoder);
-    case ProductName::Id:
-        return ReadStringAttribute(mDelegate, ProductName::Id, encoder);
-    case ProductID::Id:
-        return ReadNumericAttribute(mDelegate, ProductID::Id, encoder);
-    case HardwareVersion::Id:
-        return ReadNumericAttribute(mDelegate, HardwareVersion::Id, encoder);
-    case HardwareVersionString::Id:
-        return ReadStringAttribute(mDelegate, HardwareVersionString::Id, encoder);
-    case SoftwareVersion::Id:
-        return ReadNumericAttribute(mDelegate, SoftwareVersion::Id, encoder);
-    case SoftwareVersionString::Id:
-        return ReadStringAttribute(mDelegate, SoftwareVersionString::Id, encoder);
-    case ManufacturingDate::Id:
-        return ReadStringAttribute(mDelegate, ManufacturingDate::Id, encoder);
-    case PartNumber::Id:
-        return ReadStringAttribute(mDelegate, PartNumber::Id, encoder);
-    case ProductURL::Id:
-        return ReadStringAttribute(mDelegate, ProductURL::Id, encoder);
-    case ProductLabel::Id:
-        return ReadStringAttribute(mDelegate, ProductLabel::Id, encoder);
-    case SerialNumber::Id:
-        return ReadStringAttribute(mDelegate, SerialNumber::Id, encoder);
-    case UniqueID::Id:
-        return ReadStringAttribute(mDelegate, UniqueID::Id, encoder);
     case CapabilityMinima::Id:
         return ReadCapabilityMinima(encoder, mDelegate);
     case ProductAppearance::Id:
@@ -193,15 +165,49 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
         return encoder.Encode(Revision::kSpecificationVersion);
     case MaxPathsPerInvoke::Id:
         return encoder.Encode<uint16_t>(CHIP_CONFIG_MAX_PATHS_PER_INVOKE);
-    case ConfigurationVersion::Id:
-        return ReadNumericAttribute(mDelegate, ConfigurationVersion::Id, encoder);
     case Reachable::Id:
-        // On some platforms `true` is defined as a unsigned int and that gets
-        // a ambigous TLVWriter::Put error. Hence the specialization.
         return encoder.Encode<bool>(true);
+
+    // String Attributes
+    case Location::Id:
+    case VendorName::Id:
+    case ProductName::Id:
+    case HardwareVersionString::Id:
+    case SoftwareVersionString::Id:
+    case ManufacturingDate::Id:
+    case PartNumber::Id:
+    case ProductURL::Id:
+    case ProductLabel::Id:
+    case SerialNumber::Id:
+    case UniqueID::Id:
+        readType = AttributeReadType::kString;
+        break;
+
+    // Numeric Attributes
+    case VendorID::Id:
+    case ProductID::Id:
+    case HardwareVersion::Id:
+    case SoftwareVersion::Id:
+    case ConfigurationVersion::Id:
+        readType = AttributeReadType::kNumeric;
+        break;
+
     default:
         return Protocols::InteractionModel::Status::UnsupportedAttribute;
     }
+
+    if (readType == AttributeReadType::kString)
+    {
+        return ReadStringAttribute(mDelegate, attributeId, encoder);
+    }
+
+    if (readType == AttributeReadType::kNumeric)
+    {
+        return ReadNumericAttribute(mDelegate, attributeId, encoder);
+    }
+
+    // Should not be reached if kOther is not set for any fallthrough cases
+    return Protocols::InteractionModel::Status::UnsupportedAttribute;
 }
 
 DataModel::ActionReturnStatus BasicInformationCluster::WriteAttribute(const DataModel::WriteAttributeRequest & request,

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 #include <app/clusters/basic-information/BasicInformationCluster.h>
+#include <app/clusters/basic-information/BasicInformationDelegate.h>
 
 #include <app/SpecificationDefinedRevisions.h>
 #include <app/persistence/AttributePersistence.h>
@@ -30,8 +31,9 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
-#include <platform/DeviceInstanceInfoProvider.h>
+#include <platform/ConfigurationManager.h>
 #include <platform/PlatformManager.h>
+#include <platform/CHIPDeviceError.h>
 #include <protocols/interaction_model/StatusCode.h>
 #include <tracing/macros.h>
 
@@ -74,8 +76,7 @@ constexpr DataModel::AttributeEntry kMandatoryAttributes[] = {
 };
 
 constexpr size_t kExpectedFixedLocationLength = 2;
-static_assert(kExpectedFixedLocationLength == DeviceLayer::ConfigurationManager::kMaxLocationLength,
-              "Fixed location storage must be of size 2");
+
 
 CHIP_ERROR ClearNullTerminatedStringWhenUnimplemented(CHIP_ERROR status, char * strBuf)
 {
@@ -107,12 +108,12 @@ constexpr size_t kMaxStringLength = std::max({
 
 /// Reads a single device info string. Separate function to optimize for flash cost
 /// as querying strings seems to be a frequent operation.
-CHIP_ERROR ReadConfigurationString(DeviceInstanceInfoProvider & deviceInfoProvider,
-                                   CHIP_ERROR (DeviceInstanceInfoProvider::*getter)(char *, size_t), bool unimplementedAllowed,
+CHIP_ERROR ReadConfigurationString(BasicInformation::BasicInformationDelegate * delegate,
+                                   CHIP_ERROR (BasicInformation::BasicInformationDelegate::*getter)(char *, size_t), bool unimplementedAllowed,
                                    AttributeValueEncoder & encoder)
 {
     char buffer[kMaxStringLength + 1] = { 0 };
-    CHIP_ERROR status                 = ((deviceInfoProvider).*(getter))(buffer, sizeof(buffer));
+    CHIP_ERROR status                 = ((delegate)->*(getter))(buffer, sizeof(buffer));
     if (unimplementedAllowed)
     {
         status = ClearNullTerminatedStringWhenUnimplemented(status, buffer);
@@ -120,52 +121,52 @@ CHIP_ERROR ReadConfigurationString(DeviceInstanceInfoProvider & deviceInfoProvid
     return EncodeStringOnSuccess(status, encoder, buffer, kMaxStringLength);
 }
 
-inline CHIP_ERROR ReadVendorID(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadVendorID(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
     uint16_t vendorId = 0;
-    ReturnErrorOnFailure(deviceInfoProvider.GetVendorId(vendorId));
+    ReturnErrorOnFailure(delegate->GetVendorId(vendorId));
     return aEncoder.Encode(vendorId);
 }
 
-inline CHIP_ERROR ReadProductID(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadProductID(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
     uint16_t productId = 0;
-    ReturnErrorOnFailure(deviceInfoProvider.GetProductId(productId));
+    ReturnErrorOnFailure(delegate->GetProductId(productId));
     return aEncoder.Encode(productId);
 }
 
-inline CHIP_ERROR ReadLocalConfigDisabled(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadLocalConfigDisabled(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
     bool localConfigDisabled = false;
-    ReturnErrorOnFailure(deviceInfoProvider.GetLocalConfigDisabled(localConfigDisabled));
+    ReturnErrorOnFailure(delegate->GetLocalConfigDisabled(localConfigDisabled));
     return aEncoder.Encode(localConfigDisabled);
 }
 
-inline CHIP_ERROR ReadHardwareVersion(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadHardwareVersion(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
     uint16_t hardwareVersion = 0;
-    ReturnErrorOnFailure(deviceInfoProvider.GetHardwareVersion(hardwareVersion));
+    ReturnErrorOnFailure(delegate->GetHardwareVersion(hardwareVersion));
     return aEncoder.Encode(hardwareVersion);
 }
 
-inline CHIP_ERROR ReadSoftwareVersion(DeviceLayer::ConfigurationManager & configManager, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadSoftwareVersion(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
     uint32_t softwareVersion = 0;
-    ReturnErrorOnFailure(configManager.GetSoftwareVersion(softwareVersion));
+    ReturnErrorOnFailure(delegate->GetSoftwareVersion(softwareVersion));
     return aEncoder.Encode(softwareVersion);
 }
 
-inline CHIP_ERROR ReadSoftwareVersionString(DeviceLayer::ConfigurationManager & configManager, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadSoftwareVersionString(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
-    constexpr size_t kMaxLen                = DeviceLayer::ConfigurationManager::kMaxSoftwareVersionStringLength;
+    constexpr size_t kMaxLen                = BasicInformation::Attributes::SoftwareVersionString::TypeInfo::MaxLength();
     char softwareVersionString[kMaxLen + 1] = { 0 };
-    ReturnErrorOnFailure(configManager.GetSoftwareVersionString(softwareVersionString, sizeof(softwareVersionString)));
+    ReturnErrorOnFailure(delegate->GetSoftwareVersionString(softwareVersionString, sizeof(softwareVersionString)));
     return aEncoder.Encode(CharSpan(softwareVersionString, strnlen(softwareVersionString, kMaxLen)));
 }
 
-inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadManufacturingDate(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
-    constexpr size_t kMaxLen        = DeviceLayer::ConfigurationManager::kMaxManufacturingDateLength;
+    constexpr size_t kMaxLen        = BasicInformation::Attributes::ManufacturingDate::TypeInfo::MaxLength();
     constexpr size_t kMaxDateLength = 8; // YYYYMMDD
     static_assert(kMaxLen > kMaxDateLength, "kMaxLen must be greater than kMaxDateLength");
     char manufacturingDateString[kMaxLen + 1] = { 0 };
@@ -173,8 +174,8 @@ inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider & deviceInfoP
     uint8_t manufacturingMonth;
     uint8_t manufacturingDayOfMonth;
     size_t totalManufacturingDateLen = 0;
-    MutableCharSpan vendorSuffixSpan(manufacturingDateString + kMaxDateLength, sizeof(manufacturingDateString) - kMaxDateLength);
-    CHIP_ERROR status = deviceInfoProvider.GetManufacturingDate(manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
+    MutableCharSpan vendorSuffixSpan(manufacturingDateString + kMaxDateLength, kMaxLen - kMaxDateLength);
+    CHIP_ERROR status = delegate->GetManufacturingDate(manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
 
     // TODO: Remove defaulting once proper runtime defaulting of unimplemented factory data is done
     if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
@@ -192,7 +193,7 @@ inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider & deviceInfoP
              manufacturingDayOfMonth);
 
     totalManufacturingDateLen = kMaxDateLength;
-    status                    = deviceInfoProvider.GetManufacturingDateSuffix(vendorSuffixSpan);
+    status                    = delegate->GetManufacturingDateSuffix(vendorSuffixSpan);
     if (status == CHIP_NO_ERROR)
     {
         totalManufacturingDateLen += vendorSuffixSpan.size();
@@ -203,28 +204,27 @@ inline CHIP_ERROR ReadManufacturingDate(DeviceInstanceInfoProvider & deviceInfoP
     return aEncoder.Encode(CharSpan(manufacturingDateString, totalManufacturingDateLen));
 }
 
-inline CHIP_ERROR ReadUniqueID(DeviceLayer::ConfigurationManager & configManager, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadUniqueID(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
-    constexpr size_t kMaxLen   = DeviceLayer::ConfigurationManager::kMaxUniqueIDLength;
+    constexpr size_t kMaxLen   = BasicInformation::Attributes::UniqueID::TypeInfo::MaxLength();
     char uniqueId[kMaxLen + 1] = { 0 };
 
-    CHIP_ERROR status = configManager.GetUniqueId(uniqueId, sizeof(uniqueId));
+    CHIP_ERROR status = delegate->GetUniqueId(uniqueId, sizeof(uniqueId));
     status            = ClearNullTerminatedStringWhenUnimplemented(status, uniqueId);
     return EncodeStringOnSuccess(status, aEncoder, uniqueId, kMaxLen);
 }
 
-inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, DeviceInstanceInfoProvider & deviceInfoProvider,
-                                       uint16_t & subscriptionsPerFabric)
+inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, BasicInformation::BasicInformationDelegate * delegate)
 {
     BasicInformation::Structs::CapabilityMinimaStruct::Type capabilityMinima;
 
     // TODO: These values must be set from something based on the SDK impl, but there are no such constants today.
     constexpr uint16_t kMinCaseSessionsPerFabricMandatedBySpec = 3;
 
-    auto capabilityMinimasFromDeviceInfo = deviceInfoProvider.GetSupportedCapabilityMinimaValues();
+    auto capabilityMinimasFromDeviceInfo = delegate->GetSupportedCapabilityMinimaValues();
 
     capabilityMinima.caseSessionsPerFabric  = kMinCaseSessionsPerFabricMandatedBySpec;
-    capabilityMinima.subscriptionsPerFabric = subscriptionsPerFabric;
+    capabilityMinima.subscriptionsPerFabric = delegate->GetSubscriptionsPerFabric();
     capabilityMinima.simultaneousInvocationsSupported =
         chip::MakeOptional<uint16_t>(capabilityMinimasFromDeviceInfo.simultaneousInvocationsSupported);
     capabilityMinima.simultaneousWritesSupported =
@@ -236,20 +236,20 @@ inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, DeviceI
     return aEncoder.Encode(capabilityMinima);
 }
 
-inline CHIP_ERROR ReadConfigurationVersion(DeviceLayer::ConfigurationManager & configManager, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadConfigurationVersion(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
     uint32_t configurationVersion = 0;
-    ReturnErrorOnFailure(configManager.GetConfigurationVersion(configurationVersion));
+    ReturnErrorOnFailure(delegate->GetConfigurationVersion(configurationVersion));
     return aEncoder.Encode(configurationVersion);
 }
 
-inline CHIP_ERROR ReadLocation(DeviceLayer::ConfigurationManager & configManager, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadLocation(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
     char location[kExpectedFixedLocationLength + 1] = { 0 };
     size_t codeLen                                  = 0;
     CharSpan countryCodeSpan;
 
-    CHIP_ERROR err = configManager.GetCountryCode(location, sizeof(location), codeLen);
+    CHIP_ERROR err = delegate->GetCountryCode(location, sizeof(location), codeLen);
     if ((err != CHIP_NO_ERROR) || (codeLen != kExpectedFixedLocationLength))
     {
         countryCodeSpan = "XX"_span;
@@ -262,13 +262,13 @@ inline CHIP_ERROR ReadLocation(DeviceLayer::ConfigurationManager & configManager
     return aEncoder.Encode(countryCodeSpan);
 }
 
-inline CHIP_ERROR ReadProductAppearance(DeviceInstanceInfoProvider & deviceInfoProvider, AttributeValueEncoder & aEncoder)
+inline CHIP_ERROR ReadProductAppearance(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
 {
     ProductFinishEnum finish;
-    ReturnErrorOnFailure(deviceInfoProvider.GetProductFinish(&finish));
+    ReturnErrorOnFailure(delegate->GetProductFinish(&finish));
 
     ColorEnum color;
-    CHIP_ERROR colorStatus = deviceInfoProvider.GetProductPrimaryColor(&color);
+    CHIP_ERROR colorStatus = delegate->GetProductPrimaryColor(&color);
     if (colorStatus != CHIP_NO_ERROR && colorStatus != CHIP_ERROR_NOT_IMPLEMENTED)
     {
         return colorStatus;
@@ -297,8 +297,7 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
 {
     using namespace BasicInformation::Attributes;
 
-    auto & deviceInfoProvider = mClusterContext.deviceInstanceInfoProvider;
-    auto & configManager      = mClusterContext.configurationManager;
+
 
     switch (request.path.mAttributeId)
     {
@@ -315,56 +314,56 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
     case NodeLabel::Id:
         return encoder.Encode(mNodeLabel.Content());
     case LocalConfigDisabled::Id:
-        return ReadLocalConfigDisabled(deviceInfoProvider, encoder);
+        return ReadLocalConfigDisabled(mDelegate, encoder);
     case DataModelRevision::Id:
         return encoder.Encode(Revision::kDataModelRevision);
     case Location::Id:
-        return ReadLocation(configManager, encoder);
+        return ReadLocation(mDelegate, encoder);
     case VendorName::Id:
-        return ReadConfigurationString(deviceInfoProvider, &DeviceInstanceInfoProvider::GetVendorName,
+        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetVendorName,
                                        false /* unimplementedAllowed */, encoder);
     case VendorID::Id:
-        return ReadVendorID(deviceInfoProvider, encoder);
+        return ReadVendorID(mDelegate, encoder);
     case ProductName::Id:
-        return ReadConfigurationString(deviceInfoProvider, &DeviceInstanceInfoProvider::GetProductName,
+        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetProductName,
                                        false /* unimplementedAllowed */, encoder);
     case ProductID::Id:
-        return ReadProductID(deviceInfoProvider, encoder);
+        return ReadProductID(mDelegate, encoder);
     case HardwareVersion::Id:
-        return ReadHardwareVersion(deviceInfoProvider, encoder);
+        return ReadHardwareVersion(mDelegate, encoder);
     case HardwareVersionString::Id:
-        return ReadConfigurationString(deviceInfoProvider, &DeviceInstanceInfoProvider::GetHardwareVersionString,
+        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetHardwareVersionString,
                                        false /* unimplementedAllowed */, encoder);
     case SoftwareVersion::Id:
-        return ReadSoftwareVersion(configManager, encoder);
+        return ReadSoftwareVersion(mDelegate, encoder);
     case SoftwareVersionString::Id:
-        return ReadSoftwareVersionString(configManager, encoder);
+        return ReadSoftwareVersionString(mDelegate, encoder);
     case ManufacturingDate::Id:
-        return ReadManufacturingDate(deviceInfoProvider, encoder);
+        return ReadManufacturingDate(mDelegate, encoder);
     case PartNumber::Id:
-        return ReadConfigurationString(deviceInfoProvider, &DeviceInstanceInfoProvider::GetPartNumber,
+        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetPartNumber,
                                        true /* unimplementedAllowed */, encoder);
     case ProductURL::Id:
-        return ReadConfigurationString(deviceInfoProvider, &DeviceInstanceInfoProvider::GetProductURL,
+        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetProductURL,
                                        true /* unimplementedAllowed */, encoder);
     case ProductLabel::Id:
-        return ReadConfigurationString(deviceInfoProvider, &DeviceInstanceInfoProvider::GetProductLabel,
+        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetProductLabel,
                                        true /* unimplementedAllowed */, encoder);
     case SerialNumber::Id:
-        return ReadConfigurationString(deviceInfoProvider, &DeviceInstanceInfoProvider::GetSerialNumber,
+        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetSerialNumber,
                                        true /* unimplementedAllowed */, encoder);
     case UniqueID::Id:
-        return ReadUniqueID(configManager, encoder);
+        return ReadUniqueID(mDelegate, encoder);
     case CapabilityMinima::Id:
-        return ReadCapabilityMinima(encoder, deviceInfoProvider, mClusterContext.subscriptionsPerFabric);
+        return ReadCapabilityMinima(encoder, mDelegate);
     case ProductAppearance::Id:
-        return ReadProductAppearance(deviceInfoProvider, encoder);
+        return ReadProductAppearance(mDelegate, encoder);
     case SpecificationVersion::Id:
         return encoder.Encode(Revision::kSpecificationVersion);
     case MaxPathsPerInvoke::Id:
         return encoder.Encode<uint16_t>(CHIP_CONFIG_MAX_PATHS_PER_INVOKE);
     case ConfigurationVersion::Id:
-        return ReadConfigurationVersion(configManager, encoder);
+        return ReadConfigurationVersion(mDelegate, encoder);
     case Reachable::Id:
         // On some platforms `true` is defined as a unsigned int and that gets
         // a ambigous TLVWriter::Put error. Hence the specialization.
@@ -383,8 +382,8 @@ DataModel::ActionReturnStatus BasicInformationCluster::WriteAttribute(const Data
 CHIP_ERROR BasicInformationCluster::IncreaseConfigurationVersion()
 {
     uint32_t globalConfig = 0;
-    ReturnErrorOnFailure(mClusterContext.configurationManager.GetConfigurationVersion(globalConfig));
-    ReturnErrorOnFailure(mClusterContext.configurationManager.StoreConfigurationVersion(globalConfig + 1));
+    ReturnErrorOnFailure(mDelegate->GetConfigurationVersion(globalConfig));
+    ReturnErrorOnFailure(mDelegate->StoreConfigurationVersion(globalConfig + 1));
     NotifyAttributeChanged(ConfigurationVersion::Id);
     return CHIP_NO_ERROR;
 }
@@ -402,7 +401,7 @@ DataModel::ActionReturnStatus BasicInformationCluster::WriteImpl(const DataModel
         CharSpan location;
         ReturnErrorOnFailure(decoder.Decode(location));
         VerifyOrReturnError(location.size() == kExpectedFixedLocationLength, Protocols::InteractionModel::Status::ConstraintError);
-        return mClusterContext.configurationManager.StoreCountryCode(location.data(), location.size());
+        return mDelegate->StoreCountryCode(location.data(), location.size());
     }
     case NodeLabel::Id: {
         CharSpan label;
@@ -411,11 +410,10 @@ DataModel::ActionReturnStatus BasicInformationCluster::WriteImpl(const DataModel
         return persistence.StoreString(request.path, mNodeLabel);
     }
     case LocalConfigDisabled::Id: {
-        auto & deviceInfoProvider = mClusterContext.deviceInstanceInfoProvider;
         bool localConfigDisabled  = false;
-        ReturnErrorOnFailure(deviceInfoProvider.GetLocalConfigDisabled(localConfigDisabled));
+        ReturnErrorOnFailure(mDelegate->GetLocalConfigDisabled(localConfigDisabled));
         auto decodeStatus = persistence.DecodeAndStoreNativeEndianValue(request.path, decoder, localConfigDisabled);
-        ReturnErrorOnFailure(deviceInfoProvider.SetLocalConfigDisabled(localConfigDisabled));
+        ReturnErrorOnFailure(mDelegate->SetLocalConfigDisabled(localConfigDisabled));
         return decodeStatus;
     }
     default:
@@ -458,9 +456,9 @@ CHIP_ERROR BasicInformationCluster::Startup(ServerClusterContext & context)
     // This prevents the cluster from overwriting a delegate that may have been explicitly
     // registered by the application logic. If a delegate is already present, this cluster
     // will simply not intercept the shutdown signal via this mechanism.
-    if (mClusterContext.platformManager.GetDelegate() == nullptr)
+    if (mPlatformManager.GetDelegate() == nullptr)
     {
-        mClusterContext.platformManager.SetDelegate(this);
+        mPlatformManager.SetDelegate(this);
     }
 
     AttributePersistence persistence(context.attributeStorage);
@@ -476,16 +474,16 @@ CHIP_ERROR BasicInformationCluster::Startup(ServerClusterContext & context)
 
     // Propagate the restored 'LocalConfigDisabled' state to the DeviceInstanceInfoProvider
     // so the underlying platform layer is aware of the configuration.
-    ReturnErrorOnFailure(mClusterContext.deviceInstanceInfoProvider.SetLocalConfigDisabled(localConfigDisabled));
+    ReturnErrorOnFailure(mDelegate->SetLocalConfigDisabled(localConfigDisabled));
 
     return CHIP_NO_ERROR;
 }
 
 void BasicInformationCluster::Shutdown(ClusterShutdownType shutdownType)
 {
-    if (mClusterContext.platformManager.GetDelegate() == this)
+    if (mPlatformManager.GetDelegate() == this)
     {
-        mClusterContext.platformManager.SetDelegate(nullptr);
+        mPlatformManager.SetDelegate(nullptr);
     }
     DefaultServerCluster::Shutdown(shutdownType);
 }

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -137,8 +137,13 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
 {
     using namespace BasicInformation::Attributes;
 
-    enum class AttributeReadType { kString, kNumeric, kOther };
-    AttributeReadType readType = AttributeReadType::kOther;
+    enum class AttributeReadType
+    {
+        kString,
+        kNumeric,
+        kOther
+    };
+    AttributeReadType readType    = AttributeReadType::kOther;
     const AttributeId attributeId = request.path.mAttributeId;
 
     switch (attributeId)

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -31,9 +31,9 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
+#include <platform/CHIPDeviceError.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/PlatformManager.h>
-#include <platform/CHIPDeviceError.h>
 #include <protocols/interaction_model/StatusCode.h>
 #include <tracing/macros.h>
 
@@ -77,24 +77,6 @@ constexpr DataModel::AttributeEntry kMandatoryAttributes[] = {
 
 constexpr size_t kExpectedFixedLocationLength = 2;
 
-
-CHIP_ERROR ClearNullTerminatedStringWhenUnimplemented(CHIP_ERROR status, char * strBuf)
-{
-    if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
-    {
-        *strBuf = '\0';
-        return CHIP_NO_ERROR;
-    }
-
-    return status;
-}
-
-CHIP_ERROR EncodeStringOnSuccess(CHIP_ERROR status, AttributeValueEncoder & encoder, const char * buf, size_t maxBufSize)
-{
-    ReturnErrorOnFailure(status);
-    return encoder.Encode(chip::CharSpan(buf, strnlen(buf, maxBufSize)));
-}
-
 constexpr size_t kMaxStringLength = std::max({
     DeviceLayer::ConfigurationManager::kMaxVendorNameLength,
     DeviceLayer::ConfigurationManager::kMaxHardwareVersionStringLength,
@@ -106,19 +88,13 @@ constexpr size_t kMaxStringLength = std::max({
     DeviceLayer::ConfigurationManager::kMaxUniqueIDLength,
 });
 
-/// Reads a single device info string. Separate function to optimize for flash cost
-/// as querying strings seems to be a frequent operation.
-CHIP_ERROR ReadConfigurationString(BasicInformation::BasicInformationDelegate * delegate,
-                                   CHIP_ERROR (BasicInformation::BasicInformationDelegate::*getter)(char *, size_t), bool unimplementedAllowed,
-                                   AttributeValueEncoder & encoder)
+CHIP_ERROR ReadStringAttribute(BasicInformation::BasicInformationDelegate * delegate, AttributeId attributeId,
+                               AttributeValueEncoder & encoder)
 {
-    char buffer[kMaxStringLength + 1] = { 0 };
-    CHIP_ERROR status                 = ((delegate)->*(getter))(buffer, sizeof(buffer));
-    if (unimplementedAllowed)
-    {
-        status = ClearNullTerminatedStringWhenUnimplemented(status, buffer);
-    }
-    return EncodeStringOnSuccess(status, encoder, buffer, kMaxStringLength);
+    char buffer[kMaxStringLength + 1];
+    MutableCharSpan span(buffer, sizeof(buffer));
+    ReturnErrorOnFailure(delegate->GetStringAttribute(attributeId, span));
+    return encoder.Encode(span);
 }
 
 inline CHIP_ERROR ReadVendorID(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
@@ -154,14 +130,6 @@ inline CHIP_ERROR ReadSoftwareVersion(BasicInformation::BasicInformationDelegate
     uint32_t softwareVersion = 0;
     ReturnErrorOnFailure(delegate->GetSoftwareVersion(softwareVersion));
     return aEncoder.Encode(softwareVersion);
-}
-
-inline CHIP_ERROR ReadSoftwareVersionString(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
-{
-    constexpr size_t kMaxLen                = BasicInformation::Attributes::SoftwareVersionString::TypeInfo::MaxLength();
-    char softwareVersionString[kMaxLen + 1] = { 0 };
-    ReturnErrorOnFailure(delegate->GetSoftwareVersionString(softwareVersionString, sizeof(softwareVersionString)));
-    return aEncoder.Encode(CharSpan(softwareVersionString, strnlen(softwareVersionString, kMaxLen)));
 }
 
 inline CHIP_ERROR ReadManufacturingDate(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
@@ -204,16 +172,6 @@ inline CHIP_ERROR ReadManufacturingDate(BasicInformation::BasicInformationDelega
     return aEncoder.Encode(CharSpan(manufacturingDateString, totalManufacturingDateLen));
 }
 
-inline CHIP_ERROR ReadUniqueID(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
-{
-    constexpr size_t kMaxLen   = BasicInformation::Attributes::UniqueID::TypeInfo::MaxLength();
-    char uniqueId[kMaxLen + 1] = { 0 };
-
-    CHIP_ERROR status = delegate->GetUniqueId(uniqueId, sizeof(uniqueId));
-    status            = ClearNullTerminatedStringWhenUnimplemented(status, uniqueId);
-    return EncodeStringOnSuccess(status, aEncoder, uniqueId, kMaxLen);
-}
-
 inline CHIP_ERROR ReadCapabilityMinima(AttributeValueEncoder & aEncoder, BasicInformation::BasicInformationDelegate * delegate)
 {
     BasicInformation::Structs::CapabilityMinimaStruct::Type capabilityMinima;
@@ -241,25 +199,6 @@ inline CHIP_ERROR ReadConfigurationVersion(BasicInformation::BasicInformationDel
     uint32_t configurationVersion = 0;
     ReturnErrorOnFailure(delegate->GetConfigurationVersion(configurationVersion));
     return aEncoder.Encode(configurationVersion);
-}
-
-inline CHIP_ERROR ReadLocation(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
-{
-    char location[kExpectedFixedLocationLength + 1] = { 0 };
-    size_t codeLen                                  = 0;
-    CharSpan countryCodeSpan;
-
-    CHIP_ERROR err = delegate->GetCountryCode(location, sizeof(location), codeLen);
-    if ((err != CHIP_NO_ERROR) || (codeLen != kExpectedFixedLocationLength))
-    {
-        countryCodeSpan = "XX"_span;
-        err             = CHIP_NO_ERROR;
-    }
-    else
-    {
-        countryCodeSpan = CharSpan{ location, codeLen };
-    }
-    return aEncoder.Encode(countryCodeSpan);
 }
 
 inline CHIP_ERROR ReadProductAppearance(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)
@@ -297,8 +236,6 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
 {
     using namespace BasicInformation::Attributes;
 
-
-
     switch (request.path.mAttributeId)
     {
     case FeatureMap::Id:
@@ -318,42 +255,35 @@ DataModel::ActionReturnStatus BasicInformationCluster::ReadAttribute(const DataM
     case DataModelRevision::Id:
         return encoder.Encode(Revision::kDataModelRevision);
     case Location::Id:
-        return ReadLocation(mDelegate, encoder);
+        return ReadStringAttribute(mDelegate, Location::Id, encoder);
     case VendorName::Id:
-        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetVendorName,
-                                       false /* unimplementedAllowed */, encoder);
+        return ReadStringAttribute(mDelegate, VendorName::Id, encoder);
     case VendorID::Id:
         return ReadVendorID(mDelegate, encoder);
     case ProductName::Id:
-        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetProductName,
-                                       false /* unimplementedAllowed */, encoder);
+        return ReadStringAttribute(mDelegate, ProductName::Id, encoder);
     case ProductID::Id:
         return ReadProductID(mDelegate, encoder);
     case HardwareVersion::Id:
         return ReadHardwareVersion(mDelegate, encoder);
     case HardwareVersionString::Id:
-        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetHardwareVersionString,
-                                       false /* unimplementedAllowed */, encoder);
+        return ReadStringAttribute(mDelegate, HardwareVersionString::Id, encoder);
     case SoftwareVersion::Id:
         return ReadSoftwareVersion(mDelegate, encoder);
     case SoftwareVersionString::Id:
-        return ReadSoftwareVersionString(mDelegate, encoder);
+        return ReadStringAttribute(mDelegate, SoftwareVersionString::Id, encoder);
     case ManufacturingDate::Id:
         return ReadManufacturingDate(mDelegate, encoder);
     case PartNumber::Id:
-        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetPartNumber,
-                                       true /* unimplementedAllowed */, encoder);
+        return ReadStringAttribute(mDelegate, PartNumber::Id, encoder);
     case ProductURL::Id:
-        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetProductURL,
-                                       true /* unimplementedAllowed */, encoder);
+        return ReadStringAttribute(mDelegate, ProductURL::Id, encoder);
     case ProductLabel::Id:
-        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetProductLabel,
-                                       true /* unimplementedAllowed */, encoder);
+        return ReadStringAttribute(mDelegate, ProductLabel::Id, encoder);
     case SerialNumber::Id:
-        return ReadConfigurationString(mDelegate, &BasicInformationDelegate::GetSerialNumber,
-                                       true /* unimplementedAllowed */, encoder);
+        return ReadStringAttribute(mDelegate, SerialNumber::Id, encoder);
     case UniqueID::Id:
-        return ReadUniqueID(mDelegate, encoder);
+        return ReadStringAttribute(mDelegate, UniqueID::Id, encoder);
     case CapabilityMinima::Id:
         return ReadCapabilityMinima(encoder, mDelegate);
     case ProductAppearance::Id:
@@ -401,7 +331,7 @@ DataModel::ActionReturnStatus BasicInformationCluster::WriteImpl(const DataModel
         CharSpan location;
         ReturnErrorOnFailure(decoder.Decode(location));
         VerifyOrReturnError(location.size() == kExpectedFixedLocationLength, Protocols::InteractionModel::Status::ConstraintError);
-        return mDelegate->StoreCountryCode(location.data(), location.size());
+        return mDelegate->StoreLocation(location);
     }
     case NodeLabel::Id: {
         CharSpan label;
@@ -410,7 +340,7 @@ DataModel::ActionReturnStatus BasicInformationCluster::WriteImpl(const DataModel
         return persistence.StoreString(request.path, mNodeLabel);
     }
     case LocalConfigDisabled::Id: {
-        bool localConfigDisabled  = false;
+        bool localConfigDisabled = false;
         ReturnErrorOnFailure(mDelegate->GetLocalConfigDisabled(localConfigDisabled));
         auto decodeStatus = persistence.DecodeAndStoreNativeEndianValue(request.path, decoder, localConfigDisabled);
         ReturnErrorOnFailure(mDelegate->SetLocalConfigDisabled(localConfigDisabled));

--- a/src/app/clusters/basic-information/BasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/BasicInformationCluster.cpp
@@ -96,7 +96,7 @@ CHIP_ERROR ReadStringAttribute(BasicInformation::BasicInformationDelegate * dele
     ReturnErrorOnFailure(delegate->GetStringAttribute(attributeId, span));
 
     // explicit char span creation to not synthesize a writer for Span<char> on top of Span<const char>
-    return encoder.Encode(CharSpan{buffer, span.size()});
+    return encoder.Encode(CharSpan{ buffer, span.size() });
 }
 
 inline CHIP_ERROR ReadVendorID(BasicInformation::BasicInformationDelegate * delegate, AttributeValueEncoder & aEncoder)

--- a/src/app/clusters/basic-information/BasicInformationCluster.h
+++ b/src/app/clusters/basic-information/BasicInformationCluster.h
@@ -52,9 +52,10 @@ public:
         BasicInformation::Attributes::UniqueID::Id //
         >;
 
-    BasicInformationCluster(OptionalAttributesSet optionalAttributeSet, BasicInformation::BasicInformationDelegate * delegate, DeviceLayer::PlatformManager & platformManager) :
-      DefaultServerCluster({ kRootEndpointId, BasicInformation::Id }), mEnabledOptionalAttributes(optionalAttributeSet),
-      mDelegate(delegate), mPlatformManager(platformManager)
+    BasicInformationCluster(OptionalAttributesSet optionalAttributeSet, BasicInformation::BasicInformationDelegate * delegate,
+                            DeviceLayer::PlatformManager & platformManager) :
+        DefaultServerCluster({ kRootEndpointId, BasicInformation::Id }),
+        mEnabledOptionalAttributes(optionalAttributeSet), mDelegate(delegate), mPlatformManager(platformManager)
 
     {
         mEnabledOptionalAttributes

--- a/src/app/clusters/basic-information/BasicInformationCluster.h
+++ b/src/app/clusters/basic-information/BasicInformationCluster.h
@@ -16,14 +16,13 @@
  */
 #pragma once
 
+#include <app/clusters/basic-information/BasicInformationDelegate.h>
 #include <app/persistence/String.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server-cluster/OptionalAttributeSet.h>
 #include <clusters/BasicInformation/AttributeIds.h>
 #include <clusters/BasicInformation/ClusterId.h>
 #include <lib/core/DataModelTypes.h>
-#include <platform/ConfigurationManager.h>
-#include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/PlatformManager.h>
 
 namespace chip {
@@ -38,15 +37,6 @@ namespace Clusters {
 class BasicInformationCluster : public DefaultServerCluster, public DeviceLayer::PlatformManagerDelegate
 {
 public:
-    // Define the Context struct with References
-    struct Context
-    {
-        DeviceLayer::DeviceInstanceInfoProvider & deviceInstanceInfoProvider;
-        DeviceLayer::ConfigurationManager & configurationManager;
-        DeviceLayer::PlatformManager & platformManager;
-        uint16_t subscriptionsPerFabric;
-    };
-
     using OptionalAttributesSet = chip::app::OptionalAttributeSet< //
         BasicInformation::Attributes::ManufacturingDate::Id,       //
         BasicInformation::Attributes::PartNumber::Id,              //
@@ -62,9 +52,10 @@ public:
         BasicInformation::Attributes::UniqueID::Id //
         >;
 
-    BasicInformationCluster(OptionalAttributesSet optionalAttributeSet, Context ctx) :
-        DefaultServerCluster({ kRootEndpointId, BasicInformation::Id }), mEnabledOptionalAttributes(optionalAttributeSet),
-        mClusterContext(ctx)
+    BasicInformationCluster(OptionalAttributesSet optionalAttributeSet, BasicInformation::BasicInformationDelegate * delegate, DeviceLayer::PlatformManager & platformManager) :
+      DefaultServerCluster({ kRootEndpointId, BasicInformation::Id }), mEnabledOptionalAttributes(optionalAttributeSet),
+      mDelegate(delegate), mPlatformManager(platformManager)
+
     {
         mEnabledOptionalAttributes
             .Set<BasicInformation::Attributes::UniqueID::Id>(); // Unless told otherwise, unique id is mandatory
@@ -109,7 +100,8 @@ private:
     OptionalAttributesSet mEnabledOptionalAttributes;
 
     Storage::String<32> mNodeLabel;
-    Context mClusterContext;
+    BasicInformation::BasicInformationDelegate * mDelegate;
+    DeviceLayer::PlatformManager & mPlatformManager;
 };
 
 } // namespace Clusters

--- a/src/app/clusters/basic-information/BasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/BasicInformationDelegate.h
@@ -1,0 +1,74 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+#include <clusters/BasicInformation/Enums.h>
+#include <platform/DeviceInstanceInfoProvider.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace BasicInformation {
+
+class BasicInformationDelegate
+{
+public:
+    virtual ~BasicInformationDelegate() = default;
+
+    // String Getters
+    virtual CHIP_ERROR GetVendorName(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetProductName(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetProductURL(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) = 0;
+    virtual CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) = 0;
+    virtual CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer) = 0;
+    virtual CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) = 0;
+
+    // Value Getters
+    virtual CHIP_ERROR GetVendorId(uint16_t & vendorId) = 0;
+    virtual CHIP_ERROR GetProductId(uint16_t & productId) = 0;
+    virtual CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) = 0;
+    virtual CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion) = 0;
+    virtual CHIP_ERROR GetProductFinish(ProductFinishEnum * finish) = 0;
+    virtual CHIP_ERROR GetProductPrimaryColor(ColorEnum * primaryColor) = 0;
+    virtual CHIP_ERROR GetLocalConfigDisabled(bool & localConfigDisabled) = 0;
+    virtual CHIP_ERROR GetConfigurationVersion(uint32_t & configurationVersion) = 0;
+    virtual DeviceLayer::DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues() = 0;
+
+    // Setters
+    virtual CHIP_ERROR SetLocalConfigDisabled(bool localConfigDisabled) = 0;
+    virtual CHIP_ERROR StoreConfigurationVersion(uint32_t configurationVersion) = 0;
+    virtual CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) = 0;
+
+    // Misc
+    virtual uint16_t GetSubscriptionsPerFabric() const = 0;
+};
+
+} // namespace BasicInformation
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/basic-information/BasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/BasicInformationDelegate.h
@@ -16,10 +16,10 @@
  */
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 
 #include <clusters/BasicInformation/Enums.h>
+#include <clusters/BasicInformation/Structs.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/Span.h>
@@ -38,15 +38,12 @@ public:
     // String Getters
     virtual CHIP_ERROR GetStringAttribute(chip::AttributeId attributeId, MutableCharSpan & buffer) = 0;
 
+    // Numeric Getters
+    virtual CHIP_ERROR GetNumericAttribute(chip::AttributeId attributeId, uint32_t & value) = 0;
+
     // Value Getters
-    virtual CHIP_ERROR GetVendorId(uint16_t & vendorId)                                                               = 0;
-    virtual CHIP_ERROR GetProductId(uint16_t & productId)                                                             = 0;
-    virtual CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion)                                                 = 0;
-    virtual CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion)                                                 = 0;
-    virtual CHIP_ERROR GetProductFinish(ProductFinishEnum * finish)                                                   = 0;
-    virtual CHIP_ERROR GetProductPrimaryColor(ColorEnum * primaryColor)                                               = 0;
+    virtual CHIP_ERROR GetProductAppearance(Structs::ProductAppearanceStruct::Type & outProductAppearance) = 0;
     virtual CHIP_ERROR GetLocalConfigDisabled(bool & localConfigDisabled)                                             = 0;
-    virtual CHIP_ERROR GetConfigurationVersion(uint32_t & configurationVersion)                                       = 0;
     virtual DeviceLayer::DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues() = 0;
 
     // Setters

--- a/src/app/clusters/basic-information/BasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/BasicInformationDelegate.h
@@ -54,7 +54,7 @@ public:
     // Setters
     virtual CHIP_ERROR SetLocalConfigDisabled(bool localConfigDisabled)         = 0;
     virtual CHIP_ERROR StoreConfigurationVersion(uint32_t configurationVersion) = 0;
-    virtual CHIP_ERROR StoreLocation(const CharSpan & code)                  = 0;
+    virtual CHIP_ERROR StoreLocation(const CharSpan & code)                     = 0;
 
     // Misc
     virtual uint16_t GetSubscriptionsPerFabric() const = 0;

--- a/src/app/clusters/basic-information/BasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/BasicInformationDelegate.h
@@ -37,8 +37,6 @@ public:
 
     // String Getters
     virtual CHIP_ERROR GetStringAttribute(chip::AttributeId attributeId, MutableCharSpan & buffer) = 0;
-    virtual CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)       = 0;
-    virtual CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer)                  = 0;
 
     // Value Getters
     virtual CHIP_ERROR GetVendorId(uint16_t & vendorId)                                                               = 0;

--- a/src/app/clusters/basic-information/BasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/BasicInformationDelegate.h
@@ -19,9 +19,10 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <lib/core/CHIPError.h>
-#include <lib/support/Span.h>
 #include <clusters/BasicInformation/Enums.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/Span.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 
 namespace chip {
@@ -35,34 +36,25 @@ public:
     virtual ~BasicInformationDelegate() = default;
 
     // String Getters
-    virtual CHIP_ERROR GetVendorName(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetProductName(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetProductURL(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) = 0;
-    virtual CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) = 0;
-    virtual CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer) = 0;
-    virtual CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) = 0;
+    virtual CHIP_ERROR GetStringAttribute(chip::AttributeId attributeId, MutableCharSpan & buffer) = 0;
+    virtual CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)       = 0;
+    virtual CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer)                  = 0;
 
     // Value Getters
-    virtual CHIP_ERROR GetVendorId(uint16_t & vendorId) = 0;
-    virtual CHIP_ERROR GetProductId(uint16_t & productId) = 0;
-    virtual CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) = 0;
-    virtual CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion) = 0;
-    virtual CHIP_ERROR GetProductFinish(ProductFinishEnum * finish) = 0;
-    virtual CHIP_ERROR GetProductPrimaryColor(ColorEnum * primaryColor) = 0;
-    virtual CHIP_ERROR GetLocalConfigDisabled(bool & localConfigDisabled) = 0;
-    virtual CHIP_ERROR GetConfigurationVersion(uint32_t & configurationVersion) = 0;
+    virtual CHIP_ERROR GetVendorId(uint16_t & vendorId)                                                               = 0;
+    virtual CHIP_ERROR GetProductId(uint16_t & productId)                                                             = 0;
+    virtual CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion)                                                 = 0;
+    virtual CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion)                                                 = 0;
+    virtual CHIP_ERROR GetProductFinish(ProductFinishEnum * finish)                                                   = 0;
+    virtual CHIP_ERROR GetProductPrimaryColor(ColorEnum * primaryColor)                                               = 0;
+    virtual CHIP_ERROR GetLocalConfigDisabled(bool & localConfigDisabled)                                             = 0;
+    virtual CHIP_ERROR GetConfigurationVersion(uint32_t & configurationVersion)                                       = 0;
     virtual DeviceLayer::DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues() = 0;
 
     // Setters
-    virtual CHIP_ERROR SetLocalConfigDisabled(bool localConfigDisabled) = 0;
+    virtual CHIP_ERROR SetLocalConfigDisabled(bool localConfigDisabled)         = 0;
     virtual CHIP_ERROR StoreConfigurationVersion(uint32_t configurationVersion) = 0;
-    virtual CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) = 0;
+    virtual CHIP_ERROR StoreLocation(const CharSpan & code)                  = 0;
 
     // Misc
     virtual uint16_t GetSubscriptionsPerFabric() const = 0;

--- a/src/app/clusters/basic-information/BasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/BasicInformationDelegate.h
@@ -43,16 +43,13 @@ public:
 
     // Value Getters
     virtual CHIP_ERROR GetProductAppearance(Structs::ProductAppearanceStruct::Type & outProductAppearance) = 0;
-    virtual CHIP_ERROR GetLocalConfigDisabled(bool & localConfigDisabled)                                             = 0;
-    virtual DeviceLayer::DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues() = 0;
+    virtual CHIP_ERROR GetLocalConfigDisabled(bool & localConfigDisabled)                                  = 0;
+    virtual CHIP_ERROR GetCapabilityMinima(Structs::CapabilityMinimaStruct::Type & outCapabilityMinima)    = 0;
 
     // Setters
     virtual CHIP_ERROR SetLocalConfigDisabled(bool localConfigDisabled)         = 0;
     virtual CHIP_ERROR StoreConfigurationVersion(uint32_t configurationVersion) = 0;
     virtual CHIP_ERROR StoreLocation(const CharSpan & code)                     = 0;
-
-    // Misc
-    virtual uint16_t GetSubscriptionsPerFabric() const = 0;
 };
 
 } // namespace BasicInformation

--- a/src/app/clusters/basic-information/CodegenIntegration.cpp
+++ b/src/app/clusters/basic-information/CodegenIntegration.cpp
@@ -17,6 +17,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/basic-information/BasicInformationCluster.h>
+#include <app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h>
 #include <app/static-cluster-config/BasicInformation.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
@@ -63,13 +64,13 @@ public:
         DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();
         VerifyOrDie(provider != nullptr);
 
-        BasicInformationCluster::Context context = {
+        static chip::app::Clusters::BasicInformation::DeviceLayerBasicInformationDelegate delegate({
             .deviceInstanceInfoProvider = *provider,
             .configurationManager       = DeviceLayer::ConfigurationMgr(),
             .platformManager            = DeviceLayer::PlatformMgr(),
             .subscriptionsPerFabric     = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric()
-        };
-        gServer.Create(optionalAttributeSet, context);
+        });
+        gServer.Create(optionalAttributeSet, &delegate, DeviceLayer::PlatformMgr());
 
         // This disabling of the unique id attribute is here only for test purposes. The uniqe id attribute
         // is mandatory, but was optional in previous versions. It is forced to be enabled in the basic information

--- a/src/app/clusters/basic-information/CodegenIntegration.cpp
+++ b/src/app/clusters/basic-information/CodegenIntegration.cpp
@@ -64,12 +64,11 @@ public:
         DeviceLayer::DeviceInstanceInfoProvider * provider = DeviceLayer::GetDeviceInstanceInfoProvider();
         VerifyOrDie(provider != nullptr);
 
-        static chip::app::Clusters::BasicInformation::DeviceLayerBasicInformationDelegate delegate({
-            .deviceInstanceInfoProvider = *provider,
-            .configurationManager       = DeviceLayer::ConfigurationMgr(),
-            .platformManager            = DeviceLayer::PlatformMgr(),
-            .subscriptionsPerFabric     = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric()
-        });
+        static chip::app::Clusters::BasicInformation::DeviceLayerBasicInformationDelegate delegate(
+            { .deviceInstanceInfoProvider = *provider,
+              .configurationManager       = DeviceLayer::ConfigurationMgr(),
+              .platformManager            = DeviceLayer::PlatformMgr(),
+              .subscriptionsPerFabric     = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric() });
         gServer.Create(optionalAttributeSet, &delegate, DeviceLayer::PlatformMgr());
 
         // This disabling of the unique id attribute is here only for test purposes. The uniqe id attribute

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
@@ -27,6 +27,20 @@ namespace chip {
 namespace app {
 namespace Clusters {
 namespace BasicInformation {
+namespace {
+// Clears the buffer and returns CHIP_NO_ERROR if input status is not-implemented.
+// Otherwise just returns status as-is.
+CHIP_ERROR IgnoreUnimplemented(CHIP_ERROR status, MutableCharSpan & buffer)
+{
+    if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+    {
+        buffer.reduce_size(0);
+        return CHIP_NO_ERROR;
+    }
+    return status;
+}
+
+} // namespace
 
 using namespace DeviceLayer;
 
@@ -136,7 +150,7 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetStringAttribute(chip::Attribu
         buffer.reduce_size(strlen(buffer.data()));
     }
 
-    return IgnoreUnimplemented(err, buffer.data(), buffer.size());
+    return IgnoreUnimplemented(err, buffer);
 }
 
 CHIP_ERROR DeviceLayerBasicInformationDelegate::GetNumericAttribute(chip::AttributeId attributeId, uint32_t & value)
@@ -232,19 +246,6 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::StoreConfigurationVersion(uint32
 CHIP_ERROR DeviceLayerBasicInformationDelegate::StoreLocation(const CharSpan & code)
 {
     return mContext.configurationManager.StoreCountryCode(code.data(), code.size());
-}
-
-CHIP_ERROR DeviceLayerBasicInformationDelegate::IgnoreUnimplemented(CHIP_ERROR status, char * buf, size_t bufSize)
-{
-    if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
-    {
-        if (bufSize > 0)
-        {
-            buf[0] = 0;
-        }
-        return CHIP_NO_ERROR;
-    }
-    return status;
 }
 
 CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductAppearance(Structs::ProductAppearanceStruct::Type & outProductAppearance)

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
@@ -45,31 +45,40 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetStringAttribute(chip::Attribu
     switch (attributeId)
     {
     case VendorName::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetVendorName(buffer.data(), buffer.size()), buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetVendorName(buffer.data(), buffer.size()), buffer.data(),
+                                  buffer.size());
         break;
     case ProductName::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductName(buffer.data(), buffer.size()), buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductName(buffer.data(), buffer.size()), buffer.data(),
+                                  buffer.size());
         break;
     case PartNumber::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetPartNumber(buffer.data(), buffer.size()), buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetPartNumber(buffer.data(), buffer.size()), buffer.data(),
+                                  buffer.size());
         break;
     case ProductURL::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductURL(buffer.data(), buffer.size()), buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductURL(buffer.data(), buffer.size()), buffer.data(),
+                                  buffer.size());
         break;
     case ProductLabel::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductLabel(buffer.data(), buffer.size()), buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductLabel(buffer.data(), buffer.size()), buffer.data(),
+                                  buffer.size());
         break;
     case SerialNumber::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetSerialNumber(buffer.data(), buffer.size()), buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetSerialNumber(buffer.data(), buffer.size()), buffer.data(),
+                                  buffer.size());
         break;
     case HardwareVersionString::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetHardwareVersionString(buffer.data(), buffer.size()), buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetHardwareVersionString(buffer.data(), buffer.size()),
+                                  buffer.data(), buffer.size());
         break;
     case SoftwareVersionString::Id:
-        err = IgnoreUnimplemented(mContext.configurationManager.GetSoftwareVersionString(buffer.data(), buffer.size()), buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.configurationManager.GetSoftwareVersionString(buffer.data(), buffer.size()),
+                                  buffer.data(), buffer.size());
         break;
     case UniqueID::Id:
-        err = IgnoreUnimplemented(mContext.configurationManager.GetUniqueId(buffer.data(), buffer.size()), buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.configurationManager.GetUniqueId(buffer.data(), buffer.size()), buffer.data(),
+                                  buffer.size());
         break;
     case Location::Id: {
         constexpr size_t kExpectedFixedLocationLength = 2;

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
@@ -15,7 +15,10 @@
  *    limitations under the License.
  */
 
+#include "lib/core/CHIPError.h"
+#include "lib/support/Span.h"
 #include <app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h>
+#include <clusters/BasicInformation/Attributes.h>
 #include <clusters/BasicInformation/Enums.h>
 #include <platform/CHIPDeviceError.h>
 
@@ -26,49 +29,70 @@ namespace BasicInformation {
 
 using namespace DeviceLayer;
 
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetVendorName(char * buf, size_t bufSize)
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetStringAttribute(chip::AttributeId attributeId, MutableCharSpan & buffer)
 {
-    return mContext.deviceInstanceInfoProvider.GetVendorName(buf, bufSize);
-}
+    using namespace Attributes;
 
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductName(char * buf, size_t bufSize)
-{
-    return mContext.deviceInstanceInfoProvider.GetProductName(buf, bufSize);
-}
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    size_t dataLen = 0;
 
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetPartNumber(char * buf, size_t bufSize)
-{
-    return IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetPartNumber(buf, bufSize), buf, bufSize);
-}
+    switch (attributeId)
+    {
+    case VendorName::Id:
+        err = mContext.deviceInstanceInfoProvider.GetVendorName(buffer.data(), buffer.size());
+        break;
+    case ProductName::Id:
+        err = mContext.deviceInstanceInfoProvider.GetProductName(buffer.data(), buffer.size());
+        break;
+    case PartNumber::Id:
+        err = mContext.deviceInstanceInfoProvider.GetPartNumber(buffer.data(), buffer.size());
+        break;
+    case ProductURL::Id:
+        err = mContext.deviceInstanceInfoProvider.GetProductURL(buffer.data(), buffer.size());
+        break;
+    case ProductLabel::Id:
+        err = mContext.deviceInstanceInfoProvider.GetProductLabel(buffer.data(), buffer.size());
+        break;
+    case SerialNumber::Id:
+        err = mContext.deviceInstanceInfoProvider.GetSerialNumber(buffer.data(), buffer.size());
+        break;
+    case HardwareVersionString::Id:
+        err = mContext.deviceInstanceInfoProvider.GetHardwareVersionString(buffer.data(), buffer.size());
+        break;
+    case SoftwareVersionString::Id:
+        err = mContext.configurationManager.GetSoftwareVersionString(buffer.data(), buffer.size());
+        break;
+    case UniqueID::Id:
+        err = mContext.configurationManager.GetUniqueId(buffer.data(), buffer.size());
+        break;
+    case Location::Id: {
+        constexpr size_t kExpectedFixedLocationLength = 2;
+        err = mContext.configurationManager.GetCountryCode(buffer.data(), buffer.size(), dataLen);
+        if ((err != CHIP_NO_ERROR) || (dataLen != kExpectedFixedLocationLength))
+        {
+            // Fallback that was here historically
+            return CopyCharSpanToMutableCharSpan("XX"_span, buffer);
+        }
 
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductURL(char * buf, size_t bufSize)
-{
-    return IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductURL(buf, bufSize), buf, bufSize);
-}
+        buffer.reduce_size(dataLen);
+        return err;
+    }
+    default:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductLabel(char * buf, size_t bufSize)
-{
-    return IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductLabel(buf, bufSize), buf, bufSize);
-}
+    if (err == CHIP_NO_ERROR)
+    {
+        buffer.reduce_size(strlen(buffer.data()));
+    }
+    else if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+    {
+        // If the config is not found or the feature is unsupported, return an empty string.
+        buffer.reduce_size(0);
+        err = CHIP_NO_ERROR;
+    }
 
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetSerialNumber(char * buf, size_t bufSize)
-{
-    return IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetSerialNumber(buf, bufSize), buf, bufSize);
-}
-
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetHardwareVersionString(char * buf, size_t bufSize)
-{
-    return mContext.deviceInstanceInfoProvider.GetHardwareVersionString(buf, bufSize);
-}
-
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetSoftwareVersionString(char * buf, size_t bufSize)
-{
-    return mContext.configurationManager.GetSoftwareVersionString(buf, bufSize);
-}
-
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetUniqueId(char * buf, size_t bufSize)
-{
-    return IgnoreUnimplemented(mContext.configurationManager.GetUniqueId(buf, bufSize), buf, bufSize);
+    return err;
 }
 
 CHIP_ERROR DeviceLayerBasicInformationDelegate::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)
@@ -79,11 +103,6 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetManufacturingDate(uint16_t & 
 CHIP_ERROR DeviceLayerBasicInformationDelegate::GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer)
 {
     return mContext.deviceInstanceInfoProvider.GetManufacturingDateSuffix(suffixBuffer);
-}
-
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)
-{
-    return mContext.configurationManager.GetCountryCode(buf, bufSize, codeLen);
 }
 
 CHIP_ERROR DeviceLayerBasicInformationDelegate::GetVendorId(uint16_t & vendorId)
@@ -141,9 +160,9 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::StoreConfigurationVersion(uint32
     return mContext.configurationManager.StoreConfigurationVersion(configurationVersion);
 }
 
-CHIP_ERROR DeviceLayerBasicInformationDelegate::StoreCountryCode(const char * code, size_t codeLen)
+CHIP_ERROR DeviceLayerBasicInformationDelegate::StoreLocation(const CharSpan & code)
 {
-    return mContext.configurationManager.StoreCountryCode(code, codeLen);
+    return mContext.configurationManager.StoreCountryCode(code.data(), code.size());
 }
 
 uint16_t DeviceLayerBasicInformationDelegate::GetSubscriptionsPerFabric() const

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
@@ -36,49 +36,34 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetStringAttribute(chip::Attribu
     CHIP_ERROR err = CHIP_NO_ERROR;
     size_t dataLen = 0;
 
-    // Ensure buffer is null-terminated on entry for safety, as IgnoreUnimplemented relies on it.
-    if (buffer.size() > 0)
-    {
-        buffer.data()[0] = '\0';
-    }
-
     switch (attributeId)
     {
     case VendorName::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetVendorName(buffer.data(), buffer.size()), buffer.data(),
-                                  buffer.size());
+        err = mContext.deviceInstanceInfoProvider.GetVendorName(buffer.data(), buffer.size());
         break;
     case ProductName::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductName(buffer.data(), buffer.size()), buffer.data(),
-                                  buffer.size());
+        err = mContext.deviceInstanceInfoProvider.GetProductName(buffer.data(), buffer.size());
         break;
     case PartNumber::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetPartNumber(buffer.data(), buffer.size()), buffer.data(),
-                                  buffer.size());
+        err = mContext.deviceInstanceInfoProvider.GetPartNumber(buffer.data(), buffer.size());
         break;
     case ProductURL::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductURL(buffer.data(), buffer.size()), buffer.data(),
-                                  buffer.size());
+        err = mContext.deviceInstanceInfoProvider.GetProductURL(buffer.data(), buffer.size());
         break;
     case ProductLabel::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductLabel(buffer.data(), buffer.size()), buffer.data(),
-                                  buffer.size());
+        err = mContext.deviceInstanceInfoProvider.GetProductLabel(buffer.data(), buffer.size());
         break;
     case SerialNumber::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetSerialNumber(buffer.data(), buffer.size()), buffer.data(),
-                                  buffer.size());
+        err = mContext.deviceInstanceInfoProvider.GetSerialNumber(buffer.data(), buffer.size());
         break;
     case HardwareVersionString::Id:
-        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetHardwareVersionString(buffer.data(), buffer.size()),
-                                  buffer.data(), buffer.size());
+        err = mContext.deviceInstanceInfoProvider.GetHardwareVersionString(buffer.data(), buffer.size());
         break;
     case SoftwareVersionString::Id:
-        err = IgnoreUnimplemented(mContext.configurationManager.GetSoftwareVersionString(buffer.data(), buffer.size()),
-                                  buffer.data(), buffer.size());
+        err = mContext.configurationManager.GetSoftwareVersionString(buffer.data(), buffer.size());
         break;
     case UniqueID::Id:
-        err = IgnoreUnimplemented(mContext.configurationManager.GetUniqueId(buffer.data(), buffer.size()), buffer.data(),
-                                  buffer.size());
+        err = mContext.configurationManager.GetUniqueId(buffer.data(), buffer.size());
         break;
     case Location::Id: {
         constexpr size_t kExpectedFixedLocationLength = 2;
@@ -101,7 +86,7 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetStringAttribute(chip::Attribu
         buffer.reduce_size(strlen(buffer.data()));
     }
 
-    return err;
+    return IgnoreUnimplemented(err, buffer.data(), buffer.size());
 }
 
 CHIP_ERROR DeviceLayerBasicInformationDelegate::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
@@ -63,9 +63,55 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetStringAttribute(chip::Attribu
         err = mContext.configurationManager.GetSoftwareVersionString(buffer.data(), buffer.size());
         break;
     case UniqueID::Id:
-        err = mContext.configurationManager.GetUniqueId(buffer.data(), buffer.size());
-        break;
-    case Location::Id: {
+                err = mContext.configurationManager.GetUniqueId(buffer.data(), buffer.size());
+                break;
+            case ManufacturingDate::Id: {
+                constexpr size_t kMaxLen        = BasicInformation::Attributes::ManufacturingDate::TypeInfo::MaxLength();
+                constexpr size_t kMaxDateLength = 8; // YYYYMMDD
+                static_assert(kMaxLen > kMaxDateLength, "kMaxLen must be greater than kMaxDateLength");
+                uint16_t manufacturingYear;
+                uint8_t manufacturingMonth;
+                uint8_t manufacturingDayOfMonth;
+                size_t totalManufacturingDateLen = 0;
+
+                CHIP_ERROR status = mContext.deviceInstanceInfoProvider.GetManufacturingDate(manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
+
+                if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+                {
+                    // Default to an empty string if not found
+                    buffer.reduce_size(0);
+                    return CHIP_NO_ERROR;
+                }
+                ReturnErrorOnFailure(status);
+
+                if (buffer.size() < kMaxDateLength) {
+                    return CHIP_ERROR_BUFFER_TOO_SMALL;
+                }
+
+                // Format is YYYYMMDD
+                int written = snprintf(buffer.data(), buffer.size(), "%04u%02u%02u", manufacturingYear, manufacturingMonth,
+                         manufacturingDayOfMonth);
+                if (written < 0 || written >= static_cast<int>(buffer.size())) {
+                    return CHIP_ERROR_BUFFER_TOO_SMALL;
+                }
+                totalManufacturingDateLen = static_cast<size_t>(written);
+
+                if (buffer.size() > kMaxDateLength)
+                {
+                    MutableCharSpan vendorSuffixSpan(buffer.data() + kMaxDateLength, buffer.size() - kMaxDateLength);
+                    status = mContext.deviceInstanceInfoProvider.GetManufacturingDateSuffix(vendorSuffixSpan);
+                    if (status == CHIP_NO_ERROR)
+                    {
+                        totalManufacturingDateLen += vendorSuffixSpan.size();
+                    }
+                    // Suffix is optional, so errors other than NO_ERROR are ignored.
+                }
+
+                buffer.reduce_size(totalManufacturingDateLen);
+                return CHIP_NO_ERROR;
+            }
+            case Location::Id: {
+
         constexpr size_t kExpectedFixedLocationLength = 2;
         err = mContext.configurationManager.GetCountryCode(buffer.data(), buffer.size(), dataLen);
         if ((err != CHIP_NO_ERROR) || (dataLen != kExpectedFixedLocationLength))
@@ -87,16 +133,6 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetStringAttribute(chip::Attribu
     }
 
     return IgnoreUnimplemented(err, buffer.data(), buffer.size());
-}
-
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)
-{
-    return mContext.deviceInstanceInfoProvider.GetManufacturingDate(year, month, day);
-}
-
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer)
-{
-    return mContext.deviceInstanceInfoProvider.GetManufacturingDateSuffix(suffixBuffer);
 }
 
 CHIP_ERROR DeviceLayerBasicInformationDelegate::GetVendorId(uint16_t & vendorId)

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
@@ -19,8 +19,8 @@
 #include "lib/support/Span.h"
 #include <app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h>
 #include <clusters/BasicInformation/Attributes.h>
-#include <lib/support/logging/CHIPLogging.h>
 #include <clusters/BasicInformation/Enums.h>
+#include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceError.h>
 
 namespace chip {
@@ -149,37 +149,43 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetNumericAttribute(chip::Attrib
     case VendorID::Id: {
         uint16_t val;
         err = mContext.deviceInstanceInfoProvider.GetVendorId(val);
-        if (err == CHIP_NO_ERROR) value = val;
+        if (err == CHIP_NO_ERROR)
+            value = val;
         break;
     }
     case ProductID::Id: {
         uint16_t val;
         err = mContext.deviceInstanceInfoProvider.GetProductId(val);
-        if (err == CHIP_NO_ERROR) value = val;
+        if (err == CHIP_NO_ERROR)
+            value = val;
         break;
     }
     case HardwareVersion::Id: {
         uint16_t val;
         err = mContext.deviceInstanceInfoProvider.GetHardwareVersion(val);
-        if (err == CHIP_NO_ERROR) value = val;
+        if (err == CHIP_NO_ERROR)
+            value = val;
         break;
     }
     case SoftwareVersion::Id: {
         uint32_t val;
         err = mContext.configurationManager.GetSoftwareVersion(val);
-        if (err == CHIP_NO_ERROR) value = val;
+        if (err == CHIP_NO_ERROR)
+            value = val;
         break;
     }
     case LocalConfigDisabled::Id: {
         bool val;
         err = mContext.deviceInstanceInfoProvider.GetLocalConfigDisabled(val);
-        if (err == CHIP_NO_ERROR) value = val;
+        if (err == CHIP_NO_ERROR)
+            value = val;
         break;
     }
     case ConfigurationVersion::Id: {
         uint32_t val;
         err = mContext.configurationManager.GetConfigurationVersion(val);
-        if (err == CHIP_NO_ERROR) value = val;
+        if (err == CHIP_NO_ERROR)
+            value = val;
         break;
     }
     default:
@@ -194,9 +200,23 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetLocalConfigDisabled(bool & lo
     return mContext.deviceInstanceInfoProvider.GetLocalConfigDisabled(localConfigDisabled);
 }
 
-DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas DeviceLayerBasicInformationDelegate::GetSupportedCapabilityMinimaValues()
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetCapabilityMinima(Structs::CapabilityMinimaStruct::Type & outCapabilityMinima)
 {
-    return mContext.deviceInstanceInfoProvider.GetSupportedCapabilityMinimaValues();
+    constexpr uint16_t kMinCaseSessionsPerFabricMandatedBySpec = 3;
+
+    auto capabilityMinimasFromDeviceInfo = mContext.deviceInstanceInfoProvider.GetSupportedCapabilityMinimaValues();
+
+    outCapabilityMinima.caseSessionsPerFabric  = kMinCaseSessionsPerFabricMandatedBySpec;
+    outCapabilityMinima.subscriptionsPerFabric = mContext.subscriptionsPerFabric;
+    outCapabilityMinima.simultaneousInvocationsSupported =
+        chip::MakeOptional<uint16_t>(capabilityMinimasFromDeviceInfo.simultaneousInvocationsSupported);
+    outCapabilityMinima.simultaneousWritesSupported =
+        chip::MakeOptional<uint16_t>(capabilityMinimasFromDeviceInfo.simultaneousWritesSupported);
+    outCapabilityMinima.readPathsSupported = chip::MakeOptional<uint16_t>(capabilityMinimasFromDeviceInfo.readPathsSupported);
+    outCapabilityMinima.subscribePathsSupported =
+        chip::MakeOptional<uint16_t>(capabilityMinimasFromDeviceInfo.subscribePathsSupported);
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DeviceLayerBasicInformationDelegate::SetLocalConfigDisabled(bool localConfigDisabled)
@@ -212,11 +232,6 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::StoreConfigurationVersion(uint32
 CHIP_ERROR DeviceLayerBasicInformationDelegate::StoreLocation(const CharSpan & code)
 {
     return mContext.configurationManager.StoreCountryCode(code.data(), code.size());
-}
-
-uint16_t DeviceLayerBasicInformationDelegate::GetSubscriptionsPerFabric() const
-{
-    return mContext.subscriptionsPerFabric;
 }
 
 CHIP_ERROR DeviceLayerBasicInformationDelegate::IgnoreUnimplemented(CHIP_ERROR status, char * buf, size_t bufSize)

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
@@ -36,34 +36,40 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetStringAttribute(chip::Attribu
     CHIP_ERROR err = CHIP_NO_ERROR;
     size_t dataLen = 0;
 
+    // Ensure buffer is null-terminated on entry for safety, as IgnoreUnimplemented relies on it.
+    if (buffer.size() > 0)
+    {
+        buffer.data()[0] = '\0';
+    }
+
     switch (attributeId)
     {
     case VendorName::Id:
-        err = mContext.deviceInstanceInfoProvider.GetVendorName(buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetVendorName(buffer.data(), buffer.size()), buffer.data(), buffer.size());
         break;
     case ProductName::Id:
-        err = mContext.deviceInstanceInfoProvider.GetProductName(buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductName(buffer.data(), buffer.size()), buffer.data(), buffer.size());
         break;
     case PartNumber::Id:
-        err = mContext.deviceInstanceInfoProvider.GetPartNumber(buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetPartNumber(buffer.data(), buffer.size()), buffer.data(), buffer.size());
         break;
     case ProductURL::Id:
-        err = mContext.deviceInstanceInfoProvider.GetProductURL(buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductURL(buffer.data(), buffer.size()), buffer.data(), buffer.size());
         break;
     case ProductLabel::Id:
-        err = mContext.deviceInstanceInfoProvider.GetProductLabel(buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductLabel(buffer.data(), buffer.size()), buffer.data(), buffer.size());
         break;
     case SerialNumber::Id:
-        err = mContext.deviceInstanceInfoProvider.GetSerialNumber(buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetSerialNumber(buffer.data(), buffer.size()), buffer.data(), buffer.size());
         break;
     case HardwareVersionString::Id:
-        err = mContext.deviceInstanceInfoProvider.GetHardwareVersionString(buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetHardwareVersionString(buffer.data(), buffer.size()), buffer.data(), buffer.size());
         break;
     case SoftwareVersionString::Id:
-        err = mContext.configurationManager.GetSoftwareVersionString(buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.configurationManager.GetSoftwareVersionString(buffer.data(), buffer.size()), buffer.data(), buffer.size());
         break;
     case UniqueID::Id:
-        err = mContext.configurationManager.GetUniqueId(buffer.data(), buffer.size());
+        err = IgnoreUnimplemented(mContext.configurationManager.GetUniqueId(buffer.data(), buffer.size()), buffer.data(), buffer.size());
         break;
     case Location::Id: {
         constexpr size_t kExpectedFixedLocationLength = 2;
@@ -84,12 +90,6 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetStringAttribute(chip::Attribu
     if (err == CHIP_NO_ERROR)
     {
         buffer.reduce_size(strlen(buffer.data()));
-    }
-    else if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
-    {
-        // If the config is not found or the feature is unsupported, return an empty string.
-        buffer.reduce_size(0);
-        err = CHIP_NO_ERROR;
     }
 
     return err;

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
@@ -19,6 +19,7 @@
 #include "lib/support/Span.h"
 #include <app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h>
 #include <clusters/BasicInformation/Attributes.h>
+#include <lib/support/logging/CHIPLogging.h>
 #include <clusters/BasicInformation/Enums.h>
 #include <platform/CHIPDeviceError.h>
 
@@ -138,44 +139,59 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetStringAttribute(chip::Attribu
     return IgnoreUnimplemented(err, buffer.data(), buffer.size());
 }
 
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetVendorId(uint16_t & vendorId)
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetNumericAttribute(chip::AttributeId attributeId, uint32_t & value)
 {
-    return mContext.deviceInstanceInfoProvider.GetVendorId(vendorId);
-}
+    using namespace Attributes;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductId(uint16_t & productId)
-{
-    return mContext.deviceInstanceInfoProvider.GetProductId(productId);
-}
+    switch (attributeId)
+    {
+    case VendorID::Id: {
+        uint16_t val;
+        err = mContext.deviceInstanceInfoProvider.GetVendorId(val);
+        if (err == CHIP_NO_ERROR) value = val;
+        break;
+    }
+    case ProductID::Id: {
+        uint16_t val;
+        err = mContext.deviceInstanceInfoProvider.GetProductId(val);
+        if (err == CHIP_NO_ERROR) value = val;
+        break;
+    }
+    case HardwareVersion::Id: {
+        uint16_t val;
+        err = mContext.deviceInstanceInfoProvider.GetHardwareVersion(val);
+        if (err == CHIP_NO_ERROR) value = val;
+        break;
+    }
+    case SoftwareVersion::Id: {
+        uint32_t val;
+        err = mContext.configurationManager.GetSoftwareVersion(val);
+        if (err == CHIP_NO_ERROR) value = val;
+        break;
+    }
+    case LocalConfigDisabled::Id: {
+        bool val;
+        err = mContext.deviceInstanceInfoProvider.GetLocalConfigDisabled(val);
+        if (err == CHIP_NO_ERROR) value = val;
+        break;
+    }
+    case ConfigurationVersion::Id: {
+        uint32_t val;
+        err = mContext.configurationManager.GetConfigurationVersion(val);
+        if (err == CHIP_NO_ERROR) value = val;
+        break;
+    }
+    default:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetHardwareVersion(uint16_t & hardwareVersion)
-{
-    return mContext.deviceInstanceInfoProvider.GetHardwareVersion(hardwareVersion);
-}
-
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetSoftwareVersion(uint32_t & softwareVersion)
-{
-    return mContext.configurationManager.GetSoftwareVersion(softwareVersion);
-}
-
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductFinish(ProductFinishEnum * finish)
-{
-    return mContext.deviceInstanceInfoProvider.GetProductFinish(finish);
-}
-
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductPrimaryColor(ColorEnum * primaryColor)
-{
-    return mContext.deviceInstanceInfoProvider.GetProductPrimaryColor(primaryColor);
+    return err;
 }
 
 CHIP_ERROR DeviceLayerBasicInformationDelegate::GetLocalConfigDisabled(bool & localConfigDisabled)
 {
     return mContext.deviceInstanceInfoProvider.GetLocalConfigDisabled(localConfigDisabled);
-}
-
-CHIP_ERROR DeviceLayerBasicInformationDelegate::GetConfigurationVersion(uint32_t & configurationVersion)
-{
-    return mContext.configurationManager.GetConfigurationVersion(configurationVersion);
 }
 
 DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas DeviceLayerBasicInformationDelegate::GetSupportedCapabilityMinimaValues()
@@ -214,6 +230,31 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::IgnoreUnimplemented(CHIP_ERROR s
         return CHIP_NO_ERROR;
     }
     return status;
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductAppearance(Structs::ProductAppearanceStruct::Type & outProductAppearance)
+{
+    ProductFinishEnum finish;
+    ReturnErrorOnFailure(mContext.deviceInstanceInfoProvider.GetProductFinish(&finish));
+    outProductAppearance.finish = finish;
+
+    ColorEnum color;
+    CHIP_ERROR colorStatus = mContext.deviceInstanceInfoProvider.GetProductPrimaryColor(&color);
+
+    if (colorStatus == CHIP_NO_ERROR)
+    {
+        outProductAppearance.primaryColor.SetNonNull(color);
+    }
+    else if (colorStatus == CHIP_ERROR_NOT_IMPLEMENTED)
+    {
+        outProductAppearance.primaryColor.SetNull();
+    }
+    else
+    {
+        return colorStatus;
+    }
+
+    return CHIP_NO_ERROR;
 }
 
 } // namespace BasicInformation

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
@@ -63,54 +63,57 @@ CHIP_ERROR DeviceLayerBasicInformationDelegate::GetStringAttribute(chip::Attribu
         err = mContext.configurationManager.GetSoftwareVersionString(buffer.data(), buffer.size());
         break;
     case UniqueID::Id:
-                err = mContext.configurationManager.GetUniqueId(buffer.data(), buffer.size());
-                break;
-            case ManufacturingDate::Id: {
-                constexpr size_t kMaxLen        = BasicInformation::Attributes::ManufacturingDate::TypeInfo::MaxLength();
-                constexpr size_t kMaxDateLength = 8; // YYYYMMDD
-                static_assert(kMaxLen > kMaxDateLength, "kMaxLen must be greater than kMaxDateLength");
-                uint16_t manufacturingYear;
-                uint8_t manufacturingMonth;
-                uint8_t manufacturingDayOfMonth;
-                size_t totalManufacturingDateLen = 0;
+        err = mContext.configurationManager.GetUniqueId(buffer.data(), buffer.size());
+        break;
+    case ManufacturingDate::Id: {
+        constexpr size_t kMaxLen        = BasicInformation::Attributes::ManufacturingDate::TypeInfo::MaxLength();
+        constexpr size_t kMaxDateLength = 8; // YYYYMMDD
+        static_assert(kMaxLen > kMaxDateLength, "kMaxLen must be greater than kMaxDateLength");
+        uint16_t manufacturingYear;
+        uint8_t manufacturingMonth;
+        uint8_t manufacturingDayOfMonth;
+        size_t totalManufacturingDateLen = 0;
 
-                CHIP_ERROR status = mContext.deviceInstanceInfoProvider.GetManufacturingDate(manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
+        CHIP_ERROR status = mContext.deviceInstanceInfoProvider.GetManufacturingDate(manufacturingYear, manufacturingMonth,
+                                                                                     manufacturingDayOfMonth);
 
-                if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
-                {
-                    // Default to an empty string if not found
-                    buffer.reduce_size(0);
-                    return CHIP_NO_ERROR;
-                }
-                ReturnErrorOnFailure(status);
+        if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+        {
+            // Default to an empty string if not found
+            buffer.reduce_size(0);
+            return CHIP_NO_ERROR;
+        }
+        ReturnErrorOnFailure(status);
 
-                if (buffer.size() < kMaxDateLength) {
-                    return CHIP_ERROR_BUFFER_TOO_SMALL;
-                }
+        if (buffer.size() < kMaxDateLength)
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
 
-                // Format is YYYYMMDD
-                int written = snprintf(buffer.data(), buffer.size(), "%04u%02u%02u", manufacturingYear, manufacturingMonth,
-                         manufacturingDayOfMonth);
-                if (written < 0 || written >= static_cast<int>(buffer.size())) {
-                    return CHIP_ERROR_BUFFER_TOO_SMALL;
-                }
-                totalManufacturingDateLen = static_cast<size_t>(written);
+        // Format is YYYYMMDD
+        int written =
+            snprintf(buffer.data(), buffer.size(), "%04u%02u%02u", manufacturingYear, manufacturingMonth, manufacturingDayOfMonth);
+        if (written < 0 || written >= static_cast<int>(buffer.size()))
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+        totalManufacturingDateLen = static_cast<size_t>(written);
 
-                if (buffer.size() > kMaxDateLength)
-                {
-                    MutableCharSpan vendorSuffixSpan(buffer.data() + kMaxDateLength, buffer.size() - kMaxDateLength);
-                    status = mContext.deviceInstanceInfoProvider.GetManufacturingDateSuffix(vendorSuffixSpan);
-                    if (status == CHIP_NO_ERROR)
-                    {
-                        totalManufacturingDateLen += vendorSuffixSpan.size();
-                    }
-                    // Suffix is optional, so errors other than NO_ERROR are ignored.
-                }
-
-                buffer.reduce_size(totalManufacturingDateLen);
-                return CHIP_NO_ERROR;
+        if (buffer.size() > kMaxDateLength)
+        {
+            MutableCharSpan vendorSuffixSpan(buffer.data() + kMaxDateLength, buffer.size() - kMaxDateLength);
+            status = mContext.deviceInstanceInfoProvider.GetManufacturingDateSuffix(vendorSuffixSpan);
+            if (status == CHIP_NO_ERROR)
+            {
+                totalManufacturingDateLen += vendorSuffixSpan.size();
             }
-            case Location::Id: {
+            // Suffix is optional, so errors other than NO_ERROR are ignored.
+        }
+
+        buffer.reduce_size(totalManufacturingDateLen);
+        return CHIP_NO_ERROR;
+    }
+    case Location::Id: {
 
         constexpr size_t kExpectedFixedLocationLength = 2;
         err = mContext.configurationManager.GetCountryCode(buffer.data(), buffer.size(), dataLen);

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.cpp
@@ -1,0 +1,170 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h>
+#include <clusters/BasicInformation/Enums.h>
+#include <platform/CHIPDeviceError.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace BasicInformation {
+
+using namespace DeviceLayer;
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetVendorName(char * buf, size_t bufSize)
+{
+    return mContext.deviceInstanceInfoProvider.GetVendorName(buf, bufSize);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductName(char * buf, size_t bufSize)
+{
+    return mContext.deviceInstanceInfoProvider.GetProductName(buf, bufSize);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetPartNumber(char * buf, size_t bufSize)
+{
+    return IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetPartNumber(buf, bufSize), buf, bufSize);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductURL(char * buf, size_t bufSize)
+{
+    return IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductURL(buf, bufSize), buf, bufSize);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductLabel(char * buf, size_t bufSize)
+{
+    return IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetProductLabel(buf, bufSize), buf, bufSize);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetSerialNumber(char * buf, size_t bufSize)
+{
+    return IgnoreUnimplemented(mContext.deviceInstanceInfoProvider.GetSerialNumber(buf, bufSize), buf, bufSize);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetHardwareVersionString(char * buf, size_t bufSize)
+{
+    return mContext.deviceInstanceInfoProvider.GetHardwareVersionString(buf, bufSize);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetSoftwareVersionString(char * buf, size_t bufSize)
+{
+    return mContext.configurationManager.GetSoftwareVersionString(buf, bufSize);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetUniqueId(char * buf, size_t bufSize)
+{
+    return IgnoreUnimplemented(mContext.configurationManager.GetUniqueId(buf, bufSize), buf, bufSize);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)
+{
+    return mContext.deviceInstanceInfoProvider.GetManufacturingDate(year, month, day);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer)
+{
+    return mContext.deviceInstanceInfoProvider.GetManufacturingDateSuffix(suffixBuffer);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetCountryCode(char * buf, size_t bufSize, size_t & codeLen)
+{
+    return mContext.configurationManager.GetCountryCode(buf, bufSize, codeLen);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetVendorId(uint16_t & vendorId)
+{
+    return mContext.deviceInstanceInfoProvider.GetVendorId(vendorId);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductId(uint16_t & productId)
+{
+    return mContext.deviceInstanceInfoProvider.GetProductId(productId);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetHardwareVersion(uint16_t & hardwareVersion)
+{
+    return mContext.deviceInstanceInfoProvider.GetHardwareVersion(hardwareVersion);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetSoftwareVersion(uint32_t & softwareVersion)
+{
+    return mContext.configurationManager.GetSoftwareVersion(softwareVersion);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductFinish(ProductFinishEnum * finish)
+{
+    return mContext.deviceInstanceInfoProvider.GetProductFinish(finish);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetProductPrimaryColor(ColorEnum * primaryColor)
+{
+    return mContext.deviceInstanceInfoProvider.GetProductPrimaryColor(primaryColor);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetLocalConfigDisabled(bool & localConfigDisabled)
+{
+    return mContext.deviceInstanceInfoProvider.GetLocalConfigDisabled(localConfigDisabled);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::GetConfigurationVersion(uint32_t & configurationVersion)
+{
+    return mContext.configurationManager.GetConfigurationVersion(configurationVersion);
+}
+
+DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas DeviceLayerBasicInformationDelegate::GetSupportedCapabilityMinimaValues()
+{
+    return mContext.deviceInstanceInfoProvider.GetSupportedCapabilityMinimaValues();
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::SetLocalConfigDisabled(bool localConfigDisabled)
+{
+    return mContext.deviceInstanceInfoProvider.SetLocalConfigDisabled(localConfigDisabled);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::StoreConfigurationVersion(uint32_t configurationVersion)
+{
+    return mContext.configurationManager.StoreConfigurationVersion(configurationVersion);
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::StoreCountryCode(const char * code, size_t codeLen)
+{
+    return mContext.configurationManager.StoreCountryCode(code, codeLen);
+}
+
+uint16_t DeviceLayerBasicInformationDelegate::GetSubscriptionsPerFabric() const
+{
+    return mContext.subscriptionsPerFabric;
+}
+
+CHIP_ERROR DeviceLayerBasicInformationDelegate::IgnoreUnimplemented(CHIP_ERROR status, char * buf, size_t bufSize)
+{
+    if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+    {
+        if (bufSize > 0)
+        {
+            buf[0] = 0;
+        }
+        return CHIP_NO_ERROR;
+    }
+    return status;
+}
+
+} // namespace BasicInformation
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
@@ -53,8 +53,6 @@ public:
     CHIP_ERROR StoreLocation(const CharSpan & code) override;
 
 private:
-    CHIP_ERROR IgnoreUnimplemented(CHIP_ERROR status, char * buf, size_t bufSize);
-
     Context mContext;
 };
 

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
@@ -42,15 +42,10 @@ public:
 
     // BasicInformationDelegate Interface
     CHIP_ERROR GetStringAttribute(chip::AttributeId attributeId, MutableCharSpan & buffer) override;
+    CHIP_ERROR GetNumericAttribute(chip::AttributeId attributeId, uint32_t & value) override;
 
-    CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
-    CHIP_ERROR GetProductId(uint16_t & productId) override;
-    CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override;
-    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion) override;
-    CHIP_ERROR GetProductFinish(ProductFinishEnum * finish) override;
-    CHIP_ERROR GetProductPrimaryColor(ColorEnum * primaryColor) override;
+    CHIP_ERROR GetProductAppearance(Structs::ProductAppearanceStruct::Type & outProductAppearance) override;
     CHIP_ERROR GetLocalConfigDisabled(bool & localConfigDisabled) override;
-    CHIP_ERROR GetConfigurationVersion(uint32_t & configurationVersion) override;
     DeviceLayer::DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues() override;
 
     CHIP_ERROR SetLocalConfigDisabled(bool localConfigDisabled) override;

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
@@ -42,8 +42,6 @@ public:
 
     // BasicInformationDelegate Interface
     CHIP_ERROR GetStringAttribute(chip::AttributeId attributeId, MutableCharSpan & buffer) override;
-    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;
-    CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer) override;
 
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
@@ -1,0 +1,82 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/clusters/basic-information/BasicInformationDelegate.h>
+#include <clusters/BasicInformation/Enums.h>
+#include <platform/ConfigurationManager.h>
+#include <platform/DeviceInstanceInfoProvider.h>
+#include <platform/PlatformManager.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace BasicInformation {
+
+class DeviceLayerBasicInformationDelegate : public BasicInformationDelegate
+{
+public:
+    struct Context
+    {
+        DeviceLayer::DeviceInstanceInfoProvider & deviceInstanceInfoProvider;
+        DeviceLayer::ConfigurationManager & configurationManager;
+        DeviceLayer::PlatformManager & platformManager;
+        uint16_t subscriptionsPerFabric;
+    };
+
+    DeviceLayerBasicInformationDelegate(Context ctx) : mContext(ctx) {}
+
+    // BasicInformationDelegate Interface
+    CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;
+    CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer) override;
+    CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) override;
+
+    CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
+    CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override;
+    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion) override;
+    CHIP_ERROR GetProductFinish(ProductFinishEnum * finish) override;
+    CHIP_ERROR GetProductPrimaryColor(ColorEnum * primaryColor) override;
+    CHIP_ERROR GetLocalConfigDisabled(bool & localConfigDisabled) override;
+    CHIP_ERROR GetConfigurationVersion(uint32_t & configurationVersion) override;
+    DeviceLayer::DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues() override;
+
+    CHIP_ERROR SetLocalConfigDisabled(bool localConfigDisabled) override;
+    CHIP_ERROR StoreConfigurationVersion(uint32_t configurationVersion) override;
+    CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) override;
+
+    uint16_t GetSubscriptionsPerFabric() const override;
+
+private:
+    CHIP_ERROR IgnoreUnimplemented(CHIP_ERROR status, char * buf, size_t bufSize);
+
+    Context mContext;
+};
+
+} // namespace BasicInformation
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
@@ -46,13 +46,11 @@ public:
 
     CHIP_ERROR GetProductAppearance(Structs::ProductAppearanceStruct::Type & outProductAppearance) override;
     CHIP_ERROR GetLocalConfigDisabled(bool & localConfigDisabled) override;
-    DeviceLayer::DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues() override;
+    CHIP_ERROR GetCapabilityMinima(Structs::CapabilityMinimaStruct::Type & outCapabilityMinima) override;
 
     CHIP_ERROR SetLocalConfigDisabled(bool localConfigDisabled) override;
     CHIP_ERROR StoreConfigurationVersion(uint32_t configurationVersion) override;
     CHIP_ERROR StoreLocation(const CharSpan & code) override;
-
-    uint16_t GetSubscriptionsPerFabric() const override;
 
 private:
     CHIP_ERROR IgnoreUnimplemented(CHIP_ERROR status, char * buf, size_t bufSize);

--- a/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/DeviceLayerBasicInformationDelegate.h
@@ -41,18 +41,9 @@ public:
     DeviceLayerBasicInformationDelegate(Context ctx) : mContext(ctx) {}
 
     // BasicInformationDelegate Interface
-    CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetStringAttribute(chip::AttributeId attributeId, MutableCharSpan & buffer) override;
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;
     CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer) override;
-    CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) override;
 
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
@@ -66,7 +57,7 @@ public:
 
     CHIP_ERROR SetLocalConfigDisabled(bool localConfigDisabled) override;
     CHIP_ERROR StoreConfigurationVersion(uint32_t configurationVersion) override;
-    CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) override;
+    CHIP_ERROR StoreLocation(const CharSpan & code) override;
 
     uint16_t GetSubscriptionsPerFabric() const override;
 

--- a/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
@@ -86,29 +86,13 @@ public:
             return CopyCharSpanToMutableCharSpan(kSoftwareVersionString, buffer);
         case Attributes::UniqueID::Id:
             return CopyCharSpanToMutableCharSpan(kUniqueId, buffer);
+        case Attributes::ManufacturingDate::Id:
+            return CopyCharSpanToMutableCharSpan(CharSpan::fromCharString(mManufacturingDate), buffer);
         case Attributes::Location::Id:
             return CopyCharSpanToMutableCharSpan(CharSpan::fromCharString(mLocation), buffer);
         default:
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-    }
-
-    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override
-    {
-        year  = kManufacturingYear;
-        month = kManufacturingMonth;
-        day   = kManufacturingDay;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer) override
-    {
-        if (mManufacturingDateSuffix == nullptr)
-        {
-            suffixBuffer.reduce_size(0);
-            return CHIP_NO_ERROR;
-        }
-        return CopyCharSpanToMutableCharSpan(CharSpan::fromCharString(mManufacturingDateSuffix), suffixBuffer);
     }
 
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override
@@ -181,17 +165,15 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    uint16_t GetSubscriptionsPerFabric() const override { return 3; }
-    // Helper for tests
-    void SetManufacturingDateSuffix(const char * suffix) { mManufacturingDateSuffix = suffix; }
-
 public: // Public for test access
     uint32_t mConfigurationVersion       = 10u;
     uint32_t mStoreConfigVersionCalled   = 0u;
     CHIP_ERROR mStoreConfigVersionReturn = CHIP_NO_ERROR;
+    char mManufacturingDate[17]   = "20230615"; // YYYYMMDD + optional suffix
+
+    uint16_t GetSubscriptionsPerFabric() const override { return 3; }
 
 private:
-    const char * mManufacturingDateSuffix = nullptr;
     bool mLocalConfigDisabled             = false;
     char mLocation[kLocationLength + 1]   = "XX";
 };

--- a/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
@@ -1,0 +1,195 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/clusters/basic-information/BasicInformationDelegate.h>
+#include <clusters/BasicInformation/Enums.h>
+#include <lib/support/CHIPMemString.h>
+#include <lib/support/Span.h>
+#include <platform/CHIPDeviceLayer.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace BasicInformation {
+namespace tests {
+
+using namespace chip::DeviceLayer;
+
+static constexpr const char * kVendorName            = "TestVendor";
+static constexpr const char * kProductName           = "TestProduct";
+static constexpr const char * kHardwareVersionString = "HW1.0";
+static constexpr const char * kPartNumber            = "PART123";
+static constexpr const char * kProductURL            = "http://example.com";
+static constexpr const char * kProductLabel          = "Label123";
+static constexpr const char * kSerialNumber          = "SN123456";
+static constexpr uint16_t kVendorId                  = static_cast<uint16_t>(VendorId::TestVendor1);
+static constexpr uint16_t kProductId                 = 0x5678;
+static constexpr uint16_t kHardwareVersion           = 1;
+static constexpr uint16_t kManufacturingYear         = 2023;
+static constexpr uint8_t kManufacturingMonth         = 6;
+static constexpr uint8_t kManufacturingDay           = 15;
+static constexpr ProductFinishEnum kProductFinish    = ProductFinishEnum::kMatte;
+static constexpr ColorEnum kProductPrimaryColor      = ColorEnum::kBlack;
+static constexpr size_t kCountryCodeLength = 2;
+static constexpr const char * kUniqueId    = "TEST_UNIQUE_ID_12345";
+static constexpr const char * kSoftwareVersionString = "SW1.0";
+static constexpr uint32_t kSoftwareVersion         = 1;
+
+// Helper function to safely copy strings and check for buffer size
+inline CHIP_ERROR SafeCopyString(char * buf, size_t bufSize, const char * source)
+{
+    if (strlen(source) >= bufSize)
+    {
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
+    Platform::CopyString(buf, bufSize, source);
+    return CHIP_NO_ERROR;
+}
+
+class MockBasicInformationDelegate : public BasicInformationDelegate
+{
+public:
+    CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kVendorName); }
+    CHIP_ERROR GetProductName(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductName); }
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kPartNumber); }
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductURL); }
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductLabel); }
+    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kSerialNumber); }
+    CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override
+    {
+        return SafeCopyString(buf, bufSize, kHardwareVersionString);
+    }
+    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override
+    {
+        return SafeCopyString(buf, bufSize, kSoftwareVersionString);
+    }
+    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kUniqueId); }
+    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override
+    {
+        year  = kManufacturingYear;
+        month = kManufacturingMonth;
+        day   = kManufacturingDay;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer) override
+    {
+        if (mManufacturingDateSuffix == nullptr)
+        {
+            suffixBuffer.reduce_size(0);
+            return CHIP_NO_ERROR;
+        }
+        return CopyCharSpanToMutableCharSpan(CharSpan::fromCharString(mManufacturingDateSuffix), suffixBuffer);
+    }
+
+    CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & countryCodeLen) override
+    {
+        VerifyOrReturnError(bufSize > kCountryCodeLength, CHIP_ERROR_BUFFER_TOO_SMALL);
+        Platform::CopyString(buf, bufSize, mCountryCode);
+        countryCodeLen = kCountryCodeLength;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetVendorId(uint16_t & vendorId) override
+    {
+        vendorId = kVendorId;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR GetProductId(uint16_t & productId) override
+    {
+        productId = kProductId;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override
+    {
+        hardwareVersion = kHardwareVersion;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion) override
+    {
+        softwareVersion = kSoftwareVersion;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR GetProductFinish(ProductFinishEnum * finish) override
+    {
+        *finish = kProductFinish;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR GetProductPrimaryColor(ColorEnum * primaryColor) override
+    {
+        *primaryColor = kProductPrimaryColor;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR GetLocalConfigDisabled(bool & localConfigDisabled) override
+    {
+        localConfigDisabled = mLocalConfigDisabled;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR GetConfigurationVersion(uint32_t & configurationVersion) override
+    {
+        configurationVersion = mConfigurationVersion;
+        return CHIP_NO_ERROR;
+    }
+    DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues() override
+    {
+        return {
+            .simultaneousInvocationsSupported = CHIP_IM_MAX_NUM_COMMAND_HANDLER,
+            .simultaneousWritesSupported      = CHIP_IM_MAX_NUM_WRITE_HANDLER,
+            .readPathsSupported               = CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS,
+            .subscribePathsSupported          = CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS,
+        };
+    }
+
+    CHIP_ERROR SetLocalConfigDisabled(bool localConfigDisabled) override
+    {
+        mLocalConfigDisabled = localConfigDisabled;
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR StoreConfigurationVersion(uint32_t configurationVersion) override
+    {
+        mConfigurationVersion = configurationVersion;
+        mStoreConfigVersionCalled++;
+        return mStoreConfigVersionReturn;
+    }
+    CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) override
+    {
+        VerifyOrReturnError(codeLen == kCountryCodeLength, CHIP_ERROR_INVALID_ARGUMENT);
+        Platform::CopyString(mCountryCode, sizeof(mCountryCode), code);
+        return CHIP_NO_ERROR;
+    }
+
+    uint16_t GetSubscriptionsPerFabric() const override { return 3; }
+
+    // Helper for tests
+    void SetManufacturingDateSuffix(const char * suffix) { mManufacturingDateSuffix = suffix; }
+
+public: // Public for test access
+    uint32_t mConfigurationVersion = 10u;
+    uint32_t mStoreConfigVersionCalled = 0u;
+    CHIP_ERROR mStoreConfigVersionReturn = CHIP_NO_ERROR;
+
+private:
+    const char * mManufacturingDateSuffix = nullptr;
+    char mCountryCode[kCountryCodeLength + 1] = "XX";
+    bool mLocalConfigDisabled                 = false;
+};
+
+} // namespace tests
+} // namespace BasicInformation
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <app/clusters/basic-information/BasicInformationDelegate.h>
+#include <clusters/BasicInformation/Attributes.h>
 #include <clusters/BasicInformation/Enums.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/Span.h>
@@ -29,25 +30,25 @@ namespace tests {
 
 using namespace chip::DeviceLayer;
 
-static constexpr const char * kVendorName            = "TestVendor";
-static constexpr const char * kProductName           = "TestProduct";
-static constexpr const char * kHardwareVersionString = "HW1.0";
-static constexpr const char * kPartNumber            = "PART123";
-static constexpr const char * kProductURL            = "http://example.com";
-static constexpr const char * kProductLabel          = "Label123";
-static constexpr const char * kSerialNumber          = "SN123456";
-static constexpr uint16_t kVendorId                  = static_cast<uint16_t>(VendorId::TestVendor1);
-static constexpr uint16_t kProductId                 = 0x5678;
-static constexpr uint16_t kHardwareVersion           = 1;
-static constexpr uint16_t kManufacturingYear         = 2023;
-static constexpr uint8_t kManufacturingMonth         = 6;
-static constexpr uint8_t kManufacturingDay           = 15;
-static constexpr ProductFinishEnum kProductFinish    = ProductFinishEnum::kMatte;
-static constexpr ColorEnum kProductPrimaryColor      = ColorEnum::kBlack;
-static constexpr size_t kCountryCodeLength = 2;
-static constexpr const char * kUniqueId    = "TEST_UNIQUE_ID_12345";
-static constexpr const char * kSoftwareVersionString = "SW1.0";
-static constexpr uint32_t kSoftwareVersion         = 1;
+static auto kVendorName                           = "TestVendor"_span;
+static auto kProductName                          = "TestProduct"_span;
+static auto kHardwareVersionString                = "HW1.0"_span;
+static auto kPartNumber                           = "PART123"_span;
+static auto kProductURL                           = "http://example.com"_span;
+static auto kProductLabel                         = "Label123"_span;
+static auto kSerialNumber                         = "SN123456"_span;
+static constexpr uint16_t kVendorId               = static_cast<uint16_t>(VendorId::TestVendor1);
+static constexpr uint16_t kProductId              = 0x5678;
+static constexpr uint16_t kHardwareVersion        = 1;
+static constexpr uint16_t kManufacturingYear      = 2023;
+static constexpr uint8_t kManufacturingMonth      = 6;
+static constexpr uint8_t kManufacturingDay        = 15;
+static constexpr ProductFinishEnum kProductFinish = ProductFinishEnum::kMatte;
+static constexpr ColorEnum kProductPrimaryColor   = ColorEnum::kBlack;
+static constexpr size_t kLocationLength        = 2;
+static auto kUniqueId                             = "TEST_UNIQUE_ID_12345"_span;
+static auto kSoftwareVersionString                = "SW1.0"_span;
+static constexpr uint32_t kSoftwareVersion        = 1;
 
 // Helper function to safely copy strings and check for buffer size
 inline CHIP_ERROR SafeCopyString(char * buf, size_t bufSize, const char * source)
@@ -63,21 +64,35 @@ inline CHIP_ERROR SafeCopyString(char * buf, size_t bufSize, const char * source
 class MockBasicInformationDelegate : public BasicInformationDelegate
 {
 public:
-    CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kVendorName); }
-    CHIP_ERROR GetProductName(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductName); }
-    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kPartNumber); }
-    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductURL); }
-    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductLabel); }
-    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kSerialNumber); }
-    CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override
+    CHIP_ERROR GetStringAttribute(chip::AttributeId attributeId, MutableCharSpan & buffer) override
     {
-        return SafeCopyString(buf, bufSize, kHardwareVersionString);
+        switch (attributeId)
+        {
+        case Attributes::VendorName::Id:
+            return CopyCharSpanToMutableCharSpan(kVendorName, buffer);
+        case Attributes::ProductName::Id:
+            return CopyCharSpanToMutableCharSpan(kProductName, buffer);
+        case Attributes::PartNumber::Id:
+            return CopyCharSpanToMutableCharSpan(kPartNumber, buffer);
+        case Attributes::ProductURL::Id:
+            return CopyCharSpanToMutableCharSpan(kProductURL, buffer);
+        case Attributes::ProductLabel::Id:
+            return CopyCharSpanToMutableCharSpan(kProductLabel, buffer);
+        case Attributes::SerialNumber::Id:
+            return CopyCharSpanToMutableCharSpan(kSerialNumber, buffer);
+        case Attributes::HardwareVersionString::Id:
+            return CopyCharSpanToMutableCharSpan(kHardwareVersionString, buffer);
+        case Attributes::SoftwareVersionString::Id:
+            return CopyCharSpanToMutableCharSpan(kSoftwareVersionString, buffer);
+        case Attributes::UniqueID::Id:
+            return CopyCharSpanToMutableCharSpan(kUniqueId, buffer);
+        case Attributes::Location::Id:
+            return CopyCharSpanToMutableCharSpan(CharSpan::fromCharString(mLocation), buffer);
+        default:
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
     }
-    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override
-    {
-        return SafeCopyString(buf, bufSize, kSoftwareVersionString);
-    }
-    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kUniqueId); }
+
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override
     {
         year  = kManufacturingYear;
@@ -94,14 +109,6 @@ public:
             return CHIP_NO_ERROR;
         }
         return CopyCharSpanToMutableCharSpan(CharSpan::fromCharString(mManufacturingDateSuffix), suffixBuffer);
-    }
-
-    CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & countryCodeLen) override
-    {
-        VerifyOrReturnError(bufSize > kCountryCodeLength, CHIP_ERROR_BUFFER_TOO_SMALL);
-        Platform::CopyString(buf, bufSize, mCountryCode);
-        countryCodeLen = kCountryCodeLength;
-        return CHIP_NO_ERROR;
     }
 
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override
@@ -159,33 +166,34 @@ public:
         mLocalConfigDisabled = localConfigDisabled;
         return CHIP_NO_ERROR;
     }
+
     CHIP_ERROR StoreConfigurationVersion(uint32_t configurationVersion) override
     {
         mConfigurationVersion = configurationVersion;
         mStoreConfigVersionCalled++;
         return mStoreConfigVersionReturn;
     }
-    CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) override
+
+    CHIP_ERROR StoreLocation(const CharSpan & code) override
     {
-        VerifyOrReturnError(codeLen == kCountryCodeLength, CHIP_ERROR_INVALID_ARGUMENT);
-        Platform::CopyString(mCountryCode, sizeof(mCountryCode), code);
+        VerifyOrReturnError(code.size() == kLocationLength, CHIP_ERROR_INVALID_ARGUMENT);
+        Platform::CopyString(mLocation, sizeof(mLocation), code.data());
         return CHIP_NO_ERROR;
     }
 
     uint16_t GetSubscriptionsPerFabric() const override { return 3; }
-
     // Helper for tests
     void SetManufacturingDateSuffix(const char * suffix) { mManufacturingDateSuffix = suffix; }
 
 public: // Public for test access
-    uint32_t mConfigurationVersion = 10u;
-    uint32_t mStoreConfigVersionCalled = 0u;
+    uint32_t mConfigurationVersion       = 10u;
+    uint32_t mStoreConfigVersionCalled   = 0u;
     CHIP_ERROR mStoreConfigVersionReturn = CHIP_NO_ERROR;
 
 private:
-    const char * mManufacturingDateSuffix = nullptr;
-    char mCountryCode[kCountryCodeLength + 1] = "XX";
+    const char * mManufacturingDateSuffix     = nullptr;
     bool mLocalConfigDisabled                 = false;
+    char mLocation[kLocationLength + 1]     = "XX";
 };
 
 } // namespace tests

--- a/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
@@ -169,13 +169,13 @@ public: // Public for test access
     uint32_t mConfigurationVersion       = 10u;
     uint32_t mStoreConfigVersionCalled   = 0u;
     CHIP_ERROR mStoreConfigVersionReturn = CHIP_NO_ERROR;
-    char mManufacturingDate[17]   = "20230615"; // YYYYMMDD + optional suffix
+    char mManufacturingDate[17]          = "20230615"; // YYYYMMDD + optional suffix
 
     uint16_t GetSubscriptionsPerFabric() const override { return 3; }
 
 private:
-    bool mLocalConfigDisabled             = false;
-    char mLocation[kLocationLength + 1]   = "XX";
+    bool mLocalConfigDisabled           = false;
+    char mLocation[kLocationLength + 1] = "XX";
 };
 
 } // namespace tests

--- a/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
@@ -95,7 +95,7 @@ public:
         }
     }
 
-    CHIP_ERROR GetNumericAttribute(chip::AttributeId attributeId, uint64_t & value) override
+    CHIP_ERROR GetNumericAttribute(chip::AttributeId attributeId, uint32_t & value) override
     {
         switch (attributeId)
         {
@@ -111,9 +111,9 @@ public:
         case Attributes::SoftwareVersion::Id:
             value = kSoftwareVersion;
             return CHIP_NO_ERROR;
-        case Attributes::LocalConfigDisabled::Id:
-            value = mLocalConfigDisabled;
-            return CHIP_NO_ERROR;
+        // case Attributes::LocalConfigDisabled::Id: // This is a bool, not handled here
+        //     value = mLocalConfigDisabled;
+        //     return CHIP_NO_ERROR;
         case Attributes::ConfigurationVersion::Id:
             value = mConfigurationVersion;
             return CHIP_NO_ERROR;
@@ -133,14 +133,20 @@ public:
         localConfigDisabled = mLocalConfigDisabled;
         return CHIP_NO_ERROR;
     }
-    DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues() override
+
+    CHIP_ERROR GetCapabilityMinima(Structs::CapabilityMinimaStruct::Type & outCapabilityMinima) override
     {
-        return {
-            .simultaneousInvocationsSupported = CHIP_IM_MAX_NUM_COMMAND_HANDLER,
-            .simultaneousWritesSupported      = CHIP_IM_MAX_NUM_WRITE_HANDLER,
-            .readPathsSupported               = CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS,
-            .subscribePathsSupported          = CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS,
-        };
+        outCapabilityMinima.caseSessionsPerFabric  = 3;
+        outCapabilityMinima.subscriptionsPerFabric = 3;
+        outCapabilityMinima.simultaneousInvocationsSupported =
+            chip::MakeOptional<uint16_t>(static_cast<uint16_t>(CHIP_IM_MAX_NUM_COMMAND_HANDLER));
+        outCapabilityMinima.simultaneousWritesSupported =
+            chip::MakeOptional<uint16_t>(static_cast<uint16_t>(CHIP_IM_MAX_NUM_WRITE_HANDLER));
+        outCapabilityMinima.readPathsSupported =
+            chip::MakeOptional<uint16_t>(static_cast<uint16_t>(CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_READS));
+        outCapabilityMinima.subscribePathsSupported =
+            chip::MakeOptional<uint16_t>(static_cast<uint16_t>(CHIP_IM_SERVER_MAX_NUM_PATH_GROUPS_FOR_SUBSCRIPTIONS));
+        return CHIP_NO_ERROR;
     }
 
     CHIP_ERROR SetLocalConfigDisabled(bool localConfigDisabled) override
@@ -168,8 +174,6 @@ public: // Public for test access
     uint32_t mStoreConfigVersionCalled   = 0u;
     CHIP_ERROR mStoreConfigVersionReturn = CHIP_NO_ERROR;
     char mManufacturingDate[17]          = "20230615"; // YYYYMMDD + optional suffix
-
-    uint16_t GetSubscriptionsPerFabric() const override { return 3; }
 
 private:
     bool mLocalConfigDisabled           = false;

--- a/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
@@ -45,7 +45,7 @@ static constexpr uint8_t kManufacturingMonth      = 6;
 static constexpr uint8_t kManufacturingDay        = 15;
 static constexpr ProductFinishEnum kProductFinish = ProductFinishEnum::kMatte;
 static constexpr ColorEnum kProductPrimaryColor   = ColorEnum::kBlack;
-static constexpr size_t kLocationLength        = 2;
+static constexpr size_t kLocationLength           = 2;
 static auto kUniqueId                             = "TEST_UNIQUE_ID_12345"_span;
 static auto kSoftwareVersionString                = "SW1.0"_span;
 static constexpr uint32_t kSoftwareVersion        = 1;
@@ -191,9 +191,9 @@ public: // Public for test access
     CHIP_ERROR mStoreConfigVersionReturn = CHIP_NO_ERROR;
 
 private:
-    const char * mManufacturingDateSuffix     = nullptr;
-    bool mLocalConfigDisabled                 = false;
-    char mLocation[kLocationLength + 1]     = "XX";
+    const char * mManufacturingDateSuffix = nullptr;
+    bool mLocalConfigDisabled             = false;
+    char mLocation[kLocationLength + 1]   = "XX";
 };
 
 } // namespace tests

--- a/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
+++ b/src/app/clusters/basic-information/tests/MockBasicInformationDelegate.h
@@ -95,44 +95,42 @@ public:
         }
     }
 
-    CHIP_ERROR GetVendorId(uint16_t & vendorId) override
+    CHIP_ERROR GetNumericAttribute(chip::AttributeId attributeId, uint64_t & value) override
     {
-        vendorId = kVendorId;
-        return CHIP_NO_ERROR;
+        switch (attributeId)
+        {
+        case Attributes::VendorID::Id:
+            value = kVendorId;
+            return CHIP_NO_ERROR;
+        case Attributes::ProductID::Id:
+            value = kProductId;
+            return CHIP_NO_ERROR;
+        case Attributes::HardwareVersion::Id:
+            value = kHardwareVersion;
+            return CHIP_NO_ERROR;
+        case Attributes::SoftwareVersion::Id:
+            value = kSoftwareVersion;
+            return CHIP_NO_ERROR;
+        case Attributes::LocalConfigDisabled::Id:
+            value = mLocalConfigDisabled;
+            return CHIP_NO_ERROR;
+        case Attributes::ConfigurationVersion::Id:
+            value = mConfigurationVersion;
+            return CHIP_NO_ERROR;
+        default:
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
     }
-    CHIP_ERROR GetProductId(uint16_t & productId) override
+
+    CHIP_ERROR GetProductAppearance(Structs::ProductAppearanceStruct::Type & outProductAppearance) override
     {
-        productId = kProductId;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override
-    {
-        hardwareVersion = kHardwareVersion;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion) override
-    {
-        softwareVersion = kSoftwareVersion;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR GetProductFinish(ProductFinishEnum * finish) override
-    {
-        *finish = kProductFinish;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR GetProductPrimaryColor(ColorEnum * primaryColor) override
-    {
-        *primaryColor = kProductPrimaryColor;
+        outProductAppearance.finish = kProductFinish;
+        outProductAppearance.primaryColor.SetNonNull(kProductPrimaryColor);
         return CHIP_NO_ERROR;
     }
     CHIP_ERROR GetLocalConfigDisabled(bool & localConfigDisabled) override
     {
         localConfigDisabled = mLocalConfigDisabled;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR GetConfigurationVersion(uint32_t & configurationVersion) override
-    {
-        configurationVersion = mConfigurationVersion;
         return CHIP_NO_ERROR;
     }
     DeviceInstanceInfoProvider::DeviceInfoCapabilityMinimas GetSupportedCapabilityMinimaValues() override

--- a/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
@@ -27,7 +27,7 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/BitFlags.h>
 #include <lib/support/ReadOnlyBuffer.h>
-#include <platform/DeviceInfoProvider.h>
+#include "MockBasicInformationDelegate.h"
 #include <platform/NetworkCommissioning.h>
 
 namespace {
@@ -36,109 +36,19 @@ using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::BasicInformation;
 using namespace chip::app::Clusters::BasicInformation::Attributes;
+using namespace chip::app::Clusters::BasicInformation::tests;
 
 using chip::app::DataModel::AcceptedCommandEntry;
 using chip::app::DataModel::AttributeEntry;
 
-static constexpr const char * kVendorName            = "TestVendor";
-static constexpr const char * kProductName           = "TestProduct";
-static constexpr const char * kHardwareVersionString = "HW1.0";
-static constexpr const char * kPartNumber            = "PART123";
-static constexpr const char * kProductURL            = "http://example.com";
-static constexpr const char * kProductLabel          = "Label123";
-static constexpr const char * kSerialNumber          = "SN123456";
-static constexpr uint16_t kVendorId                  = static_cast<uint16_t>(VendorId::TestVendor1);
-static constexpr uint16_t kProductId                 = 0x5678;
-static constexpr uint16_t kHardwareVersion           = 1;
-static constexpr uint16_t kManufacturingYear         = 2023;
-static constexpr uint8_t kManufacturingMonth         = 6;
-static constexpr uint8_t kManufacturingDay           = 15;
-static constexpr ProductFinishEnum kProductFinish    = ProductFinishEnum::kMatte;
-static constexpr ColorEnum kProductPrimaryColor      = ColorEnum::kBlack;
 
-// Helper function to safely copy strings and check for buffer size
-CHIP_ERROR SafeCopyString(char * buf, size_t bufSize, const char * source)
-{
-    if (strlen(source) >= bufSize)
-    {
-        return CHIP_ERROR_BUFFER_TOO_SMALL;
-    }
-    Platform::CopyString(buf, bufSize, source);
-    return CHIP_NO_ERROR;
-}
 
-// Mock DeviceInstanceInfoProvider for testing
-class MockDeviceInstanceInfoProvider : public DeviceLayer::DeviceInstanceInfoProvider
-{
-public:
-    CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kVendorName); }
 
-    CHIP_ERROR GetVendorId(uint16_t & vendorId) override
-    {
-        vendorId = kVendorId;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetProductName(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductName); }
-
-    CHIP_ERROR GetProductId(uint16_t & productId) override
-    {
-        productId = kProductId;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override
-    {
-        hardwareVersion = kHardwareVersion;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override
-    {
-        return SafeCopyString(buf, bufSize, kHardwareVersionString);
-    }
-
-    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override
-    {
-        year  = kManufacturingYear;
-        month = kManufacturingMonth;
-        day   = kManufacturingDay;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kPartNumber); }
-
-    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductURL); }
-
-    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductLabel); }
-
-    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kSerialNumber); }
-
-    CHIP_ERROR GetProductFinish(ProductFinishEnum * finish) override
-    {
-        *finish = kProductFinish;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetProductPrimaryColor(ColorEnum * color) override
-    {
-        *color = kProductPrimaryColor;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override { return CHIP_NO_ERROR; }
-};
 
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestBasicInformationCluster : public ::testing::Test
 {
-    MockDeviceInstanceInfoProvider mDeviceInfoProvider;
-    BasicInformationCluster::Context mContext = {
-        .deviceInstanceInfoProvider = mDeviceInfoProvider,
-        .configurationManager       = chip::DeviceLayer::ConfigurationMgr(),
-        .platformManager            = chip::DeviceLayer::PlatformMgr(),
-        .subscriptionsPerFabric     = app::InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric(),
-    };
+    tests::MockBasicInformationDelegate mMockDelegate;
 
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
@@ -150,7 +60,7 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
     // check without optional attributes
     {
         const BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
-        BasicInformationCluster cluster(optionalAttributeSet, mContext);
+        BasicInformationCluster cluster(optionalAttributeSet, &mMockDelegate, chip::DeviceLayer::PlatformMgr());
 
         EXPECT_TRUE(Testing::IsAttributesListEqualTo(
             cluster,
@@ -168,7 +78,7 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
     // Check that disabling unique id works
     {
         const BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
-        BasicInformationCluster cluster(optionalAttributeSet, mContext);
+        BasicInformationCluster cluster(optionalAttributeSet, &mMockDelegate, chip::DeviceLayer::PlatformMgr());
 
         // UniqueID is EXPLICITLY NOT SET
         cluster.OptionalAttributes() = BasicInformationCluster::OptionalAttributesSet();
@@ -206,7 +116,7 @@ TEST_F(TestBasicInformationCluster, TestAttributes)
                                                                                         .Set<ProductAppearance::Id>()
                                                                                         .Set<UniqueID::Id>();
 
-        BasicInformationCluster cluster(optionalAttributeSet, mContext);
+        BasicInformationCluster cluster(optionalAttributeSet, &mMockDelegate, chip::DeviceLayer::PlatformMgr());
 
         EXPECT_TRUE(Testing::IsAttributesListEqualTo(cluster,
 

--- a/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationCluster.cpp
@@ -15,6 +15,7 @@
  */
 #include <pw_unit_test/framework.h>
 
+#include "MockBasicInformationDelegate.h"
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/basic-information/BasicInformationCluster.h>
 #include <app/data-model-provider/MetadataTypes.h>
@@ -27,7 +28,6 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/BitFlags.h>
 #include <lib/support/ReadOnlyBuffer.h>
-#include "MockBasicInformationDelegate.h"
 #include <platform/NetworkCommissioning.h>
 
 namespace {
@@ -40,10 +40,6 @@ using namespace chip::app::Clusters::BasicInformation::tests;
 
 using chip::app::DataModel::AcceptedCommandEntry;
 using chip::app::DataModel::AttributeEntry;
-
-
-
-
 
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestBasicInformationCluster : public ::testing::Test

--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include "MockBasicInformationDelegate.h"
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/basic-information/BasicInformationCluster.h>
 #include <app/persistence/AttributePersistence.h>
@@ -30,7 +31,6 @@
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/DeviceInstanceInfoProvider.h>
-#include "MockBasicInformationDelegate.h"
 #include <pw_unit_test/framework.h>
 
 namespace {
@@ -40,8 +40,6 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::BasicInformation;
 using namespace chip::app::Clusters::BasicInformation::tests;
-
-
 
 struct TestBasicInformationReadWrite : public ::testing::Test
 {
@@ -143,7 +141,7 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
         char buf[64];
         CharSpan val(buf);
         ASSERT_EQ(tester.ReadAttribute(Attributes::VendorName::Id, val), CHIP_NO_ERROR);
-        EXPECT_TRUE(val.data_equal(CharSpan::fromCharString(kVendorName)));
+        EXPECT_TRUE(val.data_equal(kVendorName));
     }
 
     // VendorID
@@ -158,7 +156,7 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
         char buf[64];
         CharSpan val(buf);
         ASSERT_EQ(tester.ReadAttribute(Attributes::ProductName::Id, val), CHIP_NO_ERROR);
-        EXPECT_TRUE(val.data_equal(CharSpan::fromCharString(kProductName)));
+        EXPECT_TRUE(val.data_equal(kProductName));
     }
     // ProductID
     {
@@ -187,7 +185,7 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
         char buf[64];
         CharSpan val(buf);
         ASSERT_EQ(tester.ReadAttribute(Attributes::HardwareVersionString::Id, val), CHIP_NO_ERROR);
-        EXPECT_TRUE(val.data_equal(CharSpan::fromCharString(kHardwareVersionString)));
+        EXPECT_TRUE(val.data_equal(kHardwareVersionString));
     }
 
     // SoftwareVersion is read from ConfigurationManager
@@ -232,7 +230,7 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
         else
         {
             // If UniqueID is readable, it must match what the mock returns.
-            EXPECT_TRUE(val.data_equal(CharSpan::fromCharString(kUniqueId)));
+            EXPECT_TRUE(val.data_equal(kUniqueId));
             EXPECT_EQ(clusterRev, BasicInformation::kRevision);
         }
     }
@@ -290,8 +288,8 @@ TEST_F(TestBasicInformationReadWrite, TestWriteLocation)
     // --- Test Case 1: Write a valid 2-character location ---
     {
         CharSpan validLocation = "US"_span;
-        char readBuffer[8];
-        CharSpan readSpan(readBuffer);
+        char readBuffer[32];
+        CharSpan readSpan(readBuffer, sizeof(readBuffer));
         ASSERT_EQ(tester.WriteAttribute(Attributes::Location::Id, validLocation), CHIP_NO_ERROR);
         ASSERT_EQ(tester.ReadAttribute(Attributes::Location::Id, readSpan), CHIP_NO_ERROR);
         EXPECT_TRUE(readSpan.data_equal(validLocation));

--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -207,10 +207,10 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
     {
         char buf[32];
         CharSpan val(buf);
-        mMockDelegate.SetManufacturingDateSuffix("ABCDEFGH");
+        strcpy(mMockDelegate.mManufacturingDate, "20230615ABCDEFGH");
         ASSERT_EQ(tester.ReadAttribute(Attributes::ManufacturingDate::Id, val), CHIP_NO_ERROR);
         EXPECT_TRUE(val.data_equal("20230615ABCDEFGH"_span));
-        mMockDelegate.SetManufacturingDateSuffix(nullptr);
+        strcpy(mMockDelegate.mManufacturingDate, "20230615"); // Reset
     }
 
     // UniqueID (Mandatory in Rev 4+, so if it fails, cluster rev must be < 4)

--- a/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
+++ b/src/app/clusters/basic-information/tests/TestBasicInformationReadWrite.cpp
@@ -30,6 +30,7 @@
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/DeviceInstanceInfoProvider.h>
+#include "MockBasicInformationDelegate.h"
 #include <pw_unit_test/framework.h>
 
 namespace {
@@ -38,238 +39,10 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::BasicInformation;
+using namespace chip::app::Clusters::BasicInformation::tests;
 
-static constexpr const char * kVendorName            = "TestVendor";
-static constexpr const char * kProductName           = "TestProduct";
-static constexpr const char * kHardwareVersionString = "HW1.0";
-static constexpr const char * kPartNumber            = "PART123";
-static constexpr const char * kProductURL            = "http://example.com";
-static constexpr const char * kProductLabel          = "Label123";
-static constexpr const char * kSerialNumber          = "SN123456";
-static constexpr uint16_t kVendorId                  = static_cast<uint16_t>(VendorId::TestVendor1);
-static constexpr uint16_t kProductId                 = 0x5678;
-static constexpr uint16_t kHardwareVersion           = 1;
-static constexpr uint16_t kManufacturingYear         = 2023;
-static constexpr uint8_t kManufacturingMonth         = 6;
-static constexpr uint8_t kManufacturingDay           = 15;
-static constexpr ProductFinishEnum kProductFinish    = ProductFinishEnum::kMatte;
-static constexpr ColorEnum kProductPrimaryColor      = ColorEnum::kBlack;
 
-// Helper function to safely copy strings and check for buffer size
-CHIP_ERROR SafeCopyString(char * buf, size_t bufSize, const char * source)
-{
-    if (strlen(source) >= bufSize)
-    {
-        return CHIP_ERROR_BUFFER_TOO_SMALL;
-    }
-    Platform::CopyString(buf, bufSize, source);
-    return CHIP_NO_ERROR;
-}
-// Mock DeviceInstanceInfoProvider for testing
-class MockDeviceInstanceInfoProvider : public DeviceLayer::DeviceInstanceInfoProvider
-{
-public:
-    CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kVendorName); }
 
-    CHIP_ERROR GetVendorId(uint16_t & vendorId) override
-    {
-        vendorId = kVendorId;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetProductName(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductName); }
-
-    CHIP_ERROR GetProductId(uint16_t & productId) override
-    {
-        productId = kProductId;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override
-    {
-        hardwareVersion = kHardwareVersion;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override
-    {
-        return SafeCopyString(buf, bufSize, kHardwareVersionString);
-    }
-
-    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override
-    {
-        year  = kManufacturingYear;
-        month = kManufacturingMonth;
-        day   = kManufacturingDay;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetManufacturingDateSuffix(MutableCharSpan & suffixBuffer) override
-    {
-        if (mManufacturingDateSuffix == nullptr)
-        {
-            suffixBuffer.reduce_size(0);
-            return CHIP_NO_ERROR;
-        }
-        return CopyCharSpanToMutableCharSpan(CharSpan::fromCharString(mManufacturingDateSuffix), suffixBuffer);
-    }
-
-    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kPartNumber); }
-
-    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductURL); }
-
-    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kProductLabel); }
-
-    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kSerialNumber); }
-
-    CHIP_ERROR GetProductFinish(ProductFinishEnum * finish) override
-    {
-        *finish = kProductFinish;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetProductPrimaryColor(ColorEnum * color) override
-    {
-        *color = kProductPrimaryColor;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override { return CHIP_NO_ERROR; }
-
-    // NOTE: suffix lifetime MUST be longer than this object lifetime as just a pointer is kept.
-    void SetManufacturingDateSuffix(const char * suffix) { mManufacturingDateSuffix = suffix; }
-
-private:
-    const char * mManufacturingDateSuffix = nullptr;
-};
-
-static constexpr size_t kCountryCodeLength = 2;
-static constexpr const char * kUniqueId    = "TEST_UNIQUE_ID_12345";
-// Mock ConfigurationManager for testing
-class MockConfigurationManager : public chip::DeviceLayer::ConfigurationManager
-{
-public:
-    // ========================================================================
-    // Methods used by the Test Logic
-    // ========================================================================
-    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return SafeCopyString(buf, bufSize, kUniqueId); }
-
-    CHIP_ERROR StoreCountryCode(const char * countryCode, size_t countryCodeLen) override
-    {
-        VerifyOrReturnError(countryCodeLen == kCountryCodeLength, CHIP_ERROR_INVALID_ARGUMENT);
-        Platform::CopyString(mCountryCode, sizeof(mCountryCode), countryCode);
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & countryCodeLen) override
-    {
-        VerifyOrReturnError(bufSize > kCountryCodeLength, CHIP_ERROR_BUFFER_TOO_SMALL);
-        Platform::CopyString(buf, bufSize, mCountryCode);
-        countryCodeLen = kCountryCodeLength;
-        return CHIP_NO_ERROR;
-    }
-
-    // ========================================================================
-    // Stubs required to satisfy the ConfigurationManager Interface
-    // ========================================================================
-
-    CHIP_ERROR Init() override { return CHIP_NO_ERROR; }
-
-    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan & buf) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVersion) override { return CHIP_NO_ERROR; }
-    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    CHIP_ERROR GetFirmwareBuildChipEpochTime(System::Clock::Seconds32 & buildTime) override
-    {
-        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-    }
-
-    CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override { return CHIP_NO_ERROR; }
-    CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) override { return CHIP_NO_ERROR; }
-    CHIP_ERROR StoreSoftwareVersion(uint32_t softwareVer) override { return CHIP_NO_ERROR; }
-    CHIP_ERROR StoreHardwareVersion(uint16_t hardwareVer) override { return CHIP_NO_ERROR; }
-    CHIP_ERROR StoreRegulatoryLocation(uint8_t location) override { return CHIP_NO_ERROR; }
-    CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override { return CHIP_NO_ERROR; }
-    CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-
-    CHIP_ERROR GetFailSafeArmed(bool & val) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    CHIP_ERROR SetFailSafeArmed(bool val) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-
-    CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) override
-    {
-        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-    }
-
-    void RunUnitTests() override {}
-    bool IsFullyProvisioned() override { return false; }
-    void LogDeviceConfig() override {}
-
-    bool IsCommissionableDeviceTypeEnabled() override { return false; }
-    CHIP_ERROR GetDeviceTypeId(uint32_t & deviceType) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    bool IsCommissionableDeviceNameEnabled() override { return false; }
-    CHIP_ERROR GetCommissionableDeviceName(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-
-    CHIP_ERROR GetInitialPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    CHIP_ERROR GetSecondaryPairingHint(uint16_t & pairingHint) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    CHIP_ERROR GetSecondaryPairingInstruction(char * buf, size_t bufSize) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-#if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID)
-    CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    CHIP_ERROR IncrementLifetimeCounter() override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    CHIP_ERROR SetRotatingDeviceIdUniqueId(const ByteSpan & uniqueIdSpan) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-    CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override { return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE; }
-#endif
-
-    CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override
-    {
-        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-    }
-    CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override
-    {
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetRebootCount(uint32_t & v) override
-    {
-        v = 0;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR StoreRebootCount(uint32_t) override { return CHIP_NO_ERROR; }
-    CHIP_ERROR GetTotalOperationalHours(uint32_t & v) override
-    {
-        v = 0;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR StoreTotalOperationalHours(uint32_t) override { return CHIP_NO_ERROR; }
-    CHIP_ERROR GetBootReason(uint32_t & v) override
-    {
-        v = 0;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR StoreBootReason(uint32_t) override { return CHIP_NO_ERROR; }
-    CHIP_ERROR GetRegulatoryLocation(uint8_t & loc) override
-    {
-        loc = 0;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR GetLocationCapability(uint8_t & cap) override
-    {
-        cap = 0;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR GetConfigurationVersion(uint32_t & v) override
-    {
-        v = 1;
-        return CHIP_NO_ERROR;
-    }
-    CHIP_ERROR StoreConfigurationVersion(uint32_t) override { return CHIP_NO_ERROR; }
-    bool CanFactoryReset() override { return false; }
-    void InitiateFactoryReset() override {}
-
-private:
-    char mCountryCode[kCountryCodeLength + 1] = "XX";
-};
 struct TestBasicInformationReadWrite : public ::testing::Test
 {
     static void SetUpTestSuite()
@@ -295,18 +68,11 @@ struct TestBasicInformationReadWrite : public ::testing::Test
         chip::Platform::MemoryShutdown();
     }
 
-    TestBasicInformationReadWrite() {}
+    TestBasicInformationReadWrite() = default;
     chip::Testing::TestServerClusterContext testContext;
     static DeviceLayer::DeviceInstanceInfoProvider * sDeviceInstanceInfoProviderBackup;
     // Context
-    MockDeviceInstanceInfoProvider mDeviceInfoProvider;
-    MockConfigurationManager mMockConfigurationManager;
-    BasicInformationCluster::Context mContext = {
-        .deviceInstanceInfoProvider = mDeviceInfoProvider,
-        .configurationManager       = mMockConfigurationManager,
-        .platformManager            = chip::DeviceLayer::PlatformMgr(),
-        .subscriptionsPerFabric     = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric(),
-    };
+    tests::MockBasicInformationDelegate mMockDelegate;
 };
 
 DeviceLayer::DeviceInstanceInfoProvider * TestBasicInformationReadWrite::sDeviceInstanceInfoProviderBackup = nullptr;
@@ -314,7 +80,7 @@ DeviceLayer::DeviceInstanceInfoProvider * TestBasicInformationReadWrite::sDevice
 TEST_F(TestBasicInformationReadWrite, TestNodeLabelLoadAndSave)
 {
     const BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
-    BasicInformationCluster cluster(optionalAttributeSet, mContext);
+    BasicInformationCluster cluster(optionalAttributeSet, &mMockDelegate, chip::DeviceLayer::PlatformMgr());
     ASSERT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
     chip::Testing::ClusterTester tester(cluster);
 
@@ -369,7 +135,7 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
 
     BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
     optionalAttributeSet.Set<Attributes::ManufacturingDate::Id>();
-    BasicInformationCluster cluster(optionalAttributeSet, mContext);
+    BasicInformationCluster cluster(optionalAttributeSet, &mMockDelegate, chip::DeviceLayer::PlatformMgr());
     chip::Testing::ClusterTester tester(cluster);
 
     // VendorName
@@ -443,10 +209,10 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
     {
         char buf[32];
         CharSpan val(buf);
-        mDeviceInfoProvider.SetManufacturingDateSuffix("ABCDEFGH");
+        mMockDelegate.SetManufacturingDateSuffix("ABCDEFGH");
         ASSERT_EQ(tester.ReadAttribute(Attributes::ManufacturingDate::Id, val), CHIP_NO_ERROR);
         EXPECT_TRUE(val.data_equal("20230615ABCDEFGH"_span));
-        mDeviceInfoProvider.SetManufacturingDateSuffix(nullptr);
+        mMockDelegate.SetManufacturingDateSuffix(nullptr);
     }
 
     // UniqueID (Mandatory in Rev 4+, so if it fails, cluster rev must be < 4)
@@ -495,7 +261,7 @@ TEST_F(TestBasicInformationReadWrite, TestAllAttributesSpecCompliance)
 TEST_F(TestBasicInformationReadWrite, TestWriteNodeLabel)
 {
     const BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
-    BasicInformationCluster cluster(optionalAttributeSet, mContext);
+    BasicInformationCluster cluster(optionalAttributeSet, &mMockDelegate, chip::DeviceLayer::PlatformMgr());
     ASSERT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
     chip::Testing::ClusterTester tester(cluster);
 
@@ -517,7 +283,7 @@ TEST_F(TestBasicInformationReadWrite, TestWriteNodeLabel)
 TEST_F(TestBasicInformationReadWrite, TestWriteLocation)
 {
     const BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
-    BasicInformationCluster cluster(optionalAttributeSet, mContext);
+    BasicInformationCluster cluster(optionalAttributeSet, &mMockDelegate, chip::DeviceLayer::PlatformMgr());
     ASSERT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
     chip::Testing::ClusterTester tester(cluster);
 
@@ -551,7 +317,7 @@ TEST_F(TestBasicInformationReadWrite, TestWriteLocalConfigDisabled)
 
     BasicInformationCluster::OptionalAttributesSet optionalAttributeSet;
     optionalAttributeSet.Set<Attributes::LocalConfigDisabled::Id>();
-    BasicInformationCluster cluster(optionalAttributeSet, mContext);
+    BasicInformationCluster cluster(optionalAttributeSet, &mMockDelegate, chip::DeviceLayer::PlatformMgr());
     ASSERT_EQ(cluster.Startup(testContext.Get()), CHIP_NO_ERROR);
     chip::Testing::ClusterTester tester(cluster);
 

--- a/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
@@ -17,6 +17,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <app/clusters/basic-information/BasicInformationCluster.h>
+#include <app/clusters/basic-information/tests/MockBasicInformationDelegate.h>
 #include <app/clusters/bridged-device-basic-information-server/BasicInformationClusterProxy.h>
 #include <app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.h>
 #include <app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationDelegate.h>
@@ -43,10 +44,9 @@
 #include <lib/support/BitFlags.h>
 #include <lib/support/ReadOnlyBuffer.h>
 #include <lib/support/TimerDelegateMock.h>
-#include <protocols/interaction_model/Constants.h>
 #include <platform/PersistedStorage.h>
-#include <app/clusters/basic-information/tests/MockBasicInformationDelegate.h>
 #include <platform/PlatformManager.h>
+#include <protocols/interaction_model/Constants.h>
 #include <string>
 
 namespace {

--- a/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
+++ b/src/app/clusters/bridged-device-basic-information-server/tests/TestBridgedDeviceBasicInformationCluster.cpp
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "lib/core/Optional.h"
 #include <lib/support/tests/ExtraPwTestMacros.h>
 #include <pw_unit_test/framework.h>
 
@@ -45,6 +44,9 @@
 #include <lib/support/ReadOnlyBuffer.h>
 #include <lib/support/TimerDelegateMock.h>
 #include <protocols/interaction_model/Constants.h>
+#include <platform/PersistedStorage.h>
+#include <app/clusters/basic-information/tests/MockBasicInformationDelegate.h>
+#include <platform/PlatformManager.h>
 #include <string>
 
 namespace {
@@ -62,28 +64,11 @@ constexpr EndpointId kTestEndpointId = 1;
 class MockConfigurationManager : public DeviceLayer::ConfigurationManager
 {
 public:
-    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan & buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetConfigurationVersion(uint32_t & configurationVer) override
     {
         configurationVer = mConfigurationVersion;
         return CHIP_NO_ERROR;
     }
-    CHIP_ERROR GetFirmwareBuildChipEpochTime(System::Clock::Seconds32 & buildTime) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-#if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID)
-    CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR IncrementLifetimeCounter() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR SetRotatingDeviceIdUniqueId(const ByteSpan & uniqueIdSpan) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-#endif
-    CHIP_ERROR GetRegulatoryLocation(uint8_t & location) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StoreSoftwareVersion(uint32_t softwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreConfigurationVersion(uint32_t configurationVer) override
     {
         if (mReturnError != CHIP_NO_ERROR)
@@ -94,18 +79,12 @@ public:
         mStoreCalled++;
         return CHIP_NO_ERROR;
     }
-    CHIP_ERROR StoreHardwareVersion(uint16_t hardwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StoreRegulatoryLocation(uint8_t location) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetBootReason(uint32_t & bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StoreBootReason(uint32_t bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID)
+    CHIP_ERROR GetLifetimeCounter(uint16_t & lifetimeCounter) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR IncrementLifetimeCounter() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR SetRotatingDeviceIdUniqueId(const ByteSpan & uniqueIdSpan) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#endif
     CHIP_ERROR GetFailSafeArmed(bool & val) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR SetFailSafeArmed(bool val) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetBLEDeviceIdentificationInfo(Ble::ChipBLEDeviceIdentificationInfo & deviceIdInfo) override
@@ -136,6 +115,44 @@ public:
     }
 
     void RunUnitTests() override {}
+
+    // Remaining pure virtuals from ConfigurationManager
+    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan & buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetFirmwareBuildChipEpochTime(System::Clock::Seconds32 & buildTime) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetRegulatoryLocation(uint8_t & location) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetCountryCode(char * buf, size_t bufSize, size_t & codeLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreSoftwareVersion(uint32_t softwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreHardwareVersion(uint16_t hardwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreRegulatoryLocation(uint8_t location) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreCountryCode(const char * code, size_t codeLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetBootReason(uint32_t & bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreBootReason(uint32_t bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    // Methods from DeviceInstanceInfoProvider that are now pure virtual in ConfigurationManager
+    CHIP_ERROR GetVendorName(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetVendorId(uint16_t & vendorId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductName(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductId(uint16_t & productId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     uint32_t mConfigurationVersion = 10;
     uint32_t mStoreCalled          = 0;
@@ -209,13 +226,6 @@ struct TestBridgedDeviceBasicInformationCluster : public ::testing::Test
 
     MockDeviceInstanceInfoProvider mDeviceInfoProvider;
     MockConfigurationManager mMockConfigManager;
-
-    BasicInformationCluster::Context mBasicInfoContext = {
-        .deviceInstanceInfoProvider = mDeviceInfoProvider,
-        .configurationManager       = mMockConfigManager,
-        .platformManager            = DeviceLayer::PlatformMgr(),
-        .subscriptionsPerFabric     = 1,
-    };
 
     TestServerClusterContext mContext;
     MockDelegate mDelegate;
@@ -1068,23 +1078,24 @@ TEST_F(TestBridgedDeviceBasicInformationCluster, TestNodeLabelPersistence)
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestBasicInformationClusterProxy)
 {
-    BasicInformationCluster basicInfo(BasicInformationCluster::OptionalAttributesSet(), mBasicInfoContext);
+    BasicInformation::tests::MockBasicInformationDelegate mockDelegate;
+    BasicInformationCluster basicInfo(BasicInformationCluster::OptionalAttributesSet(), &mockDelegate, DeviceLayer::PlatformMgr());
 
-    // Initial value in our mock is 10
-    EXPECT_EQ(mMockConfigManager.mConfigurationVersion, 10u);
-    EXPECT_EQ(mMockConfigManager.mStoreCalled, 0u);
+    // Initial value in the mock delegate is 10
+    EXPECT_EQ(mockDelegate.mConfigurationVersion, 10u);
+    EXPECT_EQ(mockDelegate.mStoreConfigVersionCalled, 0u);
 
     BasicInformationClusterProxy proxy(basicInfo);
     EXPECT_EQ(proxy.IncreaseConfigurationVersion(), CHIP_NO_ERROR);
 
-    EXPECT_EQ(mMockConfigManager.mConfigurationVersion, 11u);
-    EXPECT_EQ(mMockConfigManager.mStoreCalled, 1u);
+    EXPECT_EQ(mockDelegate.mConfigurationVersion, 11u);
+    EXPECT_EQ(mockDelegate.mStoreConfigVersionCalled, 1u);
 
     // Test failure
-    mMockConfigManager.mReturnError = CHIP_ERROR_INTERNAL;
+    mockDelegate.mStoreConfigVersionReturn = CHIP_ERROR_INTERNAL;
     EXPECT_EQ(proxy.IncreaseConfigurationVersion(), CHIP_ERROR_INTERNAL);
-    EXPECT_EQ(mMockConfigManager.mConfigurationVersion, 11u);
-    EXPECT_EQ(mMockConfigManager.mStoreCalled, 1u);
+    EXPECT_EQ(mockDelegate.mConfigurationVersion, 12u); // Version should still increment before store fails
+    EXPECT_EQ(mockDelegate.mStoreConfigVersionCalled, 2u);
 }
 
 TEST_F(TestBridgedDeviceBasicInformationCluster, TestStartupPersistence)


### PR DESCRIPTION
#### Summary

This is similar to #43511 however it fetches data via a delegate instead of using templates.

This is to assess flash overhead of delegates.

#### Testing

CI will validate. I adjusted unit tests.