### PR TITLE
[Silabs] Splitting the scan, connect and disconnect for the Wi-Fi

### DIFF
--- a/src/platform/silabs/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/ConfigurationManagerImpl.cpp
@@ -315,11 +315,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     PersistedStorage::KeyValueStoreMgrImpl().ErasePartition();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
-    error = WifiInterface::GetInstance().TriggerDisconnection();
-    if (error != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "TriggerDisconnection() failed: %" CHIP_ERROR_FORMAT, error.Format());
-    }
+    WifiInterface::GetInstance().TriggerDisconnection();
 
     ChipLogProgress(DeviceLayer, "Clearing WiFi provision");
     WifiInterface::GetInstance().ClearWifiCredentials();

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -257,10 +257,7 @@ void ConnectivityManagerImpl::DriveStationState()
         {
             ChipLogProgress(DeviceLayer, "Disconnecting WiFi station interface");
 
-            CHIP_ERROR error = WifiInterface::GetInstance().TriggerDisconnection();
-            SuccessOrExitAction(error,
-                                ChipLogError(DeviceLayer, "TriggerDisconnection() failed: %" CHIP_ERROR_FORMAT, error.Format()));
-
+            WifiInterface::GetInstance().TriggerDisconnection();
             ChangeWiFiStationState(kWiFiStationState_Disconnecting);
         }
 #endif

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -143,7 +143,7 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
     if (ConnectivityMgr().IsWiFiStationProvisioned())
     {
         ChipLogProgress(DeviceLayer, "Disconnecting for current wifi");
-        ReturnErrorOnFailure(WifiInterface::GetInstance().TriggerDisconnection());
+        WifiInterface::GetInstance().TriggerDisconnection();
     }
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled));
 

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -163,8 +163,7 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
     ChipLogProgress(NetworkProvisioning, "Setting up connection for WiFi SSID: %s", NullTerminated(ssid, ssidLen).c_str());
     // Resetting the retry connection state machine for a new access point connection
     WifiInterface::GetInstance().ResetConnectionRetryInterval();
-    // Configure the WFX WiFi interface.
-    WifiInterface::GetInstance().SetWifiCredentials(wifiConfig);
+    ReturnErrorOnFailure(WifiInterface::GetInstance().SetWifiCredentials(wifiConfig));
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled));
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Enabled));
     return CHIP_NO_ERROR;

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -800,7 +800,7 @@ sl_status_t WifiInterfaceImpl::JoinCallback(sl_wifi_event_t event, char * result
         ChipLogError(DeviceLayer, "JoinCallback: failed: 0x%lx", status);
         wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnected);
 
-        mInstance.mUseQuickJoin = (status == SL_STATUS_SI91X_NO_AP_FOUND) ? false : true; // Quick join
+        mInstance.mUseQuickJoin = !(status == SL_STATUS_SI91X_NO_AP_FOUND);
         mInstance.ScheduleConnectionAttempt();
     }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -771,7 +771,7 @@ sl_status_t WifiInterfaceImpl::JoinWifiNetwork(void)
     ChipLogError(DeviceLayer, "sl_net_up failed: 0x%lx", static_cast<uint32_t>(status));
 
     wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnecting).Clear(WifiInterface::WifiState::kStationConnected);
-    mUseQuickJoin = (status == SL_STATUS_SI91X_NO_AP_FOUND) ? false : true; // Quick join
+    mUseQuickJoin = !(status == SL_STATUS_SI91X_NO_AP_FOUND);
     ScheduleConnectionAttempt();
 
     return status;

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -771,16 +771,8 @@ sl_status_t WifiInterfaceImpl::JoinWifiNetwork(void)
     ChipLogError(DeviceLayer, "sl_net_up failed: 0x%lx", static_cast<uint32_t>(status));
 
     wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnecting).Clear(WifiInterface::WifiState::kStationConnected);
-    if (status == SL_STATUS_SI91X_NO_AP_FOUND)
-    {
-        mUseQuickJoin = false; // Scan and join
-        ScheduleConnectionAttempt();
-    }
-    else
-    {
-        mUseQuickJoin = true; // Quick join
-        ScheduleConnectionAttempt();
-    }
+    mUseQuickJoin = (status == SL_STATUS_SI91X_NO_AP_FOUND) ? false : true; // Quick join
+    ScheduleConnectionAttempt();
 
     return status;
 }
