### PR TITLE
Add support for parsing optional struct fields

### DIFF
--- a/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
@@ -300,13 +300,16 @@ class MatterIdlTransformer(Transformer):
     def command_qualities(self, attrs):
         return UnionOfAllFlags(attrs) or CommandQuality.NONE
 
-    def struct_field(self, args):
+    @v_args(meta=True)
+    def struct_field(self, meta, args):
         # Last argument is the named_member, the rest
         # are qualities
         field = args[-1]
         field.qualities = UnionOfAllFlags(args[1:-1]) or FieldQuality.NONE
         if args[0] is not None:
             field.api_maturity = args[0]
+
+        field.parse_meta = None if self.skip_meta else ParseMetaData(meta)
         return field
 
     def command_access(self, privilege):

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -144,6 +144,8 @@ class TestParser(unittest.TestCase):
                 struct TestStruct {
                     /** Struct field comment */
                     int8u returnValue = 0;
+                    /** Optional struct field comment */
+                    optional int8u optionalValue = 1;
                 }
 
                 /** Multi line
@@ -190,6 +192,8 @@ class TestParser(unittest.TestCase):
             actual.clusters[1].structs[0].description, "Multi line\n                Struct comment")
         self.assertIdlEqual(
             actual.clusters[1].structs[0].fields[0].description, "Struct field comment")
+        self.assertIdlEqual(
+            actual.clusters[1].structs[0].fields[1].description, "Optional struct field comment")
         self.assertIdlEqual(
             actual.clusters[1].bitmaps[0].description, "Multi line\n                Bitmap comment")
         self.assertIdlEqual(actual.clusters[1].bitmaps[0].entries[0].description,


### PR DESCRIPTION
#### Summary
Update the matter idl parser to store documentation for struct field types. Previously struct fields would not store comments if a keyword (ex. `optional`) appeared before the type of the field.

This change is desired to retain comments made on fields with keywords in the matter IDL and align with the comment retention behavior on other fields.

#### Related issues
No related issues that I am aware of. Related PR includes #42412. 

#### Testing
Updated unit tests in `matter_idl_parser.py`.