### PR TITLE
[ESP32] Fix compile flag parsing in create_args_gn.py for ESP-IDF v6.0

### DIFF
--- a/config/esp32/components/chip/create_args_gn.py
+++ b/config/esp32/components/chip/create_args_gn.py
@@ -61,8 +61,8 @@ def expand_response_file(flag):
         with open(response_file_path, 'r') as f:
             content = f.read()
             return shlex.split(content)
-    except (IOError, OSError):
-        return []
+    except (IOError, OSError) as e:
+        raise Exception(f"Failed to read response file '{response_file_path}': {e}")
 
 
 with open(compile_commands_path) as compile_commands_json:

--- a/config/esp32/components/chip/create_args_gn.py
+++ b/config/esp32/components/chip/create_args_gn.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2021 Project CHIP Authors
+#    Copyright (c) 2021-2026 Project CHIP Authors
 #    Copyright (c) 2018 Nest Labs, Inc.
 #    All rights reserved.
 #
@@ -22,6 +22,7 @@
 import argparse
 import json
 import os
+import shlex
 
 # Parse the build's compile_commands.json to generate
 # final args file for CHIP build.
@@ -40,6 +41,28 @@ args = argparser.parse_args()
 
 compile_commands_path = os.path.join(args.build_dir, "compile_commands.json")
 
+# From esp-idf v6.0 and onwards, compile flags are stored in files, so we need to explicitly expand them
+# eg: @\"/Users/esp/connectedhomeip/examples/lighting-app/esp32/build/toolchain/asmflags\"
+#     @\"/Users/esp/connectedhomeip/examples/lighting-app/esp32/build/toolchain/cflags\"
+# this function reads that file and returns the flags
+def expand_response_file(flag):
+    """Expand response file references (flags starting with @) into their contents."""
+    # Handle both @path and @"path" formats
+    if flag.startswith('@"') and flag.endswith('"'):
+        response_file_path = flag[2:-1]  # Remove @" and trailing "
+    elif flag.startswith('@'):
+        response_file_path = flag[1:]  # Remove @
+    else:
+        return [flag]
+
+    try:
+        with open(response_file_path, 'r') as f:
+            content = f.read()
+            return shlex.split(content)
+    except (IOError, OSError):
+        return []
+
+
 with open(compile_commands_path) as compile_commands_json:
     compile_commands = json.load(compile_commands_json)
 
@@ -52,19 +75,31 @@ with open(compile_commands_path) as compile_commands_json:
             raise Exception(f"Failed to resolve compile flags for {src_file}")
 
         compile_command = compile_command[0]
+        compile_parts = shlex.split(compile_command)
         # Trim compiler, input and output
-        compile_flags = compile_command.split()[1:-4]
+        compile_flags = compile_parts[1:-4]
+
+        # Expand any response file references
+        expanded_flags = []
+        for flag in compile_flags:
+            expanded_flags.extend(expand_response_file(flag))
 
         replace = "-I%s" % args.idf_path
         replace_with = "-isystem%s" % args.idf_path
 
-        compile_flags = [f'"{f}"'.replace(replace, replace_with) for f in compile_flags]
+        # Escape any embedded double quotes for GN string syntax, then wrap in quotes
+        def quote_for_gn(flag):
+            # Escape backslashes first, then escape double quotes
+            escaped = flag.replace('\\', '\\\\').replace('"', '\\"')
+            return f'"{escaped}"'
+
+        expanded_flags = [quote_for_gn(f).replace(replace, replace_with) for f in expanded_flags]
 
         if args.filter_out:
             filter_out = [f'"{f}"' for f in args.filter_out.split(';')]
-            compile_flags = [c for c in compile_flags if c not in filter_out]
+            expanded_flags = [c for c in expanded_flags if c not in filter_out]
 
-        return compile_flags
+        return expanded_flags
 
     c_flags = get_compile_flags(args.c_file)
     cpp_flags = get_compile_flags(args.cpp_file)

--- a/config/esp32/components/chip/create_args_gn.py
+++ b/config/esp32/components/chip/create_args_gn.py
@@ -45,6 +45,8 @@ compile_commands_path = os.path.join(args.build_dir, "compile_commands.json")
 # eg: @\"/Users/esp/connectedhomeip/examples/lighting-app/esp32/build/toolchain/asmflags\"
 #     @\"/Users/esp/connectedhomeip/examples/lighting-app/esp32/build/toolchain/cflags\"
 # this function reads that file and returns the flags
+
+
 def expand_response_file(flag):
     """Expand response file references (flags starting with @) into their contents."""
     # Handle both @path and @"path" formats


