### PR TITLE
Fix `mUsedEndpointCount` underflow from TCP connection failures

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -315,9 +315,9 @@ CHIP_ERROR TCPBase::StartConnect(const PeerAddress & addr, Transport::AppTCPConn
     activeConnection->mAppState        = appState;
     activeConnection->mConnectionState = TCPState::kConnecting;
 
-    ReturnErrorOnFailure(endPoint->Connect(addr.GetIPAddress(), addr.GetPort(), addr.GetInterface()));
-
     mUsedEndPointCount++;
+
+    ReturnErrorOnFailure(endPoint->Connect(addr.GetIPAddress(), addr.GetPort(), addr.GetInterface()));
 
     // Set the return value of the peer connection state to the allocated
     // connection.

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -944,22 +944,22 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
 
     // Test a single packet buffer.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { 111, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ 111, 0 }));
     err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_EQ(gMockTransportMgrDelegate.mReceiveHandlerCallCount, 1);
 
     // Test a message in a chain of three packet buffers. The message length is split across buffers.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { 1, 122, 123, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ 1, 122, 123, 0 }));
     err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_EQ(gMockTransportMgrDelegate.mReceiveHandlerCallCount, 1);
 
     // Test two messages in a chain.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { 131, 0 }));
-    EXPECT_TRUE(testData[1].Init((const uint32_t[]) { 132, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ 131, 0 }));
+    EXPECT_TRUE(testData[1].Init((const uint32_t[]){ 132, 0 }));
     testData[0].mHandle->AddToEnd(std::move(testData[1].mHandle));
     err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
     EXPECT_EQ(err, CHIP_NO_ERROR);
@@ -967,8 +967,8 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
 
     // Test a chain of two messages, each a chain.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { 141, 142, 0 }));
-    EXPECT_TRUE(testData[1].Init((const uint32_t[]) { 143, 144, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ 141, 142, 0 }));
+    EXPECT_TRUE(testData[1].Init((const uint32_t[]){ 143, 144, 0 }));
     testData[0].mHandle->AddToEnd(std::move(testData[1].mHandle));
     err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
     EXPECT_EQ(err, CHIP_NO_ERROR);
@@ -977,7 +977,7 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
     // Test a single packet buffer that is larger than
     // kMaxSizeWithoutReserve but less than CHIP_CONFIG_MAX_LARGE_PAYLOAD_SIZE_BYTES.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { System::PacketBuffer::kMaxSizeWithoutReserve + 1, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ System::PacketBuffer::kMaxSizeWithoutReserve + 1, 0 }));
     err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_EQ(gMockTransportMgrDelegate.mReceiveHandlerCallCount, 1);
@@ -985,7 +985,7 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
     // Test a message that is too large to coalesce into a single packet buffer.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
     gMockTransportMgrDelegate.SetCallback(TestDataCallbackCheck, &testData[1]);
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { 51, CHIP_SYSTEM_CONFIG_MAX_LARGE_BUFFER_SIZE_BYTES, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ 51, CHIP_SYSTEM_CONFIG_MAX_LARGE_BUFFER_SIZE_BYTES, 0 }));
     // Sending only the first buffer of the long chain. This should be enough to trigger the error.
     System::PacketBufferHandle head = testData[0].mHandle.PopHead();
     err                             = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(head));

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -944,22 +944,22 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
 
     // Test a single packet buffer.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ 111, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { 111, 0 }));
     err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_EQ(gMockTransportMgrDelegate.mReceiveHandlerCallCount, 1);
 
     // Test a message in a chain of three packet buffers. The message length is split across buffers.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ 1, 122, 123, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { 1, 122, 123, 0 }));
     err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_EQ(gMockTransportMgrDelegate.mReceiveHandlerCallCount, 1);
 
     // Test two messages in a chain.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ 131, 0 }));
