### PR TITLE
code-driven: migrate Air Quality cluster

### DIFF
--- a/examples/air-purifier-app/air-purifier-common/air-purifier-app.matter
+++ b/examples/air-purifier-app/air-purifier-common/air-purifier-app.matter
@@ -3192,7 +3192,7 @@ endpoint 2 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     callback attribute featureMap;
-    ram      attribute clusterRevision default = 1;
+    callback attribute clusterRevision;
   }
 
   server cluster CarbonMonoxideConcentrationMeasurement {

--- a/examples/air-purifier-app/air-purifier-common/include/air-quality-sensor-manager.h
+++ b/examples/air-purifier-app/air-purifier-common/include/air-quality-sensor-manager.h
@@ -18,7 +18,7 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/clusters/air-quality-server/air-quality-server.h>
+#include <app/clusters/air-quality-server/CodegenIntegration.h>
 #include <app/clusters/concentration-measurement-server/concentration-measurement-server.h>
 
 #pragma once
@@ -32,10 +32,6 @@ class AirQualitySensorManager
 public:
     AirQualitySensorManager(EndpointId aEndpointId) :
         mEndpointId(aEndpointId),
-        airQualityInstance(mEndpointId,
-                           BitMask<AirQuality::Feature, uint32_t>(AirQuality::Feature::kModerate, AirQuality::Feature::kFair,
-                                                                  AirQuality::Feature::kVeryPoor,
-                                                                  AirQuality::Feature::kExtremelyPoor)),
         carbonDioxideConcentrationMeasurementInstance(mEndpointId, CarbonDioxideConcentrationMeasurement::Id,
                                                       ConcentrationMeasurement::MeasurementMediumEnum::kAir,
                                                       ConcentrationMeasurement::MeasurementUnitEnum::kPpm),
@@ -65,13 +61,13 @@ public:
                                               ConcentrationMeasurement::MeasurementUnitEnum::kPpm),
         formaldehydeConcentrationMeasurementInstance(mEndpointId, FormaldehydeConcentrationMeasurement::Id,
                                                      ConcentrationMeasurement::MeasurementMediumEnum::kAir,
-                                                     ConcentrationMeasurement::MeasurementUnitEnum::kPpm){};
+                                                     ConcentrationMeasurement::MeasurementUnitEnum::kPpm) {};
 
     void Init();
 
 private:
     EndpointId mEndpointId;
-    AirQuality::Instance airQualityInstance;
+    AirQualityCluster * airQualityCluster = nullptr;
     ConcentrationMeasurement::Instance<true, true, true, true, true, true> carbonDioxideConcentrationMeasurementInstance;
     ConcentrationMeasurement::Instance<true, true, true, true, true, true> carbonMonoxideConcentrationMeasurementInstance;
     ConcentrationMeasurement::Instance<true, true, true, true, true, true> nitrogenDioxideConcentrationMeasurementInstance;

--- a/examples/air-purifier-app/air-purifier-common/src/air-quality-sensor-manager.cpp
+++ b/examples/air-purifier-app/air-purifier-common/src/air-quality-sensor-manager.cpp
@@ -32,9 +32,10 @@ void AirQualitySensorManager::Init()
      * They are also fixed.
      */
 
-    // Air Quality
-    TEMPORARY_RETURN_IGNORED airQualityInstance.Init();
-    airQualityInstance.UpdateAirQuality(AirQualityEnum::kGood);
+    // Air Quality - look up the framework-created cluster
+    airQualityCluster = FindClusterOnEndpoint(mEndpointId);
+    VerifyOrDie(airQualityCluster != nullptr);
+    airQualityCluster->UpdateAirQuality(AirQualityEnum::kGood);
 
     // CO2
     TEMPORARY_RETURN_IGNORED carbonDioxideConcentrationMeasurementInstance.Init();

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.matter
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.matter
@@ -2827,7 +2827,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     callback attribute featureMap;
-    ram      attribute clusterRevision default = 1;
+    callback attribute clusterRevision;
   }
 
   server cluster TemperatureMeasurement {

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/icd-lit-air-quality-sensor-app.matter
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/icd-lit-air-quality-sensor-app.matter
@@ -2916,7 +2916,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     callback attribute featureMap;
-    ram      attribute clusterRevision default = 1;
+    callback attribute clusterRevision;
   }
 
   server cluster TemperatureMeasurement {

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/include/air-quality-sensor-manager.h
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/include/air-quality-sensor-manager.h
@@ -1,6 +1,6 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/clusters/air-quality-server/air-quality-server.h>
+#include <app/clusters/air-quality-server/CodegenIntegration.h>
 #include <app/clusters/concentration-measurement-server/concentration-measurement-server.h>
 
 #include <relative-humidity-sensor-manager.h>
@@ -129,7 +129,7 @@ public:
 private:
     inline static AirQualitySensorManager * mInstance;
     EndpointId mEndpointId;
-    AirQuality::Instance mAirQualityInstance;
+    AirQualityCluster * mAirQualityCluster = nullptr;
     ConcentrationMeasurement::Instance<true, true, true, true, true, true> mCarbonDioxideConcentrationMeasurementInstance;
     ConcentrationMeasurement::Instance<true, true, true, true, true, true> mCarbonMonoxideConcentrationMeasurementInstance;
     ConcentrationMeasurement::Instance<true, true, true, true, true, true> mNitrogenDioxideConcentrationMeasurementInstance;
@@ -150,10 +150,6 @@ private:
      */
     AirQualitySensorManager(EndpointId aEndpointId) :
         mEndpointId(aEndpointId),
-        mAirQualityInstance(mEndpointId,
-                            BitMask<AirQuality::Feature, uint32_t>(AirQuality::Feature::kModerate, AirQuality::Feature::kFair,
-                                                                   AirQuality::Feature::kVeryPoor,
-                                                                   AirQuality::Feature::kExtremelyPoor)),
         mCarbonDioxideConcentrationMeasurementInstance(mEndpointId, CarbonDioxideConcentrationMeasurement::Id,
                                                        ConcentrationMeasurement::MeasurementMediumEnum::kAir,
                                                        ConcentrationMeasurement::MeasurementUnitEnum::kPpm),
@@ -184,7 +180,7 @@ private:
         mFormaldehydeConcentrationMeasurementInstance(mEndpointId, FormaldehydeConcentrationMeasurement::Id,
                                                       ConcentrationMeasurement::MeasurementMediumEnum::kAir,
                                                       ConcentrationMeasurement::MeasurementUnitEnum::kPpm),
-        mTemperatureSensorManager(mEndpointId), mHumiditySensorManager(mEndpointId){};
+        mTemperatureSensorManager(mEndpointId), mHumiditySensorManager(mEndpointId) {};
 };
 
 } // namespace Clusters

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/src/air-quality-sensor-manager.cpp
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/src/air-quality-sensor-manager.cpp
@@ -9,9 +9,10 @@ using namespace chip::app::Clusters::AirQuality;
 
 void AirQualitySensorManager::Init()
 {
-    // Air Quality
-    TEMPORARY_RETURN_IGNORED mAirQualityInstance.Init();
-    mAirQualityInstance.UpdateAirQuality(AirQualityEnum::kGood);
+    // Air Quality - look up the framework-created cluster
+    mAirQualityCluster = FindClusterOnEndpoint(mEndpointId);
+    VerifyOrDie(mAirQualityCluster != nullptr);
+    mAirQualityCluster->UpdateAirQuality(AirQualityEnum::kGood);
 
     // CO2
     TEMPORARY_RETURN_IGNORED mCarbonDioxideConcentrationMeasurementInstance.Init();
@@ -139,12 +140,12 @@ void AirQualitySensorManager::Init()
 
 AirQualityEnum AirQualitySensorManager::GetAirQuality()
 {
-    return mAirQualityInstance.GetAirQuality();
+    return mAirQualityCluster->GetAirQuality();
 }
 
 void AirQualitySensorManager::OnAirQualityChangeHandler(AirQualityEnum newValue)
 {
-    mAirQualityInstance.UpdateAirQuality(newValue);
+    mAirQualityCluster->UpdateAirQuality(newValue);
     ChipLogDetail(NotSpecified, "Updated AirQuality value: %huu", chip::to_underlying(newValue));
 }
 

--- a/examples/air-quality-sensor-app/telink/src/ZclCallbacks.cpp
+++ b/examples/air-quality-sensor-app/telink/src/ZclCallbacks.cpp
@@ -44,16 +44,3 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     }
 }
 
