### PR TITLE
setup: add pydantic-core constraint for Python 3.13+ compatibility

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -239,3 +239,8 @@ setuptools==68.0.0
 # Higher versions depend on proto-plus, which break
 # nanopb code generation (due to name conflict of the 'proto' module)
 google-api-core==2.17.0
+
+# pydantic-core < 2.20 uses PyO3 0.21.x which does not support Python 3.13+
+# (no pre-built wheels for cp313, build from source fails with PyO3 version check)
+# See: https://github.com/pydantic/pydantic/issues/11524
+pydantic-core>=2.20.0; python_version >= "3.13"

--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -241,6 +241,5 @@ setuptools==68.0.0
 google-api-core==2.17.0
 
 # pydantic-core < 2.20 uses PyO3 0.21.x which does not support Python 3.13+
-# (no pre-built wheels for cp313, build from source fails with PyO3 version check)
 # See: https://github.com/pydantic/pydantic/issues/11524
-pydantic-core>=2.20.0; python_version >= "3.13"
+pydantic-core>=2.20.0,<3.0.0; python_version >= "3.13"


### PR DESCRIPTION
#### Summary

pydantic-core < 2.20 ships no pre-built wheels for cp313 and attempts to build from source using PyO3 0.21.x which does not support Python 3.13+, causing bootstrap to fail.

Add a version-gated constraint so pip resolves a compatible pydantic-core when running on Python >= 3.13.

#### Related issues
- https://github.com/espressif/esp-matter/issues/1667
- https://github.com/pydantic/pydantic/issues/11524

#### Testing

- Manually tested
    - Spawned ubuntu 24.04 docker image
    - installed Python3.13 and set it to higher priority using `update-alternatives`
    - bootstrapped and ran into similar problem mentioned in https://github.com/espressif/esp-matter/issues/1667
    - rm -rf .environment
    - bootstrapped again with these changes and bootstrap was successful

<details> <summary> Click to view error logs </summary>