@@ -808,16 +800,8 @@ sl_status_t WifiInterfaceImpl::JoinCallback(sl_wifi_event_t event, char * result
         ChipLogError(DeviceLayer, "JoinCallback: failed: 0x%lx", status);
         wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnected);
 
-        if (status == SL_STATUS_SI91X_NO_AP_FOUND)
-        {
-            mInstance.mUseQuickJoin = false; // Scan and join
-            mInstance.ScheduleConnectionAttempt();
-        }
-        else
-        {
-            mInstance.mUseQuickJoin = true; // Quick join
-            mInstance.ScheduleConnectionAttempt();
-        }
+        mInstance.mUseQuickJoin = (status == SL_STATUS_SI91X_NO_AP_FOUND) ? false : true; // Quick join
+        mInstance.ScheduleConnectionAttempt();
     }
 
     return status;

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -503,6 +503,9 @@ sl_status_t SetWifiConfigurations()
             .encryption = SL_WIFI_DEFAULT_ENCRYPTION,
             .client_options = SL_WIFI_JOIN_WITH_SCAN,
             .credential_id = SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID,
+            .channel_bitmap = {
+                .channel_bitmap_2_4 = SL_WIFI_DEFAULT_CHANNEL_BITMAP
+            },
         },
         .ip = {
             .mode = SL_IP_MANAGEMENT_DHCP,
@@ -520,7 +523,8 @@ sl_status_t SetWifiConfigurations()
     {
         // AP channel is known - This indicates that the network scan was done for a specific SSID.
         // Providing the channel and BSSID in the profile avoids scanning all channels again.
-        profile.config.channel.channel = wfx_rsi.ap_chan;
+        profile.config.channel.channel                   = wfx_rsi.ap_chan;
+        profile.config.channel_bitmap.channel_bitmap_2_4 = (1UL << (wfx_rsi.ap_chan - 1));
 
         chip::MutableByteSpan bssidSpan(profile.config.bssid.octet, kWiFiBSSIDLength);
         chip::ByteSpan inBssid(wfx_rsi.ap_bssid.data(), kWiFiBSSIDLength);
@@ -661,7 +665,7 @@ void WifiInterfaceImpl::ProcessEvent(WifiPlatformEvent event)
 
     case WifiPlatformEvent::kStationDisconnect: {
         ChipLogDetail(DeviceLayer, "WifiPlatformEvent::kStationDisconnect");
-        // TODO: This event is not being posted anywhere, seems to be a dead code or we are missing something
+        TriggerPlatformWifiDisconnection();
 
         wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationReady)
             .Clear(WifiInterface::WifiState::kStationConnecting)
@@ -680,15 +684,18 @@ void WifiInterfaceImpl::ProcessEvent(WifiPlatformEvent event)
         // TODO: Currently unimplemented
         break;
 
-    case WifiPlatformEvent::kStationStartJoin:
-        ChipLogDetail(DeviceLayer, "WifiPlatformEvent::kStationStartJoin");
-
-// To avoid IOP issues, it is recommended to enable high-performance mode before joining the network.
-// TODO: Remove this once the IOP issue related to power save mode switching is fixed in the Wi-Fi SDK.
+    case WifiPlatformEvent::kStationStartScan:
+        ChipLogDetail(DeviceLayer, "WifiPlatformEvent::kStationStartScan");
+        // To avoid IOP issues, enable high-performance mode before scan/join. TODO: Remove once IOP fix is in Wi-Fi SDK.
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
         TEMPORARY_RETURN_IGNORED chip::DeviceLayer::Silabs::WifiSleepManager::GetInstance().RequestHighPerformanceWithTransition();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
         InitiateScan();
+        PostWifiPlatformEvent(WifiPlatformEvent::kStationStartJoin);
+        break;
+
+    case WifiPlatformEvent::kStationStartJoin:
+        ChipLogDetail(DeviceLayer, "WifiPlatformEvent::kStationStartJoin");
         JoinWifiNetwork();
         break;
 
@@ -764,7 +771,16 @@ sl_status_t WifiInterfaceImpl::JoinWifiNetwork(void)
     ChipLogError(DeviceLayer, "sl_net_up failed: 0x%lx", static_cast<uint32_t>(status));
 
     wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnecting).Clear(WifiInterface::WifiState::kStationConnected);
-    ScheduleConnectionAttempt();
+    if (status == SL_STATUS_SI91X_NO_AP_FOUND)
+    {
+        mUseQuickJoin = false; // Scan and join
+        ScheduleConnectionAttempt();
+    }
+    else
+    {
+        mUseQuickJoin = true; // Quick join
+        ScheduleConnectionAttempt();
+    }
 
     return status;
 }
