### PR TITLE
Group Auxiliary ACL Entries Follow-ups

### DIFF
--- a/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
+++ b/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
@@ -184,7 +184,7 @@ public:
                 if (mEndpointIterator->Next(endpoint))
                 {
                     // Groups cannot be created with endpoint 0, this state should never be reached
-                    // because of restrictions with creating/joining groups. Something has gone wrong 
+                    // because of restrictions with creating/joining groups. Something has gone wrong
                     // there if this condition is reached.
                     if (endpoint.endpoint_id == kRootEndpointId) {
                         return CHIP_ERROR_INCORRECT_STATE;
@@ -220,14 +220,14 @@ public:
 
             if (mIterateOverFabricIndices)
             {
-                // This indicates that there are no more fabric indices to iterate over (unless it is 
-                // determined in the conditions below that at least 1 more is remaining, in which 
+                // This indicates that there are no more fabric indices to iterate over (unless it is
+                // determined in the conditions below that at least 1 more is remaining, in which
                 // case this will be set to true again).
                 mIterateOverFabricIndices = false;
 
                 if (mFabricTable && mFabricTableIter.HasValue())
                 {
-                    if ((mFabricTableIter.Value() != mFabricTable->end()) 
+                    if ((mFabricTableIter.Value() != mFabricTable->end())
                         && (++mFabricTableIter.Value() != mFabricTable->end()))
                     {
                         mFabricIndex       = mFabricTableIter.Value()->GetFabricIndex();
@@ -257,7 +257,7 @@ private:
     GroupId mGroupId                                                       = kUndefinedGroupId;
 
     // When true, this indicates the entries are not fabric scoped. AuxiliaryEntries() through
-    // the Next() funciton will iterate over all fabrics to fetch auxiliary ACL entries. This 
+    // the Next() funciton will iterate over all fabrics to fetch auxiliary ACL entries. This
     // will be set to true when a fabric index is not specified (kUndefinedFabricIndex).
     bool mIterateOverFabricIndices = false;
 };

--- a/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
+++ b/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
@@ -186,7 +186,8 @@ public:
                     // Groups cannot be created with endpoint 0, this state should never be reached
                     // because of restrictions with creating/joining groups. Something has gone wrong
                     // there if this condition is reached.
-                    if (endpoint.endpoint_id == kRootEndpointId) {
+                    if (endpoint.endpoint_id == kRootEndpointId)
+                    {
                         return CHIP_ERROR_INCORRECT_STATE;
                     }
 
@@ -227,19 +228,18 @@ public:
 
                 if (mFabricTable && mFabricTableIter.HasValue())
                 {
-                    if ((mFabricTableIter.Value() != mFabricTable->end())
-                        && (++mFabricTableIter.Value() != mFabricTable->end()))
+                    if ((mFabricTableIter.Value() != mFabricTable->end()) && (++mFabricTableIter.Value() != mFabricTable->end()))
                     {
-                        mFabricIndex       = mFabricTableIter.Value()->GetFabricIndex();
-                        mGroupInfoIterator = mGroupDataProvider->IterateGroupInfo(mFabricIndex);
-                        mIterateOverFabricIndices        = true;
+                        mFabricIndex              = mFabricTableIter.Value()->GetFabricIndex();
+                        mGroupInfoIterator        = mGroupDataProvider->IterateGroupInfo(mFabricIndex);
+                        mIterateOverFabricIndices = true;
                     }
                 }
                 else if (mFabricIndex < kMaxValidFabricIndex)
                 {
                     mFabricIndex++;
-                    mGroupInfoIterator = mGroupDataProvider->IterateGroupInfo(mFabricIndex);
-                    mIterateOverFabricIndices        = true;
+                    mGroupInfoIterator        = mGroupDataProvider->IterateGroupInfo(mFabricIndex);
+                    mIterateOverFabricIndices = true;
                 }
             }
         }

--- a/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
+++ b/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
@@ -257,7 +257,7 @@ private:
     GroupId mGroupId                                                       = kUndefinedGroupId;
 
     // When true, this indicates the entries are not fabric scoped. AuxiliaryEntries() through
-    // the Next() funciton will iterate over all fabrics to fetch auxiliary ACL entries. This
+    // the Next() function will iterate over all fabrics to fetch auxiliary ACL entries. This
     // will be set to true when a fabric index is not specified (kUndefinedFabricIndex).
     bool mIterateOverFabricIndices = false;
 };

--- a/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
+++ b/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
@@ -269,12 +269,12 @@ namespace Access {
 namespace Examples {
 
 /*
-* This function (in conjunction with Next() from the AuxiliaryEntryIteratorDelegate) will create an auxiliary
-* ACL entry for every <fabric index, group ID, endpoint ID> that belongs based on the information from
-* the group data provider. This is the simplest base case of what a set of auxiliary ACL entries will look
-* like. The structure of auxiliary ACL entries can be formatted differently, as long as the equivalence class
-* maps to this simplest base case.
-*/
+ * This function (in conjunction with Next() from the AuxiliaryEntryIteratorDelegate) will create an auxiliary
+ * ACL entry for every <fabric index, group ID, endpoint ID> that belongs based on the information from
+ * the group data provider. This is the simplest base case of what a set of auxiliary ACL entries will look
+ * like. The structure of auxiliary ACL entries can be formatted differently, as long as the equivalence class
+ * maps to this simplest base case.
+ */
 CHIP_ERROR GroupAuxiliaryAccessControlDelegate::AuxiliaryEntries(AccessControl::EntryIterator & iterator,
                                                                  const FabricIndex * fabricIndex) const
 {
@@ -293,7 +293,10 @@ CHIP_ERROR GroupAuxiliaryAccessControlDelegate::Check(const SubjectDescriptor & 
     if (IsGroupId(subjectDescriptor.subject) && (mGroupDataProvider != nullptr))
     {
         GroupId groupId = GroupIdFromNodeId(subjectDescriptor.subject);
-        if ((requestPath.endpoint != kRootEndpointId) && (mGroupDataProvider->HasEndpoint(subjectDescriptor.fabricIndex, groupId, requestPath.endpoint)) && (requestPath.requestType == Access::RequestType::kCommandInvokeRequest) && (requestPrivilege == Privilege::kOperate) && (subjectDescriptor.authMode == Access::AuthMode::kGroup))
+        if ((requestPath.endpoint != kRootEndpointId) &&
+            (mGroupDataProvider->HasEndpoint(subjectDescriptor.fabricIndex, groupId, requestPath.endpoint)) &&
+            (requestPath.requestType == Access::RequestType::kCommandInvokeRequest) && (requestPrivilege == Privilege::kOperate) &&
+            (subjectDescriptor.authMode == Access::AuthMode::kGroup))
         {
             return CHIP_NO_ERROR;
         }

--- a/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
+++ b/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
@@ -183,12 +183,12 @@ public:
                 Credentials::GroupDataProvider::GroupEndpoint endpoint;
                 if (mEndpointIterator->Next(endpoint))
                 {
-                    // Groups cannot be created with endpoint 0, this state should never be reached
-                    // because of restrictions with creating/joining groups. Something has gone wrong
-                    // there if this condition is reached.
+                    // Groups cannot be created with endpoint 0, so this state should never be reached
+                    // because of restrictions with creating/joining groups. We skip here in the case
+                    // this does occur, no entry would be needed to validate against for endpoint 0.
                     if (endpoint.endpoint_id == kRootEndpointId)
                     {
-                        return CHIP_ERROR_INCORRECT_STATE;
+                        continue;
                     }
 
                     auto * delegate = Platform::New<EntryDelegate>();
@@ -268,6 +268,13 @@ namespace chip {
 namespace Access {
 namespace Examples {
 
+/*
+* This function (in conjunction with Next() from the AuxiliaryEntryIteratorDelegate) will create an auxiliary
+* ACL entry for every <fabric index, group ID, endpoint ID> that belongs based on the information from 
+* the group data provider. This is the simplest base case of what a set of auxiliary ACL entries will look 
+* like. The structure of auxiliary ACL entries can be formatted differently, as long as the equivalence class 
+* maps to this simplest base case.
+*/
 CHIP_ERROR GroupAuxiliaryAccessControlDelegate::AuxiliaryEntries(AccessControl::EntryIterator & iterator,
                                                                  const FabricIndex * fabricIndex) const
 {
@@ -283,26 +290,16 @@ CHIP_ERROR GroupAuxiliaryAccessControlDelegate::AuxiliaryEntries(AccessControl::
 CHIP_ERROR GroupAuxiliaryAccessControlDelegate::Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath,
                                                       Privilege requestPrivilege)
 {
-    CHIP_ERROR err = CHIP_ERROR_ACCESS_DENIED;
-
     if (IsGroupId(subjectDescriptor.subject) && (mGroupDataProvider != nullptr))
     {
         GroupId groupId = GroupIdFromNodeId(subjectDescriptor.subject);
-        if (mGroupDataProvider->HasEndpoint(subjectDescriptor.fabricIndex, groupId, requestPath.endpoint))
+        if ((requestPath.endpoint != kRootEndpointId) && (mGroupDataProvider->HasEndpoint(subjectDescriptor.fabricIndex, groupId, requestPath.endpoint)) && (requestPath.requestType == Access::RequestType::kCommandInvokeRequest) && (requestPrivilege == Privilege::kOperate) && (subjectDescriptor.authMode == Access::AuthMode::kGroup))
         {
-            if (requestPath.endpoint == kRootEndpointId)
-            {
-                // Root endpoint should never be present in the group
-                err = CHIP_ERROR_INCORRECT_STATE;
-            }
-            else if (requestPrivilege == Privilege::kOperate && subjectDescriptor.authMode == Access::AuthMode::kGroup)
-            {
-                err = CHIP_NO_ERROR;
-            }
+            return CHIP_NO_ERROR;
         }
     }
 
-    return err;
+    return CHIP_ERROR_ACCESS_DENIED;
 }
 
 } // namespace Examples

--- a/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
+++ b/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
@@ -270,9 +270,9 @@ namespace Examples {
 
 /*
 * This function (in conjunction with Next() from the AuxiliaryEntryIteratorDelegate) will create an auxiliary
-* ACL entry for every <fabric index, group ID, endpoint ID> that belongs based on the information from 
-* the group data provider. This is the simplest base case of what a set of auxiliary ACL entries will look 
-* like. The structure of auxiliary ACL entries can be formatted differently, as long as the equivalence class 
+* ACL entry for every <fabric index, group ID, endpoint ID> that belongs based on the information from
+* the group data provider. This is the simplest base case of what a set of auxiliary ACL entries will look
+* like. The structure of auxiliary ACL entries can be formatted differently, as long as the equivalence class
 * maps to this simplest base case.
 */
 CHIP_ERROR GroupAuxiliaryAccessControlDelegate::AuxiliaryEntries(AccessControl::EntryIterator & iterator,

--- a/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
+++ b/src/access/examples/GroupAuxiliaryAccessControlDelegate.cpp
@@ -130,7 +130,7 @@ public:
 
         if (mFabricIndex == kUndefinedFabricIndex)
         {
-            mAllFabrics = true;
+            mIterateOverFabricIndices = true;
             // If the fabric table is defined, it can be used to find and iterate over all
             // valid existing fabric indices. Otherwise, iteration can be done starting from
             // the minimum fabric index and going up
@@ -176,13 +176,20 @@ public:
             return CHIP_ERROR_SENTINEL;
         }
 
-        while (mGroupInfoIterator != nullptr || mEndpointIterator != nullptr || mAllFabrics)
+        while (mGroupInfoIterator != nullptr || mEndpointIterator != nullptr || mIterateOverFabricIndices)
         {
             if (mEndpointIterator != nullptr)
             {
                 Credentials::GroupDataProvider::GroupEndpoint endpoint;
                 if (mEndpointIterator->Next(endpoint))
                 {
+                    // Groups cannot be created with endpoint 0, this state should never be reached
+                    // because of restrictions with creating/joining groups. Something has gone wrong 
+                    // there if this condition is reached.
+                    if (endpoint.endpoint_id == kRootEndpointId) {
+                        return CHIP_ERROR_INCORRECT_STATE;
+                    }
+
                     auto * delegate = Platform::New<EntryDelegate>();
                     if (delegate == nullptr)
                     {
@@ -211,23 +218,28 @@ public:
                 mGroupInfoIterator = nullptr;
             }
 
-            if (mAllFabrics)
+            if (mIterateOverFabricIndices)
             {
-                mAllFabrics = false;
+                // This indicates that there are no more fabric indices to iterate over (unless it is 
+                // determined in the conditions below that at least 1 more is remaining, in which 
+                // case this will be set to true again).
+                mIterateOverFabricIndices = false;
+
                 if (mFabricTable && mFabricTableIter.HasValue())
                 {
-                    if (mFabricTableIter.Value() != mFabricTable->end() && ++mFabricTableIter.Value() != mFabricTable->end())
+                    if ((mFabricTableIter.Value() != mFabricTable->end()) 
+                        && (++mFabricTableIter.Value() != mFabricTable->end()))
                     {
                         mFabricIndex       = mFabricTableIter.Value()->GetFabricIndex();
                         mGroupInfoIterator = mGroupDataProvider->IterateGroupInfo(mFabricIndex);
-                        mAllFabrics        = true;
+                        mIterateOverFabricIndices        = true;
                     }
                 }
                 else if (mFabricIndex < kMaxValidFabricIndex)
                 {
                     mFabricIndex++;
                     mGroupInfoIterator = mGroupDataProvider->IterateGroupInfo(mFabricIndex);
-                    mAllFabrics        = true;
+                    mIterateOverFabricIndices        = true;
                 }
             }
         }
@@ -239,11 +251,15 @@ private:
     Credentials::GroupDataProvider * mGroupDataProvider;
     FabricTable * mFabricTable;
     FabricIndex mFabricIndex;
-    bool mAllFabrics = false;
     chip::Optional<chip::ConstFabricIterator> mFabricTableIter;
     Credentials::GroupDataProvider::GroupInfoIterator * mGroupInfoIterator = nullptr;
     Credentials::GroupDataProvider::EndpointIterator * mEndpointIterator   = nullptr;
     GroupId mGroupId                                                       = kUndefinedGroupId;
+
+    // When true, this indicates the entries are not fabric scoped. AuxiliaryEntries() through
+    // the Next() funciton will iterate over all fabrics to fetch auxiliary ACL entries. This 
+    // will be set to true when a fabric index is not specified (kUndefinedFabricIndex).
+    bool mIterateOverFabricIndices = false;
 };
 
 } // namespace
@@ -267,39 +283,26 @@ CHIP_ERROR GroupAuxiliaryAccessControlDelegate::AuxiliaryEntries(AccessControl::
 CHIP_ERROR GroupAuxiliaryAccessControlDelegate::Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath,
                                                       Privilege requestPrivilege)
 {
-    AccessControl::EntryIterator iterator;
-    ReturnErrorOnFailure(AuxiliaryEntries(iterator, &subjectDescriptor.fabricIndex));
+    CHIP_ERROR err = CHIP_ERROR_ACCESS_DENIED;
 
-    AccessControl::Entry entry;
-    while (iterator.Next(entry) == CHIP_NO_ERROR)
+    if (IsGroupId(subjectDescriptor.subject) && (mGroupDataProvider != nullptr))
     {
-        // Simplest form of Auxliliary ACL Entry format assumes only 1 subject and 1 target per entry.
-        // With more compelx ACL entry format, checks should be done accross all subjects and targets
-        size_t numSubjects;
-        size_t numTargets;
-        ReturnErrorOnFailure(entry.GetSubjectCount(numSubjects));
-        ReturnErrorOnFailure(entry.GetTargetCount(numTargets));
-        VerifyOrReturnError(numSubjects == 1, CHIP_ERROR_SENTINEL);
-        VerifyOrReturnError(numTargets == 1, CHIP_ERROR_SENTINEL);
-
-        NodeId subjectFromEntry;
-        ReturnErrorOnFailure(entry.GetSubject(0, subjectFromEntry));
-        if (subjectFromEntry != subjectDescriptor.subject)
+        GroupId groupId = GroupIdFromNodeId(subjectDescriptor.subject);
+        if (mGroupDataProvider->HasEndpoint(subjectDescriptor.fabricIndex, groupId, requestPath.endpoint))
         {
-            continue;
+            if (requestPath.endpoint == kRootEndpointId)
+            {
+                // Root endpoint should never be present in the group
+                err = CHIP_ERROR_INCORRECT_STATE;
+            }
+            else if (requestPrivilege == Privilege::kOperate && subjectDescriptor.authMode == Access::AuthMode::kGroup)
+            {
+                err = CHIP_NO_ERROR;
+            }
         }
-
-        AccessControl::Entry::Target targetFromEntry;
-        ReturnErrorOnFailure(entry.GetTarget(0, targetFromEntry));
-        if (targetFromEntry.endpoint != requestPath.endpoint)
-        {
-            continue;
-        }
-
-        return CHIP_NO_ERROR;
     }
 
-    return CHIP_ERROR_ACCESS_DENIED;
+    return err;
 }
 
 } // namespace Examples

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -828,14 +828,41 @@ void ValidateAuxiliaryEntries(AccessControl & ac, FabricIndex fabric, const std:
             NodeId subject;
             if (entry.GetSubject(s, subject) == CHIP_NO_ERROR && IsGroupId(subject))
             {
-
-                for (size_t t = 0; t < targetCount; ++t)
+                GroupId groupId = GroupIdFromNodeId(subject);
+                if (targetCount > 0)
                 {
-                    Entry::Target target;
-                    if (entry.GetTarget(t, target) == CHIP_NO_ERROR)
+                    for (size_t t = 0; t < targetCount; ++t)
                     {
-                        actualSet.insert(
-                            { .fabricIndex = entryFabric, .groupId = GroupIdFromNodeId(subject), .endpointId = target.endpoint });
+                        Entry::Target target;
+                        if (entry.GetTarget(t, target) == CHIP_NO_ERROR)
+                        {
+                            actualSet.insert({ .fabricIndex = entryFabric, .groupId = groupId, .endpointId = target.endpoint });
+                        }
+                    }
+                }
+                else
+                {
+                    // Target can be unspecified, which represents a wildcard of all endpoints from
+                    // a root node's descriptor cluster part list being represented from 1 entry.
+                    // This can be verified in end-to-end tests, but for the purposes of unit tests
+                    // here checking against the group auxiliary delegate in access control, endpoint
+                    // information can be pulled from the group data provider.
+                    Credentials::GroupDataProvider * provider = Credentials::GetGroupDataProvider();
+                    if (provider)
+                    {
+                        auto * it = provider->IterateEndpoints(entryFabric, groupId);
+                        if (it)
+                        {
+                            Credentials::GroupDataProvider::GroupEndpoint endpoint;
+                            while (it->Next(endpoint))
+                            {
+                                if (endpoint.endpoint_id != kRootEndpointId)
+                                {
+                                    actualSet.insert({ .fabricIndex = entryFabric, .groupId = groupId, .endpointId = endpoint.endpoint_id });
+                                }
+                            }
+                            it->Release();
+                        }
                     }
                 }
             }

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -1189,8 +1189,15 @@ constexpr CheckData groupCheckData[] = {
       .privilege         = Privilege::kOperate,
       .allow             = true },
 
+    // Not allowed (access denied) because TestGroupAuxiliaryCheck will purposely NOT add the kHasAuxiliaryACL flag to the group.
     { .subjectDescriptor = { .fabricIndex = 1, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x2222) },
       .requestPath       = { .endpoint = 20, .requestType = Access::RequestType::kCommandInvokeRequest },
+      .privilege         = Privilege::kOperate,
+      .allow             = false },
+
+    // Not allowed (access denied) because the wrong request type is used.
+    { .subjectDescriptor = { .fabricIndex = 1, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x1111) },
+      .requestPath       = { .endpoint = 10, .requestType = Access::RequestType::kAttributeWriteRequest },
       .privilege         = Privilege::kOperate,
       .allow             = false },
 
@@ -1199,14 +1206,22 @@ constexpr CheckData groupCheckData[] = {
       .privilege         = Privilege::kOperate,
       .allow             = true },
 
+    // Not allowed (access denied) because TestGroupAuxiliaryCheck will purposely NOT add the kHasAuxiliaryACL flag to the group.
     { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x4444) },
       .requestPath       = { .endpoint = 40, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
       .allow             = false },
 
+    // Not allowed (access denied) because the wrong privilige is used.
     { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x3333) },
       .requestPath       = { .endpoint = 30, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kManage,
+      .allow             = false },
+
+    // Not allowed (access denied) because the wrong auth mode is used.
+    { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kNone, .subject = NodeIdFromGroupId(0x3333) },
+      .requestPath       = { .endpoint = 30, .requestType = Access::RequestType::kCommandInvokeRequest },
+      .privilege         = Privilege::kOperate,
       .allow             = false },
 };
 
@@ -2218,7 +2233,7 @@ TEST_F(TestAccessControl, TestGroupAuxiliaryCheck)
         EXPECT_EQ(provider->AddEndpoint(1, info.group_id, 10), CHIP_NO_ERROR);
     }
 
-    // Set up group 2 data for fabric 1
+    // Set up group 2 data for fabric 1, with no kHasAuxiliaryACL
     {
         Credentials::GroupDataProvider::GroupInfo info;
         info.group_id = 0x2222;

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -25,6 +25,7 @@
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <credentials/tests/CHIPCert_unit_test_vectors.h>
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#include <lib/core/Optional.h>
 #include <set>
 
 #include <pw_unit_test/framework.h>
@@ -922,6 +923,18 @@ struct CheckData
     bool allow;
 };
 
+struct GroupCheckData
+{
+    SubjectDescriptor subjectDescriptor;
+    RequestPath requestPath;
+    Privilege privilege;
+    // If not specified, this means the expected result is NOT CHIP_NO_ERROR, but also may not be CHIP_ERROR_ACCESS_DENIED.
+    // This can happen if tests have malformed access control requests or group data fetch requests, which are expected to 
+    // fail earlier in execution. Main purpose of tests that don't specify this are to ensure some sort of failure in the 
+    // process of doing the check occurs before approving/denying access.
+    Optional<CHIP_ERROR> expectedResult;
+};
+
 constexpr CheckData checkData1[] = {
     // Checks for implicit PASE
     { .subjectDescriptor = { .fabricIndex = 0, .authMode = AuthMode::kPase, .subject = kPaseVerifier0 },
@@ -1183,46 +1196,70 @@ constexpr CheckData checkData1[] = {
       .allow             = true },
 };
 
-constexpr CheckData groupCheckData[] = {
+const GroupCheckData groupCheckData[] = {
+    // Allowed (access granted)
     { .subjectDescriptor = { .fabricIndex = 1, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x1111) },
       .requestPath       = { .endpoint = 10, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .allow             = true },
+      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_NO_ERROR) },
 
     // Not allowed (access denied) because TestGroupAuxiliaryCheck will purposely NOT add the kHasAuxiliaryACL flag to the group.
     { .subjectDescriptor = { .fabricIndex = 1, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x2222) },
       .requestPath       = { .endpoint = 20, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .allow             = false },
+      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
 
     // Not allowed (access denied) because the wrong request type is used.
     { .subjectDescriptor = { .fabricIndex = 1, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x1111) },
       .requestPath       = { .endpoint = 10, .requestType = Access::RequestType::kAttributeWriteRequest },
       .privilege         = Privilege::kOperate,
-      .allow             = false },
+      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
 
+    // Not allowed (access denied) because access should never be granted for endpoint 0.
+    { .subjectDescriptor = { .fabricIndex = 1, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x1111) },
+      .requestPath       = { .endpoint = 0, .requestType = Access::RequestType::kCommandInvokeRequest },
+      .privilege         = Privilege::kOperate,
+      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
+
+    // Allowed (access granted)
     { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x3333) },
       .requestPath       = { .endpoint = 30, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .allow             = true },
+      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_NO_ERROR) },
 
     // Not allowed (access denied) because TestGroupAuxiliaryCheck will purposely NOT add the kHasAuxiliaryACL flag to the group.
     { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x4444) },
       .requestPath       = { .endpoint = 40, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .allow             = false },
+      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
 
     // Not allowed (access denied) because the wrong privilige is used.
     { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x3333) },
       .requestPath       = { .endpoint = 30, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kManage,
-      .allow             = false },
+      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
 
     // Not allowed (access denied) because the wrong auth mode is used.
     { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kNone, .subject = NodeIdFromGroupId(0x3333) },
       .requestPath       = { .endpoint = 30, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .allow             = false },
+      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
+
+    // Not allowed (access denied) because the endpoint does not exist on the group
+    { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x3333) },
+      .requestPath       = { .endpoint = 9, .requestType = Access::RequestType::kCommandInvokeRequest },
+      .privilege         = Privilege::kOperate,
+      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
+
+    // Not allowed (failure in execution) because the endpoint doesn't exist on the specified fabric index for the group
+    { .subjectDescriptor = { .fabricIndex = 9, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x3333) },
+      .requestPath       = { .endpoint = 30, .requestType = Access::RequestType::kCommandInvokeRequest },
+      .privilege         = Privilege::kOperate },
+
+    // Not allowed (failure in execution) because the group does not exist
+    { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x9999) },
+      .requestPath       = { .endpoint = 30, .requestType = Access::RequestType::kCommandInvokeRequest },
+      .privilege         = Privilege::kOperate },
 };
 
 class TestAccessControl : public ::testing::Test
