### PR TITLE
[IM Engine] add missing nullptr checks for IterateSubscriptions

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -170,8 +170,15 @@ class AutoReleaseSubscriptionInfoIterator
 {
 public:
     AutoReleaseSubscriptionInfoIterator(SubscriptionResumptionStorage::SubscriptionInfoIterator * iterator) : mIterator(iterator){};
-    ~AutoReleaseSubscriptionInfoIterator() { mIterator->Release(); }
+    ~AutoReleaseSubscriptionInfoIterator()
+    {
+        if (mIterator)
+        {
+            mIterator->Release();
+        }
+    }
 
+    explicit operator bool() const { return mIterator != nullptr; }
     SubscriptionResumptionStorage::SubscriptionInfoIterator * operator->() const { return mIterator; }
 
 private:
@@ -780,6 +787,7 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
             {
                 SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;
                 auto * iterator = mpSubscriptionResumptionStorage->IterateSubscriptions();
+                VerifyOrReturnError(nullptr != iterator, Status::Failure);
 
                 while (iterator->Next(subscriptionInfo))
                 {
@@ -2102,9 +2110,11 @@ CHIP_ERROR InteractionModelEngine::ResumeSubscriptions()
     // future improvements: https://github.com/project-chip/connectedhomeip/issues/25439
 
     SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;
-    auto * iterator             = mpSubscriptionResumptionStorage->IterateSubscriptions();
     mNumOfSubscriptionsToResume = 0;
     uint16_t minInterval        = 0;
+
+    auto * iterator = mpSubscriptionResumptionStorage->IterateSubscriptions();
+    VerifyOrReturnError(nullptr != iterator, CHIP_ERROR_NO_MEMORY);
     while (iterator->Next(subscriptionInfo))
     {
         mNumOfSubscriptionsToResume++;
@@ -2141,6 +2151,7 @@ void InteractionModelEngine::ResumeSubscriptionsTimerCallback(System::Layer * ap
 #endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;
     AutoReleaseSubscriptionInfoIterator iterator(imEngine->mpSubscriptionResumptionStorage->IterateSubscriptions());
+    VerifyOrReturn(iterator);
     while (iterator->Next(subscriptionInfo))
     {
         // If subscription happens between reboot and this timer callback, it's already live and should skip resumption
@@ -2213,7 +2224,8 @@ bool InteractionModelEngine::HasSubscriptionsToResume()
 
     // Look through persisted subscriptions and see if any aren't already in mReadHandlers pool
     SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;
-    auto * iterator                = mpSubscriptionResumptionStorage->IterateSubscriptions();
+    auto * iterator = mpSubscriptionResumptionStorage->IterateSubscriptions();
+    VerifyOrReturnValue(iterator != nullptr, false);
     bool foundSubscriptionToResume = false;
     while (iterator->Next(subscriptionInfo))
     {

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -2151,7 +2151,7 @@ void InteractionModelEngine::ResumeSubscriptionsTimerCallback(System::Layer * ap
 #endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;
     AutoReleaseSubscriptionInfoIterator iterator(imEngine->mpSubscriptionResumptionStorage->IterateSubscriptions());
-    VerifyOrReturn(iterator);
+    VerifyOrReturn(iterator, ChipLogError(InteractionModel, "Failed to allocate subscription resumption iterator"));
     while (iterator->Next(subscriptionInfo))
     {
         // If subscription happens between reboot and this timer callback, it's already live and should skip resumption

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -787,7 +787,7 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
             {
                 SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;
                 auto * iterator = mpSubscriptionResumptionStorage->IterateSubscriptions();
-                VerifyOrReturnError(nullptr != iterator, Status::Failure);
+                VerifyOrReturnError(nullptr != iterator, Status::ResourceExhausted);
 
                 while (iterator->Next(subscriptionInfo))
                 {
@@ -2225,7 +2225,8 @@ bool InteractionModelEngine::HasSubscriptionsToResume()
     // Look through persisted subscriptions and see if any aren't already in mReadHandlers pool
     SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;
     auto * iterator = mpSubscriptionResumptionStorage->IterateSubscriptions();
-    VerifyOrReturnValue(iterator != nullptr, false);
+    // Conservatively assume there may be subscriptions to resume if we cannot get an iterator.
+    VerifyOrReturnValue(iterator != nullptr, true);
     bool foundSubscriptionToResume = false;
     while (iterator->Next(subscriptionInfo))
     {

--- a/src/app/SubscriptionResumptionStorage.h
+++ b/src/app/SubscriptionResumptionStorage.h
@@ -141,6 +141,9 @@ public:
      * Iterate through persisted subscriptions
      *
      * @return A valid iterator on success. Use CommonIterator accessor to retrieve SubscriptionInfo
+     *
+     * Warning: Implementations using fixed-size pools may return nullptr if the iterator pool is exhausted.
+     * Callers should check for nullptr before using the iterator.
      */
     virtual SubscriptionInfoIterator * IterateSubscriptions() = 0;
 

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -861,7 +861,7 @@ TEST_F(TestInteractionModelEngine, TestResumeSubscriptionsHandlesNullIterators)
 
 #if CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 
-// Test verifies that HasSubscriptionsToResume handles a nullptr iterator gracefully by returning false and not crashing.
+// Test verifies that HasSubscriptionsToResume handles a nullptr iterator gracefully by returning true and not crashing.
 TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestHasSubscriptionsToResumeHandlesNullIterator)
 {
     InteractionModelEngine * engine = InteractionModelEngine::GetInstance();
@@ -873,10 +873,9 @@ TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestHasSubscriptionsToResumeHand
               engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler(), nullptr,
                            &nullIteratorStorage));
 
-    EXPECT_FALSE(engine->HasSubscriptionsToResume());
+    EXPECT_TRUE(engine->HasSubscriptionsToResume());
 }
 #endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
-
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
 } // namespace app

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -68,6 +68,7 @@ public:
     void TestSubjectHasActiveSubscriptionSubWithCAT();
     void TestSubscriptionResumptionTimer();
     void TestDecrementNumSubscriptionsToResume();
+    void TestHasSubscriptionsToResumeHandlesNullIterator();
     void TestFabricHasAtLeastOneActiveSubscription();
     void TestFabricHasAtLeastOneActiveSubscriptionWithMixedStates();
     static int GetAttributePathListLength(SingleLinkedListNode<AttributePathParams> * apattributePathParamsList);
@@ -826,6 +827,54 @@ TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestFabricHasAtLeastOneActiveSub
     // Verify that the fabric has no active subscriptions
     EXPECT_FALSE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex));
 }
+
+#if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
+
+// Mock SubscriptionResumptionStorage that always returns nullptr from IterateSubscriptions(). Used to test null-check handling in
+// the InteractionModelEngine.
+class NullIteratorSubscriptionResumptionStorage : public chip::app::SubscriptionResumptionStorage
+{
+public:
+    SubscriptionInfoIterator * IterateSubscriptions() override { return nullptr; }
+    CHIP_ERROR Save(SubscriptionInfo & subscriptionInfo) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR Delete(chip::NodeId nodeId, chip::FabricIndex fabricIndex, chip::SubscriptionId subscriptionId) override
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR DeleteAll(chip::FabricIndex fabricIndex) override { return CHIP_NO_ERROR; }
+};
+
+// Test verifies that ResumeSubscriptions handles a nullptr iterator gracefully by returning CHIP_ERROR_NO_MEMORY and not crashing
+TEST_F(TestInteractionModelEngine, TestResumeSubscriptions_HandlesNullIterators)
+{
+    InteractionModelEngine * engine = InteractionModelEngine::GetInstance();
+
+    NullIteratorSubscriptionResumptionStorage nullIteratorStorage;
+
+    engine->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    EXPECT_EQ(CHIP_NO_ERROR,
+              engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler(), nullptr,
+                           &nullIteratorStorage));
+
+    EXPECT_EQ(engine->ResumeSubscriptions(), CHIP_ERROR_NO_MEMORY);
+}
+
+// Test verifies that HasSubscriptionsToResume handles a nullptr iterator gracefully by returning false and not crashing.
+TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestHasSubscriptionsToResume_HandlesNullIterator)
+{
+    InteractionModelEngine * engine = InteractionModelEngine::GetInstance();
+
+    NullIteratorSubscriptionResumptionStorage nullIteratorStorage;
+
+    engine->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    EXPECT_EQ(CHIP_NO_ERROR,
+              engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler(), nullptr,
+                           &nullIteratorStorage));
+
+    EXPECT_FALSE(engine->HasSubscriptionsToResume());
+}
+
+#endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
 } // namespace app
 } // namespace chip

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -845,7 +845,7 @@ public:
 };
 
 // Test verifies that ResumeSubscriptions handles a nullptr iterator gracefully by returning CHIP_ERROR_NO_MEMORY and not crashing