@@ -792,7 +808,16 @@ sl_status_t WifiInterfaceImpl::JoinCallback(sl_wifi_event_t event, char * result
         ChipLogError(DeviceLayer, "JoinCallback: failed: 0x%lx", status);
         wfx_rsi.dev_state.Clear(WifiInterface::WifiState::kStationConnected);
 
-        mInstance.ScheduleConnectionAttempt();
+        if (status == SL_STATUS_SI91X_NO_AP_FOUND)
+        {
+            mInstance.mUseQuickJoin = false; // Scan and join
+            mInstance.ScheduleConnectionAttempt();
+        }
+        else
+        {
+            mInstance.mUseQuickJoin = true; // Quick join
+            mInstance.ScheduleConnectionAttempt();
+        }
     }
 
     return status;
@@ -893,7 +918,10 @@ void WifiInterfaceImpl::PostWifiPlatformEvent(WifiPlatformEvent event)
 
 sl_status_t WifiInterfaceImpl::TriggerPlatformWifiDisconnection()
 {
-    return sl_net_down(SL_NET_WIFI_CLIENT_INTERFACE);
+    sl_status_t status = sl_net_down(SL_NET_WIFI_CLIENT_INTERFACE);
+    VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "sl_net_down failed: 0x%lx", status));
+
+    return SL_STATUS_OK;
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -1064,9 +1092,7 @@ bool WifiInterfaceImpl::IsStationReady()
 
 CHIP_ERROR WifiInterfaceImpl::TriggerDisconnection()
 {
-    VerifyOrReturnError(TriggerPlatformWifiDisconnection() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
-    wfx_rsi.dev_state.Clear(WifiState::kStationConnected);
-
+    PostWifiPlatformEvent(WifiPlatformEvent::kStationDisconnect);
     return CHIP_NO_ERROR;
 }
 
@@ -1126,25 +1152,22 @@ bool WifiInterfaceImpl::IsWifiProvisioned()
     return wfx_rsi.dev_state.Has(WifiState::kStationProvisioned);
 }
 