```
Environment looks good, you are ready to go!

To reactivate this environment in the future, run this in your
terminal:

  source ./activate.sh

To deactivate this environment, run this:

  deactivate

Installing pip requirements for all...



[notice] A new release of pip is available: 23.2.1 -> 26.0.1
[notice] To update, run: pip install --upgrade pip
Installing pip requirements for esp32...
  error: subprocess-exited-with-error

  × Building wheel for pydantic-core (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [96 lines of output]
      Running `maturin pep517 build-wheel -i /root/esp-matter/connectedhomeip/connectedhomeip/.environment/pigweed-venv/bin/python --compatibility off`
      Python reports SOABI: cpython-313-x86_64-linux-gnu
      Computed rustc target triple: x86_64-unknown-linux-gnu
      Installation directory: /root/.cache/puccinialin
      Rustup already downloaded
      Installing rust to /root/.cache/puccinialin/rustup
      warn: It looks like you have an existing rustup settings file at:
      warn: /root/.rustup/settings.toml
      warn: Rustup will install the default toolchain as specified in the settings file,
      warn: instead of the one inferred from the default host triple.
      info: profile set to minimal
      info: default host triple is x86_64-unknown-linux-gnu
      warn: Updating existing toolchain, profile choice will be ignored
      info: syncing channel updates for stable-x86_64-unknown-linux-gnu
      info: default toolchain set to stable-x86_64-unknown-linux-gnu
      Checking if cargo is installed
      cargo 1.94.0 (85eff7c80 2026-01-15)
      📦 Including license file `LICENSE`
      🍹 Building a mixed python/rust project
      🔗 Found pyo3 bindings
      🐍 Found CPython 3.13 at /root/esp-matter/connectedhomeip/connectedhomeip/.environment/pigweed-venv/bin/python
      📡 Using build options features, bindings from pyproject.toml
         Compiling target-lexicon v0.12.9
         Compiling autocfg v1.1.0
         Compiling proc-macro2 v1.0.76
         Compiling python3-dll-a v0.2.9
         Compiling unicode-ident v1.0.10
         Compiling once_cell v1.18.0
         Compiling libc v0.2.147
         Compiling heck v0.4.1
         Compiling rustversion v1.0.13
         Compiling cfg-if v1.0.0
         Compiling version_check v0.9.4
         Compiling parking_lot_core v0.9.8
         Compiling radium v0.7.0
         Compiling portable-atomic v1.6.0
         Compiling tinyvec_macros v0.1.1
         Compiling smallvec v1.13.2
         Compiling scopeguard v1.1.0
         Compiling static_assertions v1.1.0
         Compiling num-traits v0.2.16
         Compiling num-integer v0.1.45
         Compiling lock_api v0.4.10
         Compiling num-bigint v0.4.4
         Compiling memoffset v0.9.0
         Compiling lexical-util v0.8.5
         Compiling ahash v0.8.10
         Compiling tinyvec v1.6.0
         Compiling pyo3-build-config v0.21.2
         Compiling quote v1.0.35
         Compiling tap v1.0.1
         Compiling memchr v2.6.3
         Compiling serde v1.0.203
         Compiling parking_lot v0.12.1
         Compiling syn v2.0.48
         Compiling wyz v0.5.1
         Compiling lexical-parse-integer v0.8.6
         Compiling unicode-normalization v0.1.22
         Compiling getrandom v0.2.10
         Compiling aho-corasick v1.0.2
         Compiling unindent v0.2.3
         Compiling regex-syntax v0.8.2
         Compiling indoc v2.0.4
         Compiling equivalent v1.0.1
         Compiling serde_json v1.0.116
         Compiling zerocopy v0.7.32
         Compiling percent-encoding v2.3.1
         Compiling funty v2.0.0
         Compiling hashbrown v0.14.3
         Compiling unicode-bidi v0.3.13
         Compiling pyo3-ffi v0.21.2
         Compiling pyo3-macros-backend v0.21.2
         Compiling pyo3 v0.21.2
         Compiling jiter v0.4.1
      error: failed to run custom build command for `pyo3-ffi v0.21.2`

      Caused by:
        process didn't exit successfully: `/tmp/pip-install-gcl8zefs/pydantic-core_da0714f6d64a4c54b6eb4750c096bc49/target/release/build/pyo3-ffi-1b03df9c9d9e5b02/build-script-build` (exit status: 1)
        --- stdout
        cargo:rerun-if-env-changed=PYO3_CROSS
        cargo:rerun-if-env-changed=PYO3_CROSS_LIB_DIR
        cargo:rerun-if-env-changed=PYO3_CROSS_PYTHON_VERSION
        cargo:rerun-if-env-changed=PYO3_CROSS_PYTHON_IMPLEMENTATION
        cargo:rerun-if-env-changed=PYO3_PRINT_CONFIG
        cargo:rerun-if-env-changed=PYO3_USE_ABI3_FORWARD_COMPATIBILITY

        --- stderr
        error: the configured Python interpreter version (3.13) is newer than PyO3's maximum supported version (3.12)
        = help: please check if an updated version of PyO3 is available. Current version: 0.21.2
        = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI
      warning: build failed, waiting for other jobs to finish...
      💥 maturin failed
        Caused by: Failed to build a native library through cargo
        Caused by: Cargo build finished with "exit status: 101": `env -u CARGO PYO3_BUILD_EXTENSION_MODULE="1" PYO3_ENVIRONMENT_SIGNATURE="cpython-3.13-64bit" PYO3_PYTHON="/root/esp-matter/connectedhomeip/connectedhomeip/.environment/pigweed-venv/bin/python" PYTHON_SYS_EXECUTABLE="/root/esp-matter/connectedhomeip/connectedhomeip/.environment/pigweed-venv/bin/python" "cargo" "rustc" "--profile" "release" "--features" "pyo3/extension-module" "--message-format" "json-render-diagnostics" "--manifest-path" "/tmp/pip-install-gcl8zefs/pydantic-core_da0714f6d64a4c54b6eb4750c096bc49/Cargo.toml" "--lib" "--crate-type" "cdylib"`
      Rust not found, installing into a temporary directory
      Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/root/esp-matter/connectedhomeip/connectedhomeip/.environment/pigweed-venv/bin/python', '--compatibility', 'off'] returned non-zero exit status 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pydantic-core
ERROR: Could not build wheels for pydantic-core, which is required to install pyproject.toml-based projects

[notice] A new release of pip is available: 23.2.1 -> 26.0.1
[notice] To update, run: pip install --upgrade pip
```

</details>