-TEST_F(TestInteractionModelEngine, TestResumeSubscriptions_HandlesNullIterators)
+TEST_F(TestInteractionModelEngine, TestResumeSubscriptionsHandlesNullIterators)
 {
     InteractionModelEngine * engine = InteractionModelEngine::GetInstance();
 
@@ -859,8 +859,10 @@ TEST_F(TestInteractionModelEngine, TestResumeSubscriptions_HandlesNullIterators)
     EXPECT_EQ(engine->ResumeSubscriptions(), CHIP_ERROR_NO_MEMORY);
 }
 
+#if CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+
 // Test verifies that HasSubscriptionsToResume handles a nullptr iterator gracefully by returning false and not crashing.
-TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestHasSubscriptionsToResume_HandlesNullIterator)
+TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestHasSubscriptionsToResumeHandlesNullIterator)
 {
     InteractionModelEngine * engine = InteractionModelEngine::GetInstance();
 
@@ -873,6 +875,7 @@ TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestHasSubscriptionsToResume_Han
 
     EXPECT_FALSE(engine->HasSubscriptionsToResume());
 }
+#endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 


### PR DESCRIPTION
#### Summary

- 4 null-checks were missing in `SubscriptionResumption` code paths in the InteractionModel Engine.
-  They all relate to `IterateSubscriptions()` which can fail to allocate an Iterator from ObjectPool when a fixed-size pool is used and two iterators have already been allocated.


#### Testing

- Added unit test cases for a couple of the null checks
