### PR TITLE
ESP32: Fix a few more CHIP_ERROR nodiscard warnings

### DIFF
--- a/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
@@ -130,7 +130,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         if (blockBuf.IsNull())
         {
             // TODO: AbortTransfer() needs to support GeneralStatusCode failures as well as BDX specific errors.
-            mTransfer.AbortTransfer(StatusCode::kUnknown);
+            LogErrorOnFailure(mTransfer.AbortTransfer(StatusCode::kUnknown));
             return;
         }
 
@@ -141,14 +141,14 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
                                              mNumBytesSent))
             {
                 ChipLogError(BDX, "onBlockQuery Callback failed");
-                mTransfer.AbortTransfer(StatusCode::kUnknown);
+                LogErrorOnFailure(mTransfer.AbortTransfer(StatusCode::kUnknown));
                 return;
             }
         }
         else
         {
             ChipLogError(BDX, "onBlockQuery Callback not set");
-            mTransfer.AbortTransfer(StatusCode::kUnknown);
+            LogErrorOnFailure(mTransfer.AbortTransfer(StatusCode::kUnknown));
             return;
         }
 
@@ -158,7 +158,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         if (CHIP_NO_ERROR != mTransfer.PrepareBlock(blockData))
         {
             ChipLogError(BDX, "PrepareBlock failed: %" CHIP_ERROR_FORMAT, err.Format());
-            mTransfer.AbortTransfer(StatusCode::kUnknown);
+            LogErrorOnFailure(mTransfer.AbortTransfer(StatusCode::kUnknown));
         }
         break;
     }

--- a/examples/ota-provider-app/esp32/main/main.cpp
+++ b/examples/ota-provider-app/esp32/main/main.cpp
@@ -281,5 +281,5 @@ extern "C" void app_main()
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
 
-    chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+    LogErrorOnFailure(chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr)));
 }

--- a/examples/platform/esp32/common/Esp32AppServer.cpp
+++ b/examples/platform/esp32/common/Esp32AppServer.cpp
@@ -238,15 +238,15 @@ void Esp32AppServer::Init(AppDelegate * sAppDelegate)
 #endif
 
 #if CHIP_DEVICE_CONFIG_WIFI_NETWORK_DRIVER
-    TEMPORARY_RETURN_IGNORED sWiFiNetworkCommissioningInstance.Init();
+    LogErrorOnFailure(sWiFiNetworkCommissioningInstance.Init());
 #endif // CHIP_DEVICE_CONFIG_WIFI_NETWORK_DRIVER
 #if CHIP_DEVICE_CONFIG_ETHERNET_NETWORK_DRIVER
-    sEthernetNetworkCommissioningInstance.Init();
+    LogErrorOnFailure(sEthernetNetworkCommissioningInstance.Init());
 #endif // CHIP_DEVICE_CONFIG_ETHERNET_NETWORK_DRIVER
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #ifdef CONFIG_THREAD_NETWORK_COMMISSIONING_DRIVER
-    sThreadNetworkDriver.Init();
+    LogErrorOnFailure(sThreadNetworkDriver.Init());
 #endif // CONFIG_THREAD_NETWORK_COMMISSIONING_DRIVER
     if (chip::DeviceLayer::ConnectivityMgr().IsThreadProvisioned() &&
         (chip::Server::GetInstance().GetFabricTable().FabricCount() != 0))


### PR DESCRIPTION
#### Summary

- Came across a few CHIP_ERROR nodiscard warnings when building ota-provider-app/esp32 and lighting-app/esp32 for thread targets

#### Testing
- Manually built the apps and verified that I do not see the CHIP_ERROR nodiscard warnings