-    EXPECT_TRUE(testData[1].Init((const uint32_t[]){ 132, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { 131, 0 }));
+    EXPECT_TRUE(testData[1].Init((const uint32_t[]) { 132, 0 }));
     testData[0].mHandle->AddToEnd(std::move(testData[1].mHandle));
     err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
     EXPECT_EQ(err, CHIP_NO_ERROR);
@@ -967,8 +967,8 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
 
     // Test a chain of two messages, each a chain.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ 141, 142, 0 }));
-    EXPECT_TRUE(testData[1].Init((const uint32_t[]){ 143, 144, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { 141, 142, 0 }));
+    EXPECT_TRUE(testData[1].Init((const uint32_t[]) { 143, 144, 0 }));
     testData[0].mHandle->AddToEnd(std::move(testData[1].mHandle));
     err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
     EXPECT_EQ(err, CHIP_NO_ERROR);
@@ -977,7 +977,7 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
     // Test a single packet buffer that is larger than
     // kMaxSizeWithoutReserve but less than CHIP_CONFIG_MAX_LARGE_PAYLOAD_SIZE_BYTES.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ System::PacketBuffer::kMaxSizeWithoutReserve + 1, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { System::PacketBuffer::kMaxSizeWithoutReserve + 1, 0 }));
     err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
     EXPECT_EQ(err, CHIP_NO_ERROR);
     EXPECT_EQ(gMockTransportMgrDelegate.mReceiveHandlerCallCount, 1);
@@ -985,7 +985,7 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
     // Test a message that is too large to coalesce into a single packet buffer.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
     gMockTransportMgrDelegate.SetCallback(TestDataCallbackCheck, &testData[1]);
-    EXPECT_TRUE(testData[0].Init((const uint32_t[]){ 51, CHIP_SYSTEM_CONFIG_MAX_LARGE_BUFFER_SIZE_BYTES, 0 }));
+    EXPECT_TRUE(testData[0].Init((const uint32_t[]) { 51, CHIP_SYSTEM_CONFIG_MAX_LARGE_BUFFER_SIZE_BYTES, 0 }));
     // Sending only the first buffer of the long chain. This should be enough to trigger the error.
     System::PacketBufferHandle head = testData[0].mHandle.PopHead();
     err                             = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(head));
@@ -995,6 +995,33 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
     // The receipt of a message exceeding the allowed size should have
     // closed the connection.
     EXPECT_TRUE(TestAccess::GetEndpoint(state).IsNull());
+}
+
+TEST_F(TestTCP, RepeatedImmediateConnectFailuresDoNotExhaustEndpoints)
+{
+    TCPImpl tcp;
+    auto tcpListenParams = Transport::TcpListenParameters(mIOContext->GetTCPEndPointManager());
+
+    uint16_t chosenPort;
+    ASSERT_SUCCESS(RetryPortSetup(chosenPort, [&](uint16_t port) {
+        return tcp.Init(tcpListenParams.SetAddressType(IPAddressType::kIPv6).SetListenPort(port).SetServerListenEnabled(false));
+    }));
+
+    IPAddress addr;
+    ASSERT_TRUE(IPAddress::FromString("fe80::1", addr));
+
+    constexpr uint16_t kTestPort = 5540;
+    constexpr size_t kAttempts   = kMaxTcpActiveConnectionCount * 3;
+
+    for (size_t i = 0; i < kAttempts; ++i)
+    {
+        ActiveTCPConnectionHandle conn;
+        CHIP_ERROR err = tcp.TCPConnect(Transport::PeerAddress::TCP(addr, kTestPort, InterfaceId::Null()), nullptr, conn);
+
+        EXPECT_NE(err, CHIP_NO_ERROR);
+        EXPECT_NE(err, CHIP_ERROR_NO_MEMORY);
+        EXPECT_TRUE(conn.IsNull());
+    }
 }
 
 } // namespace


### PR DESCRIPTION
#### Summary

Inside `TCPBase::StartConnect`:
- `mUsedEndPointCount` was incremented after `endPoint->Connect(...)`.
- If `Connect(...)` fails immediately (like `ENETUNREACH`), function exits early.
- During unwind, the temporary `ActiveTCPConnectionHandle` releases and calls disconnect cleanup, which decrements `mUsedEndPointCount`.
- Since increment never happened, counter underflows (`size_t` wrap), and later `TCPConnect` check at `TCP.cpp:691` (`mUsedEndPointCount` < `mActiveConnectionsSize`) fails forever with No memory.

I fixed it by moving the increment before the connect call so increment/decrement stay balanced in all paths.

#### Related issues

Fixes https://github.com/project-chip/connectedhomeip/issues/43638

#### Testing

Added unit tests that catch the regression (fail without the fix). 
Also validating it manually by running it on the same controller <-> device setup where this was originally reproduced.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase