### PR TITLE
Added water-heater-app reference app

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -189,6 +189,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-closure-ipv6only \
     --target linux-x64-jf-control-app-ipv6only \
     --target linux-x64-jf-admin-app-ipv6only \
+    --target linux-x64-water-heater-ipv6only \
     build \
     && mv out/linux-x64-chip-tool-ipv6only-platform-mdns-nfc-commission/chip-tool out/chip-tool \
     && mv out/linux-x64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
@@ -222,6 +223,7 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-x64-closure-ipv6only/closure-app out/closure-app \
     && mv out/linux-x64-jf-control-app-ipv6only/jfc-app out/jfc-app \
     && mv out/linux-x64-jf-admin-app-ipv6only/jfa-app out/jfa-app \
+    && mv out/linux-x64-water-heater-ipv6only/matter-water-heater-app out/matter-water-heater-app \
     ;; \
     "linux/arm64")\
     set -x \
@@ -259,6 +261,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-arm64-closure-ipv6only \
     --target linux-arm64-jf-control-app-ipv6only \
     --target linux-arm64-jf-admin-app-ipv6only \
+    --target linux-arm64-water-heater-ipv6only \
     build \
     && mv out/linux-arm64-chip-tool-ipv6only-platform-mdns-nfc-commission/chip-tool out/chip-tool \
     && mv out/linux-arm64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
@@ -292,6 +295,7 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-arm64-closure-ipv6only/closure-app out/closure-app \
     && mv out/linux-arm64-jf-control-app-ipv6only/jfc-app out/jfc-app \
     && mv out/linux-arm64-jf-admin-app-ipv6only/jfa-app out/jfa-app \
+    && mv out/linux-arm64-water-heater-ipv6only/matter-water-heater-app out/matter-water-heater-app \
     ;; \
     *) ;; \
     esac
@@ -382,6 +386,7 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-camera-controlle
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/closure-app apps/closure-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/jfc-app apps/jfc-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/jfa-app apps/jfa-app
+COPY --from=chip-build-cert-bins /root/connectedhomeip/out/matter-water-heater-app apps/matter-water-heater-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/src/tools/push_av_server apps/push_av_server
 
 # Create symbolic links for now since this allows users to use existing configurations


### PR DESCRIPTION
#### Summary
The goal of this PR is to add water-heater-app app to chip-cert-bins image.

#### Related issues
https://github.com/project-chip/certification-tool/issues/913

#### Testing
The matter-water-heater-app app was available in local build.

<img width="1486" height="118" alt="Screenshot 2026-03-20 at 09 02 18" src="https://github.com/user-attachments/assets/2ec76ed1-1f84-45fd-a231-98e0149f65ff" />

#### Readability checklist
The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
