### PR TITLE
[Silabs] GroupAuxiliaryAccessControlDelegate injection.

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -20,6 +20,7 @@
 #include "AppConfig.h"
 #include "BaseApplication.h"
 #include <MatterConfig.h>
+#include <access/examples/GroupAuxiliaryAccessControlDelegate.h>
 #include <cmsis_os2.h>
 
 #include <mbedtls/platform.h>
@@ -336,6 +337,10 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     // This is needed by localization configuration cluster so we set it before the initialization
     gExampleDeviceInfoProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
+
+    // Inject group auxiliary access control delegate
+    static chip::Access::Examples::GroupAuxiliaryAccessControlDelegate sGroupAuxAccessDelegate(initParams.groupDataProvider);
+    initParams.groupAuxiliaryAccessControlDelegate = &sGroupAuxAccessDelegate;
 
     // Init Matter Server and Start Event Loop
     err = chip::Server::GetInstance().Init(initParams);


### PR DESCRIPTION
#### Summary

[AccessControl now requires a GroupAuxiliaryAccessControlDelegate](https://github.com/project-chip/connectedhomeip/pull/43357) to check incoming Groupcast messages. This PR injects the [ExampleAccessControlDelegate](https://github.com/project-chip/connectedhomeip/blob/master/src/access/examples/ExampleAccessControlDelegate.cpp) from [SilabsMatterConfig::AppInit](https://github.com/project-chip/connectedhomeip/blob/4428cc97f06e6346c2ce486c5c26976e2d3f36a9/examples/platform/silabs/MatterConfig.cpp#L231).

#### Related issues

N/A

#### Testing

* Groupcast unit tests run successfully.
* Groupcast on/off successful on BRD4187C (MG24) and BRD4116A (MG26).

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
