### PR TITLE
Add "nfc-ethernet" in Python controller

### DIFF
--- a/src/controller/python/matter/ChipDeviceCtrl.py
+++ b/src/controller/python/matter/ChipDeviceCtrl.py
@@ -2917,6 +2917,20 @@ class ChipDeviceController(ChipDeviceControllerBase):
         self.SetWiFiCredentials(ssid, credentials)
         return await self.ConnectNFC(discriminator, setupPinCode, nodeId)
 
+    async def CommissionNfcEthernet(self, discriminator, setupPinCode, nodeId: int) -> int:
+        '''
+        Commissions an Ethernet device over NFC.
+
+        Args:
+            discriminator (int): The long discriminator for the DNS-SD advertisement. Valid range: 0-4095.
+            setupPinCode (int): The setup pin code of the device.
+            nodeId (int): The node ID of the device.
+
+        Returns:
+            int: Effective Node ID of the device (as defined by the assigned NOC).
+        '''
+        return await self.ConnectNFC(discriminator, setupPinCode, nodeId)
+
     async def CommissionBleWiFi(self, discriminator, setupPinCode, nodeId: int, ssid: str, credentials: str, isShortDiscriminator: bool = False) -> int:
         '''
         Commissions a Wi-Fi device over BLE.

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/commissioning.py
@@ -232,6 +232,17 @@ async def commission_device(
         except ChipStackError as e:  # chipstack-ok: Can not use 'with' because we handle and return the exception, not assert it
             LOGGER.exception("Commissioning failed")
             return PairingStatus(exception=e)
+    elif commissioning_info.commissioning_method == "nfc-ethernet":
+        try:
+            await dev_ctrl.CommissionNfcEthernet(
+                info.filter_value,
+                info.passcode,
+                node_id,
+            )
+            return PairingStatus()
+        except ChipStackError as e:  # chipstack-ok: Can not use 'with' because we handle and return the exception, not assert it
+            LOGGER.exception("Commissioning failed")
+            return PairingStatus(exception=e)
     elif commissioning_info.commissioning_method == "thread-meshcop":
         try:
             asserts.assert_is_not_none(commissioning_info.thread_operational_dataset,

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -997,11 +997,11 @@ def parse_matter_test_args(argv: Optional[List[str]] = None):
 
     commission_group.add_argument('-m', '--commissioning-method', type=str,
                                   metavar='METHOD_NAME',
-                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread", "nfc-wifi", "thread-meshcop"],
+                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread", "nfc-wifi", "nfc-ethernet", "thread-meshcop"],
                                   help='Name of commissioning method to use')
     commission_group.add_argument('--in-test-commissioning-method', type=str,
                                   metavar='METHOD_NAME',
-                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread", "nfc-wifi", "thread-meshcop"],
+                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread", "nfc-wifi", "nfc-ethernet", "thread-meshcop"],
                                   help='Name of commissioning method to use, for commissioning tests')
     commission_group.add_argument('-d', '--discriminator', type=int_decimal_or_hex,
                                   metavar='LONG_DISCRIMINATOR',

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -998,12 +998,12 @@ def parse_matter_test_args(argv: Optional[List[str]] = None):
     commission_group.add_argument('-m', '--commissioning-method', type=str,
                                   metavar='METHOD_NAME',
                                   choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread",
-                                    "nfc-wifi", "nfc-ethernet", "thread-meshcop"],
+                                           "nfc-wifi", "nfc-ethernet", "thread-meshcop"],
                                   help='Name of commissioning method to use')
     commission_group.add_argument('--in-test-commissioning-method', type=str,
                                   metavar='METHOD_NAME',
                                   choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread",
-                                    "nfc-wifi", "nfc-ethernet", "thread-meshcop"],
+                                           "nfc-wifi", "nfc-ethernet", "thread-meshcop"],
                                   help='Name of commissioning method to use, for commissioning tests')
     commission_group.add_argument('-d', '--discriminator', type=int_decimal_or_hex,
                                   metavar='LONG_DISCRIMINATOR',

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -997,13 +997,13 @@ def parse_matter_test_args(argv: Optional[List[str]] = None):
 
     commission_group.add_argument('-m', '--commissioning-method', type=str,
                                   metavar='METHOD_NAME',
-                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread", "nfc-wifi", 
-                                  "nfc-ethernet", "thread-meshcop"],
+                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread",
+                                    "nfc-wifi", "nfc-ethernet", "thread-meshcop"],
                                   help='Name of commissioning method to use')
     commission_group.add_argument('--in-test-commissioning-method', type=str,
                                   metavar='METHOD_NAME',
-                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread", "nfc-wifi", 
-                                  "nfc-ethernet", "thread-meshcop"],
+                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread",
+                                    "nfc-wifi", "nfc-ethernet", "thread-meshcop"],
                                   help='Name of commissioning method to use, for commissioning tests')
     commission_group.add_argument('-d', '--discriminator', type=int_decimal_or_hex,
                                   metavar='LONG_DISCRIMINATOR',

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/runner.py
@@ -997,11 +997,13 @@ def parse_matter_test_args(argv: Optional[List[str]] = None):
 
     commission_group.add_argument('-m', '--commissioning-method', type=str,
                                   metavar='METHOD_NAME',
-                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread", "nfc-wifi", "nfc-ethernet", "thread-meshcop"],
+                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread", "nfc-wifi", 
+                                  "nfc-ethernet", "thread-meshcop"],
                                   help='Name of commissioning method to use')
     commission_group.add_argument('--in-test-commissioning-method', type=str,
                                   metavar='METHOD_NAME',
-                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread", "nfc-wifi", "nfc-ethernet", "thread-meshcop"],
+                                  choices=["on-network", "ble-wifi", "ble-thread", "nfc-thread", "nfc-wifi", 
+                                  "nfc-ethernet", "thread-meshcop"],
                                   help='Name of commissioning method to use, for commissioning tests')
     commission_group.add_argument('-d', '--discriminator', type=int_decimal_or_hex,
                                   metavar='LONG_DISCRIMINATOR',


### PR DESCRIPTION
#### Summary
Add `nfc-ethernet` in python controller pairing method to support NFC based commissioning for Matter over Ethernet products.


#### Related issues
https://github.com/project-chip/connectedhomeip/issues/40531
https://github.com/project-chip/connectedhomeip/pull/43613
https://github.com/project-chip/connectedhomeip/pull/43227

#### Testing
##### Precondition
- NFC reader
- Matter over Ethernet device supports NFC based commissioning

##### Build python controller
```shell
$ scripts/build_python.sh -m platform -i out/python_env --enable_nfc true
```
##### Run commissioning in python controller
```shell
$ source out/python_env/bin/activate
(python_env) $ matter-repl 
Python 3.12.3 (main, Mar  3 2026, 12:15:18) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.11.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: You can use `files = !ls *.png`
[1774076489.412] [99532:99532] [CTL] Setting attestation nonce to random value
[1774076489.413] [99532:99532] [CTL] Setting CSR nonce to random value
[1774076489.437] [99532:99532] [DL] NVS set: chip-counters/reboot-count = 82 (0x52)
[1774076489.438] [99532:99532] [DL] Got Ethernet interface: eth0
[1774076489.448] [99532:99532] [DL] Found the primary Ethernet interface:eth0
[1774076489.448] [99532:99532] [DL] Failed to get WiFi interface
[1774076489.448] [99532:99532] [DL] Failed to reset WiFi statistic counts
[1774076489.448] [99532:99532] [PAF] WiFiPAF: WiFiPAFLayer::Init()
─────────────────────────────────────────────────────────────────────────────── Matter REPL ────────────────────────────────────────────────────────────────────────────────

            Welcome to the Matter Python REPL!

            For help, please type matterhelp()

            To get more information on a particular object/class, you can pass
            that into matterhelp() as well.
            
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
2026-03-21 15:01:29 ElthamLiu matter.native.DL[99532] ERROR Long dispatch time: 158 ms, for event type 2

The following objects have been created:

        certificateAuthorityManager:    Manages a list of CertificateAuthority instances
        caList:                         The list of CertificateAuthority instances
        caList[n].adminList[m]:         A specific FabricAdmin object at index m for the nth CertificateAuthority instance
        devCtrl:                        Default Matter Device Controller (nodeId=0x000000000001B669) to manage caList[0].adminList[0] (fabricId=1)
    

In [1]: await devCtrl.CommissionNfcEthernet(1381, 20202021, 1234)
Out[1]: 1234

```