### PR TITLE
[Fix] Apply preset setpoints when changing active preset

### DIFF
--- a/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
@@ -148,8 +148,9 @@ CHIP_ERROR GetMatchingPresetInPresets(Delegate * delegate, const ByteSpan & pres
             return err;
         }
 
-        // Note: presets coming from our delegate always have a handle.
-        if (presetHandle.data_equal(matchingPreset.GetPresetHandle().Value()))
+        // Treat presets with a null handle as non-matching.
+        auto presetHandleFromPreset = matchingPreset.GetPresetHandle();
+        if (!presetHandleFromPreset.IsNull() && presetHandle.data_equal(presetHandleFromPreset.Value()))
         {
             found = true;
             return CHIP_NO_ERROR;

--- a/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
@@ -309,7 +309,7 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
     {
         PresetStructWithOwnedMembers matchingPreset;
         // Look up the preset once and reuse it to apply any setpoints it carries.
-        bool found         = false;
+        bool found           = false;
         CHIP_ERROR lookupErr = GetMatchingPresetInPresets(delegate, presetHandle.Value(), matchingPreset, found);
         if (lookupErr != CHIP_NO_ERROR)
         {
@@ -324,9 +324,9 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
         if (coolingSetpointValue.HasValue())
         {
             int16_t constrainedCoolingSetpoint = EnforceCoolingSetpointLimits(coolingSetpointValue.Value(), endpoint);
-            Status status = emAfWriteAttributeExternal(ConcreteAttributePath(endpoint, Thermostat::Id, OccupiedCoolingSetpoint::Id),
-                                                       EmberAfWriteDataInput(reinterpret_cast<uint8_t *>(&constrainedCoolingSetpoint),
-                                                                             ZCL_INT16S_ATTRIBUTE_TYPE));
+            Status status                      = emAfWriteAttributeExternal(
+                ConcreteAttributePath(endpoint, Thermostat::Id, OccupiedCoolingSetpoint::Id),
+                EmberAfWriteDataInput(reinterpret_cast<uint8_t *>(&constrainedCoolingSetpoint), ZCL_INT16S_ATTRIBUTE_TYPE));
             if (status != Status::Success)
             {
                 ChipLogError(Zcl, "Failed to set OccupiedCoolingSetpoint with status %u", to_underlying(status));
@@ -338,9 +338,9 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
         if (heatingSetpointValue.HasValue())
         {
             int16_t constrainedHeatingSetpoint = EnforceHeatingSetpointLimits(heatingSetpointValue.Value(), endpoint);
-            Status status = emAfWriteAttributeExternal(ConcreteAttributePath(endpoint, Thermostat::Id, OccupiedHeatingSetpoint::Id),
-                                                       EmberAfWriteDataInput(reinterpret_cast<uint8_t *>(&constrainedHeatingSetpoint),
-                                                                             ZCL_INT16S_ATTRIBUTE_TYPE));
+            Status status                      = emAfWriteAttributeExternal(
+                ConcreteAttributePath(endpoint, Thermostat::Id, OccupiedHeatingSetpoint::Id),
+                EmberAfWriteDataInput(reinterpret_cast<uint8_t *>(&constrainedHeatingSetpoint), ZCL_INT16S_ATTRIBUTE_TYPE));
             if (status != Status::Success)
             {
                 ChipLogError(Zcl, "Failed to set OccupiedHeatingSetpoint with status %u", to_underlying(status));
@@ -382,7 +382,7 @@ CHIP_ERROR ThermostatAttrAccess::AppendPendingPreset(Thermostat::Delegate * dele
         // Per spec we need to check that:
         // (a) There is an existing non-pending preset with this handle.
         PresetStructWithOwnedMembers matchingPreset;
-        bool found         = false;
+        bool found           = false;
         CHIP_ERROR lookupErr = GetMatchingPresetInPresets(delegate, preset.GetPresetHandle().Value(), matchingPreset, found);
         if (lookupErr != CHIP_NO_ERROR)
         {

--- a/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
@@ -18,7 +18,7 @@
 #include "thermostat-server-presets.h"
 #include "thermostat-server.h"
 
-#include <app/util/attribute-table-detail.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 using namespace chip;
@@ -327,9 +327,7 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
         if (coolingSetpointValue.HasValue())
         {
             int16_t constrainedCoolingSetpoint = EnforceCoolingSetpointLimits(coolingSetpointValue.Value(), endpoint);
-            Status status                      = emAfWriteAttributeExternal(
-                ConcreteAttributePath(endpoint, Thermostat::Id, OccupiedCoolingSetpoint::Id),
-                EmberAfWriteDataInput(reinterpret_cast<uint8_t *>(&constrainedCoolingSetpoint), ZCL_INT16S_ATTRIBUTE_TYPE));
+            Status status                      = OccupiedCoolingSetpoint::Set(endpoint, constrainedCoolingSetpoint);
             if (status != Status::Success)
             {
                 ChipLogError(Zcl, "Failed to set OccupiedCoolingSetpoint with status %u", to_underlying(status));
@@ -341,9 +339,7 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
         if (heatingSetpointValue.HasValue())
         {
             int16_t constrainedHeatingSetpoint = EnforceHeatingSetpointLimits(heatingSetpointValue.Value(), endpoint);
-            Status status                      = emAfWriteAttributeExternal(
-                ConcreteAttributePath(endpoint, Thermostat::Id, OccupiedHeatingSetpoint::Id),
-                EmberAfWriteDataInput(reinterpret_cast<uint8_t *>(&constrainedHeatingSetpoint), ZCL_INT16S_ATTRIBUTE_TYPE));
+            Status status                      = OccupiedHeatingSetpoint::Set(endpoint, constrainedHeatingSetpoint);
             if (status != Status::Success)
             {
                 ChipLogError(Zcl, "Failed to set OccupiedHeatingSetpoint with status %u", to_underlying(status));

--- a/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
@@ -18,6 +18,7 @@
 #include "thermostat-server-presets.h"
 #include "thermostat-server.h"
 
+#include <app/util/attribute-table-detail.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 using namespace chip;
@@ -314,8 +315,10 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
         Optional<int16_t> coolingSetpointValue = matchingPreset.GetCoolingSetpoint();
         if (coolingSetpointValue.HasValue())
         {
-            Status status =
-                OccupiedCoolingSetpoint::Set(endpoint, EnforceCoolingSetpointLimits(coolingSetpointValue.Value(), endpoint));
+            int16_t constrainedCoolingSetpoint = EnforceCoolingSetpointLimits(coolingSetpointValue.Value(), endpoint);
+            Status status = emAfWriteAttributeExternal(ConcreteAttributePath(endpoint, Thermostat::Id, OccupiedCoolingSetpoint::Id),
+                                                       EmberAfWriteDataInput(reinterpret_cast<uint8_t *>(&constrainedCoolingSetpoint),
+                                                                             ZCL_INT16S_ATTRIBUTE_TYPE));
             if (status != Status::Success)
             {
                 ChipLogError(Zcl, "Failed to set OccupiedCoolingSetpoint with status %u", to_underlying(status));
@@ -326,8 +329,10 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
         Optional<int16_t> heatingSetpointValue = matchingPreset.GetHeatingSetpoint();
         if (heatingSetpointValue.HasValue())
         {
-            Status status =
-                OccupiedHeatingSetpoint::Set(endpoint, EnforceHeatingSetpointLimits(heatingSetpointValue.Value(), endpoint));
+            int16_t constrainedHeatingSetpoint = EnforceHeatingSetpointLimits(heatingSetpointValue.Value(), endpoint);
+            Status status = emAfWriteAttributeExternal(ConcreteAttributePath(endpoint, Thermostat::Id, OccupiedHeatingSetpoint::Id),
+                                                       EmberAfWriteDataInput(reinterpret_cast<uint8_t *>(&constrainedHeatingSetpoint),
+                                                                             ZCL_INT16S_ATTRIBUTE_TYPE));
             if (status != Status::Success)
             {
                 ChipLogError(Zcl, "Failed to set OccupiedHeatingSetpoint with status %u", to_underlying(status));

--- a/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
@@ -302,10 +302,38 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
         return Status::InvalidInState;
     }
 
-    // If the preset handle passed in the command is not present in the Presets attribute, return INVALID_COMMAND.
-    if (!presetHandle.IsNull() && !IsPresetHandlePresentInPresets(delegate, presetHandle.Value()))
+    if (!presetHandle.IsNull())
     {
-        return Status::InvalidCommand;
+        PresetStructWithOwnedMembers matchingPreset;
+        // Look up the preset once and reuse it to apply any setpoints it carries.
+        if (!GetMatchingPresetInPresets(delegate, presetHandle, matchingPreset))
+        {
+            return Status::InvalidCommand;
+        }
+
+        Optional<int16_t> coolingSetpointValue = matchingPreset.GetCoolingSetpoint();
+        if (coolingSetpointValue.HasValue())
+        {
+            Status status =
+                OccupiedCoolingSetpoint::Set(endpoint, EnforceCoolingSetpointLimits(coolingSetpointValue.Value(), endpoint));
+            if (status != Status::Success)
+            {
+                ChipLogError(Zcl, "Failed to set OccupiedCoolingSetpoint with status %u", to_underlying(status));
+                return status;
+            }
+        }
+
+        Optional<int16_t> heatingSetpointValue = matchingPreset.GetHeatingSetpoint();
+        if (heatingSetpointValue.HasValue())
+        {
+            Status status =
+                OccupiedHeatingSetpoint::Set(endpoint, EnforceHeatingSetpointLimits(heatingSetpointValue.Value(), endpoint));
+            if (status != Status::Success)
+            {
+                ChipLogError(Zcl, "Failed to set OccupiedHeatingSetpoint with status %u", to_underlying(status));
+                return status;
+            }
+        }
     }
 
     CHIP_ERROR err = delegate->SetActivePresetHandle(presetHandle);

--- a/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
@@ -131,8 +131,8 @@ bool MatchingPendingPresetExists(Delegate * delegate, const PresetStructWithOwne
 CHIP_ERROR GetMatchingPresetInPresets(Delegate * delegate, const ByteSpan & presetHandle,
                                       PresetStructWithOwnedMembers & matchingPreset, bool & found)
 {
-    VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     found = false;
+    VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     for (uint8_t i = 0; true; i++)
     {

--- a/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
@@ -117,13 +117,16 @@ bool MatchingPendingPresetExists(Delegate * delegate, const PresetStructWithOwne
 
 /**
  * @brief Finds and returns an entry in the Presets attribute list that matches
- *        a preset, if such an entry exists. The presetToMatch must have a preset handle.
+ *        the given preset handle, if such an entry exists.
  *
  * @param[in] delegate The delegate to use.
- * @param[in] presetToMatch The preset to match with.
- * @param[out] matchingPreset The preset in the Presets attribute list that has the same PresetHandle as the presetToMatch.
+ * @param[in] presetHandle The preset handle to match against entries in the Presets attribute list.
+ * @param[out] matchingPreset The preset in the Presets attribute list that has the same PresetHandle as @p presetHandle.
+ *                            Only valid if @p found is set to true.
+ * @param[out] found Set to true if a matching preset was found; set to false if no matching preset exists.
  *
- * @return CHIP_NO_ERROR if the lookup completed; otherwise an error code.
+ * @return CHIP_NO_ERROR if the lookup completed (regardless of whether a matching preset was found);
+ *         otherwise an appropriate error code.
  */
 CHIP_ERROR GetMatchingPresetInPresets(Delegate * delegate, const ByteSpan & presetHandle,
                                       PresetStructWithOwnedMembers & matchingPreset, bool & found)

--- a/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
@@ -317,7 +317,8 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
         CHIP_ERROR lookupErr = GetMatchingPresetInPresets(delegate, presetHandle.Value(), matchingPreset, found);
         if (lookupErr != CHIP_NO_ERROR)
         {
-            return Status::InvalidInState;
+            ChipLogError(Zcl, "Failed to lookup preset with error %" CHIP_ERROR_FORMAT, lookupErr.Format());
+            return StatusIB(lookupErr).mStatus;
         }
         if (!found)
         {

--- a/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
@@ -123,12 +123,13 @@ bool MatchingPendingPresetExists(Delegate * delegate, const PresetStructWithOwne
  * @param[in] presetToMatch The preset to match with.
  * @param[out] matchingPreset The preset in the Presets attribute list that has the same PresetHandle as the presetToMatch.
  *
- * @return true if a matching entry was found in the  presets attribute list, false otherwise.
+ * @return CHIP_NO_ERROR if the lookup completed; otherwise an error code.
  */
-bool GetMatchingPresetInPresets(Delegate * delegate, const DataModel::Nullable<ByteSpan> & presetHandle,
-                                PresetStructWithOwnedMembers & matchingPreset)
+CHIP_ERROR GetMatchingPresetInPresets(Delegate * delegate, const ByteSpan & presetHandle,
+                                      PresetStructWithOwnedMembers & matchingPreset, bool & found)
 {
-    VerifyOrReturnValue(delegate != nullptr, false);
+    VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    found = false;
 
     for (uint8_t i = 0; true; i++)
     {
@@ -141,16 +142,17 @@ bool GetMatchingPresetInPresets(Delegate * delegate, const DataModel::Nullable<B
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl, "GetMatchingPresetInPresets: GetPresetAtIndex failed with error %" CHIP_ERROR_FORMAT, err.Format());
-            return false;
+            return err;
         }
 
         // Note: presets coming from our delegate always have a handle.
-        if (presetHandle.Value().data_equal(matchingPreset.GetPresetHandle().Value()))
+        if (presetHandle.data_equal(matchingPreset.GetPresetHandle().Value()))
         {
-            return true;
+            found = true;
+            return CHIP_NO_ERROR;
         }
     }
-    return false;
+    return CHIP_NO_ERROR;
 }
 
 /**
@@ -307,7 +309,13 @@ Status ThermostatAttrAccess::SetActivePreset(EndpointId endpoint, DataModel::Nul
     {
         PresetStructWithOwnedMembers matchingPreset;
         // Look up the preset once and reuse it to apply any setpoints it carries.
-        if (!GetMatchingPresetInPresets(delegate, presetHandle, matchingPreset))
+        bool found         = false;
+        CHIP_ERROR lookupErr = GetMatchingPresetInPresets(delegate, presetHandle.Value(), matchingPreset, found);
+        if (lookupErr != CHIP_NO_ERROR)
+        {
+            return Status::InvalidInState;
+        }
+        if (!found)
         {
             return Status::InvalidCommand;
         }
@@ -374,7 +382,13 @@ CHIP_ERROR ThermostatAttrAccess::AppendPendingPreset(Thermostat::Delegate * dele
         // Per spec we need to check that:
         // (a) There is an existing non-pending preset with this handle.
         PresetStructWithOwnedMembers matchingPreset;
-        if (!GetMatchingPresetInPresets(delegate, preset.GetPresetHandle().Value(), matchingPreset))
+        bool found         = false;
+        CHIP_ERROR lookupErr = GetMatchingPresetInPresets(delegate, preset.GetPresetHandle().Value(), matchingPreset, found);
+        if (lookupErr != CHIP_NO_ERROR)
+        {
+            return CHIP_IM_GLOBAL_STATUS(InvalidInState);
+        }
+        if (!found)
         {
             return CHIP_IM_GLOBAL_STATUS(NotFound);
         }


### PR DESCRIPTION
#### Summary

This PR fixes Thermostat `SetActivePreset` behavior so that changing the active preset correctly applies the preset’s occupied setpoints before updating `ActivePresetHandle`.

**Technical details**

- Updated `SetActivePreset` to:
  - Resolve the target preset once,
  - Apply `OccupiedCoolingSetpoint` / `OccupiedHeatingSetpoint` from that preset (with existing limit enforcement),
  - Then set `ActivePresetHandle`.
- Improved error handling:
  - Return `InvalidCommand` when the requested preset handle is not found.
  - Propagate underlying lookup/write failures as IM status values instead of collapsing them into a generic status.
  - Added explicit logging on failure paths for easier debugging.
- Added protection against callback-driven re-entrancy while applying preset setpoints, preventing unintended transient clearing of `ActivePresetHandle`.


**Impact**

- Preset activation now updates runtime setpoints consistently.
- Error reporting is more accurate for clients and easier to diagnose.
- Reduces risk of side effects from attribute-changed callback recursion.

#### Related issues

#### Testing

Tested with thermostat/linux example:
https://github.com/project-chip/connectedhomeip/tree/master/examples/thermostat/linux

I am not a member of the CSA, so I do not have permission to update the Python test file. I don't know what step number to assign to a new test.

- Built and validated with targeted local thermostat/app test builds.
- No new compile errors in touched code paths.

```
[1773449586.126] [181640:181640] [EM] >>> [E:1392r S:64189 M:46217965] (S) Msg RX from 1:000000000001B669 [269A] to 000000000000005E --- Type 0001:08 (IM:InvokeCommandRequest) (B:80)
[1773449586.126] [181640:181640] [EM] Handling via exchange: 1392r, Delegate: 0x58802974e7c8
[1773449586.126] [181640:181640] [DMG] InvokeRequestMessage =
[1773449586.126] [181640:181640] [DMG] {
[1773449586.126] [181640:181640] [DMG]  suppressResponse = false,
[1773449586.126] [181640:181640] [DMG]  timedRequest = false,
[1773449586.126] [181640:181640] [DMG]  InvokeRequests =
[1773449586.126] [181640:181640] [DMG]  [
[1773449586.126] [181640:181640] [DMG]          CommandDataIB =
[1773449586.126] [181640:181640] [DMG]          {
[1773449586.126] [181640:181640] [DMG]                  CommandPathIB =
[1773449586.127] [181640:181640] [DMG]                  {
[1773449586.127] [181640:181640] [DMG]                          ClusterId = 0x201,
[1773449586.127] [181640:181640] [DMG]                          CommandId = 0x6,
[1773449586.127] [181640:181640] [DMG]                          EndpointId = 0x1,
[1773449586.127] [181640:181640] [DMG]                  },
[1773449586.127] [181640:181640] [DMG]
[1773449586.127] [181640:181640] [DMG]                  CommandFields =
[1773449586.127] [181640:181640] [DMG]                  {
[1773449586.127] [181640:181640] [DMG]                          0x0 = [
[1773449586.127] [181640:181640] [DMG]                                          0x02,
[1773449586.127] [181640:181640] [DMG]                          ] (1 bytes)
[1773449586.127] [181640:181640] [DMG]                  },
[1773449586.127] [181640:181640] [DMG]          },
[1773449586.127] [181640:181640] [DMG]
[1773449586.127] [181640:181640] [DMG]  ],
[1773449586.127] [181640:181640] [DMG]
[1773449586.127] [181640:181640] [DMG]  InteractionModelRevision = 11
[1773449586.127] [181640:181640] [DMG] },
[1773449586.127] [181640:181640] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0201 e=1 p=o r=i
[1773449586.127] [181640:181640] [DMG] AccessControl: allowed
[1773449586.127] [181640:181640] [DMG] Received command for Endpoint=1 Cluster=0x0000_0201 Command=0x0000_0006
[1773449586.128] [181640:181640] [DL] Wrote settings to /tmp/chip_kvs
[1773449586.128] [181640:181640] [DMG] Endpoint 1, Cluster 0x0000_0201 update version to e9c5b5f4
[1773449586.128] [181640:181640] [DMG] Cannot merge the new path into any existing path, create one.
[1773449586.128] [181640:181640] [ZCL] Setting active preset to null
[1773449586.128] [181640:181640] [-] Clear ActivePresetHandle
[1773449586.128] [181640:181640] [DMG] Endpoint 1, Cluster 0x0000_0201 update version to e9c5b5f5
[1773449586.128] [181640:181640] [DMG] Cannot merge the new path into any existing path, create one.
[1773449586.131] [181640:181640] [DL] Wrote settings to /tmp/chip_kvs
[1773449586.131] [181640:181640] [DMG] Endpoint 1, Cluster 0x0000_0201 update version to e9c5b5f6
[1773449586.131] [181640:181640] [DMG] Cannot merge the new path into any existing path, create one.
[1773449586.131] [181640:181640] [ZCL] Setting active preset to null
[1773449586.131] [181640:181640] [-] Clear ActivePresetHandle
[1773449586.131] [181640:181640] [DMG] Endpoint 1, Cluster 0x0000_0201 update version to e9c5b5f7
[1773449586.131] [181640:181640] [-] Set ActivePresetHandle to
[1773449586.131] [181640:181640] [-] 0x02,
[1773449586.131] [181640:181640] [DMG] Endpoint 1, Cluster 0x0000_0201 update version to e9c5b5f8
[1773449586.131] [181640:181640] [DMG] Command handler moving to [NewRespons]
[1773449586.131] [181640:181640] [DMG] Command handler moving to [ Preparing]
[1773449586.131] [181640:181640] [DMG] Command handler moving to [AddingComm]
[1773449586.131] [181640:181640] [DMG] Command handler moving to [AddedComma]
[1773449586.131] [181640:181640] [DMG] Decreasing reference count for CommandHandlerImpl, remaining 1
[1773449586.131] [181640:181640] [DMG] Decreasing reference count for CommandHandlerImpl, remaining 0
[1773449586.131] [181640:181640] [DMG] Command handler moving to [AwaitingDe]
[1773449586.131] [181640:181640] [EM] <<< [E:1392r S:64189 M:82471305 (Ack:46217965)] (S) Msg TX from 000000000000005E to 1:000000000001B669 [269A] [UDP:[2a01:e0a:102b:8280:58a7:3cb5:d1bf:5241]:37418] --- Type 0001:09 (IM:InvokeCommandResponse) (B:68)
[1773449586.132] [181640:181640] [EM] ??1 [E:1392r S:64189 M:82471305] (S) Msg Retransmission to 1:000000000001B669 scheduled for 376ms from now [State:Active II:500 AI:300 AT:4000]
[1773449586.132] [181640:181640] [DMG] Command response sender moving to [AllInvokeR]
[1773449586.132] [181640:181640] [DMG] Building Reports for ReadHandler with LastReportGeneration = 0x0000001C DirtyGeneration = 0x00000021
[1773449586.132] [181640:181640] [DMG] <RE:Run> Cluster 201, Attribute 11 is dirty
[1773449586.132] [181640:181640] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0201 e=1 p=v r=r
[1773449586.132] [181640:181640] [DMG] AccessControl: allowed
[1773449586.132] [181640:181640] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0201 e=1 p=v r=r
[1773449586.132] [181640:181640] [DMG] AccessControl: allowed
[1773449586.132] [181640:181640] [DMG] Reading attribute: Cluster=0x0000_0201 Endpoint=0x1 AttributeId=0x0000_0011 (expanded=1)
[1773449586.132] [181640:181640] [DMG] <RE:Run> Cluster 201, Attribute 12 is dirty
[1773449586.132] [181640:181640] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0201 e=1 p=v r=r
[1773449586.132] [181640:181640] [DMG] AccessControl: allowed
[1773449586.132] [181640:181640] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0201 e=1 p=v r=r
[1773449586.132] [181640:181640] [DMG] AccessControl: allowed
[1773449586.132] [181640:181640] [DMG] Reading attribute: Cluster=0x0000_0201 Endpoint=0x1 AttributeId=0x0000_0012 (expanded=1)
[1773449586.132] [181640:181640] [DMG] <RE:Run> Cluster 201, Attribute 4e is dirty
[1773449586.133] [181640:181640] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0201 e=1 p=v r=r
[1773449586.133] [181640:181640] [DMG] AccessControl: allowed
[1773449586.133] [181640:181640] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0201 e=1 p=v r=r
[1773449586.133] [181640:181640] [DMG] AccessControl: allowed
[1773449586.133] [181640:181640] [DMG] Reading attribute: Cluster=0x0000_0201 Endpoint=0x1 AttributeId=0x0000_004E (expanded=1)
[1773449586.133] [181640:181640] [DMG] Fetched 0 events
[1773449586.133] [181640:181640] [DMG] <RE> Sending report (payload has 98 bytes)...
[1773449586.133] [181640:181640] [EM] <<< [E:56886i S:64189 M:82471306] (S) Msg TX from 000000000000005E to 1:000000000001B669 [269A] [UDP:[2a01:e0a:102b:8280:58a7:3cb5:d1bf:5241]:37418] --- Type 0001:05 (IM:ReportData) (B:128)
[1773449586.133] [181640:181640] [EM] ??1 [E:56886i S:64189 M:82471306] (S) Msg Retransmission to 1:000000000001B669 scheduled for 395ms from now [State:Active II:500 AI:300 AT:4000]
[1773449586.133] [181640:181640] [DMG] IM RH moving to [AwaitingReportResponse]
[1773449586.133] [181640:181640] [DMG] <RE> ReportsInFlight = 1 with readHandler 0, RE has no more messages
[1773449586.133] [181640:181640] [DMG] All ReadHandler-s are clean, clear GlobalDirtySet
[1773449586.137] [181640:181640] [EM] >>> [E:1392r S:64189 M:46217966 (Ack:82471305)] (S) Msg RX from 1:000000000001B669 [269A] to 000000000000005E --- Type 0000:10 (SecureChannel:StandaloneAck) (B:50)
[1773449586.137] [181640:181640] [EM] Found matching exchange: 1392r, Delegate: (nil)
[1773449586.137] [181640:181640] [EM] Rxd Ack; Removing MessageCounter:82471305 from Retrans Table on exchange 1392r
[1773449586.144] [181640:181640] [EM] >>> [E:56886i S:64189 M:46217967 (Ack:82471306)] (S) Msg RX from 1:000000000001B669 [269A] to 000000000000005E --- Type 0001:01 (IM:StatusResponse) (B:42)
[1773449586.144] [181640:181640] [EM] Found matching exchange: 56886i, Delegate: 0x58804f0cfc98
[1773449586.144] [181640:181640] [EM] Rxd Ack; Removing MessageCounter:82471306 from Retrans Table on exchange 56886i
[1773449586.144] [181640:181640] [DMG] StatusResponseMessage =
[1773449586.144] [181640:181640] [DMG] {
[1773449586.144] [181640:181640] [DMG]  Status = 0x00 (SUCCESS),
[1773449586.144] [181640:181640] [DMG]  InteractionModelRevision = 13
[1773449586.144] [181640:181640] [DMG] }
[1773449586.144] [181640:181640] [IM] Received status response, status is 0x00 (SUCCESS)
[1773449586.144] [181640:181640] [DMG] <RE> OnReportConfirm: NumReports = 0
[1773449586.144] [181640:181640] [DMG] IM RH moving to [CanStartReporting]
[1773449586.145] [181640:181640] [EM] <<< [E:56886i S:64189 M:82471307 (Ack:46217967)] (S) Msg TX from 000000000000005E to 1:000000000001B669 [269A] [UDP:[2a01:e0a:102b:8280:58a7:3cb5:d1bf:5241]:37418] --- Type 0000:10 (SecureChannel:StandaloneAck) (B:34)
[1773449586.145] [181640:181640] [EM] Flushed pending ack for MessageCounter:46217967 on exchange 56886i
```


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