### PR DESCRIPTION
#### Summary

This is the First PR for adding esp-idf v6.0 support

ESP-IDF v6.0 stores compile flags in response files (e.g. @"/path/to/cflags") rather than inline in compile_commands.json. This breaks the GN args generation as the script was splitting on whitespace without expanding these references.

- Add `expand_response_file()` to read and expand @file references
- Use `shlex.split()` instead of `str.split()` for proper command parsing
- Add `quote_for_gn()` to correctly escape embedded quotes and backslashes for GN string syntax

Basically the error we see is:

```
ERROR at build arg file (use "gn args <out_dir>" to edit):30:14354: Invalid token
...
I have no idea what this is.
```

<details> <summary> Click to see complete build failure logs </summary>

```
Executing action: all (aliases: build)
Running ninja in directory /Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/build
Executing "ninja all"...
[1/635] Performing configure step for 'chip_gn'
FAILED: [code=1] esp-idf/chip/chip_gn-prefix/src/chip_gn-stamp/chip_gn-configure /Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/build/esp-idf/chip/chip_gn-prefix/src/chip_gn-stamp/chip_gn-configure 
cd /Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/build/esp-idf/chip && /Users/shubhampatil/esp/connectedhomeip/.environment/cipd/packages/pigweed/gn --root=/Users/shubhampatil/esp/connectedhomeip/config/esp32 gen --check --fail-on-unused-args /Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/build/esp-idf/chip && /opt/homebrew/Cellar/cmake/3.30.0/bin/cmake -E touch /Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/build/esp-idf/chip/chip_gn-prefix/src/chip_gn-stamp/chip_gn-configure
ERROR at build arg file (use "gn args <out_dir>" to edit):30:14354: Invalid token.
target_cflags_c = ["-DESP_MDNS_VERSION_NUMBER=\"1.11.0\"", "-DESP_PLATFORM", "-DESP_PSA_ITS_AVAILABLE", "-DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\"", "-DMBEDTLS_MAJOR_VERSION=4", "-DSOC_MMU_PAGE_SIZE=CONFIG_MMU_PAGE_SIZE", "-DSOC_XTAL_FREQ_MHZ=CONFIG_XTAL_FREQ", "-DTF_PSA_CRYPTO_USER_CONFIG_FILE=\"mbedtls/esp_config.h\"", "-D_GLIBCXX_HAVE_POSIX_SEMAPHORE", "-D_GLIBCXX_USE_POSIX_SEMAPHORE", "-D_GNU_SOURCE", "-D_POSIX_READER_WRITER_LOCKS", "-I/Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/build/config", "-isystem/Users/shubhampatil/esp/esp-idf/components/freertos/include/freertos", "-isystem/Users/shubhampatil/esp/esp-idf/components/freertos/FreeRTOS-Kernel/include/freertos", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_libc/platform_include", "-isystem/Users/shubhampatil/esp/esp-idf/components/freertos/config/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/freertos/config/include/freertos", "-isystem/Users/shubhampatil/esp/esp-idf/components/freertos/config/xtensa/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/freertos/FreeRTOS-Kernel/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/include/freertos", "-isystem/Users/shubhampatil/esp/esp-idf/components/freertos/esp_additions/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hw_support/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hw_support/include/soc", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hw_support/ldo/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hw_support/debug_probe/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hw_support/etm/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hw_support/mspi_timing_tuning/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hw_support/mspi_timing_tuning/tuning_scheme_impl/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hw_support/power_supply/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hw_support/modem/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hw_support/port/esp32/.", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hw_support/port/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/heap/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/heap/tlsf", "-isystem/Users/shubhampatil/esp/esp-idf/components/log/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/soc/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/soc/esp32", "-isystem/Users/shubhampatil/esp/esp-idf/components/soc/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/soc/esp32/register", "-isystem/Users/shubhampatil/esp/esp-idf/components/hal/platform_port/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/hal/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/hal/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_rom/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_rom/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_rom/esp32/include/esp32", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_rom/esp32", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_common/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_system/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_system/port/soc", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_system/port/include/private", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_stdio/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/xtensa/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/xtensa/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/xtensa/deprecated_include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_gpio/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_gpio/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_usb/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_pmu/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_pmu/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_ana_conv/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_ana_conv/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_dma/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_i2s/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_i2s/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/lwip/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/lwip/include/apps", "-isystem/Users/shubhampatil/esp/esp-idf/components/lwip/lwip/src/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/lwip/port/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/lwip/port/freertos/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/lwip/port/esp32xx/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/lwip/port/esp32xx/include/arch", "-isystem/Users/shubhampatil/esp/esp-idf/components/lwip/port/esp32xx/include/sys", "-I/Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/managed_components/espressif__esp_delta_ota/include", "-I/Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/managed_components/espressif__esp_encrypted_img/include", "-I/Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/managed_components/espressif__esp_insights/include", "-I/Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/managed_components/espressif__esp_diagnostics/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_eth/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_event/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_driver_spi/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_pm/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_gpspi/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_gpspi/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_driver_dma/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/include/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/common/osi/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/common/api/include/api", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/common/btc/profile/esp/blufi/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/common/btc/profile/esp/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/common/hci_log/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/common/ble_log/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/common/tinycrypt/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/common/tinycrypt/port", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/ans/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/bas/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/dis/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/gap/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/gatt/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/hr/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/htp/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/ias/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/ipss/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/lls/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/prox/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/cts/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/tps/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/hid/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/sps/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/cte/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/util/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/store/ram/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/store/config/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/ras/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/porting/nimble/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/port/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/nimble/transport/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/porting/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/nimble/porting/npl/freertos/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bt/host/nimble/esp-hci/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_timer/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_wifi/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_wifi/include/local", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_wifi/wifi_apps/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_wifi/wifi_apps/nan_app/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_phy/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_phy/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_netif/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/mbedtls/port/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/mbedtls/mbedtls/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/mbedtls/mbedtls/library", "-isystem/Users/shubhampatil/esp/esp-idf/components/mbedtls/mbedtls/tf-psa-crypto/core", "-isystem/Users/shubhampatil/esp/esp-idf/components/mbedtls/mbedtls/tf-psa-crypto/drivers/builtin/src", "-isystem/Users/shubhampatil/esp/esp-idf/components/mbedtls/esp_crt_bundle/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/mbedtls/port/psa_driver/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_security/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_security/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_security/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/mbedtls/mbedtls/tf-psa-crypto/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/mbedtls/mbedtls/tf-psa-crypto/drivers/builtin/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/mbedtls/mbedtls/tf-psa-crypto/drivers/everest/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/mbedtls/mbedtls/tf-psa-crypto/drivers/p256-m", "-isystem/Users/shubhampatil/esp/esp-idf/components/fatfs/diskio", "-isystem/Users/shubhampatil/esp/esp-idf/components/fatfs/src", "-isystem/Users/shubhampatil/esp/esp-idf/components/fatfs/vfs", "-isystem/Users/shubhampatil/esp/esp-idf/components/wear_levelling/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_partition/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_blockdev/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/sdmmc/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_driver_sdmmc/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_driver_sdmmc/legacy/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_driver_sd_intf/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_driver_sdspi/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_driver_gpio/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/app_update/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bootloader_support/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/bootloader_support/bootloader_flash/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_app_format/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_bootloader_format/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/console", "-isystem/Users/shubhampatil/esp/esp-idf/components/vfs/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_driver_uart/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_uart/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_uart/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_driver_usb_serial_jtag/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/nvs_flash/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/spi_flash/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_mspi/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_mspi/esp32/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_clock/include", "-isystem/Users/shubhampatil/esp/esp-idf/components/esp_hal_clock/esp32/include", "-I/Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/managed_components/espressif__mdns/include", "-I/Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/managed_components/espressif__esp_secure_cert_mgr/include", "@"/Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/build/toolchain/cflags"", "-fdiagnostics-color=always", "-ffunction-sections", "-fdata-sections", "-Wall", "-Werror", "-Wno-error=unused-function", "-Wno-error=unused-variable", "-Wno-error=unused-but-set-variable", "-Wno-error=deprecated-declarations", "-Wextra", "-Wno-error=extra", "-Wno-unused-parameter", "-Wno-sign-compare", "-Wno-enum-conversion", "-gdwarf-4", "-ggdb", "-Og", "-fno-shrink-wrap", "-fmacro-prefix-map=/Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32=.", "-fmacro-prefix-map=/Users/shubhampatil/esp/esp-idf=/IDF", "-fstrict-volatile-bitfields", "-fno-jump-tables", "-fno-tree-switch-conversion", "-Wno-format-nonliteral", "-Wno-format-security", "-Wno-error=maybe-uninitialized", "-Wno-error=uninitialized", "-std=gnu23", "-Wno-old-style-declaration", "-fzero-init-padding-bits=all", "-fno-malloc-dce", "-Os", "-I/Users/shubhampatil/esp/connectedhomeip/examples/lighting-app/esp32/build/config"]
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 ^
I have no idea what this is.

```

</details>

#### Testing
- Build the `examples/lighting-app/esp32` with the fix and build progresses further.