-/** @brief AirQuality Cluster Init
- *
- * This function is called when a specific cluster is initialized. It gives the
- * application an opportunity to take care of cluster initialization procedures.
- * It is called exactly once for each endpoint where cluster is present.
- *
- * @param endpoint   Ver.: always
- *
- */
-void emberAfAirQualityClusterInitCallback(EndpointId endpoint)
-{
-    // TODO: implement any additional Cluster Server init actions
-}

--- a/examples/all-clusters-app/all-clusters-common/include/air-quality-instance.h
+++ b/examples/all-clusters-app/all-clusters-common/include/air-quality-instance.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <app/clusters/air-quality-server/air-quality-server.h>
+#include <app/clusters/air-quality-server/CodegenIntegration.h>
 
 namespace chip {
 namespace app {
 namespace Clusters {
 namespace AirQuality {
 
-Instance * GetInstance();
+AirQualityCluster * GetInstance();
 
 void Shutdown();
 

--- a/examples/all-clusters-app/all-clusters-common/src/air-quality-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/air-quality-instance.cpp
@@ -20,33 +20,9 @@
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::AirQuality;
 
-Instance * gAirQualityCluster = nullptr;
-
-Instance * AirQuality::GetInstance()
+AirQualityCluster * AirQuality::GetInstance()
 {
-    return gAirQualityCluster;
+    return FindClusterOnEndpoint(1);
 }
 
-void AirQuality::Shutdown()
-{
-    if (gAirQualityCluster != nullptr)
-    {
-        delete gAirQualityCluster;
-        gAirQualityCluster = nullptr;
-    }
-}
-
-void emberAfAirQualityClusterInitCallback(chip::EndpointId endpointId)
-{
-    VerifyOrDie(endpointId == 1); // this cluster is only enabled for endpoint 1.
-    VerifyOrDie(gAirQualityCluster == nullptr);
-    chip::BitMask<Feature, uint32_t> airQualityFeatures(Feature::kModerate, Feature::kFair, Feature::kVeryPoor,
-                                                        Feature::kExtremelyPoor);
-    gAirQualityCluster = new Instance(1, airQualityFeatures);
-    TEMPORARY_RETURN_IGNORED gAirQualityCluster->Init();
-}
-
-void emberAfAirQualityClusterShutdownCallback(chip::EndpointId endpointId)
-{
-    AirQuality::Shutdown();
-}
+void AirQuality::Shutdown() {}

--- a/examples/chef/common/chef-air-quality.cpp
+++ b/examples/chef/common/chef-air-quality.cpp
@@ -19,26 +19,14 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/config.h>
 #include <lib/core/DataModelTypes.h>
-#include <map>
 
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 
 #ifdef MATTER_DM_PLUGIN_AIR_QUALITY_SERVER
-#include <app/clusters/air-quality-server/air-quality-server.h>
+#include <app/clusters/air-quality-server/CodegenIntegration.h>
 using namespace chip::app::Clusters::AirQuality;
-
-static chip::BitMask<Feature, uint32_t> airQualityFeatures(Feature::kFair, Feature::kModerate, Feature::kVeryPoor,
-                                                           Feature::kExtremelyPoor);
-static std::map<int, Instance *> gAirQualityClusterInstance{};
-
-void emberAfAirQualityClusterInitCallback(chip::EndpointId endpointId)
-{
-    Instance * clusterInstance = new Instance(endpointId, airQualityFeatures);
-    TEMPORARY_RETURN_IGNORED clusterInstance->Init();
-    gAirQualityClusterInstance[endpointId] = clusterInstance;
-}
 
 Protocols::InteractionModel::Status chefAirQualityWriteCallback(EndpointId endpoint, ClusterId clusterId,
                                                                 const EmberAfAttributeMetadata * attributeMetadata,
@@ -46,14 +34,14 @@ Protocols::InteractionModel::Status chefAirQualityWriteCallback(EndpointId endpo
 {
     Protocols::InteractionModel::Status ret = Protocols::InteractionModel::Status::Success;
 
-    if (gAirQualityClusterInstance.find(endpoint) == gAirQualityClusterInstance.end())
+    AirQualityCluster * clusterInstance = FindClusterOnEndpoint(endpoint);
+    if (clusterInstance == nullptr)
     {
         ChipLogError(DeviceLayer, "Invalid Endpoind ID: %d", endpoint);
         return Protocols::InteractionModel::Status::UnsupportedEndpoint;
     }
 
-    Instance * clusterInstance = gAirQualityClusterInstance[endpoint];
-    AttributeId attributeId    = attributeMetadata->attributeId;
+    AttributeId attributeId = attributeMetadata->attributeId;
 
     switch (attributeId)
     {

--- a/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
+++ b/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
@@ -3034,7 +3034,7 @@ endpoint 2 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     callback attribute featureMap;
-    ram      attribute clusterRevision default = 1;
+    callback attribute clusterRevision;
   }
 
   server cluster CarbonMonoxideConcentrationMeasurement {

--- a/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.matter
+++ b/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.matter
@@ -2738,7 +2738,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     callback attribute featureMap;
-    ram      attribute clusterRevision default = 1;
+    callback attribute clusterRevision;
   }
 
   server cluster TemperatureMeasurement {

--- a/examples/chef/devices/rootnode_contactsensor_lightsensor_occupancysensor_temperaturesensor_pressuresensor_flowsensor_humiditysensor_airqualitysensor_powersource_367e7cea91.matter
+++ b/examples/chef/devices/rootnode_contactsensor_lightsensor_occupancysensor_temperaturesensor_pressuresensor_flowsensor_humiditysensor_airqualitysensor_powersource_367e7cea91.matter
@@ -3013,7 +3013,7 @@ endpoint 8 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     callback attribute featureMap;
-    ram      attribute clusterRevision default = 1;
+    callback attribute clusterRevision;
   }
 
   server cluster CarbonMonoxideConcentrationMeasurement {

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/CodeDrivenCallback.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/CodeDrivenCallback.h
@@ -124,6 +124,10 @@ void MatterTemperatureControlClusterInitCallback(chip::EndpointId endpointId);
 
 void MatterTemperatureControlClusterShutdownCallback(chip::EndpointId endpointId, MatterClusterShutdownType shutdownType);
 
+void MatterAirQualityClusterInitCallback(chip::EndpointId endpointId);
+
+void MatterAirQualityClusterShutdownCallback(chip::EndpointId endpointId, MatterClusterShutdownType shutdownType);
+
 void MatterScenesManagementClusterInitCallback(chip::EndpointId endpointId);
 
 void MatterScenesManagementClusterShutdownCallback(chip::EndpointId endpointId, MatterClusterShutdownType shutdownType);

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/CodeDrivenInitShutdown.cpp
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/CodeDrivenInitShutdown.cpp
@@ -103,6 +103,9 @@ void MatterClusterServerInitCallback(EndpointId endpoint, ClusterId clusterId)
     case app::Clusters::TemperatureControl::Id:
         MatterTemperatureControlClusterInitCallback(endpoint);
         break;
+    case app::Clusters::AirQuality::Id:
+        MatterAirQualityClusterInitCallback(endpoint);
+        break;
     case app::Clusters::ScenesManagement::Id:
         MatterScenesManagementClusterInitCallback(endpoint);
         break;
@@ -229,6 +232,9 @@ void MatterClusterServerShutdownCallback(EndpointId endpoint, ClusterId clusterI
         break;
     case app::Clusters::TemperatureControl::Id:
         MatterTemperatureControlClusterShutdownCallback(endpoint, shutdownType);
+        break;
+    case app::Clusters::AirQuality::Id:
+        MatterAirQualityClusterShutdownCallback(endpoint, shutdownType);
         break;
     case app::Clusters::ScenesManagement::Id:
         MatterScenesManagementClusterShutdownCallback(endpoint, shutdownType);

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -55,6 +55,7 @@ if (chip_build_tests) {
       "${chip_root}/src/app/cluster-building-blocks/tests",
       "${chip_root}/src/app/clusters/access-control-server/tests",
       "${chip_root}/src/app/clusters/administrator-commissioning-server/tests",
+      "${chip_root}/src/app/clusters/air-quality-server/tests",
       "${chip_root}/src/app/clusters/basic-information/tests",
       "${chip_root}/src/app/clusters/bindings/tests",
       "${chip_root}/src/app/clusters/boolean-state-configuration-server/tests",

--- a/src/app/clusters/BUILD.gn
+++ b/src/app/clusters/BUILD.gn
@@ -19,6 +19,7 @@ source_set("clusters") {
     # keep-sorted: start
     "access-control-server",
     "administrator-commissioning-server",
+    "air-quality-server",
     "basic-information",
     "boolean-state-configuration-server",
     "boolean-state-server",

--- a/src/app/clusters/air-quality-server/AirQualityCluster.cpp
+++ b/src/app/clusters/air-quality-server/AirQualityCluster.cpp
@@ -16,50 +16,50 @@
  *    limitations under the License.
  */
 
-#include "app-common/zap-generated/ids/Clusters.h"
-#include <app-common/zap-generated/attributes/Accessors.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/clusters/air-quality-server/AirQualityCluster.h>
-#include <app/reporting/reporting.h>
-#include <app/util/attribute-storage.h>
-
-using namespace chip;
-using namespace chip::app;
-using namespace chip::app::Clusters;
-using chip::Protocols::InteractionModel::Status;
+#include <app/server-cluster/AttributeListBuilder.h>
+#include <clusters/AirQuality/Metadata.h>
 
 namespace chip {
 namespace app {
 namespace Clusters {
-namespace AirQuality {
 
-Instance::Instance(EndpointId aEndpointId, BitMask<Feature> aFeature) :
-    AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id), mEndpointId(aEndpointId), mFeature(aFeature)
-{}
+using AirQuality::AirQualityEnum;
+using AirQuality::Feature;
 
-Instance::~Instance()
+AirQualityCluster::AirQualityCluster(EndpointId endpointId) : DefaultServerCluster({ endpointId, AirQuality::Id }) {}
+
+DataModel::ActionReturnStatus AirQualityCluster::ReadAttribute(const DataModel::ReadAttributeRequest & request,
+                                                               AttributeValueEncoder & encoder)
 {
-    AttributeAccessInterfaceRegistry::Instance().Unregister(this);
+    switch (request.path.mAttributeId)
+    {
+    case AirQuality::Attributes::AirQuality::Id:
+        return encoder.Encode(mAirQuality);
+    case AirQuality::Attributes::ClusterRevision::Id:
+        return encoder.Encode(AirQuality::kRevision);
+    case AirQuality::Attributes::FeatureMap::Id:
+        return encoder.Encode(mFeature.Raw());
+    default:
+        return Protocols::InteractionModel::Status::UnsupportedAttribute;
+    }
 }
 
-CHIP_ERROR Instance::Init()
+CHIP_ERROR AirQualityCluster::Attributes(const ConcreteClusterPath & path,
+                                         ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
 {
-    // Check if the cluster has been selected in zap
-    VerifyOrDie(emberAfContainsServer(mEndpointId, Id) == true);
-
-    VerifyOrReturnError(AttributeAccessInterfaceRegistry::Instance().Register(this), CHIP_ERROR_INCORRECT_STATE);
-
-    return CHIP_NO_ERROR;
+    AttributeListBuilder listBuilder(builder);
+    return listBuilder.Append(Span(AirQuality::Attributes::kMandatoryMetadata), {});
 }
 
-bool Instance::HasFeature(Feature aFeature) const
+bool AirQualityCluster::HasFeature(Feature aFeature) const
 {
     return mFeature.Has(aFeature);
 }
 
-Protocols::InteractionModel::Status Instance::UpdateAirQuality(AirQualityEnum aNewAirQuality)
+Protocols::InteractionModel::Status AirQualityCluster::SetAirQuality(AirQualityEnum aNewAirQuality)
 {
-    // Check that the value in is valid according to the enabled features.
+    // Check that the value is valid according to the enabled features.
     switch (aNewAirQuality)
     {
     case AirQualityEnum::kFair: {
@@ -99,31 +99,20 @@ Protocols::InteractionModel::Status Instance::UpdateAirQuality(AirQualityEnum aN
     }
     }
 
-    mAirQuality = aNewAirQuality;
-    MatterReportingAttributeChangeCallback(ConcreteAttributePath(mEndpointId, Id, Attributes::AirQuality::Id));
+    SetAttributeValue(mAirQuality, aNewAirQuality, AirQuality::Attributes::AirQuality::Id);
     return Protocols::InteractionModel::Status::Success;
 }
 
-AirQualityEnum Instance::GetAirQuality()
+AirQualityEnum AirQualityCluster::GetAirQuality() const
 {
     return mAirQuality;
 }
 
-CHIP_ERROR Instance::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
+void AirQualityCluster::SetFeatureMap(BitFlags<Feature> features)
 {
-    switch (aPath.mAttributeId)
-    {
-    case Attributes::AirQuality::Id:
-        ReturnErrorOnFailure(aEncoder.Encode(mAirQuality));
-        break;
-    case Attributes::FeatureMap::Id:
-        ReturnErrorOnFailure(aEncoder.Encode(mFeature.Raw()));
-        break;
-    }
-    return CHIP_NO_ERROR;
+    mFeature = features;
 }
 
-} // namespace AirQuality
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/air-quality-server/AirQualityCluster.h
+++ b/src/app/clusters/air-quality-server/AirQualityCluster.h
@@ -18,59 +18,69 @@
 
 #pragma once
 
-#include <app/AttributeAccessInterface.h>
+#include <app/server-cluster/DefaultServerCluster.h>
 
 namespace chip {
 namespace app {
 namespace Clusters {
-namespace AirQuality {
 
-class Instance : public AttributeAccessInterface
+/**
+ * Code-driven implementation of the Matter Air Quality cluster.
+ * Manages a single AirQuality attribute with feature-gated validation.
+ * Instances are created by the framework via CodegenIntegration.
+ */
+class AirQualityCluster : public DefaultServerCluster
 {
 public:
     /**
-     * Creates an air quality cluster instance. The Init() function needs to be called for this instance to be registered and
-     * called by the interaction model at the appropriate times.
-     * @param aEndpointId The endpoint on which this cluster exists. This must match the zap configuration.
-     * @param aFeature The bitmask value that identifies which features are supported by this instance.
+     * @param endpointId The endpoint on which this cluster exists.
      */
-    Instance(EndpointId aEndpointId, BitMask<Feature> aFeature);
+    AirQualityCluster(EndpointId endpointId);
 
-    ~Instance() override;
-
-    /**
-     * Initialises the air quality cluster instance
-     * @return Returns an error if an air quality cluster has not been enabled in zap for the given endpoint ID or
-     * if the AttributeHandler registration fails.
-     */
-    CHIP_ERROR Init();
+    // Server cluster implementation
+    DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
+                                                AttributeValueEncoder & encoder) override;
+    CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
 
     /**
      * Returns true if the feature is supported.
      * @param feature the feature to check.
      */
-    bool HasFeature(Feature aFeature) const;
+    bool HasFeature(AirQuality::Feature aFeature) const;
 
     /**
      * Sets the AirQuality attribute.
      * @param aNewAirQuality The value to which the AirQuality attribute is to be set.
      * @return Returns a ConstraintError if the aNewAirQuality value is not valid. Returns Success otherwise.
      */
-    Protocols::InteractionModel::Status UpdateAirQuality(AirQualityEnum aNewAirQuality);
+    Protocols::InteractionModel::Status SetAirQuality(AirQuality::AirQualityEnum aNewAirQuality);
+
+    // Backward compatibility alias
+    inline Protocols::InteractionModel::Status UpdateAirQuality(AirQuality::AirQualityEnum aNewAirQuality)
+    {
+        return SetAirQuality(aNewAirQuality);
+    }
 
     /**
      * @return The current AirQuality enum.
      */
-    AirQualityEnum GetAirQuality();
+    AirQuality::AirQualityEnum GetAirQuality() const;
 
-private:
-    EndpointId mEndpointId;
-    AirQualityEnum mAirQuality = AirQualityEnum::kUnknown;
-    BitMask<Feature> mFeature;
+    /**
+     * Sets the feature map for this cluster instance.
+     * Called by CodegenIntegration during creation.
+     */
+    void SetFeatureMap(BitFlags<AirQuality::Feature> features);
 
-    // AttributeAccessInterface
-    CHIP_ERROR Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder) override;
+protected:
+    AirQuality::AirQualityEnum mAirQuality = AirQuality::AirQualityEnum::kUnknown;
+    BitFlags<AirQuality::Feature> mFeature;
 };
+
+namespace AirQuality {
+
+// Backward compatibility alias
+using Instance = AirQualityCluster;
 
 } // namespace AirQuality
 } // namespace Clusters

--- a/src/app/clusters/air-quality-server/BUILD.gn
+++ b/src/app/clusters/air-quality-server/BUILD.gn
@@ -11,5 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-group("air-quality-server") {
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+source_set("air-quality-server") {
+  sources = [
+    "AirQualityCluster.cpp",
+    "AirQualityCluster.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/app/data-model-provider",
+    "${chip_root}/src/app/server",
+    "${chip_root}/src/app/server-cluster",
+    "${chip_root}/zzz_generated/app-common/clusters/AirQuality",
+  ]
 }

--- a/src/app/clusters/air-quality-server/CodegenIntegration.cpp
+++ b/src/app/clusters/air-quality-server/CodegenIntegration.cpp
@@ -1,0 +1,108 @@
+/*
+ *
+ *    Copyright (c) 2026 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "CodegenIntegration.h"
+#include <app/clusters/air-quality-server/AirQualityCluster.h>
+#include <app/static-cluster-config/AirQuality.h>
+#include <app/util/attribute-storage.h>
+#include <data-model-providers/codegen/ClusterIntegration.h>
+#include <data-model-providers/codegen/CodegenDataModelProvider.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+
+namespace {
+
+constexpr uint16_t kAirQualityFixedClusterCount =
+    static_cast<uint16_t>(Clusters::AirQuality::StaticApplicationConfig::kFixedClusterConfig.size());
+constexpr uint16_t kAirQualityMaxClusterCount = kAirQualityFixedClusterCount + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
+
+LazyRegisteredServerCluster<AirQualityCluster> gServers[kAirQualityMaxClusterCount];
+
+class IntegrationDelegate : public CodegenClusterIntegration::Delegate
+{
+public:
+    ServerClusterRegistration & CreateRegistration(EndpointId endpointId, unsigned clusterInstanceIndex,
+                                                   uint32_t optionalAttributeBits, uint32_t featureMap) override
+    {
+        gServers[clusterInstanceIndex].Create(endpointId);
+        gServers[clusterInstanceIndex].Cluster().SetFeatureMap(BitFlags<Clusters::AirQuality::Feature>(featureMap));
+        return gServers[clusterInstanceIndex].Registration();
+    }
+
+    ServerClusterInterface * FindRegistration(unsigned clusterInstanceIndex) override
+    {
+        VerifyOrReturnValue(gServers[clusterInstanceIndex].IsConstructed(), nullptr);
+        return &gServers[clusterInstanceIndex].Cluster();
+    }
+
+    void ReleaseRegistration(unsigned clusterInstanceIndex) override { gServers[clusterInstanceIndex].Destroy(); }
+};
+
+} // namespace
+
+void MatterAirQualityClusterInitCallback(EndpointId endpointId)
+{
+    IntegrationDelegate integrationDelegate;
+
+    CodegenClusterIntegration::RegisterServer(
+        {
+            .endpointId                = endpointId,
+            .clusterId                 = Clusters::AirQuality::Id,
+            .fixedClusterInstanceCount = kAirQualityFixedClusterCount,
+            .maxClusterInstanceCount   = kAirQualityMaxClusterCount,
+            .fetchFeatureMap           = true,
+            .fetchOptionalAttributes   = false,
+        },
+        integrationDelegate);
+}
+
+void MatterAirQualityClusterShutdownCallback(EndpointId endpointId, MatterClusterShutdownType shutdownType)
+{
+    IntegrationDelegate integrationDelegate;
+
+    CodegenClusterIntegration::UnregisterServer(
+        {
+            .endpointId                = endpointId,
+            .clusterId                 = Clusters::AirQuality::Id,
+            .fixedClusterInstanceCount = kAirQualityFixedClusterCount,
+            .maxClusterInstanceCount   = kAirQualityMaxClusterCount,
+        },
+        integrationDelegate, shutdownType);
+}
+
+namespace chip::app::Clusters::AirQuality {
+
+AirQualityCluster * FindClusterOnEndpoint(EndpointId endpointId)
+{
+    IntegrationDelegate integrationDelegate;
+
+    ServerClusterInterface * airQuality = CodegenClusterIntegration::FindClusterOnEndpoint(
+        {
+            .endpointId                = endpointId,
+            .clusterId                 = chip::app::Clusters::AirQuality::Id,
+            .fixedClusterInstanceCount = kAirQualityFixedClusterCount,
+            .maxClusterInstanceCount   = kAirQualityMaxClusterCount,
+        },
+        integrationDelegate);
+
+    return static_cast<AirQualityCluster *>(airQuality);
+}
+
+} // namespace chip::app::Clusters::AirQuality

--- a/src/app/clusters/air-quality-server/CodegenIntegration.h
+++ b/src/app/clusters/air-quality-server/CodegenIntegration.h
@@ -18,7 +18,10 @@
 
 #pragma once
 
-// Note: This file exists for backwards compatibility only.
-// New code should directly use AirQualityCluster.h instead.
+#include <app/clusters/air-quality-server/AirQualityCluster.h>
 
-#include <app/clusters/air-quality-server/CodegenIntegration.h>
+namespace chip::app::Clusters::AirQuality {
+
+AirQualityCluster * FindClusterOnEndpoint(EndpointId endpointId);
+
+} // namespace chip::app::Clusters::AirQuality

--- a/src/app/clusters/air-quality-server/README.md
+++ b/src/app/clusters/air-quality-server/README.md
@@ -1,0 +1,64 @@
+# Air Quality Cluster
+
+This cluster uses a code-driven implementation based on `DefaultServerCluster`.
+
+## Overview
+
+The `AirQualityCluster` manages a single `AirQuality` attribute (enum) with
+feature-gated validation. Features (`Fair`, `Moderate`, `VeryPoor`,
+`ExtremelyPoor`) control which enum values are allowed.
+
+The framework creates cluster instances automatically via `CodegenIntegration`.
+Applications access instances using `FindClusterOnEndpoint()`.
+
+## Usage
+
+### Accessing the cluster instance
+
+```cpp
+#include <app/clusters/air-quality-server/CodegenIntegration.h>
+
+using namespace chip::app::Clusters;
+
+AirQualityCluster * cluster = AirQuality::FindClusterOnEndpoint(endpointId);
+```
+
+### Setting the air quality value
+
+```cpp
+auto status = cluster->SetAirQuality(AirQuality::AirQualityEnum::kGood);
+if (status != Protocols::InteractionModel::Status::Success)
+{
+    // Value rejected (feature not enabled or invalid value)
+}
+```
+
+### Reading the current value
+
+```cpp
+AirQuality::AirQualityEnum current = cluster->GetAirQuality();
+```
+
+## Migration from Legacy API
+
+Previously, applications manually created instances:
+
+```cpp
+// Old pattern (no longer needed)
+AirQuality::Instance * instance = new AirQuality::Instance(endpoint, featureBits);
+instance->Init();
+instance->UpdateAirQuality(AirQuality::AirQualityEnum::kGood);
+```
+
+Now the framework manages instances. The Accessors for `AirQuality` and
+`FeatureMap` attributes are no longer available. Use the cluster API instead:
+
+```cpp
+// New pattern
+auto * cluster = AirQuality::FindClusterOnEndpoint(endpoint);
+cluster->SetAirQuality(AirQuality::AirQualityEnum::kGood);
+```
+
+`UpdateAirQuality()` is retained as a backward-compatibility alias for
+`SetAirQuality()`. The type alias `AirQuality::Instance` maps to
+`AirQualityCluster` for backward compatibility.

--- a/src/app/clusters/air-quality-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/air-quality-server/app_config_dependent_sources.gni
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 app_config_dependent_sources = [
-  "AirQualityCluster.cpp",
+  "CodegenIntegration.cpp",
+  "CodegenIntegration.h",
   "air-quality-server.h",
 ]

--- a/src/app/clusters/air-quality-server/tests/BUILD.gn
+++ b/src/app/clusters/air-quality-server/tests/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Project CHIP Authors
+# Copyright (c) 2026 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,11 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# This is the equivalent to app_config_dependent_sources.gni
-TARGET_SOURCES(
-  ${APP_TARGET}
-  PRIVATE
-    "${CLUSTER_DIR}/CodegenIntegration.h"
-    "${CLUSTER_DIR}/CodegenIntegration.cpp"
-    "${CLUSTER_DIR}/air-quality-server.h"
-)
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "libTestAirQualityCluster"
+
+  test_sources = [ "TestAirQualityCluster.cpp" ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/app/clusters/air-quality-server",
+    "${chip_root}/src/app/server-cluster/testing:testing",
+    "${chip_root}/src/lib/support",
+  ]
+}

--- a/src/app/clusters/air-quality-server/tests/TestAirQualityCluster.cpp
+++ b/src/app/clusters/air-quality-server/tests/TestAirQualityCluster.cpp
@@ -1,0 +1,243 @@
+/*
+ *    Copyright (c) 2026 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/air-quality-server/AirQualityCluster.h>
+#include <pw_unit_test/framework.h>
+
+#include <app/server-cluster/testing/AttributeTesting.h>
+#include <app/server-cluster/testing/ClusterTester.h>
+#include <app/server-cluster/testing/TestServerClusterContext.h>
+#include <app/server-cluster/testing/ValidateGlobalAttributes.h>
+#include <clusters/AirQuality/Attributes.h>
+#include <clusters/AirQuality/Enums.h>
+#include <clusters/AirQuality/Metadata.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::AirQuality;
+using namespace chip::Testing;
+using chip::Testing::IsAttributesListEqualTo;
+
+namespace {
+
+struct TestAirQualityCluster : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+
+    void SetUp() override
+    {
+        airQuality.SetFeatureMap(
+            BitFlags<Feature>(Feature::kFair, Feature::kModerate, Feature::kVeryPoor, Feature::kExtremelyPoor));
+        ASSERT_EQ(airQuality.Startup(testContext.Get()), CHIP_NO_ERROR);
+    }
+
+    void TearDown() override { airQuality.Shutdown(ClusterShutdownType::kClusterShutdown); }
+
+    TestAirQualityCluster() : airQuality(kRootEndpointId) {}
+
+    TestServerClusterContext testContext;
+    AirQualityCluster airQuality;
+};
+
+struct TestAirQualityClusterNoFeatures : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+
+    void SetUp() override { ASSERT_EQ(airQuality.Startup(testContext.Get()), CHIP_NO_ERROR); }
+
+    void TearDown() override { airQuality.Shutdown(ClusterShutdownType::kClusterShutdown); }
+
+    TestAirQualityClusterNoFeatures() : airQuality(kRootEndpointId) {}
+
+    TestServerClusterContext testContext;
+    AirQualityCluster airQuality;
+};
+
+} // namespace
+
+TEST_F(TestAirQualityCluster, AttributeList)
+{
+    ASSERT_TRUE(IsAttributesListEqualTo(airQuality,
+                                        {
+                                            Clusters::AirQuality::Attributes::AirQuality::kMetadataEntry,
+                                        }));
+}
+
+TEST_F(TestAirQualityCluster, ReadAttributes)
+{
+    ClusterTester tester(airQuality);
+
+    uint16_t revision{};
+    ASSERT_EQ(tester.ReadAttribute(Globals::Attributes::ClusterRevision::Id, revision), CHIP_NO_ERROR);
+    EXPECT_EQ(revision, AirQuality::kRevision);
+
+    uint32_t features{};
+    ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, features), CHIP_NO_ERROR);
+    EXPECT_EQ(features,
+              to_underlying(Feature::kFair) | to_underlying(Feature::kModerate) | to_underlying(Feature::kVeryPoor) |
+                  to_underlying(Feature::kExtremelyPoor));
+
+    uint8_t airQualityVal{};
+    ASSERT_EQ(tester.ReadAttribute(Clusters::AirQuality::Attributes::AirQuality::Id, airQualityVal), CHIP_NO_ERROR);
+    EXPECT_EQ(airQualityVal, to_underlying(AirQualityEnum::kUnknown));
+}
+
+TEST_F(TestAirQualityCluster, DefaultValue)
+{
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kUnknown);
+}
+
+TEST_F(TestAirQualityCluster, SetAndGetAirQuality)
+{
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kGood), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kGood);
+
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kFair), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kFair);
+
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kModerate), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kModerate);
+
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kPoor), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kPoor);
+
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kVeryPoor), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kVeryPoor);
+
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kExtremelyPoor), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kExtremelyPoor);
+
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kUnknown), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kUnknown);
+}
+
+TEST_F(TestAirQualityCluster, SetSameValueNoChange)
+{
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kGood), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kGood);
+
+    // Setting the same value again should still succeed
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kGood), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kGood);
+}
+
+TEST_F(TestAirQualityCluster, InvalidValueRejected)
+{
+    EXPECT_EQ(airQuality.SetAirQuality(static_cast<AirQualityEnum>(0xFF)), Protocols::InteractionModel::Status::InvalidValue);
+    // Value should remain unchanged
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kUnknown);
+}
+
+TEST_F(TestAirQualityCluster, HasFeature)
+{
+    EXPECT_TRUE(airQuality.HasFeature(Feature::kFair));
+    EXPECT_TRUE(airQuality.HasFeature(Feature::kModerate));
+    EXPECT_TRUE(airQuality.HasFeature(Feature::kVeryPoor));
+    EXPECT_TRUE(airQuality.HasFeature(Feature::kExtremelyPoor));
+}
+
+TEST_F(TestAirQualityClusterNoFeatures, FeatureConstrainedValuesRejected)
+{
+    // With no features enabled, Fair/Moderate/VeryPoor/ExtremelyPoor should be rejected
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kFair), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kModerate), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kVeryPoor), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kExtremelyPoor), Protocols::InteractionModel::Status::ConstraintError);
+
+    // Unknown, Good, Poor should still work (no feature required)
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kUnknown), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kGood), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kPoor), Protocols::InteractionModel::Status::Success);
+}
+
+TEST_F(TestAirQualityClusterNoFeatures, HasFeatureReturnsFalse)
+{
+    EXPECT_FALSE(airQuality.HasFeature(Feature::kFair));
+    EXPECT_FALSE(airQuality.HasFeature(Feature::kModerate));
+    EXPECT_FALSE(airQuality.HasFeature(Feature::kVeryPoor));
+    EXPECT_FALSE(airQuality.HasFeature(Feature::kExtremelyPoor));
+}
+
+TEST_F(TestAirQualityCluster, BackwardCompatAlias)
+{
+    // UpdateAirQuality should work as an alias for SetAirQuality
+    EXPECT_EQ(airQuality.UpdateAirQuality(AirQualityEnum::kGood), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(airQuality.GetAirQuality(), AirQualityEnum::kGood);
+}
+
+TEST_F(TestAirQualityCluster, PartialFeaturesFairOnly)
+{
+    // Teardown the all-features instance and create one with only kFair
+    airQuality.Shutdown(ClusterShutdownType::kClusterShutdown);
+
+    AirQualityCluster fairOnly(kRootEndpointId);
+    fairOnly.SetFeatureMap(BitFlags<Feature>(Feature::kFair));
+    ASSERT_EQ(fairOnly.Startup(testContext.Get()), CHIP_NO_ERROR);
+
+    // Fair should be accepted
+    EXPECT_EQ(fairOnly.SetAirQuality(AirQualityEnum::kFair), Protocols::InteractionModel::Status::Success);
+
+    // Other feature-gated values should be rejected
+    EXPECT_EQ(fairOnly.SetAirQuality(AirQualityEnum::kModerate), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(fairOnly.SetAirQuality(AirQualityEnum::kVeryPoor), Protocols::InteractionModel::Status::ConstraintError);
+    EXPECT_EQ(fairOnly.SetAirQuality(AirQualityEnum::kExtremelyPoor), Protocols::InteractionModel::Status::ConstraintError);
+
+    // Non-feature-gated values should still work
+    EXPECT_EQ(fairOnly.SetAirQuality(AirQualityEnum::kGood), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(fairOnly.SetAirQuality(AirQualityEnum::kPoor), Protocols::InteractionModel::Status::Success);
+    EXPECT_EQ(fairOnly.SetAirQuality(AirQualityEnum::kUnknown), Protocols::InteractionModel::Status::Success);
+
+    fairOnly.Shutdown(ClusterShutdownType::kClusterShutdown);
+}
+
+TEST_F(TestAirQualityCluster, ReadAttributeAfterSet)
+{
+    ClusterTester tester(airQuality);
+
+    // Set via API
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kPoor), Protocols::InteractionModel::Status::Success);
+
+    // Read via ClusterTester to verify ReadAttribute returns the updated value
+    uint8_t airQualityVal{};
+    ASSERT_EQ(tester.ReadAttribute(Clusters::AirQuality::Attributes::AirQuality::Id, airQualityVal), CHIP_NO_ERROR);
+    EXPECT_EQ(airQualityVal, to_underlying(AirQualityEnum::kPoor));
+
+    // Change again and verify
+    EXPECT_EQ(airQuality.SetAirQuality(AirQualityEnum::kExtremelyPoor), Protocols::InteractionModel::Status::Success);
+    ASSERT_EQ(tester.ReadAttribute(Clusters::AirQuality::Attributes::AirQuality::Id, airQualityVal), CHIP_NO_ERROR);
+    EXPECT_EQ(airQualityVal, to_underlying(AirQualityEnum::kExtremelyPoor));
+}
+
+TEST_F(TestAirQualityClusterNoFeatures, FeatureMapReflectsSetFeatureMap)
+{
+    ClusterTester tester(airQuality);
+
+    // No features set — FeatureMap should be 0
+    uint32_t features{};
+    ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, features), CHIP_NO_ERROR);
+    EXPECT_EQ(features, 0u);
+
+    // Set a specific combination and re-read
+    airQuality.SetFeatureMap(BitFlags<Feature>(Feature::kModerate, Feature::kExtremelyPoor));
+
+    ASSERT_EQ(tester.ReadAttribute(Attributes::FeatureMap::Id, features), CHIP_NO_ERROR);
+    EXPECT_EQ(features, to_underlying(Feature::kModerate) | to_underlying(Feature::kExtremelyPoor));
+}

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -113,6 +113,7 @@ CodeDrivenClusters:
     # keep-sorted start
     - Access Control
     - Activated Carbon Filter Monitoring
+    - Air Quality
     - Administrator Commissioning
     - Basic Information
     - Binding

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -750,7 +750,7 @@
             "LevelValue",
             "FeatureMap"
         ],
-        "Air Quality": ["AirQuality", "FeatureMap"],
+        "Air Quality": ["AirQuality", "ClusterRevision", "FeatureMap"],
         "Electrical Energy Measurement": [
             "Accuracy",
             "CumulativeEnergyImported",

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -7829,56 +7829,7 @@ Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
 } // namespace DishwasherMode
 
 namespace AirQuality {
-namespace Attributes {
-
-namespace ClusterRevision {
-
-Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value)
-{
-    using Traits = NumericAttributeTraits<uint16_t>;
-    Traits::StorageType temp;
-    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
-    Protocols::InteractionModel::Status status =
-        emberAfReadAttribute(endpoint, Clusters::AirQuality::Id, Id, readable, sizeof(temp));
-    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    *value = Traits::StorageToWorking(temp);
-    return status;
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<uint16_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(ConcreteAttributePath(endpoint, Clusters::AirQuality::Id, Id),
-                                 EmberAfWriteDataInput(writable, ZCL_INT16U_ATTRIBUTE_TYPE).SetMarkDirty(markDirty));
-}
-
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value)
-{
-    using Traits = NumericAttributeTraits<uint16_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::AirQuality::Id, Id, writable, ZCL_INT16U_ATTRIBUTE_TYPE);
-}
-
-} // namespace ClusterRevision
-
-} // namespace Attributes
+namespace Attributes {} // namespace Attributes
 } // namespace AirQuality
 
 namespace SmokeCoAlarm {

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -1372,15 +1372,7 @@ Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, Mar
 } // namespace DishwasherMode
 
 namespace AirQuality {
-namespace Attributes {
-
-namespace ClusterRevision {
-Protocols::InteractionModel::Status Get(EndpointId endpoint, uint16_t * value); // int16u
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value);
-Protocols::InteractionModel::Status Set(EndpointId endpoint, uint16_t value, MarkAttributeDirty markDirty);
-} // namespace ClusterRevision
-
-} // namespace Attributes
+namespace Attributes {} // namespace Attributes
 } // namespace AirQuality
 
 namespace SmokeCoAlarm {


### PR DESCRIPTION
Migrate the Air Quality cluster from the legacy AttributeAccessInterface (AAI) pattern to the code-driven approach using DefaultServerCluster.

Key changes:
- Rewrite AirQualityCluster to inherit DefaultServerCluster
- Add CodegenIntegration for framework-managed cluster instances
- Apps now use FindClusterOnEndpoint() instead of manual instantiation
- Rename UpdateAirQuality() to SetAirQuality() per code-driven convention (backward compat alias retained)
- Add unit tests (10 tests covering attributes, features, constraints)
- Update all example apps (all-clusters, air-quality-sensor, air-purifier, chef)
- Register Air Quality in CodeDrivenClusters config

#### Testing

- Added unit tests