@@ -2231,6 +2268,9 @@ TEST_F(TestAccessControl, TestGroupAuxiliaryCheck)
         info.flags = to_underlying(Credentials::GroupDataProvider::GroupInfo::Flags::kHasAuxiliaryACL);
         EXPECT_EQ(provider->SetGroupInfo(1, info), CHIP_NO_ERROR);
         EXPECT_EQ(provider->AddEndpoint(1, info.group_id, 10), CHIP_NO_ERROR);
+        // Noramally, Endpoint 0 should not be allowed to join a group. Test will confirm access control
+        // checks with this fail.
+        EXPECT_EQ(provider->AddEndpoint(1, info.group_id, 0), CHIP_NO_ERROR);
     }
 
     // Set up group 2 data for fabric 1, with no kHasAuxiliaryACL
@@ -2263,8 +2303,11 @@ TEST_F(TestAccessControl, TestGroupAuxiliaryCheck)
 
     for (const auto & data : groupCheckData)
     {
-        CHIP_ERROR expectedResult = data.allow ? CHIP_NO_ERROR : CHIP_ERROR_ACCESS_DENIED;
-        EXPECT_EQ(accessControl.Check(data.subjectDescriptor, data.requestPath, data.privilege), expectedResult);
+        if (data.expectedResult.HasValue()) {
+            EXPECT_EQ(accessControl.Check(data.subjectDescriptor, data.requestPath, data.privilege), data.expectedResult.Value());
+        } else {
+            EXPECT_NE(accessControl.Check(data.subjectDescriptor, data.requestPath, data.privilege), CHIP_NO_ERROR);
+        }
     }
 
     // Cleanup

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -858,7 +858,8 @@ void ValidateAuxiliaryEntries(AccessControl & ac, FabricIndex fabric, const std:
                             {
                                 if (endpoint.endpoint_id != kRootEndpointId)
                                 {
-                                    actualSet.insert({ .fabricIndex = entryFabric, .groupId = groupId, .endpointId = endpoint.endpoint_id });
+                                    actualSet.insert(
+                                        { .fabricIndex = entryFabric, .groupId = groupId, .endpointId = endpoint.endpoint_id });
                                 }
                             }
                             it->Release();

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -929,8 +929,8 @@ struct GroupCheckData
     RequestPath requestPath;
     Privilege privilege;
     // If not specified, this means the expected result is NOT CHIP_NO_ERROR, but also may not be CHIP_ERROR_ACCESS_DENIED.
-    // This can happen if tests have malformed access control requests or group data fetch requests, which are expected to 
-    // fail earlier in execution. Main purpose of tests that don't specify this are to ensure some sort of failure in the 
+    // This can happen if tests have malformed access control requests or group data fetch requests, which are expected to
+    // fail earlier in execution. Main purpose of tests that don't specify this are to ensure some sort of failure in the
     // process of doing the check occurs before approving/denying access.
     Optional<CHIP_ERROR> expectedResult;
 };

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -1201,55 +1201,55 @@ const GroupCheckData groupCheckData[] = {
     { .subjectDescriptor = { .fabricIndex = 1, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x1111) },
       .requestPath       = { .endpoint = 10, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_NO_ERROR) },