-void WifiInterfaceImpl::SetWifiCredentials(const WiFiCredentials & credentials)
+CHIP_ERROR WifiInterfaceImpl::SetWifiCredentials(const WiFiCredentials & credentials)
 {
+    VerifyOrReturnError(credentials.ssidLen, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(credentials.ssidLen <= kMaxWiFiSSIDLength, CHIP_ERROR_INVALID_ARGUMENT);
     wfx_rsi.credentials = credentials;
     wfx_rsi.dev_state.Set(WifiState::kStationProvisioned);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR WifiInterfaceImpl::ConnectToAccessPoint()
 {
     VerifyOrReturnError(IsWifiProvisioned(), CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(wfx_rsi.credentials.ssidLen, CHIP_ERROR_INCORRECT_STATE);
 
-    // TODO: We should move this validation to where we set the credentials. It is too late here.
-    VerifyOrReturnError(wfx_rsi.credentials.ssidLen <= kMaxWiFiSSIDLength, CHIP_ERROR_INVALID_ARGUMENT);
+    ChipLogProgress(DeviceLayer, "%s to access point: %s", mUseQuickJoin ? "quick join" : "connect", wfx_rsi.credentials.ssid);
 
-    ChipLogProgress(DeviceLayer, "connect to access point: %s", wfx_rsi.credentials.ssid);
-
-    WifiPlatformEvent event = WifiPlatformEvent::kStationStartJoin;
-    PostWifiPlatformEvent(event);
-
+    PostWifiPlatformEvent(mUseQuickJoin ? WifiPlatformEvent::kStationStartJoin : WifiPlatformEvent::kStationStartScan);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -1074,10 +1074,9 @@ bool WifiInterfaceImpl::IsStationReady()
     return wfx_rsi.dev_state.Has(WifiState::kStationInit);
 }
 
-CHIP_ERROR WifiInterfaceImpl::TriggerDisconnection()
+void WifiInterfaceImpl::TriggerDisconnection()
 {
     PostWifiPlatformEvent(WifiPlatformEvent::kStationDisconnect);
-    return CHIP_NO_ERROR;
 }
 
 void WifiInterfaceImpl::NotifyConnectivity(void)

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.h
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.h
@@ -34,10 +34,11 @@ public:
         kStationDisconnect  = 1,
         kAPStart            = 2,
         kAPStop             = 3,
-        kStationStartJoin   = 5,
-        kConnectionComplete = 6, /* This combines the DHCP and Notify */
-        kStationDhcpDone    = 7,
-        kStationDhcpPoll    = 8,
+        kStationStartScan   = 5,
+        kStationStartJoin   = 6,
+        kConnectionComplete = 7, /* This combines the DHCP and Notify */
+        kStationDhcpDone    = 8,
+        kStationDhcpPoll    = 9,
     };
 
     static WifiInterfaceImpl & GetInstance() { return mInstance; }
@@ -58,7 +59,7 @@ public:
     bool IsStationReady() override;
     CHIP_ERROR TriggerDisconnection() override;
     void ClearWifiCredentials() override;
-    void SetWifiCredentials(const WiFiCredentials & credentials) override;
+    CHIP_ERROR SetWifiCredentials(const WiFiCredentials & credentials) override;
     CHIP_ERROR GetWifiCredentials(WiFiCredentials & credentials) override;
     CHIP_ERROR ConnectToAccessPoint(void) override;
     bool HasAnIPv4Address() override;
@@ -153,6 +154,7 @@ private:
     void NotifySuccessfulConnection();
 
     bool mHasNotifiedWifiConnectivity = false;
+    bool mUseQuickJoin                = false;
 
     static WifiInterfaceImpl mInstance;
 };

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.h
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.h
@@ -57,7 +57,7 @@ public:
     bool IsStationConnected() override;
     bool IsStationModeEnabled() override;
     bool IsStationReady() override;
-    CHIP_ERROR TriggerDisconnection() override;
+    void TriggerDisconnection() override;
     void ClearWifiCredentials() override;
     CHIP_ERROR SetWifiCredentials(const WiFiCredentials & credentials) override;
     CHIP_ERROR GetWifiCredentials(WiFiCredentials & credentials) override;

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -288,8 +288,9 @@ public:
      *       The function will overwrite any existing Wi-Fi credentials.
      *
      * @param[in] credentials
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, CHIP_ERROR_INVALID_ARGUMENT if ssidLength is 0 or exceeds max SSID length
      */
-    virtual void SetWifiCredentials(const WiFiCredentials & credentials) = 0;
+    virtual CHIP_ERROR SetWifiCredentials(const WiFiCredentials & credentials) = 0;
 
     /**
      * @brief Returns the configured Wi-Fi credentials
@@ -307,6 +308,7 @@ public:
      *        connection attempt was successful or not.
      *
      *        The returned error code only indicates if the connection attempt was triggered or not.
+     *        On retry after failure, the implementation may use quick join (no scan) when channel/BSSID are known.
      *
      * @return CHIP_ERROR CHIP_NO_ERROR, the connection attempt was succesfully triggered
      *                    CHIP_ERROR_INCORRECT_STATE, the Wi-Fi station does not have any Wi-Fi credentials

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -238,11 +238,9 @@ public:
      *
      * @note The disconnection is not immediate. It can take a certain amount of time for the device to be in a disconnected state
      * once the function is called. When the function returns, the device might not have yet disconnected from the Wi-Fi network.
-     *
-     * @return CHIP_ERROR CHIP_NO_ERROR, disconnection request was succesfully triggered
-     *         otherwise, CHIP_ERROR_INTERNAL
+     * The implementation may only enqueue a disconnect (e.g. post an event); there is no synchronous success/failure to report.
      */
-    virtual CHIP_ERROR TriggerDisconnection() = 0;
+    virtual void TriggerDisconnection() = 0;
 
     /**
      * @brief Gets the connected access point information.


### PR DESCRIPTION
#### Summary
The Wi-Fi connection flow has been refactored to separate scan and join into distinct platform events. Disconnection is now handled asynchronously on the Wi-Fi task, improving responsiveness and task isolation.

The retry logic has been improved to dynamically choose between “scan then join” and “quick join” based on the failure reason, ensuring a more efficient recovery path.

#### Related issues
NA

#### Testing
Tested with the 917 SoC:
- Commissioning process
- When an incorrect AP SSID is provided, the device attempts to scan and connect instead of performing a quick join
- When an incorrect AP PSK is provided, the scan still succeeds, causing the device to attempt a quick join instead of a scan-and-join process
- When the AP is turned off, the device first attempts a quick join, fails to scan, and then proceeds with the scan-and-join flow
- Disconnection occurs during factory reset
