### PR TITLE
[inet] Fix UDPEndPointImplSockets uninitialized control data

### DIFF
--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -595,7 +595,7 @@ void UDPEndPointImplSockets::HandlePendingIO(System::SocketEvents events)
         msgIOV.iov_len  = lBuffer->AvailableDataLength();
 
         memset(&lPeerSockAddr, 0, sizeof(lPeerSockAddr));
-
+        memset(controlData, 0, sizeof(controlData));
         memset(&msgHeader, 0, sizeof(msgHeader));
 
         msgHeader.msg_name       = &lPeerSockAddr;


### PR DESCRIPTION
#### Summary
The `controlData` buffer is not initialized (set to zero) in function `UDPEndPointImplSockets::HandlePendingIO`.
This could lead to an infinite loop when iterating over `struct cmsghdr` entries in `controlData` due to pointer arithmetic overflow when evaluating `cmsg_len` from uninitialized data.

Seen in association with:
https://github.com/nrfconnect/sdk-zephyr/blob/ff8f0c579eeb896876b6f36aca70c2bbfa756e19/subsys/net/lib/sockets/sockets_inet.c#L963

Looking at the following loop in [insert_pktinfo](https://github.com/nrfconnect/sdk-zephyr/blob/ff8f0c579eeb896876b6f36aca70c2bbfa756e19/subsys/net/lib/sockets/sockets_inet.c#963), which iterates over the `struct cmsghdr` entries `msgHeader.msg_control` (`controlData`):
```c
for (cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg))
```
with simplified version of [CMSG_NXTHDR](https://github.com/nrfconnect/sdk-zephyr/blob/ff8f0c579eeb896876b6f36aca70c2bbfa756e19/include/zephyr/net/net_ip.h#L305):
```c
#define CMSG_NXTHDR(msghdr, cmsg)                                                                                                  \
    (uint8_t *) (cmsg) + ALIGN_H((cmsg)->cmsg_len) + ALIGN_D(sizeof(struct cmsghdr)) >                                             \
            (uint8_t *) ((msghdr)->msg_control) + (msghdr)->msg_controllen                                                         \
        ? NULL                                                                                                                     \
        : (struct cmsghdr *) ((uint8_t *) (cmsg) + ALIGN_H((cmsg)->cmsg_len))
```

If `cmsg->cmsg_len` is large enough (e.g. due to uninitialized memory), the pointer arithmetic `(uint8_t *) (cmsg) + ALIGN_H((cmsg)->cmsg_len) + ALIGN_D(sizeof(struct cmsghdr))` could overflow and the termination criteria is not fulfilled, leading to an infinite loop.

The issue can be fixed by **explicitly initializing** the `controlData` buffer **to zero** in [UDPEndPointImplSockets::HandlePendingIO](https://github.com/MichaelHopfengaertnerTado/connectedhomeip/blob/370f98c7e8486df8c4c9777b20c7c0e4e0d14c23/src/inet/UDPEndPointImplSockets.cpp#L598).

#### Related issues

#### Testing
Manually tested:
* Tested bad case, by `memset(controlData, 0xFF, sizeof(controlData));`. This lead to an infinite loop (and finally watchdog reset) during device commissioning.
* Tested good case, by `memset(controlData, 0, sizeof(controlData));`. The infinite loop issue couldn't be reproduced anymore.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