+      .expectedResult    = Optional<CHIP_ERROR>::Value(CHIP_NO_ERROR) },
 
     // Not allowed (access denied) because TestGroupAuxiliaryCheck will purposely NOT add the kHasAuxiliaryACL flag to the group.
     { .subjectDescriptor = { .fabricIndex = 1, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x2222) },
       .requestPath       = { .endpoint = 20, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
+      .expectedResult    = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
 
     // Not allowed (access denied) because the wrong request type is used.
     { .subjectDescriptor = { .fabricIndex = 1, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x1111) },
       .requestPath       = { .endpoint = 10, .requestType = Access::RequestType::kAttributeWriteRequest },
       .privilege         = Privilege::kOperate,
-      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
+      .expectedResult    = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
 
     // Not allowed (access denied) because access should never be granted for endpoint 0.
     { .subjectDescriptor = { .fabricIndex = 1, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x1111) },
       .requestPath       = { .endpoint = 0, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
+      .expectedResult    = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
 
     // Allowed (access granted)
     { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x3333) },
       .requestPath       = { .endpoint = 30, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_NO_ERROR) },
+      .expectedResult    = Optional<CHIP_ERROR>::Value(CHIP_NO_ERROR) },
 
     // Not allowed (access denied) because TestGroupAuxiliaryCheck will purposely NOT add the kHasAuxiliaryACL flag to the group.
     { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x4444) },
       .requestPath       = { .endpoint = 40, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
+      .expectedResult    = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
 
     // Not allowed (access denied) because the wrong privilige is used.
     { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x3333) },
       .requestPath       = { .endpoint = 30, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kManage,
-      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
+      .expectedResult    = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
 
     // Not allowed (access denied) because the wrong auth mode is used.
     { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kNone, .subject = NodeIdFromGroupId(0x3333) },
       .requestPath       = { .endpoint = 30, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
+      .expectedResult    = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
 
     // Not allowed (access denied) because the endpoint does not exist on the group
     { .subjectDescriptor = { .fabricIndex = 2, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x3333) },
       .requestPath       = { .endpoint = 9, .requestType = Access::RequestType::kCommandInvokeRequest },
       .privilege         = Privilege::kOperate,
-      .expectedResult            = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
+      .expectedResult    = Optional<CHIP_ERROR>::Value(CHIP_ERROR_ACCESS_DENIED) },
 
     // Not allowed (failure in execution) because the endpoint doesn't exist on the specified fabric index for the group
     { .subjectDescriptor = { .fabricIndex = 9, .authMode = AuthMode::kGroup, .subject = NodeIdFromGroupId(0x3333) },
@@ -2303,9 +2303,12 @@ TEST_F(TestAccessControl, TestGroupAuxiliaryCheck)
 
     for (const auto & data : groupCheckData)
     {
-        if (data.expectedResult.HasValue()) {
+        if (data.expectedResult.HasValue())
+        {
             EXPECT_EQ(accessControl.Check(data.subjectDescriptor, data.requestPath, data.privilege), data.expectedResult.Value());
-        } else {
+        }
+        else
+        {
             EXPECT_NE(accessControl.Check(data.subjectDescriptor, data.requestPath, data.privilege), CHIP_NO_ERROR);
         }
     }

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -43,7 +43,7 @@ GroupcastCluster::GroupcastCluster(GroupcastContext && context, BitFlags<Groupca
 {}
 
 GroupcastCluster::~GroupcastCluster() {
-    // Context will be non null when the cluster is initialized. Calling 
+    // Context will be non null when the cluster is initialized. Calling
     // Shutdown() to ensure proper cleanup if the cluster was started.
     if (mContext != nullptr) {
         Shutdown(ClusterShutdownType::kPermanentRemove);

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -42,7 +42,13 @@ GroupcastCluster::GroupcastCluster(GroupcastContext && context, BitFlags<Groupca
     mMembershipChangedTimer(*this), mGroupcastTestingTimer(*this)
 {}
 
-GroupcastCluster::~GroupcastCluster() {}
+GroupcastCluster::~GroupcastCluster() {
+    // Context will be non null when the cluster is initialized. Calling 
+    // Shutdown() to ensure proper cleanup if the cluster was started.
+    if (mContext != nullptr) {
+        Shutdown(ClusterShutdownType::kPermanentRemove);
+    }
+}
 
 CHIP_ERROR GroupcastCluster::Startup(ServerClusterContext & context)
 {

--- a/src/app/clusters/groupcast/GroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/GroupcastCluster.cpp
@@ -42,10 +42,12 @@ GroupcastCluster::GroupcastCluster(GroupcastContext && context, BitFlags<Groupca
     mMembershipChangedTimer(*this), mGroupcastTestingTimer(*this)
 {}
 
-GroupcastCluster::~GroupcastCluster() {
+GroupcastCluster::~GroupcastCluster()
+{
     // Context will be non null when the cluster is initialized. Calling
     // Shutdown() to ensure proper cleanup if the cluster was started.
-    if (mContext != nullptr) {
+    if (mContext != nullptr)
+    {
         Shutdown(ClusterShutdownType::kPermanentRemove);
     }
 }

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -1619,7 +1619,7 @@ TEST_F(TestGroupcastCluster, TestAuxiliaryAccessUpdatedEvent)
 
         // Now call JoinGroup again with same data but different multicast policy
         data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kPerGroup);
-        auto result = tester.Invoke(Commands::JoinGroup::Id, data);
+        auto result          = tester.Invoke(Commands::JoinGroup::Id, data);
         AssertStatus(result.status, Protocols::InteractionModel::Status::Success);
 
         auto event = logOnlyEvents.GetNextEvent();

--- a/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
+++ b/src/app/clusters/groupcast/tests/TestGroupcastCluster.cpp
@@ -1458,8 +1458,9 @@ TEST_F(TestGroupcastCluster, TestGroupcastTestingCommand)
 TEST_F(TestGroupcastCluster, TestAuxiliaryAccessUpdatedEvent)
 {
     const uint8_t key[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
-    const EndpointId kEndpoints[] = { 1 };
+    const EndpointId kEndpoints[] = { 1, 2 };
     const GroupId kGroupId        = 0x1234;
+    const GroupId kGroupIdNoAux   = 0x5678;
     const KeysetId kKeyset        = 0xabcd;
 
     ClusterTester tester(mListener);
@@ -1516,7 +1517,7 @@ TEST_F(TestGroupcastCluster, TestAuxiliaryAccessUpdatedEvent)
         EXPECT_EQ(event.value().eventOptions.mPath.mEventId, Clusters::AccessControl::Events::AuxiliaryAccessUpdated::Id);
     }
 
-    // 4. Test LeaveGroup with endpoints (partial remove) -> Should NOT generate event
+    // 4. Test LeaveGroup with endpoints (partial remove) -> Should NOT generate event (as hasAuxiliaryACL is false)
     {
         Commands::LeaveGroup::Type data;
         data.groupID   = kGroupId;
@@ -1544,7 +1545,7 @@ TEST_F(TestGroupcastCluster, TestAuxiliaryAccessUpdatedEvent)
         ASSERT_TRUE(event.has_value());
     }
 
-    // 5. Test LeaveGroup (whole group) -> Should generate event
+    // 5. Test LeaveGroup (whole group) -> Should generate event (as hasAuxiliaryACL is true)
     {
         Commands::LeaveGroup::Type data;
         data.groupID = kGroupId;
@@ -1555,6 +1556,74 @@ TEST_F(TestGroupcastCluster, TestAuxiliaryAccessUpdatedEvent)
         auto event = logOnlyEvents.GetNextEvent();
         ASSERT_TRUE(event.has_value());
         EXPECT_EQ(event.value().eventOptions.mPath.mEventId, Clusters::AccessControl::Events::AuxiliaryAccessUpdated::Id);
+    }
+
+    // 6. Test JoinGroup for a group WITHOUT auxiliary ACL -> Should NOT generate event
+    {
+        Commands::JoinGroup::Type data;
+        data.groupID         = kGroupIdNoAux;
+        data.keySetID        = kKeyset;
+        data.useAuxiliaryACL = MakeOptional(false);
+        data.endpoints       = DataModel::List<const EndpointId>(kEndpoints, MATTER_ARRAY_SIZE(kEndpoints));
+
+        auto result = tester.Invoke(Commands::JoinGroup::Id, data);
+        AssertStatus(result.status, Protocols::InteractionModel::Status::Success);
+
+        auto event = logOnlyEvents.GetNextEvent();
+        EXPECT_FALSE(event.has_value());
+    }
+
+    // 7. Test Add Endpoint to group WITHOUT auxiliary ACL -> Should NOT generate event
+    {
+        const EndpointId kEndpoints2[] = { 3 };
+        Commands::JoinGroup::Type data;
+        data.groupID         = kGroupIdNoAux;
+        data.keySetID        = kKeyset;
+        data.useAuxiliaryACL = MakeOptional(false);
+        data.endpoints       = DataModel::List<const EndpointId>(kEndpoints2, MATTER_ARRAY_SIZE(kEndpoints2));
+
+        auto result = tester.Invoke(Commands::JoinGroup::Id, data);
+        AssertStatus(result.status, Protocols::InteractionModel::Status::Success);
+
+        auto event = logOnlyEvents.GetNextEvent();
+        EXPECT_FALSE(event.has_value());
+    }
+
+    // 8. Test LeaveGroup (partial) for group WITHOUT auxiliary ACL -> Should NOT generate event
+    {
+        const EndpointId kEndpoints2[] = { 2 };
+        Commands::LeaveGroup::Type data;
+        data.groupID   = kGroupIdNoAux;
+        data.endpoints = MakeOptional(DataModel::List<const EndpointId>(kEndpoints2, MATTER_ARRAY_SIZE(kEndpoints2)));
+
+        auto result = tester.Invoke(Commands::LeaveGroup::Id, data);
+        AssertStatus(result.status, Protocols::InteractionModel::Status::Success);
+
+        auto event = logOnlyEvents.GetNextEvent();
+        EXPECT_FALSE(event.has_value());
+    }
+
+    // 9. Test JoinGroup with different multicast policy (no updates resulting in ACL change) -> Should NOT generate event
+    {
+        // First, ensure group exists with Aux ACL, endpoint and IANA policy
+        Commands::JoinGroup::Type data;
+        data.groupID         = kGroupId;
+        data.keySetID        = kKeyset;
+        data.useAuxiliaryACL = MakeOptional(true);
+        data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kIanaAddr);
+        data.endpoints       = DataModel::List<const EndpointId>(kEndpoints, MATTER_ARRAY_SIZE(kEndpoints));
+
+        auto setupResult = tester.Invoke(Commands::JoinGroup::Id, data);
+        AssertStatus(setupResult.status, Protocols::InteractionModel::Status::Success);
+        (void) logOnlyEvents.GetNextEvent(); // Clear event from setup
+
+        // Now call JoinGroup again with same data but different multicast policy
+        data.mcastAddrPolicy = MakeOptional(app::Clusters::Groupcast::MulticastAddrPolicyEnum::kPerGroup);
+        auto result = tester.Invoke(Commands::JoinGroup::Id, data);
+        AssertStatus(result.status, Protocols::InteractionModel::Status::Success);
+
+        auto event = logOnlyEvents.GetNextEvent();
+        EXPECT_FALSE(event.has_value());
     }
 }
 

--- a/src/python_testing/test_testing/DeviceConformanceTests.py
+++ b/src/python_testing/test_testing/DeviceConformanceTests.py
@@ -144,6 +144,7 @@ class DeviceConformanceTests(BasicCompositionTests):
 
         if is_ci:
             # This is a manually curated list of features that are present in the SDK, but not in the spec.
+            # TODO: Remove the AUX feature (0x04) from here once spec updates are merged to include the feature. See issue #43606
             ci_ignore_features = {Clusters.AccessControl.id: [0x04]}
             ignore_feature_masks.update(ci_ignore_features)
 

--- a/src/python_testing/test_testing/DeviceConformanceTests.py
+++ b/src/python_testing/test_testing/DeviceConformanceTests.py
@@ -144,7 +144,7 @@ class DeviceConformanceTests(BasicCompositionTests):
 
         if is_ci:
             # This is a manually curated list of features that are present in the SDK, but not in the spec.
-            # TODO: Remove the AUX feature (0x04) from here once spec updates are merged to include the feature. See issue #43606
+            # TODO(#43606): Remove the AUX feature (0x04) from here once spec updates are merged to include the feature.
             ci_ignore_features = {Clusters.AccessControl.id: [0x04]}
             ignore_feature_masks.update(ci_ignore_features)
 


### PR DESCRIPTION
#### Summary

This PR is a follow-up to #43357. This addresses some smaller comments as part of this PR, which are listed out in the related issue linked below. Overall, this PR:
- Ensures the root endpoint is not present in group information, and throws an error if so (does this in both the Next() and Check() functions of `GroupAuxiliaryAccessControlDelegate`
- Simplifies the Check() function for the `GroupAuxiliaryAccessControlDelegate`
   - Adds some more Check() related unit tests 
- Renames some variables and documents code  in `GroupAuxiliaryAccessControlDelegate`
- Ensures proper cleanup in the groupcast cluster destructor 
- Adds TODO to remove temporary device conformance ignore for a feature once spec is updated
- Additional tests for event logic for `AuxiliaryAccessUpdated`

#### Related issues
- #43584 
- #43606 

#### Testing

- Updated and added some unit tests
- CI should still pass
