### PR TITLE
[ThreadNetworkDirectoryServer] Add missing nullptr check for iterator

### DIFF
--- a/src/app/clusters/thread-network-directory-server/thread-network-directory-server.cpp
+++ b/src/app/clusters/thread-network-directory-server/thread-network-directory-server.cpp
@@ -133,6 +133,7 @@ CHIP_ERROR ThreadNetworkDirectoryServer::ReadThreadNetworks(const ConcreteDataAt
         CHIP_ERROR err = CHIP_NO_ERROR;
         ExtendedPanId exPanId;
         auto * iterator = mStorage.IterateNetworkIds();
+        VerifyOrReturnError(iterator != nullptr, CHIP_ERROR_NO_MEMORY);
         while (iterator->Next(exPanId))
         {
             uint8_t datasetBuffer[kSizeOperationalDataset];


### PR DESCRIPTION
#### Summary

- Missing nullptr check in `ReadThreadNetworks`, which can occur if we fail to allocate an object from pool (relevant for devices with fixed size pools and not heap)

#### Testing

Testing in CI, this Cluster is not testable using unit tests yet