### PR TITLE
[v1.5] setup: add pydantic-core constraint for Python 3.13+ compatibility (#43575)

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -292,3 +292,7 @@ setuptools==68.0.0
 # Higher versions depend on proto-plus, which break
 # nanopb code generation (due to name conflict of the 'proto' module)
 google-api-core==2.17.0
+
+# pydantic-core < 2.20 uses PyO3 0.21.x which does not support Python 3.13+
+# See: https://github.com/pydantic/pydantic/issues/11524
+pydantic-core>=2.20.0,<3.0.0; python_version >= "3.13"


### PR DESCRIPTION
#### Summary

Cherry picking https://github.com/project-chip/connectedhomeip/pull/43575 on v1.5-branch

#### Testing
- Clean Cherry-pick